### PR TITLE
feat(editor): render MoonDiff top-level sections with DiffEditor

### DIFF
--- a/desktop/frontend/fileeditor/active_editor_surface_wbtest.mbt
+++ b/desktop/frontend/fileeditor/active_editor_surface_wbtest.mbt
@@ -1,24 +1,28 @@
 ///|
 test "only the visible editor surface participates in host layout" {
   assert_true(
-    active_editor_surface_from_visibility(true, false, false)
+    active_editor_surface_from_visibility(true, false, false, false)
     is Some(CodeEditorSurface),
   )
   assert_true(
-    active_editor_surface_from_visibility(false, true, false)
+    active_editor_surface_from_visibility(false, true, false, false)
     is Some(MarkdownEditorSurface),
   )
   assert_true(
-    active_editor_surface_from_visibility(false, false, true)
+    active_editor_surface_from_visibility(false, false, true, false)
     is Some(DiffEditorSurface),
   )
   assert_true(
-    active_editor_surface_from_visibility(false, false, false) is None,
+    active_editor_surface_from_visibility(false, false, false, false) is None,
   )
   // If a host patch briefly overlaps visibility, the product's most specific
   // comparison surface wins and parked source surfaces remain untouched.
   assert_true(
-    active_editor_surface_from_visibility(true, true, true)
+    active_editor_surface_from_visibility(true, true, true, false)
     is Some(DiffEditorSurface),
+  )
+  assert_true(
+    active_editor_surface_from_visibility(true, true, true, true)
+    is Some(SemanticEditorSurface),
   )
 }

--- a/desktop/frontend/fileeditor/diff_provider_policy_wbtest.mbt
+++ b/desktop/frontend/fileeditor/diff_provider_policy_wbtest.mbt
@@ -17,6 +17,7 @@ test "selecting a Moon diff algorithm enters Diff view and retains policy" {
   let initial = State::empty()
   assert_true(initial.review_diff_mode is ReviewDiffCore)
   assert_true(initial.review_diff_ignore_comments)
+  assert_true(initial.review_diff_ignore_tests)
   assert_eq(initial.review_diff_status, None)
 
   let path = @pathx.Relative("src/main.mbt")
@@ -34,6 +35,13 @@ test "selecting a Moon diff algorithm enters Diff view and retains policy" {
   }
   let state = { ..owned_state(), docs, review_view_mode: ReviewSource, }
   let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path), }
+  let (_, core_unchanged) = update(
+    test_emit(),
+    ToggleReviewDiffIgnoreTests,
+    state,
+    ctx,
+  )
+  assert_true(core_unchanged == state)
   let (_, tree) = update(
     test_emit(),
     ReviewDiffModeSelected(ReviewDiffTree),
@@ -54,6 +62,13 @@ test "selecting a Moon diff algorithm enters Diff view and retains policy" {
     ctx,
   )
   assert_false(include_comments.review_diff_ignore_comments)
+  let (_, include_tests) = update(
+    test_emit(),
+    ToggleReviewDiffIgnoreTests,
+    include_comments,
+    ctx,
+  )
+  assert_false(include_tests.review_diff_ignore_tests)
   let fallback : ReviewDiffStatus = {
     requested: ReviewDiffTree,
     effective: ReviewDiffToken,
@@ -62,10 +77,28 @@ test "selecting a Moon diff algorithm enters Diff view and retains policy" {
   let (_, settled) = update(
     test_emit(),
     ReviewDiffStatusChanged(fallback),
-    include_comments,
+    include_tests,
     ctx,
   )
   assert_eq(settled.review_diff_status, Some(fallback))
+}
+
+///|
+test "diff provider filter preferences survive owner replacement" {
+  let configured = {
+    ..owned_state(),
+    review_diff_mode: ReviewDiffTree,
+    review_diff_ignore_comments: false,
+    review_diff_ignore_tests: false,
+  }
+  let next_owner : @interop.ConversationKey = {
+    ..test_ctx().owner,
+    session: "next-session",
+  }
+  let prepared = configured.prepare_owner(next_owner, [])
+  assert_true(prepared.review_diff_mode is ReviewDiffTree)
+  assert_false(prepared.review_diff_ignore_comments)
+  assert_false(prepared.review_diff_ignore_tests)
 }
 
 ///|
@@ -92,4 +125,11 @@ test "non-MoonBit review parks the last Moon provider preference" {
     ctx,
   )
   assert_true(unchanged.review_diff_mode is ReviewDiffTree)
+  let (_, filters_unchanged) = update(
+    test_emit(),
+    ToggleReviewDiffIgnoreTests,
+    state,
+    ctx,
+  )
+  assert_true(filters_unchanged == state)
 }

--- a/desktop/frontend/fileeditor/diff_provider_policy_wbtest.mbt
+++ b/desktop/frontend/fileeditor/diff_provider_policy_wbtest.mbt
@@ -1,24 +1,15 @@
 ///|
-test "diff provider forces Core outside .mbt without overwriting preference" {
-  assert_true(
-    effective_diff_provider_mode(ReviewDiffTree, true)
-    is @moon_diff_provider.Tree,
-  )
-  assert_true(
-    effective_diff_provider_mode(ReviewDiffTree, false)
-    is @moon_diff_provider.Core,
-  )
+test "semantic review is available only for MoonBit source files" {
   assert_true(supports_moon_diff("SRC/MAIN.MBT"))
   assert_false(supports_moon_diff("src/main.mbti"))
 }
 
 ///|
-test "selecting a Moon diff algorithm enters Diff view and retains policy" {
+test "selecting a Moon semantic algorithm enters Diff view and retains policy" {
   let initial = State::empty()
   assert_true(initial.review_diff_mode is ReviewDiffCore)
   assert_true(initial.review_diff_ignore_comments)
   assert_true(initial.review_diff_ignore_tests)
-  assert_eq(initial.review_diff_status, None)
 
   let path = @pathx.Relative("src/main.mbt")
   let selected = test_modified_change(path)
@@ -54,7 +45,6 @@ test "selecting a Moon diff algorithm enters Diff view and retains policy" {
     tree.docs.get(path)
     is Some({ review: Some({ view_mode: ReviewDiff, .. }), .. }),
   )
-  assert_eq(tree.review_diff_status, None)
   let (_, include_comments) = update(
     test_emit(),
     ToggleReviewDiffIgnoreComments,
@@ -69,22 +59,10 @@ test "selecting a Moon diff algorithm enters Diff view and retains policy" {
     ctx,
   )
   assert_false(include_tests.review_diff_ignore_tests)
-  let fallback : ReviewDiffStatus = {
-    requested: ReviewDiffTree,
-    effective: ReviewDiffToken,
-    fell_back: true,
-  }
-  let (_, settled) = update(
-    test_emit(),
-    ReviewDiffStatusChanged(fallback),
-    include_tests,
-    ctx,
-  )
-  assert_eq(settled.review_diff_status, Some(fallback))
 }
 
 ///|
-test "diff provider filter preferences survive owner replacement" {
+test "semantic review preferences survive owner replacement" {
   let configured = {
     ..owned_state(),
     review_diff_mode: ReviewDiffTree,
@@ -102,7 +80,7 @@ test "diff provider filter preferences survive owner replacement" {
 }
 
 ///|
-test "non-MoonBit review parks the last Moon provider preference" {
+test "non-MoonBit review parks the last semantic review preference" {
   let path = @pathx.Relative("README.md")
   let selected = test_modified_change(path)
   let docs = owned_state().docs.copy()

--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -1,9 +1,10 @@
 // The embedded read-only code viewer (moonbitlang/editor). Rabbita has
-// no escape hatch for a foreign DOM widget, so the source viewer and full-diff
-// comparison each own a stable, never-diffed host element. The view renders both
-// hosts empty, and after the first paint each widget attaches its imperative DOM.
-// The host elements are always rendered (merely hidden by CSS when inactive or
-// the panel is closed), so each widget attaches once and survives screen switches.
+// no escape hatch for a foreign DOM widget, so the source viewer and Core
+// full-file comparison each own a stable, never-diffed host element. The view
+// renders those hosts empty, and after the first paint each widget attaches its
+// imperative DOM. Token/Tree uses a fourth stable sibling containing keyed,
+// empty per-section hosts; each receives a real DiffEditor. Every top-level
+// stays independent, so no global monotonic line mapping is synthesized.
 
 ///|
 /// The id of the stable element the viewer attaches into; the panel view must
@@ -19,6 +20,11 @@ const MarkdownViewerHostId = "markdown-viewer-host"
 ///|
 /// The stable sibling host reserved for the switchable DiffEditor.
 const DiffEditorHostId = "diff-editor-host"
+
+///|
+/// The stable sibling host for Token/Tree semantic review. Rabbita owns its
+/// section chrome and the imperative section DiffEditors own their host DOM.
+const SemanticReviewHostId = "semantic-review-host"
 
 ///|
 /// A model in this URI scheme is a Git HEAD snapshot, not a document the
@@ -67,13 +73,6 @@ priv struct ViewerHost {
   // Desired full-comparison layout survives a pre-mount command in the same
   // way font settings do for the source Viewer.
   mut diff_options : @viewer.DiffEditorOptions
-  // Desktop owns MoonBit-specific comparison policy. The provider stays
-  // outside the reusable editor so non-`.mbt` documents can force Core while
-  // retaining the user's last Token/Tree preference.
-  diff_provider : @moon_diff_provider.MoonDocumentDiffProvider
-  mut diff_mode : ReviewDiffMode
-  mut diff_ignore_comments : Bool
-  mut diff_ignore_tests : Bool
   // A positioned transcript link keeps its caret collapsed at the requested
   // column. This persistent whole-line decoration makes the destination visible
   // without turning the line into a selection and opening Comment UI. Symbol
@@ -139,10 +138,6 @@ let viewer_state : ViewerHost = {
     automatic_inline=false,
     diff_word_wrap=@viewer.Off,
   ),
-  diff_provider: @moon_diff_provider.MoonDocumentDiffProvider(),
-  diff_mode: ReviewDiffCore,
-  diff_ignore_comments: true,
-  diff_ignore_tests: true,
   point_range_highlight: None,
   search_match_highlights: None,
   services: None,
@@ -178,6 +173,7 @@ priv enum ActiveEditorSurface {
   CodeEditorSurface
   MarkdownEditorSurface
   DiffEditorSurface
+  SemanticEditorSurface
 }
 
 ///|
@@ -185,8 +181,11 @@ fn active_editor_surface_from_visibility(
   code_visible : Bool,
   markdown_visible : Bool,
   diff_visible : Bool,
+  semantic_visible : Bool,
 ) -> ActiveEditorSurface? {
-  if diff_visible {
+  if semantic_visible {
+    Some(SemanticEditorSurface)
+  } else if diff_visible {
     Some(DiffEditorSurface)
   } else if markdown_visible {
     Some(MarkdownEditorSurface)
@@ -212,6 +211,7 @@ fn active_editor_surface() -> ActiveEditorSurface? {
     editor_surface_host_visible(ViewerHostId),
     editor_surface_host_visible(MarkdownViewerHostId),
     editor_surface_host_visible(DiffEditorHostId),
+    editor_surface_host_visible(SemanticReviewHostId),
   )
 }
 
@@ -233,6 +233,7 @@ fn layout_active_editor_surface() -> Unit {
         Some(viewer) => viewer.layout()
         None => ()
       }
+    Some(SemanticEditorSurface) => layout_semantic_review_editors()
     None => ()
   }
 }
@@ -282,26 +283,6 @@ fn register_tokenizers() -> Unit {
 }
 
 ///|
-fn ReviewDiffMode::provider_mode(
-  self : ReviewDiffMode,
-) -> @moon_diff_provider.MoonDiffMode {
-  match self {
-    ReviewDiffCore => @moon_diff_provider.Core
-    ReviewDiffToken => @moon_diff_provider.Token
-    ReviewDiffTree => @moon_diff_provider.Tree
-  }
-}
-
-///|
-fn review_diff_mode(mode : @moon_diff_provider.MoonDiffMode) -> ReviewDiffMode {
-  match mode {
-    @moon_diff_provider.Core => ReviewDiffCore
-    @moon_diff_provider.Token => ReviewDiffToken
-    @moon_diff_provider.Tree => ReviewDiffTree
-  }
-}
-
-///|
 fn supports_moon_diff(path : String) -> Bool {
   path.to_lower().has_suffix(".mbt")
 }
@@ -318,51 +299,6 @@ fn markdown_resource_kind(name : String) -> @viewer.MarkdownResourceKind {
   } else {
     @viewer.OrdinaryMarkdown
   }
-}
-
-///|
-fn effective_diff_provider_mode(
-  mode : ReviewDiffMode,
-  supports_moonbit : Bool,
-) -> @moon_diff_provider.MoonDiffMode {
-  if supports_moonbit {
-    mode.provider_mode()
-  } else {
-    @moon_diff_provider.Core
-  }
-}
-
-///|
-fn configure_diff_provider(supports_moonbit : Bool) -> Unit {
-  let provider_mode = effective_diff_provider_mode(
-    viewer_state.diff_mode,
-    supports_moonbit,
-  )
-  viewer_state.diff_provider.set_ignore_comments(
-    viewer_state.diff_ignore_comments,
-  )
-  viewer_state.diff_provider.set_ignore_tests(viewer_state.diff_ignore_tests)
-  viewer_state.diff_provider.set_mode(provider_mode)
-}
-
-///|
-/// Apply desktop-owned provider preferences to the current comparison. The
-/// requested Moon mode is retained even when a non-`.mbt` model forces Core.
-fn apply_review_diff_provider(
-  mode : ReviewDiffMode,
-  ignore_comments : Bool,
-  ignore_tests : Bool,
-) -> @cmd.Cmd {
-  @cmd.custom_cmd(_scheduler => {
-    viewer_state.diff_mode = mode
-    viewer_state.diff_ignore_comments = ignore_comments
-    viewer_state.diff_ignore_tests = ignore_tests
-    let supports_moonbit = viewer_state.diff_editor
-      .bind(editor => editor.get_model())
-      .map(model => supports_moon_diff(model.modified.uri.path))
-      .unwrap_or(false)
-    configure_diff_provider(supports_moonbit)
-  })
 }
 
 ///|
@@ -504,7 +440,6 @@ fn request_viewer_mount(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
           diff_host,
           services=services.viewer_services,
           options=viewer_state.diff_options,
-          provider=viewer_state.diff_provider,
         )
         diff_editor.on_did_update_diff(() => {
           let navigation_available = if diff_editor.is_diff_up_to_date() {
@@ -520,18 +455,6 @@ fn request_viewer_mount(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
               ReviewDiffNavigationAvailabilityChanged(navigation_available),
             ),
           )
-          if diff_editor.is_diff_up_to_date() {
-            let status = viewer_state.diff_provider.get_status()
-            scheduler.add(
-              dispatch(
-                ReviewDiffStatusChanged({
-                  requested: review_diff_mode(status.requested),
-                  effective: review_diff_mode(status.effective),
-                  fell_back: status.fell_back,
-                }),
-              ),
-            )
-          }
         })
         |> ignore
         viewer_state.diff_editor = Some(diff_editor)
@@ -577,6 +500,7 @@ fn apply_review_diff_layout(layout : ReviewDiffLayout) -> @cmd.Cmd {
     if viewer_state.diff_editor is Some(diff_editor) {
       diff_editor.update_options(options)
     }
+    update_semantic_review_editor_layout(layout)
   })
 }
 
@@ -599,6 +523,7 @@ fn refresh_diff_pane_options() -> Unit {
   if viewer_state.diff_editor is Some(diff_editor) {
     diff_editor.update_options(options)
   }
+  refresh_semantic_review_editor_options()
 }
 
 ///|
@@ -809,7 +734,6 @@ fn show_diff_comparison(
     "diff-v" + model_version.to_string(),
     modified_content,
   )
-  configure_diff_provider(supports_moon_diff(name))
   let previous = diff_editor.set_model(
     Some(@viewer.DiffEditorModel(original_model, modified_model)),
   )
@@ -902,7 +826,6 @@ fn show_history_diff_in_viewer(
       "history-modified-v" + version.to_string(),
       modified_content,
     )
-    configure_diff_provider(supports_moon_diff(diff.path.0))
     let previous = diff_editor.set_model(
       Some(@viewer.DiffEditorModel(original_model, modified_model)),
     )
@@ -1414,6 +1337,7 @@ fn clear_viewer() -> @cmd.Cmd {
     viewer_state.relative = None
     viewer_state.navigation = None
     clear_diff_comparison()
+    clear_semantic_review_editors()
   })
 }
 

--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -351,6 +351,27 @@ fn request_viewer_mount(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
           guard event.feedback.kind is @agent_feedback_api.UserReview else {
             return
           }
+          if semantic_feedback_model_projection(event.feedback.resource)
+            is Some(projection) {
+            let range = project_semantic_feedback_range(
+              event.feedback.range,
+              projection.line_offset,
+            )
+            scheduler.add(
+              dispatch(
+                semantic_feedback_message(
+                  projection.file,
+                  projection.side,
+                  range,
+                  projection.model.get_value_in_range(event.feedback.range),
+                  event.feedback.text,
+                  ModelUri(event.feedback.resource.to_string()),
+                  event.feedback.id,
+                ),
+              ),
+            )
+            return
+          }
           guard viewer_state.relative is Some(file) else { return }
           // The modified pane and code source use the same live URI. Rich
           // Markdown detaches that source Viewer, so resolve the modified diff

--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -73,6 +73,7 @@ priv struct ViewerHost {
   diff_provider : @moon_diff_provider.MoonDocumentDiffProvider
   mut diff_mode : ReviewDiffMode
   mut diff_ignore_comments : Bool
+  mut diff_ignore_tests : Bool
   // A positioned transcript link keeps its caret collapsed at the requested
   // column. This persistent whole-line decoration makes the destination visible
   // without turning the line into a selection and opening Comment UI. Symbol
@@ -141,6 +142,7 @@ let viewer_state : ViewerHost = {
   diff_provider: @moon_diff_provider.MoonDocumentDiffProvider(),
   diff_mode: ReviewDiffCore,
   diff_ignore_comments: true,
+  diff_ignore_tests: true,
   point_range_highlight: None,
   search_match_highlights: None,
   services: None,
@@ -339,6 +341,7 @@ fn configure_diff_provider(supports_moonbit : Bool) -> Unit {
   viewer_state.diff_provider.set_ignore_comments(
     viewer_state.diff_ignore_comments,
   )
+  viewer_state.diff_provider.set_ignore_tests(viewer_state.diff_ignore_tests)
   viewer_state.diff_provider.set_mode(provider_mode)
 }
 
@@ -348,10 +351,12 @@ fn configure_diff_provider(supports_moonbit : Bool) -> Unit {
 fn apply_review_diff_provider(
   mode : ReviewDiffMode,
   ignore_comments : Bool,
+  ignore_tests : Bool,
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(_scheduler => {
     viewer_state.diff_mode = mode
     viewer_state.diff_ignore_comments = ignore_comments
+    viewer_state.diff_ignore_tests = ignore_tests
     let supports_moonbit = viewer_state.diff_editor
       .bind(editor => editor.get_model())
       .map(model => supports_moon_diff(model.modified.uri.path))

--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -1409,6 +1409,7 @@ fn apply_diagnostics(
         uri,
         DiagnosticsProjection(diagnostics).to_viewer(),
       )
+      refresh_semantic_modified_diagnostics(uri)
     }
   })
 }

--- a/desktop/frontend/fileeditor/git_history_wbtest.mbt
+++ b/desktop/frontend/fileeditor/git_history_wbtest.mbt
@@ -241,6 +241,12 @@ test "historical tabs use only the inert diff surface and history controls" {
     ),
   )
   inspect(
+    render_review_control(review_tests_control(test_emit(), state, ctx)),
+    content=(
+      #|<button aria-label="Ignore tests" aria-pressed="false" title="Available in Token and Tree diff" type="button" class="review-tests-control" disabled>Tests: ignored</button>
+    ),
+  )
+  inspect(
     render_review_control(review_diff_navigation(test_emit(), state, ctx)),
     content=(
       #|<div role="group" aria-label="Diff change navigation" class="review-diff-navigation">
@@ -278,37 +284,6 @@ test "historical tabs use only the inert diff surface and history controls" {
       #|</span>
       #|</button>
       #|</div>
-    ),
-  )
-
-  let text_diff = { ..diff, path: @pathx.Relative("README.md"), }
-  let text_history_docs : Map[String, HistoryDiffDoc] = Map([])
-  text_history_docs[history_diff_key(text_diff)] = {
-    diff: text_diff,
-    generation: 1,
-    original: HistoryBlobContent("old"),
-    modified: HistoryBlobContent("new"),
-  }
-  let text_state = {
-    ..state,
-    history_docs: text_history_docs,
-    review_diff_mode: ReviewDiffTree,
-    review_diff_status: Some({
-      requested: ReviewDiffTree,
-      effective: ReviewDiffToken,
-      fell_back: true,
-    }),
-  }
-  let text_ctx = {
-    ..ctx,
-    open_history_diffs: [text_diff],
-    active_history_diff: Some(text_diff),
-  }
-  inspect(
-    render_review_control(review_diff_status(text_state, text_ctx)),
-    content=(
-      #|<span role="status" aria-live="polite" class="review-diff-mode-status hidden">
-      #|</span>
     ),
   )
 }

--- a/desktop/frontend/fileeditor/lsp.mbt
+++ b/desktop/frontend/fileeditor/lsp.mbt
@@ -46,11 +46,16 @@ fn model_uri_path(uri : @common.Uri) -> @common.Uri? {
 
 ///|
 /// Desktop language features are revision-sensitive today: host operations
-/// read the live checkout named by an `openseek` URI. Restricting provider
-/// selection at the registry boundary keeps an original-revision diff model
-/// from showing actions that could only resolve against the working tree.
-fn live_moonbit_model_selector() -> @language.LanguageSelector {
-  LanguageFilter(LanguageFilter(language="moonbit", scheme=@resource.Scheme))
+/// read the live checkout named by an `openseek` URI. Token/Tree's Modified
+/// fragments opt in through their distinct scheme and an explicit coordinate
+/// projection; Original and historical schemes remain excluded.
+fn moon_ide_model_selector() -> @language.LanguageSelector {
+  LanguageSelectorList([
+    LanguageFilter(LanguageFilter(language="moonbit", scheme=@resource.Scheme)),
+    LanguageFilter(
+      LanguageFilter(language="moonbit", scheme=SemanticReviewModifiedScheme),
+    ),
+  ])
 }
 
 ///|
@@ -66,25 +71,23 @@ impl @language.HoverProvider for LspHoverProvider with fn provide_hover(
   // v1 covers MoonBit only; other languages have no tooling behind the op.
   guard model.language_id == "moonbit" else { return None }
   guard !token.is_cancellation_requested() else { return None }
-  // The provider is registry-global, so use the document route recorded when
-  // Desktop placed this exact model in the Viewer.
-  guard model_uri_path(model.uri) is Some(absolute) &&
-    viewer_state.absolute == Some(absolute) &&
-    viewer_state.navigation is Some(context) &&
-    viewer_state.relative is Some(path) else {
+  // The provider is registry-global, so resolve either the live full model or
+  // a currently mounted semantic Modified projection before addressing the
+  // host checkout.
+  guard moon_ide_model_projection(model) is Some(projection) else {
     return None
   }
   let reply = request_hover(
-    owner=context.owner,
-    root=context.root,
-    path~,
+    owner=projection.context.owner,
+    root=projection.context.root,
+    path=projection.path,
     // The viewer's Position is 1-based; the host op speaks 0-based LSP coords.
-    line=position.line_number - 1,
+    line=projection.source_line_number(position.line_number) - 1,
     character=position.column - 1,
   ) catch {
     _ => return None
   }
-  HoverProjection::{ reply, model, }.to_viewer()
+  HoverProjection::{ reply, model, line_offset: projection.line_offset, }.to_viewer()
 }
 
 ///|
@@ -92,7 +95,7 @@ impl @language.HoverProvider for LspHoverProvider with fn provide_hover(
 fn register_hover_provider() -> Unit {
   let provider = LspHoverProvider::{ }
   @languages.languages.register_hover_provider(
-    live_moonbit_model_selector(),
+    moon_ide_model_selector(),
     provider,
   )
   |> ignore
@@ -123,6 +126,7 @@ async fn request_hover(
 priv struct HoverProjection {
   reply : @protocol.LspHoverReply
   model : @model.TextModel
+  line_offset : Int
 }
 
 ///|
@@ -149,11 +153,11 @@ fn HoverProjection::range(self : HoverProjection) -> @common.Range {
   // The reply carries 0-based LSP positions; shift to the viewer's 1-based
   // line/column, then round-trip through offsets so the range stays clamped.
   let start = snapshot.get_offset_at(
-    self.reply.start_line + 1,
+    self.reply.start_line + 1 - self.line_offset,
     self.reply.start_character + 1,
   )
   let end = snapshot.get_offset_at(
-    self.reply.end_line + 1,
+    self.reply.end_line + 1 - self.line_offset,
     self.reply.end_character + 1,
   )
   snapshot.range_of(@common.OffsetRange::from_to(start, end))
@@ -308,7 +312,7 @@ test "foreign uris do not parse as model paths or channels" {
 }
 
 ///|
-test "live language selector excludes an original revision model" {
+test "IDE language selector includes semantic Modified but excludes revisions" {
   let live = @model.TextModel(
     @common.Uri::parse("openseek://local/work/main.mbt"),
     "main.mbt",
@@ -325,6 +329,56 @@ test "live language selector excludes an original revision model" {
     "head",
     "fn main {}",
   )
-  assert_true(live_moonbit_model_selector().score(live) > 0)
-  assert_eq(live_moonbit_model_selector().score(original), 0)
+  let semantic_modified = @model.TextModel(
+    @common.Uri::parse("\{SemanticReviewModifiedScheme}:/section-1.mbt"),
+    "main.mbt",
+    "moonbit",
+    1,
+    "semantic-new",
+    "fn main {}",
+  )
+  let semantic_original = @model.TextModel(
+    @common.Uri::parse("\{SemanticReviewOriginalScheme}:/section-1.mbt"),
+    "main.mbt",
+    "moonbit",
+    1,
+    "semantic-old",
+    "fn main {}",
+  )
+  defer live.dispose()
+  defer original.dispose()
+  defer semantic_modified.dispose()
+  defer semantic_original.dispose()
+  assert_true(moon_ide_model_selector().score(live) > 0)
+  assert_true(moon_ide_model_selector().score(semantic_modified) > 0)
+  assert_eq(moon_ide_model_selector().score(original), 0)
+  assert_eq(moon_ide_model_selector().score(semantic_original), 0)
+}
+
+///|
+test "semantic hover response range projects back to fragment coordinates" {
+  let model = @model.TextModel(
+    @common.Uri::parse("\{SemanticReviewModifiedScheme}:/section-2.mbt"),
+    "main.mbt",
+    "moonbit",
+    1,
+    "semantic-new",
+    "fn value() -> Int {\n  2\n}",
+  )
+  defer model.dispose()
+  let projected = HoverProjection::{
+    reply: {
+      value: "Int",
+      markdown: false,
+      has_range: true,
+      start_line: 30,
+      start_character: 2,
+      end_line: 30,
+      end_character: 3,
+    },
+    model,
+    line_offset: 29,
+  }.to_viewer()
+  guard projected is Some(hover) else { fail("expected projected hover") }
+  assert_eq(hover.range, @common.Range(2, 3, 2, 4))
 }

--- a/desktop/frontend/fileeditor/navigation.mbt
+++ b/desktop/frontend/fileeditor/navigation.mbt
@@ -70,6 +70,51 @@ fn navigation_context_for_file(
 }
 
 ///|
+/// One Viewer model projected back onto the live checkout document MoonIDE
+/// understands. Full-file models have a zero offset; Token/Tree Modified
+/// fragments carry the section's zero-based line displacement.
+priv struct MoonIdeModelProjection {
+  context : NavigationContext
+  path : @pathx.Relative
+  line_offset : Int
+}
+
+///|
+fn MoonIdeModelProjection::source_line_number(
+  self : MoonIdeModelProjection,
+  model_line_number : Int,
+) -> Int {
+  model_line_number + self.line_offset
+}
+
+///|
+/// Resolve IDE ownership without ever treating an Original or historical
+/// revision as the current checkout. The semantic branch additionally proves
+/// that the live resource still belongs to the active navigation context, so
+/// a stale fragment cannot address a replacement worktree.
+fn moon_ide_model_projection(
+  model : @model.TextModel,
+) -> MoonIdeModelProjection? {
+  guard viewer_state.navigation is Some(context) else { return None }
+  match model_uri_path(model.uri) {
+    Some(absolute) => {
+      guard viewer_state.absolute == Some(absolute) &&
+        context.relative_path(absolute) is Some(path) else {
+        return None
+      }
+      Some({ context, path, line_offset: 0, })
+    }
+    None => {
+      guard semantic_modified_model_projection(model) is Some(semantic) &&
+        context.relative_path(semantic.resource) == Some(semantic.path) else {
+        return None
+      }
+      Some({ context, path: semantic.path, line_offset: semantic.line_offset, })
+    }
+  }
+}
+
+///|
 /// One implementation serves both editor provider traits. The model URI names
 /// the absolute file and host; `NavigationContext` supplies its editor root.
 priv struct MoonIdeNavigationProvider {
@@ -89,25 +134,21 @@ impl @language.DefinitionProvider for MoonIdeNavigationProvider with fn provide_
   if token.is_cancellation_requested() || model.language_id != "moonbit" {
     return []
   }
-  guard viewer_state.navigation is Some(context) &&
-    model_uri_path(model.uri) is Some(absolute) &&
-    context.relative_path(absolute) is Some(path) else {
-    return []
-  }
+  guard moon_ide_model_projection(model) is Some(projection) else { return [] }
   let locations = request_moon_ide_locations(
-    context.owner.channel,
+    projection.context.owner.channel,
     @commands.moonide_definition,
     {
-      session: context.owner.session,
-      root: context.root.path,
-      path: path.0,
-      line: position.line_number,
+      session: projection.context.owner.session,
+      root: projection.context.root.path,
+      path: projection.path.0,
+      line: projection.source_line_number(position.line_number),
       column: position.column,
     },
   ) catch {
     error => {
       (self.on_error)(
-        context.owner,
+        projection.context.owner,
         "Go to definition failed: \{@interop.bridge_error_text(error)}",
       )
       return []
@@ -130,25 +171,21 @@ impl @language.ReferencesProvider for MoonIdeNavigationProvider with fn provide_
   if token.is_cancellation_requested() || model.language_id != "moonbit" {
     return []
   }
-  guard viewer_state.navigation is Some(context) &&
-    model_uri_path(model.uri) is Some(absolute) &&
-    context.relative_path(absolute) is Some(path) else {
-    return []
-  }
+  guard moon_ide_model_projection(model) is Some(projection) else { return [] }
   let locations = request_moon_ide_locations(
-    context.owner.channel,
+    projection.context.owner.channel,
     @commands.moonide_references,
     {
-      session: context.owner.session,
-      root: context.root.path,
-      path: path.0,
-      line: position.line_number,
+      session: projection.context.owner.session,
+      root: projection.context.root.path,
+      path: projection.path.0,
+      line: projection.source_line_number(position.line_number),
       column: position.column,
     },
   ) catch {
     error => {
       (self.on_error)(
-        context.owner,
+        projection.context.owner,
         "Find references failed: \{@interop.bridge_error_text(error)}",
       )
       return []
@@ -171,11 +208,11 @@ fn register_moon_ide_navigation_providers(
   let provider = MoonIdeNavigationProvider::{ on_error, }
   [
     @languages.languages.register_definition_provider(
-      live_moonbit_model_selector(),
+      moon_ide_model_selector(),
       provider,
     ),
     @languages.languages.register_references_provider(
-      live_moonbit_model_selector(),
+      moon_ide_model_selector(),
       provider,
     ),
   ]
@@ -343,6 +380,21 @@ test "navigation root follows resource and workspace-relative paths" {
     navigation_root_from_file(outside, Relative("lib/main.mbt")) is None,
   )
   assert_true(context.relative_path(outside) is None)
+}
+
+///|
+test "semantic navigation projects fragment-local lines onto the source" {
+  let context : NavigationContext = {
+    owner: { channel: @interop.ChannelId::Local, session: "test", },
+    root: @common.Uri::parse("openseek://local/work"),
+  }
+  let projection : MoonIdeModelProjection = {
+    context,
+    path: Relative("src/main.mbt"),
+    line_offset: 29,
+  }
+  assert_eq(projection.source_line_number(1), 30)
+  assert_eq(projection.source_line_number(3), 32)
 }
 
 ///|

--- a/desktop/frontend/fileeditor/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/pkg.generated.mbti
@@ -7,6 +7,7 @@ import {
   "moonbit-community/rabbita/sub",
   "moonbitlang/core/debug",
   "moonbitlang/editor/base/common",
+  "moonbitlang/editor/viewer/diff_provider/moondiff",
   "openseek_desktop/frontend/dock",
   "openseek_desktop/frontend/grep_search",
   "openseek_desktop/frontend/interop",
@@ -27,7 +28,7 @@ pub fn apply_theme(String) -> @cmd.Cmd
 
 pub fn basename(@pathx.Relative) -> String
 
-pub fn body_view(@cmd.Emit[Msg], State, Ctx) -> @html.Html
+pub fn body_view(@cmd.Emit[Msg], State, Ctx, semantic_review? : @html.Html) -> @html.Html
 
 pub fn breadcrumb_view(@cmd.Emit[Msg], State, Ctx) -> @html.Html
 
@@ -55,9 +56,15 @@ pub fn request_viewer_remeasure() -> @cmd.Cmd
 
 pub fn resize_handle_view() -> @html.Html
 
+pub fn semantic_review_input(State, Ctx) -> SemanticReviewInput?
+
+pub fn semantic_review_view(@cmd.Emit[Msg], State) -> @html.Html
+
 pub fn subscriptions(State, Ctx, @cmd.Emit[Msg]) -> @sub.Sub
 
 pub fn sync(@cmd.Emit[Msg], State, Ctx) -> (State, @cmd.Cmd)
+
+pub fn sync_semantic_review_editors(State) -> @cmd.Cmd
 
 pub fn update(@cmd.Emit[Msg], Msg, State, Ctx) -> (@cmd.Cmd, State)
 
@@ -247,7 +254,8 @@ pub(all) enum Msg {
   ToggleReviewDiffLayout
   ReviewDiffModeSelected(ReviewDiffMode)
   ToggleReviewDiffIgnoreComments
-  ReviewDiffStatusChanged(ReviewDiffStatus)
+  ToggleReviewDiffIgnoreTests
+  SemanticReviewSectionToggled(String)
   ReviewDiffNavigationAvailabilityChanged(Bool)
   RevealPreviousReviewDiffChange
   RevealNextReviewDiffChange
@@ -305,12 +313,6 @@ pub(all) enum ReviewDiffMode {
   ReviewDiffTree
 } derive(Eq, @debug.Debug)
 
-pub(all) struct ReviewDiffStatus {
-  requested : ReviewDiffMode
-  effective : ReviewDiffMode
-  fell_back : Bool
-} derive(Eq, @debug.Debug)
-
 pub(all) struct ReviewState {
   generation : Int
   working_generation : Int
@@ -328,6 +330,19 @@ pub(all) enum ReviewViewMode {
 pub fn ReviewViewMode::equal(Self, Self) -> Bool
 pub fn ReviewViewMode::not_equal(Self, Self) -> Bool
 
+pub(all) struct SemanticReviewInput {
+  old_name : String
+  new_name : String
+  old_source : String
+  new_source : String
+  mode : @moondiff.MoonDiffMode
+  ignore_comments : Bool
+  ignore_tests : Bool
+} derive(Eq, @debug.Debug)
+pub fn SemanticReviewInput::equal(Self, Self) -> Bool
+pub fn SemanticReviewInput::not_equal(Self, Self) -> Bool
+pub fn SemanticReviewInput::to_repr(Self) -> @debug.Repr
+
 pub(all) struct State {
   owner : @interop.ConversationKey?
   placement : ReconciledPlacement
@@ -338,7 +353,10 @@ pub(all) struct State {
   review_diff_layout : ReviewDiffLayout
   review_diff_mode : ReviewDiffMode
   review_diff_ignore_comments : Bool
-  review_diff_status : ReviewDiffStatus?
+  review_diff_ignore_tests : Bool
+  semantic_review_input : SemanticReviewInput?
+  semantic_review_plan : @moondiff.SectionedSemanticReviewPlan?
+  semantic_review_collapsed : Array[String]
   review_diff_navigation_available : Bool
   changes : ChangeList
   git_graph : GitGraphState

--- a/desktop/frontend/fileeditor/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/pkg.generated.mbti
@@ -275,6 +275,7 @@ pub(all) enum Msg {
   DiagnosticsPublished(channel~ : @interop.ChannelId, absolute~ : @common.Uri, diagnostics~ : Array[@protocol.LspDiagnostic])
   LanguageRequestFailed(owner~ : @interop.ConversationKey, message~ : String)
   EditorCommentAdded(resource~ : ModelUri, file~ : @pathx.Relative, range~ : @common.Range, quote~ : String, comment~ : String, feedback_id~ : String)
+  ApplyAllFeedback
   DiffCommentAdded(file~ : @pathx.Relative, original_line_number~ : Int?, modified_line_number~ : Int?, quote~ : String, comment~ : String, resource~ : ModelUri?, feedback_id~ : String?)
 }
 
@@ -338,10 +339,16 @@ pub(all) struct SemanticReviewInput {
   mode : @moondiff.MoonDiffMode
   ignore_comments : Bool
   ignore_tests : Bool
+  live_modified : SemanticReviewLiveDocument?
 } derive(Eq, @debug.Debug)
 pub fn SemanticReviewInput::equal(Self, Self) -> Bool
 pub fn SemanticReviewInput::not_equal(Self, Self) -> Bool
 pub fn SemanticReviewInput::to_repr(Self) -> @debug.Repr
+
+pub(all) struct SemanticReviewLiveDocument {
+  resource : @common.Uri
+  path : @pathx.Relative
+} derive(Eq, @debug.Debug)
 
 pub(all) struct State {
   owner : @interop.ConversationKey?

--- a/desktop/frontend/fileeditor/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/pkg.generated.mbti
@@ -56,15 +56,11 @@ pub fn request_viewer_remeasure() -> @cmd.Cmd
 
 pub fn resize_handle_view() -> @html.Html
 
-pub fn semantic_review_input(State, Ctx) -> SemanticReviewInput?
-
 pub fn semantic_review_view(@cmd.Emit[Msg], State) -> @html.Html
 
 pub fn subscriptions(State, Ctx, @cmd.Emit[Msg]) -> @sub.Sub
 
 pub fn sync(@cmd.Emit[Msg], State, Ctx) -> (State, @cmd.Cmd)
-
-pub fn sync_semantic_review_editors(State) -> @cmd.Cmd
 
 pub fn update(@cmd.Emit[Msg], Msg, State, Ctx) -> (@cmd.Cmd, State)
 

--- a/desktop/frontend/fileeditor/review_surfaces_wbtest.mbt
+++ b/desktop/frontend/fileeditor/review_surfaces_wbtest.mbt
@@ -244,7 +244,9 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
     ),
   )
 
-  let token_state = { ..diff_state, review_diff_mode: ReviewDiffToken, }
+  let token_state = { ..diff_state, review_diff_mode: ReviewDiffToken, }.sync_semantic_review(
+    ctx,
+  )
   let token = render_review_html(body_view(test_emit(), token_state, ctx))
   assert_true(
     token.contains(
@@ -273,12 +275,14 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
       ctx,
     ),
   )
-  assert_true(token_navigation.contains("review-diff-navigation hidden"))
-  assert_false(
+  assert_true(
     token_navigation.contains("aria-label=\"Diff change navigation\""),
   )
+  assert_false(token_navigation.contains("disabled"))
 
-  let tree_state = { ..diff_state, review_diff_mode: ReviewDiffTree, }
+  let tree_state = { ..diff_state, review_diff_mode: ReviewDiffTree, }.sync_semantic_review(
+    ctx,
+  )
   let tree = render_review_html(body_view(test_emit(), tree_state, ctx))
   assert_true(
     tree.contains(
@@ -307,10 +311,8 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
       ctx,
     ),
   )
-  assert_true(tree_navigation.contains("review-diff-navigation hidden"))
-  assert_false(
-    tree_navigation.contains("aria-label=\"Diff change navigation\""),
-  )
+  assert_true(tree_navigation.contains("aria-label=\"Diff change navigation\""))
+  assert_false(tree_navigation.contains("disabled"))
 
   inspect(
     render_review_control(

--- a/desktop/frontend/fileeditor/review_surfaces_wbtest.mbt
+++ b/desktop/frontend/fileeditor/review_surfaces_wbtest.mbt
@@ -67,6 +67,11 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
       "id=\"diff-editor-host\" class=\"viewer-host editor-shell moonbit-viewer-surface-hidden\"",
     ),
   )
+  assert_true(
+    source.contains(
+      "id=\"semantic-review-host\" class=\"viewer-host editor-shell semantic-review-host moonbit-viewer-surface-hidden\"",
+    ),
+  )
   inspect(
     render_review_control(review_mode_toolbar(test_emit(), source_state, ctx)),
     content=(
@@ -145,6 +150,11 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
   )
   assert_true(
     diff.contains("id=\"diff-editor-host\" class=\"viewer-host editor-shell\""),
+  )
+  assert_true(
+    diff.contains(
+      "id=\"semantic-review-host\" class=\"viewer-host editor-shell semantic-review-host moonbit-viewer-surface-hidden\"",
+    ),
   )
   inspect(
     render_review_control(review_mode_toolbar(test_emit(), diff_state, ctx)),
@@ -234,36 +244,72 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
     ),
   )
 
-  let fallback_state = {
-    ..diff_state,
-    review_diff_mode: ReviewDiffTree,
-    review_diff_status: Some({
-      requested: ReviewDiffTree,
-      effective: ReviewDiffToken,
-      fell_back: true,
-    }),
-  }
-  inspect(
-    render_review_control(review_diff_status(fallback_state, ctx)),
-    content=(
-      #|<span role="status" aria-live="polite" class="review-diff-mode-status">Tree unavailable — showing Token diff</span>
+  let token_state = { ..diff_state, review_diff_mode: ReviewDiffToken, }
+  let token = render_review_html(body_view(test_emit(), token_state, ctx))
+  assert_true(
+    token.contains(
+      "id=\"viewer-host\" class=\"viewer-host editor-shell moonbit-viewer-surface-hidden\"",
     ),
   )
-
-  let core_fallback_state = {
-    ..diff_state,
-    review_diff_mode: ReviewDiffToken,
-    review_diff_status: Some({
-      requested: ReviewDiffToken,
-      effective: ReviewDiffCore,
-      fell_back: true,
-    }),
-  }
-  inspect(
-    render_review_control(review_diff_status(core_fallback_state, ctx)),
-    content=(
-      #|<span role="status" aria-live="polite" class="review-diff-mode-status">Token unavailable — showing Line diff</span>
+  assert_true(
+    token.contains(
+      "id=\"markdown-viewer-host\" class=\"viewer-host editor-shell moonbit-viewer-surface-hidden\"",
     ),
+  )
+  assert_true(
+    token.contains(
+      "id=\"diff-editor-host\" class=\"viewer-host editor-shell moonbit-viewer-surface-hidden\"",
+    ),
+  )
+  assert_true(
+    token.contains(
+      "id=\"semantic-review-host\" class=\"viewer-host editor-shell semantic-review-host\"",
+    ),
+  )
+  let token_navigation = render_review_html(
+    review_diff_navigation(
+      test_emit(),
+      { ..token_state, review_diff_navigation_available: true, },
+      ctx,
+    ),
+  )
+  assert_true(token_navigation.contains("review-diff-navigation hidden"))
+  assert_false(
+    token_navigation.contains("aria-label=\"Diff change navigation\""),
+  )
+
+  let tree_state = { ..diff_state, review_diff_mode: ReviewDiffTree, }
+  let tree = render_review_html(body_view(test_emit(), tree_state, ctx))
+  assert_true(
+    tree.contains(
+      "id=\"viewer-host\" class=\"viewer-host editor-shell moonbit-viewer-surface-hidden\"",
+    ),
+  )
+  assert_true(
+    tree.contains(
+      "id=\"markdown-viewer-host\" class=\"viewer-host editor-shell moonbit-viewer-surface-hidden\"",
+    ),
+  )
+  assert_true(
+    tree.contains(
+      "id=\"diff-editor-host\" class=\"viewer-host editor-shell moonbit-viewer-surface-hidden\"",
+    ),
+  )
+  assert_true(
+    tree.contains(
+      "id=\"semantic-review-host\" class=\"viewer-host editor-shell semantic-review-host\"",
+    ),
+  )
+  let tree_navigation = render_review_html(
+    review_diff_navigation(
+      test_emit(),
+      { ..tree_state, review_diff_navigation_available: true, },
+      ctx,
+    ),
+  )
+  assert_true(tree_navigation.contains("review-diff-navigation hidden"))
+  assert_false(
+    tree_navigation.contains("aria-label=\"Diff change navigation\""),
   )
 
   inspect(
@@ -320,6 +366,11 @@ test "desktop explicitly routes Markdown source while DiffEditor stays code-only
       "id=\"diff-editor-host\" class=\"viewer-host editor-shell moonbit-viewer-surface-hidden\"",
     ),
   )
+  assert_true(
+    source.contains(
+      "id=\"semantic-review-host\" class=\"viewer-host editor-shell semantic-review-host moonbit-viewer-surface-hidden\"",
+    ),
+  )
 
   let selected = test_modified_change(path)
   let diff_docs = docs.copy()
@@ -349,10 +400,15 @@ test "desktop explicitly routes Markdown source while DiffEditor stays code-only
   assert_true(
     diff.contains("id=\"diff-editor-host\" class=\"viewer-host editor-shell\""),
   )
+  assert_true(
+    diff.contains(
+      "id=\"semantic-review-host\" class=\"viewer-host editor-shell semantic-review-host moonbit-viewer-surface-hidden\"",
+    ),
+  )
 }
 
 ///|
-test "non-MoonBit review keeps File and Line without specialized controls" {
+test "non-MoonBit review keeps File and Line on the Core surface" {
   let path = @pathx.Relative("README.md")
   let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path), }
   let selected = test_modified_change(path)
@@ -367,17 +423,26 @@ test "non-MoonBit review keeps File and Line without specialized controls" {
       selected,
     }),
   }
-  let state = {
-    ..owned_state(),
-    docs,
-    review_diff_mode: ReviewDiffTree,
-    // Reproduce switching away after a Moon provider reported a fallback.
-    review_diff_status: Some({
-      requested: ReviewDiffTree,
-      effective: ReviewDiffToken,
-      fell_back: true,
-    }),
-  }
+  let state = { ..owned_state(), docs, review_diff_mode: ReviewDiffTree, }
+  let body = render_review_html(body_view(test_emit(), state, ctx))
+  assert_true(
+    body.contains(
+      "id=\"viewer-host\" class=\"viewer-host editor-shell moonbit-viewer-surface-hidden\"",
+    ),
+  )
+  assert_true(
+    body.contains(
+      "id=\"markdown-viewer-host\" class=\"viewer-host editor-shell moonbit-viewer-surface-hidden\"",
+    ),
+  )
+  assert_true(
+    body.contains("id=\"diff-editor-host\" class=\"viewer-host editor-shell\""),
+  )
+  assert_true(
+    body.contains(
+      "id=\"semantic-review-host\" class=\"viewer-host editor-shell semantic-review-host moonbit-viewer-surface-hidden\"",
+    ),
+  )
   inspect(
     render_review_control(review_mode_toolbar(test_emit(), state, ctx)),
     content=(
@@ -409,13 +474,6 @@ test "non-MoonBit review keeps File and Line without specialized controls" {
     render_review_control(review_tests_control(test_emit(), state, ctx)),
     content=(
       #|<span class="review-tests-control hidden">
-      #|</span>
-    ),
-  )
-  inspect(
-    render_review_control(review_diff_status(state, ctx)),
-    content=(
-      #|<span role="status" aria-live="polite" class="review-diff-mode-status hidden">
       #|</span>
     ),
   )
@@ -467,6 +525,11 @@ test "pending full diff never reveals the source surface" {
       "id=\"diff-editor-host\" class=\"viewer-host editor-shell\"",
     ),
   )
+  assert_true(
+    pending.contains(
+      "id=\"semantic-review-host\" class=\"viewer-host editor-shell semantic-review-host moonbit-viewer-surface-hidden\"",
+    ),
+  )
   assert_false(pending.contains("Loading diff for main.mbt…"))
   assert_true(pending.contains("viewer-notice diff-transition-shield"))
   let pending_breadcrumb = render_review_html(
@@ -507,6 +570,11 @@ test "pending full diff never reveals the source surface" {
   assert_true(
     unavailable.contains(
       "id=\"diff-editor-host\" class=\"viewer-host editor-shell moonbit-viewer-surface-hidden\"",
+    ),
+  )
+  assert_true(
+    unavailable.contains(
+      "id=\"semantic-review-host\" class=\"viewer-host editor-shell semantic-review-host moonbit-viewer-surface-hidden\"",
     ),
   )
 }

--- a/desktop/frontend/fileeditor/review_surfaces_wbtest.mbt
+++ b/desktop/frontend/fileeditor/review_surfaces_wbtest.mbt
@@ -100,6 +100,12 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
     ),
   )
   inspect(
+    render_review_control(review_tests_control(test_emit(), source_state, ctx)),
+    content=(
+      #|<button aria-label="Ignore tests" aria-pressed="false" title="Available in diff view" type="button" class="review-tests-control" disabled>Tests: ignored</button>
+    ),
+  )
+  inspect(
     render_review_control(
       review_diff_navigation(test_emit(), source_state, ctx),
     ),
@@ -168,6 +174,40 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
     render_review_control(review_comments_control(test_emit(), diff_state, ctx)),
     content=(
       #|<button aria-label="Ignore comments" aria-pressed="false" title="Available in Token and Tree diff" type="button" class="review-comments-control" disabled>Comments: ignored</button>
+    ),
+  )
+  inspect(
+    render_review_control(review_tests_control(test_emit(), diff_state, ctx)),
+    content=(
+      #|<button aria-label="Ignore tests" aria-pressed="false" title="Available in Token and Tree diff" type="button" class="review-tests-control" disabled>Tests: ignored</button>
+    ),
+  )
+  inspect(
+    render_review_control(
+      review_tests_control(
+        test_emit(),
+        { ..diff_state, review_diff_mode: ReviewDiffToken, },
+        ctx,
+      ),
+    ),
+    content=(
+      #|<button aria-label="Ignore tests" aria-pressed="true" title="Include tests in the comparison" type="button" class="review-tests-control active">Tests: ignored</button>
+    ),
+  )
+  inspect(
+    render_review_control(
+      review_tests_control(
+        test_emit(),
+        {
+          ..diff_state,
+          review_diff_mode: ReviewDiffTree,
+          review_diff_ignore_tests: false,
+        },
+        ctx,
+      ),
+    ),
+    content=(
+      #|<button aria-label="Ignore tests" aria-pressed="false" title="Ignore MoonBit test blocks" type="button" class="review-tests-control">Tests: included</button>
     ),
   )
   inspect(
@@ -362,6 +402,13 @@ test "non-MoonBit review keeps File and Line without specialized controls" {
     render_review_control(review_comments_control(test_emit(), state, ctx)),
     content=(
       #|<span class="review-comments-control hidden">
+      #|</span>
+    ),
+  )
+  inspect(
+    render_review_control(review_tests_control(test_emit(), state, ctx)),
+    content=(
+      #|<span class="review-tests-control hidden">
       #|</span>
     ),
   )

--- a/desktop/frontend/fileeditor/semantic_review_view.mbt
+++ b/desktop/frontend/fileeditor/semantic_review_view.mbt
@@ -1,4 +1,7 @@
 ///|
+using @cmd {trait Scheduler}
+
+///|
 /// The working-tree document behind Token/Tree's synthetic Modified models.
 /// Historical comparisons and a deleted working file deliberately carry no
 /// live document because current-checkout IDE requests would be misleading.
@@ -19,6 +22,10 @@ pub(all) struct SemanticReviewInput {
   mode : @moon_diff_provider.MoonDiffMode
   ignore_comments : Bool
   ignore_tests : Bool
+  /// The working-tree file comments should name. History has no active review
+  /// target; a deleted working file still does, even though it has no live
+  /// Modified document for language requests.
+  feedback_file : @pathx.Relative?
   live_modified : SemanticReviewLiveDocument?
 } derive(Eq, Debug)
 
@@ -41,7 +48,7 @@ fn semantic_review_input(state : State, ctx : Ctx) -> SemanticReviewInput? {
   guard state.review_diff_mode.semantic_mode() is Some(mode) else {
     return None
   }
-  let (old_name, new_name, old_source, new_source, live_modified) = match
+  let (old_name, new_name, old_source, new_source, feedback_file, live_modified) = match
     ctx.active_history_diff {
     Some(diff) => {
       guard supports_moon_diff(diff.path.0) &&
@@ -55,6 +62,7 @@ fn semantic_review_input(state : State, ctx : Ctx) -> SemanticReviewInput? {
         diff.path.0,
         old_source,
         new_source,
+        None,
         None,
       )
     }
@@ -74,7 +82,7 @@ fn semantic_review_input(state : State, ctx : Ctx) -> SemanticReviewInput? {
         | TabReadFailed(_)
         | TabUnavailable(_) => None
       }
-      (doc.name, doc.name, old_source, new_source, live_modified)
+      (doc.name, doc.name, old_source, new_source, Some(path), live_modified)
     }
   }
   Some({
@@ -85,6 +93,7 @@ fn semantic_review_input(state : State, ctx : Ctx) -> SemanticReviewInput? {
     mode,
     ignore_comments: state.review_diff_ignore_comments,
     ignore_tests: state.review_diff_ignore_tests,
+    feedback_file,
     live_modified,
   })
 }
@@ -449,15 +458,106 @@ priv struct SemanticReviewEditorHost {
   section : @moon_diff_provider.SemanticReviewSection
   old_name : String
   new_name : String
+  feedback_file : @pathx.Relative?
   live_modified : SemanticReviewLiveDocument?
   host : @dom.Element
   editor : @viewer.DiffEditor
   provider : @moon_diff_provider.MoonFragmentDiffProvider?
   subscription : @common.Disposable
+  focus_subscription : @common.Disposable
 }
 
 ///|
 let semantic_review_editors : Map[String, SemanticReviewEditorHost] = Map([])
+
+///|
+let semantic_review_order : Array[String] = []
+
+///|
+let semantic_review_active_key : Ref[String?] = Ref(None)
+
+///|
+priv enum SemanticReviewNavigationDirection {
+  SemanticReviewPrevious
+  SemanticReviewNext
+}
+
+///|
+priv suberror SemanticReviewNavigationSubscription {
+  SemanticReviewNavigationSubscription(@cmd.Emit[Msg])
+}
+
+///|
+fn semantic_review_navigation_sub_loader(
+  payload : Error,
+  scheduler : &Scheduler,
+) -> @sub.RunningSub? {
+  match payload {
+    SemanticReviewNavigationSubscription(dispatch) => {
+      let mut dispatch = dispatch
+      let target = @dom.document().as_event_target()
+      let listener : @dom.Listener = event => {
+        guard event.to_keyboard_event() is Some(keyboard) &&
+          keyboard.key() == "F7" &&
+          @dom.document().get_element_by_id(SemanticReviewHostId).to_option()
+          is Some(host) &&
+          @base_browser.event_target_has_matching_ancestor(
+            event, host, ".semantic-diff-editor-host",
+          ) else {
+          return
+        }
+        // Capture runs before the child DiffEditor performs its own cyclic F7
+        // command, so exactly one aggregate MultiDiff navigation is emitted.
+        event.prevent_default()
+        event.stop_propagation()
+        scheduler.add(
+          dispatch(
+            if keyboard.shift_key() {
+              RevealPreviousReviewDiffChange
+            } else {
+              RevealNextReviewDiffChange
+            },
+          ),
+        )
+      }
+      target.add_event_listener_with_options("keydown", listener, capture=true)
+      Some({
+        unload: _ => {
+          target.remove_event_listener_with_options(
+            "keydown",
+            listener,
+            capture=true,
+          )
+        },
+        update_tagger: payload => {
+          guard payload is SemanticReviewNavigationSubscription(next) else {
+            return
+          }
+          dispatch = next
+        },
+      })
+    }
+    _ => None
+  }
+}
+
+///|
+fn semantic_review_navigation_subscription(
+  state : State,
+  ctx : Ctx,
+  dispatch : @cmd.Emit[Msg],
+) -> @sub.Sub {
+  guard review_diff_navigation_enabled(state, ctx) &&
+    !core_diff_ready(state, ctx) else {
+    return @sub.none
+  }
+  @sub.custom_sub(
+    "fileeditor-semantic-review-navigation",
+    @sub.Local,
+    SemanticReviewNavigationSubscription(dispatch),
+    semantic_review_navigation_sub_loader,
+  )
+}
 
 ///|
 fn update_semantic_review_scroll_width() -> Unit {
@@ -544,6 +644,158 @@ fn semantic_model_uri(side : SemanticReviewSide, key : String) -> @common.Uri? {
 }
 
 ///|
+/// Map one section-local side back into its physical source line domain.
+/// Whole-file fallback keeps full-file coordinates; top-level sections carry
+/// their own old/new ranges, and an absent side remains absent.
+fn semantic_feedback_line_offset(
+  section : @moon_diff_provider.SemanticReviewSection,
+  side : SemanticReviewSide,
+) -> Int? {
+  if section.kind is @moon_diff_provider.SemanticReviewSectionKind::Whole {
+    return Some(0)
+  }
+  let range = match side {
+    SemanticReviewOriginal => section.old_range
+    SemanticReviewModified => section.new_range
+  }
+  match range {
+    Some(range) if range.start_line_number > 0 =>
+      Some(range.start_line_number - 1)
+    _ => None
+  }
+}
+
+///|
+/// Historical sections and physically absent/empty sides must not advertise
+/// the selection-driven feedback UI.
+fn semantic_feedback_side_enabled(
+  feedback_file : @pathx.Relative?,
+  section : @moon_diff_provider.SemanticReviewSection,
+  side : SemanticReviewSide,
+) -> Bool {
+  guard feedback_file is Some(_) &&
+    semantic_feedback_line_offset(section, side) is Some(_) else {
+    return false
+  }
+  match side {
+    SemanticReviewOriginal => !section.original_source.is_empty()
+    SemanticReviewModified => !section.modified_source.is_empty()
+  }
+}
+
+///|
+fn project_semantic_feedback_range(
+  range : @common.Range,
+  line_offset : Int,
+) -> @common.Range {
+  @common.Range(
+    range.start_line_number + line_offset,
+    range.start_column,
+    range.end_line_number + line_offset,
+    range.end_column,
+  )
+}
+
+///|
+/// Preserve the existing full-diff comment contract: Modified feedback owns
+/// an exact working-tree range, while Original feedback retains revision-side
+/// identity without pretending that range exists in the working document.
+fn semantic_feedback_message(
+  file : @pathx.Relative,
+  side : SemanticReviewSide,
+  range : @common.Range,
+  quote : String,
+  comment : String,
+  resource : ModelUri,
+  feedback_id : String,
+) -> Msg {
+  match side {
+    SemanticReviewModified =>
+      EditorCommentAdded(
+        resource~,
+        file~,
+        range~,
+        quote~,
+        comment~,
+        feedback_id~,
+      )
+    SemanticReviewOriginal =>
+      diff_comment_message(
+        file,
+        original_line_number=Some(range.start_line_number),
+        modified_line_number=None,
+        quote~,
+        comment~,
+        resource~,
+        feedback_id~,
+      )
+  }
+}
+
+///|
+priv struct SemanticFeedbackModelProjection {
+  model : @model.TextModel
+  file : @pathx.Relative
+  side : SemanticReviewSide
+  line_offset : Int
+}
+
+///|
+/// Resolve only mounted working-tree semantic models. History and an absent
+/// one-sided model stay non-commentable even though their DiffEditor kernels
+/// still exist for rendering.
+fn semantic_feedback_model_projection(
+  resource : @common.Uri,
+) -> SemanticFeedbackModelProjection? {
+  for _, entry in semantic_review_editors {
+    guard entry.feedback_file is Some(file) &&
+      entry.editor.get_model() is Some(pair) else {
+      continue
+    }
+    for side in [SemanticReviewOriginal, SemanticReviewModified] {
+      guard semantic_feedback_side_enabled(Some(file), entry.section, side) &&
+        semantic_feedback_line_offset(entry.section, side) is Some(line_offset) else {
+        continue
+      }
+      let model = match side {
+        SemanticReviewOriginal => pair.original
+        SemanticReviewModified => pair.modified
+      }
+      if model.uri.to_string() == resource.to_string() {
+        return Some({ model, file, side, line_offset, })
+      }
+    }
+  }
+  None
+}
+
+///|
+fn sync_semantic_feedback(
+  services : DesktopViewerServices,
+  feedback_file : @pathx.Relative?,
+  section : @moon_diff_provider.SemanticReviewSection,
+  original : @model.TextModel,
+  modified : @model.TextModel,
+) -> Unit {
+  services.feedback.set_feedback_enabled(
+    original.uri,
+    semantic_feedback_side_enabled(
+      feedback_file,
+      section,
+      SemanticReviewOriginal,
+    ),
+  )
+  services.feedback.set_feedback_enabled(
+    modified.uri,
+    semantic_feedback_side_enabled(
+      feedback_file,
+      section,
+      SemanticReviewModified,
+    ),
+  )
+}
+
+///|
 /// The semantic model's line numbers are local to one MoonDiff section. Keep
 /// the projection explicit instead of making a fragment impersonate the full
 /// working file: the host IDE receives the real path and global line number,
@@ -558,12 +810,7 @@ priv struct SemanticModifiedModelProjection {
 fn @moon_diff_provider.SemanticReviewSection::modified_line_offset(
   self : @moon_diff_provider.SemanticReviewSection,
 ) -> Int? {
-  match (self.kind, self.new_range) {
-    (@moon_diff_provider.SemanticReviewSectionKind::Whole, _) => Some(0)
-    (_, Some(range)) if range.start_line_number > 0 =>
-      Some(range.start_line_number - 1)
-    _ => None
-  }
+  semantic_feedback_line_offset(self, SemanticReviewModified)
 }
 
 ///|
@@ -720,6 +967,7 @@ fn schedule_semantic_review_editor_resize(key : String) -> Unit {
 ///|
 fn dispose_semantic_review_editor(entry : SemanticReviewEditorHost) -> Unit {
   entry.subscription.dispose()
+  entry.focus_subscription.dispose()
   match entry.editor.set_model(None) {
     Some(previous) => {
       if viewer_state.services is Some(services) {
@@ -727,6 +975,10 @@ fn dispose_semantic_review_editor(entry : SemanticReviewEditorHost) -> Unit {
           DiagnosticsOwner,
           previous.modified.uri,
         )
+        services.feedback.set_feedback_enabled(previous.original.uri, false)
+        services.feedback.set_feedback_enabled(previous.modified.uri, false)
+        services.feedback.clear_feedback(previous.original.uri)
+        services.feedback.clear_feedback(previous.modified.uri)
       }
       dispose_diff_comparison_models(previous)
     }
@@ -805,7 +1057,21 @@ fn create_semantic_review_editor(
   let subscription = editor.on_did_update_diff(() => {
     schedule_semantic_review_editor_resize(key)
   })
+  let focus_listener : @dom.Listener = _ => {
+    semantic_review_active_key.val = Some(key)
+  }
+  host.add_event_listener("focusin", focus_listener)
+  let focus_subscription = @common.Disposable::from(() => {
+    host.remove_event_listener("focusin", focus_listener)
+  })
   editor.set_model(Some(@viewer.DiffEditorModel(original, modified))) |> ignore
+  sync_semantic_feedback(
+    services,
+    input.feedback_file,
+    section,
+    original,
+    modified,
+  )
   sync_semantic_modified_diagnostics(
     services,
     input.live_modified,
@@ -820,11 +1086,13 @@ fn create_semantic_review_editor(
     section,
     old_name: input.old_name,
     new_name: input.new_name,
+    feedback_file: input.feedback_file,
     live_modified: input.live_modified,
     host,
     editor,
     provider,
     subscription,
+    focus_subscription,
   })
 }
 
@@ -880,7 +1148,94 @@ fn clear_semantic_review_editors() -> Unit {
       semantic_review_editors.remove(key)
     }
   }
+  semantic_review_order.clear()
+  semantic_review_active_key.val = None
   update_semantic_review_scroll_width()
+}
+
+///|
+fn semantic_review_navigation_index(current : String?) -> Int {
+  guard current is Some(current) else { return 0 }
+  let index = semantic_review_order.search(current)
+  index.unwrap_or(0)
+}
+
+///|
+/// Move within the focused DiffEditor first, then cycle across Token/Tree
+/// items exactly like VS Code's MultiDiffEditor navigation action.
+fn navigate_semantic_review_change(
+  dispatch : @cmd.Emit[Msg],
+  collapsed : Array[String],
+  direction : SemanticReviewNavigationDirection,
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(scheduler => {
+    guard !semantic_review_order.is_empty() else { return }
+    let index = semantic_review_navigation_index(semantic_review_active_key.val)
+    let current = semantic_review_order[index]
+    if !collapsed.contains(current) &&
+      semantic_review_editors.get(current) is Some(entry) {
+      let revealed = match direction {
+        SemanticReviewPrevious =>
+          entry.editor.reveal_previous_change_without_wrap()
+        SemanticReviewNext => entry.editor.reveal_next_change_without_wrap()
+      }
+      if revealed {
+        semantic_review_active_key.val = Some(current)
+        entry.host.scroll_into_view_with_options(
+          block="nearest",
+          inline="nearest",
+        )
+        entry.editor.focus()
+        return
+      }
+    }
+    let target_index = match direction {
+      SemanticReviewPrevious =>
+        if index == 0 {
+          semantic_review_order.length() - 1
+        } else {
+          index - 1
+        }
+      SemanticReviewNext => (index + 1) % semantic_review_order.length()
+    }
+    scheduler.add(
+      dispatch(
+        RevealSemanticReviewSectionChange(
+          semantic_review_order[target_index],
+          direction is SemanticReviewPrevious,
+        ),
+      ),
+    )
+  })
+}
+
+///|
+/// Complete a cross-item navigation after Rabbita has expanded and committed
+/// the destination section.
+fn reveal_semantic_review_section_change(
+  key : String,
+  reveal_last : Bool,
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(
+    _scheduler => {
+      guard semantic_review_editors.get(key) is Some(entry) &&
+        @base_browser.element_is_connected(entry.host) else {
+        return
+      }
+      semantic_review_active_key.val = Some(key)
+      entry.host.scroll_into_view_with_options(
+        block="nearest",
+        inline="nearest",
+      )
+      if reveal_last {
+        entry.editor.reveal_last_diff()
+      } else {
+        entry.editor.reveal_first_diff()
+      }
+      entry.editor.focus()
+    },
+    kind=@cmd.after_render,
+  )
 }
 
 ///|
@@ -895,6 +1250,12 @@ fn sync_semantic_review_editors(state : State) -> @cmd.Cmd {
       }
       let desired = semantic_sections(state.semantic_review_plan)
       let desired_keys = desired.map(section => section.key)
+      semantic_review_order.clear()
+      semantic_review_order.append(desired_keys)
+      if semantic_review_active_key.val is Some(key) &&
+        !desired_keys.contains(key) {
+        semantic_review_active_key.val = None
+      }
       let stale = semantic_review_editors
         .to_array()
         .map(pair => pair.0)
@@ -923,6 +1284,7 @@ fn sync_semantic_review_editors(state : State) -> @cmd.Cmd {
             previous.section == section &&
             previous.old_name == input.old_name &&
             previous.new_name == input.new_name &&
+            previous.feedback_file == input.feedback_file &&
             previous.live_modified == input.live_modified &&
             previous.host.is_same_node(host.as_node())
           })

--- a/desktop/frontend/fileeditor/semantic_review_view.mbt
+++ b/desktop/frontend/fileeditor/semantic_review_view.mbt
@@ -1,4 +1,13 @@
 ///|
+/// The working-tree document behind Token/Tree's synthetic Modified models.
+/// Historical comparisons and a deleted working file deliberately carry no
+/// live document because current-checkout IDE requests would be misleading.
+pub(all) struct SemanticReviewLiveDocument {
+  resource : @common.Uri
+  path : @pathx.Relative
+} derive(Eq, Debug)
+
+///|
 /// The smallest input that can change a Token/Tree section plan. Layout is
 /// deliberately absent: switching split/inline updates existing DiffEditors
 /// and never reruns MoonDiff.
@@ -10,6 +19,7 @@ pub(all) struct SemanticReviewInput {
   mode : @moon_diff_provider.MoonDiffMode
   ignore_comments : Bool
   ignore_tests : Bool
+  live_modified : SemanticReviewLiveDocument?
 } derive(Eq, Debug)
 
 ///|
@@ -31,7 +41,7 @@ pub fn semantic_review_input(state : State, ctx : Ctx) -> SemanticReviewInput? {
   guard state.review_diff_mode.semantic_mode() is Some(mode) else {
     return None
   }
-  let (old_name, new_name, old_source, new_source) = match
+  let (old_name, new_name, old_source, new_source, live_modified) = match
     ctx.active_history_diff {
     Some(diff) => {
       guard supports_moon_diff(diff.path.0) &&
@@ -45,6 +55,7 @@ pub fn semantic_review_input(state : State, ctx : Ctx) -> SemanticReviewInput? {
         diff.path.0,
         old_source,
         new_source,
+        None,
       )
     }
     None => {
@@ -54,7 +65,16 @@ pub fn semantic_review_input(state : State, ctx : Ctx) -> SemanticReviewInput? {
         doc.visible_diff() is Some((old_source, new_source)) else {
         return None
       }
-      (doc.name, doc.name, old_source, new_source)
+      let live_modified = match doc.state {
+        TabLoaded(absolute~, ..) => Some({ resource: absolute, path, })
+        TabDeleted
+        | TabLoading
+        | TabBinary
+        | TabOversized
+        | TabReadFailed(_)
+        | TabUnavailable(_) => None
+      }
+      (doc.name, doc.name, old_source, new_source, live_modified)
     }
   }
   Some({
@@ -65,6 +85,7 @@ pub fn semantic_review_input(state : State, ctx : Ctx) -> SemanticReviewInput? {
     mode,
     ignore_comments: state.review_diff_ignore_comments,
     ignore_tests: state.review_diff_ignore_tests,
+    live_modified,
   })
 }
 
@@ -151,6 +172,21 @@ fn semantic_editor_host_id(key : String) -> String {
 
 ///|
 const SemanticReviewScrollWidthId = "semantic-review-scroll-width"
+
+///|
+/// Semantic fragments use side-specific schemes so the language registry can
+/// expose current-checkout IDE actions on Modified without advertising them on
+/// an Original revision that the host cannot answer for.
+const SemanticReviewOriginalScheme = "openseek-semantic-diff-original"
+
+///|
+const SemanticReviewModifiedScheme = "openseek-semantic-diff-modified"
+
+///|
+priv enum SemanticReviewSide {
+  SemanticReviewOriginal
+  SemanticReviewModified
+}
 
 ///|
 fn semantic_fallback_notice(
@@ -413,6 +449,7 @@ priv struct SemanticReviewEditorHost {
   section : @moon_diff_provider.SemanticReviewSection
   old_name : String
   new_name : String
+  live_modified : SemanticReviewLiveDocument?
   host : @dom.Element
   editor : @viewer.DiffEditor
   provider : @moon_diff_provider.MoonFragmentDiffProvider?
@@ -493,14 +530,146 @@ fn semantic_diff_options(
 }
 
 ///|
-fn semantic_model_uri(side : String, key : String) -> @common.Uri? {
+fn semantic_model_uri(side : SemanticReviewSide, key : String) -> @common.Uri? {
   let uri = @common.Uri::from(
-    scheme="openseek-semantic-diff",
-    path="/\{side}/\{key}.mbt",
+    scheme=match side {
+      SemanticReviewOriginal => SemanticReviewOriginalScheme
+      SemanticReviewModified => SemanticReviewModifiedScheme
+    },
+    path="/\{key}.mbt",
   ) catch {
     _ => return None
   }
   Some(uri)
+}
+
+///|
+/// The semantic model's line numbers are local to one MoonDiff section. Keep
+/// the projection explicit instead of making a fragment impersonate the full
+/// working file: the host IDE receives the real path and global line number,
+/// while the editor continues rendering the section-local diff document.
+priv struct SemanticModifiedModelProjection {
+  resource : @common.Uri
+  path : @pathx.Relative
+  line_offset : Int
+}
+
+///|
+fn @moon_diff_provider.SemanticReviewSection::modified_line_offset(
+  self : @moon_diff_provider.SemanticReviewSection,
+) -> Int? {
+  match (self.kind, self.new_range) {
+    (@moon_diff_provider.SemanticReviewSectionKind::Whole, _) => Some(0)
+    (_, Some(range)) if range.start_line_number > 0 =>
+      Some(range.start_line_number - 1)
+    _ => None
+  }
+}
+
+///|
+/// Resolve only the Modified model of a currently mounted working-tree
+/// section. Original and historical models intentionally return `None`.
+fn semantic_modified_model_projection(
+  model : @model.TextModel,
+) -> SemanticModifiedModelProjection? {
+  for _, entry in semantic_review_editors {
+    match
+      (
+        entry.live_modified,
+        entry.section.modified_line_offset(),
+        entry.editor.get_model(),
+      ) {
+      (Some(live), Some(line_offset), Some(pair)) if pair.modified.same(model) =>
+        return Some({ resource: live.resource, path: live.path, line_offset, })
+      _ => ()
+    }
+  }
+  None
+}
+
+///|
+/// Project full-file diagnostics into one section-local Modified model. A
+/// diagnostic outside the section is absent; one crossing a section boundary
+/// is clipped to the visible model before `TextModel::validate_range` clamps
+/// UTF-16 columns against the actual fragment text.
+fn project_semantic_modified_diagnostics(
+  diagnostics : ArrayView[@language.Diagnostic],
+  model : @model.TextModel,
+  line_offset : Int,
+) -> Array[@language.Diagnostic] {
+  let projected : Array[@language.Diagnostic] = []
+  let line_count = model.get_line_count()
+  for diagnostic in diagnostics {
+    let local_start = diagnostic.range.start_line_number - line_offset
+    let local_end = diagnostic.range.end_line_number - line_offset
+    if local_end < 1 || local_start > line_count {
+      continue
+    }
+    let start_line = local_start.max(1)
+    let end_line = local_end.min(line_count)
+    let range = model.validate_range(
+      @common.Range(
+        start_line,
+        if local_start < 1 {
+          1
+        } else {
+          diagnostic.range.start_column
+        },
+        end_line,
+        if local_end > line_count {
+          model.get_line_max_column(end_line)
+        } else {
+          diagnostic.range.end_column
+        },
+      ),
+    )
+    projected.push({ ..diagnostic, range, })
+  }
+  projected
+}
+
+///|
+/// Seed or refresh the synthetic Modified resource from the diagnostics
+/// already owned by the live working model. The shared marker service then
+/// drives the ordinary diff-pane marker contribution without teaching the
+/// reusable Viewer about OpenSeek's fragment projection.
+fn sync_semantic_modified_diagnostics(
+  services : DesktopViewerServices,
+  live_modified : SemanticReviewLiveDocument?,
+  section : @moon_diff_provider.SemanticReviewSection,
+  model : @model.TextModel,
+) -> Unit {
+  guard live_modified is Some(live) &&
+    section.modified_line_offset() is Some(line_offset) else {
+    services.markers.remove_owner_resource(DiagnosticsOwner, model.uri)
+    return
+  }
+  let diagnostics = services.markers.diagnostics_for_resource(live.resource)
+  services.markers.set_diagnostics(
+    DiagnosticsOwner,
+    model.uri,
+    project_semantic_modified_diagnostics(diagnostics, model, line_offset),
+  )
+}
+
+///|
+/// Refresh every mounted section backed by `resource` after the live LSP
+/// diagnostic batch changes.
+fn refresh_semantic_modified_diagnostics(resource : @common.Uri) -> Unit {
+  guard viewer_state.services is Some(services) else { return }
+  for _, entry in semantic_review_editors {
+    guard entry.live_modified is Some(live) &&
+      live.resource == resource &&
+      entry.editor.get_model() is Some(pair) else {
+      continue
+    }
+    sync_semantic_modified_diagnostics(
+      services,
+      entry.live_modified,
+      entry.section,
+      pair.modified,
+    )
+  }
 }
 
 ///|
@@ -552,7 +721,15 @@ fn schedule_semantic_review_editor_resize(key : String) -> Unit {
 fn dispose_semantic_review_editor(entry : SemanticReviewEditorHost) -> Unit {
   entry.subscription.dispose()
   match entry.editor.set_model(None) {
-    Some(previous) => dispose_diff_comparison_models(previous)
+    Some(previous) => {
+      if viewer_state.services is Some(services) {
+        services.markers.remove_owner_resource(
+          DiagnosticsOwner,
+          previous.modified.uri,
+        )
+      }
+      dispose_diff_comparison_models(previous)
+    }
     None => ()
   }
   entry.editor.dispose()
@@ -571,8 +748,11 @@ fn create_semantic_review_editor(
   layout : ReviewDiffLayout,
   host : @dom.Element,
 ) -> SemanticReviewEditorHost? {
-  guard semantic_model_uri("old", section.key) is Some(original_uri) &&
-    semantic_model_uri("new", section.key) is Some(modified_uri) else {
+  guard semantic_model_uri(SemanticReviewOriginal, section.key)
+    is Some(original_uri) &&
+    semantic_model_uri(SemanticReviewModified, section.key)
+    is Some(modified_uri) &&
+    viewer_state.services is Some(services) else {
     return None
   }
   viewer_state.version = viewer_state.version + 1
@@ -601,7 +781,11 @@ fn create_semantic_review_editor(
   let (editor, provider) = match section.diff {
     @moon_diff_provider.SemanticReviewDiff::Core =>
       (
-        @viewer.DiffEditor::create(host, options=semantic_diff_options(layout)),
+        @viewer.DiffEditor::create(
+          host,
+          services=services.viewer_services,
+          options=semantic_diff_options(layout),
+        ),
         None,
       )
     @moon_diff_provider.SemanticReviewDiff::Fragment(document) => {
@@ -609,6 +793,7 @@ fn create_semantic_review_editor(
       (
         @viewer.DiffEditor::create(
           host,
+          services=services.viewer_services,
           options=semantic_diff_options(layout),
           provider=provider.as_document_diff_provider(),
         ),
@@ -621,6 +806,12 @@ fn create_semantic_review_editor(
     schedule_semantic_review_editor_resize(key)
   })
   editor.set_model(Some(@viewer.DiffEditorModel(original, modified))) |> ignore
+  sync_semantic_modified_diagnostics(
+    services,
+    input.live_modified,
+    section,
+    modified,
+  )
   // Each VS Code multi-diff item opens on its own first change. Without this,
   // a comment-only section can initially show only the unchanged declaration
   // body below the changed documentation comment.
@@ -629,6 +820,7 @@ fn create_semantic_review_editor(
     section,
     old_name: input.old_name,
     new_name: input.new_name,
+    live_modified: input.live_modified,
     host,
     editor,
     provider,
@@ -731,6 +923,7 @@ pub fn sync_semantic_review_editors(state : State) -> @cmd.Cmd {
             previous.section == section &&
             previous.old_name == input.old_name &&
             previous.new_name == input.new_name &&
+            previous.live_modified == input.live_modified &&
             previous.host.is_same_node(host.as_node())
           })
           .unwrap_or(false)

--- a/desktop/frontend/fileeditor/semantic_review_view.mbt
+++ b/desktop/frontend/fileeditor/semantic_review_view.mbt
@@ -37,7 +37,7 @@ fn ReviewDiffMode::semantic_mode(
 /// Extract the visible semantic comparison from either a working-tree review
 /// or Git history. Core, source mode, non-MoonBit files, and unavailable text
 /// deliberately produce no input.
-pub fn semantic_review_input(state : State, ctx : Ctx) -> SemanticReviewInput? {
+fn semantic_review_input(state : State, ctx : Ctx) -> SemanticReviewInput? {
   guard state.review_diff_mode.semantic_mode() is Some(mode) else {
     return None
   }
@@ -886,7 +886,7 @@ fn clear_semantic_review_editors() -> Unit {
 ///|
 /// Reconcile section widgets after Rabbita has committed their keyed hosts.
 /// Unchanged sections retain their editor models, selection, and scroll state.
-pub fn sync_semantic_review_editors(state : State) -> @cmd.Cmd {
+fn sync_semantic_review_editors(state : State) -> @cmd.Cmd {
   @cmd.custom_cmd(
     _scheduler => {
       guard state.semantic_review_input is Some(input) else {

--- a/desktop/frontend/fileeditor/semantic_review_view.mbt
+++ b/desktop/frontend/fileeditor/semantic_review_view.mbt
@@ -463,7 +463,8 @@ priv struct SemanticReviewEditorHost {
   host : @dom.Element
   editor : @viewer.DiffEditor
   provider : @moon_diff_provider.MoonFragmentDiffProvider?
-  subscription : @common.Disposable
+  diff_subscription : @common.Disposable
+  content_height_subscription : @common.Disposable
   focus_subscription : @common.Disposable
 }
 
@@ -619,13 +620,13 @@ fn semantic_diff_options(
     diff_word_wrap=@viewer.Off,
     overview_ruler=false,
     render_indicators=true,
-    render_markdown_comments=false,
+    render_markdown_comments=true,
     handle_mouse_wheel=false,
-    // Semantic diff items must expose comment changes as source rows. Rich
-    // documentation replaces and hides those rows, which makes a comment-only
-    // MoonDiff section look unchanged even though its fragment is correct.
-    // The outer MultiDiff scroll plane owns wheel input, matching VS Code's
-    // per-item `handleMouseWheel: false` configuration.
+    // Token/Tree use the same rich, initially folded Markdown-comment
+    // presentation as ordinary code reading and Core diff. MoonDiff has already
+    // decided which sections exist, so presentation must not fall back to raw
+    // `///` rows. The outer MultiDiff scroll plane owns wheel input, matching
+    // VS Code's per-item `handleMouseWheel: false` configuration.
   )
 }
 
@@ -934,30 +935,35 @@ fn semantic_estimated_height(
 }
 
 ///|
-fn resize_semantic_review_editor(key : String) -> Unit {
-  guard semantic_review_editors.get(key) is Some(entry) &&
-    @base_browser.element_is_connected(entry.host) else {
+/// Commit one final DiffEditor height to its MultiDiff item. The content-height
+/// event can arrive while `create_semantic_review_editor` is still constructing
+/// the map entry, so this helper deliberately captures the concrete host and
+/// editor instead of looking them up by key.
+fn apply_semantic_review_editor_height(
+  host : @dom.Element,
+  editor : @viewer.DiffEditor,
+  content_height : Double,
+) -> Unit {
+  if !@base_browser.element_is_connected(host) {
     return
   }
-  let content_height = entry.editor.get_content_height()
   if content_height <= 0.0 {
     return
   }
   let height = (content_height.ceil() + 2.0).max(40.0)
   let css_height = "\{height}px"
-  if @base_browser.element_style_value(entry.host, "height") != css_height {
-    @base_browser.set_style_property(entry.host, "height", css_height)
-    entry.editor.layout()
+  if @base_browser.element_style_value(host, "height") != css_height {
+    @base_browser.set_style_property(host, "height", css_height)
+    editor.layout()
   }
-  update_semantic_review_scroll_width()
 }
 
 ///|
-fn schedule_semantic_review_editor_resize(key : String) -> Unit {
+fn schedule_semantic_review_scroll_width_update() -> Unit {
   @dom.window().request_animation_frame(_ => {
-    resize_semantic_review_editor(key)
+    update_semantic_review_scroll_width()
     @dom.window().request_animation_frame(_ => {
-      resize_semantic_review_editor(key)
+      update_semantic_review_scroll_width()
     })
     |> ignore
   })
@@ -966,7 +972,8 @@ fn schedule_semantic_review_editor_resize(key : String) -> Unit {
 
 ///|
 fn dispose_semantic_review_editor(entry : SemanticReviewEditorHost) -> Unit {
-  entry.subscription.dispose()
+  entry.diff_subscription.dispose()
+  entry.content_height_subscription.dispose()
   entry.focus_subscription.dispose()
   match entry.editor.set_model(None) {
     Some(previous) => {
@@ -1054,8 +1061,19 @@ fn create_semantic_review_editor(
     }
   }
   let key = section.key
-  let subscription = editor.on_did_update_diff(() => {
-    schedule_semantic_review_editor_resize(key)
+  // Diff readiness still owns the post-render horizontal overflow refresh.
+  // Vertical Markdown/ViewZone changes use the paired content-height event
+  // below and do not wait for these compatibility layout frames.
+  let diff_subscription = editor.on_did_update_diff(() => {
+    schedule_semantic_review_scroll_width_update()
+  })
+  // DiffEditor publishes only after the comment ViewZone and both panes'
+  // derived alignment zones have committed. Resize synchronously in that same
+  // geometry batch; a delayed retry would only hide a missing notification and
+  // leave this MultiDiff item displaying a stale intermediate height.
+  let content_height_subscription = editor.on_did_change_content_height(content_height => {
+    apply_semantic_review_editor_height(host, editor, content_height)
+    update_semantic_review_scroll_width()
   })
   let focus_listener : @dom.Listener = _ => {
     semantic_review_active_key.val = Some(key)
@@ -1091,7 +1109,8 @@ fn create_semantic_review_editor(
     host,
     editor,
     provider,
-    subscription,
+    diff_subscription,
+    content_height_subscription,
     focus_subscription,
   })
 }
@@ -1108,35 +1127,35 @@ fn semantic_sections(
 
 ///|
 fn layout_semantic_review_editors() -> Unit {
-  for key, entry in semantic_review_editors {
+  for _, entry in semantic_review_editors {
     entry.editor.layout()
-    schedule_semantic_review_editor_resize(key)
   }
   update_semantic_review_scroll_width()
+  schedule_semantic_review_scroll_width_update()
 }
 
 ///|
 fn update_semantic_review_editor_layout(layout : ReviewDiffLayout) -> Unit {
-  for key, entry in semantic_review_editors {
+  for _, entry in semantic_review_editors {
     entry.editor.update_options(semantic_diff_options(layout))
     entry.editor.layout()
-    schedule_semantic_review_editor_resize(key)
   }
   update_semantic_review_scroll_width()
+  schedule_semantic_review_scroll_width_update()
 }
 
 ///|
 fn refresh_semantic_review_editor_options() -> Unit {
-  for key, entry in semantic_review_editors {
+  for _, entry in semantic_review_editors {
     let layout = match entry.editor.get_layout() {
       @viewer.SideBySide => ReviewSideBySide
       @viewer.Inline => ReviewInline
     }
     entry.editor.update_options(semantic_diff_options(layout))
     entry.editor.layout()
-    schedule_semantic_review_editor_resize(key)
   }
   update_semantic_review_scroll_width()
+  schedule_semantic_review_scroll_width_update()
 }
 
 ///|
@@ -1295,7 +1314,6 @@ fn sync_semantic_review_editors(state : State) -> @cmd.Cmd {
             semantic_diff_options(state.review_diff_layout),
           )
           entry.editor.layout()
-          schedule_semantic_review_editor_resize(key)
           continue
         }
         if semantic_review_editors.get(key) is Some(previous) {
@@ -1310,10 +1328,10 @@ fn sync_semantic_review_editors(state : State) -> @cmd.Cmd {
           )
           is Some(entry) {
           semantic_review_editors[key] = entry
-          schedule_semantic_review_editor_resize(key)
         }
       }
       update_semantic_review_scroll_width()
+      schedule_semantic_review_scroll_width_update()
     },
     kind=@cmd.after_render,
   )

--- a/desktop/frontend/fileeditor/semantic_review_view.mbt
+++ b/desktop/frontend/fileeditor/semantic_review_view.mbt
@@ -1,0 +1,771 @@
+///|
+/// The smallest input that can change a Token/Tree section plan. Layout is
+/// deliberately absent: switching split/inline updates existing DiffEditors
+/// and never reruns MoonDiff.
+pub(all) struct SemanticReviewInput {
+  old_name : String
+  new_name : String
+  old_source : String
+  new_source : String
+  mode : @moon_diff_provider.MoonDiffMode
+  ignore_comments : Bool
+  ignore_tests : Bool
+} derive(Eq, Debug)
+
+///|
+fn ReviewDiffMode::semantic_mode(
+  self : ReviewDiffMode,
+) -> @moon_diff_provider.MoonDiffMode? {
+  match self {
+    ReviewDiffCore => None
+    ReviewDiffToken => Some(@moon_diff_provider.Token)
+    ReviewDiffTree => Some(@moon_diff_provider.Tree)
+  }
+}
+
+///|
+/// Extract the visible semantic comparison from either a working-tree review
+/// or Git history. Core, source mode, non-MoonBit files, and unavailable text
+/// deliberately produce no input.
+pub fn semantic_review_input(state : State, ctx : Ctx) -> SemanticReviewInput? {
+  guard state.review_diff_mode.semantic_mode() is Some(mode) else {
+    return None
+  }
+  let (old_name, new_name, old_source, new_source) = match
+    ctx.active_history_diff {
+    Some(diff) => {
+      guard supports_moon_diff(diff.path.0) &&
+        state.history_docs.get(history_diff_key(diff)) is Some(history) &&
+        history.original.text() is Some(old_source) &&
+        history.modified.text() is Some(new_source) else {
+        return None
+      }
+      (
+        diff.original_path.unwrap_or(diff.path).0,
+        diff.path.0,
+        old_source,
+        new_source,
+      )
+    }
+    None => {
+      guard ctx.active_file is Some(path) &&
+        supports_moon_diff(path.0) &&
+        state.docs.get(path) is Some(doc) &&
+        doc.visible_diff() is Some((old_source, new_source)) else {
+        return None
+      }
+      (doc.name, doc.name, old_source, new_source)
+    }
+  }
+  Some({
+    old_name,
+    new_name,
+    old_source,
+    new_source,
+    mode,
+    ignore_comments: state.review_diff_ignore_comments,
+    ignore_tests: state.review_diff_ignore_tests,
+  })
+}
+
+///|
+/// Cache the expensive MoonDiff computation in panel state. The renderer and
+/// imperative editor lifecycle consume the same immutable section plan.
+fn State::sync_semantic_review(self : State, ctx : Ctx) -> State {
+  let input = semantic_review_input(self, ctx)
+  if input == self.semantic_review_input {
+    return self
+  }
+  let plan = input.bind(input => {
+    @moon_diff_provider.compute_sectioned_semantic_review_plan(
+      input.old_source,
+      input.new_source,
+      input.mode,
+      old_name=input.old_name,
+      new_name=input.new_name,
+      ignore_comments=input.ignore_comments,
+      ignore_tests=input.ignore_tests,
+    )
+  })
+  {
+    ..self,
+    semantic_review_input: input,
+    semantic_review_plan: plan,
+    semantic_review_collapsed: [],
+  }
+}
+
+///|
+fn semantic_range_label(
+  range : @moon_diff_provider.SemanticReviewSourceRange,
+) -> String {
+  if range.line_count <= 1 {
+    "L\{range.start_line_number}"
+  } else {
+    "L\{range.start_line_number}-\{range.start_line_number + range.line_count - 1}"
+  }
+}
+
+///|
+fn semantic_section_label(
+  section : @moon_diff_provider.SemanticReviewSection,
+) -> String {
+  match (section.new_context, section.old_context, section.identity) {
+    (Some(context), _, _) | (None, Some(context), _) => context
+    (None, None, Some(identity)) => "Top-level #\{identity + 1}"
+    (None, None, None) => "Whole file"
+  }
+}
+
+///|
+fn semantic_section_location(
+  section : @moon_diff_provider.SemanticReviewSection,
+) -> String {
+  match (section.old_range, section.new_range) {
+    (Some(old), Some(new)) =>
+      "\{semantic_range_label(old)} → \{semantic_range_label(new)}"
+    (Some(old), None) => semantic_range_label(old)
+    (None, Some(new)) => semantic_range_label(new)
+    (None, None) => ""
+  }
+}
+
+///|
+fn semantic_section_status(
+  kind : @moon_diff_provider.SemanticReviewSectionKind,
+) -> @html.Html {
+  match kind {
+    @moon_diff_provider.SemanticReviewSectionKind::Inserted =>
+      @html.span(class="semantic-entry-status added", "A")
+    @moon_diff_provider.SemanticReviewSectionKind::Deleted =>
+      @html.span(class="semantic-entry-status deleted", "D")
+    @moon_diff_provider.SemanticReviewSectionKind::Whole
+    | @moon_diff_provider.SemanticReviewSectionKind::Matched => @html.nothing
+  }
+}
+
+///|
+fn semantic_editor_host_id(key : String) -> String {
+  "semantic-diff-editor-\{key}"
+}
+
+///|
+const SemanticReviewScrollWidthId = "semantic-review-scroll-width"
+
+///|
+fn semantic_fallback_notice(
+  section : @moon_diff_provider.SemanticReviewSection,
+  requested : @moon_diff_provider.MoonDiffMode,
+) -> @html.Html {
+  if section.fallbacks.is_empty() {
+    return @html.nothing
+  }
+  let whole = section.kind
+    is @moon_diff_provider.SemanticReviewSectionKind::Whole
+  let tree = requested is @moon_diff_provider.Tree
+  @html.div(
+    class=if whole {
+      "diff-notice fallback"
+    } else {
+      "diff-notice partial-fallback"
+    },
+    [
+      @html.strong(
+        if whole && tree {
+          "Lexical fallback"
+        } else if whole {
+          "Sectioning fallback"
+        } else if tree {
+          "Section lexical fallback"
+        } else {
+          "Section diff fallback"
+        },
+      ),
+      @html.span(section.fallbacks.join("; ")),
+    ],
+  )
+}
+
+///|
+/// Rabbita owns only section chrome and this stable empty host. Source lines,
+/// intraline spans, gutters, and alignment zones are all rendered by the real
+/// DiffEditor mounted after paint.
+fn semantic_section_view(
+  dispatch : @cmd.Emit[Msg],
+  section : @moon_diff_provider.SemanticReviewSection,
+  requested : @moon_diff_provider.MoonDiffMode,
+  collapsed : Bool,
+) -> @html.Html {
+  let label = semantic_section_label(section)
+  let location = semantic_section_location(section)
+  let content : Array[@html.Html] = [
+    semantic_fallback_notice(section, requested),
+    @html.div(
+      class="semantic-entry-editor-parent",
+      @html.div(
+        attrs=@html.Attrs::build()
+          .id(semantic_editor_host_id(section.key))
+          .class("semantic-diff-editor-host")
+          .data_set("semantic-section", section.key),
+        ([] : Array[@html.Html]),
+      ),
+    ),
+  ]
+  @html.section(
+    class=if collapsed {
+      "semantic-diff-entry collapsed"
+    } else {
+      "semantic-diff-entry"
+    },
+    attrs=@html.Attrs::build().data_set("semantic-entry", section.key),
+    [
+      @html.header(
+        class="semantic-entry-header",
+        @html.button(
+          type_="button",
+          class="semantic-entry-header-content",
+          title=if location.is_empty() {
+            label
+          } else {
+            "\{label} · \{location}"
+          },
+          on_click=dispatch(SemanticReviewSectionToggled(section.key)),
+          attrs=@html.Attrs::build()
+            .aria_expanded((!collapsed).to_string())
+            .aria_label(
+              if collapsed {
+                "Expand \{label}"
+              } else {
+                "Collapse \{label}"
+              },
+            ),
+          [
+            @html.span(
+              class=if collapsed {
+                "codicon codicon-chevron-right semantic-entry-chevron"
+              } else {
+                "codicon codicon-chevron-down semantic-entry-chevron"
+              },
+              "",
+            ),
+            @html.span(class="semantic-entry-file-icon", ""),
+            @html.span(class="semantic-entry-path", [
+              @html.span(class="semantic-entry-label", label),
+              @html.span(class="semantic-entry-location", location),
+            ]),
+            semantic_section_status(section.kind),
+          ],
+        ),
+      ),
+      @html.div(class="semantic-entry-content", content),
+    ],
+  )
+}
+
+///|
+fn semantic_empty_view(message : String) -> @html.Html {
+  @html.div(class="semantic-empty", [@html.p(message)])
+}
+
+///|
+fn semantic_status_empty_view(
+  plan : @moon_diff_provider.SectionedSemanticReviewPlan,
+  input : SemanticReviewInput,
+) -> @html.Html? {
+  match plan.status {
+    @moon_diff_provider.SemanticReviewStatus::IgnoredOnly => {
+      let subject = if input.ignore_comments && input.ignore_tests {
+        "comments, blank lines, or test blocks"
+      } else if input.ignore_tests {
+        "test blocks"
+      } else {
+        "comments or blank lines"
+      }
+      Some(
+        semantic_empty_view(
+          "No changes besides ignored \{subject} were found. Turn off the relevant Ignore filter to view them.",
+        ),
+      )
+    }
+    @moon_diff_provider.SemanticReviewStatus::Identical =>
+      Some(
+        semantic_empty_view(
+          if input.mode is @moon_diff_provider.Tree {
+            "No structural changes found. Switch to Token or Core to inspect text."
+          } else {
+            "No token changes found."
+          },
+        ),
+      )
+    @moon_diff_provider.SemanticReviewStatus::NoStructuralChanges =>
+      Some(
+        semantic_empty_view(
+          if input.mode is @moon_diff_provider.Tree {
+            "No structural changes found. Switch to Token to view text changes."
+          } else {
+            "No declaration-owned token changes found. Switch to Core to inspect the complete file."
+          },
+        ),
+      )
+    @moon_diff_provider.SemanticReviewStatus::Changed
+    | @moon_diff_provider.SemanticReviewStatus::Reordered => None
+  }
+}
+
+///|
+fn semantic_plan_view(
+  dispatch : @cmd.Emit[Msg],
+  plan : @moon_diff_provider.SectionedSemanticReviewPlan,
+  input : SemanticReviewInput,
+  collapsed : Array[String],
+) -> @html.Html {
+  if semantic_status_empty_view(plan, input) is Some(empty) {
+    return empty
+  }
+  let sections : Map[String, @html.Html] = Map([])
+  if plan.reordered {
+    sections["reordered"] = @html.div(
+      class="semantic-reorder",
+      "Top-level declarations are reordered; each declaration keeps its own DiffEditor.",
+    )
+  }
+  for section in plan.main_sections {
+    sections["main:\{section.key}"] = semantic_section_view(
+      dispatch,
+      section,
+      plan.requested,
+      collapsed.contains(section.key),
+    )
+  }
+  // Deleted identities cannot participate in the new-side order. Like VS
+  // Code's multi-diff items, keep them in the same flat item list and use a D
+  // status rather than introducing a second visual document hierarchy.
+  for section in plan.deleted_sections {
+    sections["deleted:\{section.key}"] = semantic_section_view(
+      dispatch,
+      section,
+      plan.requested,
+      collapsed.contains(section.key),
+    )
+  }
+  if sections.is_empty() {
+    semantic_empty_view(
+      "No semantic section changes found. Switch to Core to inspect the complete file.",
+    )
+  } else {
+    @html.div(class="semantic-document", sections)
+  }
+}
+
+///|
+/// Render section metadata and stable DiffEditor mount points. Source text is
+/// intentionally absent from this HTML tree.
+pub fn semantic_review_view(
+  dispatch : @cmd.Emit[Msg],
+  state : State,
+) -> @html.Html {
+  guard state.semantic_review_input is Some(input) else { return @html.nothing }
+  guard state.semantic_review_plan is Some(plan) else {
+    return @html.div(class="semantic-review", [
+      semantic_empty_view(
+        "The semantic result was invalid. Switch to Core to inspect the complete file.",
+      ),
+    ])
+  }
+  @html.div(
+    class="semantic-review",
+    attrs=@html.Attrs::build()
+      .data_set(
+        "mode",
+        if input.mode is @moon_diff_provider.Token {
+          "token"
+        } else {
+          "tree"
+        },
+      )
+      .data_set(
+        "layout",
+        if state.review_diff_layout is ReviewSideBySide {
+          "split"
+        } else {
+          "unified"
+        },
+      ),
+    [
+      semantic_plan_view(dispatch, plan, input, state.semantic_review_collapsed),
+      // VS Code's MultiDiffEditor owns one horizontal scroll extent. The
+      // imperative lifecycle sizes this otherwise invisible element from the
+      // widest local DiffEditor and mirrors the outer scrollLeft into all
+      // entries.
+      @html.div(
+        attrs=@html.Attrs::build()
+          .id(SemanticReviewScrollWidthId)
+          .class("semantic-review-scroll-width")
+          .aria_hidden("true"),
+        ([] : Array[@html.Html]),
+      ),
+    ],
+  )
+}
+
+///|
+priv struct SemanticReviewEditorHost {
+  section : @moon_diff_provider.SemanticReviewSection
+  old_name : String
+  new_name : String
+  host : @dom.Element
+  editor : @viewer.DiffEditor
+  provider : @moon_diff_provider.MoonFragmentDiffProvider?
+  subscription : @common.Disposable
+}
+
+///|
+let semantic_review_editors : Map[String, SemanticReviewEditorHost] = Map([])
+
+///|
+fn update_semantic_review_scroll_width() -> Unit {
+  guard @dom.document().get_element_by_id(SemanticReviewHostId).to_option()
+    is Some(host) &&
+    @dom.document().get_element_by_id(SemanticReviewScrollWidthId).to_option()
+    is Some(spacer) else {
+    return
+  }
+  let mut max_scroll = 0.0
+  for _, entry in semantic_review_editors {
+    if @base_browser.element_is_connected(entry.host) {
+      max_scroll = max_scroll.max(entry.editor.get_max_scroll_left())
+    }
+  }
+  @base_browser.set_style_property(
+    spacer,
+    "width",
+    "\{(host.get_client_width() + max_scroll).ceil()}px",
+  )
+  sync_semantic_review_scroll_left(host.get_scroll_left())
+}
+
+///|
+/// Project the single outer MultiDiffEditor scrollbar into every item. This
+/// mirrors VS Code's `VirtualizedViewItem.setScrollLeft` without exposing each
+/// DiffEditor's own horizontal scrollbar.
+fn sync_semantic_review_scroll_left(scroll_left : Double) -> Unit {
+  // A native overflow element supplies the one visible scrollbar, but VS
+  // Code's SmoothScrollableElement does not translate the MultiDiff item DOM.
+  // Counter the browser's native translation, then project the offset into
+  // every DiffEditor so headers stay put and code moves exactly once.
+  if @dom.document().get_element_by_id(SemanticReviewHostId).to_option()
+    is Some(host) &&
+    host.query_selector(".semantic-document") is Some(document) {
+    @base_browser.set_style_property(
+      document,
+      "transform",
+      "translateX(\{scroll_left}px)",
+    )
+  }
+  for _, entry in semantic_review_editors {
+    entry.editor.set_scroll_left(scroll_left)
+  }
+}
+
+///|
+fn semantic_diff_options(
+  layout : ReviewDiffLayout,
+) -> @viewer.DiffEditorOptions {
+  @viewer.DiffEditorOptions(
+    editor_options=current_diff_pane_options(),
+    layout=match layout {
+      ReviewSideBySide => @viewer.SideBySide
+      ReviewInline => @viewer.Inline
+    },
+    automatic_inline=false,
+    sash_enabled=true,
+    diff_word_wrap=@viewer.Off,
+    overview_ruler=false,
+    render_indicators=true,
+    render_markdown_comments=false,
+    handle_mouse_wheel=false,
+    // Semantic diff items must expose comment changes as source rows. Rich
+    // documentation replaces and hides those rows, which makes a comment-only
+    // MoonDiff section look unchanged even though its fragment is correct.
+    // The outer MultiDiff scroll plane owns wheel input, matching VS Code's
+    // per-item `handleMouseWheel: false` configuration.
+  )
+}
+
+///|
+fn semantic_model_uri(side : String, key : String) -> @common.Uri? {
+  let uri = @common.Uri::from(
+    scheme="openseek-semantic-diff",
+    path="/\{side}/\{key}.mbt",
+  ) catch {
+    _ => return None
+  }
+  Some(uri)
+}
+
+///|
+fn semantic_estimated_height(
+  section : @moon_diff_provider.SemanticReviewSection,
+  layout : ReviewDiffLayout,
+) -> Double {
+  let old_lines = section.original_source.split("\n").length()
+  let new_lines = section.modified_source.split("\n").length()
+  let lines = match layout {
+    ReviewSideBySide => old_lines.max(new_lines)
+    ReviewInline => old_lines + new_lines
+  }
+  (lines.max(1).to_double() * 20.0 + 8.0).max(40.0)
+}
+
+///|
+fn resize_semantic_review_editor(key : String) -> Unit {
+  guard semantic_review_editors.get(key) is Some(entry) &&
+    @base_browser.element_is_connected(entry.host) else {
+    return
+  }
+  let content_height = entry.editor.get_content_height()
+  if content_height <= 0.0 {
+    return
+  }
+  let height = (content_height.ceil() + 2.0).max(40.0)
+  let css_height = "\{height}px"
+  if @base_browser.element_style_value(entry.host, "height") != css_height {
+    @base_browser.set_style_property(entry.host, "height", css_height)
+    entry.editor.layout()
+  }
+  update_semantic_review_scroll_width()
+}
+
+///|
+fn schedule_semantic_review_editor_resize(key : String) -> Unit {
+  @dom.window().request_animation_frame(_ => {
+    resize_semantic_review_editor(key)
+    @dom.window().request_animation_frame(_ => {
+      resize_semantic_review_editor(key)
+    })
+    |> ignore
+  })
+  |> ignore
+}
+
+///|
+fn dispose_semantic_review_editor(entry : SemanticReviewEditorHost) -> Unit {
+  entry.subscription.dispose()
+  match entry.editor.set_model(None) {
+    Some(previous) => dispose_diff_comparison_models(previous)
+    None => ()
+  }
+  entry.editor.dispose()
+  // Keep the concrete fragment provider alive until after DiffEditor has
+  // disposed its ViewModel and provider subscription.
+  match entry.provider {
+    Some(_) => ()
+    None => ()
+  }
+}
+
+///|
+fn create_semantic_review_editor(
+  input : SemanticReviewInput,
+  section : @moon_diff_provider.SemanticReviewSection,
+  layout : ReviewDiffLayout,
+  host : @dom.Element,
+) -> SemanticReviewEditorHost? {
+  guard semantic_model_uri("old", section.key) is Some(original_uri) &&
+    semantic_model_uri("new", section.key) is Some(modified_uri) else {
+    return None
+  }
+  viewer_state.version = viewer_state.version + 1
+  let version = viewer_state.version
+  let original = @model.TextModel(
+    original_uri,
+    input.old_name,
+    "moonbit",
+    version,
+    "semantic-old-v\{version}",
+    section.original_source,
+  )
+  let modified = @model.TextModel(
+    modified_uri,
+    input.new_name,
+    "moonbit",
+    version,
+    "semantic-new-v\{version}",
+    section.modified_source,
+  )
+  @base_browser.set_style_property(
+    host,
+    "height",
+    "\{semantic_estimated_height(section, layout)}px",
+  )
+  let (editor, provider) = match section.diff {
+    @moon_diff_provider.SemanticReviewDiff::Core =>
+      (
+        @viewer.DiffEditor::create(host, options=semantic_diff_options(layout)),
+        None,
+      )
+    @moon_diff_provider.SemanticReviewDiff::Fragment(document) => {
+      let provider = @moon_diff_provider.MoonFragmentDiffProvider(document)
+      (
+        @viewer.DiffEditor::create(
+          host,
+          options=semantic_diff_options(layout),
+          provider=provider.as_document_diff_provider(),
+        ),
+        Some(provider),
+      )
+    }
+  }
+  let key = section.key
+  let subscription = editor.on_did_update_diff(() => {
+    schedule_semantic_review_editor_resize(key)
+  })
+  editor.set_model(Some(@viewer.DiffEditorModel(original, modified))) |> ignore
+  // Each VS Code multi-diff item opens on its own first change. Without this,
+  // a comment-only section can initially show only the unchanged declaration
+  // body below the changed documentation comment.
+  editor.reveal_first_diff()
+  Some({
+    section,
+    old_name: input.old_name,
+    new_name: input.new_name,
+    host,
+    editor,
+    provider,
+    subscription,
+  })
+}
+
+///|
+fn semantic_sections(
+  plan : @moon_diff_provider.SectionedSemanticReviewPlan?,
+) -> Array[@moon_diff_provider.SemanticReviewSection] {
+  guard plan is Some(plan) else { return [] }
+  let sections = plan.main_sections.copy()
+  sections.append(plan.deleted_sections)
+  sections
+}
+
+///|
+fn layout_semantic_review_editors() -> Unit {
+  for key, entry in semantic_review_editors {
+    entry.editor.layout()
+    schedule_semantic_review_editor_resize(key)
+  }
+  update_semantic_review_scroll_width()
+}
+
+///|
+fn update_semantic_review_editor_layout(layout : ReviewDiffLayout) -> Unit {
+  for key, entry in semantic_review_editors {
+    entry.editor.update_options(semantic_diff_options(layout))
+    entry.editor.layout()
+    schedule_semantic_review_editor_resize(key)
+  }
+  update_semantic_review_scroll_width()
+}
+
+///|
+fn refresh_semantic_review_editor_options() -> Unit {
+  for key, entry in semantic_review_editors {
+    let layout = match entry.editor.get_layout() {
+      @viewer.SideBySide => ReviewSideBySide
+      @viewer.Inline => ReviewInline
+    }
+    entry.editor.update_options(semantic_diff_options(layout))
+    entry.editor.layout()
+    schedule_semantic_review_editor_resize(key)
+  }
+  update_semantic_review_scroll_width()
+}
+
+///|
+fn clear_semantic_review_editors() -> Unit {
+  let keys = semantic_review_editors.to_array().map(pair => pair.0)
+  for key in keys {
+    if semantic_review_editors.get(key) is Some(entry) {
+      dispose_semantic_review_editor(entry)
+      semantic_review_editors.remove(key)
+    }
+  }
+  update_semantic_review_scroll_width()
+}
+
+///|
+/// Reconcile section widgets after Rabbita has committed their keyed hosts.
+/// Unchanged sections retain their editor models, selection, and scroll state.
+pub fn sync_semantic_review_editors(state : State) -> @cmd.Cmd {
+  @cmd.custom_cmd(
+    _scheduler => {
+      guard state.semantic_review_input is Some(input) else {
+        clear_semantic_review_editors()
+        return
+      }
+      let desired = semantic_sections(state.semantic_review_plan)
+      let desired_keys = desired.map(section => section.key)
+      let stale = semantic_review_editors
+        .to_array()
+        .map(pair => pair.0)
+        .filter(key => !desired_keys.contains(key))
+      for key in stale {
+        if semantic_review_editors.get(key) is Some(entry) {
+          dispose_semantic_review_editor(entry)
+          semantic_review_editors.remove(key)
+        }
+      }
+      for section in desired {
+        let key = section.key
+        guard @dom.document()
+          .get_element_by_id(semantic_editor_host_id(key))
+          .to_option()
+          is Some(host) else {
+          if semantic_review_editors.get(key) is Some(previous) {
+            dispose_semantic_review_editor(previous)
+            semantic_review_editors.remove(key)
+          }
+          continue
+        }
+        let reusable = semantic_review_editors
+          .get(key)
+          .map(previous => {
+            previous.section == section &&
+            previous.old_name == input.old_name &&
+            previous.new_name == input.new_name &&
+            previous.host.is_same_node(host.as_node())
+          })
+          .unwrap_or(false)
+        if reusable {
+          let entry = semantic_review_editors[key]
+          entry.editor.update_options(
+            semantic_diff_options(state.review_diff_layout),
+          )
+          entry.editor.layout()
+          schedule_semantic_review_editor_resize(key)
+          continue
+        }
+        if semantic_review_editors.get(key) is Some(previous) {
+          dispose_semantic_review_editor(previous)
+          semantic_review_editors.remove(key)
+        }
+        if create_semantic_review_editor(
+            input,
+            section,
+            state.review_diff_layout,
+            host,
+          )
+          is Some(entry) {
+          semantic_review_editors[key] = entry
+          schedule_semantic_review_editor_resize(key)
+        }
+      }
+      update_semantic_review_scroll_width()
+    },
+    kind=@cmd.after_render,
+  )
+}
+
+///|
+pub extend SemanticReviewInput with Eq::{equal, not_equal}
+
+///|
+pub extend SemanticReviewInput with Debug::{to_repr}

--- a/desktop/frontend/fileeditor/semantic_review_view_wbtest.mbt
+++ b/desktop/frontend/fileeditor/semantic_review_view_wbtest.mbt
@@ -1,0 +1,311 @@
+///|
+#warnings("-alert_unstable")
+fn render_semantic_review_html(node : @html.Html) -> String {
+  @rabbita.render_to_string(() => @rabbita.Val::constant(node))
+}
+
+///|
+fn semantic_test_input(
+  mode : @moon_diff_provider.MoonDiffMode,
+) -> SemanticReviewInput {
+  {
+    old_name: "old.mbt",
+    new_name: "new.mbt",
+    old_source: "",
+    new_source: "",
+    mode,
+    ignore_comments: true,
+    ignore_tests: true,
+  }
+}
+
+///|
+fn semantic_test_section(
+  key : String,
+  identity : Int?,
+  kind : @moon_diff_provider.SemanticReviewSectionKind,
+  original_source : String,
+  modified_source : String,
+) -> @moon_diff_provider.SemanticReviewSection {
+  {
+    key,
+    identity,
+    kind,
+    old_range: Some({ start_line_number: 10, line_count: 2, }),
+    new_range: Some({ start_line_number: 30, line_count: 2, }),
+    old_context: Some("fn old_context"),
+    new_context: Some("fn new_context"),
+    fallbacks: [],
+    original_source,
+    modified_source,
+    diff: @moon_diff_provider.SemanticReviewDiff::Core,
+  }
+}
+
+///|
+test "semantic view renders keyed DiffEditor hosts instead of source HTML" {
+  let main = semantic_test_section(
+    "section-1",
+    Some(1),
+    @moon_diff_provider.SemanticReviewSectionKind::Matched,
+    "OLD_SOURCE_MUST_NOT_BE_HTML",
+    "NEW_SOURCE_MUST_NOT_BE_HTML",
+  )
+  let deleted = {
+    ..semantic_test_section(
+      "section-0",
+      Some(0),
+      @moon_diff_provider.SemanticReviewSectionKind::Deleted,
+      "DELETED_SOURCE_MUST_NOT_BE_HTML",
+      "",
+    ),
+    new_range: None,
+    new_context: None,
+  }
+  let plan : @moon_diff_provider.SectionedSemanticReviewPlan = {
+    requested: @moon_diff_provider.Tree,
+    status: @moon_diff_provider.SemanticReviewStatus::Reordered,
+    reordered: true,
+    main_sections: [main],
+    deleted_sections: [deleted],
+  }
+  let html = render_semantic_review_html(
+    semantic_plan_view(
+      test_emit(),
+      plan,
+      semantic_test_input(@moon_diff_provider.Tree),
+      [],
+    ),
+  )
+  let reordered = html.find("Top-level declarations are reordered").unwrap()
+  let main_title = html.find("fn new_context").unwrap()
+  let deleted_title = html.find("fn old_context").unwrap()
+  assert_true(reordered < main_title)
+  assert_true(main_title < deleted_title)
+  assert_true(html.contains("class=\"semantic-entry-status deleted\">D</span>"))
+  assert_true(html.contains("aria-expanded=\"true\""))
+  assert_true(html.contains("id=\"semantic-diff-editor-section-1\""))
+  assert_true(html.contains("id=\"semantic-diff-editor-section-0\""))
+  assert_false(html.contains("OLD_SOURCE_MUST_NOT_BE_HTML"))
+  assert_false(html.contains("NEW_SOURCE_MUST_NOT_BE_HTML"))
+  assert_false(html.contains("DELETED_SOURCE_MUST_NOT_BE_HTML"))
+  assert_false(html.contains("<table"))
+  assert_false(html.contains("class=\"diff-scroll\""))
+}
+
+///|
+test "semantic whole fallback keeps metadata beside an empty editor host" {
+  let whole = {
+    ..semantic_test_section(
+      "whole",
+      None,
+      @moon_diff_provider.SemanticReviewSectionKind::Whole,
+      "old",
+      "new",
+    ),
+    fallbacks: ["syntax matching unavailable"],
+    old_range: None,
+    new_range: None,
+    old_context: None,
+    new_context: None,
+  }
+  let plan : @moon_diff_provider.SectionedSemanticReviewPlan = {
+    requested: @moon_diff_provider.Tree,
+    status: @moon_diff_provider.SemanticReviewStatus::Changed,
+    reordered: false,
+    main_sections: [whole],
+    deleted_sections: [],
+  }
+  let html = render_semantic_review_html(
+    semantic_plan_view(
+      test_emit(),
+      plan,
+      semantic_test_input(@moon_diff_provider.Tree),
+      [],
+    ),
+  )
+  assert_true(html.contains("Lexical fallback"))
+  assert_true(html.contains("syntax matching unavailable"))
+  assert_true(html.contains("id=\"semantic-diff-editor-whole\""))
+  assert_true(html.contains("Whole file"))
+}
+
+///|
+test "semantic empty statuses do not allocate editor hosts" {
+  for
+    case in [
+      (
+        @moon_diff_provider.SemanticReviewStatus::IgnoredOnly,
+        "No changes besides ignored",
+      ),
+      (
+        @moon_diff_provider.SemanticReviewStatus::Identical,
+        "No structural changes found",
+      ),
+      (
+        @moon_diff_provider.SemanticReviewStatus::NoStructuralChanges,
+        "No structural changes found",
+      ),
+    ] {
+    let (status, expected) = case
+    let plan : @moon_diff_provider.SectionedSemanticReviewPlan = {
+      requested: @moon_diff_provider.Tree,
+      status,
+      reordered: false,
+      main_sections: [],
+      deleted_sections: [],
+    }
+    let html = render_semantic_review_html(
+      semantic_plan_view(
+        test_emit(),
+        plan,
+        semantic_test_input(@moon_diff_provider.Tree),
+        [],
+      ),
+    )
+    assert_true(html.contains(expected))
+    assert_false(html.contains("semantic-diff-editor-"))
+  }
+}
+
+///|
+test "default semantic filters explain an ignored-only empty result" {
+  let plan : @moon_diff_provider.SectionedSemanticReviewPlan = {
+    requested: @moon_diff_provider.Token,
+    status: @moon_diff_provider.SemanticReviewStatus::IgnoredOnly,
+    reordered: false,
+    main_sections: [],
+    deleted_sections: [],
+  }
+  let html = render_semantic_review_html(
+    semantic_plan_view(
+      test_emit(),
+      plan,
+      semantic_test_input(@moon_diff_provider.Token),
+      [],
+    ),
+  )
+  assert_true(
+    html.contains(
+      "No changes besides ignored comments, blank lines, or test blocks were found. Turn off the relevant Ignore filter to view them.",
+    ),
+  )
+  assert_true(html.contains("class=\"semantic-empty\""))
+  assert_false(html.contains("semantic-diff-editor-"))
+}
+
+///|
+test "semantic input follows active MoonBit review and ignores layout" {
+  let path = @pathx.Relative("src/main.mbt")
+  let selected = test_modified_change(path)
+  let docs = owned_state().docs.copy()
+  docs[path] = {
+    ..loaded_doc(path.0),
+    state: TabLoaded(
+      content="fn value() { 2 }",
+      absolute=test_ctx().test_resource("/work/src/main.mbt"),
+      sig="working",
+    ),
+    review: Some({
+      generation: 1,
+      working_generation: 1,
+      baseline: ReviewContent("fn value() { 1 }"),
+      view_mode: ReviewDiff,
+      selected,
+    }),
+  }
+  let state = {
+    ..owned_state(),
+    docs,
+    review_diff_mode: ReviewDiffToken,
+    review_diff_layout: ReviewInline,
+  }
+  let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path), }
+  guard semantic_review_input(state, ctx) is Some(input) else {
+    fail("expected semantic review input")
+  }
+  assert_eq(input.old_source, "fn value() { 1 }")
+  assert_eq(input.new_source, "fn value() { 2 }")
+  assert_true(input.mode is @moon_diff_provider.Token)
+  assert_eq(
+    semantic_review_input({ ..state, review_diff_mode: ReviewDiffCore, }, ctx),
+    None,
+  )
+}
+
+///|
+test "semantic state cache drives section chrome" {
+  let input = semantic_test_input(@moon_diff_provider.Token)
+  let section = semantic_test_section(
+    "section-2",
+    Some(2),
+    @moon_diff_provider.SemanticReviewSectionKind::Matched,
+    "old",
+    "new",
+  )
+  let plan : @moon_diff_provider.SectionedSemanticReviewPlan = {
+    requested: @moon_diff_provider.Token,
+    status: @moon_diff_provider.SemanticReviewStatus::Changed,
+    reordered: false,
+    main_sections: [section],
+    deleted_sections: [],
+  }
+  let state = {
+    ..State::empty(),
+    semantic_review_input: Some(input),
+    semantic_review_plan: Some(plan),
+    semantic_review_collapsed: ["section-2"],
+    review_diff_layout: ReviewInline,
+  }
+  let html = render_semantic_review_html(
+    semantic_review_view(test_emit(), state),
+  )
+  assert_true(html.contains("data-mode=\"token\""))
+  assert_true(html.contains("data-layout=\"unified\""))
+  assert_true(html.contains("semantic-diff-entry collapsed"))
+  assert_true(html.contains("aria-expanded=\"false\""))
+  assert_true(html.contains("id=\"semantic-diff-editor-section-2\""))
+  assert_true(html.contains("id=\"semantic-review-scroll-width\""))
+}
+
+///|
+test "semantic multi-diff entry collapse is tab-local retained state" {
+  let section = semantic_test_section(
+    "section-4",
+    Some(4),
+    @moon_diff_provider.SemanticReviewSectionKind::Matched,
+    "old",
+    "new",
+  )
+  let state = {
+    ..State::empty(),
+    semantic_review_plan: Some({
+      requested: @moon_diff_provider.Token,
+      status: @moon_diff_provider.SemanticReviewStatus::Changed,
+      reordered: false,
+      main_sections: [section],
+      deleted_sections: [],
+    }),
+  }
+  let (_, collapsed) = update(
+    test_emit(),
+    SemanticReviewSectionToggled("section-4"),
+    state,
+    test_ctx(),
+  )
+  assert_eq(collapsed.semantic_review_collapsed, ["section-4"])
+  let (_, expanded) = update(
+    test_emit(),
+    SemanticReviewSectionToggled("section-4"),
+    collapsed,
+    test_ctx(),
+  )
+  assert_true(expanded.semantic_review_collapsed.is_empty())
+  let (_, unknown) = update(
+    test_emit(),
+    SemanticReviewSectionToggled("missing"),
+    expanded,
+    test_ctx(),
+  )
+  assert_true(unknown == expanded)
+}

--- a/desktop/frontend/fileeditor/semantic_review_view_wbtest.mbt
+++ b/desktop/frontend/fileeditor/semantic_review_view_wbtest.mbt
@@ -16,6 +16,7 @@ fn semantic_test_input(
     mode,
     ignore_comments: true,
     ignore_tests: true,
+    feedback_file: None,
     live_modified: None,
   }
 }
@@ -228,11 +229,20 @@ test "semantic input follows active MoonBit review and ignores layout" {
   assert_eq(input.old_source, "fn value() { 1 }")
   assert_eq(input.new_source, "fn value() { 2 }")
   assert_true(input.mode is @moon_diff_provider.Token)
+  assert_eq(input.feedback_file, Some(path))
   assert_true(
     input.live_modified is Some({ resource, path: live_path, }) &&
     resource.path == "/work/src/main.mbt" &&
     live_path == path,
   )
+  let deleted_docs = docs.copy()
+  deleted_docs[path] = { ..docs[path], state: TabDeleted, }
+  guard semantic_review_input({ ..state, docs: deleted_docs, }, ctx)
+    is Some(deleted_input) else {
+    fail("expected deleted semantic review input")
+  }
+  assert_eq(deleted_input.feedback_file, Some(path))
+  assert_eq(deleted_input.live_modified, None)
   assert_eq(
     semantic_review_input({ ..state, review_diff_mode: ReviewDiffCore, }, ctx),
     None,
@@ -250,6 +260,141 @@ test "semantic model identity enables IDE only on Modified" {
   assert_eq(modified.scheme, SemanticReviewModifiedScheme)
   assert_eq(original.path, "/section-3.mbt")
   assert_eq(modified.path, "/section-3.mbt")
+}
+
+///|
+test "semantic feedback enables only physical sides of working-tree sections" {
+  let file = @pathx.Relative("src/main.mbt")
+  let matched = semantic_test_section(
+    "section-1",
+    Some(1),
+    @moon_diff_provider.SemanticReviewSectionKind::Matched,
+    "old",
+    "new",
+  )
+  assert_true(
+    semantic_feedback_side_enabled(Some(file), matched, SemanticReviewOriginal),
+  )
+  assert_true(
+    semantic_feedback_side_enabled(Some(file), matched, SemanticReviewModified),
+  )
+  assert_false(
+    semantic_feedback_side_enabled(None, matched, SemanticReviewOriginal),
+  )
+  let deleted = {
+    ..matched,
+    kind: @moon_diff_provider.SemanticReviewSectionKind::Deleted,
+    new_range: None,
+    modified_source: "",
+  }
+  assert_true(
+    semantic_feedback_side_enabled(Some(file), deleted, SemanticReviewOriginal),
+  )
+  assert_false(
+    semantic_feedback_side_enabled(Some(file), deleted, SemanticReviewModified),
+  )
+  let inserted = {
+    ..matched,
+    kind: @moon_diff_provider.SemanticReviewSectionKind::Inserted,
+    old_range: None,
+    original_source: "",
+  }
+  assert_false(
+    semantic_feedback_side_enabled(Some(file), inserted, SemanticReviewOriginal),
+  )
+  assert_true(
+    semantic_feedback_side_enabled(Some(file), inserted, SemanticReviewModified),
+  )
+}
+
+///|
+test "semantic feedback projects local ranges into each physical source side" {
+  let section = semantic_test_section(
+    "section-2",
+    Some(2),
+    @moon_diff_provider.SemanticReviewSectionKind::Matched,
+    "old one\nold two",
+    "new one\nnew two",
+  )
+  assert_eq(
+    semantic_feedback_line_offset(section, SemanticReviewOriginal),
+    Some(9),
+  )
+  assert_eq(
+    semantic_feedback_line_offset(section, SemanticReviewModified),
+    Some(29),
+  )
+  let local_range = @common.Range(1, 2, 2, 5)
+  assert_eq(
+    project_semantic_feedback_range(local_range, 9),
+    @common.Range(10, 2, 11, 5),
+  )
+  assert_eq(
+    project_semantic_feedback_range(local_range, 29),
+    @common.Range(30, 2, 31, 5),
+  )
+  let whole = {
+    ..section,
+    key: "whole",
+    identity: None,
+    kind: @moon_diff_provider.SemanticReviewSectionKind::Whole,
+    old_range: None,
+    new_range: None,
+  }
+  assert_eq(
+    semantic_feedback_line_offset(whole, SemanticReviewOriginal),
+    Some(0),
+  )
+  assert_eq(
+    semantic_feedback_line_offset(whole, SemanticReviewModified),
+    Some(0),
+  )
+}
+
+///|
+test "semantic feedback messages preserve projected side and range identity" {
+  let file = @pathx.Relative("src/main.mbt")
+  let resource = ModelUri("openseek-semantic-diff-modified:/section-2.mbt")
+  let modified = semantic_feedback_message(
+    file,
+    SemanticReviewModified,
+    @common.Range(30, 2, 31, 5),
+    "new one\nnew two",
+    "keep this",
+    resource,
+    "feedback-modified",
+  )
+  assert_true(
+    modified
+    is EditorCommentAdded(
+      file=@pathx.Relative("src/main.mbt"),
+      range=modified_range,
+      quote="new one\nnew two",
+      comment="keep this",
+      ..
+    ) &&
+    modified_range == @common.Range(30, 2, 31, 5),
+  )
+  let original = semantic_feedback_message(
+    file,
+    SemanticReviewOriginal,
+    @common.Range(10, 2, 11, 5),
+    "old one\nold two",
+    "restore this",
+    ModelUri("openseek-semantic-diff-original:/section-2.mbt"),
+    "feedback-original",
+  )
+  assert_true(
+    original
+    is DiffCommentAdded(
+      file=@pathx.Relative("src/main.mbt"),
+      original_line_number=Some(10),
+      modified_line_number=None,
+      quote="old one\nold two",
+      comment="restore this",
+      ..
+    ),
+  )
 }
 
 ///|

--- a/desktop/frontend/fileeditor/semantic_review_view_wbtest.mbt
+++ b/desktop/frontend/fileeditor/semantic_review_view_wbtest.mbt
@@ -16,6 +16,7 @@ fn semantic_test_input(
     mode,
     ignore_comments: true,
     ignore_tests: true,
+    live_modified: None,
   }
 }
 
@@ -227,10 +228,67 @@ test "semantic input follows active MoonBit review and ignores layout" {
   assert_eq(input.old_source, "fn value() { 1 }")
   assert_eq(input.new_source, "fn value() { 2 }")
   assert_true(input.mode is @moon_diff_provider.Token)
+  assert_true(
+    input.live_modified is Some({ resource, path: live_path, }) &&
+    resource.path == "/work/src/main.mbt" &&
+    live_path == path,
+  )
   assert_eq(
     semantic_review_input({ ..state, review_diff_mode: ReviewDiffCore, }, ctx),
     None,
   )
+}
+
+///|
+test "semantic model identity enables IDE only on Modified" {
+  guard semantic_model_uri(SemanticReviewOriginal, "section-3")
+    is Some(original) &&
+    semantic_model_uri(SemanticReviewModified, "section-3") is Some(modified) else {
+    fail("expected semantic model URIs")
+  }
+  assert_eq(original.scheme, SemanticReviewOriginalScheme)
+  assert_eq(modified.scheme, SemanticReviewModifiedScheme)
+  assert_eq(original.path, "/section-3.mbt")
+  assert_eq(modified.path, "/section-3.mbt")
+}
+
+///|
+test "semantic diagnostics retain only and relocate the section overlap" {
+  let model = @model.TextModel(
+    @common.Uri::parse("\{SemanticReviewModifiedScheme}:/section-4.mbt"),
+    "main.mbt",
+    "moonbit",
+    1,
+    "semantic-new",
+    "fn value() -> Int {\n  2\n}",
+  )
+  defer model.dispose()
+  let diagnostics : Array[@language.Diagnostic] = [
+    {
+      range: @common.Range(2, 1, 2, 4),
+      severity: Error,
+      message: "outside",
+      tags: None,
+    },
+    {
+      range: @common.Range(30, 4, 30, 9),
+      severity: Warning,
+      message: "inside",
+      tags: None,
+    },
+    {
+      range: @common.Range(28, 8, 32, 8),
+      severity: Info,
+      message: "crossing",
+      tags: None,
+    },
+  ]
+  let projected = project_semantic_modified_diagnostics(diagnostics, model, 29)
+  assert_eq(projected.length(), 2)
+  assert_eq(projected[0].message, "inside")
+  assert_eq(projected[0].range, @common.Range(1, 4, 1, 9))
+  assert_eq(projected[1].message, "crossing")
+  assert_eq(projected[1].range, @common.Range(1, 1, 3, 2))
 }
 
 ///|

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -846,6 +846,9 @@ pub(all) enum Msg {
   ReviewDiffNavigationAvailabilityChanged(Bool)
   RevealPreviousReviewDiffChange
   RevealNextReviewDiffChange
+  // Continue multi-diff navigation in another Token/Tree section. `true`
+  // reveals the final change when moving backward; `false` reveals the first.
+  RevealSemanticReviewSectionChange(String, Bool)
   // Mark the active changed-file review as reviewed, or return it to the
   // unreviewed queue. Ordinary file tabs ignore the action.
   ToggleReviewProgress

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -84,33 +84,22 @@ pub(all) enum ReviewViewMode {
 } derive(Eq)
 
 ///|
-/// The layout of the full textual comparison. This panel-level preference is
-/// independent from `ReviewViewMode`: returning to source keeps the chosen
-/// layout for the next full-diff open and for the next changed file.
+/// The layout shared by Core and sectioned semantic comparison. This
+/// panel-level preference is independent from `ReviewViewMode`: returning to
+/// source keeps it for the next review and the next changed file.
 pub(all) enum ReviewDiffLayout {
   ReviewSideBySide
   ReviewInline
 } derive(Eq)
 
 ///|
-/// Desktop-owned comparison algorithm preference. Non-MoonBit comparisons
-/// force Core at the provider boundary without overwriting this preference,
-/// so returning to a `.mbt` review restores Token or Tree.
+/// Desktop-owned comparison algorithm preference. Core keeps the complete
+/// file DiffEditor; Token and Tree select the sectioned semantic review.
+/// Non-MoonBit comparisons keep using Core without overwriting this preference.
 pub(all) enum ReviewDiffMode {
   ReviewDiffCore
   ReviewDiffToken
   ReviewDiffTree
-} derive(Eq, Debug)
-
-///|
-/// The last provider result for the visible MoonBit comparison. A requested
-/// Tree calculation can legitimately settle as Token; malformed specialized
-/// output settles as Core. The host renders this fallback instead of placing
-/// product controls inside the reusable diff editor.
-pub(all) struct ReviewDiffStatus {
-  requested : ReviewDiffMode
-  effective : ReviewDiffMode
-  fell_back : Bool
 } derive(Eq, Debug)
 
 ///|
@@ -410,18 +399,25 @@ pub(all) struct State {
   // not force the reviewer to request the full diff again.
   review_view_mode : ReviewViewMode
   // Side-by-side/inline is likewise a reviewer preference rather than
-  // document state. The imperative DiffEditor retains both models while
-  // applying it.
+  // document state. Core applies it to its retained models; Token/Tree update
+  // the DiffEditor mounted inside every semantic section.
   review_diff_layout : ReviewDiffLayout
   // The requested MoonBit-aware algorithm and filtering policy are desktop
-  // preferences. The provider is forced to Core for other file types while
+  // preferences. Other file types keep rendering the Core surface while
   // these values remain parked for the next `.mbt` comparison.
   review_diff_mode : ReviewDiffMode
   review_diff_ignore_comments : Bool
   review_diff_ignore_tests : Bool
-  // Updated from DiffEditor's completed provider transaction. `None` means a
-  // new model/options calculation has not yet produced host-visible status.
-  review_diff_status : ReviewDiffStatus?
+  // Token/Tree comparisons are computed once during state reconciliation.
+  // The view renders only section chrome and stable editor hosts; the
+  // imperative lifecycle consumes the same plan to mount one DiffEditor per
+  // top-level fragment.
+  semantic_review_input : SemanticReviewInput?
+  semantic_review_plan : @moon_diff_provider.SectionedSemanticReviewPlan?
+  // VS Code's MultiDiffEditor keeps collapse state per document item. Our
+  // semantic input is one tab-local document, so reset these section keys when
+  // that input changes while preserving them across layout/theme rerenders.
+  semantic_review_collapsed : Array[String]
   // Whether DiffEditor's current (possibly source-mode parked) comparison has
   // at least one completed change for cyclic previous/next navigation.
   review_diff_navigation_available : Bool
@@ -537,9 +533,13 @@ pub fn State::empty() -> State {
     review_view_mode: ReviewDiff,
     review_diff_layout: ReviewSideBySide,
     review_diff_mode: ReviewDiffCore,
+    // Token/Tree starts from semantic production changes. Both explicit
+    // toggles can restore comments/blank lines or test blocks when needed.
     review_diff_ignore_comments: true,
     review_diff_ignore_tests: true,
-    review_diff_status: None,
+    semantic_review_input: None,
+    semantic_review_plan: None,
+    semantic_review_collapsed: [],
     review_diff_navigation_available: false,
     changes: ChangeListIdle,
     git_graph: GitGraphIdle,
@@ -830,20 +830,17 @@ pub(all) enum Msg {
   // presentation and the full comparison. Unavailable/loading reviews ignore
   // the action.
   ToggleReviewDiff
-  // Switch a visible full comparison between side-by-side panes and inline
-  // rows.
+  // Switch a visible comparison between side-by-side panes and inline rows.
   // Source mode and unavailable/loading comparisons ignore the action.
   ToggleReviewDiffLayout
-  // Select the desktop-owned comparison provider mode. Token and Tree are
-  // accepted only for a visible `.mbt` comparison; other files keep the
-  // preference parked while their provider is forced to Core.
+  // Select the desktop-owned comparison mode. Token and Tree are accepted
+  // only for a visible `.mbt` comparison; other files keep the preference
+  // parked while rendering Core.
   ReviewDiffModeSelected(ReviewDiffMode)
   ToggleReviewDiffIgnoreComments
   ToggleReviewDiffIgnoreTests
-  // Provider completion is asynchronous with respect to the Rabbita update
-  // loop. This message republishes the requested/effective mode so the host
-  // toolbar can announce Tree→Token and specialized→Core fallbacks.
-  ReviewDiffStatusChanged(ReviewDiffStatus)
+  // Toggle one top-level entry in the Token/Tree multi-diff container.
+  SemanticReviewSectionToggled(String)
   // DiffEditor's provider transaction also controls whether its existing
   // cyclic change-navigation commands have a target.
   ReviewDiffNavigationAvailabilityChanged(Bool)

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -413,11 +413,12 @@ pub(all) struct State {
   // document state. The imperative DiffEditor retains both models while
   // applying it.
   review_diff_layout : ReviewDiffLayout
-  // The requested MoonBit-aware algorithm and comment policy are desktop
+  // The requested MoonBit-aware algorithm and filtering policy are desktop
   // preferences. The provider is forced to Core for other file types while
   // these values remain parked for the next `.mbt` comparison.
   review_diff_mode : ReviewDiffMode
   review_diff_ignore_comments : Bool
+  review_diff_ignore_tests : Bool
   // Updated from DiffEditor's completed provider transaction. `None` means a
   // new model/options calculation has not yet produced host-visible status.
   review_diff_status : ReviewDiffStatus?
@@ -537,6 +538,7 @@ pub fn State::empty() -> State {
     review_diff_layout: ReviewSideBySide,
     review_diff_mode: ReviewDiffCore,
     review_diff_ignore_comments: true,
+    review_diff_ignore_tests: true,
     review_diff_status: None,
     review_diff_navigation_available: false,
     changes: ChangeListIdle,
@@ -605,6 +607,7 @@ pub fn State::prepare_owner(
     review_diff_layout: self.review_diff_layout,
     review_diff_mode: self.review_diff_mode,
     review_diff_ignore_comments: self.review_diff_ignore_comments,
+    review_diff_ignore_tests: self.review_diff_ignore_tests,
     changes_generation: self.changes_generation,
     request_epoch: self.request_epoch + 1,
     file_link_generation: self.file_link_generation,
@@ -836,6 +839,7 @@ pub(all) enum Msg {
   // preference parked while their provider is forced to Core.
   ReviewDiffModeSelected(ReviewDiffMode)
   ToggleReviewDiffIgnoreComments
+  ToggleReviewDiffIgnoreTests
   // Provider completion is asynchronous with respect to the Rabbita update
   // loop. This message republishes the requested/effective mode so the host
   // toolbar can announce Tree→Token and specialized→Core fallbacks.

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -1552,6 +1552,7 @@ pub fn subscriptions(
 ) -> @sub.Sub {
   @sub.batch([
     changes_poll_subscription(state, ctx, dispatch),
+    semantic_review_navigation_subscription(state, ctx, dispatch),
     state.search.subscription(
       ctx.search_input(),
       dispatch.map(msg => Search(msg)),
@@ -2339,18 +2340,53 @@ pub fn update(
     ReviewDiffNavigationAvailabilityChanged(available) =>
       (@cmd.none, { ..state, review_diff_navigation_available: available, })
     RevealPreviousReviewDiffChange => {
-      guard core_diff_ready(state, ctx) &&
-        state.review_diff_navigation_available else {
+      guard review_diff_navigation_enabled(state, ctx) else {
         return (@cmd.none, state)
       }
-      (reveal_previous_review_diff_change(), state)
+      if core_diff_ready(state, ctx) {
+        (reveal_previous_review_diff_change(), state)
+      } else {
+        (
+          navigate_semantic_review_change(
+            dispatch,
+            state.semantic_review_collapsed,
+            SemanticReviewPrevious,
+          ),
+          state,
+        )
+      }
     }
     RevealNextReviewDiffChange => {
-      guard core_diff_ready(state, ctx) &&
-        state.review_diff_navigation_available else {
+      guard review_diff_navigation_enabled(state, ctx) else {
         return (@cmd.none, state)
       }
-      (reveal_next_review_diff_change(), state)
+      if core_diff_ready(state, ctx) {
+        (reveal_next_review_diff_change(), state)
+      } else {
+        (
+          navigate_semantic_review_change(
+            dispatch,
+            state.semantic_review_collapsed,
+            SemanticReviewNext,
+          ),
+          state,
+        )
+      }
+    }
+    RevealSemanticReviewSectionChange(key, reveal_last) => {
+      guard !core_diff_ready(state, ctx) &&
+        semantic_sections(state.semantic_review_plan).any(section => {
+          section.key == key
+        }) else {
+        return (@cmd.none, state)
+      }
+      let semantic_review_collapsed = state.semantic_review_collapsed.filter(collapsed => {
+        collapsed != key
+      })
+      (
+        reveal_semantic_review_section_change(key, reveal_last),
+        { ..state, semantic_review_collapsed, },
+      )
     }
     ToggleReviewProgress => {
       guard ctx.active_file is Some(path) &&

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -1900,6 +1900,7 @@ pub fn sync(
         review_diff_layout: state.review_diff_layout,
         review_diff_mode: state.review_diff_mode,
         review_diff_ignore_comments: state.review_diff_ignore_comments,
+        review_diff_ignore_tests: state.review_diff_ignore_tests,
         changes_collapsed: state.changes_collapsed,
         git_graph_collapsed: state.git_graph_collapsed,
         // Request tokens must outlive the per-conversation cache. Resetting
@@ -2280,6 +2281,7 @@ pub fn update(
       let provider = apply_review_diff_provider(
         mode,
         state.review_diff_ignore_comments,
+        state.review_diff_ignore_tests,
       )
       let selected = {
         ..state,
@@ -2307,10 +2309,33 @@ pub fn update(
       }
       let ignore_comments = !state.review_diff_ignore_comments
       (
-        apply_review_diff_provider(state.review_diff_mode, ignore_comments),
+        apply_review_diff_provider(
+          state.review_diff_mode,
+          ignore_comments,
+          state.review_diff_ignore_tests,
+        ),
         {
           ..state,
           review_diff_ignore_comments: ignore_comments,
+          review_diff_status: None,
+        },
+      )
+    }
+    ToggleReviewDiffIgnoreTests => {
+      guard moon_diff_ready(state, ctx) &&
+        state.review_diff_mode != ReviewDiffCore else {
+        return (@cmd.none, state)
+      }
+      let ignore_tests = !state.review_diff_ignore_tests
+      (
+        apply_review_diff_provider(
+          state.review_diff_mode,
+          state.review_diff_ignore_comments,
+          ignore_tests,
+        ),
+        {
+          ..state,
+          review_diff_ignore_tests: ignore_tests,
           review_diff_status: None,
         },
       )

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -2286,10 +2286,7 @@ pub fn update(
     }
     ReviewDiffModeSelected(mode) => {
       guard moon_diff_available(state, ctx) else { return (@cmd.none, state) }
-      let selected = {
-        ..state,
-        review_diff_mode: mode,
-      }
+      let selected = { ..state, review_diff_mode: mode, }
       if ctx.active_file is Some(path) &&
         state.docs.get(path)
         is Some({ review: Some({ view_mode: ReviewSource, .. }), .. }) {

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -2127,8 +2127,15 @@ pub fn sync(
   } else {
     (@cmd.none, state)
   }
+  let state = state.sync_semantic_review(ctx)
   let pending_cmd = @cmd.batch([
-    retire_index_cmd, reroot_cmd, restore_cmd, changes_cmd, graph_cmd, history_cmd,
+    retire_index_cmd,
+    reroot_cmd,
+    restore_cmd,
+    changes_cmd,
+    graph_cmd,
+    history_cmd,
+    sync_semantic_review_editors(state),
   ])
   // A closed panel re-roots (above) and keeps the watcher placed, but the tree
   // itself can wait for the reopen. Unresolved placement takes the same early
@@ -2278,15 +2285,9 @@ pub fn update(
     }
     ReviewDiffModeSelected(mode) => {
       guard moon_diff_available(state, ctx) else { return (@cmd.none, state) }
-      let provider = apply_review_diff_provider(
-        mode,
-        state.review_diff_ignore_comments,
-        state.review_diff_ignore_tests,
-      )
       let selected = {
         ..state,
         review_diff_mode: mode,
-        review_diff_status: None,
       }
       if ctx.active_file is Some(path) &&
         state.docs.get(path)
@@ -2297,9 +2298,9 @@ pub fn update(
           ctx,
           ReviewDiff,
         )
-        (@cmd.batch([provider, show]), diff)
+        (@cmd.batch([show, request_viewer_remeasure()]), diff)
       } else {
-        (provider, selected)
+        (request_viewer_remeasure(), selected)
       }
     }
     ToggleReviewDiffIgnoreComments => {
@@ -2308,18 +2309,7 @@ pub fn update(
         return (@cmd.none, state)
       }
       let ignore_comments = !state.review_diff_ignore_comments
-      (
-        apply_review_diff_provider(
-          state.review_diff_mode,
-          ignore_comments,
-          state.review_diff_ignore_tests,
-        ),
-        {
-          ..state,
-          review_diff_ignore_comments: ignore_comments,
-          review_diff_status: None,
-        },
-      )
+      (@cmd.none, { ..state, review_diff_ignore_comments: ignore_comments, })
     }
     ToggleReviewDiffIgnoreTests => {
       guard moon_diff_ready(state, ctx) &&
@@ -2327,37 +2317,36 @@ pub fn update(
         return (@cmd.none, state)
       }
       let ignore_tests = !state.review_diff_ignore_tests
-      (
-        apply_review_diff_provider(
-          state.review_diff_mode,
-          state.review_diff_ignore_comments,
-          ignore_tests,
-        ),
-        {
-          ..state,
-          review_diff_ignore_tests: ignore_tests,
-          review_diff_status: None,
-        },
-      )
+      (@cmd.none, { ..state, review_diff_ignore_tests: ignore_tests, })
     }
-    ReviewDiffStatusChanged(status) =>
-      if moon_diff_ready(state, ctx) &&
-        status.requested == state.review_diff_mode {
-        (@cmd.none, { ..state, review_diff_status: Some(status), })
-      } else {
-        (@cmd.none, state)
+    SemanticReviewSectionToggled(key) => {
+      guard semantic_sections(state.semantic_review_plan).any(section => {
+        section.key == key
+      }) else {
+        return (@cmd.none, state)
       }
+      let semantic_review_collapsed = if state.semantic_review_collapsed.contains(
+          key,
+        ) {
+        state.semantic_review_collapsed.filter(item => item != key)
+      } else {
+        let collapsed = state.semantic_review_collapsed.copy()
+        collapsed.push(key)
+        collapsed
+      }
+      (@cmd.none, { ..state, semantic_review_collapsed, })
+    }
     ReviewDiffNavigationAvailabilityChanged(available) =>
       (@cmd.none, { ..state, review_diff_navigation_available: available, })
     RevealPreviousReviewDiffChange => {
-      guard full_diff_ready(state, ctx) &&
+      guard core_diff_ready(state, ctx) &&
         state.review_diff_navigation_available else {
         return (@cmd.none, state)
       }
       (reveal_previous_review_diff_change(), state)
     }
     RevealNextReviewDiffChange => {
-      guard full_diff_ready(state, ctx) &&
+      guard core_diff_ready(state, ctx) &&
         state.review_diff_navigation_available else {
         return (@cmd.none, state)
       }

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -297,7 +297,8 @@ pub fn resize_handle_view() -> @html.Html {
 /// viewer with its notice overlay, and the workspace tree (expandable and
 /// always rooted at the workspace root) as a toggleable pane on
 /// the viewer's right. Always rendered so the viewer's host element
-/// (`viewer-host`, `markdown-viewer-host`, and `diff-editor-host`) stay put
+/// (`viewer-host`, `markdown-viewer-host`, `diff-editor-host`, and
+/// `semantic-review-host`) stay put
 /// across renders and screen
 /// switches; CSS hides the inactive surface and the tree pane when toggled off,
 /// and collapses the whole panel to zero width when it is closed. The children's
@@ -307,10 +308,11 @@ pub fn body_view(
   dispatch : @cmd.Emit[Msg],
   state : State,
   ctx : Ctx,
+  semantic_review? : @html.Html = @html.nothing,
 ) -> @html.Html {
-  // The stable elements the code Viewer, MarkdownViewer, and switchable
-  // DiffEditor attach their imperative DOM into; they stay empty and are
-  // never re-keyed
+  // The stable elements the code Viewer, MarkdownViewer, and switchable Core
+  // DiffEditor attach their imperative DOM into. Semantic review owns keyed
+  // empty child hosts under its stable sibling.
   // (see editor_panel.mbt).
   // `editor-shell` brings in the viewer's `--vscode-*` / `--editor-*` theme
   // variables (defined on that class in the bundled viewer.css); `data-theme`
@@ -336,6 +338,13 @@ pub fn body_view(
           state.docs.get(path).map(doc => doc.name).unwrap_or(path.0),
         )
       None => false
+    })
+  let use_semantic_surface = use_diff_surface &&
+    state.review_diff_mode != ReviewDiffCore &&
+    (match ctx.active_history_diff {
+      Some(diff) => supports_moon_diff(diff.path.0)
+      None =>
+        ctx.active_file.map(path => supports_moon_diff(path.0)).unwrap_or(false)
     })
   let viewer_host = @html.div(
     attrs=@html.Attrs::build()
@@ -367,7 +376,7 @@ pub fn body_view(
     attrs=@html.Attrs::build()
       .id(DiffEditorHostId)
       .class(
-        if use_diff_surface {
+        if use_diff_surface && !use_semantic_surface {
           "viewer-host editor-shell"
         } else {
           "viewer-host editor-shell moonbit-viewer-surface-hidden"
@@ -376,11 +385,32 @@ pub fn body_view(
       .data_set("theme", if ctx.dark_mode { "dark" } else { "light" }),
     ([] : Array[@html.Html]),
   )
+  let semantic_review_host = @html.div(
+    attrs=@html.Attrs::build()
+      .id(SemanticReviewHostId)
+      .class(
+        if use_semantic_surface {
+          "viewer-host editor-shell semantic-review-host"
+        } else {
+          "viewer-host editor-shell semantic-review-host moonbit-viewer-surface-hidden"
+        },
+      )
+      .data_set("theme", if ctx.dark_mode { "dark" } else { "light" })
+      .on_scroll(event => {
+        guard event.target().to_element() is Some(element) else {
+          return @cmd.none
+        }
+        sync_semantic_review_scroll_left(element.get_scroll_left())
+        @cmd.none
+      }),
+    semantic_review,
+  )
   @html.div(class="editor-body", [
     @html.div(class="viewer-stack", [
       viewer_host,
       markdown_viewer_host,
       diff_editor_host,
+      semantic_review_host,
       viewer_notice(state, ctx),
     ]),
     tree_pane(dispatch, state, ctx),
@@ -1730,7 +1760,6 @@ pub fn breadcrumb_view(
           review_diff_layout_toggle(dispatch, state, ctx),
           review_comments_control(dispatch, state, ctx),
           review_tests_control(dispatch, state, ctx),
-          review_diff_status(state, ctx),
           review_diff_navigation(dispatch, state, ctx),
         ]),
       ],
@@ -1798,7 +1827,6 @@ pub fn breadcrumb_view(
         review_diff_layout_toggle(dispatch, state, ctx),
         review_comments_control(dispatch, state, ctx),
         review_tests_control(dispatch, state, ctx),
-        review_diff_status(state, ctx),
         review_diff_navigation(dispatch, state, ctx),
       ]),
     ]
@@ -1865,6 +1893,15 @@ fn moon_diff_available(state : State, ctx : Ctx) -> Bool {
 ///|
 fn moon_diff_ready(state : State, ctx : Ctx) -> Bool {
   moon_diff_available(state, ctx) && full_diff_ready(state, ctx)
+}
+
+///|
+/// Whether the visible comparison is the complete Core DiffEditor. A parked
+/// Token/Tree preference does not affect non-MoonBit files, which always keep
+/// the Core surface.
+fn core_diff_ready(state : State, ctx : Ctx) -> Bool {
+  full_diff_ready(state, ctx) &&
+  (state.review_diff_mode == ReviewDiffCore || !moon_diff_ready(state, ctx))
 }
 
 ///|
@@ -2015,39 +2052,6 @@ fn review_diff_mode_toolbar(
 }
 
 ///|
-fn review_diff_fallback_text(state : State) -> String {
-  guard state.review_diff_status is Some(status) &&
-    status.requested == state.review_diff_mode &&
-    status.fell_back else {
-    return ""
-  }
-  status.requested.label() +
-  " unavailable — showing " +
-  status.effective.label() +
-  " diff"
-}
-
-///|
-fn review_diff_status(state : State, ctx : Ctx) -> @html.Html {
-  // Provider status may outlive the comparison that produced it. Only a
-  // Moon-aware active diff can interpret that retained status.
-  let fallback = if moon_diff_ready(state, ctx) {
-    review_diff_fallback_text(state)
-  } else {
-    ""
-  }
-  @html.span(
-    class=if fallback.is_empty() {
-      "review-diff-mode-status hidden"
-    } else {
-      "review-diff-mode-status"
-    },
-    attrs=@html.Attrs::build().role("status").aria_live("polite"),
-    fallback,
-  )
-}
-
-///|
 fn review_comments_control(
   dispatch : @cmd.Emit[Msg],
   state : State,
@@ -2139,7 +2143,10 @@ fn review_diff_navigation(
   guard full_diff_available(state, ctx) else {
     return @html.span(class="review-diff-navigation hidden", "")
   }
-  let enabled = full_diff_ready(state, ctx) &&
+  if full_diff_ready(state, ctx) && !core_diff_ready(state, ctx) {
+    return @html.span(class="review-diff-navigation hidden", "")
+  }
+  let enabled = core_diff_ready(state, ctx) &&
     state.review_diff_navigation_available
   @html.div(
     class="review-diff-navigation",
@@ -2176,9 +2183,9 @@ fn review_diff_navigation(
 }
 
 ///|
-/// The full comparison keeps its two models mounted while this explicit pair
-/// changes only their layout. File mode preserves the preference but disables
-/// both choices so it cannot imply that a source file is split or unified.
+/// Core keeps its two models mounted while Token/Tree reuse one section plan;
+/// this explicit pair changes either presentation. File mode preserves the
+/// preference but disables both choices until the next review reveal.
 fn review_diff_layout_toggle(
   dispatch : @cmd.Emit[Msg],
   state : State,

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -1905,6 +1905,19 @@ fn core_diff_ready(state : State, ctx : Ctx) -> Bool {
 }
 
 ///|
+/// Core receives availability from its mounted provider. Token/Tree plans are
+/// already nonempty change documents, so their aggregate navigation is ready
+/// once at least one semantic item exists.
+fn review_diff_navigation_enabled(state : State, ctx : Ctx) -> Bool {
+  if core_diff_ready(state, ctx) {
+    state.review_diff_navigation_available
+  } else {
+    full_diff_ready(state, ctx) &&
+    !semantic_sections(state.semantic_review_plan).is_empty()
+  }
+}
+
+///|
 fn ReviewDiffMode::label(self : ReviewDiffMode) -> String {
   match self {
     ReviewDiffCore => "Line"
@@ -2143,11 +2156,8 @@ fn review_diff_navigation(
   guard full_diff_available(state, ctx) else {
     return @html.span(class="review-diff-navigation hidden", "")
   }
-  if full_diff_ready(state, ctx) && !core_diff_ready(state, ctx) {
-    return @html.span(class="review-diff-navigation hidden", "")
-  }
-  let enabled = core_diff_ready(state, ctx) &&
-    state.review_diff_navigation_available
+  let enabled = full_diff_ready(state, ctx) &&
+    review_diff_navigation_enabled(state, ctx)
   @html.div(
     class="review-diff-navigation",
     attrs=@html.Attrs::build()

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -1729,6 +1729,7 @@ pub fn breadcrumb_view(
           ),
           review_diff_layout_toggle(dispatch, state, ctx),
           review_comments_control(dispatch, state, ctx),
+          review_tests_control(dispatch, state, ctx),
           review_diff_status(state, ctx),
           review_diff_navigation(dispatch, state, ctx),
         ]),
@@ -1796,6 +1797,7 @@ pub fn breadcrumb_view(
         ),
         review_diff_layout_toggle(dispatch, state, ctx),
         review_comments_control(dispatch, state, ctx),
+        review_tests_control(dispatch, state, ctx),
         review_diff_status(state, ctx),
         review_diff_navigation(dispatch, state, ctx),
       ]),
@@ -2081,6 +2083,46 @@ fn review_comments_control(
       "Comments: ignored"
     } else {
       "Comments: included"
+    },
+  )
+}
+
+///|
+fn review_tests_control(
+  dispatch : @cmd.Emit[Msg],
+  state : State,
+  ctx : Ctx,
+) -> @html.Html {
+  guard moon_diff_available(state, ctx) else {
+    return @html.span(class="review-tests-control hidden", "")
+  }
+  let enabled = full_diff_ready(state, ctx) &&
+    state.review_diff_mode != ReviewDiffCore
+  @html.button(
+    type_="button",
+    class=if enabled && state.review_diff_ignore_tests {
+      "review-tests-control active"
+    } else {
+      "review-tests-control"
+    },
+    title=if !full_diff_ready(state, ctx) {
+      "Available in diff view"
+    } else if state.review_diff_mode == ReviewDiffCore {
+      "Available in Token and Tree diff"
+    } else if state.review_diff_ignore_tests {
+      "Include tests in the comparison"
+    } else {
+      "Ignore MoonBit test blocks"
+    },
+    disabled=!enabled,
+    on_click=dispatch(ToggleReviewDiffIgnoreTests),
+    attrs=@html.Attrs::build()
+      .aria_label("Ignore tests")
+      .aria_pressed((enabled && state.review_diff_ignore_tests).to_string()),
+    if state.review_diff_ignore_tests {
+      "Tests: ignored"
+    } else {
+      "Tests: included"
     },
   )
 }

--- a/desktop/frontend/right_panel/component.mbt
+++ b/desktop/frontend/right_panel/component.mbt
@@ -54,7 +54,12 @@ pub fn component(
   input : @rabbita.Val[Input],
   actions : Actions,
 ) -> @rabbita.Val[@html.Html] {
-  input.map(input => panel_view(input, actions))
+  let semantic_review = input.map(input => {
+    @fileeditor.semantic_review_view(actions.file_editor, input.file_panel)
+  })
+  input.view2(semantic_review, (input, semantic_review) => {
+    panel_view(input, actions, semantic_review~)
+  })
 }
 
 ///|

--- a/desktop/frontend/right_panel/pkg.generated.mbti
+++ b/desktop/frontend/right_panel/pkg.generated.mbti
@@ -37,6 +37,8 @@ pub(all) struct Actions {
 
 type Input derive(Eq)
 pub fn Input::Input(dock~ : @dock.State, file_panel~ : @fileeditor.State, preview~ : @preview.State, file_ctx~ : @fileeditor.Ctx, is_desktop~ : Bool, menu_open~ : Bool, expanded~ : Bool) -> Self
+pub fn Input::equal(Self, Self) -> Bool
+pub fn Input::not_equal(Self, Self) -> Bool
 
 // Type aliases
 

--- a/desktop/frontend/right_panel/view.mbt
+++ b/desktop/frontend/right_panel/view.mbt
@@ -2,7 +2,11 @@
 /// The dock strip sits above the file breadcrumb and its permanent body hosts.
 /// Child order is structural because Rabbita diffs by index; the viewer and
 /// browser placeholders must not be re-keyed when the active tab changes.
-fn panel_view(input : Input, actions : Actions) -> @html.Html {
+fn panel_view(
+  input : Input,
+  actions : Actions,
+  semantic_review? : @html.Html = @html.nothing,
+) -> @html.Html {
   let chips : Array[@dock.TabChip] = input.dock.tabs.map(tab => {
     match tab {
       File(path~) => {
@@ -124,6 +128,7 @@ fn panel_view(input : Input, actions : Actions) -> @html.Html {
         actions.file_editor,
         input.file_panel,
         input.file_ctx,
+        semantic_review~,
       ),
       @html.div(class="browser-chrome", [
         @preview.toolbar_view(active_page, toolbar),

--- a/desktop/styles/file_panel.css
+++ b/desktop/styles/file_panel.css
@@ -2094,8 +2094,7 @@ button.git-history-file.selected {
 .review-layout-control.hidden,
 .review-comments-control.hidden,
 .review-tests-control.hidden,
-.review-control-divider.hidden,
-.review-diff-mode-status.hidden {
+.review-control-divider.hidden {
   display: none;
 }
 
@@ -2192,16 +2191,6 @@ button.git-history-file.selected {
   margin-left: auto;
 }
 
-.review-diff-mode-status {
-  flex: 1 1 120px;
-  min-width: 0;
-  max-width: 220px;
-  overflow: hidden;
-  color: var(--color-text-muted);
-  font-size: var(--font-size-xs);
-  text-overflow: ellipsis;
-}
-
 .review-progress {
   appearance: none;
   font: inherit;
@@ -2222,4 +2211,271 @@ button.git-history-file.selected {
   min-width: 0;
   min-height: 0;
   overflow: hidden;
+}
+
+/* Port of VS Code's MultiDiffEditor container/item presentation from
+   editor/vscode/src/vs/editor/browser/widget/multiDiffEditor/{style.css,
+   diffEditorItemTemplate.ts}. MoonDiff supplies top-level items; each item
+   retains our real DiffEditor while this host owns the single scroll plane. */
+.semantic-review-host {
+  overflow: auto;
+  color: var(--vscode-editor-foreground, var(--color-text-primary));
+  background: var(--vscode-editor-background, var(--color-bg-surface));
+  font-family: var(--font-family-mono);
+  overscroll-behavior: contain;
+}
+
+.semantic-review-host .semantic-review {
+  position: relative;
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 100%;
+  min-width: 0;
+}
+
+.semantic-review-host .semantic-document {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  min-width: 0;
+}
+
+.semantic-review-host .semantic-review-scroll-width {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 1px;
+  pointer-events: none;
+  visibility: hidden;
+}
+
+.semantic-review-host .semantic-diff-entry {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  min-width: 0;
+  overflow: visible;
+  background: var(--vscode-editor-background, var(--color-bg-surface));
+}
+
+.semantic-review-host .semantic-entry-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  box-sizing: border-box;
+  width: 100%;
+  height: 40px;
+  margin: 0;
+  padding-top: 8px;
+  background: var(--vscode-editor-background, var(--color-bg-surface));
+}
+
+.semantic-review-host .semantic-entry-header-content {
+  appearance: none;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 32px;
+  min-width: 0;
+  margin: 0;
+  border: 0;
+  border-top: 1px solid var(--color-separator);
+  border-bottom: 1px solid var(--color-separator);
+  border-radius: 0;
+  padding: 4px 5px;
+  color: var(--vscode-editor-foreground, var(--color-text-primary));
+  background: var(--color-bg-subtle);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.semantic-review-host .semantic-diff-entry.collapsed
+  .semantic-entry-header-content {
+  border-bottom-color: transparent;
+}
+
+.semantic-review-host .semantic-entry-header-content:hover {
+  background: color-mix(
+    in srgb,
+    var(--color-text-primary) 5%,
+    var(--color-bg-subtle)
+  );
+}
+
+.semantic-review-host .semantic-entry-header-content:focus-visible {
+  outline: 1px solid var(--color-accent);
+  outline-offset: -1px;
+}
+
+.semantic-review-host .semantic-entry-chevron {
+  flex: 0 0 16px;
+  width: 16px;
+  margin: 0 5px;
+  color: var(--color-text-secondary);
+}
+
+.semantic-review-host .semantic-entry-file-icon {
+  position: relative;
+  flex: 0 0 13px;
+  box-sizing: border-box;
+  width: 13px;
+  height: 16px;
+  margin-right: 7px;
+  border: 1px solid currentColor;
+  border-radius: 1px;
+  color: var(--color-text-secondary);
+  opacity: 0.8;
+}
+
+.semantic-review-host .semantic-entry-file-icon::after {
+  content: "";
+  position: absolute;
+  right: -1px;
+  bottom: 3px;
+  left: 3px;
+  border-top: 1px solid currentColor;
+  box-shadow: 0 -3px 0 currentColor;
+}
+
+.semantic-review-host .semantic-entry-path {
+  display: flex;
+  flex: 1 1 auto;
+  align-items: baseline;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.semantic-review-host .semantic-entry-label {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 22px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.semantic-review-host .semantic-entry-location {
+  flex: 1 1 auto;
+  min-width: 0;
+  margin-left: 8px;
+  overflow: hidden;
+  color: var(--color-text-secondary);
+  font-size: 12px;
+  line-height: 22px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.semantic-review-host .semantic-entry-location:empty {
+  display: none;
+}
+
+.semantic-review-host .semantic-entry-status {
+  flex: 0 0 auto;
+  margin: 0 10px;
+  font-weight: 600;
+  line-height: 22px;
+  opacity: 0.8;
+}
+
+.semantic-review-host .semantic-entry-status.added {
+  color: var(--color-success);
+}
+
+.semantic-review-host .semantic-entry-status.deleted {
+  color: var(--color-danger);
+}
+
+.semantic-review-host .semantic-entry-content {
+  border-bottom: 1px solid var(--color-separator);
+  overflow: hidden;
+}
+
+.semantic-review-host .semantic-diff-entry.collapsed .semantic-entry-content {
+  display: none;
+}
+
+.semantic-review-host .semantic-reorder,
+.semantic-review-host .diff-notice {
+  color: var(--color-warning, #806615);
+  background: color-mix(
+    in srgb,
+    var(--color-warning, #b99a36) 9%,
+    var(--vscode-editor-background, var(--color-bg-surface))
+  );
+}
+
+.semantic-review-host .semantic-reorder {
+  margin: 8px 0 0;
+  border-top: 1px solid var(--color-separator);
+  border-bottom: 1px solid var(--color-separator);
+  padding: 7px 12px;
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  line-height: 1.45;
+}
+
+.semantic-review-host .diff-notice {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 8px 12px;
+  font-family: var(--font-family-sans);
+  font-size: var(--font-size-xs);
+  line-height: 1.4;
+}
+
+.semantic-review-host .diff-notice strong {
+  flex: 0 0 auto;
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.semantic-review-host .semantic-empty {
+  display: grid;
+  min-height: 100%;
+  place-items: center;
+  padding: 24px;
+  color: var(--color-text-secondary);
+  font-family: var(--font-family-sans);
+  text-align: center;
+}
+
+.semantic-review-host .semantic-empty p {
+  margin: 0;
+}
+
+.semantic-review-host .semantic-entry-editor-parent {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.semantic-review-host .semantic-diff-editor-host {
+  position: relative;
+  box-sizing: border-box;
+  width: 100%;
+  min-width: 0;
+  min-height: 40px;
+  overflow: hidden;
+  background: var(--vscode-editor-background, var(--color-bg-surface));
+}
+
+.semantic-review-host .semantic-diff-editor-host > .moonbit-diff-editor {
+  position: absolute;
+  inset: 0;
+}
+
+/* Each item expands to content height, so only the shared outer host owns
+   scrollbars. This matches VS Code's per-item `vertical: hidden`,
+   `horizontal: hidden`, and `handleMouseWheel: false` presentation. */
+.semantic-review-host .semantic-diff-editor-host .scrollbar.vertical,
+.semantic-review-host .semantic-diff-editor-host .scrollbar.horizontal {
+  display: none !important;
 }

--- a/desktop/styles/file_panel.css
+++ b/desktop/styles/file_panel.css
@@ -2093,6 +2093,7 @@ button.git-history-file.selected {
 .review-mode-toolbar.hidden,
 .review-layout-control.hidden,
 .review-comments-control.hidden,
+.review-tests-control.hidden,
 .review-control-divider.hidden,
 .review-diff-mode-status.hidden {
   display: none;
@@ -2152,7 +2153,8 @@ button.git-history-file.selected {
   cursor: default;
 }
 
-.review-comments-control {
+.review-comments-control,
+.review-tests-control {
   appearance: none;
   flex: 0 0 auto;
   min-height: 28px;
@@ -2167,17 +2169,20 @@ button.git-history-file.selected {
   cursor: pointer;
 }
 
-.review-comments-control:hover:not(:disabled) {
+.review-comments-control:hover:not(:disabled),
+.review-tests-control:hover:not(:disabled) {
   color: var(--color-text-primary);
   background: var(--color-bg-surface);
 }
 
-.review-comments-control.active {
+.review-comments-control.active,
+.review-tests-control.active {
   color: var(--color-accent-strong);
   background: color-mix(in srgb, var(--color-accent) 20%, transparent);
 }
 
-.review-comments-control:disabled {
+.review-comments-control:disabled,
+.review-tests-control:disabled {
   color: var(--color-text-muted);
   cursor: default;
   opacity: 0.5;

--- a/editor/internal/shell/examples/embedded_viewer/public_api_contract.mbt
+++ b/editor/internal/shell/examples/embedded_viewer/public_api_contract.mbt
@@ -235,6 +235,10 @@ fn compile_external_viewer_api_contract(
     options=diff_options,
   )
   let diff_subscription = diff_editor.on_did_update_diff(() => ())
+  let diff_content_height_subscription = diff_editor.on_did_change_content_height(_height => {
+      ()
+    },
+  )
   let diff_model = @viewer.DiffEditorModel(model, model)
   diff_editor.set_model(Some(diff_model)) |> ignore
   diff_editor.reveal_first_diff()
@@ -254,6 +258,7 @@ fn compile_external_viewer_api_contract(
   // compile-only contract intentionally leaves the borrowed model alive.
   diff_editor.set_model(None) |> ignore
   diff_subscription.dispose()
+  diff_content_height_subscription.dispose()
   diff_editor.dispose()
 
   // Explicit bundles and concrete backings remain caller-owned.

--- a/editor/internal/viewer/code_editor_widget/input.mbt
+++ b/editor/internal/viewer/code_editor_widget/input.mbt
@@ -93,6 +93,9 @@ fn CodeEditorWidget::hook_view_input(
     }
   })
   add_view_event_listener(view, view.overflow_guard, "wheel", event => {
+    guard self.configuration.snapshot().options.handle_mouse_wheel else {
+      return
+    }
     match event.to_wheel_event() {
       Some(wheel) =>
         if handler.handle_editor_wheel(event, wheel) {

--- a/editor/internal/viewer/code_editor_widget/pkg.generated.mbti
+++ b/editor/internal/viewer/code_editor_widget/pkg.generated.mbti
@@ -67,7 +67,7 @@ pub fn CodeEditorModelLineHeight::not_equal(Self, Self) -> Bool
 pub fn CodeEditorModelLineHeight::to_repr(Self) -> @debug.Repr
 
 type CodeEditorOptions derive(Eq, @debug.Debug)
-pub fn CodeEditorOptions::CodeEditorOptions(soft_wrap? : Bool, tab_size? : Int, wrapping_indent? : @editor_api.WrappingIndent, render_whitespace? : @editor_api.RenderWhitespace, render_control_characters? : Bool, render_line_highlight? : @editor_api.RenderLineHighlight, render_line_highlight_only_when_focus? : Bool, render_validation_decorations? : @editor_api.RenderValidationDecorations, theme? : String, placeholder? : String, line_decorations_width? : Int, line_numbers_min_chars? : Int, folding? : Bool, show_folding_controls? : @editor_api.ShowFoldingControls, folding_highlight? : Bool, folding_maximum_regions? : Int, unfold_on_click_after_end_of_line? : Bool, smooth_scrolling? : Bool, show_unused? : Bool, show_deprecated? : Bool, font_family? : String, font_weight? : String, font_size? : Double, line_height? : Double, letter_spacing? : Double) -> Self
+pub fn CodeEditorOptions::CodeEditorOptions(soft_wrap? : Bool, tab_size? : Int, wrapping_indent? : @editor_api.WrappingIndent, render_whitespace? : @editor_api.RenderWhitespace, render_control_characters? : Bool, render_line_highlight? : @editor_api.RenderLineHighlight, render_line_highlight_only_when_focus? : Bool, render_validation_decorations? : @editor_api.RenderValidationDecorations, theme? : String, placeholder? : String, line_decorations_width? : Int, line_numbers_min_chars? : Int, folding? : Bool, show_folding_controls? : @editor_api.ShowFoldingControls, folding_highlight? : Bool, folding_maximum_regions? : Int, unfold_on_click_after_end_of_line? : Bool, smooth_scrolling? : Bool, handle_mouse_wheel? : Bool, show_unused? : Bool, show_deprecated? : Bool, font_family? : String, font_weight? : String, font_size? : Double, line_height? : Double, letter_spacing? : Double) -> Self
 pub fn CodeEditorOptions::default() -> Self
 pub fn CodeEditorOptions::equal(Self, Self) -> Bool
 pub fn CodeEditorOptions::line_height(Self) -> Double
@@ -76,6 +76,7 @@ pub fn CodeEditorOptions::soft_wrap(Self) -> Bool
 pub fn CodeEditorOptions::with_folding(Self, Bool) -> Self
 pub fn CodeEditorOptions::with_font_family(Self, String) -> Self
 pub fn CodeEditorOptions::with_font_size(Self, Double) -> Self
+pub fn CodeEditorOptions::with_handle_mouse_wheel(Self, Bool) -> Self
 pub fn CodeEditorOptions::with_line_decorations_width(Self, Int) -> Self
 pub fn CodeEditorOptions::with_line_height(Self, Double) -> Self
 pub fn CodeEditorOptions::with_line_numbers_min_chars(Self, Int) -> Self

--- a/editor/internal/viewer/code_editor_widget/viewer_options.mbt
+++ b/editor/internal/viewer/code_editor_widget/viewer_options.mbt
@@ -47,6 +47,9 @@ struct CodeEditorOptions {
   /// Monaco's `smoothScrolling` option (`false` by default). Physical mouse
   /// wheels animate for 125 ms when enabled; trackpads remain immediate.
   smooth_scrolling : Bool
+  /// Monaco's `handleMouseWheel` option (`true` by default). MultiDiffEditor
+  /// items disable this so their single outer scroll plane owns wheel input.
+  handle_mouse_wheel : Bool
   /// Monaco's `showUnused` editor option (default `true`,
   /// `editorOptions.ts:6645-6647`): adds the `showUnused` root class that
   /// gates the `squiggly-unnecessary` / `squiggly-inline-unnecessary`
@@ -97,6 +100,7 @@ pub fn CodeEditorOptions::CodeEditorOptions(
   folding_maximum_regions? : Int = 5000,
   unfold_on_click_after_end_of_line? : Bool = false,
   smooth_scrolling? : Bool = false,
+  handle_mouse_wheel? : Bool = true,
   show_unused? : Bool = true,
   show_deprecated? : Bool = true,
   font_family? : String = @config.editor_font_defaults.font_family,
@@ -124,6 +128,7 @@ pub fn CodeEditorOptions::CodeEditorOptions(
     folding_maximum_regions,
     unfold_on_click_after_end_of_line,
     smooth_scrolling,
+    handle_mouse_wheel,
     show_unused,
     show_deprecated,
     font_family,
@@ -149,6 +154,7 @@ fn CodeEditorOptions::same_layout_options(
     show_unused: other.show_unused,
     show_deprecated: other.show_deprecated,
     smooth_scrolling: other.smooth_scrolling,
+    handle_mouse_wheel: other.handle_mouse_wheel,
   } ==
   other
 }
@@ -266,6 +272,15 @@ pub fn CodeEditorOptions::with_folding(
   folding : Bool,
 ) -> CodeEditorOptions {
   { ..self, folding, }
+}
+
+///|
+/// Returns a copy with Monaco's `handleMouseWheel` policy changed.
+pub fn CodeEditorOptions::with_handle_mouse_wheel(
+  self : CodeEditorOptions,
+  handle_mouse_wheel : Bool,
+) -> CodeEditorOptions {
+  { ..self, handle_mouse_wheel, }
 }
 
 ///|

--- a/editor/internal/viewer/code_editor_widget/viewer_options_wbtest.mbt
+++ b/editor/internal/viewer/code_editor_widget/viewer_options_wbtest.mbt
@@ -2,6 +2,7 @@
 test "viewer options default to no soft wrap view model options" {
   let options = CodeEditorOptions(tab_size=7)
   assert_false(options.smooth_scrolling)
+  assert_true(options.handle_mouse_wheel)
   assert_eq(options.soft_wrap_column_for_content_width(720.0, 7.2), 0)
   let view_model_options = options.view_model_options(
     100,
@@ -9,6 +10,14 @@ test "viewer options default to no soft wrap view model options" {
   )
   assert_false(view_model_options.is_soft_wrap_enabled())
   assert_eq(view_model_options.tab_size, 7)
+}
+
+///|
+test "viewer wheel ownership is a live non-layout option" {
+  let defaults = CodeEditorOptions::default()
+  let external = defaults.with_handle_mouse_wheel(false)
+  assert_false(external.handle_mouse_wheel)
+  assert_true(defaults.same_layout_options(external))
 }
 
 ///|

--- a/editor/internal/viewer/diff_editor/diff_state.mbt
+++ b/editor/internal/viewer/diff_editor/diff_state.mbt
@@ -165,6 +165,25 @@ fn DiffState::next_change_from_modified_line(
 }
 
 ///|
+/// Resolve the next navigation group without wrapping to the first group.
+/// Multi-diff hosts use this to decide whether F7 stays in the active item or
+/// advances to the next comparison.
+fn DiffState::next_change_from_modified_line_without_wrap(
+  self : DiffState,
+  current_line_number : Int,
+) -> DiffNavigationTarget? {
+  let changes = self.navigation_changes()
+  let count = changes.length()
+  let mut index = 0
+  while index < count &&
+        changes[index].modified.start_line_number <= current_line_number {
+    index += 1
+  }
+  guard index < count else { return None }
+  Some({ change_index: index, change_count: count, change: changes[index], })
+}
+
+///|
 fn DiffState::previous_change_from_modified_line(
   self : DiffState,
   current_line_number : Int,
@@ -182,5 +201,22 @@ fn DiffState::previous_change_from_modified_line(
   if index < 0 {
     index = count - 1
   }
+  Some({ change_index: index, change_count: count, change: changes[index], })
+}
+
+///|
+/// Resolve the previous navigation group without wrapping to the final group.
+fn DiffState::previous_change_from_modified_line_without_wrap(
+  self : DiffState,
+  current_line_number : Int,
+) -> DiffNavigationTarget? {
+  let changes = self.navigation_changes()
+  let count = changes.length()
+  let mut index = count - 1
+  while index >= 0 &&
+        changes[index].modified.start_line_number >= current_line_number {
+    index -= 1
+  }
+  guard index >= 0 else { return None }
   Some({ change_index: index, change_count: count, change: changes[index], })
 }

--- a/editor/internal/viewer/diff_editor/diff_state_wbtest.mbt
+++ b/editor/internal/viewer/diff_editor/diff_state_wbtest.mbt
@@ -100,6 +100,39 @@ test "grouped F7 navigation starts at the modified cursor and wraps" {
 }
 
 ///|
+test "multi-diff navigation detects an item boundary without wrapping" {
+  let state = DiffState::from_diff_result({
+    changes: [
+      diff_state_test_change(2, 3, 2, 3),
+      diff_state_test_change(9, 10, 9, 10),
+    ],
+    additional_alignments: [],
+  })
+  assert_eq(
+    state.next_change_from_modified_line_without_wrap(2).unwrap().change_index,
+    1,
+  )
+  assert_true(state.next_change_from_modified_line_without_wrap(9) is None)
+  assert_eq(
+    state.previous_change_from_modified_line_without_wrap(9).unwrap().change_index,
+    0,
+  )
+  assert_true(state.previous_change_from_modified_line_without_wrap(2) is None)
+}
+
+///|
+test "multi-diff next includes an EOF deletion anchor" {
+  let state = DiffState::from_diff_result({
+    changes: [diff_state_test_change(11, 12, 11, 11)],
+    additional_alignments: [],
+  })
+  assert_eq(
+    state.next_change_from_modified_line_without_wrap(10).unwrap().change_index,
+    0,
+  )
+}
+
+///|
 test "next F7 at the last modified line wraps before an EOF deletion anchor" {
   let state = DiffState::from_diff_result({
     changes: [

--- a/editor/internal/viewer/diff_editor/editors.mbt
+++ b/editor/internal/viewer/diff_editor/editors.mbt
@@ -34,6 +34,8 @@ fn DiffEditorEditors::create(
   editor_options : @code_widget.CodeEditorOptions,
   diff_word_wrap : DiffWordWrap,
   layout : DiffEditorLayout,
+  render_markdown_comments : Bool,
+  handle_mouse_wheel : Bool,
 ) -> DiffEditorEditors {
   let (shared_services, owned_services) = match services {
     Some(services) => (services, None)
@@ -42,10 +44,10 @@ fn DiffEditorEditors::create(
       (services, Some(services))
     }
   }
-  let pane_options = match diff_word_wrap {
+  let pane_options = (match diff_word_wrap {
     Inherit => editor_options.with_folding(false)
     Off => editor_options.with_soft_wrap(false).with_folding(false)
-  }
+  }).with_handle_mouse_wheel(handle_mouse_wheel)
   let editors : DiffEditorEditors = {
     original: @code_widget.CodeEditorWidget::create(
       original_host,
@@ -66,7 +68,7 @@ fn DiffEditorEditors::create(
   // Apply the initial policy before either kernel ever receives a model. This
   // also covers explicit Inline widgets mounted under display:none, where no
   // positive-size layout transaction will run until much later.
-  editors.sync_markdown_comment_presentations(layout)
+  editors.sync_markdown_comment_presentations(layout, render_markdown_comments)
   editors
 }
 
@@ -166,14 +168,15 @@ fn DiffEditorEditors::update_options(
   editor_options : @code_widget.CodeEditorOptions,
   diff_word_wrap : DiffWordWrap,
   layout : DiffEditorLayout,
+  handle_mouse_wheel : Bool,
 ) -> Unit {
   if self.disposed {
     return
   }
-  let pane_options = match diff_word_wrap {
+  let pane_options = (match diff_word_wrap {
     Inherit => editor_options.with_folding(false)
     Off => editor_options.with_soft_wrap(false).with_folding(false)
-  }
+  }).with_handle_mouse_wheel(handle_mouse_wheel)
   // Pinned DiffEditorEditors always updates both kernels. Inline's clipped
   // original must never wrap: deleted text wraps with the modified editor and
   // paired original ViewZones supply the continuation height.
@@ -193,12 +196,15 @@ fn DiffEditorEditors::update_options(
 fn DiffEditorEditors::sync_markdown_comment_presentations(
   self : DiffEditorEditors,
   layout : DiffEditorLayout,
+  enabled : Bool,
 ) -> Unit {
   if self.disposed {
     return
   }
-  self.original.set_markdown_comment_presentation_enabled(layout == SideBySide)
-  self.modified.set_markdown_comment_presentation_enabled(true)
+  self.original.set_markdown_comment_presentation_enabled(
+    enabled && layout == SideBySide,
+  )
+  self.modified.set_markdown_comment_presentation_enabled(enabled)
 }
 
 ///|

--- a/editor/internal/viewer/diff_editor/options.mbt
+++ b/editor/internal/viewer/diff_editor/options.mbt
@@ -27,6 +27,8 @@ pub(all) struct DiffEditorOptions {
   diff_word_wrap : DiffWordWrap
   overview_ruler : Bool
   render_indicators : Bool
+  render_markdown_comments : Bool
+  handle_mouse_wheel : Bool
   ignore_trim_whitespace : Bool
 }
 
@@ -40,6 +42,8 @@ pub fn DiffEditorOptions::DiffEditorOptions(
   diff_word_wrap? : DiffWordWrap = Inherit,
   overview_ruler? : Bool = true,
   render_indicators? : Bool = true,
+  render_markdown_comments? : Bool = true,
+  handle_mouse_wheel? : Bool = true,
   ignore_trim_whitespace? : Bool = true,
 ) -> DiffEditorOptions {
   {
@@ -51,6 +55,8 @@ pub fn DiffEditorOptions::DiffEditorOptions(
     diff_word_wrap,
     overview_ruler,
     render_indicators,
+    render_markdown_comments,
+    handle_mouse_wheel,
     ignore_trim_whitespace,
   }
 }

--- a/editor/internal/viewer/diff_editor/pkg.generated.mbti
+++ b/editor/internal/viewer/diff_editor/pkg.generated.mbti
@@ -56,9 +56,11 @@ pub(all) struct DiffEditorOptions {
   diff_word_wrap : DiffWordWrap
   overview_ruler : Bool
   render_indicators : Bool
+  render_markdown_comments : Bool
+  handle_mouse_wheel : Bool
   ignore_trim_whitespace : Bool
 }
-pub fn DiffEditorOptions::DiffEditorOptions(layout? : DiffEditorLayout, automatic_inline? : Bool, automatic_inline_width? : Double, sash_enabled? : Bool, split_ratio? : Double, diff_word_wrap? : DiffWordWrap, overview_ruler? : Bool, render_indicators? : Bool, ignore_trim_whitespace? : Bool) -> Self
+pub fn DiffEditorOptions::DiffEditorOptions(layout? : DiffEditorLayout, automatic_inline? : Bool, automatic_inline_width? : Double, sash_enabled? : Bool, split_ratio? : Double, diff_word_wrap? : DiffWordWrap, overview_ruler? : Bool, render_indicators? : Bool, render_markdown_comments? : Bool, handle_mouse_wheel? : Bool, ignore_trim_whitespace? : Bool) -> Self
 pub fn DiffEditorOptions::default() -> Self
 
 pub struct DiffEditorViewModel {
@@ -149,8 +151,10 @@ pub struct DiffEditorWidget {
 pub fn DiffEditorWidget::create(@dom.Element, services? : @code_editor_widget.CodeEditorServices, editor_options? : @code_editor_widget.CodeEditorOptions, options? : DiffEditorOptions, &@diff.DocumentDiffProvider) -> Self
 pub fn DiffEditorWidget::dispose(Self) -> Unit
 pub fn DiffEditorWidget::focus(Self) -> Unit
+pub fn DiffEditorWidget::get_content_height(Self) -> Double
 pub fn DiffEditorWidget::get_diff(Self) -> @diff.DocumentDiff?
 pub fn DiffEditorWidget::get_layout(Self) -> DiffEditorLayout
+pub fn DiffEditorWidget::get_max_scroll_left(Self) -> Double
 pub fn DiffEditorWidget::get_model(Self) -> DiffEditorModelData?
 pub fn DiffEditorWidget::is_diff_up_to_date(Self) -> Bool
 pub fn DiffEditorWidget::layout(Self) -> Unit
@@ -161,6 +165,7 @@ pub fn DiffEditorWidget::reveal_next_change(Self) -> Bool
 pub fn DiffEditorWidget::reveal_previous_change(Self) -> Bool
 pub fn DiffEditorWidget::set_diff_provider(Self, &@diff.DocumentDiffProvider) -> Unit
 pub fn DiffEditorWidget::set_model(Self, DiffEditorModelData?) -> DiffEditorModelData?
+pub fn DiffEditorWidget::set_scroll_left(Self, Double) -> Unit
 pub fn DiffEditorWidget::update_options(Self, @code_editor_widget.CodeEditorOptions, DiffEditorOptions) -> Unit
 
 pub(all) struct DiffEditorWidgetLifecycleSnapshot {

--- a/editor/internal/viewer/diff_editor/pkg.generated.mbti
+++ b/editor/internal/viewer/diff_editor/pkg.generated.mbti
@@ -130,6 +130,8 @@ pub struct DiffEditorWidget {
   mut original_alignment_geometry : PaneGeometrySnapshot?
   mut modified_alignment_geometry : PaneGeometrySnapshot?
   mut diff_state : DiffState?
+  did_change_content_height : @common.Emitter[Double]
+  mut last_published_content_height : Double?
   mut pending_reveal_first_diff_generation : Int?
   mut pending_reveal_last_diff_generation : Int?
   mut reconciling_generation : Int
@@ -160,6 +162,7 @@ pub fn DiffEditorWidget::get_model(Self) -> DiffEditorModelData?
 pub fn DiffEditorWidget::is_diff_up_to_date(Self) -> Bool
 pub fn DiffEditorWidget::layout(Self) -> Unit
 pub fn DiffEditorWidget::lifecycle_snapshot(Self) -> DiffEditorWidgetLifecycleSnapshot
+pub fn DiffEditorWidget::on_did_change_content_height(Self, (Double) -> Unit) -> @common.Disposable
 pub fn DiffEditorWidget::on_did_update_diff(Self, () -> Unit) -> @common.Disposable
 pub fn DiffEditorWidget::reveal_first_diff(Self) -> Unit
 pub fn DiffEditorWidget::reveal_last_diff(Self) -> Unit

--- a/editor/internal/viewer/diff_editor/pkg.generated.mbti
+++ b/editor/internal/viewer/diff_editor/pkg.generated.mbti
@@ -131,6 +131,7 @@ pub struct DiffEditorWidget {
   mut modified_alignment_geometry : PaneGeometrySnapshot?
   mut diff_state : DiffState?
   mut pending_reveal_first_diff_generation : Int?
+  mut pending_reveal_last_diff_generation : Int?
   mut reconciling_generation : Int
   mut is_reconciling : Bool
   layout_render_waiters : Array[@common.Disposable]
@@ -161,8 +162,11 @@ pub fn DiffEditorWidget::layout(Self) -> Unit
 pub fn DiffEditorWidget::lifecycle_snapshot(Self) -> DiffEditorWidgetLifecycleSnapshot
 pub fn DiffEditorWidget::on_did_update_diff(Self, () -> Unit) -> @common.Disposable
 pub fn DiffEditorWidget::reveal_first_diff(Self) -> Unit
+pub fn DiffEditorWidget::reveal_last_diff(Self) -> Unit
 pub fn DiffEditorWidget::reveal_next_change(Self) -> Bool
+pub fn DiffEditorWidget::reveal_next_change_without_wrap(Self) -> Bool
 pub fn DiffEditorWidget::reveal_previous_change(Self) -> Bool
+pub fn DiffEditorWidget::reveal_previous_change_without_wrap(Self) -> Bool
 pub fn DiffEditorWidget::set_diff_provider(Self, &@diff.DocumentDiffProvider) -> Unit
 pub fn DiffEditorWidget::set_model(Self, DiffEditorModelData?) -> DiffEditorModelData?
 pub fn DiffEditorWidget::set_scroll_left(Self, Double) -> Unit

--- a/editor/internal/viewer/diff_editor/widget.mbt
+++ b/editor/internal/viewer/diff_editor/widget.mbt
@@ -42,6 +42,9 @@ pub struct DiffEditorWidget {
   /// asynchronous diff computation and hidden/layout render barriers, but a
   /// replacement pair makes it stale instead of moving the new document.
   mut pending_reveal_first_diff_generation : Int?
+  /// Symmetric request used when a multi-diff host enters this item while
+  /// navigating backward.
+  mut pending_reveal_last_diff_generation : Int?
   mut reconciling_generation : Int
   mut is_reconciling : Bool
   /// Cancellable paint barrier for the latest outer layout transaction.
@@ -207,6 +210,7 @@ pub fn DiffEditorWidget::create(
     modified_alignment_geometry: None,
     diff_state: None,
     pending_reveal_first_diff_generation: None,
+    pending_reveal_last_diff_generation: None,
     reconciling_generation: 0,
     is_reconciling: false,
     layout_render_waiters: [],
@@ -1264,11 +1268,13 @@ fn DiffEditorWidget::reconcile_view_model(self : DiffEditorWidget) -> Unit {
     self.view_model.get_model() is Some(model) else {
     self.commit_empty_diff_features(generation)
     self.try_reveal_first_diff()
+    self.try_reveal_last_diff()
     return
   }
   let diff_state = DiffState::from_diff_result(document_diff)
   self.commit_diff_state(diff_state, model, generation)
   self.try_reveal_first_diff()
+  self.try_reveal_last_diff()
 }
 
 ///|
@@ -1304,6 +1310,7 @@ pub fn DiffEditorWidget::set_model(
     return None
   }
   self.pending_reveal_first_diff_generation = None
+  self.pending_reveal_last_diff_generation = None
   self.pending_layout_modified_viewport = None
   self.clear_pending_scroll_echoes()
   self.clear_diff_features_for_transition()
@@ -1640,6 +1647,49 @@ pub fn DiffEditorWidget::reveal_first_diff(self : DiffEditorWidget) -> Unit {
 }
 
 ///|
+/// Consume a deferred final-diff request under the same model/layout fences as
+/// `reveal_first_diff`.
+fn DiffEditorWidget::try_reveal_last_diff(self : DiffEditorWidget) -> Unit {
+  guard self.pending_reveal_last_diff_generation is Some(generation) else {
+    return
+  }
+  if self.editors.committed_model_generation() != generation ||
+    !self.editors.same_model(self.view_model.get_model()) {
+    self.pending_reveal_last_diff_generation = None
+    return
+  }
+  match self.view_model.get_state() {
+    Pending => return
+    NoModel | Failed => {
+      self.pending_reveal_last_diff_generation = None
+      return
+    }
+    Ready => ()
+  }
+  guard self.diff_state is Some(diff_state) else { return }
+  self.pending_reveal_last_diff_generation = None
+  guard !diff_state.mappings.is_empty() else { return }
+  self.reveal_change(
+    diff_state.mappings[diff_state.mappings.length() - 1].line_range_mapping,
+    source="diffEditor.revealLastDiff",
+  )
+  |> ignore
+}
+
+///|
+/// Request a one-shot reveal of the current comparison's final raw mapping.
+/// Multi-diff hosts use this when Shift+F7 crosses into the previous item.
+pub fn DiffEditorWidget::reveal_last_diff(self : DiffEditorWidget) -> Unit {
+  if self.disposed || self.view_model.get_model() is None {
+    return
+  }
+  self.pending_reveal_last_diff_generation = Some(
+    self.editors.committed_model_generation(),
+  )
+  self.try_reveal_last_diff()
+}
+
+///|
 pub fn DiffEditorWidget::reveal_next_change(self : DiffEditorWidget) -> Bool {
   guard self.view_model.get_model() is Some(model) else { return false }
   let current_line = self.editors.modified
@@ -1657,6 +1707,23 @@ pub fn DiffEditorWidget::reveal_next_change(self : DiffEditorWidget) -> Bool {
 }
 
 ///|
+/// Reveal the next change only when it remains inside this comparison. A
+/// multi-diff host uses `false` as the signal to advance to its next item.
+pub fn DiffEditorWidget::reveal_next_change_without_wrap(
+  self : DiffEditorWidget,
+) -> Bool {
+  let current_line = self.editors.modified
+    .get_position()
+    .map_or(1, position => position.line_number)
+  guard self.diff_state is Some(diff_state) &&
+    diff_state.next_change_from_modified_line_without_wrap(current_line)
+    is Some(target) else {
+    return false
+  }
+  self.reveal_navigation_target(target)
+}
+
+///|
 pub fn DiffEditorWidget::reveal_previous_change(
   self : DiffEditorWidget,
 ) -> Bool {
@@ -1665,6 +1732,22 @@ pub fn DiffEditorWidget::reveal_previous_change(
     .map_or(1, position => position.line_number)
   guard self.diff_state is Some(diff_state) &&
     diff_state.previous_change_from_modified_line(current_line) is Some(target) else {
+    return false
+  }
+  self.reveal_navigation_target(target)
+}
+
+///|
+/// Reveal the previous change only when it remains inside this comparison.
+pub fn DiffEditorWidget::reveal_previous_change_without_wrap(
+  self : DiffEditorWidget,
+) -> Bool {
+  let current_line = self.editors.modified
+    .get_position()
+    .map_or(1, position => position.line_number)
+  guard self.diff_state is Some(diff_state) &&
+    diff_state.previous_change_from_modified_line_without_wrap(current_line)
+    is Some(target) else {
     return false
   }
   self.reveal_navigation_target(target)
@@ -1823,6 +1906,7 @@ pub fn DiffEditorWidget::dispose(self : DiffEditorWidget) -> Unit {
   self.modified_alignment_geometry = None
   self.diff_state = None
   self.pending_reveal_first_diff_generation = None
+  self.pending_reveal_last_diff_generation = None
   self.reconciling_generation = 0
   self.is_reconciling = false
   self.layout_render_generation = 0

--- a/editor/internal/viewer/diff_editor/widget.mbt
+++ b/editor/internal/viewer/diff_editor/widget.mbt
@@ -171,6 +171,8 @@ pub fn DiffEditorWidget::create(
     editor_options,
     options.diff_word_wrap,
     options.layout,
+    options.render_markdown_comments,
+    options.handle_mouse_wheel,
   )
   let view_model = DiffEditorViewModel(provider, options={
     ignore_trim_whitespace: options.ignore_trim_whitespace,
@@ -1382,10 +1384,12 @@ pub fn DiffEditorWidget::update_options(
       editor_options,
       options.diff_word_wrap,
       self.layout_state.actual_layout,
+      options.handle_mouse_wheel,
     )
     self.apply_layout_dom()
     self.editors.sync_markdown_comment_presentations(
       self.layout_state.actual_layout,
+      options.render_markdown_comments,
     )
     self.layout_editors_after_render()
   }
@@ -1399,6 +1403,39 @@ pub fn DiffEditorWidget::get_layout(
   self : DiffEditorWidget,
 ) -> DiffEditorLayout {
   self.layout_state.actual_layout
+}
+
+///|
+/// Total height required by the taller pane, including diff alignment view
+/// zones. Hosts that stack independent DiffEditors use this to size each
+/// section without introducing a nested vertical scrollbar.
+pub fn DiffEditorWidget::get_content_height(self : DiffEditorWidget) -> Double {
+  self.editors.original
+  .get_content_height()
+  .max(self.editors.modified.get_content_height())
+}
+
+///|
+/// Largest horizontal overflow of either code pane. MultiDiffEditor uses one
+/// outer horizontal scrollbar and projects its offset into every item, just as
+/// VS Code's DiffEditorItemTemplate reports `maxScroll` to its parent widget.
+pub fn DiffEditorWidget::get_max_scroll_left(self : DiffEditorWidget) -> Double {
+  let original = (self.editors.original.get_scroll_width() -
+  self.editors.original.get_layout_info().content_width).max(0.0)
+  let modified = (self.editors.modified.get_scroll_width() -
+  self.editors.modified.get_layout_info().content_width).max(0.0)
+  original.max(modified)
+}
+
+///|
+/// Apply the MultiDiffEditor's shared horizontal offset to both panes. The
+/// existing pane synchronization absorbs any resulting scroll event echo.
+pub fn DiffEditorWidget::set_scroll_left(
+  self : DiffEditorWidget,
+  scroll_left : Double,
+) -> Unit {
+  self.editors.original.set_scroll_left(scroll_left)
+  self.editors.modified.set_scroll_left(scroll_left)
 }
 
 ///|
@@ -1721,10 +1758,12 @@ pub fn DiffEditorWidget::layout(self : DiffEditorWidget) -> Unit {
     self.editor_options,
     self.options.diff_word_wrap,
     self.layout_state.actual_layout,
+    self.options.handle_mouse_wheel,
   )
   self.apply_layout_dom()
   self.editors.sync_markdown_comment_presentations(
     self.layout_state.actual_layout,
+    self.options.render_markdown_comments,
   )
   self.layout_editors_after_render()
 }

--- a/editor/internal/viewer/diff_editor/widget.mbt
+++ b/editor/internal/viewer/diff_editor/widget.mbt
@@ -37,6 +37,12 @@ pub struct DiffEditorWidget {
   mut original_alignment_geometry : PaneGeometrySnapshot?
   mut modified_alignment_geometry : PaneGeometrySnapshot?
   mut diff_state : DiffState?
+  /// The section-host contract is published only after one complete geometry
+  /// reconcile has committed both panes' owned alignment zones. Retaining the
+  /// last value prevents a host height write followed by `layout()` from
+  /// feeding the same height back into the host.
+  did_change_content_height : @base_common.Emitter[Double]
+  mut last_published_content_height : Double?
   /// One VS Code-style `revealFirstDiff` request, bound to the model-pair
   /// generation that was current when the host made it. The request survives
   /// asynchronous diff computation and hidden/layout render barriers, but a
@@ -209,6 +215,8 @@ pub fn DiffEditorWidget::create(
     original_alignment_geometry: None,
     modified_alignment_geometry: None,
     diff_state: None,
+    did_change_content_height: Emitter(),
+    last_published_content_height: None,
     pending_reveal_first_diff_generation: None,
     pending_reveal_last_diff_generation: None,
     reconciling_generation: 0,
@@ -1215,11 +1223,13 @@ fn DiffEditorWidget::commit_diff_state(
 fn DiffEditorWidget::reconcile_geometry_if_changed(
   self : DiffEditorWidget,
 ) -> Unit {
-  if self.disposed ||
-    self.editors.is_committing_model_pair() ||
-    self.is_reconciling ||
-    self.diff_state is None ||
-    self.view_model.get_diff() is None {
+  // Always re-enter through the paired transaction. Besides committing both
+  // sides' derived alignment zones, `reconcile_view_model` owns the pane-render
+  // barrier, positive-layout, model-pair, and generation fences. Publishing
+  // directly from this child event would expose the exact one-pane
+  // intermediate state this event is designed to hide.
+  if self.diff_state is None || self.view_model.get_diff() is None {
+    self.reconcile_view_model()
     return
   }
   let (original, modified) = self.capture_alignment_geometry()
@@ -1229,10 +1239,35 @@ fn DiffEditorWidget::reconcile_geometry_if_changed(
     self.original_alignment_geometry,
     self.modified_alignment_geometry,
   )
-  if !geometry_changed {
+  let content_height = self.get_content_height()
+  let content_height_changed = content_height > 0.0 &&
+    self.last_published_content_height != Some(content_height)
+  if geometry_changed || content_height_changed {
+    // Even the content-height-only path must cross the complete reconciliation
+    // gate; it must never publish directly from one child editor.
+    self.reconcile_view_model()
+  }
+}
+
+///|
+/// Publish the final paired height, never an intermediate child-editor height.
+/// In particular, a Markdown-comment ViewZone first changes one pane, then the
+/// diff geometry transaction replaces alignment zones in both panes. This
+/// method runs only after that transaction and updates the retained value
+/// before firing so a synchronous host resize cannot re-enter with a duplicate.
+fn DiffEditorWidget::publish_content_height_if_changed(
+  self : DiffEditorWidget,
+) -> Unit {
+  if self.disposed {
     return
   }
-  self.reconcile_view_model()
+  let content_height = self.get_content_height()
+  if content_height <= 0.0 ||
+    self.last_published_content_height == Some(content_height) {
+    return
+  }
+  self.last_published_content_height = Some(content_height)
+  self.did_change_content_height.fire(content_height)
 }
 
 ///|
@@ -1261,6 +1296,10 @@ fn DiffEditorWidget::reconcile_view_model(self : DiffEditorWidget) -> Unit {
   self.is_reconciling = true
   defer {
     self.is_reconciling = false
+    // `commit_diff_state` has now replaced both sides' alignment zones. A
+    // section host can synchronously adopt this height without observing the
+    // one-pane Markdown/ViewZone intermediate state.
+    self.publish_content_height_if_changed()
   }
   self.reconciling_generation += 1
   let generation = self.reconciling_generation
@@ -1420,6 +1459,17 @@ pub fn DiffEditorWidget::get_content_height(self : DiffEditorWidget) -> Double {
   self.editors.original
   .get_content_height()
   .max(self.editors.modified.get_content_height())
+}
+
+///|
+/// Fires after a complete paired geometry transaction changes the final
+/// content height. The payload already includes Markdown/foreign ViewZones and
+/// both panes' committed alignment zones.
+pub fn DiffEditorWidget::on_did_change_content_height(
+  self : DiffEditorWidget,
+  listener : (Double) -> Unit,
+) -> @base_common.Disposable {
+  self.did_change_content_height.event(listener)
 }
 
 ///|
@@ -1905,6 +1955,7 @@ pub fn DiffEditorWidget::dispose(self : DiffEditorWidget) -> Unit {
   self.original_alignment_geometry = None
   self.modified_alignment_geometry = None
   self.diff_state = None
+  self.last_published_content_height = None
   self.pending_reveal_first_diff_generation = None
   self.pending_reveal_last_diff_generation = None
   self.reconciling_generation = 0
@@ -1913,5 +1964,6 @@ pub fn DiffEditorWidget::dispose(self : DiffEditorWidget) -> Unit {
   self.has_valid_layout_box = false
   self.inline_original_strip_width = -1.0
   self.clear_pending_scroll_echoes()
+  self.did_change_content_height.dispose()
   self.host.remove_child(self.root.as_node())
 }

--- a/editor/moon.mod
+++ b/editor/moon.mod
@@ -20,7 +20,7 @@ warnings = "+prefer_readonly_array"
 
 import {
   "moonbit-community/cmark@0.4.5",
-  "moonbit-community/moondiff@0.0.1",
+  "moonbit-community/moondiff@0.0.3",
   "moonbitlang/async@0.21.0",
   "moonbit-community/rabbita@0.14.3",
   "Milky2018/diago@0.3.0",

--- a/editor/moon.mod
+++ b/editor/moon.mod
@@ -20,7 +20,7 @@ warnings = "+prefer_readonly_array"
 
 import {
   "moonbit-community/cmark@0.4.5",
-  "moonbit-community/moondiff@0.0.3",
+  "moonbit-community/moondiff@0.0.5",
   "moonbitlang/async@0.21.0",
   "moonbit-community/rabbita@0.14.3",
   "Milky2018/diago@0.3.0",

--- a/editor/moon.mod
+++ b/editor/moon.mod
@@ -20,7 +20,7 @@ warnings = "+prefer_readonly_array"
 
 import {
   "moonbit-community/cmark@0.4.5",
-  "moonbit-community/moondiff@0.0.5",
+  "moonbit-community/moondiff@0.0.6",
   "moonbitlang/async@0.21.0",
   "moonbit-community/rabbita@0.14.3",
   "Milky2018/diago@0.3.0",

--- a/editor/tests/browser/component/diff_editor_lifecycle.spec.js
+++ b/editor/tests/browser/component/diff_editor_lifecycle.spec.js
@@ -123,6 +123,28 @@ test('reveals raw mappings[0] when the first hunk starts on the cursor line', as
   await disposeDiffLifecycle(page);
 });
 
+test('reveals the final raw mapping for backward multi-diff navigation', async ({ page }) => {
+  const root = await openDiffLifecycle(page);
+  const modified = root.locator('.moonbit-diff-editor-modified');
+  await setDiffLifecycleFixture(page, 'first-line');
+  await waitForDiffLifecycleIdle(page);
+
+  await page.evaluate(() =>
+    globalThis.__diffEditorLifecycleControls.reveal_last_diff(),
+  );
+
+  await expect(
+    modified.locator('.line-numbers.active-line-number'),
+  ).toHaveText('100');
+  await expect(
+    modified.locator('.view-line').filter({
+      hasText: 'new second hunk at line 100',
+    }),
+  ).toBeVisible();
+
+  await disposeDiffLifecycle(page);
+});
+
 test('defers a one-shot first-diff reveal through computation and hidden layout', async ({ page }) => {
   const root = await openDiffLifecycle(page);
   const host = page.locator('.diff-lifecycle-host');

--- a/editor/tests/browser/component/diff_markdown_comments.spec.js
+++ b/editor/tests/browser/component/diff_markdown_comments.spec.js
@@ -69,6 +69,18 @@ async function expectOriginalLineNumbers(original, expected) {
   )).toEqual(expect.arrayContaining(expected));
 }
 
+async function contentHeightState(page) {
+  return page.evaluate(() => {
+    const controls = globalThis.__diffMarkdownCommentsControls;
+    const host = document.querySelector('.diff-markdown-comments-host');
+    return {
+      eventCount: controls.content_height_event_count(),
+      contentHeight: controls.content_height(),
+      hostHeight: host.getBoundingClientRect().height,
+    };
+  });
+}
+
 test('keeps rich comments in both split panes and only the modified inline pane', async ({ page }) => {
   const root = await openFixture(page);
   const original = root.locator('.moonbit-diff-editor-original');
@@ -189,4 +201,73 @@ test('balances a final-line change inside a compact multi-line comment', async (
   await expect(modified.locator(commentSelector)).toHaveCount(1);
   await expect(modifiedCompensation).toHaveCount(1);
   await expectTailAlignment(root);
+});
+
+test('publishes one final paired height for a Markdown comment fold change', async ({ page }) => {
+  const root = await openFixture(page);
+  const original = root.locator('.moonbit-diff-editor-original');
+  const modified = root.locator('.moonbit-diff-editor-modified');
+
+  await control(page, 'set_layout', 'split');
+  await expect(original.locator(commentSelector)).toHaveCount(1);
+  await expect(modified.locator(commentSelector)).toHaveCount(1);
+  await waitForFrames(page, 6);
+  await page.evaluate(() => {
+    globalThis.__diffMarkdownCommentsControls.enable_auto_height();
+  });
+  await waitForFrames(page, 4);
+
+  const folded = await contentHeightState(page);
+  expect(Math.abs(
+    folded.hostHeight - Math.max(40, Math.ceil(folded.contentHeight) + 2),
+  )).toBeLessThanOrEqual(1);
+
+  await modified.locator(
+    '.moonbit-viewer-markdown-comment-toggle[aria-label="Expand API documentation"]',
+  ).click();
+  await expect.poll(async () =>
+    (await contentHeightState(page)).eventCount,
+  ).toBe(folded.eventCount + 1);
+
+  const expanded = await contentHeightState(page);
+  expect(expanded.hostHeight).toBeGreaterThan(folded.hostHeight);
+  expect(Math.abs(
+    expanded.hostHeight - Math.max(40, Math.ceil(expanded.contentHeight) + 2),
+  )).toBeLessThanOrEqual(1);
+  await expect.poll(() => modified.locator(commentSelector).evaluate((node) => {
+    const content = node.querySelector(
+      '.moonbit-viewer-markdown-comment-content',
+    );
+    return Math.abs(
+      node.getBoundingClientRect().height - content.offsetHeight,
+    );
+  })).toBeLessThanOrEqual(1);
+  await expectTailAlignment(root);
+
+  await waitForFrames(page, 6);
+  const stableExpanded = await contentHeightState(page);
+  expect(stableExpanded.eventCount).toBe(expanded.eventCount);
+  expect(Math.abs(stableExpanded.hostHeight - expanded.hostHeight))
+    .toBeLessThanOrEqual(1);
+
+  await modified.locator(
+    '.moonbit-viewer-markdown-comment-toggle[aria-label="Collapse API documentation"]',
+  ).click();
+  await expect.poll(async () =>
+    (await contentHeightState(page)).eventCount,
+  ).toBe(expanded.eventCount + 1);
+  const collapsed = await contentHeightState(page);
+  expect(collapsed.hostHeight).toBeLessThan(expanded.hostHeight);
+  expect(Math.abs(
+    collapsed.hostHeight - Math.max(40, Math.ceil(collapsed.contentHeight) + 2),
+  )).toBeLessThanOrEqual(1);
+  expect(Math.abs(collapsed.hostHeight - folded.hostHeight))
+    .toBeLessThanOrEqual(1);
+  await expectTailAlignment(root);
+
+  await waitForFrames(page, 6);
+  const stableCollapsed = await contentHeightState(page);
+  expect(stableCollapsed.eventCount).toBe(collapsed.eventCount);
+  expect(Math.abs(stableCollapsed.hostHeight - collapsed.hostHeight))
+    .toBeLessThanOrEqual(1);
 });

--- a/editor/tests/browser/moonbit/component/diff_editor_lifecycle_scenario.mbt
+++ b/editor/tests/browser/moonbit/component/diff_editor_lifecycle_scenario.mbt
@@ -265,6 +265,7 @@ fn run_diff_editor_lifecycle_test() -> Unit {
       |> ignore
     },
     () => widget.reveal_first_diff(),
+    () => widget.reveal_last_diff(),
     () => widget.dispose(),
     () => {
       original.dispose()
@@ -292,10 +293,11 @@ extern "js" fn install_diff_editor_lifecycle_controls(
   set_provider : (String) -> Unit,
   set_model_attached : (Bool) -> Unit,
   reveal_first_diff : () -> Unit,
+  reveal_last_diff : () -> Unit,
   dispose : () -> Unit,
   dispose_models : () -> Unit,
 ) -> Unit =
-  #| (snapshot, setFixture, setDigitLineCount, setOptions, setProvider, setModelAttached, revealFirstDiff, dispose, disposeModels) => {
+  #| (snapshot, setFixture, setDigitLineCount, setOptions, setProvider, setModelAttached, revealFirstDiff, revealLastDiff, dispose, disposeModels) => {
   #|   globalThis.__diffEditorLifecycleControls = Object.freeze({
   #|     snapshot() { return JSON.parse(snapshot()); },
   #|     set_fixture: setFixture,
@@ -304,6 +306,7 @@ extern "js" fn install_diff_editor_lifecycle_controls(
   #|     set_provider: setProvider,
   #|     set_model_attached: setModelAttached,
   #|     reveal_first_diff: revealFirstDiff,
+  #|     reveal_last_diff: revealLastDiff,
   #|     dispose,
   #|     dispose_models: disposeModels,
   #|   });

--- a/editor/tests/browser/moonbit/component/diff_markdown_comments_scenario.mbt
+++ b/editor/tests/browser/moonbit/component/diff_markdown_comments_scenario.mbt
@@ -90,6 +90,47 @@ fn diff_markdown_comment_partial_modified_source() -> String {
 }
 
 ///|
+priv struct DiffMarkdownCommentProvider {}
+
+///|
+impl @language.MarkdownCommentProvider for DiffMarkdownCommentProvider with fn provide_markdown_comments(
+  _self,
+  model,
+) {
+  let snapshot = model.snapshot()
+  let blocks : Array[@language.MarkdownCommentBlock] = []
+  let mut line_number = 1
+  while line_number <= snapshot.line_count() {
+    let line = snapshot.get_line_content(line_number).trim().to_owned()
+    if !line.has_prefix("///") {
+      line_number += 1
+      continue
+    }
+    let start_line_number = line_number
+    let markdown : Array[String] = []
+    while line_number <= snapshot.line_count() {
+      let line = snapshot.get_line_content(line_number).trim().to_owned()
+      if !line.has_prefix("///") {
+        break
+      }
+      let mut content_start = 3
+      if content_start < line.length() && line[content_start].to_int() == 32 {
+        content_start += 1
+      }
+      markdown.push(
+        line.unsafe_substring(start=content_start, end=line.length()),
+      )
+      line_number += 1
+    }
+    blocks.push({
+      line_range: LineRange(start_line_number, line_number),
+      markdown: "---\n\n" + markdown.join("\n"),
+    })
+  }
+  blocks
+}
+
+///|
 fn run_diff_markdown_comments_test() -> Unit {
   let document = @rdom.document()
   guard document.query_selector("#app").to_option() is Some(app) else {
@@ -111,6 +152,11 @@ fn run_diff_markdown_comments_test() -> Unit {
   })
   languages.set_tokens_provider("moonbit", @lang_moonbit.MoonBitTokenizer())
   |> ignore
+  let markdown_registration = languages.register_markdown_comment_provider(
+    LanguageId("moonbit"),
+    DiffMarkdownCommentProvider::{ },
+    foldable=true,
+  )
   let services = @viewer.ViewerServices(
     languages=languages.language_handle(log_service.log_handle()),
     log_service=log_service.log_handle(),
@@ -129,6 +175,25 @@ fn run_diff_markdown_comments_test() -> Unit {
       automatic_inline=false,
     ),
   )
+  let content_height_event_count = Ref(0)
+  let auto_height_enabled = Ref(false)
+  let apply_content_height = content_height => {
+    if content_height <= 0.0 {
+      return
+    }
+    @base_browser.set_style_property(
+      host,
+      "height",
+      "\{(content_height.ceil() + 2.0).max(40.0)}px",
+    )
+    diff_editor.layout()
+  }
+  let content_height_subscription = diff_editor.on_did_change_content_height(content_height => {
+    content_height_event_count.val += 1
+    if auto_height_enabled.val {
+      apply_content_height(content_height)
+    }
+  })
   let unchanged_original = diff_markdown_comment_model(
     "unchanged-original",
     diff_markdown_comment_unchanged_source(),
@@ -189,6 +254,13 @@ fn run_diff_markdown_comments_test() -> Unit {
       diff_editor.layout()
     },
     () => {
+      auto_height_enabled.val = true
+      apply_content_height(diff_editor.get_content_height())
+    },
+    () => content_height_event_count.val,
+    () => diff_editor.get_content_height(),
+    () => {
+      content_height_subscription.dispose()
       diff_editor.dispose()
       unchanged_original.dispose()
       unchanged_modified.dispose()
@@ -196,6 +268,7 @@ fn run_diff_markdown_comments_test() -> Unit {
       replacement_modified.dispose()
       partial_original.dispose()
       partial_modified.dispose()
+      markdown_registration.dispose()
       services.dispose()
     },
   )
@@ -207,14 +280,20 @@ extern "js" fn install_diff_markdown_comments_controls(
   set_fixture : (String) -> Unit,
   set_layout : (String) -> Unit,
   resize : (Int) -> Unit,
+  enable_auto_height : () -> Unit,
+  content_height_event_count : () -> Int,
+  content_height : () -> Double,
   dispose : () -> Unit,
 ) -> Unit =
-  #| (initialHiddenOriginalComments, setFixture, setLayout, resize, dispose) => {
+  #| (initialHiddenOriginalComments, setFixture, setLayout, resize, enableAutoHeight, contentHeightEventCount, contentHeight, dispose) => {
   #|   globalThis.__diffMarkdownCommentsControls = Object.freeze({
   #|     initialHiddenOriginalComments,
   #|     set_fixture: setFixture,
   #|     set_layout: setLayout,
   #|     resize,
+  #|     enable_auto_height: enableAutoHeight,
+  #|     content_height_event_count: contentHeightEventCount,
+  #|     content_height: contentHeight,
   #|     dispose,
   #|   });
   #| }

--- a/editor/tests/browser/moonbit/component/moon.pkg
+++ b/editor/tests/browser/moonbit/component/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "moonbitlang/editor/base/browser" @base_browser,
   "moonbitlang/editor/base/common" @base_common,
   "moonbitlang/editor/language",
   "moonbitlang/editor/platform/log",

--- a/editor/viewer/README.mbt.md
+++ b/editor/viewer/README.mbt.md
@@ -151,9 +151,11 @@ features. Its `MarkdownResourceKind` is explicit and is never inferred inside
 the widget.
 
 `DiffEditor` owns the model pair, provider/options, layout, focus, current diff
-state, update event, and next/previous change navigation. It is readonly; moves,
-hide-unchanged, revert, editing, and the full accessible diff viewer are outside
-the current scope.
+state, update event, paired content-height event, and next/previous change
+navigation. The height event is published only after both panes' alignment
+zones commit, so a stacked host never consumes a one-pane intermediate height.
+It is readonly; moves, hide-unchanged, revert, editing, and the full accessible
+diff viewer are outside the current scope.
 
 ## Package and architecture boundaries
 

--- a/editor/viewer/diff_editor_facade.mbt
+++ b/editor/viewer/diff_editor_facade.mbt
@@ -287,13 +287,33 @@ pub fn DiffEditor::reveal_first_diff(self : DiffEditor) -> Unit {
 }
 
 ///|
+/// Reveal the final raw diff mapping once the current comparison is ready.
+pub fn DiffEditor::reveal_last_diff(self : DiffEditor) -> Unit {
+  self.widget.reveal_last_diff()
+}
+
+///|
 pub fn DiffEditor::reveal_next_change(self : DiffEditor) -> Bool {
   self.widget.reveal_next_change()
 }
 
 ///|
+/// Reveal the next change only when it remains inside this comparison.
+pub fn DiffEditor::reveal_next_change_without_wrap(self : DiffEditor) -> Bool {
+  self.widget.reveal_next_change_without_wrap()
+}
+
+///|
 pub fn DiffEditor::reveal_previous_change(self : DiffEditor) -> Bool {
   self.widget.reveal_previous_change()
+}
+
+///|
+/// Reveal the previous change only when it remains inside this comparison.
+pub fn DiffEditor::reveal_previous_change_without_wrap(
+  self : DiffEditor,
+) -> Bool {
+  self.widget.reveal_previous_change_without_wrap()
 }
 
 ///|

--- a/editor/viewer/diff_editor_facade.mbt
+++ b/editor/viewer/diff_editor_facade.mbt
@@ -39,6 +39,8 @@ struct DiffEditorOptions {
   diff_word_wrap : DiffWordWrap
   overview_ruler : Bool
   render_indicators : Bool
+  render_markdown_comments : Bool
+  handle_mouse_wheel : Bool
   ignore_trim_whitespace : Bool
 }
 
@@ -55,6 +57,8 @@ pub fn DiffEditorOptions::DiffEditorOptions(
   diff_word_wrap? : DiffWordWrap = Inherit,
   overview_ruler? : Bool = true,
   render_indicators? : Bool = true,
+  render_markdown_comments? : Bool = true,
+  handle_mouse_wheel? : Bool = true,
   ignore_trim_whitespace? : Bool = true,
 ) -> DiffEditorOptions {
   {
@@ -67,6 +71,8 @@ pub fn DiffEditorOptions::DiffEditorOptions(
     diff_word_wrap,
     overview_ruler,
     render_indicators,
+    render_markdown_comments,
+    handle_mouse_wheel,
     ignore_trim_whitespace,
   }
 }
@@ -138,6 +144,8 @@ fn DiffEditorOptions::internal(
     diff_word_wrap=self.diff_word_wrap.internal(),
     overview_ruler=self.overview_ruler,
     render_indicators=self.render_indicators,
+    render_markdown_comments=self.render_markdown_comments,
+    handle_mouse_wheel=self.handle_mouse_wheel,
     ignore_trim_whitespace=self.ignore_trim_whitespace,
   )
 }
@@ -229,6 +237,27 @@ pub fn DiffEditor::get_layout(self : DiffEditor) -> DiffEditorLayout {
     SideBySide => SideBySide
     Inline => Inline
   }
+}
+
+///|
+/// Total height required by the taller diff pane, including alignment zones.
+pub fn DiffEditor::get_content_height(self : DiffEditor) -> Double {
+  self.widget.get_content_height()
+}
+
+///|
+/// Horizontal overflow exposed for VS Code-shaped MultiDiffEditor hosts.
+pub fn DiffEditor::get_max_scroll_left(self : DiffEditor) -> Double {
+  self.widget.get_max_scroll_left()
+}
+
+///|
+/// Set the shared horizontal offset of both diff panes.
+pub fn DiffEditor::set_scroll_left(
+  self : DiffEditor,
+  scroll_left : Double,
+) -> Unit {
+  self.widget.set_scroll_left(scroll_left)
 }
 
 ///|

--- a/editor/viewer/diff_editor_facade.mbt
+++ b/editor/viewer/diff_editor_facade.mbt
@@ -246,6 +246,16 @@ pub fn DiffEditor::get_content_height(self : DiffEditor) -> Double {
 }
 
 ///|
+/// Fires when a complete paired geometry reconciliation changes the final
+/// maximum content height, after derived alignment zones have committed.
+pub fn DiffEditor::on_did_change_content_height(
+  self : DiffEditor,
+  listener : (Double) -> Unit,
+) -> @base_common.Disposable {
+  self.widget.on_did_change_content_height(listener)
+}
+
+///|
 /// Horizontal overflow exposed for VS Code-shaped MultiDiffEditor hosts.
 pub fn DiffEditor::get_max_scroll_left(self : DiffEditor) -> Double {
   self.widget.get_max_scroll_left()

--- a/editor/viewer/diff_provider/moondiff/moon.pkg
+++ b/editor/viewer/diff_provider/moondiff/moon.pkg
@@ -3,5 +3,4 @@ import {
   "moonbitlang/editor/viewer/common/diff",
   "moonbitlang/editor/viewer/common/model",
   "moonbit-community/moondiff/mbtdiff",
-  "moonbit-community/moondiff/tokdiff",
 }

--- a/editor/viewer/diff_provider/moondiff/pkg.generated.mbti
+++ b/editor/viewer/diff_provider/moondiff/pkg.generated.mbti
@@ -5,12 +5,11 @@ import {
   "moonbitlang/core/debug",
   "moonbitlang/editor/base/common",
   "moonbitlang/editor/viewer/common/diff",
+  "moonbitlang/editor/viewer/common/model",
 }
 
 // Values
 pub fn compute_sectioned_semantic_review_plan(String, String, MoonDiffMode, old_name? : String, new_name? : String, ignore_comments? : Bool, ignore_tests? : Bool) -> SectionedSemanticReviewPlan?
-
-pub fn fragment_document_diff(@moonbit-community/moondiff/model.HunkDocument, String, String) -> @diff.DocumentDiff?
 
 // Errors
 

--- a/editor/viewer/diff_provider/moondiff/pkg.generated.mbti
+++ b/editor/viewer/diff_provider/moondiff/pkg.generated.mbti
@@ -34,17 +34,20 @@ pub fn MoonDiffStatus::to_repr(Self) -> @debug.Repr
 pub struct MoonDocumentDiffProvider {
   mut mode : MoonDiffMode
   mut ignore_comments : Bool
+  mut ignore_tests : Bool
   mut status : MoonDiffStatus
   did_change : @common.Emitter[Unit]
   mut disposed : Bool
 }
-pub fn MoonDocumentDiffProvider::MoonDocumentDiffProvider(mode? : MoonDiffMode, ignore_comments? : Bool) -> Self
+pub fn MoonDocumentDiffProvider::MoonDocumentDiffProvider(mode? : MoonDiffMode, ignore_comments? : Bool, ignore_tests? : Bool) -> Self
 pub fn MoonDocumentDiffProvider::as_document_diff_provider(Self) -> &@diff.DocumentDiffProvider
 pub fn MoonDocumentDiffProvider::dispose(Self) -> Unit
 pub fn MoonDocumentDiffProvider::get_ignore_comments(Self) -> Bool
+pub fn MoonDocumentDiffProvider::get_ignore_tests(Self) -> Bool
 pub fn MoonDocumentDiffProvider::get_mode(Self) -> MoonDiffMode
 pub fn MoonDocumentDiffProvider::get_status(Self) -> MoonDiffStatus
 pub fn MoonDocumentDiffProvider::set_ignore_comments(Self, Bool) -> Unit
+pub fn MoonDocumentDiffProvider::set_ignore_tests(Self, Bool) -> Unit
 pub fn MoonDocumentDiffProvider::set_mode(Self, MoonDiffMode) -> Unit
 pub impl @diff.DocumentDiffProvider for MoonDocumentDiffProvider
 

--- a/editor/viewer/diff_provider/moondiff/pkg.generated.mbti
+++ b/editor/viewer/diff_provider/moondiff/pkg.generated.mbti
@@ -5,10 +5,12 @@ import {
   "moonbitlang/core/debug",
   "moonbitlang/editor/base/common",
   "moonbitlang/editor/viewer/common/diff",
-  "moonbitlang/editor/viewer/common/model",
 }
 
 // Values
+pub fn compute_sectioned_semantic_review_plan(String, String, MoonDiffMode, old_name? : String, new_name? : String, ignore_comments? : Bool, ignore_tests? : Bool) -> SectionedSemanticReviewPlan?
+
+pub fn fragment_document_diff(@moonbit-community/moondiff/model.HunkDocument, String, String) -> @diff.DocumentDiff?
 
 // Errors
 
@@ -22,34 +24,77 @@ pub fn MoonDiffMode::equal(Self, Self) -> Bool
 pub fn MoonDiffMode::not_equal(Self, Self) -> Bool
 pub fn MoonDiffMode::to_repr(Self) -> @debug.Repr
 
-pub(all) struct MoonDiffStatus {
-  requested : MoonDiffMode
-  effective : MoonDiffMode
-  fell_back : Bool
+pub struct MoonFragmentDiffProvider {
+  document : @diff.DocumentDiff
 } derive(Eq, @debug.Debug)
-pub fn MoonDiffStatus::equal(Self, Self) -> Bool
-pub fn MoonDiffStatus::not_equal(Self, Self) -> Bool
-pub fn MoonDiffStatus::to_repr(Self) -> @debug.Repr
+pub fn MoonFragmentDiffProvider::MoonFragmentDiffProvider(@diff.DocumentDiff) -> Self
+pub fn MoonFragmentDiffProvider::as_document_diff_provider(Self) -> &@diff.DocumentDiffProvider
+pub impl @diff.DocumentDiffProvider for MoonFragmentDiffProvider
 
-pub struct MoonDocumentDiffProvider {
-  mut mode : MoonDiffMode
-  mut ignore_comments : Bool
-  mut ignore_tests : Bool
-  mut status : MoonDiffStatus
-  did_change : @common.Emitter[Unit]
-  mut disposed : Bool
-}
-pub fn MoonDocumentDiffProvider::MoonDocumentDiffProvider(mode? : MoonDiffMode, ignore_comments? : Bool, ignore_tests? : Bool) -> Self
-pub fn MoonDocumentDiffProvider::as_document_diff_provider(Self) -> &@diff.DocumentDiffProvider
-pub fn MoonDocumentDiffProvider::dispose(Self) -> Unit
-pub fn MoonDocumentDiffProvider::get_ignore_comments(Self) -> Bool
-pub fn MoonDocumentDiffProvider::get_ignore_tests(Self) -> Bool
-pub fn MoonDocumentDiffProvider::get_mode(Self) -> MoonDiffMode
-pub fn MoonDocumentDiffProvider::get_status(Self) -> MoonDiffStatus
-pub fn MoonDocumentDiffProvider::set_ignore_comments(Self, Bool) -> Unit
-pub fn MoonDocumentDiffProvider::set_ignore_tests(Self, Bool) -> Unit
-pub fn MoonDocumentDiffProvider::set_mode(Self, MoonDiffMode) -> Unit
-pub impl @diff.DocumentDiffProvider for MoonDocumentDiffProvider
+pub(all) struct SectionedSemanticReviewPlan {
+  requested : MoonDiffMode
+  status : SemanticReviewStatus
+  reordered : Bool
+  main_sections : Array[SemanticReviewSection]
+  deleted_sections : Array[SemanticReviewSection]
+} derive(Eq, @debug.Debug)
+pub fn SectionedSemanticReviewPlan::equal(Self, Self) -> Bool
+pub fn SectionedSemanticReviewPlan::not_equal(Self, Self) -> Bool
+pub fn SectionedSemanticReviewPlan::to_repr(Self) -> @debug.Repr
+
+pub(all) enum SemanticReviewDiff {
+  Core
+  Fragment(@diff.DocumentDiff)
+} derive(Eq, @debug.Debug)
+pub fn SemanticReviewDiff::equal(Self, Self) -> Bool
+pub fn SemanticReviewDiff::not_equal(Self, Self) -> Bool
+pub fn SemanticReviewDiff::to_repr(Self) -> @debug.Repr
+
+pub(all) struct SemanticReviewSection {
+  key : String
+  identity : Int?
+  kind : SemanticReviewSectionKind
+  old_range : SemanticReviewSourceRange?
+  new_range : SemanticReviewSourceRange?
+  old_context : String?
+  new_context : String?
+  fallbacks : Array[String]
+  original_source : String
+  modified_source : String
+  diff : SemanticReviewDiff
+} derive(Eq, @debug.Debug)
+pub fn SemanticReviewSection::equal(Self, Self) -> Bool
+pub fn SemanticReviewSection::not_equal(Self, Self) -> Bool
+pub fn SemanticReviewSection::to_repr(Self) -> @debug.Repr
+
+pub(all) enum SemanticReviewSectionKind {
+  Whole
+  Matched
+  Deleted
+  Inserted
+} derive(Eq, @debug.Debug)
+pub fn SemanticReviewSectionKind::equal(Self, Self) -> Bool
+pub fn SemanticReviewSectionKind::not_equal(Self, Self) -> Bool
+pub fn SemanticReviewSectionKind::to_repr(Self) -> @debug.Repr
+
+pub(all) struct SemanticReviewSourceRange {
+  start_line_number : Int
+  line_count : Int
+} derive(Eq, @debug.Debug)
+pub fn SemanticReviewSourceRange::equal(Self, Self) -> Bool
+pub fn SemanticReviewSourceRange::not_equal(Self, Self) -> Bool
+pub fn SemanticReviewSourceRange::to_repr(Self) -> @debug.Repr
+
+pub(all) enum SemanticReviewStatus {
+  Identical
+  Changed
+  Reordered
+  NoStructuralChanges
+  IgnoredOnly
+} derive(Eq, @debug.Debug)
+pub fn SemanticReviewStatus::equal(Self, Self) -> Bool
+pub fn SemanticReviewStatus::not_equal(Self, Self) -> Bool
+pub fn SemanticReviewStatus::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/editor/viewer/diff_provider/moondiff/provider.mbt
+++ b/editor/viewer/diff_provider/moondiff/provider.mbt
@@ -1,7 +1,7 @@
 ///|
-/// Algorithms offered by the optional MoonBit-aware provider. Core remains a
-/// first-class choice so one host-owned toolbar can keep a single provider
-/// instance while switching modes.
+/// MoonDiff mode selected by the desktop review host. Core is intentionally
+/// absent from the fragment provider below: Core continues to use the normal
+/// full-file DiffEditor provider.
 pub(all) enum MoonDiffMode {
   Core
   Token
@@ -9,213 +9,48 @@ pub(all) enum MoonDiffMode {
 } derive(Eq, Debug)
 
 ///|
-/// The result mode is host-visible product state. Tree can legitimately
-/// degrade to Token, while invalid specialized output degrades to Core.
-pub(all) struct MoonDiffStatus {
-  requested : MoonDiffMode
-  effective : MoonDiffMode
-  fell_back : Bool
+/// Immutable provider for one already-aligned MoonDiff fragment. A fragment
+/// is linear by construction; top-level ordering stays outside this provider
+/// and is represented by separate DiffEditor instances in the desktop host.
+pub struct MoonFragmentDiffProvider {
+  document : @diff.DocumentDiff
 } derive(Eq, Debug)
 
 ///|
-/// Optional synchronous provider used only by the desktop review host. The
-/// diff editor core depends exclusively on DocumentDiffProvider and therefore
-/// has no MoonDiff modes, controls, or fallback policy.
-pub struct MoonDocumentDiffProvider {
-  mut mode : MoonDiffMode
-  mut ignore_comments : Bool
-  mut ignore_tests : Bool
-  mut status : MoonDiffStatus
-  did_change : @base_common.Emitter[Unit]
-  mut disposed : Bool
+pub fn MoonFragmentDiffProvider::MoonFragmentDiffProvider(
+  document : @diff.DocumentDiff,
+) -> MoonFragmentDiffProvider {
+  { document, }
 }
 
 ///|
-pub fn MoonDocumentDiffProvider::MoonDocumentDiffProvider(
-  mode? : MoonDiffMode = Core,
-  ignore_comments? : Bool = true,
-  ignore_tests? : Bool = true,
-) -> MoonDocumentDiffProvider {
-  {
-    mode,
-    ignore_comments,
-    ignore_tests,
-    status: { requested: mode, effective: mode, fell_back: false, },
-    did_change: Emitter(),
-    disposed: false,
-  }
-}
-
-///|
-pub fn MoonDocumentDiffProvider::set_mode(
-  self : MoonDocumentDiffProvider,
-  mode : MoonDiffMode,
-) -> Unit {
-  if self.disposed || self.mode == mode {
-    return
-  }
-  self.mode = mode
-  self.status = { requested: mode, effective: mode, fell_back: false, }
-  self.did_change.fire(())
-}
-
-///|
-pub fn MoonDocumentDiffProvider::get_mode(
-  self : MoonDocumentDiffProvider,
-) -> MoonDiffMode {
-  self.mode
-}
-
-///|
-pub fn MoonDocumentDiffProvider::set_ignore_comments(
-  self : MoonDocumentDiffProvider,
-  ignore_comments : Bool,
-) -> Unit {
-  if self.disposed || self.ignore_comments == ignore_comments {
-    return
-  }
-  self.ignore_comments = ignore_comments
-  self.status = {
-    requested: self.mode,
-    effective: self.mode,
-    fell_back: false,
-  }
-  self.did_change.fire(())
-}
-
-///|
-pub fn MoonDocumentDiffProvider::get_ignore_comments(
-  self : MoonDocumentDiffProvider,
-) -> Bool {
-  self.ignore_comments
-}
-
-///|
-pub fn MoonDocumentDiffProvider::set_ignore_tests(
-  self : MoonDocumentDiffProvider,
-  ignore_tests : Bool,
-) -> Unit {
-  if self.disposed || self.ignore_tests == ignore_tests {
-    return
-  }
-  self.ignore_tests = ignore_tests
-  self.status = { requested: self.mode, effective: self.mode, fell_back: false }
-  self.did_change.fire(())
-}
-
-///|
-pub fn MoonDocumentDiffProvider::get_ignore_tests(
-  self : MoonDocumentDiffProvider,
-) -> Bool {
-  self.ignore_tests
-}
-
-///|
-pub fn MoonDocumentDiffProvider::get_status(
-  self : MoonDocumentDiffProvider,
-) -> MoonDiffStatus {
-  self.status
-}
-
-///|
-/// Explicit host-facing coercion keeps the optional package independently
-/// checkable while exposing only the common diff contract to DiffEditor.
-pub fn MoonDocumentDiffProvider::as_document_diff_provider(
-  self : MoonDocumentDiffProvider,
+pub fn MoonFragmentDiffProvider::as_document_diff_provider(
+  self : MoonFragmentDiffProvider,
 ) -> &@diff.DocumentDiffProvider {
   self
 }
 
 ///|
-pub fn MoonDocumentDiffProvider::dispose(
-  self : MoonDocumentDiffProvider,
-) -> Unit {
-  if self.disposed {
-    return
-  }
-  self.disposed = true
-  self.did_change.dispose()
+pub impl @diff.DocumentDiffProvider for MoonFragmentDiffProvider with fn compute_diff(
+  self,
+  _original,
+  _modified,
+  _options,
+) {
+  self.document
 }
 
 ///|
-fn snapshot_lines(snapshot : @model.TextSnapshot) -> Array[String] {
-  let lines = []
-  for line_number in 1..<=snapshot.line_count() {
-    lines.push(snapshot.get_line_content(line_number))
-  }
-  lines
+pub impl @diff.DocumentDiffProvider for MoonFragmentDiffProvider with fn on_did_change(
+  _self,
+  _listener,
+) {
+  @base_common.Disposable::from(() => ())
 }
 
 ///|
-fn same_line_change_shape(
-  first : @diff.DocumentDiff,
-  second : @diff.DocumentDiff,
-) -> Bool {
-  if first.changes.length() != second.changes.length() {
-    return false
-  }
-  for index in 0..<first.changes.length() {
-    if first.changes[index].original != second.changes[index].original ||
-      first.changes[index].modified != second.changes[index].modified {
-      return false
-    }
-  }
-  true
-}
-
-///|
-fn edge_whitespace_signature(line : String) -> (Array[Int], Array[Int]) {
-  let leading : Array[Int] = []
-  let trailing : Array[Int] = []
-  let mut saw_content = false
-  for character in line {
-    if character.is_whitespace() {
-      if saw_content {
-        trailing.push(character.to_int())
-      } else {
-        leading.push(character.to_int())
-      }
-    } else {
-      saw_content = true
-      trailing.clear()
-    }
-  }
-  (leading, trailing)
-}
-
-///|
-fn change_has_edge_whitespace_difference(
-  change : @diff.DetailedLineRangeMapping,
-  original : @model.TextSnapshot,
-  modified : @model.TextSnapshot,
-) -> Bool {
-  if change.original.length() != change.modified.length() {
-    return false
-  }
-  for offset in 0..<change.original.length() {
-    let original_line = original.get_line_content(
-      change.original.start_line_number + offset,
-    )
-    let modified_line = modified.get_line_content(
-      change.modified.start_line_number + offset,
-    )
-    if edge_whitespace_signature(original_line) !=
-      edge_whitespace_signature(modified_line) {
-      return true
-    }
-  }
-  false
-}
-
-///|
-fn paired_change_has_edge_whitespace_difference(
-  strict : @diff.DocumentDiff,
-  original : @model.TextSnapshot,
-  modified : @model.TextSnapshot,
-) -> Bool {
-  strict.changes.any(change => {
-    change_has_edge_whitespace_difference(change, original, modified)
-  })
+fn source_lines(source : String) -> Array[String] {
+  source.split("\n").map(line => line.to_owned()).collect()
 }
 
 ///|
@@ -224,7 +59,7 @@ fn valid_hunk_range(start : Int, len : Int, total : Int) -> Bool {
 }
 
 ///|
-fn valid_line(
+fn valid_fragment_line(
   line : @mbtdiff.DiffLine,
   expected_index : Int,
   source : Array[String],
@@ -237,14 +72,12 @@ fn valid_line(
 
 ///|
 fn changed_ranges(line : @mbtdiff.DiffLine) -> Array[@base_common.Range] {
-  let ranges = []
+  let ranges : Array[@base_common.Range] = []
   let mut column = 1
   for segment in line.segments {
     let end_column = column + segment.text.length()
     if segment.kind is Changed && end_column > column {
-      ranges.push(
-        @base_common.Range(line.index + 1, column, line.index + 1, end_column),
-      )
+      ranges.push(Range(line.index + 1, column, line.index + 1, end_column))
     }
     column = end_column
   }
@@ -252,6 +85,30 @@ fn changed_ranges(line : @mbtdiff.DiffLine) -> Array[@base_common.Range] {
 }
 
 ///|
+fn line_end_anchor(line : @mbtdiff.DiffLine) -> @base_common.Range {
+  let column = line.text().length() + 1
+  Range(line.index + 1, column, line.index + 1, column)
+}
+
+///|
+fn cursor_anchor(lines : Array[String], cursor : Int) -> @base_common.Range {
+  if lines.is_empty() {
+    return Range(1, 1, 1, 1)
+  }
+  if cursor < lines.length() {
+    let line_number = cursor.max(0) + 1
+    return Range(line_number, 1, line_number, 1)
+  }
+  let line_number = lines.length()
+  let column = lines[line_number - 1].length() + 1
+  Range(line_number, column, line_number, column)
+}
+
+///|
+/// Preserve every changed segment. When one side has more changed spans than
+/// the other, the surplus spans map to the opposite line end instead of being
+/// dropped. This is local intraline geometry, not a synthesized top-level
+/// ordering.
 fn paired_inner_changes(
   original : @mbtdiff.DiffLine,
   modified : @mbtdiff.DiffLine,
@@ -261,69 +118,27 @@ fn paired_inner_changes(
   if original_ranges.is_empty() && modified_ranges.is_empty() {
     return Some([])
   }
-  if original_ranges.is_empty() || modified_ranges.is_empty() {
-    return None
-  }
-  let mappings = []
-  let count = original_ranges.length().min(modified_ranges.length())
+  let mappings : Array[@diff.RangeMapping] = []
+  let count = original_ranges.length().max(modified_ranges.length())
+  let original_anchor = line_end_anchor(original)
+  let modified_anchor = line_end_anchor(modified)
   for index in 0..<count {
     mappings.push(
-      @diff.RangeMapping(original_ranges[index], modified_ranges[index]),
+      RangeMapping(
+        if index < original_ranges.length() {
+          original_ranges[index]
+        } else {
+          original_anchor
+        },
+        if index < modified_ranges.length() {
+          modified_ranges[index]
+        } else {
+          modified_anchor
+        },
+      ),
     )
   }
   Some(mappings)
-}
-
-///|
-// Convert a between-line cursor into a valid zero-width document range. At
-// EOF, the position belongs to the end of the last model line rather than the
-// non-existent line after it.
-fn cursor_anchor_range(
-  lines : Array[String],
-  cursor : Int,
-) -> @base_common.Range {
-  let line_number = cursor + 1
-  if lines.is_empty() {
-    return Range(1, 1, 1, 1)
-  }
-  if line_number <= lines.length() {
-    let line_number = line_number.max(1)
-    return Range(line_number, 1, line_number, 1)
-  }
-  let last_line_number = lines.length()
-  let column = lines[last_line_number - 1].length() + 1
-  Range(last_line_number, column, last_line_number, column)
-}
-
-///|
-// A one-sided row can still contain token-level Changed segments. Mapping
-// them to the opposite cursor preserves their decoration and hunk geometry;
-// an empty array records a computed pure reflow rather than missing work.
-fn old_only_inner_changes(
-  original : @mbtdiff.DiffLine,
-  modified_cursor : Int,
-  modified_lines : Array[String],
-) -> Array[@diff.RangeMapping]? {
-  let anchor = cursor_anchor_range(modified_lines, modified_cursor)
-  Some(
-    changed_ranges(original).map(original_range => {
-      @diff.RangeMapping(original_range, anchor)
-    }),
-  )
-}
-
-///|
-fn new_only_inner_changes(
-  modified : @mbtdiff.DiffLine,
-  original_cursor : Int,
-  original_lines : Array[String],
-) -> Array[@diff.RangeMapping]? {
-  let anchor = cursor_anchor_range(original_lines, original_cursor)
-  Some(
-    changed_ranges(modified).map(modified_range => {
-      @diff.RangeMapping(anchor, modified_range)
-    }),
-  )
 }
 
 ///|
@@ -344,10 +159,15 @@ fn old_only_change(
   modified_cursor : Int,
   modified_lines : Array[String],
 ) -> @diff.DetailedLineRangeMapping {
+  let anchor = cursor_anchor(modified_lines, modified_cursor)
   DetailedLineRangeMapping(
     LineRange(original.index + 1, original.index + 2),
     LineRange(modified_cursor + 1, modified_cursor + 1),
-    old_only_inner_changes(original, modified_cursor, modified_lines),
+    Some(
+      changed_ranges(original).map(original_range => {
+        RangeMapping(original_range, anchor)
+      }),
+    ),
   )
 }
 
@@ -357,15 +177,20 @@ fn new_only_change(
   original_cursor : Int,
   original_lines : Array[String],
 ) -> @diff.DetailedLineRangeMapping {
+  let anchor = cursor_anchor(original_lines, original_cursor)
   DetailedLineRangeMapping(
     LineRange(original_cursor + 1, original_cursor + 1),
     LineRange(modified.index + 1, modified.index + 2),
-    new_only_inner_changes(modified, original_cursor, original_lines),
+    Some(
+      changed_ranges(modified).map(modified_range => {
+        RangeMapping(anchor, modified_range)
+      }),
+    ),
   )
 }
 
 ///|
-fn line_ranges_intersect_or_touch(
+fn ranges_touch(
   left : @base_common.LineRange,
   right : @base_common.LineRange,
 ) -> Bool {
@@ -374,43 +199,30 @@ fn line_ranges_intersect_or_touch(
 }
 
 ///|
-fn line_ranges_intersect(
-  left : @base_common.LineRange,
-  right : @base_common.LineRange,
-) -> Bool {
-  !left.is_empty() &&
-  !right.is_empty() &&
-  left.start_line_number < right.end_line_number_exclusive &&
-  right.start_line_number < left.end_line_number_exclusive
-}
-
-///|
-// MoonDiff exposes changed rows. VS Code's renderer consumes grouped
-// DetailedLineRangeMappings, so touching rows must be joined before the
-// provider result crosses that boundary.
-fn append_coalesced_change(
+fn append_change(
   changes : Array[@diff.DetailedLineRangeMapping],
   change : @diff.DetailedLineRangeMapping,
 ) -> Unit {
-  if changes.is_empty() {
+  guard !changes.is_empty() else {
     changes.push(change)
     return
   }
-  let previous = changes[changes.length() - 1]
-  if !line_ranges_intersect_or_touch(previous.original, change.original) &&
-    !line_ranges_intersect_or_touch(previous.modified, change.modified) {
+  let index = changes.length() - 1
+  let previous = changes[index]
+  if !ranges_touch(previous.original, change.original) &&
+    !ranges_touch(previous.modified, change.modified) {
     changes.push(change)
     return
   }
   let inner_changes = match (previous.inner_changes, change.inner_changes) {
-    (Some(previous_inner), Some(change_inner)) => {
-      let joined = previous_inner.copy()
-      joined.append(change_inner)
+    (Some(first), Some(second)) => {
+      let joined = first.copy()
+      joined.append(second)
       Some(joined)
     }
     _ => None
   }
-  changes[changes.length() - 1] = DetailedLineRangeMapping(
+  changes[index] = DetailedLineRangeMapping(
     previous.original.join(change.original),
     previous.modified.join(change.modified),
     inner_changes,
@@ -418,900 +230,31 @@ fn append_coalesced_change(
 }
 
 ///|
-fn append_coalesced_alignment(
+fn append_alignment(
   alignments : Array[@diff.LineRangeMapping],
   alignment : @diff.LineRangeMapping,
 ) -> Unit {
-  if alignments.is_empty() {
+  guard !alignments.is_empty() else {
     alignments.push(alignment)
     return
   }
-  let previous = alignments[alignments.length() - 1]
-  if !line_ranges_intersect_or_touch(previous.original, alignment.original) &&
-    !line_ranges_intersect_or_touch(previous.modified, alignment.modified) {
+  let index = alignments.length() - 1
+  let previous = alignments[index]
+  if !ranges_touch(previous.original, alignment.original) &&
+    !ranges_touch(previous.modified, alignment.modified) {
     alignments.push(alignment)
     return
   }
-  alignments[alignments.length() - 1] = LineRangeMapping(
+  alignments[index] = LineRangeMapping(
     previous.original.join(alignment.original),
     previous.modified.join(alignment.modified),
   )
 }
 
 ///|
-fn mapping_overlaps_document(
-  mapping : @diff.LineRangeMapping,
-  changes : Array[@diff.DetailedLineRangeMapping],
-  alignments : Array[@diff.LineRangeMapping],
-) -> Bool {
-  for change in changes {
-    if (
-        !mapping.original.is_empty() &&
-        line_ranges_intersect(mapping.original, change.original)
-      ) ||
-      (
-        !mapping.modified.is_empty() &&
-        line_ranges_intersect(mapping.modified, change.modified)
-      ) {
-      return true
-    }
-  }
-  for alignment in alignments {
-    if (
-        !mapping.original.is_empty() &&
-        line_ranges_intersect(mapping.original, alignment.original)
-      ) ||
-      (
-        !mapping.modified.is_empty() &&
-        line_ranges_intersect(mapping.modified, alignment.modified)
-      ) {
-      return true
-    }
-  }
-  false
-}
-
-///|
-// Recover filtered one-sided rows that are not already represented by a
-// visible change or an IgnoredBlock alignment.
-fn append_unrepresented_one_sided_alignments(
-  unfiltered : @diff.DocumentDiff,
-  changes : Array[@diff.DetailedLineRangeMapping],
-  alignments : Array[@diff.LineRangeMapping],
-) -> Unit {
-  for change in unfiltered.changes {
-    let mapping = change.line_mapping()
-    if mapping.original.is_empty() && !mapping.modified.is_empty() {
-      let mut run_start : Int? = None
-      for
-        line in mapping.modified.start_line_number..<mapping.modified.end_line_number_exclusive {
-        let unit = @diff.LineRangeMapping(
-          mapping.original,
-          @base_common.LineRange(line, line + 1),
-        )
-        if mapping_overlaps_document(unit, changes, alignments) {
-          if run_start is Some(start) {
-            alignments.push(
-              @diff.LineRangeMapping(
-                mapping.original,
-                @base_common.LineRange(start, line),
-              ),
-            )
-            run_start = None
-          }
-        } else if run_start is None {
-          run_start = Some(line)
-        }
-      }
-      if run_start is Some(start) {
-        alignments.push(
-          @diff.LineRangeMapping(
-            mapping.original,
-            @base_common.LineRange(
-              start,
-              mapping.modified.end_line_number_exclusive,
-            ),
-          ),
-        )
-      }
-    } else if mapping.modified.is_empty() && !mapping.original.is_empty() {
-      let mut run_start : Int? = None
-      for
-        line in mapping.original.start_line_number..<mapping.original.end_line_number_exclusive {
-        let unit = @diff.LineRangeMapping(
-          @base_common.LineRange(line, line + 1),
-          mapping.modified,
-        )
-        if mapping_overlaps_document(unit, changes, alignments) {
-          if run_start is Some(start) {
-            alignments.push(
-              @diff.LineRangeMapping(
-                @base_common.LineRange(start, line),
-                mapping.modified,
-              ),
-            )
-            run_start = None
-          }
-        } else if run_start is None {
-          run_start = Some(line)
-        }
-      }
-      if run_start is Some(start) {
-        alignments.push(
-          @diff.LineRangeMapping(
-            @base_common.LineRange(
-              start,
-              mapping.original.end_line_number_exclusive,
-            ),
-            mapping.modified,
-          ),
-        )
-      }
-    }
-  }
-}
-
-///|
-fn compare_line_mapping_start(
-  left : @diff.LineRangeMapping,
-  right : @diff.LineRangeMapping,
-) -> Int {
-  let original = left.original.start_line_number -
-    right.original.start_line_number
-  if original != 0 {
-    return original
-  }
-  left.modified.start_line_number - right.modified.start_line_number
-}
-
-///|
-fn compare_detailed_mapping_start(
-  left : @diff.DetailedLineRangeMapping,
-  right : @diff.DetailedLineRangeMapping,
-) -> Int {
-  compare_line_mapping_start(left.line_mapping(), right.line_mapping())
-}
-
-///|
-fn append_flattened_change(
-  changes : Array[@diff.DetailedLineRangeMapping],
-  change : @diff.DetailedLineRangeMapping,
-) -> Unit {
-  if changes.is_empty() {
-    changes.push(change)
-    return
-  }
-  let previous = changes[changes.length() - 1]
-  if !line_ranges_intersect_or_touch(previous.original, change.original) ||
-    !line_ranges_intersect_or_touch(previous.modified, change.modified) {
-    changes.push(change)
-    return
-  }
-  let inner_changes = match (previous.inner_changes, change.inner_changes) {
-    (Some(previous_inner), Some(change_inner)) => {
-      let joined = previous_inner.copy()
-      joined.append(change_inner)
-      Some(joined)
-    }
-    _ => None
-  }
-  changes[changes.length() - 1] = DetailedLineRangeMapping(
-    previous.original.join(change.original),
-    previous.modified.join(change.modified),
-    inner_changes,
-  )
-}
-
-///|
-fn append_flattened_alignment(
-  alignments : Array[@diff.LineRangeMapping],
-  alignment : @diff.LineRangeMapping,
-) -> Unit {
-  if alignments.is_empty() {
-    alignments.push(alignment)
-    return
-  }
-  let previous = alignments[alignments.length() - 1]
-  if !line_ranges_intersect_or_touch(previous.original, alignment.original) ||
-    !line_ranges_intersect_or_touch(previous.modified, alignment.modified) {
-    alignments.push(alignment)
-    return
-  }
-  alignments[alignments.length() - 1] = LineRangeMapping(
-    previous.original.join(alignment.original),
-    previous.modified.join(alignment.modified),
-  )
-}
-
-///|
-fn order_document_mappings(diff : @diff.DocumentDiff) -> @diff.DocumentDiff {
-  let raw_changes = diff.changes.copy()
-  raw_changes.sort_by(compare_detailed_mapping_start)
-  let changes : Array[@diff.DetailedLineRangeMapping] = []
-  for change in raw_changes {
-    append_flattened_change(changes, change)
-  }
-  let raw_alignments = diff.additional_alignments.copy()
-  raw_alignments.sort_by(compare_line_mapping_start)
-  let alignments : Array[@diff.LineRangeMapping] = []
-  for alignment in raw_alignments {
-    append_flattened_alignment(alignments, alignment)
-  }
-  { changes, additional_alignments: alignments }
-}
-
-///|
-priv struct FlattenedSection {
-  fragment : @mbtdiff.DiffFragment
-  old_base : Int
-  new_base : Int
-  old_len : Int
-  new_len : Int
-  matched : Bool
-  layout : @diff.LineRangeMapping
-}
-
-///|
-priv struct IgnoredTestOwnership {
-  original : Array[@base_common.LineRange]
-  modified : Array[@base_common.LineRange]
-}
-
-///|
-fn semantic_line_count(lines : Array[String]) -> Int {
-  if !lines.is_empty() && lines[lines.length() - 1].is_empty() {
-    lines.length() - 1
-  } else {
-    lines.length()
-  }
-}
-
-///|
-fn source_line_slice(lines : Array[String], start : Int, len : Int) -> String {
-  if len == 0 {
-    return ""
-  }
-  let selected : Array[String] = []
-  for index in start..<(start + len) {
-    selected.push(lines[index])
-  }
-  selected.join("\n") + "\n"
-}
-
-///|
-fn raw_range_difference_is_ignored(
-  original_lines : Array[String],
-  old_start : Int,
-  old_len : Int,
-  modified_lines : Array[String],
-  new_start : Int,
-  new_len : Int,
-  ignore_comments : Bool,
-  ignore_tests : Bool,
-  mode : @mbtdiff.DiffMode,
-) -> Bool {
-  let old_source = source_line_slice(original_lines, old_start, old_len)
-  let new_source = source_line_slice(modified_lines, new_start, new_len)
-  if old_source == new_source {
-    return true
-  }
-  if !ignore_comments && !ignore_tests {
-    return false
-  }
-  @mbtdiff.diff(
-    old_source,
-    new_source,
-    options=@mbtdiff.DiffOptions(
-      context_lines=0,
-      ignore_comments~,
-      ignore_tests~,
-      mode~,
-    ),
-  ).status()
-  is @mbtdiff.DiffStatus::IgnoredOnly
-}
-
-///|
-fn adapt_ignored_test_ranges(
-  ranges : ArrayView[@mbtdiff.LineRange],
-  line_count : Int,
-) -> Array[@base_common.LineRange]? {
-  let adapted : Array[@base_common.LineRange] = []
-  let mut previous_end = 0
-  for range in ranges {
-    if !valid_hunk_range(range.start, range.len, line_count) ||
-      range.start < previous_end {
-      return None
-    }
-    adapted.push(
-      @base_common.LineRange(range.start + 1, range.start + range.len + 1),
-    )
-    previous_end = range.start + range.len
-  }
-  Some(adapted)
-}
-
-///|
-fn ignored_test_ownership(
-  result : @mbtdiff.DiffResult,
-  original_lines : Array[String],
-  modified_lines : Array[String],
-) -> IgnoredTestOwnership? {
-  match
-    (
-      adapt_ignored_test_ranges(
-        result.ignored_test_ranges(@mbtdiff.DiffSide::Old),
-        semantic_line_count(original_lines),
-      ),
-      adapt_ignored_test_ranges(
-        result.ignored_test_ranges(@mbtdiff.DiffSide::New),
-        semantic_line_count(modified_lines),
-      ),
-    ) {
-    (Some(original_ranges), Some(modified_ranges)) =>
-      Some({ original: original_ranges, modified: modified_ranges })
-    _ => None
-  }
-}
-
-///|
-fn strip_owned_lines(
-  lines : Array[String],
-  start : Int,
-  len : Int,
-  owned : Array[@base_common.LineRange],
-) -> (Array[String], Bool) {
-  let visible : Array[String] = []
-  let mut removed = false
-  for index in start..<(start + len) {
-    if owned.any(range => range.contains(index + 1)) {
-      removed = true
-    } else {
-      visible.push(lines[index])
-    }
-  }
-  (visible, removed)
-}
-
-///|
-fn range_difference_is_ignored(
-  original_lines : Array[String],
-  old_start : Int,
-  old_len : Int,
-  modified_lines : Array[String],
-  new_start : Int,
-  new_len : Int,
-  ignore_comments : Bool,
-  ignore_tests : Bool,
-  mode : @mbtdiff.DiffMode,
-  test_ownership : IgnoredTestOwnership,
-) -> Bool {
-  let old_source = source_line_slice(original_lines, old_start, old_len)
-  let new_source = source_line_slice(modified_lines, new_start, new_len)
-  if old_source == new_source {
-    return true
-  }
-  if !ignore_tests {
-    return raw_range_difference_is_ignored(
-      original_lines, old_start, old_len, modified_lines, new_start, new_len, ignore_comments,
-      false, mode,
-    )
-  }
-  let (old_visible, old_removed) = strip_owned_lines(
-    original_lines,
-    old_start,
-    old_len,
-    test_ownership.original,
-  )
-  let (new_visible, new_removed) = strip_owned_lines(
-    modified_lines,
-    new_start,
-    new_len,
-    test_ownership.modified,
-  )
-  if !old_removed && !new_removed {
-    return if ignore_comments {
-      raw_range_difference_is_ignored(
-        original_lines, old_start, old_len, modified_lines, new_start, new_len, true,
-        false, mode,
-      )
-    } else {
-      false
-    }
-  }
-  let old_visible_source = source_line_slice(
-    old_visible,
-    0,
-    old_visible.length(),
-  )
-  let new_visible_source = source_line_slice(
-    new_visible,
-    0,
-    new_visible.length(),
-  )
-  if old_visible_source == new_visible_source {
-    return true
-  }
-  ignore_comments &&
-  @mbtdiff.diff(
-    old_visible_source,
-    new_visible_source,
-    options=@mbtdiff.DiffOptions(
-      context_lines=0,
-      ignore_comments=true,
-      ignore_tests=false,
-      mode~,
-    ),
-  ).status()
-  is @mbtdiff.DiffStatus::IgnoredOnly
-}
-
-///|
-fn rebase_line_mapping(
-  mapping : @diff.LineRangeMapping,
-  old_base : Int,
-  new_base : Int,
-) -> @diff.LineRangeMapping {
-  @diff.LineRangeMapping(
-    @base_common.LineRange(
-      mapping.original.start_line_number + old_base,
-      mapping.original.end_line_number_exclusive + old_base,
-    ),
-    @base_common.LineRange(
-      mapping.modified.start_line_number + new_base,
-      mapping.modified.end_line_number_exclusive + new_base,
-    ),
-  )
-}
-
-///|
-fn ignored_range_geometry(
-  original_lines : Array[String],
-  old_start : Int,
-  old_len : Int,
-  modified_lines : Array[String],
-  new_start : Int,
-  new_len : Int,
-  ignore_comments : Bool,
-  ignore_tests : Bool,
-  mode : @mbtdiff.DiffMode,
-  test_ownership : IgnoredTestOwnership,
-) -> Array[@diff.LineRangeMapping]? {
-  if !range_difference_is_ignored(
-      original_lines, old_start, old_len, modified_lines, new_start, new_len, ignore_comments,
-      ignore_tests, mode, test_ownership,
-    ) {
-    return None
-  }
-  let core = @diff.CoreDocumentDiffProvider().compute_diff(
-    @model.TextSnapshot(source_line_slice(original_lines, old_start, old_len)),
-    @model.TextSnapshot(source_line_slice(modified_lines, new_start, new_len)),
-    { ignore_trim_whitespace: false },
-  )
-  let alignments = core.changes.filter_map(change => {
-    if change.original.length() != change.modified.length() {
-      Some(rebase_line_mapping(change.line_mapping(), old_start, new_start))
-    } else {
-      None
-    }
-  })
-  if old_len != new_len && alignments.is_empty() {
-    None
-  } else {
-    Some(alignments)
-  }
-}
-
-///|
-fn valid_top_level_orders(
-  top : @mbtdiff.TopLevelDiff,
-  original_line_count : Int,
-  modified_line_count : Int,
-) -> Bool {
-  let old_seen = Array::make(top.sections.length(), false)
-  let new_seen = Array::make(top.sections.length(), false)
-  let mut new_end = 0
-  for index in top.new_order {
-    if index < 0 || index >= top.sections.length() || new_seen[index] {
-      return false
-    }
-    let range = match top.sections[index] {
-      Matched(new~, ..) | Inserted(new~, ..) => new
-      Deleted(..) => return false
-    }
-    if !valid_hunk_range(range.start, range.len, modified_line_count) ||
-      range.start < new_end {
-      return false
-    }
-    new_seen[index] = true
-    new_end = range.start + range.len
-  }
-  let mut old_end = 0
-  for index in top.old_order {
-    if index < 0 || index >= top.sections.length() || old_seen[index] {
-      return false
-    }
-    let range = match top.sections[index] {
-      Matched(old~, ..) | Deleted(old~, ..) => old
-      Inserted(..) => return false
-    }
-    if !valid_hunk_range(range.start, range.len, original_line_count) ||
-      range.start < old_end {
-      return false
-    }
-    old_seen[index] = true
-    old_end = range.start + range.len
-  }
-  for index, section in top.sections {
-    match section {
-      Matched(..) => if !old_seen[index] || !new_seen[index] { return false }
-      Deleted(..) => if !old_seen[index] || new_seen[index] { return false }
-      Inserted(..) => if old_seen[index] || !new_seen[index] { return false }
-    }
-  }
-  true
-}
-
-///|
-fn flatten_top_level_sections(
-  top : @mbtdiff.TopLevelDiff,
-  original_lines : Array[String],
-  modified_lines : Array[String],
-  ignore_comments : Bool,
-  ignore_tests : Bool,
-  mode : @mbtdiff.DiffMode,
-  test_ownership : IgnoredTestOwnership,
-) -> Array[FlattenedSection]? {
-  let original_line_count = semantic_line_count(original_lines)
-  let modified_line_count = semantic_line_count(modified_lines)
-  if top.reordered ||
-    !valid_top_level_orders(top, original_line_count, modified_line_count) {
-    return None
-  }
-  let sections : Array[FlattenedSection] = []
-  let mut old_order_index = 0
-  let mut new_order_index = 0
-  let mut old_cursor = 0
-  let mut new_cursor = 0
-  while old_order_index < top.old_order.length() ||
-        new_order_index < top.new_order.length() {
-    let has_old = old_order_index < top.old_order.length()
-    let has_new = new_order_index < top.new_order.length()
-    let old_index = if has_old { top.old_order[old_order_index] } else { -1 }
-    let new_index = if has_new { top.new_order[new_order_index] } else { -1 }
-    let old_target = if has_old {
-      match top.sections[old_index] {
-        Matched(old~, ..) | Deleted(old~, ..) => old.start
-        Inserted(..) => return None
-      }
-    } else {
-      original_line_count
-    }
-    let new_target = if has_new {
-      match top.sections[new_index] {
-        Matched(new~, ..) | Inserted(new~, ..) => new.start
-        Deleted(..) => return None
-      }
-    } else {
-      modified_line_count
-    }
-    if old_target < old_cursor || new_target < new_cursor {
-      return None
-    }
-    let old_gap_len = old_target - old_cursor
-    let new_gap_len = new_target - new_cursor
-    if source_line_slice(original_lines, old_cursor, old_gap_len) ==
-      source_line_slice(modified_lines, new_cursor, new_gap_len) {
-      old_cursor = old_target
-      new_cursor = new_target
-    }
-    if has_old && has_new && old_index == new_index {
-      guard top.sections[old_index] is Matched(old~, new~, diff~, ..) else {
-        return None
-      }
-      if old_cursor != old_target || new_cursor != new_target {
-        if !range_difference_is_ignored(
-            original_lines,
-            old_cursor,
-            old_target - old_cursor,
-            modified_lines,
-            new_cursor,
-            new_target - new_cursor,
-            ignore_comments,
-            ignore_tests,
-            mode,
-            test_ownership,
-          ) {
-          return None
-        }
-        old_cursor = old_target
-        new_cursor = new_target
-      }
-      sections.push({
-        fragment: diff,
-        old_base: old.start,
-        new_base: new.start,
-        old_len: old.len,
-        new_len: new.len,
-        matched: true,
-        layout: @diff.LineRangeMapping(
-          @base_common.LineRange(old.start + 1, old.start + old.len + 1),
-          @base_common.LineRange(new.start + 1, new.start + new.len + 1),
-        ),
-      })
-      old_cursor = old.start + old.len
-      new_cursor = new.start + new.len
-      old_order_index += 1
-      new_order_index += 1
-      continue
-    }
-    if has_old &&
-      has_new &&
-      old_cursor == old_target &&
-      new_cursor == new_target &&
-      top.sections[old_index] is Deleted(old~, diff=old_diff, ..) &&
-      top.sections[new_index] is Inserted(new~, diff=new_diff, ..) {
-      sections.push({
-        fragment: old_diff,
-        old_base: old.start,
-        new_base: new_cursor,
-        old_len: old.len,
-        new_len: 0,
-        matched: false,
-        layout: @diff.LineRangeMapping(
-          @base_common.LineRange(old.start + 1, old.start + old.len + 1),
-          @base_common.LineRange(new_cursor + 1, new_cursor + 1),
-        ),
-      })
-      old_cursor = old.start + old.len
-      old_order_index += 1
-      sections.push({
-        fragment: new_diff,
-        old_base: old_cursor,
-        new_base: new.start,
-        old_len: 0,
-        new_len: new.len,
-        matched: false,
-        layout: @diff.LineRangeMapping(
-          @base_common.LineRange(old_cursor + 1, old_cursor + 1),
-          @base_common.LineRange(new.start + 1, new.start + new.len + 1),
-        ),
-      })
-      new_cursor = new.start + new.len
-      new_order_index += 1
-      continue
-    }
-    if has_old &&
-      old_cursor == old_target &&
-      top.sections[old_index] is Deleted(old~, diff~, ..) {
-      sections.push({
-        fragment: diff,
-        old_base: old.start,
-        new_base: new_cursor,
-        old_len: old.len,
-        new_len: 0,
-        matched: false,
-        layout: @diff.LineRangeMapping(
-          @base_common.LineRange(old.start + 1, old.start + old.len + 1),
-          @base_common.LineRange(new_cursor + 1, new_cursor + 1),
-        ),
-      })
-      old_cursor = old.start + old.len
-      old_order_index += 1
-      continue
-    }
-    if has_new &&
-      new_cursor == new_target &&
-      top.sections[new_index] is Inserted(new~, diff~, ..) {
-      sections.push({
-        fragment: diff,
-        old_base: old_cursor,
-        new_base: new.start,
-        old_len: 0,
-        new_len: new.len,
-        matched: false,
-        layout: @diff.LineRangeMapping(
-          @base_common.LineRange(old_cursor + 1, old_cursor + 1),
-          @base_common.LineRange(new.start + 1, new.start + new.len + 1),
-        ),
-      })
-      new_cursor = new.start + new.len
-      new_order_index += 1
-      continue
-    }
-    if (old_cursor < old_target || new_cursor < new_target) &&
-      range_difference_is_ignored(
-        original_lines,
-        old_cursor,
-        old_target - old_cursor,
-        modified_lines,
-        new_cursor,
-        new_target - new_cursor,
-        ignore_comments,
-        ignore_tests,
-        mode,
-        test_ownership,
-      ) {
-      old_cursor = old_target
-      new_cursor = new_target
-      continue
-    }
-    return None
-  }
-  Some(sections)
-}
-
-///|
-fn append_layout_gap(
-  old_start : Int,
-  old_len : Int,
-  new_start : Int,
-  new_len : Int,
-  changes : Array[@diff.DetailedLineRangeMapping],
-  alignments : Array[@diff.LineRangeMapping],
-) -> Unit {
-  if old_len == new_len {
-    return
-  }
-  let mapping = @diff.LineRangeMapping(
-    @base_common.LineRange(old_start + 1, old_start + old_len + 1),
-    @base_common.LineRange(new_start + 1, new_start + new_len + 1),
-  )
-  if !mapping_overlaps_document(mapping, changes, alignments) {
-    alignments.push(mapping)
-  }
-}
-
-///|
-// Test filtering removes whole top-level sections before fragment calculation.
-// Their line spans remain observable between semantic section ranges, so
-// preserve only their height difference as neutral alignment geometry.
-fn append_layout_gap_alignments(
-  layout : ArrayView[@diff.LineRangeMapping],
-  original_lines : Array[String],
-  modified_lines : Array[String],
-  ignore_comments : Bool,
-  ignore_tests : Bool,
-  mode : @mbtdiff.DiffMode,
-  test_ownership : IgnoredTestOwnership,
-  changes : Array[@diff.DetailedLineRangeMapping],
-  alignments : Array[@diff.LineRangeMapping],
-) -> Bool {
-  let mut old_cursor = 0
-  let mut new_cursor = 0
-  for section in layout {
-    let old_start = section.original.start_line_number - 1
-    let new_start = section.modified.start_line_number - 1
-    if old_start < old_cursor || new_start < new_cursor {
-      return false
-    }
-    let old_len = old_start - old_cursor
-    let new_len = new_start - new_cursor
-    if !range_difference_is_ignored(
-        original_lines, old_cursor, old_len, modified_lines, new_cursor, new_len,
-        ignore_comments, ignore_tests, mode, test_ownership,
-      ) {
-      return false
-    }
-    append_layout_gap(
-      old_cursor, old_len, new_cursor, new_len, changes, alignments,
-    )
-    old_cursor = section.original.end_line_number_exclusive - 1
-    new_cursor = section.modified.end_line_number_exclusive - 1
-  }
-  if old_cursor > original_lines.length() ||
-    new_cursor > modified_lines.length() {
-    return false
-  }
-  let old_len = original_lines.length() - old_cursor
-  let new_len = modified_lines.length() - new_cursor
-  if !range_difference_is_ignored(
-      original_lines, old_cursor, old_len, modified_lines, new_cursor, new_len, ignore_comments,
-      ignore_tests, mode, test_ownership,
-    ) {
-    return false
-  }
-  append_layout_gap(
-    old_cursor, old_len, new_cursor, new_len, changes, alignments,
-  )
-  true
-}
-
-///|
-fn line_is_test_owned(
-  line_number : Int,
-  ranges : Array[@base_common.LineRange],
-) -> Bool {
-  ranges.any(range => range.contains(line_number))
-}
-
-///|
-fn ignored_rows_are_filter_owned(
+fn append_fragment_rows(
   rows : ArrayView[@mbtdiff.DiffRow],
-  original_lines : Array[String],
-  modified_lines : Array[String],
-  ignore_comments : Bool,
-  ignore_tests : Bool,
-  mode : @mbtdiff.DiffMode,
-  test_ownership : IgnoredTestOwnership,
-) -> Bool {
-  for row in rows {
-    match row {
-      Paired(original, modified) => {
-        if original.text() == modified.text() {
-          continue
-        }
-        if ignore_tests &&
-          line_is_test_owned(original.index + 1, test_ownership.original) &&
-          line_is_test_owned(modified.index + 1, test_ownership.modified) {
-          continue
-        }
-        if !ignore_comments ||
-          !raw_range_difference_is_ignored(
-            original_lines,
-            original.index,
-            1,
-            modified_lines,
-            modified.index,
-            1,
-            true,
-            false,
-            mode,
-          ) {
-          return false
-        }
-      }
-      OldOnly(original) => {
-        if ignore_tests &&
-          line_is_test_owned(original.index + 1, test_ownership.original) {
-          continue
-        }
-        let empty : Array[String] = []
-        if !ignore_comments ||
-          !raw_range_difference_is_ignored(
-            original_lines,
-            original.index,
-            1,
-            empty,
-            0,
-            0,
-            true,
-            false,
-            mode,
-          ) {
-          return false
-        }
-      }
-      NewOnly(modified) => {
-        if ignore_tests &&
-          line_is_test_owned(modified.index + 1, test_ownership.modified) {
-          continue
-        }
-        let empty : Array[String] = []
-        if !ignore_comments ||
-          !raw_range_difference_is_ignored(
-            empty,
-            0,
-            0,
-            modified_lines,
-            modified.index,
-            1,
-            true,
-            false,
-            mode,
-          ) {
-          return false
-        }
-      }
-    }
-  }
-  true
-}
-
-///|
-fn append_rows(
-  rows : ArrayView[@mbtdiff.DiffRow],
-  render_changes : Bool,
+  visible : Bool,
   original_lines : Array[String],
   modified_lines : Array[String],
   original_cursor : Int,
@@ -1321,48 +264,42 @@ fn append_rows(
 ) -> (Int, Int)? {
   let mut old_cursor = original_cursor
   let mut new_cursor = modified_cursor
-  // A ChangeBlock or IgnoredBlock is a coalescing boundary. Keeping its rows
-  // local prevents an empty-side anchor from joining mappings across the other
-  // block kind and making a geometry-only alignment overlap a real change.
-  let block_changes = []
-  let block_alignments = []
+  let block_changes : Array[@diff.DetailedLineRangeMapping] = []
+  let block_alignments : Array[@diff.LineRangeMapping] = []
   for row in rows {
     match row {
       Paired(original, modified) => {
-        if !valid_line(original, old_cursor, original_lines) ||
-          !valid_line(modified, new_cursor, modified_lines) {
+        if !valid_fragment_line(original, old_cursor, original_lines) ||
+          !valid_fragment_line(modified, new_cursor, modified_lines) {
           return None
         }
-        if render_changes {
-          append_coalesced_change(
-            block_changes,
-            paired_change(original, modified),
-          )
+        if visible {
+          append_change(block_changes, paired_change(original, modified))
         }
         old_cursor += 1
         new_cursor += 1
       }
       OldOnly(original) => {
-        if !valid_line(original, old_cursor, original_lines) {
+        if !valid_fragment_line(original, old_cursor, original_lines) {
           return None
         }
-        let mapping = old_only_change(original, new_cursor, modified_lines)
-        if render_changes {
-          append_coalesced_change(block_changes, mapping)
+        let change = old_only_change(original, new_cursor, modified_lines)
+        if visible {
+          append_change(block_changes, change)
         } else {
-          append_coalesced_alignment(block_alignments, mapping.line_mapping())
+          append_alignment(block_alignments, change.line_mapping())
         }
         old_cursor += 1
       }
       NewOnly(modified) => {
-        if !valid_line(modified, new_cursor, modified_lines) {
+        if !valid_fragment_line(modified, new_cursor, modified_lines) {
           return None
         }
-        let mapping = new_only_change(modified, old_cursor, original_lines)
-        if render_changes {
-          append_coalesced_change(block_changes, mapping)
+        let change = new_only_change(modified, old_cursor, original_lines)
+        if visible {
+          append_change(block_changes, change)
         } else {
-          append_coalesced_alignment(block_alignments, mapping.line_mapping())
+          append_alignment(block_alignments, change.line_mapping())
         }
         new_cursor += 1
       }
@@ -1374,29 +311,14 @@ fn append_rows(
 }
 
 ///|
-fn adapt_hunk_document(
+fn adapt_fragment_document(
   document : @mbtdiff.HunkDocument,
-  old_base : Int,
-  new_base : Int,
-  old_len : Int,
-  new_len : Int,
   original_lines : Array[String],
   modified_lines : Array[String],
-  ignore_comments : Bool,
-  ignore_tests : Bool,
-  mode : @mbtdiff.DiffMode,
-  test_ownership : IgnoredTestOwnership,
 ) -> @diff.DocumentDiff? {
+  let changes : Array[@diff.DetailedLineRangeMapping] = []
+  let alignments : Array[@diff.LineRangeMapping] = []
   for hunk in document.hunks {
-    if !valid_hunk_range(hunk.old_start, hunk.old_len, old_len) ||
-      !valid_hunk_range(hunk.new_start, hunk.new_len, new_len) {
-      return None
-    }
-  }
-  let rebased = document.rebase(old_base, new_base)
-  let changes = []
-  let alignments = []
-  for hunk in rebased.hunks {
     if !valid_hunk_range(hunk.old_start, hunk.old_len, original_lines.length()) ||
       !valid_hunk_range(hunk.new_start, hunk.new_len, modified_lines.length()) {
       return None
@@ -1418,36 +340,22 @@ fn adapt_hunk_document(
             old_cursor += 1
             new_cursor += 1
           }
-        ChangeBlock(rows) =>
-          match
-            append_rows(
-              rows, true, original_lines, modified_lines, old_cursor, new_cursor,
-              changes, alignments,
-            ) {
-            Some((next_old, next_new)) => {
-              old_cursor = next_old
-              new_cursor = next_new
-            }
-            None => return None
-          }
-        IgnoredBlock(rows) => {
-          if !ignored_rows_are_filter_owned(
-              rows, original_lines, modified_lines, ignore_comments, ignore_tests,
-              mode, test_ownership,
-            ) {
+        ChangeBlock(rows) | IgnoredBlock(rows) => {
+          guard append_fragment_rows(
+              rows,
+              block is ChangeBlock(_),
+              original_lines,
+              modified_lines,
+              old_cursor,
+              new_cursor,
+              changes,
+              alignments,
+            )
+            is Some((next_old, next_new)) else {
             return None
           }
-          match
-            append_rows(
-              rows, false, original_lines, modified_lines, old_cursor, new_cursor,
-              changes, alignments,
-            ) {
-            Some((next_old, next_new)) => {
-              old_cursor = next_old
-              new_cursor = next_new
-            }
-            None => return None
-          }
+          old_cursor = next_old
+          new_cursor = next_new
         }
       }
     }
@@ -1460,609 +368,24 @@ fn adapt_hunk_document(
 }
 
 ///|
-fn adapt_document(
-  document : @mbtdiff.DiffDocument,
-  original_lines : Array[String],
-  modified_lines : Array[String],
-  ignore_comments : Bool,
-  ignore_tests : Bool,
-  mode : @mbtdiff.DiffMode,
-  test_ownership : IgnoredTestOwnership,
-) -> (@diff.DocumentDiff, Array[@diff.LineRangeMapping])? {
-  match document {
-    Whole(fragment) => {
-      guard adapt_hunk_document(
-          fragment.document,
-          0,
-          0,
-          original_lines.length(),
-          modified_lines.length(),
-          original_lines,
-          modified_lines,
-          ignore_comments,
-          ignore_tests,
-          mode,
-          test_ownership,
-        )
-        is Some(diff) else {
-        return None
-      }
-      Some((order_document_mappings(diff), []))
-    }
-    TopLevel(top) => {
-      guard flatten_top_level_sections(
-          top, original_lines, modified_lines, ignore_comments, ignore_tests, mode,
-          test_ownership,
-        )
-        is Some(sections) else {
-        return None
-      }
-      let changes : Array[@diff.DetailedLineRangeMapping] = []
-      let alignments : Array[@diff.LineRangeMapping] = []
-      let layout : Array[@diff.LineRangeMapping] = []
-      for section in sections {
-        guard adapt_hunk_document(
-            section.fragment.document,
-            section.old_base,
-            section.new_base,
-            section.old_len,
-            section.new_len,
-            original_lines,
-            modified_lines,
-            ignore_comments,
-            ignore_tests,
-            mode,
-            test_ownership,
-          )
-          is Some(fragment_diff) else {
-          return None
-        }
-        changes.append(fragment_diff.changes)
-        alignments.append(fragment_diff.additional_alignments)
-        if section.matched &&
-          section.old_len != section.new_len &&
-          fragment_diff.changes.is_empty() &&
-          fragment_diff.additional_alignments.is_empty() {
-          guard ignored_range_geometry(
-              original_lines,
-              section.old_base,
-              section.old_len,
-              modified_lines,
-              section.new_base,
-              section.new_len,
-              ignore_comments,
-              ignore_tests,
-              mode,
-              test_ownership,
-            )
-            is Some(section_alignments) else {
-            return None
-          }
-          alignments.append(section_alignments)
-        }
-        layout.push(section.layout)
-      }
-      let diff = order_document_mappings({
-        changes,
-        additional_alignments: alignments,
-      })
-      Some((diff, layout))
-    }
-  }
-}
-
-///|
-fn fragment_has_fallback(fragment : @mbtdiff.DiffFragment) -> Bool {
-  !fragment.fallbacks.is_empty()
-}
-
-///|
-fn document_has_fallback(document : @mbtdiff.DiffDocument) -> Bool {
-  match document {
-    Whole(fragment) => fragment_has_fallback(fragment)
-    TopLevel(top) =>
-      top.sections.any(section => {
-        match section {
-          Matched(diff~, ..) | Deleted(diff~, ..) | Inserted(diff~, ..) =>
-            fragment_has_fallback(diff)
-        }
-      })
-  }
-}
-
-///|
-fn source_range_is_ignored(
-  lines : Array[String],
-  start : Int,
-  len : Int,
-  ignore_comments : Bool,
-  mode : @mbtdiff.DiffMode,
-  ignored_tests : Array[@base_common.LineRange],
-) -> Bool {
-  let range = @base_common.LineRange(start + 1, start + len + 1)
-  if ignored_tests.any(ignored => {
-      ignored.start_line_number <= range.start_line_number &&
-      ignored.end_line_number_exclusive >= range.end_line_number_exclusive
-    }) {
-    return true
-  }
-  if !ignore_comments {
-    return false
-  }
-  let empty : Array[String] = []
-  raw_range_difference_is_ignored(
-    lines, start, len, empty, 0, 0, true, false, mode,
-  )
-}
-
-///|
-fn ignored_only_semantic_geometry(
-  original : @model.TextSnapshot,
-  modified : @model.TextSnapshot,
-  original_lines : Array[String],
-  modified_lines : Array[String],
-  ignore_comments : Bool,
-  ignore_tests : Bool,
-  mode : @mbtdiff.DiffMode,
-  test_ownership : IgnoredTestOwnership,
+/// Convert exactly one MoonDiff fragment into the common DiffEditor contract.
+/// No top-level ranges are rebased, sorted, padded, or flattened here.
+pub fn fragment_document_diff(
+  document : @mbtdiff.HunkDocument,
+  original_source : String,
+  modified_source : String,
 ) -> @diff.DocumentDiff? {
-  let document = @mbtdiff.diff(
-    original.get_value(),
-    modified.get_value(),
-    options=@mbtdiff.DiffOptions(
-      context_lines=0,
-      ignore_comments=false,
-      ignore_tests=false,
-      mode~,
-    ),
-  ).document()
-  guard document is TopLevel(top) &&
-    valid_top_level_orders(
-      top,
-      semantic_line_count(original_lines),
-      semantic_line_count(modified_lines),
-    ) else {
-    return None
-  }
-  let retained = Array::make(top.sections.length(), false)
-  for index, section in top.sections {
-    match section {
-      Matched(old~, new~, ..) => {
-        let old_ignored = source_range_is_ignored(
-          original_lines,
-          old.start,
-          old.len,
-          ignore_comments,
-          mode,
-          test_ownership.original,
-        )
-        let new_ignored = source_range_is_ignored(
-          modified_lines,
-          new.start,
-          new.len,
-          ignore_comments,
-          mode,
-          test_ownership.modified,
-        )
-        if old_ignored != new_ignored {
-          return None
-        }
-        retained[index] = !old_ignored
-      }
-      Deleted(old~, ..) =>
-        if !source_range_is_ignored(
-            original_lines,
-            old.start,
-            old.len,
-            ignore_comments,
-            mode,
-            test_ownership.original,
-          ) {
-          return None
-        }
-      Inserted(new~, ..) =>
-        if !source_range_is_ignored(
-            modified_lines,
-            new.start,
-            new.len,
-            ignore_comments,
-            mode,
-            test_ownership.modified,
-          ) {
-          return None
-        }
-    }
-  }
-  let old_retained = top.old_order.filter(index => retained[index])
-  let new_retained = top.new_order.filter(index => retained[index])
-  if old_retained != new_retained {
-    return None
-  }
-  let layout : Array[@diff.LineRangeMapping] = []
-  let alignments : Array[@diff.LineRangeMapping] = []
-  for index in old_retained {
-    guard top.sections[index] is Matched(old~, new~, ..) else { return None }
-    let mapping = @diff.LineRangeMapping(
-      @base_common.LineRange(old.start + 1, old.start + old.len + 1),
-      @base_common.LineRange(new.start + 1, new.start + new.len + 1),
-    )
-    layout.push(mapping)
-    if old.len != new.len {
-      guard ignored_range_geometry(
-          original_lines,
-          old.start,
-          old.len,
-          modified_lines,
-          new.start,
-          new.len,
-          ignore_comments,
-          ignore_tests,
-          mode,
-          test_ownership,
-        )
-        is Some(section_alignments) else {
-        return None
-      }
-      alignments.append(section_alignments)
-    }
-  }
-  let changes : Array[@diff.DetailedLineRangeMapping] = []
-  if !append_layout_gap_alignments(
-      layout, original_lines, modified_lines, ignore_comments, ignore_tests, mode,
-      test_ownership, changes, alignments,
-    ) {
-    return None
-  }
-  Some(order_document_mappings({ changes, additional_alignments: alignments }))
-}
-
-///|
-fn unfiltered_lexical_diff(
-  original : @model.TextSnapshot,
-  modified : @model.TextSnapshot,
-  original_lines : Array[String],
-  modified_lines : Array[String],
-) -> @diff.DocumentDiff? {
-  let document = @mbtdiff.diff(
-    original.get_value(),
-    modified.get_value(),
-    options=@mbtdiff.DiffOptions(
-      context_lines=0,
-      ignore_comments=false,
-      ignore_tests=false,
-      mode=@mbtdiff.DiffMode::Lexical,
-    ),
-  ).document()
-  match
-    adapt_document(
+  let original : @model.TextSnapshot = TextSnapshot(original_source)
+  let modified : @model.TextSnapshot = TextSnapshot(modified_source)
+  guard adapt_fragment_document(
       document,
-      original_lines,
-      modified_lines,
-      false,
-      false,
-      @mbtdiff.DiffMode::Lexical,
-      { original: [], modified: [] },
-    ) {
-    Some((diff, _)) => Some(diff)
-    None => None
-  }
-}
-
-///|
-fn mapping_has_whitespace_conflict(
-  change : @diff.DetailedLineRangeMapping,
-  original_lines : Array[String],
-  modified_lines : Array[String],
-) -> Bool {
-  let original = @model.TextSnapshot(
-    source_line_slice(
-      original_lines,
-      change.original.start_line_number - 1,
-      change.original.length(),
-    ),
-  )
-  let modified = @model.TextSnapshot(
-    source_line_slice(
-      modified_lines,
-      change.modified.start_line_number - 1,
-      change.modified.length(),
-    ),
-  )
-  let core = @diff.CoreDocumentDiffProvider()
-  let strict = core.compute_diff(original, modified, {
-    ignore_trim_whitespace: false,
-  })
-  let lenient = core.compute_diff(original, modified, {
-    ignore_trim_whitespace: true,
-  })
-  !same_line_change_shape(strict, lenient) ||
-  paired_change_has_edge_whitespace_difference(strict, original, modified)
-}
-
-///|
-fn specialized_source_coverage(
-  mode : MoonDiffMode,
-  ignore_comments : Bool,
-  ignore_tests : Bool,
-  original : @model.TextSnapshot,
-  modified : @model.TextSnapshot,
-  specialized : @diff.DocumentDiff,
-  test_ownership : IgnoredTestOwnership,
-) -> (Bool, Bool) {
-  if !ignore_comments && !ignore_tests {
-    return (true, false)
-  }
-  let diff_mode = match mode {
-    Core => return (false, false)
-    Token => @mbtdiff.DiffMode::Lexical
-    Tree => @mbtdiff.DiffMode::Ast
-  }
-  let original_lines = snapshot_lines(original)
-  let modified_lines = snapshot_lines(modified)
-  let mut old_cursor = 0
-  let mut new_cursor = 0
-  let mut saw_ignored_difference = false
-  for visible in specialized.changes {
-    let old_start = visible.original.start_line_number - 1
-    let new_start = visible.modified.start_line_number - 1
-    if old_start < old_cursor || new_start < new_cursor {
-      return (false, saw_ignored_difference)
-    }
-    let old_len = old_start - old_cursor
-    let new_len = new_start - new_cursor
-    if source_line_slice(original_lines, old_cursor, old_len) !=
-      source_line_slice(modified_lines, new_cursor, new_len) {
-      if !range_difference_is_ignored(
-          original_lines, old_cursor, old_len, modified_lines, new_cursor, new_len,
-          ignore_comments, ignore_tests, diff_mode, test_ownership,
-        ) {
-        return (false, saw_ignored_difference)
-      }
-      saw_ignored_difference = true
-    }
-    if mapping_has_whitespace_conflict(visible, original_lines, modified_lines) {
-      return (false, saw_ignored_difference)
-    }
-    old_cursor = visible.original.end_line_number_exclusive - 1
-    new_cursor = visible.modified.end_line_number_exclusive - 1
-  }
-  if old_cursor > original_lines.length() ||
-    new_cursor > modified_lines.length() {
-    return (false, saw_ignored_difference)
-  }
-  let old_len = original_lines.length() - old_cursor
-  let new_len = modified_lines.length() - new_cursor
-  if source_line_slice(original_lines, old_cursor, old_len) !=
-    source_line_slice(modified_lines, new_cursor, new_len) {
-    if !range_difference_is_ignored(
-        original_lines, old_cursor, old_len, modified_lines, new_cursor, new_len,
-        ignore_comments, ignore_tests, diff_mode, test_ownership,
-      ) {
-      return (false, saw_ignored_difference)
-    }
-    saw_ignored_difference = true
-  }
-  (true, saw_ignored_difference)
-}
-
-///|
-fn specialized_diff(
-  mode : MoonDiffMode,
-  ignore_comments : Bool,
-  ignore_tests : Bool,
-  original : @model.TextSnapshot,
-  modified : @model.TextSnapshot,
-  strict : @diff.DocumentDiff,
-) -> (@diff.DocumentDiff, MoonDiffMode, Bool, IgnoredTestOwnership)? {
-  let original_lines = snapshot_lines(original)
-  let modified_lines = snapshot_lines(modified)
-  let diff_mode = match mode {
-    Core => return None
-    Token => @mbtdiff.DiffMode::Lexical
-    Tree => @mbtdiff.DiffMode::Ast
-  }
-  let result = @mbtdiff.diff(
-    original.get_value(),
-    modified.get_value(),
-    options=@mbtdiff.DiffOptions(
-      context_lines=0,
-      ignore_comments~,
-      ignore_tests~,
-      mode=diff_mode,
-    ),
-  )
-  let document = result.document()
-  guard ignored_test_ownership(result, original_lines, modified_lines)
-    is Some(test_ownership) else {
+      source_lines(original_source),
+      source_lines(modified_source),
+    )
+    is Some(candidate) else {
     return None
   }
-  let fell_back = mode == Tree && document_has_fallback(document)
-  let effective = if fell_back { Token } else { mode }
-  guard adapt_document(
-      document, original_lines, modified_lines, ignore_comments, ignore_tests, diff_mode,
-      test_ownership,
-    )
-    is Some((diff, layout)) else {
-    return None
-  }
-  if (ignore_comments || ignore_tests) &&
-    document is TopLevel(_) &&
-    !append_layout_gap_alignments(
-      layout,
-      original_lines,
-      modified_lines,
-      ignore_comments,
-      ignore_tests,
-      diff_mode,
-      test_ownership,
-      diff.changes,
-      diff.additional_alignments,
-    ) {
-    return None
-  }
-  // A differing source cannot silently become an empty comparison unless the
-  // active filter classified every change as ignored.
-  if original_lines != modified_lines &&
-    diff.changes.is_empty() &&
-    diff.additional_alignments.is_empty() {
-    if !(ignore_comments || ignore_tests) ||
-      !(result.status() is @mbtdiff.DiffStatus::IgnoredOnly) {
-      return None
-    }
-    if ignored_only_semantic_geometry(
-        original, modified, original_lines, modified_lines, ignore_comments, ignore_tests,
-        diff_mode, test_ownership,
-      )
-      is Some(semantic_geometry) {
-      return Some((semantic_geometry, effective, fell_back, test_ownership))
-    }
-    let geometry_changes = match
-      unfiltered_lexical_diff(
-        original, modified, original_lines, modified_lines,
-      ) {
-      Some(unfiltered_diff) if !unfiltered_diff.changes.is_empty() =>
-        unfiltered_diff.changes
-      _ => strict.changes
-    }
-    let ignored_alignments = geometry_changes.filter_map(change => {
-      if change.original.length() != change.modified.length() {
-        Some(change.line_mapping())
-      } else {
-        None
-      }
-    })
-    let result : @diff.DocumentDiff = {
-      changes: [],
-      additional_alignments: ignored_alignments,
-    }
-    if original_lines.length() != modified_lines.length() &&
-      ignored_alignments.is_empty() {
-      return None
-    }
-    return Some(
-      (order_document_mappings(result), effective, fell_back, test_ownership),
-    )
-  }
-  if (ignore_comments || ignore_tests) &&
-    @diff.normalize_and_validate_document_diff(diff, original, modified) is None {
-    if unfiltered_lexical_diff(
-        original, modified, original_lines, modified_lines,
-      )
-      is Some(unfiltered_diff) {
-      append_unrepresented_one_sided_alignments(
-        unfiltered_diff,
-        diff.changes,
-        diff.additional_alignments,
-      )
-    }
-  }
-  Some((order_document_mappings(diff), effective, fell_back, test_ownership))
-}
-
-///|
-fn MoonDocumentDiffProvider::settle_specialized_or_core(
-  self : MoonDocumentDiffProvider,
-  requested : MoonDiffMode,
-  specialized : (@diff.DocumentDiff, MoonDiffMode, Bool)?,
-  core_fallback : @diff.DocumentDiff,
-  original : @model.TextSnapshot,
-  modified : @model.TextSnapshot,
-) -> @diff.DocumentDiff {
-  match specialized {
-    Some((candidate, effective, fell_back)) =>
-      match
-        @diff.normalize_and_validate_document_diff(
-          candidate, original, modified,
-        ) {
-        Some(result) => {
-          self.status = { requested, effective, fell_back, }
-          return result
-        }
-        None => ()
-      }
-    None => ()
-  }
-  self.status = { requested, effective: Core, fell_back: requested != Core, }
-  core_fallback
-}
-
-///|
-pub impl @diff.DocumentDiffProvider for MoonDocumentDiffProvider with fn compute_diff(
-  self,
-  original,
-  modified,
-  options,
-) {
-  let requested = self.mode
-  if requested != Core {
-    let core = @diff.CoreDocumentDiffProvider()
-    let strict = core.compute_diff(original, modified, {
-      ignore_trim_whitespace: false,
-    })
-    let lenient = core.compute_diff(original, modified, {
-      ignore_trim_whitespace: true,
-    })
-    let whitespace_conflict = !same_line_change_shape(strict, lenient) ||
-      paired_change_has_edge_whitespace_difference(strict, original, modified)
-    let raw_specialized = specialized_diff(
-      requested,
-      self.ignore_comments,
-      self.ignore_tests,
-      original,
-      modified,
-      strict,
-    )
-    let (coverage_valid, coverage_has_ignored) = match raw_specialized {
-      Some((candidate, _, _, ownership)) =>
-        specialized_source_coverage(
-          requested,
-          self.ignore_comments,
-          self.ignore_tests,
-          original,
-          modified,
-          candidate,
-          ownership,
-        )
-      _ => (false, false)
-    }
-    let specialized = if coverage_valid {
-      match raw_specialized {
-        Some((candidate, effective, fell_back, _)) =>
-          Some((candidate, effective, fell_back))
-        None => None
-      }
-    } else {
-      None
-    }
-    let whitespace_conflict_is_filtered = coverage_valid && coverage_has_ignored
-    if whitespace_conflict && !whitespace_conflict_is_filtered {
-      self.status = { requested, effective: Core, fell_back: true, }
-      return if options.ignore_trim_whitespace { lenient } else { strict }
-    }
-    return self.settle_specialized_or_core(
-      requested,
-      specialized,
-      if options.ignore_trim_whitespace {
-        lenient
-      } else {
-        strict
-      },
-      original,
-      modified,
-    )
-  }
-  let core = @diff.CoreDocumentDiffProvider().compute_diff(
-    original, modified, options,
-  )
-  self.settle_specialized_or_core(requested, None, core, original, modified)
-}
-
-///|
-pub impl @diff.DocumentDiffProvider for MoonDocumentDiffProvider with fn on_did_change(
-  self,
-  listener,
-) {
-  self.did_change.event(_ => listener())
+  @diff.normalize_and_validate_document_diff(candidate, original, modified)
 }
 
 ///|
@@ -2070,9 +393,3 @@ pub extend MoonDiffMode with Eq::{equal, not_equal}
 
 ///|
 pub extend MoonDiffMode with Debug::{to_repr}
-
-///|
-pub extend MoonDiffStatus with Eq::{equal, not_equal}
-
-///|
-pub extend MoonDiffStatus with Debug::{to_repr}

--- a/editor/viewer/diff_provider/moondiff/provider.mbt
+++ b/editor/viewer/diff_provider/moondiff/provider.mbt
@@ -184,29 +184,38 @@ fn edge_whitespace_signature(line : String) -> (Array[Int], Array[Int]) {
 }
 
 ///|
+fn change_has_edge_whitespace_difference(
+  change : @diff.DetailedLineRangeMapping,
+  original : @model.TextSnapshot,
+  modified : @model.TextSnapshot,
+) -> Bool {
+  if change.original.length() != change.modified.length() {
+    return false
+  }
+  for offset in 0..<change.original.length() {
+    let original_line = original.get_line_content(
+      change.original.start_line_number + offset,
+    )
+    let modified_line = modified.get_line_content(
+      change.modified.start_line_number + offset,
+    )
+    if edge_whitespace_signature(original_line) !=
+      edge_whitespace_signature(modified_line) {
+      return true
+    }
+  }
+  false
+}
+
+///|
 fn paired_change_has_edge_whitespace_difference(
   strict : @diff.DocumentDiff,
   original : @model.TextSnapshot,
   modified : @model.TextSnapshot,
 ) -> Bool {
-  for change in strict.changes {
-    if change.original.length() != change.modified.length() {
-      continue
-    }
-    for offset in 0..<change.original.length() {
-      let original_line = original.get_line_content(
-        change.original.start_line_number + offset,
-      )
-      let modified_line = modified.get_line_content(
-        change.modified.start_line_number + offset,
-      )
-      if edge_whitespace_signature(original_line) !=
-        edge_whitespace_signature(modified_line) {
-        return true
-      }
-    }
-  }
-  false
+  strict.changes.any(change => {
+    change_has_edge_whitespace_difference(change, original, modified)
+  })
 }
 
 ///|
@@ -406,10 +415,8 @@ fn mapping_overlaps_document(
 }
 
 ///|
-// moondiff 0.0.3 can place a filtered one-sided row in a top-level section
-// outside the visible hunk that explains the adjacent code change. Recover
-// only disjoint one-sided rows as geometry; overlapping rows are already
-// represented by a visible change or an IgnoredBlock alignment.
+// Recover filtered one-sided rows that are not already represented by a
+// visible change or an IgnoredBlock alignment.
 fn append_unrepresented_one_sided_alignments(
   unfiltered : @diff.DocumentDiff,
   changes : Array[@diff.DetailedLineRangeMapping],
@@ -417,14 +424,696 @@ fn append_unrepresented_one_sided_alignments(
 ) -> Unit {
   for change in unfiltered.changes {
     let mapping = change.line_mapping()
-    if (
-        (mapping.original.is_empty() && !mapping.modified.is_empty()) ||
-        (mapping.modified.is_empty() && !mapping.original.is_empty())
-      ) &&
-      !mapping_overlaps_document(mapping, changes, alignments) {
-      alignments.push(mapping)
+    if mapping.original.is_empty() && !mapping.modified.is_empty() {
+      let mut run_start : Int? = None
+      for
+        line in mapping.modified.start_line_number..<mapping.modified.end_line_number_exclusive {
+        let unit = @diff.LineRangeMapping(
+          mapping.original,
+          @base_common.LineRange(line, line + 1),
+        )
+        if mapping_overlaps_document(unit, changes, alignments) {
+          if run_start is Some(start) {
+            alignments.push(
+              @diff.LineRangeMapping(
+                mapping.original,
+                @base_common.LineRange(start, line),
+              ),
+            )
+            run_start = None
+          }
+        } else if run_start is None {
+          run_start = Some(line)
+        }
+      }
+      if run_start is Some(start) {
+        alignments.push(
+          @diff.LineRangeMapping(
+            mapping.original,
+            @base_common.LineRange(
+              start,
+              mapping.modified.end_line_number_exclusive,
+            ),
+          ),
+        )
+      }
+    } else if mapping.modified.is_empty() && !mapping.original.is_empty() {
+      let mut run_start : Int? = None
+      for
+        line in mapping.original.start_line_number..<mapping.original.end_line_number_exclusive {
+        let unit = @diff.LineRangeMapping(
+          @base_common.LineRange(line, line + 1),
+          mapping.modified,
+        )
+        if mapping_overlaps_document(unit, changes, alignments) {
+          if run_start is Some(start) {
+            alignments.push(
+              @diff.LineRangeMapping(
+                @base_common.LineRange(start, line),
+                mapping.modified,
+              ),
+            )
+            run_start = None
+          }
+        } else if run_start is None {
+          run_start = Some(line)
+        }
+      }
+      if run_start is Some(start) {
+        alignments.push(
+          @diff.LineRangeMapping(
+            @base_common.LineRange(
+              start,
+              mapping.original.end_line_number_exclusive,
+            ),
+            mapping.modified,
+          ),
+        )
+      }
     }
   }
+}
+
+///|
+fn compare_line_mapping_start(
+  left : @diff.LineRangeMapping,
+  right : @diff.LineRangeMapping,
+) -> Int {
+  let original = left.original.start_line_number -
+    right.original.start_line_number
+  if original != 0 {
+    return original
+  }
+  left.modified.start_line_number - right.modified.start_line_number
+}
+
+///|
+fn compare_detailed_mapping_start(
+  left : @diff.DetailedLineRangeMapping,
+  right : @diff.DetailedLineRangeMapping,
+) -> Int {
+  compare_line_mapping_start(left.line_mapping(), right.line_mapping())
+}
+
+///|
+fn append_flattened_change(
+  changes : Array[@diff.DetailedLineRangeMapping],
+  change : @diff.DetailedLineRangeMapping,
+) -> Unit {
+  if changes.is_empty() {
+    changes.push(change)
+    return
+  }
+  let previous = changes[changes.length() - 1]
+  if !line_ranges_intersect_or_touch(previous.original, change.original) ||
+    !line_ranges_intersect_or_touch(previous.modified, change.modified) {
+    changes.push(change)
+    return
+  }
+  let inner_changes = match (previous.inner_changes, change.inner_changes) {
+    (Some(previous_inner), Some(change_inner)) => {
+      let joined = previous_inner.copy()
+      joined.append(change_inner)
+      Some(joined)
+    }
+    _ => None
+  }
+  changes[changes.length() - 1] = DetailedLineRangeMapping(
+    previous.original.join(change.original),
+    previous.modified.join(change.modified),
+    inner_changes,
+  )
+}
+
+///|
+fn append_flattened_alignment(
+  alignments : Array[@diff.LineRangeMapping],
+  alignment : @diff.LineRangeMapping,
+) -> Unit {
+  if alignments.is_empty() {
+    alignments.push(alignment)
+    return
+  }
+  let previous = alignments[alignments.length() - 1]
+  if !line_ranges_intersect_or_touch(previous.original, alignment.original) ||
+    !line_ranges_intersect_or_touch(previous.modified, alignment.modified) {
+    alignments.push(alignment)
+    return
+  }
+  alignments[alignments.length() - 1] = LineRangeMapping(
+    previous.original.join(alignment.original),
+    previous.modified.join(alignment.modified),
+  )
+}
+
+///|
+fn order_document_mappings(diff : @diff.DocumentDiff) -> @diff.DocumentDiff {
+  let raw_changes = diff.changes.copy()
+  raw_changes.sort_by(compare_detailed_mapping_start)
+  let changes : Array[@diff.DetailedLineRangeMapping] = []
+  for change in raw_changes {
+    append_flattened_change(changes, change)
+  }
+  let raw_alignments = diff.additional_alignments.copy()
+  raw_alignments.sort_by(compare_line_mapping_start)
+  let alignments : Array[@diff.LineRangeMapping] = []
+  for alignment in raw_alignments {
+    append_flattened_alignment(alignments, alignment)
+  }
+  { changes, additional_alignments: alignments }
+}
+
+///|
+priv struct FlattenedSection {
+  fragment : @mbtdiff.DiffFragment
+  old_base : Int
+  new_base : Int
+  old_len : Int
+  new_len : Int
+  matched : Bool
+  layout : @diff.LineRangeMapping
+}
+
+///|
+priv struct IgnoredTestOwnership {
+  original : Array[@base_common.LineRange]
+  modified : Array[@base_common.LineRange]
+}
+
+///|
+fn semantic_line_count(lines : Array[String]) -> Int {
+  if !lines.is_empty() && lines[lines.length() - 1].is_empty() {
+    lines.length() - 1
+  } else {
+    lines.length()
+  }
+}
+
+///|
+fn source_line_slice(lines : Array[String], start : Int, len : Int) -> String {
+  if len == 0 {
+    return ""
+  }
+  let selected : Array[String] = []
+  for index in start..<(start + len) {
+    selected.push(lines[index])
+  }
+  selected.join("\n") + "\n"
+}
+
+///|
+fn raw_range_difference_is_ignored(
+  original_lines : Array[String],
+  old_start : Int,
+  old_len : Int,
+  modified_lines : Array[String],
+  new_start : Int,
+  new_len : Int,
+  ignore_comments : Bool,
+  ignore_tests : Bool,
+  mode : @mbtdiff.DiffMode,
+) -> Bool {
+  let old_source = source_line_slice(original_lines, old_start, old_len)
+  let new_source = source_line_slice(modified_lines, new_start, new_len)
+  if old_source == new_source {
+    return true
+  }
+  if !ignore_comments && !ignore_tests {
+    return false
+  }
+  @mbtdiff.diff(
+    old_source,
+    new_source,
+    options=@mbtdiff.DiffOptions(
+      context_lines=0,
+      ignore_comments~,
+      ignore_tests~,
+      mode~,
+    ),
+  ).status()
+  is @mbtdiff.DiffStatus::IgnoredOnly
+}
+
+///|
+fn source_ignored_test_ranges(
+  source : @model.TextSnapshot,
+  lines : Array[String],
+  mode : @mbtdiff.DiffMode,
+) -> Array[@base_common.LineRange]? {
+  if source.get_value().is_empty() {
+    return Some([])
+  }
+  let probe = @model.TextSnapshot(source.get_value() + "\n")
+  let probe_lines = snapshot_lines(probe)
+  let document = @mbtdiff.diff(
+    source.get_value(),
+    probe.get_value(),
+    options=@mbtdiff.DiffOptions(
+      context_lines=0,
+      ignore_comments=false,
+      ignore_tests=false,
+      mode~,
+    ),
+  ).document()
+  guard document is TopLevel(top) &&
+    valid_top_level_orders(
+      top,
+      semantic_line_count(lines),
+      semantic_line_count(probe_lines),
+    ) else {
+    return None
+  }
+  let ranges : Array[@base_common.LineRange] = []
+  for section in top.sections {
+    guard section is Matched(old~, new~, ..) && old == new else { return None }
+    let empty : Array[String] = []
+    if raw_range_difference_is_ignored(
+        lines,
+        old.start,
+        old.len,
+        empty,
+        0,
+        0,
+        false,
+        true,
+        mode,
+      ) {
+      ranges.push(
+        @base_common.LineRange(old.start + 1, old.start + old.len + 1),
+      )
+    }
+  }
+  Some(ranges)
+}
+
+///|
+fn ignored_test_ownership(
+  original : @model.TextSnapshot,
+  modified : @model.TextSnapshot,
+  original_lines : Array[String],
+  modified_lines : Array[String],
+  ignore_tests : Bool,
+  mode : @mbtdiff.DiffMode,
+) -> IgnoredTestOwnership? {
+  if !ignore_tests {
+    return Some({ original: [], modified: [] })
+  }
+  match
+    (
+      source_ignored_test_ranges(original, original_lines, mode),
+      source_ignored_test_ranges(modified, modified_lines, mode),
+    ) {
+    (Some(original_ranges), Some(modified_ranges)) =>
+      Some({ original: original_ranges, modified: modified_ranges })
+    _ => Some({ original: [], modified: [] })
+  }
+}
+
+///|
+fn strip_owned_lines(
+  lines : Array[String],
+  start : Int,
+  len : Int,
+  owned : Array[@base_common.LineRange],
+) -> (Array[String], Bool) {
+  let visible : Array[String] = []
+  let mut removed = false
+  for index in start..<(start + len) {
+    if owned.any(range => range.contains(index + 1)) {
+      removed = true
+    } else {
+      visible.push(lines[index])
+    }
+  }
+  (visible, removed)
+}
+
+///|
+fn range_difference_is_ignored(
+  original_lines : Array[String],
+  old_start : Int,
+  old_len : Int,
+  modified_lines : Array[String],
+  new_start : Int,
+  new_len : Int,
+  ignore_comments : Bool,
+  ignore_tests : Bool,
+  mode : @mbtdiff.DiffMode,
+  test_ownership : IgnoredTestOwnership,
+) -> Bool {
+  let old_source = source_line_slice(original_lines, old_start, old_len)
+  let new_source = source_line_slice(modified_lines, new_start, new_len)
+  if old_source == new_source {
+    return true
+  }
+  if !ignore_tests {
+    return raw_range_difference_is_ignored(
+      original_lines, old_start, old_len, modified_lines, new_start, new_len, ignore_comments,
+      false, mode,
+    )
+  }
+  let (old_visible, old_removed) = strip_owned_lines(
+    original_lines,
+    old_start,
+    old_len,
+    test_ownership.original,
+  )
+  let (new_visible, new_removed) = strip_owned_lines(
+    modified_lines,
+    new_start,
+    new_len,
+    test_ownership.modified,
+  )
+  if !old_removed && !new_removed {
+    return if ignore_comments {
+      raw_range_difference_is_ignored(
+        original_lines, old_start, old_len, modified_lines, new_start, new_len, true,
+        false, mode,
+      )
+    } else {
+      false
+    }
+  }
+  let old_visible_source = source_line_slice(
+    old_visible,
+    0,
+    old_visible.length(),
+  )
+  let new_visible_source = source_line_slice(
+    new_visible,
+    0,
+    new_visible.length(),
+  )
+  if old_visible_source == new_visible_source {
+    return true
+  }
+  ignore_comments &&
+  @mbtdiff.diff(
+    old_visible_source,
+    new_visible_source,
+    options=@mbtdiff.DiffOptions(
+      context_lines=0,
+      ignore_comments=true,
+      ignore_tests=false,
+      mode~,
+    ),
+  ).status()
+  is @mbtdiff.DiffStatus::IgnoredOnly
+}
+
+///|
+fn rebase_line_mapping(
+  mapping : @diff.LineRangeMapping,
+  old_base : Int,
+  new_base : Int,
+) -> @diff.LineRangeMapping {
+  @diff.LineRangeMapping(
+    @base_common.LineRange(
+      mapping.original.start_line_number + old_base,
+      mapping.original.end_line_number_exclusive + old_base,
+    ),
+    @base_common.LineRange(
+      mapping.modified.start_line_number + new_base,
+      mapping.modified.end_line_number_exclusive + new_base,
+    ),
+  )
+}
+
+///|
+fn ignored_range_geometry(
+  original_lines : Array[String],
+  old_start : Int,
+  old_len : Int,
+  modified_lines : Array[String],
+  new_start : Int,
+  new_len : Int,
+  ignore_comments : Bool,
+  ignore_tests : Bool,
+  mode : @mbtdiff.DiffMode,
+  test_ownership : IgnoredTestOwnership,
+) -> Array[@diff.LineRangeMapping]? {
+  if !range_difference_is_ignored(
+      original_lines, old_start, old_len, modified_lines, new_start, new_len, ignore_comments,
+      ignore_tests, mode, test_ownership,
+    ) {
+    return None
+  }
+  let core = @diff.CoreDocumentDiffProvider().compute_diff(
+    @model.TextSnapshot(source_line_slice(original_lines, old_start, old_len)),
+    @model.TextSnapshot(source_line_slice(modified_lines, new_start, new_len)),
+    { ignore_trim_whitespace: false },
+  )
+  let alignments = core.changes.filter_map(change => {
+    if change.original.length() != change.modified.length() {
+      Some(rebase_line_mapping(change.line_mapping(), old_start, new_start))
+    } else {
+      None
+    }
+  })
+  if old_len != new_len && alignments.is_empty() {
+    None
+  } else {
+    Some(alignments)
+  }
+}
+
+///|
+fn valid_top_level_orders(
+  top : @mbtdiff.TopLevelDiff,
+  original_line_count : Int,
+  modified_line_count : Int,
+) -> Bool {
+  let old_seen = Array::make(top.sections.length(), false)
+  let new_seen = Array::make(top.sections.length(), false)
+  let mut new_end = 0
+  for index in top.new_order {
+    if index < 0 || index >= top.sections.length() || new_seen[index] {
+      return false
+    }
+    let range = match top.sections[index] {
+      Matched(new~, ..) | Inserted(new~, ..) => new
+      Deleted(..) => return false
+    }
+    if !valid_hunk_range(range.start, range.len, modified_line_count) ||
+      range.start < new_end {
+      return false
+    }
+    new_seen[index] = true
+    new_end = range.start + range.len
+  }
+  let mut old_end = 0
+  for index in top.old_order {
+    if index < 0 || index >= top.sections.length() || old_seen[index] {
+      return false
+    }
+    let range = match top.sections[index] {
+      Matched(old~, ..) | Deleted(old~, ..) => old
+      Inserted(..) => return false
+    }
+    if !valid_hunk_range(range.start, range.len, original_line_count) ||
+      range.start < old_end {
+      return false
+    }
+    old_seen[index] = true
+    old_end = range.start + range.len
+  }
+  for index, section in top.sections {
+    match section {
+      Matched(..) => if !old_seen[index] || !new_seen[index] { return false }
+      Deleted(..) => if !old_seen[index] || new_seen[index] { return false }
+      Inserted(..) => if old_seen[index] || !new_seen[index] { return false }
+    }
+  }
+  true
+}
+
+///|
+fn flatten_top_level_sections(
+  top : @mbtdiff.TopLevelDiff,
+  original_lines : Array[String],
+  modified_lines : Array[String],
+  ignore_comments : Bool,
+  ignore_tests : Bool,
+  mode : @mbtdiff.DiffMode,
+  test_ownership : IgnoredTestOwnership,
+) -> Array[FlattenedSection]? {
+  let original_line_count = semantic_line_count(original_lines)
+  let modified_line_count = semantic_line_count(modified_lines)
+  if top.reordered ||
+    !valid_top_level_orders(top, original_line_count, modified_line_count) {
+    return None
+  }
+  let sections : Array[FlattenedSection] = []
+  let mut old_order_index = 0
+  let mut new_order_index = 0
+  let mut old_cursor = 0
+  let mut new_cursor = 0
+  while old_order_index < top.old_order.length() ||
+        new_order_index < top.new_order.length() {
+    let has_old = old_order_index < top.old_order.length()
+    let has_new = new_order_index < top.new_order.length()
+    let old_index = if has_old { top.old_order[old_order_index] } else { -1 }
+    let new_index = if has_new { top.new_order[new_order_index] } else { -1 }
+    let old_target = if has_old {
+      match top.sections[old_index] {
+        Matched(old~, ..) | Deleted(old~, ..) => old.start
+        Inserted(..) => return None
+      }
+    } else {
+      original_line_count
+    }
+    let new_target = if has_new {
+      match top.sections[new_index] {
+        Matched(new~, ..) | Inserted(new~, ..) => new.start
+        Deleted(..) => return None
+      }
+    } else {
+      modified_line_count
+    }
+    if old_target < old_cursor || new_target < new_cursor {
+      return None
+    }
+    let old_gap_len = old_target - old_cursor
+    let new_gap_len = new_target - new_cursor
+    if source_line_slice(original_lines, old_cursor, old_gap_len) ==
+      source_line_slice(modified_lines, new_cursor, new_gap_len) {
+      old_cursor = old_target
+      new_cursor = new_target
+    }
+    if has_old && has_new && old_index == new_index {
+      guard top.sections[old_index] is Matched(old~, new~, diff~) else {
+        return None
+      }
+      if old_cursor != old_target || new_cursor != new_target {
+        if !range_difference_is_ignored(
+            original_lines,
+            old_cursor,
+            old_target - old_cursor,
+            modified_lines,
+            new_cursor,
+            new_target - new_cursor,
+            ignore_comments,
+            ignore_tests,
+            mode,
+            test_ownership,
+          ) {
+          return None
+        }
+        old_cursor = old_target
+        new_cursor = new_target
+      }
+      sections.push({
+        fragment: diff,
+        old_base: old.start,
+        new_base: new.start,
+        old_len: old.len,
+        new_len: new.len,
+        matched: true,
+        layout: @diff.LineRangeMapping(
+          @base_common.LineRange(old.start + 1, old.start + old.len + 1),
+          @base_common.LineRange(new.start + 1, new.start + new.len + 1),
+        ),
+      })
+      old_cursor = old.start + old.len
+      new_cursor = new.start + new.len
+      old_order_index += 1
+      new_order_index += 1
+      continue
+    }
+    if has_old &&
+      has_new &&
+      old_cursor == old_target &&
+      new_cursor == new_target &&
+      top.sections[old_index] is Deleted(old~, diff=old_diff) &&
+      top.sections[new_index] is Inserted(new~, diff=new_diff) {
+      sections.push({
+        fragment: old_diff,
+        old_base: old.start,
+        new_base: new_cursor,
+        old_len: old.len,
+        new_len: 0,
+        matched: false,
+        layout: @diff.LineRangeMapping(
+          @base_common.LineRange(old.start + 1, old.start + old.len + 1),
+          @base_common.LineRange(new_cursor + 1, new_cursor + 1),
+        ),
+      })
+      old_cursor = old.start + old.len
+      old_order_index += 1
+      sections.push({
+        fragment: new_diff,
+        old_base: old_cursor,
+        new_base: new.start,
+        old_len: 0,
+        new_len: new.len,
+        matched: false,
+        layout: @diff.LineRangeMapping(
+          @base_common.LineRange(old_cursor + 1, old_cursor + 1),
+          @base_common.LineRange(new.start + 1, new.start + new.len + 1),
+        ),
+      })
+      new_cursor = new.start + new.len
+      new_order_index += 1
+      continue
+    }
+    if has_old &&
+      old_cursor == old_target &&
+      top.sections[old_index] is Deleted(old~, diff~) {
+      sections.push({
+        fragment: diff,
+        old_base: old.start,
+        new_base: new_cursor,
+        old_len: old.len,
+        new_len: 0,
+        matched: false,
+        layout: @diff.LineRangeMapping(
+          @base_common.LineRange(old.start + 1, old.start + old.len + 1),
+          @base_common.LineRange(new_cursor + 1, new_cursor + 1),
+        ),
+      })
+      old_cursor = old.start + old.len
+      old_order_index += 1
+      continue
+    }
+    if has_new &&
+      new_cursor == new_target &&
+      top.sections[new_index] is Inserted(new~, diff~) {
+      sections.push({
+        fragment: diff,
+        old_base: old_cursor,
+        new_base: new.start,
+        old_len: 0,
+        new_len: new.len,
+        matched: false,
+        layout: @diff.LineRangeMapping(
+          @base_common.LineRange(old_cursor + 1, old_cursor + 1),
+          @base_common.LineRange(new.start + 1, new.start + new.len + 1),
+        ),
+      })
+      new_cursor = new.start + new.len
+      new_order_index += 1
+      continue
+    }
+    if (old_cursor < old_target || new_cursor < new_target) &&
+      range_difference_is_ignored(
+        original_lines,
+        old_cursor,
+        old_target - old_cursor,
+        modified_lines,
+        new_cursor,
+        new_target - new_cursor,
+        ignore_comments,
+        ignore_tests,
+        mode,
+        test_ownership,
+      ) {
+      old_cursor = old_target
+      new_cursor = new_target
+      continue
+    }
+    return None
+  }
+  Some(sections)
 }
 
 ///|
@@ -449,54 +1138,149 @@ fn append_layout_gap(
 }
 
 ///|
-// Test filtering removes whole top-level sections before hunk calculation.
-// Their line spans remain observable as gaps in DiffLayout, so preserve only
-// their height difference as neutral alignment geometry.
+// Test filtering removes whole top-level sections before fragment calculation.
+// Their line spans remain observable between semantic section ranges, so
+// preserve only their height difference as neutral alignment geometry.
 fn append_layout_gap_alignments(
-  layout : @mbtdiff.DiffLayout,
-  original_line_count : Int,
-  modified_line_count : Int,
+  layout : ArrayView[@diff.LineRangeMapping],
+  original_lines : Array[String],
+  modified_lines : Array[String],
+  ignore_comments : Bool,
+  ignore_tests : Bool,
+  mode : @mbtdiff.DiffMode,
+  test_ownership : IgnoredTestOwnership,
   changes : Array[@diff.DetailedLineRangeMapping],
   alignments : Array[@diff.LineRangeMapping],
-) -> Unit {
-  guard layout is @mbtdiff.DiffLayout::TopLevelSections(sections) else {
-    return
-  }
+) -> Bool {
   let mut old_cursor = 0
   let mut new_cursor = 0
-  for section in sections {
-    let old_start = section.old.map(range => range.start).unwrap_or(old_cursor)
-    let new_start = section.new.map(range => range.start).unwrap_or(new_cursor)
+  for section in layout {
+    let old_start = section.original.start_line_number - 1
+    let new_start = section.modified.start_line_number - 1
     if old_start < old_cursor || new_start < new_cursor {
-      return
+      return false
+    }
+    let old_len = old_start - old_cursor
+    let new_len = new_start - new_cursor
+    if !range_difference_is_ignored(
+        original_lines, old_cursor, old_len, modified_lines, new_cursor, new_len,
+        ignore_comments, ignore_tests, mode, test_ownership,
+      ) {
+      return false
     }
     append_layout_gap(
-      old_cursor,
-      old_start - old_cursor,
-      new_cursor,
-      new_start - new_cursor,
-      changes,
-      alignments,
+      old_cursor, old_len, new_cursor, new_len, changes, alignments,
     )
-    match section.old {
-      Some(range) => old_cursor = range.start + range.len
-      None => ()
-    }
-    match section.new {
-      Some(range) => new_cursor = range.start + range.len
-      None => ()
+    old_cursor = section.original.end_line_number_exclusive - 1
+    new_cursor = section.modified.end_line_number_exclusive - 1
+  }
+  if old_cursor > original_lines.length() ||
+    new_cursor > modified_lines.length() {
+    return false
+  }
+  let old_len = original_lines.length() - old_cursor
+  let new_len = modified_lines.length() - new_cursor
+  if !range_difference_is_ignored(
+      original_lines, old_cursor, old_len, modified_lines, new_cursor, new_len, ignore_comments,
+      ignore_tests, mode, test_ownership,
+    ) {
+    return false
+  }
+  append_layout_gap(
+    old_cursor, old_len, new_cursor, new_len, changes, alignments,
+  )
+  true
+}
+
+///|
+fn line_is_test_owned(
+  line_number : Int,
+  ranges : Array[@base_common.LineRange],
+) -> Bool {
+  ranges.any(range => range.contains(line_number))
+}
+
+///|
+fn ignored_rows_are_filter_owned(
+  rows : ArrayView[@mbtdiff.DiffRow],
+  original_lines : Array[String],
+  modified_lines : Array[String],
+  ignore_comments : Bool,
+  ignore_tests : Bool,
+  mode : @mbtdiff.DiffMode,
+  test_ownership : IgnoredTestOwnership,
+) -> Bool {
+  for row in rows {
+    match row {
+      Paired(original, modified) => {
+        if original.text() == modified.text() {
+          continue
+        }
+        if ignore_tests &&
+          line_is_test_owned(original.index + 1, test_ownership.original) &&
+          line_is_test_owned(modified.index + 1, test_ownership.modified) {
+          continue
+        }
+        if !ignore_comments ||
+          !raw_range_difference_is_ignored(
+            original_lines,
+            original.index,
+            1,
+            modified_lines,
+            modified.index,
+            1,
+            true,
+            false,
+            mode,
+          ) {
+          return false
+        }
+      }
+      OldOnly(original) => {
+        if ignore_tests &&
+          line_is_test_owned(original.index + 1, test_ownership.original) {
+          continue
+        }
+        let empty : Array[String] = []
+        if !ignore_comments ||
+          !raw_range_difference_is_ignored(
+            original_lines,
+            original.index,
+            1,
+            empty,
+            0,
+            0,
+            true,
+            false,
+            mode,
+          ) {
+          return false
+        }
+      }
+      NewOnly(modified) => {
+        if ignore_tests &&
+          line_is_test_owned(modified.index + 1, test_ownership.modified) {
+          continue
+        }
+        let empty : Array[String] = []
+        if !ignore_comments ||
+          !raw_range_difference_is_ignored(
+            empty,
+            0,
+            0,
+            modified_lines,
+            modified.index,
+            1,
+            true,
+            false,
+            mode,
+          ) {
+          return false
+        }
+      }
     }
   }
-  if old_cursor <= original_line_count && new_cursor <= modified_line_count {
-    append_layout_gap(
-      old_cursor,
-      original_line_count - old_cursor,
-      new_cursor,
-      modified_line_count - new_cursor,
-      changes,
-      alignments,
-    )
-  }
+  true
 }
 
 ///|
@@ -565,14 +1349,29 @@ fn append_rows(
 }
 
 ///|
-fn adapt_document(
-  document : @mbtdiff.DiffDocument,
+fn adapt_hunk_document(
+  document : @mbtdiff.HunkDocument,
+  old_base : Int,
+  new_base : Int,
+  old_len : Int,
+  new_len : Int,
   original_lines : Array[String],
   modified_lines : Array[String],
+  ignore_comments : Bool,
+  ignore_tests : Bool,
+  mode : @mbtdiff.DiffMode,
+  test_ownership : IgnoredTestOwnership,
 ) -> @diff.DocumentDiff? {
+  for hunk in document.hunks {
+    if !valid_hunk_range(hunk.old_start, hunk.old_len, old_len) ||
+      !valid_hunk_range(hunk.new_start, hunk.new_len, new_len) {
+      return None
+    }
+  }
+  let rebased = document.rebase(old_base, new_base)
   let changes = []
   let alignments = []
-  for hunk in document.hunks {
+  for hunk in rebased.hunks {
     if !valid_hunk_range(hunk.old_start, hunk.old_len, original_lines.length()) ||
       !valid_hunk_range(hunk.new_start, hunk.new_len, modified_lines.length()) {
       return None
@@ -606,7 +1405,13 @@ fn adapt_document(
             }
             None => return None
           }
-        IgnoredBlock(rows) =>
+        IgnoredBlock(rows) => {
+          if !ignored_rows_are_filter_owned(
+              rows, original_lines, modified_lines, ignore_comments, ignore_tests,
+              mode, test_ownership,
+            ) {
+            return None
+          }
           match
             append_rows(
               rows, false, original_lines, modified_lines, old_cursor, new_cursor,
@@ -618,6 +1423,7 @@ fn adapt_document(
             }
             None => return None
           }
+        }
       }
     }
     if old_cursor != hunk.old_start + hunk.old_len ||
@@ -626,6 +1432,253 @@ fn adapt_document(
     }
   }
   Some({ changes, additional_alignments: alignments, })
+}
+
+///|
+fn adapt_document(
+  document : @mbtdiff.DiffDocument,
+  original_lines : Array[String],
+  modified_lines : Array[String],
+  ignore_comments : Bool,
+  ignore_tests : Bool,
+  mode : @mbtdiff.DiffMode,
+  test_ownership : IgnoredTestOwnership,
+) -> (@diff.DocumentDiff, Array[@diff.LineRangeMapping])? {
+  match document {
+    Whole(fragment) => {
+      guard adapt_hunk_document(
+          fragment.document,
+          0,
+          0,
+          original_lines.length(),
+          modified_lines.length(),
+          original_lines,
+          modified_lines,
+          ignore_comments,
+          ignore_tests,
+          mode,
+          test_ownership,
+        )
+        is Some(diff) else {
+        return None
+      }
+      Some((order_document_mappings(diff), []))
+    }
+    TopLevel(top) => {
+      guard flatten_top_level_sections(
+          top, original_lines, modified_lines, ignore_comments, ignore_tests, mode,
+          test_ownership,
+        )
+        is Some(sections) else {
+        return None
+      }
+      let changes : Array[@diff.DetailedLineRangeMapping] = []
+      let alignments : Array[@diff.LineRangeMapping] = []
+      let layout : Array[@diff.LineRangeMapping] = []
+      for section in sections {
+        guard adapt_hunk_document(
+            section.fragment.document,
+            section.old_base,
+            section.new_base,
+            section.old_len,
+            section.new_len,
+            original_lines,
+            modified_lines,
+            ignore_comments,
+            ignore_tests,
+            mode,
+            test_ownership,
+          )
+          is Some(fragment_diff) else {
+          return None
+        }
+        changes.append(fragment_diff.changes)
+        alignments.append(fragment_diff.additional_alignments)
+        if section.matched &&
+          section.old_len != section.new_len &&
+          fragment_diff.changes.is_empty() &&
+          fragment_diff.additional_alignments.is_empty() {
+          guard ignored_range_geometry(
+              original_lines,
+              section.old_base,
+              section.old_len,
+              modified_lines,
+              section.new_base,
+              section.new_len,
+              ignore_comments,
+              ignore_tests,
+              mode,
+              test_ownership,
+            )
+            is Some(section_alignments) else {
+            return None
+          }
+          alignments.append(section_alignments)
+        }
+        layout.push(section.layout)
+      }
+      let diff = order_document_mappings({
+        changes,
+        additional_alignments: alignments,
+      })
+      Some((diff, layout))
+    }
+  }
+}
+
+///|
+fn fragment_has_fallback(fragment : @mbtdiff.DiffFragment) -> Bool {
+  !fragment.fallbacks.is_empty()
+}
+
+///|
+fn document_has_fallback(document : @mbtdiff.DiffDocument) -> Bool {
+  match document {
+    Whole(fragment) => fragment_has_fallback(fragment)
+    TopLevel(top) =>
+      top.sections.any(section => {
+        match section {
+          Matched(diff~, ..) | Deleted(diff~, ..) | Inserted(diff~, ..) =>
+            fragment_has_fallback(diff)
+        }
+      })
+  }
+}
+
+///|
+fn source_range_is_ignored(
+  lines : Array[String],
+  start : Int,
+  len : Int,
+  ignore_comments : Bool,
+  ignore_tests : Bool,
+  mode : @mbtdiff.DiffMode,
+) -> Bool {
+  let empty : Array[String] = []
+  raw_range_difference_is_ignored(
+    lines, start, len, empty, 0, 0, ignore_comments, ignore_tests, mode,
+  )
+}
+
+///|
+fn ignored_only_semantic_geometry(
+  original : @model.TextSnapshot,
+  modified : @model.TextSnapshot,
+  original_lines : Array[String],
+  modified_lines : Array[String],
+  ignore_comments : Bool,
+  ignore_tests : Bool,
+  mode : @mbtdiff.DiffMode,
+  test_ownership : IgnoredTestOwnership,
+) -> @diff.DocumentDiff? {
+  let document = @mbtdiff.diff(
+    original.get_value(),
+    modified.get_value(),
+    options=@mbtdiff.DiffOptions(
+      context_lines=0,
+      ignore_comments=false,
+      ignore_tests=false,
+      mode~,
+    ),
+  ).document()
+  guard document is TopLevel(top) &&
+    valid_top_level_orders(
+      top,
+      semantic_line_count(original_lines),
+      semantic_line_count(modified_lines),
+    ) else {
+    return None
+  }
+  let retained = Array::make(top.sections.length(), false)
+  for index, section in top.sections {
+    match section {
+      Matched(old~, new~, ..) => {
+        let old_ignored = source_range_is_ignored(
+          original_lines,
+          old.start,
+          old.len,
+          ignore_comments,
+          ignore_tests,
+          mode,
+        )
+        let new_ignored = source_range_is_ignored(
+          modified_lines,
+          new.start,
+          new.len,
+          ignore_comments,
+          ignore_tests,
+          mode,
+        )
+        if old_ignored != new_ignored {
+          return None
+        }
+        retained[index] = !old_ignored
+      }
+      Deleted(old~, ..) =>
+        if !source_range_is_ignored(
+            original_lines,
+            old.start,
+            old.len,
+            ignore_comments,
+            ignore_tests,
+            mode,
+          ) {
+          return None
+        }
+      Inserted(new~, ..) =>
+        if !source_range_is_ignored(
+            modified_lines,
+            new.start,
+            new.len,
+            ignore_comments,
+            ignore_tests,
+            mode,
+          ) {
+          return None
+        }
+    }
+  }
+  let old_retained = top.old_order.filter(index => retained[index])
+  let new_retained = top.new_order.filter(index => retained[index])
+  if old_retained != new_retained {
+    return None
+  }
+  let layout : Array[@diff.LineRangeMapping] = []
+  let alignments : Array[@diff.LineRangeMapping] = []
+  for index in old_retained {
+    guard top.sections[index] is Matched(old~, new~, ..) else { return None }
+    let mapping = @diff.LineRangeMapping(
+      @base_common.LineRange(old.start + 1, old.start + old.len + 1),
+      @base_common.LineRange(new.start + 1, new.start + new.len + 1),
+    )
+    layout.push(mapping)
+    if old.len != new.len {
+      guard ignored_range_geometry(
+          original_lines,
+          old.start,
+          old.len,
+          modified_lines,
+          new.start,
+          new.len,
+          ignore_comments,
+          ignore_tests,
+          mode,
+          test_ownership,
+        )
+        is Some(section_alignments) else {
+        return None
+      }
+      alignments.append(section_alignments)
+    }
+  }
+  let changes : Array[@diff.DetailedLineRangeMapping] = []
+  if !append_layout_gap_alignments(
+      layout, original_lines, modified_lines, ignore_comments, ignore_tests, mode,
+      test_ownership, changes, alignments,
+    ) {
+    return None
+  }
+  Some(order_document_mappings({ changes, additional_alignments: alignments }))
 }
 
 ///|
@@ -645,7 +1698,116 @@ fn unfiltered_lexical_diff(
       mode=@mbtdiff.DiffMode::Lexical,
     ),
   ).document()
-  adapt_document(document, original_lines, modified_lines)
+  match
+    adapt_document(
+      document,
+      original_lines,
+      modified_lines,
+      false,
+      false,
+      @mbtdiff.DiffMode::Lexical,
+      { original: [], modified: [] },
+    ) {
+    Some((diff, _)) => Some(diff)
+    None => None
+  }
+}
+
+///|
+fn mapping_has_whitespace_conflict(
+  change : @diff.DetailedLineRangeMapping,
+  original_lines : Array[String],
+  modified_lines : Array[String],
+) -> Bool {
+  let original = @model.TextSnapshot(
+    source_line_slice(
+      original_lines,
+      change.original.start_line_number - 1,
+      change.original.length(),
+    ),
+  )
+  let modified = @model.TextSnapshot(
+    source_line_slice(
+      modified_lines,
+      change.modified.start_line_number - 1,
+      change.modified.length(),
+    ),
+  )
+  let core = @diff.CoreDocumentDiffProvider()
+  let strict = core.compute_diff(original, modified, {
+    ignore_trim_whitespace: false,
+  })
+  let lenient = core.compute_diff(original, modified, {
+    ignore_trim_whitespace: true,
+  })
+  !same_line_change_shape(strict, lenient) ||
+  paired_change_has_edge_whitespace_difference(strict, original, modified)
+}
+
+///|
+fn specialized_source_coverage(
+  mode : MoonDiffMode,
+  ignore_comments : Bool,
+  ignore_tests : Bool,
+  original : @model.TextSnapshot,
+  modified : @model.TextSnapshot,
+  specialized : @diff.DocumentDiff,
+  test_ownership : IgnoredTestOwnership,
+) -> (Bool, Bool) {
+  if !ignore_comments && !ignore_tests {
+    return (true, false)
+  }
+  let diff_mode = match mode {
+    Core => return (false, false)
+    Token => @mbtdiff.DiffMode::Lexical
+    Tree => @mbtdiff.DiffMode::Ast
+  }
+  let original_lines = snapshot_lines(original)
+  let modified_lines = snapshot_lines(modified)
+  let mut old_cursor = 0
+  let mut new_cursor = 0
+  let mut saw_ignored_difference = false
+  for visible in specialized.changes {
+    let old_start = visible.original.start_line_number - 1
+    let new_start = visible.modified.start_line_number - 1
+    if old_start < old_cursor || new_start < new_cursor {
+      return (false, saw_ignored_difference)
+    }
+    let old_len = old_start - old_cursor
+    let new_len = new_start - new_cursor
+    if source_line_slice(original_lines, old_cursor, old_len) !=
+      source_line_slice(modified_lines, new_cursor, new_len) {
+      if !range_difference_is_ignored(
+          original_lines, old_cursor, old_len, modified_lines, new_cursor, new_len,
+          ignore_comments, ignore_tests, diff_mode, test_ownership,
+        ) {
+        return (false, saw_ignored_difference)
+      }
+      saw_ignored_difference = true
+    }
+    if mapping_has_whitespace_conflict(visible, original_lines, modified_lines) {
+      return (false, saw_ignored_difference)
+    }
+    old_cursor = visible.original.end_line_number_exclusive - 1
+    new_cursor = visible.modified.end_line_number_exclusive - 1
+  }
+  if old_cursor > original_lines.length() ||
+    new_cursor > modified_lines.length() {
+    return (false, saw_ignored_difference)
+  }
+  let old_len = original_lines.length() - old_cursor
+  let new_len = modified_lines.length() - new_cursor
+  if source_line_slice(original_lines, old_cursor, old_len) !=
+    source_line_slice(modified_lines, new_cursor, new_len) {
+    if !range_difference_is_ignored(
+        original_lines, old_cursor, old_len, modified_lines, new_cursor, new_len,
+        ignore_comments, ignore_tests, diff_mode, test_ownership,
+      ) {
+      return (false, saw_ignored_difference)
+    }
+    saw_ignored_difference = true
+  }
+  (true, saw_ignored_difference)
 }
 
 ///|
@@ -655,6 +1817,8 @@ fn specialized_diff(
   ignore_tests : Bool,
   original : @model.TextSnapshot,
   modified : @model.TextSnapshot,
+  strict : @diff.DocumentDiff,
+  test_ownership : IgnoredTestOwnership,
 ) -> (@diff.DocumentDiff, MoonDiffMode, Bool)? {
   let original_lines = snapshot_lines(original)
   let modified_lines = snapshot_lines(modified)
@@ -673,20 +1837,30 @@ fn specialized_diff(
       mode=diff_mode,
     ),
   )
-  let fell_back = mode == Tree && !result.fallbacks().is_empty()
-  let effective = if fell_back { Token } else { mode }
   let document = result.document()
-  guard adapt_document(document, original_lines, modified_lines) is Some(diff) else {
+  let fell_back = mode == Tree && document_has_fallback(document)
+  let effective = if fell_back { Token } else { mode }
+  guard adapt_document(
+      document, original_lines, modified_lines, ignore_comments, ignore_tests, diff_mode,
+      test_ownership,
+    )
+    is Some((diff, layout)) else {
     return None
   }
-  if ignore_tests {
-    append_layout_gap_alignments(
-      result.layout(),
-      original_lines.length(),
-      modified_lines.length(),
+  if (ignore_comments || ignore_tests) &&
+    document is TopLevel(_) &&
+    !append_layout_gap_alignments(
+      layout,
+      original_lines,
+      modified_lines,
+      ignore_comments,
+      ignore_tests,
+      diff_mode,
+      test_ownership,
       diff.changes,
       diff.additional_alignments,
-    )
+    ) {
+    return None
   }
   // A differing source cannot silently become an empty comparison unless the
   // active filter classified every change as ignored.
@@ -697,14 +1871,22 @@ fn specialized_diff(
       !(result.status() is @mbtdiff.DiffStatus::IgnoredOnly) {
       return None
     }
-    guard unfiltered_lexical_diff(
-        original, modified, original_lines, modified_lines,
+    if ignored_only_semantic_geometry(
+        original, modified, original_lines, modified_lines, ignore_comments, ignore_tests,
+        diff_mode, test_ownership,
       )
-      is Some(unfiltered_diff) &&
-      !unfiltered_diff.changes.is_empty() else {
-      return None
+      is Some(semantic_geometry) {
+      return Some((semantic_geometry, effective, fell_back))
     }
-    let ignored_alignments = unfiltered_diff.changes.filter_map(change => {
+    let geometry_changes = match
+      unfiltered_lexical_diff(
+        original, modified, original_lines, modified_lines,
+      ) {
+      Some(unfiltered_diff) if !unfiltered_diff.changes.is_empty() =>
+        unfiltered_diff.changes
+      _ => strict.changes
+    }
+    let ignored_alignments = geometry_changes.filter_map(change => {
       if change.original.length() != change.modified.length() {
         Some(change.line_mapping())
       } else {
@@ -715,7 +1897,11 @@ fn specialized_diff(
       changes: [],
       additional_alignments: ignored_alignments,
     }
-    return Some((result, effective, fell_back))
+    if original_lines.length() != modified_lines.length() &&
+      ignored_alignments.is_empty() {
+      return None
+    }
+    return Some((order_document_mappings(result), effective, fell_back))
   }
   if (ignore_comments || ignore_tests) &&
     @diff.normalize_and_validate_document_diff(diff, original, modified) is None {
@@ -730,7 +1916,7 @@ fn specialized_diff(
       )
     }
   }
-  Some((diff, effective, fell_back))
+  Some((order_document_mappings(diff), effective, fell_back))
 }
 
 ///|
@@ -776,20 +1962,59 @@ pub impl @diff.DocumentDiffProvider for MoonDocumentDiffProvider with fn compute
     let lenient = core.compute_diff(original, modified, {
       ignore_trim_whitespace: true,
     })
-    if !same_line_change_shape(strict, lenient) ||
-      paired_change_has_edge_whitespace_difference(strict, original, modified) {
+    let whitespace_conflict = !same_line_change_shape(strict, lenient) ||
+      paired_change_has_edge_whitespace_difference(strict, original, modified)
+    let diff_mode = match requested {
+      Token => @mbtdiff.DiffMode::Lexical
+      Tree => @mbtdiff.DiffMode::Ast
+      Core => @mbtdiff.DiffMode::Lexical
+    }
+    let original_lines = snapshot_lines(original)
+    let modified_lines = snapshot_lines(modified)
+    let test_ownership = ignored_test_ownership(
+      original,
+      modified,
+      original_lines,
+      modified_lines,
+      self.ignore_tests,
+      diff_mode,
+    )
+    let raw_specialized = match test_ownership {
+      Some(ownership) =>
+        specialized_diff(
+          requested,
+          self.ignore_comments,
+          self.ignore_tests,
+          original,
+          modified,
+          strict,
+          ownership,
+        )
+      None => None
+    }
+    let (coverage_valid, coverage_has_ignored) = match
+      (raw_specialized, test_ownership) {
+      (Some((candidate, _, _)), Some(ownership)) =>
+        specialized_source_coverage(
+          requested,
+          self.ignore_comments,
+          self.ignore_tests,
+          original,
+          modified,
+          candidate,
+          ownership,
+        )
+      _ => (false, false)
+    }
+    let specialized = if coverage_valid { raw_specialized } else { None }
+    let whitespace_conflict_is_filtered = coverage_valid && coverage_has_ignored
+    if whitespace_conflict && !whitespace_conflict_is_filtered {
       self.status = { requested, effective: Core, fell_back: true, }
       return if options.ignore_trim_whitespace { lenient } else { strict }
     }
     return self.settle_specialized_or_core(
       requested,
-      specialized_diff(
-        requested,
-        self.ignore_comments,
-        self.ignore_tests,
-        original,
-        modified,
-      ),
+      specialized,
       if options.ignore_trim_whitespace {
         lenient
       } else {

--- a/editor/viewer/diff_provider/moondiff/provider.mbt
+++ b/editor/viewer/diff_provider/moondiff/provider.mbt
@@ -24,6 +24,7 @@ pub(all) struct MoonDiffStatus {
 pub struct MoonDocumentDiffProvider {
   mut mode : MoonDiffMode
   mut ignore_comments : Bool
+  mut ignore_tests : Bool
   mut status : MoonDiffStatus
   did_change : @base_common.Emitter[Unit]
   mut disposed : Bool
@@ -33,10 +34,12 @@ pub struct MoonDocumentDiffProvider {
 pub fn MoonDocumentDiffProvider::MoonDocumentDiffProvider(
   mode? : MoonDiffMode = Core,
   ignore_comments? : Bool = true,
+  ignore_tests? : Bool = true,
 ) -> MoonDocumentDiffProvider {
   {
     mode,
     ignore_comments,
+    ignore_tests,
     status: { requested: mode, effective: mode, fell_back: false, },
     did_change: Emitter(),
     disposed: false,
@@ -85,6 +88,26 @@ pub fn MoonDocumentDiffProvider::get_ignore_comments(
   self : MoonDocumentDiffProvider,
 ) -> Bool {
   self.ignore_comments
+}
+
+///|
+pub fn MoonDocumentDiffProvider::set_ignore_tests(
+  self : MoonDocumentDiffProvider,
+  ignore_tests : Bool,
+) -> Unit {
+  if self.disposed || self.ignore_tests == ignore_tests {
+    return
+  }
+  self.ignore_tests = ignore_tests
+  self.status = { requested: self.mode, effective: self.mode, fell_back: false }
+  self.did_change.fire(())
+}
+
+///|
+pub fn MoonDocumentDiffProvider::get_ignore_tests(
+  self : MoonDocumentDiffProvider,
+) -> Bool {
+  self.ignore_tests
 }
 
 ///|
@@ -193,7 +216,7 @@ fn valid_hunk_range(start : Int, len : Int, total : Int) -> Bool {
 
 ///|
 fn valid_line(
-  line : @tokdiff.DiffLine,
+  line : @mbtdiff.DiffLine,
   expected_index : Int,
   source : Array[String],
 ) -> Bool {
@@ -204,7 +227,7 @@ fn valid_line(
 }
 
 ///|
-fn changed_ranges(line : @tokdiff.DiffLine) -> Array[@base_common.Range] {
+fn changed_ranges(line : @mbtdiff.DiffLine) -> Array[@base_common.Range] {
   let ranges = []
   let mut column = 1
   for segment in line.segments {
@@ -221,8 +244,8 @@ fn changed_ranges(line : @tokdiff.DiffLine) -> Array[@base_common.Range] {
 
 ///|
 fn paired_inner_changes(
-  original : @tokdiff.DiffLine,
-  modified : @tokdiff.DiffLine,
+  original : @mbtdiff.DiffLine,
+  modified : @mbtdiff.DiffLine,
 ) -> Array[@diff.RangeMapping]? {
   let original_ranges = changed_ranges(original)
   let modified_ranges = changed_ranges(modified)
@@ -241,8 +264,8 @@ fn paired_inner_changes(
 
 ///|
 fn paired_change(
-  original : @tokdiff.DiffLine,
-  modified : @tokdiff.DiffLine,
+  original : @mbtdiff.DiffLine,
+  modified : @mbtdiff.DiffLine,
 ) -> @diff.DetailedLineRangeMapping {
   DetailedLineRangeMapping(
     LineRange(original.index + 1, original.index + 2),
@@ -253,7 +276,7 @@ fn paired_change(
 
 ///|
 fn old_only_change(
-  original : @tokdiff.DiffLine,
+  original : @mbtdiff.DiffLine,
   modified_cursor : Int,
 ) -> @diff.DetailedLineRangeMapping {
   DetailedLineRangeMapping(
@@ -265,7 +288,7 @@ fn old_only_change(
 
 ///|
 fn new_only_change(
-  modified : @tokdiff.DiffLine,
+  modified : @mbtdiff.DiffLine,
   original_cursor : Int,
 ) -> @diff.DetailedLineRangeMapping {
   DetailedLineRangeMapping(
@@ -282,6 +305,17 @@ fn line_ranges_intersect_or_touch(
 ) -> Bool {
   left.end_line_number_exclusive >= right.start_line_number &&
   right.end_line_number_exclusive >= left.start_line_number
+}
+
+///|
+fn line_ranges_intersect(
+  left : @base_common.LineRange,
+  right : @base_common.LineRange,
+) -> Bool {
+  !left.is_empty() &&
+  !right.is_empty() &&
+  left.start_line_number < right.end_line_number_exclusive &&
+  right.start_line_number < left.end_line_number_exclusive
 }
 
 ///|
@@ -339,8 +373,135 @@ fn append_coalesced_alignment(
 }
 
 ///|
+fn mapping_overlaps_document(
+  mapping : @diff.LineRangeMapping,
+  changes : Array[@diff.DetailedLineRangeMapping],
+  alignments : Array[@diff.LineRangeMapping],
+) -> Bool {
+  for change in changes {
+    if (
+        !mapping.original.is_empty() &&
+        line_ranges_intersect(mapping.original, change.original)
+      ) ||
+      (
+        !mapping.modified.is_empty() &&
+        line_ranges_intersect(mapping.modified, change.modified)
+      ) {
+      return true
+    }
+  }
+  for alignment in alignments {
+    if (
+        !mapping.original.is_empty() &&
+        line_ranges_intersect(mapping.original, alignment.original)
+      ) ||
+      (
+        !mapping.modified.is_empty() &&
+        line_ranges_intersect(mapping.modified, alignment.modified)
+      ) {
+      return true
+    }
+  }
+  false
+}
+
+///|
+// moondiff 0.0.3 can place a filtered one-sided row in a top-level section
+// outside the visible hunk that explains the adjacent code change. Recover
+// only disjoint one-sided rows as geometry; overlapping rows are already
+// represented by a visible change or an IgnoredBlock alignment.
+fn append_unrepresented_one_sided_alignments(
+  unfiltered : @diff.DocumentDiff,
+  changes : Array[@diff.DetailedLineRangeMapping],
+  alignments : Array[@diff.LineRangeMapping],
+) -> Unit {
+  for change in unfiltered.changes {
+    let mapping = change.line_mapping()
+    if (
+        (mapping.original.is_empty() && !mapping.modified.is_empty()) ||
+        (mapping.modified.is_empty() && !mapping.original.is_empty())
+      ) &&
+      !mapping_overlaps_document(mapping, changes, alignments) {
+      alignments.push(mapping)
+    }
+  }
+}
+
+///|
+fn append_layout_gap(
+  old_start : Int,
+  old_len : Int,
+  new_start : Int,
+  new_len : Int,
+  changes : Array[@diff.DetailedLineRangeMapping],
+  alignments : Array[@diff.LineRangeMapping],
+) -> Unit {
+  if old_len == new_len {
+    return
+  }
+  let mapping = @diff.LineRangeMapping(
+    @base_common.LineRange(old_start + 1, old_start + old_len + 1),
+    @base_common.LineRange(new_start + 1, new_start + new_len + 1),
+  )
+  if !mapping_overlaps_document(mapping, changes, alignments) {
+    alignments.push(mapping)
+  }
+}
+
+///|
+// Test filtering removes whole top-level sections before hunk calculation.
+// Their line spans remain observable as gaps in DiffLayout, so preserve only
+// their height difference as neutral alignment geometry.
+fn append_layout_gap_alignments(
+  layout : @mbtdiff.DiffLayout,
+  original_line_count : Int,
+  modified_line_count : Int,
+  changes : Array[@diff.DetailedLineRangeMapping],
+  alignments : Array[@diff.LineRangeMapping],
+) -> Unit {
+  guard layout is @mbtdiff.DiffLayout::TopLevelSections(sections) else {
+    return
+  }
+  let mut old_cursor = 0
+  let mut new_cursor = 0
+  for section in sections {
+    let old_start = section.old.map(range => range.start).unwrap_or(old_cursor)
+    let new_start = section.new.map(range => range.start).unwrap_or(new_cursor)
+    if old_start < old_cursor || new_start < new_cursor {
+      return
+    }
+    append_layout_gap(
+      old_cursor,
+      old_start - old_cursor,
+      new_cursor,
+      new_start - new_cursor,
+      changes,
+      alignments,
+    )
+    match section.old {
+      Some(range) => old_cursor = range.start + range.len
+      None => ()
+    }
+    match section.new {
+      Some(range) => new_cursor = range.start + range.len
+      None => ()
+    }
+  }
+  if old_cursor <= original_line_count && new_cursor <= modified_line_count {
+    append_layout_gap(
+      old_cursor,
+      original_line_count - old_cursor,
+      new_cursor,
+      modified_line_count - new_cursor,
+      changes,
+      alignments,
+    )
+  }
+}
+
+///|
 fn append_rows(
-  rows : Array[@tokdiff.DiffRow],
+  rows : ArrayView[@mbtdiff.DiffRow],
   render_changes : Bool,
   original_lines : Array[String],
   modified_lines : Array[String],
@@ -405,7 +566,7 @@ fn append_rows(
 
 ///|
 fn adapt_document(
-  document : @tokdiff.DiffDocument,
+  document : @mbtdiff.DiffDocument,
   original_lines : Array[String],
   modified_lines : Array[String],
 ) -> @diff.DocumentDiff? {
@@ -468,64 +629,77 @@ fn adapt_document(
 }
 
 ///|
+fn unfiltered_lexical_diff(
+  original : @model.TextSnapshot,
+  modified : @model.TextSnapshot,
+  original_lines : Array[String],
+  modified_lines : Array[String],
+) -> @diff.DocumentDiff? {
+  let document = @mbtdiff.diff(
+    original.get_value(),
+    modified.get_value(),
+    options=@mbtdiff.DiffOptions(
+      context_lines=0,
+      ignore_comments=false,
+      ignore_tests=false,
+      mode=@mbtdiff.DiffMode::Lexical,
+    ),
+  ).document()
+  adapt_document(document, original_lines, modified_lines)
+}
+
+///|
 fn specialized_diff(
   mode : MoonDiffMode,
   ignore_comments : Bool,
+  ignore_tests : Bool,
   original : @model.TextSnapshot,
   modified : @model.TextSnapshot,
 ) -> (@diff.DocumentDiff, MoonDiffMode, Bool)? {
   let original_lines = snapshot_lines(original)
   let modified_lines = snapshot_lines(modified)
-  let (document, effective, fell_back) = match mode {
+  let diff_mode = match mode {
     Core => return None
-    Token =>
-      (
-        @tokdiff.diff(
-          old=original_lines,
-          new=modified_lines,
-          context=0,
-          line_cleanup=true,
-          ignore_comments~,
-        ),
-        Token,
-        false,
-      )
-    Tree => {
-      let result = @mbtdiff.diff(
-        original.get_value(),
-        modified.get_value(),
-        options=@mbtdiff.DiffOptions::new(context_lines=0, ignore_comments~),
-      )
-      (
-        result.document(),
-        if result.has_fallback() {
-          Token
-        } else {
-          Tree
-        },
-        result.has_fallback(),
-      )
-    }
+    Token => @mbtdiff.DiffMode::Lexical
+    Tree => @mbtdiff.DiffMode::Ast
   }
+  let result = @mbtdiff.diff(
+    original.get_value(),
+    modified.get_value(),
+    options=@mbtdiff.DiffOptions(
+      context_lines=0,
+      ignore_comments~,
+      ignore_tests~,
+      mode=diff_mode,
+    ),
+  )
+  let fell_back = mode == Tree && !result.fallbacks().is_empty()
+  let effective = if fell_back { Token } else { mode }
+  let document = result.document()
   guard adapt_document(document, original_lines, modified_lines) is Some(diff) else {
     return None
   }
-  // Token has no typed failure channel. A differing source cannot silently
-  // become an empty comparison unless ignored rows explain the geometry.
+  if ignore_tests {
+    append_layout_gap_alignments(
+      result.layout(),
+      original_lines.length(),
+      modified_lines.length(),
+      diff.changes,
+      diff.additional_alignments,
+    )
+  }
+  // A differing source cannot silently become an empty comparison unless the
+  // active filter classified every change as ignored.
   if original_lines != modified_lines &&
     diff.changes.is_empty() &&
     diff.additional_alignments.is_empty() {
-    if !ignore_comments {
+    if !(ignore_comments || ignore_tests) ||
+      !(result.status() is @mbtdiff.DiffStatus::IgnoredOnly) {
       return None
     }
-    let unfiltered = @tokdiff.diff(
-      old=original_lines,
-      new=modified_lines,
-      context=0,
-      line_cleanup=true,
-      ignore_comments=false,
-    )
-    guard adapt_document(unfiltered, original_lines, modified_lines)
+    guard unfiltered_lexical_diff(
+        original, modified, original_lines, modified_lines,
+      )
       is Some(unfiltered_diff) &&
       !unfiltered_diff.changes.is_empty() else {
       return None
@@ -542,6 +716,19 @@ fn specialized_diff(
       additional_alignments: ignored_alignments,
     }
     return Some((result, effective, fell_back))
+  }
+  if (ignore_comments || ignore_tests) &&
+    @diff.normalize_and_validate_document_diff(diff, original, modified) is None {
+    if unfiltered_lexical_diff(
+        original, modified, original_lines, modified_lines,
+      )
+      is Some(unfiltered_diff) {
+      append_unrepresented_one_sided_alignments(
+        unfiltered_diff,
+        diff.changes,
+        diff.additional_alignments,
+      )
+    }
   }
   Some((diff, effective, fell_back))
 }
@@ -596,7 +783,13 @@ pub impl @diff.DocumentDiffProvider for MoonDocumentDiffProvider with fn compute
     }
     return self.settle_specialized_or_core(
       requested,
-      specialized_diff(requested, self.ignore_comments, original, modified),
+      specialized_diff(
+        requested,
+        self.ignore_comments,
+        self.ignore_tests,
+        original,
+        modified,
+      ),
       if options.ignore_trim_whitespace {
         lenient
       } else {

--- a/editor/viewer/diff_provider/moondiff/provider.mbt
+++ b/editor/viewer/diff_provider/moondiff/provider.mbt
@@ -258,6 +258,9 @@ fn paired_inner_changes(
 ) -> Array[@diff.RangeMapping]? {
   let original_ranges = changed_ranges(original)
   let modified_ranges = changed_ranges(modified)
+  if original_ranges.is_empty() && modified_ranges.is_empty() {
+    return Some([])
+  }
   if original_ranges.is_empty() || modified_ranges.is_empty() {
     return None
   }
@@ -269,6 +272,58 @@ fn paired_inner_changes(
     )
   }
   Some(mappings)
+}
+
+///|
+// Convert a between-line cursor into a valid zero-width document range. At
+// EOF, the position belongs to the end of the last model line rather than the
+// non-existent line after it.
+fn cursor_anchor_range(
+  lines : Array[String],
+  cursor : Int,
+) -> @base_common.Range {
+  let line_number = cursor + 1
+  if lines.is_empty() {
+    return Range(1, 1, 1, 1)
+  }
+  if line_number <= lines.length() {
+    let line_number = line_number.max(1)
+    return Range(line_number, 1, line_number, 1)
+  }
+  let last_line_number = lines.length()
+  let column = lines[last_line_number - 1].length() + 1
+  Range(last_line_number, column, last_line_number, column)
+}
+
+///|
+// A one-sided row can still contain token-level Changed segments. Mapping
+// them to the opposite cursor preserves their decoration and hunk geometry;
+// an empty array records a computed pure reflow rather than missing work.
+fn old_only_inner_changes(
+  original : @mbtdiff.DiffLine,
+  modified_cursor : Int,
+  modified_lines : Array[String],
+) -> Array[@diff.RangeMapping]? {
+  let anchor = cursor_anchor_range(modified_lines, modified_cursor)
+  Some(
+    changed_ranges(original).map(original_range => {
+      @diff.RangeMapping(original_range, anchor)
+    }),
+  )
+}
+
+///|
+fn new_only_inner_changes(
+  modified : @mbtdiff.DiffLine,
+  original_cursor : Int,
+  original_lines : Array[String],
+) -> Array[@diff.RangeMapping]? {
+  let anchor = cursor_anchor_range(original_lines, original_cursor)
+  Some(
+    changed_ranges(modified).map(modified_range => {
+      @diff.RangeMapping(anchor, modified_range)
+    }),
+  )
 }
 
 ///|
@@ -287,11 +342,12 @@ fn paired_change(
 fn old_only_change(
   original : @mbtdiff.DiffLine,
   modified_cursor : Int,
+  modified_lines : Array[String],
 ) -> @diff.DetailedLineRangeMapping {
   DetailedLineRangeMapping(
     LineRange(original.index + 1, original.index + 2),
     LineRange(modified_cursor + 1, modified_cursor + 1),
-    None,
+    old_only_inner_changes(original, modified_cursor, modified_lines),
   )
 }
 
@@ -299,11 +355,12 @@ fn old_only_change(
 fn new_only_change(
   modified : @mbtdiff.DiffLine,
   original_cursor : Int,
+  original_lines : Array[String],
 ) -> @diff.DetailedLineRangeMapping {
   DetailedLineRangeMapping(
     LineRange(original_cursor + 1, original_cursor + 1),
     LineRange(modified.index + 1, modified.index + 2),
-    None,
+    new_only_inner_changes(modified, original_cursor, original_lines),
   )
 }
 
@@ -655,77 +712,45 @@ fn raw_range_difference_is_ignored(
 }
 
 ///|
-fn source_ignored_test_ranges(
-  source : @model.TextSnapshot,
-  lines : Array[String],
-  mode : @mbtdiff.DiffMode,
+fn adapt_ignored_test_ranges(
+  ranges : ArrayView[@mbtdiff.LineRange],
+  line_count : Int,
 ) -> Array[@base_common.LineRange]? {
-  if source.get_value().is_empty() {
-    return Some([])
-  }
-  let probe = @model.TextSnapshot(source.get_value() + "\n")
-  let probe_lines = snapshot_lines(probe)
-  let document = @mbtdiff.diff(
-    source.get_value(),
-    probe.get_value(),
-    options=@mbtdiff.DiffOptions(
-      context_lines=0,
-      ignore_comments=false,
-      ignore_tests=false,
-      mode~,
-    ),
-  ).document()
-  guard document is TopLevel(top) &&
-    valid_top_level_orders(
-      top,
-      semantic_line_count(lines),
-      semantic_line_count(probe_lines),
-    ) else {
-    return None
-  }
-  let ranges : Array[@base_common.LineRange] = []
-  for section in top.sections {
-    guard section is Matched(old~, new~, ..) && old == new else { return None }
-    let empty : Array[String] = []
-    if raw_range_difference_is_ignored(
-        lines,
-        old.start,
-        old.len,
-        empty,
-        0,
-        0,
-        false,
-        true,
-        mode,
-      ) {
-      ranges.push(
-        @base_common.LineRange(old.start + 1, old.start + old.len + 1),
-      )
+  let adapted : Array[@base_common.LineRange] = []
+  let mut previous_end = 0
+  for range in ranges {
+    if !valid_hunk_range(range.start, range.len, line_count) ||
+      range.start < previous_end {
+      return None
     }
+    adapted.push(
+      @base_common.LineRange(range.start + 1, range.start + range.len + 1),
+    )
+    previous_end = range.start + range.len
   }
-  Some(ranges)
+  Some(adapted)
 }
 
 ///|
 fn ignored_test_ownership(
-  original : @model.TextSnapshot,
-  modified : @model.TextSnapshot,
+  result : @mbtdiff.DiffResult,
   original_lines : Array[String],
   modified_lines : Array[String],
-  ignore_tests : Bool,
-  mode : @mbtdiff.DiffMode,
 ) -> IgnoredTestOwnership? {
-  if !ignore_tests {
-    return Some({ original: [], modified: [] })
-  }
   match
     (
-      source_ignored_test_ranges(original, original_lines, mode),
-      source_ignored_test_ranges(modified, modified_lines, mode),
+      adapt_ignored_test_ranges(
+        result.ignored_test_ranges(@mbtdiff.DiffSide::Old),
+        semantic_line_count(original_lines),
+      ),
+      adapt_ignored_test_ranges(
+        result.ignored_test_ranges(@mbtdiff.DiffSide::New),
+        semantic_line_count(modified_lines),
+      ),
     ) {
     (Some(original_ranges), Some(modified_ranges)) =>
       Some({ original: original_ranges, modified: modified_ranges })
-    _ => Some({ original: [], modified: [] })
+    _ => None
   }
 }
 
@@ -981,7 +1006,7 @@ fn flatten_top_level_sections(
       new_cursor = new_target
     }
     if has_old && has_new && old_index == new_index {
-      guard top.sections[old_index] is Matched(old~, new~, diff~) else {
+      guard top.sections[old_index] is Matched(old~, new~, diff~, ..) else {
         return None
       }
       if old_cursor != old_target || new_cursor != new_target {
@@ -1024,8 +1049,8 @@ fn flatten_top_level_sections(
       has_new &&
       old_cursor == old_target &&
       new_cursor == new_target &&
-      top.sections[old_index] is Deleted(old~, diff=old_diff) &&
-      top.sections[new_index] is Inserted(new~, diff=new_diff) {
+      top.sections[old_index] is Deleted(old~, diff=old_diff, ..) &&
+      top.sections[new_index] is Inserted(new~, diff=new_diff, ..) {
       sections.push({
         fragment: old_diff,
         old_base: old.start,
@@ -1058,7 +1083,7 @@ fn flatten_top_level_sections(
     }
     if has_old &&
       old_cursor == old_target &&
-      top.sections[old_index] is Deleted(old~, diff~) {
+      top.sections[old_index] is Deleted(old~, diff~, ..) {
       sections.push({
         fragment: diff,
         old_base: old.start,
@@ -1077,7 +1102,7 @@ fn flatten_top_level_sections(
     }
     if has_new &&
       new_cursor == new_target &&
-      top.sections[new_index] is Inserted(new~, diff~) {
+      top.sections[new_index] is Inserted(new~, diff~, ..) {
       sections.push({
         fragment: diff,
         old_base: old_cursor,
@@ -1321,7 +1346,7 @@ fn append_rows(
         if !valid_line(original, old_cursor, original_lines) {
           return None
         }
-        let mapping = old_only_change(original, new_cursor)
+        let mapping = old_only_change(original, new_cursor, modified_lines)
         if render_changes {
           append_coalesced_change(block_changes, mapping)
         } else {
@@ -1333,7 +1358,7 @@ fn append_rows(
         if !valid_line(modified, new_cursor, modified_lines) {
           return None
         }
-        let mapping = new_only_change(modified, old_cursor)
+        let mapping = new_only_change(modified, old_cursor, original_lines)
         if render_changes {
           append_coalesced_change(block_changes, mapping)
         } else {
@@ -1551,12 +1576,22 @@ fn source_range_is_ignored(
   start : Int,
   len : Int,
   ignore_comments : Bool,
-  ignore_tests : Bool,
   mode : @mbtdiff.DiffMode,
+  ignored_tests : Array[@base_common.LineRange],
 ) -> Bool {
+  let range = @base_common.LineRange(start + 1, start + len + 1)
+  if ignored_tests.any(ignored => {
+      ignored.start_line_number <= range.start_line_number &&
+      ignored.end_line_number_exclusive >= range.end_line_number_exclusive
+    }) {
+    return true
+  }
+  if !ignore_comments {
+    return false
+  }
   let empty : Array[String] = []
   raw_range_difference_is_ignored(
-    lines, start, len, empty, 0, 0, ignore_comments, ignore_tests, mode,
+    lines, start, len, empty, 0, 0, true, false, mode,
   )
 }
 
@@ -1598,16 +1633,16 @@ fn ignored_only_semantic_geometry(
           old.start,
           old.len,
           ignore_comments,
-          ignore_tests,
           mode,
+          test_ownership.original,
         )
         let new_ignored = source_range_is_ignored(
           modified_lines,
           new.start,
           new.len,
           ignore_comments,
-          ignore_tests,
           mode,
+          test_ownership.modified,
         )
         if old_ignored != new_ignored {
           return None
@@ -1620,8 +1655,8 @@ fn ignored_only_semantic_geometry(
             old.start,
             old.len,
             ignore_comments,
-            ignore_tests,
             mode,
+            test_ownership.original,
           ) {
           return None
         }
@@ -1631,8 +1666,8 @@ fn ignored_only_semantic_geometry(
             new.start,
             new.len,
             ignore_comments,
-            ignore_tests,
             mode,
+            test_ownership.modified,
           ) {
           return None
         }
@@ -1818,8 +1853,7 @@ fn specialized_diff(
   original : @model.TextSnapshot,
   modified : @model.TextSnapshot,
   strict : @diff.DocumentDiff,
-  test_ownership : IgnoredTestOwnership,
-) -> (@diff.DocumentDiff, MoonDiffMode, Bool)? {
+) -> (@diff.DocumentDiff, MoonDiffMode, Bool, IgnoredTestOwnership)? {
   let original_lines = snapshot_lines(original)
   let modified_lines = snapshot_lines(modified)
   let diff_mode = match mode {
@@ -1838,6 +1872,10 @@ fn specialized_diff(
     ),
   )
   let document = result.document()
+  guard ignored_test_ownership(result, original_lines, modified_lines)
+    is Some(test_ownership) else {
+    return None
+  }
   let fell_back = mode == Tree && document_has_fallback(document)
   let effective = if fell_back { Token } else { mode }
   guard adapt_document(
@@ -1876,7 +1914,7 @@ fn specialized_diff(
         diff_mode, test_ownership,
       )
       is Some(semantic_geometry) {
-      return Some((semantic_geometry, effective, fell_back))
+      return Some((semantic_geometry, effective, fell_back, test_ownership))
     }
     let geometry_changes = match
       unfiltered_lexical_diff(
@@ -1901,7 +1939,9 @@ fn specialized_diff(
       ignored_alignments.is_empty() {
       return None
     }
-    return Some((order_document_mappings(result), effective, fell_back))
+    return Some(
+      (order_document_mappings(result), effective, fell_back, test_ownership),
+    )
   }
   if (ignore_comments || ignore_tests) &&
     @diff.normalize_and_validate_document_diff(diff, original, modified) is None {
@@ -1916,7 +1956,7 @@ fn specialized_diff(
       )
     }
   }
-  Some((order_document_mappings(diff), effective, fell_back))
+  Some((order_document_mappings(diff), effective, fell_back, test_ownership))
 }
 
 ///|
@@ -1964,37 +2004,16 @@ pub impl @diff.DocumentDiffProvider for MoonDocumentDiffProvider with fn compute
     })
     let whitespace_conflict = !same_line_change_shape(strict, lenient) ||
       paired_change_has_edge_whitespace_difference(strict, original, modified)
-    let diff_mode = match requested {
-      Token => @mbtdiff.DiffMode::Lexical
-      Tree => @mbtdiff.DiffMode::Ast
-      Core => @mbtdiff.DiffMode::Lexical
-    }
-    let original_lines = snapshot_lines(original)
-    let modified_lines = snapshot_lines(modified)
-    let test_ownership = ignored_test_ownership(
+    let raw_specialized = specialized_diff(
+      requested,
+      self.ignore_comments,
+      self.ignore_tests,
       original,
       modified,
-      original_lines,
-      modified_lines,
-      self.ignore_tests,
-      diff_mode,
+      strict,
     )
-    let raw_specialized = match test_ownership {
-      Some(ownership) =>
-        specialized_diff(
-          requested,
-          self.ignore_comments,
-          self.ignore_tests,
-          original,
-          modified,
-          strict,
-          ownership,
-        )
-      None => None
-    }
-    let (coverage_valid, coverage_has_ignored) = match
-      (raw_specialized, test_ownership) {
-      (Some((candidate, _, _)), Some(ownership)) =>
+    let (coverage_valid, coverage_has_ignored) = match raw_specialized {
+      Some((candidate, _, _, ownership)) =>
         specialized_source_coverage(
           requested,
           self.ignore_comments,
@@ -2006,7 +2025,15 @@ pub impl @diff.DocumentDiffProvider for MoonDocumentDiffProvider with fn compute
         )
       _ => (false, false)
     }
-    let specialized = if coverage_valid { raw_specialized } else { None }
+    let specialized = if coverage_valid {
+      match raw_specialized {
+        Some((candidate, effective, fell_back, _)) =>
+          Some((candidate, effective, fell_back))
+        None => None
+      }
+    } else {
+      None
+    }
     let whitespace_conflict_is_filtered = coverage_valid && coverage_has_ignored
     if whitespace_conflict && !whitespace_conflict_is_filtered {
       self.status = { requested, effective: Core, fell_back: true, }

--- a/editor/viewer/diff_provider/moondiff/provider.mbt
+++ b/editor/viewer/diff_provider/moondiff/provider.mbt
@@ -370,7 +370,7 @@ fn adapt_fragment_document(
 ///|
 /// Convert exactly one MoonDiff fragment into the common DiffEditor contract.
 /// No top-level ranges are rebased, sorted, padded, or flattened here.
-pub fn fragment_document_diff(
+fn fragment_document_diff(
   document : @mbtdiff.HunkDocument,
   original_source : String,
   modified_source : String,

--- a/editor/viewer/diff_provider/moondiff/provider_wbtest.mbt
+++ b/editor/viewer/diff_provider/moondiff/provider_wbtest.mbt
@@ -161,6 +161,126 @@ test "equal-length ignored-only edit is a valid empty specialized result" {
 }
 
 ///|
+test "Token and Tree ignore MoonBit test-only edits" {
+  for mode in [Token, Tree] {
+    let provider = MoonDocumentDiffProvider(
+      mode~,
+      ignore_comments=false,
+      ignore_tests=true,
+    )
+    let ignored = compute_with_provider(
+      provider, "test \"sample\" { old_value() }", "test \"sample\" { new_value() }",
+    )
+    assert_true(ignored.changes.is_empty())
+    assert_true(ignored.additional_alignments.is_empty())
+    assert_eq(provider.get_status(), {
+      requested: mode,
+      effective: mode,
+      fell_back: false,
+    })
+    provider.set_ignore_tests(false)
+    let visible = compute_with_provider(
+      provider, "test \"sample\" { old_value() }", "test \"sample\" { new_value() }",
+    )
+    assert_false(visible.changes.is_empty())
+    provider.dispose()
+  }
+}
+
+///|
+test "ignored inserted tests become geometry-only additional alignments" {
+  for mode in [Token, Tree] {
+    let provider = MoonDocumentDiffProvider(
+      mode~,
+      ignore_comments=false,
+      ignore_tests=true,
+    )
+    let result = compute_with_provider(
+      provider, "fn stable() {}", "test \"sample\" { new_value() }\nfn stable() {}",
+    )
+    assert_true(result.changes.is_empty())
+    assert_eq(result.additional_alignments, [
+      LineRangeMapping(LineRange(1, 1), LineRange(1, 2)),
+    ])
+    assert_eq(provider.get_status().effective, mode)
+    let deleted = compute_with_provider(
+      provider, "test \"sample\" { old_value() }\nfn stable() {}", "fn stable() {}",
+    )
+    assert_true(deleted.changes.is_empty())
+    assert_eq(deleted.additional_alignments, [
+      LineRangeMapping(LineRange(1, 2), LineRange(1, 1)),
+    ])
+    assert_eq(provider.get_status().effective, mode)
+    provider.dispose()
+  }
+}
+
+///|
+test "test filtering composes with visible production changes" {
+  for mode in [Token, Tree] {
+    let provider = MoonDocumentDiffProvider(
+      mode~,
+      ignore_comments=false,
+      ignore_tests=true,
+    )
+    let result = compute_with_provider(
+      provider, "fn production() { old_value() }\nfn stable() {}", "fn production() { new_value() }\ntest \"sample\" { new_test() }\nfn stable() {}",
+    )
+    assert_eq(
+      result.changes.map(change => (change.original, change.modified)),
+      [(LineRange(1, 2), LineRange(1, 2))],
+    )
+    assert_eq(result.additional_alignments, [
+      LineRangeMapping(LineRange(2, 2), LineRange(2, 3)),
+    ])
+    assert_eq(provider.get_status().effective, mode)
+    provider.dispose()
+  }
+}
+
+///|
+test "test and comment filters remain independent" {
+  for mode in [Token, Tree] {
+    let provider = MoonDocumentDiffProvider(
+      mode~,
+      ignore_comments=false,
+      ignore_tests=true,
+    )
+    let visible = compute_with_provider(
+      provider, "fn value() { // old\n}", "fn value() { // new\n}",
+    )
+    assert_false(visible.changes.is_empty())
+    provider.set_ignore_comments(true)
+    let ignored = compute_with_provider(
+      provider, "fn value() { // old\n}", "fn value() { // new\n}",
+    )
+    assert_true(ignored.changes.is_empty())
+    provider.dispose()
+  }
+}
+
+///|
+test "parse failure keeps test changes visible" {
+  for mode in [Token, Tree] {
+    let provider = MoonDocumentDiffProvider(
+      mode~,
+      ignore_comments=false,
+      ignore_tests=true,
+    )
+    let result = compute_with_provider(
+      provider, "test \"sample\" { old_value( }", "test \"sample\" { new_value( }",
+    )
+    assert_false(result.changes.is_empty())
+    assert_eq(provider.get_status(), {
+      requested: mode,
+      effective: Token,
+      fell_back: mode is Tree,
+    })
+    provider.dispose()
+  }
+}
+
+///|
 test "Token keeps ignored inserted comments separate from code insertions" {
   let provider = MoonDocumentDiffProvider(mode=Token, ignore_comments=true)
   let result = compute_with_provider(
@@ -291,13 +411,16 @@ test "invalid specialized candidates settle to Core without reentrant changes" {
 ///|
 test "provider options notify through the standard provider contract" {
   let provider = MoonDocumentDiffProvider()
+  assert_true(provider.get_ignore_tests())
   let object : &@diff.DocumentDiffProvider = provider
   let updates = Ref(0)
   let subscription = object.on_did_change(() => updates.val += 1)
   provider.set_mode(Token)
   provider.set_ignore_comments(false)
   provider.set_ignore_comments(false)
-  assert_eq(updates.val, 2)
+  provider.set_ignore_tests(false)
+  provider.set_ignore_tests(false)
+  assert_eq(updates.val, 3)
   subscription.dispose()
   provider.dispose()
 }

--- a/editor/viewer/diff_provider/moondiff/provider_wbtest.mbt
+++ b/editor/viewer/diff_provider/moondiff/provider_wbtest.mbt
@@ -1,798 +1,119 @@
 ///|
-fn compute_with_provider(
-  provider : MoonDocumentDiffProvider,
-  original : String,
-  modified : String,
-  ignore_trim_whitespace? : Bool = true,
-) -> @diff.DocumentDiff raise {
-  let object : &@diff.DocumentDiffProvider = provider
-  object.compute_diff(TextSnapshot(original), TextSnapshot(modified), {
-    ignore_trim_whitespace,
-  })
-}
-
-///|
-test "Token and Tree honor trim-whitespace options consistently" {
-  for mode in [Token, Tree] {
-    let provider = MoonDocumentDiffProvider(mode~)
-    let ignored = compute_with_provider(
-      provider,
-      "  fn answer() { 1 }\t",
-      "fn answer() { 1 }",
-      ignore_trim_whitespace=true,
-    )
-    assert_true(ignored.changes.is_empty())
-    assert_eq(provider.get_status(), {
-      requested: mode,
-      effective: Core,
-      fell_back: true,
-    })
-    let preserved = compute_with_provider(
-      provider,
-      "  fn answer() { 1 }\t",
-      "fn answer() { 1 }",
-      ignore_trim_whitespace=false,
-    )
-    assert_false(preserved.changes.is_empty())
-    assert_eq(provider.get_status(), {
-      requested: mode,
-      effective: Core,
-      fell_back: true,
-    })
-    let mixed = compute_with_provider(
-      provider,
-      "fn answer() {\n  old_value()\n}",
-      "fn answer() {\n  new_value()\n }",
-      ignore_trim_whitespace=true,
-    )
-    assert_false(mixed.changes.is_empty())
-    assert_eq(provider.get_status(), {
-      requested: mode,
-      effective: Core,
-      fell_back: true,
-    })
-    provider.dispose()
+fn changed_line(
+  index : Int,
+  prefix : String,
+  changed : String,
+  suffix : String,
+) -> @mbtdiff.DiffLine {
+  {
+    index,
+    segments: [
+      { kind: Unchanged, text: prefix, },
+      { kind: Changed, text: changed, },
+      { kind: Unchanged, text: suffix, },
+    ],
   }
 }
 
 ///|
-test "trim-insensitive input keeps the specialized provider" {
-  let provider = MoonDocumentDiffProvider(mode=Token)
-  let result = compute_with_provider(
-    provider,
-    "fn answer() { 1 }",
-    "fn answer() { 2 }",
-    ignore_trim_whitespace=true,
-  )
-  assert_eq(result.changes.length(), 1)
-  assert_eq(provider.get_status(), {
-    requested: Token,
-    effective: Token,
-    fell_back: false,
-  })
-  provider.dispose()
-}
-
-///|
-test "Token provider exposes UTF-16 inner mappings" {
-  let provider = MoonDocumentDiffProvider(mode=Token)
-  let result = compute_with_provider(
-    provider, "fn answer() { \"😀\"; 1 }", "fn answer() { \"😀\"; 2 }",
-  )
-  guard result.changes is [change] else { fail("expected one token change") }
+test "fragment adapter keeps MoonDiff coordinates local to one section" {
+  let document : @mbtdiff.HunkDocument = {
+    hunks: [
+      {
+        old_start: 0,
+        old_len: 1,
+        new_start: 0,
+        new_len: 1,
+        blocks: [
+          ChangeBlock([
+            Paired(
+              changed_line(0, "fn value() { ", "1", " }"),
+              changed_line(0, "fn value() { ", "2", " }"),
+            ),
+          ]),
+        ],
+      },
+    ],
+  }
+  guard fragment_document_diff(document, "fn value() { 1 }", "fn value() { 2 }")
+    is Some({ changes: [change], additional_alignments: [], }) else {
+    fail("expected one valid fragment-local change")
+  }
+  assert_eq(change.original, LineRange(1, 2))
+  assert_eq(change.modified, LineRange(1, 2))
   guard change.inner_changes is Some([inner]) else {
-    fail("expected one paired inner mapping")
+    fail("expected one intraline mapping")
   }
-  assert_eq(inner.original, Range(1, 21, 1, 22))
-  assert_eq(inner.modified, Range(1, 21, 1, 22))
-  assert_eq(provider.get_status(), {
-    requested: Token,
-    effective: Token,
-    fell_back: false,
-  })
-  provider.dispose()
+  assert_eq(inner.original, Range(1, 14, 1, 15))
+  assert_eq(inner.modified, Range(1, 14, 1, 15))
 }
 
 ///|
-test "Token provider preserves one-sided token mappings across multiline expansion" {
-  let original = "fn run() {\n  compute(alpha, beta)\n}"
-  let modified = "fn run() {\n  compute(\n    alpha,\n    beta,\n    gamma < limit,\n  )\n}"
-  let inserted_comma = @base_common.Range(4, 9, 4, 10)
-  let inserted_argument = @base_common.Range(5, 5, 5, 19)
-  let forward = MoonDocumentDiffProvider(mode=Token)
-  let forward_result = compute_with_provider(forward, original, modified)
-  guard forward_result.changes is [forward_change] else {
-    fail("expected one grouped expansion hunk")
+test "fragment adapter preserves one-sided intraline mappings" {
+  let document : @mbtdiff.HunkDocument = {
+    hunks: [
+      {
+        old_start: 0,
+        old_len: 0,
+        new_start: 0,
+        new_len: 1,
+        blocks: [ChangeBlock([NewOnly(changed_line(0, "", "new()", ""))])],
+      },
+    ],
   }
-  assert_eq(forward_change.original, LineRange(2, 3))
-  assert_eq(forward_change.modified, LineRange(2, 7))
-  guard forward_change.inner_changes is Some(forward_inner) else {
-    fail("expected token mappings for expanded lines")
-  }
-  assert_eq(forward_inner.map(mapping => mapping.modified), [
-    inserted_comma, inserted_argument,
-  ])
-  assert_eq(forward_inner.map(mapping => mapping.original), [
-    @base_common.Range(3, 1, 3, 1),
-    @base_common.Range(3, 1, 3, 1),
-  ])
-  assert_true(forward_result.additional_alignments.is_empty())
-  assert_eq(forward.get_status(), {
-    requested: Token,
-    effective: Token,
-    fell_back: false,
-  })
-  forward.dispose()
-
-  let reverse = MoonDocumentDiffProvider(mode=Token)
-  let reverse_result = compute_with_provider(reverse, modified, original)
-  guard reverse_result.changes is [reverse_change] else {
-    fail("expected one grouped contraction hunk")
-  }
-  assert_eq(reverse_change.original, LineRange(2, 7))
-  assert_eq(reverse_change.modified, LineRange(2, 3))
-  guard reverse_change.inner_changes is Some(reverse_inner) else {
-    fail("expected token mappings for contracted lines")
-  }
-  assert_eq(reverse_inner.map(mapping => mapping.original), [
-    inserted_comma, inserted_argument,
-  ])
-  assert_eq(reverse_inner.map(mapping => mapping.modified), [
-    @base_common.Range(3, 1, 3, 1),
-    @base_common.Range(3, 1, 3, 1),
-  ])
-  assert_true(reverse_result.additional_alignments.is_empty())
-  assert_eq(reverse.get_status(), {
-    requested: Token,
-    effective: Token,
-    fell_back: false,
-  })
-  reverse.dispose()
-}
-
-///|
-test "Token provider marks pure multiline reflow as computed inner changes" {
-  let original = "fn run() {\n  compute(alpha, beta)\n}"
-  let modified = "fn run() {\n  compute(\n    alpha,\n    beta\n  )\n}"
-  let provider = MoonDocumentDiffProvider(mode=Token)
-  let result = compute_with_provider(provider, original, modified)
-  guard result.changes is [change] else {
-    fail("expected one grouped reflow hunk")
-  }
-  assert_eq(change.original, LineRange(2, 3))
-  assert_eq(change.modified, LineRange(2, 6))
-  assert_eq(change.inner_changes, Some([]))
-  assert_true(result.additional_alignments.is_empty())
-  assert_eq(provider.get_status(), {
-    requested: Token,
-    effective: Token,
-    fell_back: false,
-  })
-  provider.dispose()
-}
-
-///|
-test "specialized providers group touching rows into VS Code hunks" {
-  for mode in [Token, Tree] {
-    let provider = MoonDocumentDiffProvider(mode~)
-    let result = compute_with_provider(
-      provider, "fn value() {\n  let first = 1\n  let second = 2\n}", "fn value() {\n  let first = 10\n  let second = 20\n}",
-    )
-    assert_eq(result.changes.length(), 1)
-    assert_eq(result.changes[0].original, LineRange(2, 4))
-    assert_eq(result.changes[0].modified, LineRange(2, 4))
-    provider.dispose()
-  }
-}
-
-///|
-test "Tree parse failure reports Token fallback" {
-  let provider = MoonDocumentDiffProvider(mode=Tree)
-  let result = compute_with_provider(provider, "fn broken( {", "fn okay() {}")
-  assert_false(result.changes.is_empty())
-  assert_eq(provider.get_status(), {
-    requested: Tree,
-    effective: Token,
-    fell_back: true,
-  })
-  provider.dispose()
-}
-
-///|
-test "top-level edits keep specialized global mappings" {
-  let cases = [
-    (
-      "fn stable() { 0 }",
-      "fn inserted() { 1 }\nfn stable() { 2 }",
-      [(@base_common.LineRange(1, 2), @base_common.LineRange(1, 3))],
-    ),
-    (
-      "fn first() {}\nfn last() {}",
-      "fn first() {}\nfn inserted() {}\nfn last() {}",
-      [(@base_common.LineRange(2, 2), @base_common.LineRange(2, 3))],
-    ),
-    (
-      "fn first() {}",
-      "fn first() {}\nfn inserted() {}",
-      [(@base_common.LineRange(2, 2), @base_common.LineRange(2, 3))],
-    ),
-    (
-      "fn deleted() { 1 }\nfn stable() { 0 }",
-      "fn stable() { 2 }",
-      [(@base_common.LineRange(1, 3), @base_common.LineRange(1, 2))],
-    ),
-    (
-      "fn first() {}\nfn deleted() {}\nfn last() {}",
-      "fn first() {}\nfn last() {}",
-      [(@base_common.LineRange(2, 3), @base_common.LineRange(2, 2))],
-    ),
-    (
-      "fn first() {}\nfn deleted() {}",
-      "fn first() {}",
-      [(@base_common.LineRange(2, 3), @base_common.LineRange(2, 2))],
-    ),
-    (
-      "fn first() {}\nfn removed() {}\nfn last() {}",
-      "fn first() {}\nfn inserted() {}\nfn last() {}",
-      [(@base_common.LineRange(2, 3), @base_common.LineRange(2, 3))],
-    ),
-  ]
-  for mode in [Token, Tree] {
-    for case in cases {
-      let (original, modified, expected) = case
-      let provider = MoonDocumentDiffProvider(
-        mode~,
-        ignore_comments=false,
-        ignore_tests=false,
-      )
-      let result = compute_with_provider(provider, original, modified)
-      assert_eq(
-        result.changes.map(change => (change.original, change.modified)),
-        expected,
-      )
-      assert_true(result.additional_alignments.is_empty())
-      assert_eq(provider.get_status(), {
-        requested: mode,
-        effective: mode,
-        fell_back: false,
-      })
-      provider.dispose()
-    }
-  }
-}
-
-///|
-test "test filtering preserves a mixed top-level gap" {
-  let original = "fn first() {}\nfn last() {}"
-  let modified = "fn first() {}\ntest \"sample\" { new_test() }\nfn inserted() {}\nfn last() {}"
-  for mode in [Token, Tree] {
-    let provider = MoonDocumentDiffProvider(
-      mode~,
-      ignore_comments=false,
-      ignore_tests=true,
-    )
-    let result = compute_with_provider(provider, original, modified)
-    assert_eq(
-      result.changes.map(change => (change.original, change.modified)),
-      [(LineRange(2, 2), LineRange(3, 4))],
-    )
-    assert_eq(result.additional_alignments, [
-      LineRangeMapping(LineRange(2, 2), LineRange(2, 3)),
-    ])
-    assert_eq(provider.get_status(), {
-      requested: mode,
-      effective: mode,
-      fell_back: false,
-    })
-    provider.dispose()
-  }
-}
-
-///|
-test "top-level anchors preserve shared gaps and final newlines" {
-  let cases = [
-    (
-      "\nfn last() {}",
-      "fn inserted() {}\n\nfn last() {}",
-      (@base_common.LineRange(1, 1), @base_common.LineRange(1, 2)),
-      None,
-    ),
-    (
-      "fn first() {}\n",
-      "fn first() {}\nfn inserted() {}\n",
-      (@base_common.LineRange(2, 2), @base_common.LineRange(2, 3)),
-      None,
-    ),
-    (
-      "fn first() {}\n",
-      "fn first() {}\ntest \"sample\" { new_test() }\nfn inserted() {}\n",
-      (@base_common.LineRange(2, 2), @base_common.LineRange(3, 4)),
-      Some(
-        @diff.LineRangeMapping(
-          @base_common.LineRange(2, 2),
-          @base_common.LineRange(2, 3),
-        ),
-      ),
-    ),
-    (
-      "test \"sample\" { old_test() }\nfn stable() {}",
-      "test \"sample\" {\n  new_one()\n  new_two()\n}\nfn inserted() {}\nfn stable() {}",
-      (@base_common.LineRange(2, 2), @base_common.LineRange(5, 6)),
-      Some(
-        @diff.LineRangeMapping(
-          @base_common.LineRange(1, 2),
-          @base_common.LineRange(1, 5),
-        ),
-      ),
-    ),
-  ]
-  for mode in [Token, Tree] {
-    for case in cases {
-      let (original, modified, expected_change, expected_alignment) = case
-      let provider = MoonDocumentDiffProvider(
-        mode~,
-        ignore_comments=false,
-        ignore_tests=true,
-      )
-      let result = compute_with_provider(provider, original, modified)
-      guard result.changes is [change] else { fail("expected one insertion") }
-      assert_eq((change.original, change.modified), expected_change)
-      assert_eq(
-        result.additional_alignments,
-        match expected_alignment {
-          Some(alignment) => [alignment]
-          None => []
-        },
-      )
-      assert_eq(provider.get_status(), {
-        requested: mode,
-        effective: mode,
-        fell_back: false,
-      })
-      provider.dispose()
-    }
-  }
-}
-
-///|
-test "Ignore tests does not hide ordinary blank-line changes" {
-  let original = "fn first() {}\nfn last() {}"
-  let modified = "fn first() {}\n\nfn last() {}"
-  let expected = @diff.CoreDocumentDiffProvider().compute_diff(
-    TextSnapshot(original),
-    TextSnapshot(modified),
-    { ignore_trim_whitespace: true },
-  )
-  for mode in [Token, Tree] {
-    let provider = MoonDocumentDiffProvider(
-      mode~,
-      ignore_comments=false,
-      ignore_tests=true,
-    )
-    assert_eq(compute_with_provider(provider, original, modified), expected)
-    assert_eq(provider.get_status(), {
-      requested: mode,
-      effective: Core,
-      fell_back: true,
-    })
-    provider.dispose()
-  }
-}
-
-///|
-test "ignored-only and matched comment height changes retain geometry" {
-  for mode in [Token, Tree] {
-    let tests = MoonDocumentDiffProvider(
-      mode~,
-      ignore_comments=false,
-      ignore_tests=true,
-    )
-    let moved = compute_with_provider(
-      tests, "test \"sample\" {}\nfn stable() {}", "fn stable() {}\ntest \"sample\" {}",
-    )
-    assert_true(moved.changes.is_empty())
-    assert_eq(moved.additional_alignments, [
-      LineRangeMapping(LineRange(1, 2), LineRange(1, 1)),
-      LineRangeMapping(LineRange(3, 3), LineRange(2, 3)),
-    ])
-    assert_eq(tests.get_status().effective, mode)
-    tests.dispose()
-
-    let comments = MoonDocumentDiffProvider(
-      mode~,
-      ignore_comments=true,
-      ignore_tests=false,
-    )
-    let trailing = compute_with_provider(
-      comments, "fn stable() {}", "fn stable() {}\n\n",
-    )
-    assert_true(trailing.changes.is_empty())
-    assert_eq(trailing.additional_alignments, [
-      LineRangeMapping(LineRange(2, 2), LineRange(2, 4)),
-    ])
-    assert_eq(comments.get_status().effective, mode)
-    let mixed = compute_with_provider(
-      comments, "fn first() {\n  // old\n}\nfn last() {}", "fn first() {\n  // new one\n  // new two\n}\nfn inserted() {}\nfn last() {}",
-    )
-    assert_eq(mixed.changes.map(change => (change.original, change.modified)), [
-      (LineRange(4, 4), LineRange(5, 6)),
-    ])
-    assert_eq(mixed.additional_alignments, [
-      LineRangeMapping(LineRange(2, 3), LineRange(2, 4)),
-    ])
-    assert_eq(comments.get_status().effective, mode)
-    comments.dispose()
-  }
-}
-
-///|
-test "ignored-only rows become geometry-only additional alignments" {
-  let provider = MoonDocumentDiffProvider(mode=Token, ignore_comments=true)
-  let result = compute_with_provider(
-    provider, "fn value() -> Int {\n  // obsolete note\n  1\n}", "fn value() -> Int {\n\n  // updated note\n  1\n}",
-  )
-  assert_true(result.changes.is_empty())
-  assert_eq(result.additional_alignments.length(), 1)
-  provider.dispose()
-}
-
-///|
-test "equal-length ignored-only edit is a valid empty specialized result" {
-  let provider = MoonDocumentDiffProvider(mode=Token, ignore_comments=true)
-  let result = compute_with_provider(
-    provider, "fn value() {\n  // old\n}", "fn value() {\n  // new\n}",
-  )
-  assert_true(result.changes.is_empty())
-  assert_true(result.additional_alignments.is_empty())
-  assert_eq(provider.get_status().effective, Token)
-  assert_false(provider.get_status().fell_back)
-  provider.dispose()
-}
-
-///|
-test "Token and Tree ignore MoonBit test-only edits" {
-  for mode in [Token, Tree] {
-    let provider = MoonDocumentDiffProvider(
-      mode~,
-      ignore_comments=false,
-      ignore_tests=true,
-    )
-    let ignored = compute_with_provider(
-      provider, "test \"sample\" { old_value() }", "test \"sample\" { new_value() }",
-    )
-    assert_true(ignored.changes.is_empty())
-    assert_true(ignored.additional_alignments.is_empty())
-    assert_eq(provider.get_status(), {
-      requested: mode,
-      effective: mode,
-      fell_back: false,
-    })
-    let reshaped = compute_with_provider(
-      provider, "fn first() {}\nfn second() {}\ntest \"old\" {\n  value()\n}", "fn first() {}\nfn second() {}\ntest \"new one\" { value() }\ntest \"new two\" { value() }\ntest \"new three\" { value() }",
-    )
-    assert_true(reshaped.changes.is_empty())
-    assert_true(reshaped.additional_alignments.is_empty())
-    assert_eq(provider.get_status(), {
-      requested: mode,
-      effective: mode,
-      fell_back: false,
-    })
-    let mixed = compute_with_provider(
-      provider, "fn a() { old() }\ntest \"old\" {\n  value()\n}", "fn a() { new() }\ntest \"n1\" { value() }\ntest \"n2\" { value() }\ntest \"n3\" { value() }",
-    )
-    assert_eq(mixed.changes.map(change => (change.original, change.modified)), [
-      (LineRange(1, 2), LineRange(1, 2)),
-    ])
-    assert_true(mixed.additional_alignments.is_empty())
-    assert_eq(provider.get_status(), {
-      requested: mode,
-      effective: mode,
-      fell_back: false,
-    })
-    provider.set_ignore_tests(false)
-    let visible = compute_with_provider(
-      provider, "test \"sample\" { old_value() }", "test \"sample\" { new_value() }",
-    )
-    assert_false(visible.changes.is_empty())
-    provider.dispose()
-  }
-}
-
-///|
-test "ignored tests do not consume adjacent ordinary blank lines" {
-  let original = "fn a() {}\nfn b() {}"
-  let modified = "fn a() {}\ntest \"new\" { new_value() }\n\nfn b() {}"
-  let metadata = @mbtdiff.diff(
-    original,
-    modified,
-    options=@mbtdiff.DiffOptions(
-      context_lines=0,
-      ignore_comments=false,
-      ignore_tests=true,
-      mode=@mbtdiff.DiffMode::Lexical,
-    ),
-  )
-  assert_true(
-    metadata.ignored_test_ranges(@mbtdiff.DiffSide::New)
-    is [{ start: 1, len: 1 }],
-  )
-  for mode in [Token, Tree] {
-    let provider = MoonDocumentDiffProvider(
-      mode~,
-      ignore_comments=false,
-      ignore_tests=true,
-    )
-    let result = compute_with_provider(provider, original, modified)
-    assert_eq(provider.get_status(), {
-      requested: mode,
-      effective: Core,
-      fell_back: true,
-    })
-    assert_false(result.changes.is_empty())
-    provider.dispose()
-  }
-}
-
-///|
-test "ignored test reshapes preserve multiple semantic gaps" {
-  for mode in [Token, Tree] {
-    let provider = MoonDocumentDiffProvider(
-      mode~,
-      ignore_comments=false,
-      ignore_tests=true,
-    )
-    let result = compute_with_provider(
-      provider, "test \"o0\" {\n  value()\n}\ntest \"o1\" {\n  value()\n}\nfn a() {}\nfn b() {}",
-      "test \"n0\" { value() }\ntest \"n1\" { value() }\nfn a() {}\ntest \"n2\" {\n  value()\n}\nfn b() {}",
-    )
-    assert_true(result.changes.is_empty())
-    assert_eq(result.additional_alignments, [
-      LineRangeMapping(LineRange(1, 7), LineRange(1, 3)),
-      LineRangeMapping(LineRange(8, 8), LineRange(4, 7)),
-    ])
-    assert_eq(provider.get_status(), {
-      requested: mode,
-      effective: mode,
-      fell_back: false,
-    })
-    provider.dispose()
-  }
-}
-
-///|
-test "ignored inserted tests become geometry-only additional alignments" {
-  for mode in [Token, Tree] {
-    let provider = MoonDocumentDiffProvider(
-      mode~,
-      ignore_comments=false,
-      ignore_tests=true,
-    )
-    let result = compute_with_provider(
-      provider, "fn stable() {}", "test \"sample\" { new_value() }\nfn stable() {}",
-    )
-    assert_true(result.changes.is_empty())
-    assert_eq(result.additional_alignments, [
-      LineRangeMapping(LineRange(1, 1), LineRange(1, 2)),
-    ])
-    assert_eq(provider.get_status().effective, mode)
-    let deleted = compute_with_provider(
-      provider, "test \"sample\" { old_value() }\nfn stable() {}", "fn stable() {}",
-    )
-    assert_true(deleted.changes.is_empty())
-    assert_eq(deleted.additional_alignments, [
-      LineRangeMapping(LineRange(1, 2), LineRange(1, 1)),
-    ])
-    assert_eq(provider.get_status().effective, mode)
-    provider.dispose()
-  }
-}
-
-///|
-test "test filtering composes with visible production changes" {
-  for mode in [Token, Tree] {
-    let provider = MoonDocumentDiffProvider(
-      mode~,
-      ignore_comments=false,
-      ignore_tests=true,
-    )
-    let result = compute_with_provider(
-      provider, "fn production() { old_value() }\nfn stable() {}", "fn production() { new_value() }\ntest \"sample\" { new_test() }\nfn stable() {}",
-    )
-    assert_eq(
-      result.changes.map(change => (change.original, change.modified)),
-      [(LineRange(1, 2), LineRange(1, 2))],
-    )
-    assert_eq(result.additional_alignments, [
-      LineRangeMapping(LineRange(2, 2), LineRange(2, 3)),
-    ])
-    assert_eq(provider.get_status().effective, mode)
-    provider.dispose()
-  }
-}
-
-///|
-test "test and comment filters remain independent" {
-  for mode in [Token, Tree] {
-    let provider = MoonDocumentDiffProvider(
-      mode~,
-      ignore_comments=false,
-      ignore_tests=true,
-    )
-    let visible = compute_with_provider(
-      provider, "fn value() { // old\n}", "fn value() { // new\n}",
-    )
-    assert_false(visible.changes.is_empty())
-    provider.set_ignore_comments(true)
-    let ignored = compute_with_provider(
-      provider, "fn value() { // old\n}", "fn value() { // new\n}",
-    )
-    assert_true(ignored.changes.is_empty())
-    provider.dispose()
-  }
-}
-
-///|
-test "parse failure keeps test changes visible" {
-  for mode in [Token, Tree] {
-    let provider = MoonDocumentDiffProvider(
-      mode~,
-      ignore_comments=false,
-      ignore_tests=true,
-    )
-    let result = compute_with_provider(
-      provider, "test \"sample\" { old_value( }", "test \"sample\" { new_value( }",
-    )
-    assert_false(result.changes.is_empty())
-    assert_eq(provider.get_status(), {
-      requested: mode,
-      effective: Token,
-      fell_back: mode is Tree,
-    })
-    provider.dispose()
-  }
-}
-
-///|
-test "Token keeps ignored inserted comments separate from code insertions" {
-  let provider = MoonDocumentDiffProvider(mode=Token, ignore_comments=true)
-  let result = compute_with_provider(
-    provider, "fn stable() {}", "/// ignored before\nfn inserted() {}\n/// ignored after\nfn stable() {}",
-  )
-  guard result.changes is [change] else {
-    fail("expected one inserted code change")
+  guard fragment_document_diff(document, "anchor", "new()\nanchor")
+    is Some({ changes: [change], additional_alignments: [], }) else {
+    fail("expected one insertion")
   }
   assert_eq(change.original, LineRange(1, 1))
-  assert_eq(change.modified, LineRange(2, 3))
-  assert_eq(result.additional_alignments, [
-    LineRangeMapping(LineRange(1, 1), LineRange(1, 2)),
-    LineRangeMapping(LineRange(1, 1), LineRange(3, 4)),
-  ])
-  assert_eq(provider.get_status(), {
-    requested: Token,
-    effective: Token,
-    fell_back: false,
-  })
-  provider.dispose()
-}
-
-///|
-test "Token keeps ignored deleted comments separate from code deletions" {
-  let provider = MoonDocumentDiffProvider(mode=Token, ignore_comments=true)
-  let result = compute_with_provider(
-    provider, "/// ignored before\nfn deleted() {}\n/// ignored after\nfn stable() {}",
-    "fn stable() {}",
-  )
-  guard result.changes is [change] else {
-    fail("expected one deleted code change")
+  assert_eq(change.modified, LineRange(1, 2))
+  guard change.inner_changes is Some([inner]) else {
+    fail("expected the inserted token mapping")
   }
-  assert_eq(change.original, LineRange(2, 3))
-  assert_eq(change.modified, LineRange(1, 1))
-  assert_eq(result.additional_alignments, [
-    LineRangeMapping(LineRange(1, 2), LineRange(1, 1)),
-    LineRangeMapping(LineRange(3, 4), LineRange(1, 1)),
-  ])
-  assert_eq(provider.get_status(), {
-    requested: Token,
-    effective: Token,
-    fell_back: false,
-  })
-  provider.dispose()
+  assert_eq(inner.original, Range(1, 1, 1, 1))
+  assert_eq(inner.modified, Range(1, 1, 1, 6))
 }
 
 ///|
-test "Token does not join inserted code across an ignored comment" {
-  let provider = MoonDocumentDiffProvider(mode=Token, ignore_comments=true)
-  let result = compute_with_provider(
-    provider, "fn stable() {}", "fn inserted_before() {}\n/// ignored\nfn inserted_after() {}\nfn stable() {}",
-  )
-  assert_eq(result.changes.map(change => (change.original, change.modified)), [
-    (LineRange(1, 1), LineRange(1, 2)),
-    (LineRange(1, 1), LineRange(3, 4)),
-  ])
-  assert_eq(result.additional_alignments, [
-    LineRangeMapping(LineRange(1, 1), LineRange(2, 3)),
-  ])
-  assert_eq(provider.get_status().effective, Token)
-  provider.dispose()
-}
-
-///|
-test "Token does not join deleted code across an ignored comment" {
-  let provider = MoonDocumentDiffProvider(mode=Token, ignore_comments=true)
-  let result = compute_with_provider(
-    provider, "fn deleted_before() {}\n/// ignored\nfn deleted_after() {}\nfn stable() {}",
-    "fn stable() {}",
-  )
-  assert_eq(result.changes.map(change => (change.original, change.modified)), [
-    (LineRange(1, 2), LineRange(1, 1)),
-    (LineRange(3, 4), LineRange(1, 1)),
-  ])
-  assert_eq(result.additional_alignments, [
-    LineRangeMapping(LineRange(2, 3), LineRange(1, 1)),
-  ])
-  assert_eq(provider.get_status().effective, Token)
-  provider.dispose()
-}
-
-///|
-test "invalid specialized candidates settle to Core without reentrant changes" {
-  let original = @model.TextSnapshot("fn stable() {}")
-  let modified = @model.TextSnapshot(
-    "/// ignored before\nfn inserted() {}\n/// ignored after\nfn stable() {}",
-  )
-  let invalid : @diff.DocumentDiff = {
-    changes: [DetailedLineRangeMapping(LineRange(1, 1), LineRange(2, 3), None)],
-    additional_alignments: [LineRangeMapping(LineRange(1, 1), LineRange(1, 4))],
+test "ignored fragment rows do not become visible changes" {
+  let old : @mbtdiff.DiffLine = {
+    index: 0,
+    segments: [{ kind: Changed, text: "// old", }],
   }
-  let options : @diff.DocumentDiffOptions = { ignore_trim_whitespace: true, }
-  let expected = @diff.CoreDocumentDiffProvider().compute_diff(
-    original, modified, options,
-  )
-  for configuration in [(Token, Token, false), (Tree, Token, true)] {
-    let (requested, specialized_effective, specialized_fell_back) = configuration
-    let provider = MoonDocumentDiffProvider(mode=requested)
-    let provider_object : &@diff.DocumentDiffProvider = provider
-    let updates = Ref(0)
-    let subscription = provider_object.on_did_change(() => updates.val += 1)
-    let result = provider.settle_specialized_or_core(
-      requested,
-      Some((invalid, specialized_effective, specialized_fell_back)),
-      expected,
-      original,
-      modified,
-    )
-    assert_eq(result, expected)
-    assert_eq(provider.get_status(), {
-      requested,
-      effective: Core,
-      fell_back: true,
-    })
-    assert_eq(updates.val, 0)
-    provider.set_ignore_comments(false)
-    assert_eq(provider.get_status(), {
-      requested,
-      effective: requested,
-      fell_back: false,
-    })
-    assert_eq(updates.val, 1)
-    subscription.dispose()
-    provider.dispose()
+  let new : @mbtdiff.DiffLine = {
+    index: 0,
+    segments: [{ kind: Changed, text: "// new", }],
   }
+  let document : @mbtdiff.HunkDocument = {
+    hunks: [
+      {
+        old_start: 0,
+        old_len: 1,
+        new_start: 0,
+        new_len: 1,
+        blocks: [IgnoredBlock([Paired(old, new)])],
+      },
+    ],
+  }
+  guard fragment_document_diff(document, "// old", "// new") is Some(result) else {
+    fail("expected a valid ignored fragment")
+  }
+  assert_true(result.changes.is_empty())
+  assert_true(result.additional_alignments.is_empty())
 }
 
 ///|
-test "provider options notify through the standard provider contract" {
-  let provider = MoonDocumentDiffProvider()
-  assert_true(provider.get_ignore_tests())
-  let object : &@diff.DocumentDiffProvider = provider
-  let updates = Ref(0)
-  let subscription = object.on_did_change(() => updates.val += 1)
-  provider.set_mode(Token)
-  provider.set_ignore_comments(false)
-  provider.set_ignore_comments(false)
-  provider.set_ignore_tests(false)
-  provider.set_ignore_tests(false)
-  assert_eq(updates.val, 3)
-  subscription.dispose()
-  provider.dispose()
+test "fragment provider returns its prevalidated document unchanged" {
+  let document : @diff.DocumentDiff = {
+    changes: [],
+    additional_alignments: [],
+  }
+  let provider = MoonFragmentDiffProvider(document)
+  let object = provider.as_document_diff_provider()
+  assert_eq(
+    object.compute_diff(TextSnapshot("old"), TextSnapshot("new"), {
+      ignore_trim_whitespace: true,
+    }),
+    document,
+  )
 }

--- a/editor/viewer/diff_provider/moondiff/provider_wbtest.mbt
+++ b/editor/viewer/diff_provider/moondiff/provider_wbtest.mbt
@@ -39,6 +39,18 @@ test "Token and Tree honor trim-whitespace options consistently" {
       effective: Core,
       fell_back: true,
     })
+    let mixed = compute_with_provider(
+      provider,
+      "fn answer() {\n  old_value()\n}",
+      "fn answer() {\n  new_value()\n }",
+      ignore_trim_whitespace=true,
+    )
+    assert_false(mixed.changes.is_empty())
+    assert_eq(provider.get_status(), {
+      requested: mode,
+      effective: Core,
+      fell_back: true,
+    })
     provider.dispose()
   }
 }
@@ -137,6 +149,233 @@ test "invalid Tree geometry falls back to strict Core" {
 }
 
 ///|
+test "top-level edits keep specialized global mappings" {
+  let cases = [
+    (
+      "fn stable() { 0 }",
+      "fn inserted() { 1 }\nfn stable() { 2 }",
+      [(@base_common.LineRange(1, 2), @base_common.LineRange(1, 3))],
+    ),
+    (
+      "fn first() {}\nfn last() {}",
+      "fn first() {}\nfn inserted() {}\nfn last() {}",
+      [(@base_common.LineRange(2, 2), @base_common.LineRange(2, 3))],
+    ),
+    (
+      "fn first() {}",
+      "fn first() {}\nfn inserted() {}",
+      [(@base_common.LineRange(2, 2), @base_common.LineRange(2, 3))],
+    ),
+    (
+      "fn deleted() { 1 }\nfn stable() { 0 }",
+      "fn stable() { 2 }",
+      [(@base_common.LineRange(1, 3), @base_common.LineRange(1, 2))],
+    ),
+    (
+      "fn first() {}\nfn deleted() {}\nfn last() {}",
+      "fn first() {}\nfn last() {}",
+      [(@base_common.LineRange(2, 3), @base_common.LineRange(2, 2))],
+    ),
+    (
+      "fn first() {}\nfn deleted() {}",
+      "fn first() {}",
+      [(@base_common.LineRange(2, 3), @base_common.LineRange(2, 2))],
+    ),
+    (
+      "fn first() {}\nfn removed() {}\nfn last() {}",
+      "fn first() {}\nfn inserted() {}\nfn last() {}",
+      [(@base_common.LineRange(2, 3), @base_common.LineRange(2, 3))],
+    ),
+  ]
+  for mode in [Token, Tree] {
+    for case in cases {
+      let (original, modified, expected) = case
+      let provider = MoonDocumentDiffProvider(
+        mode~,
+        ignore_comments=false,
+        ignore_tests=false,
+      )
+      let result = compute_with_provider(provider, original, modified)
+      assert_eq(
+        result.changes.map(change => (change.original, change.modified)),
+        expected,
+      )
+      assert_true(result.additional_alignments.is_empty())
+      assert_eq(provider.get_status(), {
+        requested: mode,
+        effective: mode,
+        fell_back: false,
+      })
+      provider.dispose()
+    }
+  }
+}
+
+///|
+test "test filtering preserves a mixed top-level gap" {
+  let original = "fn first() {}\nfn last() {}"
+  let modified = "fn first() {}\ntest \"sample\" { new_test() }\nfn inserted() {}\nfn last() {}"
+  for mode in [Token, Tree] {
+    let provider = MoonDocumentDiffProvider(
+      mode~,
+      ignore_comments=false,
+      ignore_tests=true,
+    )
+    let result = compute_with_provider(provider, original, modified)
+    assert_eq(
+      result.changes.map(change => (change.original, change.modified)),
+      [(LineRange(2, 2), LineRange(3, 4))],
+    )
+    assert_eq(result.additional_alignments, [
+      LineRangeMapping(LineRange(2, 2), LineRange(2, 3)),
+    ])
+    assert_eq(provider.get_status(), {
+      requested: mode,
+      effective: mode,
+      fell_back: false,
+    })
+    provider.dispose()
+  }
+}
+
+///|
+test "top-level anchors preserve shared gaps and final newlines" {
+  let cases = [
+    (
+      "\nfn last() {}",
+      "fn inserted() {}\n\nfn last() {}",
+      (@base_common.LineRange(1, 1), @base_common.LineRange(1, 2)),
+      None,
+    ),
+    (
+      "fn first() {}\n",
+      "fn first() {}\nfn inserted() {}\n",
+      (@base_common.LineRange(2, 2), @base_common.LineRange(2, 3)),
+      None,
+    ),
+    (
+      "fn first() {}\n",
+      "fn first() {}\ntest \"sample\" { new_test() }\nfn inserted() {}\n",
+      (@base_common.LineRange(2, 2), @base_common.LineRange(3, 4)),
+      Some(
+        @diff.LineRangeMapping(
+          @base_common.LineRange(2, 2),
+          @base_common.LineRange(2, 3),
+        ),
+      ),
+    ),
+    (
+      "test \"sample\" { old_test() }\nfn stable() {}",
+      "test \"sample\" {\n  new_one()\n  new_two()\n}\nfn inserted() {}\nfn stable() {}",
+      (@base_common.LineRange(2, 2), @base_common.LineRange(5, 6)),
+      Some(
+        @diff.LineRangeMapping(
+          @base_common.LineRange(1, 2),
+          @base_common.LineRange(1, 5),
+        ),
+      ),
+    ),
+  ]
+  for mode in [Token, Tree] {
+    for case in cases {
+      let (original, modified, expected_change, expected_alignment) = case
+      let provider = MoonDocumentDiffProvider(
+        mode~,
+        ignore_comments=false,
+        ignore_tests=true,
+      )
+      let result = compute_with_provider(provider, original, modified)
+      guard result.changes is [change] else { fail("expected one insertion") }
+      assert_eq((change.original, change.modified), expected_change)
+      assert_eq(
+        result.additional_alignments,
+        match expected_alignment {
+          Some(alignment) => [alignment]
+          None => []
+        },
+      )
+      assert_eq(provider.get_status(), {
+        requested: mode,
+        effective: mode,
+        fell_back: false,
+      })
+      provider.dispose()
+    }
+  }
+}
+
+///|
+test "Ignore tests does not hide ordinary blank-line changes" {
+  let original = "fn first() {}\nfn last() {}"
+  let modified = "fn first() {}\n\nfn last() {}"
+  let expected = @diff.CoreDocumentDiffProvider().compute_diff(
+    TextSnapshot(original),
+    TextSnapshot(modified),
+    { ignore_trim_whitespace: true },
+  )
+  for mode in [Token, Tree] {
+    let provider = MoonDocumentDiffProvider(
+      mode~,
+      ignore_comments=false,
+      ignore_tests=true,
+    )
+    assert_eq(compute_with_provider(provider, original, modified), expected)
+    assert_eq(provider.get_status(), {
+      requested: mode,
+      effective: Core,
+      fell_back: true,
+    })
+    provider.dispose()
+  }
+}
+
+///|
+test "ignored-only and matched comment height changes retain geometry" {
+  for mode in [Token, Tree] {
+    let tests = MoonDocumentDiffProvider(
+      mode~,
+      ignore_comments=false,
+      ignore_tests=true,
+    )
+    let moved = compute_with_provider(
+      tests, "test \"sample\" {}\nfn stable() {}", "fn stable() {}\ntest \"sample\" {}",
+    )
+    assert_true(moved.changes.is_empty())
+    assert_eq(moved.additional_alignments, [
+      LineRangeMapping(LineRange(1, 2), LineRange(1, 1)),
+      LineRangeMapping(LineRange(3, 3), LineRange(2, 3)),
+    ])
+    assert_eq(tests.get_status().effective, mode)
+    tests.dispose()
+
+    let comments = MoonDocumentDiffProvider(
+      mode~,
+      ignore_comments=true,
+      ignore_tests=false,
+    )
+    let trailing = compute_with_provider(
+      comments, "fn stable() {}", "fn stable() {}\n\n",
+    )
+    assert_true(trailing.changes.is_empty())
+    assert_eq(trailing.additional_alignments, [
+      LineRangeMapping(LineRange(2, 2), LineRange(2, 4)),
+    ])
+    assert_eq(comments.get_status().effective, mode)
+    let mixed = compute_with_provider(
+      comments, "fn first() {\n  // old\n}\nfn last() {}", "fn first() {\n  // new one\n  // new two\n}\nfn inserted() {}\nfn last() {}",
+    )
+    assert_eq(mixed.changes.map(change => (change.original, change.modified)), [
+      (LineRange(4, 4), LineRange(5, 6)),
+    ])
+    assert_eq(mixed.additional_alignments, [
+      LineRangeMapping(LineRange(2, 3), LineRange(2, 4)),
+    ])
+    assert_eq(comments.get_status().effective, mode)
+    comments.dispose()
+  }
+}
+
+///|
 test "ignored-only rows become geometry-only additional alignments" {
   let provider = MoonDocumentDiffProvider(mode=Token, ignore_comments=true)
   let result = compute_with_provider(
@@ -178,11 +417,91 @@ test "Token and Tree ignore MoonBit test-only edits" {
       effective: mode,
       fell_back: false,
     })
+    let reshaped = compute_with_provider(
+      provider, "fn first() {}\nfn second() {}\ntest \"old\" {\n  value()\n}", "fn first() {}\nfn second() {}\ntest \"new one\" { value() }\ntest \"new two\" { value() }\ntest \"new three\" { value() }",
+    )
+    assert_true(reshaped.changes.is_empty())
+    assert_true(reshaped.additional_alignments.is_empty())
+    assert_eq(provider.get_status(), {
+      requested: mode,
+      effective: mode,
+      fell_back: false,
+    })
+    let mixed = compute_with_provider(
+      provider, "fn a() { old() }\ntest \"old\" {\n  value()\n}", "fn a() { new() }\ntest \"n1\" { value() }\ntest \"n2\" { value() }\ntest \"n3\" { value() }",
+    )
+    assert_eq(mixed.changes.map(change => (change.original, change.modified)), [
+      (LineRange(1, 2), LineRange(1, 2)),
+    ])
+    assert_true(mixed.additional_alignments.is_empty())
+    assert_eq(provider.get_status(), {
+      requested: mode,
+      effective: mode,
+      fell_back: false,
+    })
     provider.set_ignore_tests(false)
     let visible = compute_with_provider(
       provider, "test \"sample\" { old_value() }", "test \"sample\" { new_value() }",
     )
     assert_false(visible.changes.is_empty())
+    provider.dispose()
+  }
+}
+
+///|
+test "ignored tests do not consume adjacent ordinary blank lines" {
+  let ownership_source = @model.TextSnapshot(
+    "fn a() {}\ntest \"new\" { new_value() }\n\nfn b() {}",
+  )
+  assert_eq(
+    source_ignored_test_ranges(
+      ownership_source,
+      snapshot_lines(ownership_source),
+      @mbtdiff.DiffMode::Lexical,
+    ),
+    Some([LineRange(2, 3)]),
+  )
+  for mode in [Token, Tree] {
+    let provider = MoonDocumentDiffProvider(
+      mode~,
+      ignore_comments=false,
+      ignore_tests=true,
+    )
+    let result = compute_with_provider(
+      provider, "fn a() {}\nfn b() {}", "fn a() {}\ntest \"new\" { new_value() }\n\nfn b() {}",
+    )
+    assert_eq(provider.get_status(), {
+      requested: mode,
+      effective: Core,
+      fell_back: true,
+    })
+    assert_false(result.changes.is_empty())
+    provider.dispose()
+  }
+}
+
+///|
+test "ignored test reshapes preserve multiple semantic gaps" {
+  for mode in [Token, Tree] {
+    let provider = MoonDocumentDiffProvider(
+      mode~,
+      ignore_comments=false,
+      ignore_tests=true,
+    )
+    let result = compute_with_provider(
+      provider, "test \"o0\" {\n  value()\n}\ntest \"o1\" {\n  value()\n}\nfn a() {}\nfn b() {}",
+      "test \"n0\" { value() }\ntest \"n1\" { value() }\nfn a() {}\ntest \"n2\" {\n  value()\n}\nfn b() {}",
+    )
+    assert_true(result.changes.is_empty())
+    assert_eq(result.additional_alignments, [
+      LineRangeMapping(LineRange(1, 7), LineRange(1, 3)),
+      LineRangeMapping(LineRange(8, 8), LineRange(4, 7)),
+    ])
+    assert_eq(provider.get_status(), {
+      requested: mode,
+      effective: mode,
+      fell_back: false,
+    })
     provider.dispose()
   }
 }

--- a/editor/viewer/diff_provider/moondiff/provider_wbtest.mbt
+++ b/editor/viewer/diff_provider/moondiff/provider_wbtest.mbt
@@ -94,6 +94,84 @@ test "Token provider exposes UTF-16 inner mappings" {
 }
 
 ///|
+test "Token provider preserves one-sided token mappings across multiline expansion" {
+  let original = "fn run() {\n  compute(alpha, beta)\n}"
+  let modified = "fn run() {\n  compute(\n    alpha,\n    beta,\n    gamma < limit,\n  )\n}"
+  let inserted_comma = @base_common.Range(4, 9, 4, 10)
+  let inserted_argument = @base_common.Range(5, 5, 5, 19)
+  let forward = MoonDocumentDiffProvider(mode=Token)
+  let forward_result = compute_with_provider(forward, original, modified)
+  guard forward_result.changes is [forward_change] else {
+    fail("expected one grouped expansion hunk")
+  }
+  assert_eq(forward_change.original, LineRange(2, 3))
+  assert_eq(forward_change.modified, LineRange(2, 7))
+  guard forward_change.inner_changes is Some(forward_inner) else {
+    fail("expected token mappings for expanded lines")
+  }
+  assert_eq(forward_inner.map(mapping => mapping.modified), [
+    inserted_comma, inserted_argument,
+  ])
+  assert_eq(forward_inner.map(mapping => mapping.original), [
+    @base_common.Range(3, 1, 3, 1),
+    @base_common.Range(3, 1, 3, 1),
+  ])
+  assert_true(forward_result.additional_alignments.is_empty())
+  assert_eq(forward.get_status(), {
+    requested: Token,
+    effective: Token,
+    fell_back: false,
+  })
+  forward.dispose()
+
+  let reverse = MoonDocumentDiffProvider(mode=Token)
+  let reverse_result = compute_with_provider(reverse, modified, original)
+  guard reverse_result.changes is [reverse_change] else {
+    fail("expected one grouped contraction hunk")
+  }
+  assert_eq(reverse_change.original, LineRange(2, 7))
+  assert_eq(reverse_change.modified, LineRange(2, 3))
+  guard reverse_change.inner_changes is Some(reverse_inner) else {
+    fail("expected token mappings for contracted lines")
+  }
+  assert_eq(reverse_inner.map(mapping => mapping.original), [
+    inserted_comma, inserted_argument,
+  ])
+  assert_eq(reverse_inner.map(mapping => mapping.modified), [
+    @base_common.Range(3, 1, 3, 1),
+    @base_common.Range(3, 1, 3, 1),
+  ])
+  assert_true(reverse_result.additional_alignments.is_empty())
+  assert_eq(reverse.get_status(), {
+    requested: Token,
+    effective: Token,
+    fell_back: false,
+  })
+  reverse.dispose()
+}
+
+///|
+test "Token provider marks pure multiline reflow as computed inner changes" {
+  let original = "fn run() {\n  compute(alpha, beta)\n}"
+  let modified = "fn run() {\n  compute(\n    alpha,\n    beta\n  )\n}"
+  let provider = MoonDocumentDiffProvider(mode=Token)
+  let result = compute_with_provider(provider, original, modified)
+  guard result.changes is [change] else {
+    fail("expected one grouped reflow hunk")
+  }
+  assert_eq(change.original, LineRange(2, 3))
+  assert_eq(change.modified, LineRange(2, 6))
+  assert_eq(change.inner_changes, Some([]))
+  assert_true(result.additional_alignments.is_empty())
+  assert_eq(provider.get_status(), {
+    requested: Token,
+    effective: Token,
+    fell_back: false,
+  })
+  provider.dispose()
+}
+
+///|
 test "specialized providers group touching rows into VS Code hunks" {
   for mode in [Token, Tree] {
     let provider = MoonDocumentDiffProvider(mode~)
@@ -118,34 +196,6 @@ test "Tree parse failure reports Token fallback" {
     fell_back: true,
   })
   provider.dispose()
-}
-
-///|
-test "invalid Tree geometry falls back to strict Core" {
-  let original = "fn stable() { 0 }"
-  let modified = "fn inserted() { 1 }\nfn stable() { 2 }"
-  let options : @diff.DocumentDiffOptions = { ignore_trim_whitespace: false, }
-  let expected = @diff.CoreDocumentDiffProvider().compute_diff(
-    TextSnapshot(original),
-    TextSnapshot(modified),
-    options,
-  )
-  for ignore_comments in [false, true] {
-    let provider = MoonDocumentDiffProvider(mode=Tree, ignore_comments~)
-    let result = compute_with_provider(
-      provider,
-      original,
-      modified,
-      ignore_trim_whitespace=false,
-    )
-    assert_eq(result, expected)
-    assert_eq(provider.get_status(), {
-      requested: Tree,
-      effective: Core,
-      fell_back: true,
-    })
-    provider.dispose()
-  }
 }
 
 ///|
@@ -450,16 +500,21 @@ test "Token and Tree ignore MoonBit test-only edits" {
 
 ///|
 test "ignored tests do not consume adjacent ordinary blank lines" {
-  let ownership_source = @model.TextSnapshot(
-    "fn a() {}\ntest \"new\" { new_value() }\n\nfn b() {}",
-  )
-  assert_eq(
-    source_ignored_test_ranges(
-      ownership_source,
-      snapshot_lines(ownership_source),
-      @mbtdiff.DiffMode::Lexical,
+  let original = "fn a() {}\nfn b() {}"
+  let modified = "fn a() {}\ntest \"new\" { new_value() }\n\nfn b() {}"
+  let metadata = @mbtdiff.diff(
+    original,
+    modified,
+    options=@mbtdiff.DiffOptions(
+      context_lines=0,
+      ignore_comments=false,
+      ignore_tests=true,
+      mode=@mbtdiff.DiffMode::Lexical,
     ),
-    Some([LineRange(2, 3)]),
+  )
+  assert_true(
+    metadata.ignored_test_ranges(@mbtdiff.DiffSide::New)
+    is [{ start: 1, len: 1 }],
   )
   for mode in [Token, Tree] {
     let provider = MoonDocumentDiffProvider(
@@ -467,9 +522,7 @@ test "ignored tests do not consume adjacent ordinary blank lines" {
       ignore_comments=false,
       ignore_tests=true,
     )
-    let result = compute_with_provider(
-      provider, "fn a() {}\nfn b() {}", "fn a() {}\ntest \"new\" { new_value() }\n\nfn b() {}",
-    )
+    let result = compute_with_provider(provider, original, modified)
     assert_eq(provider.get_status(), {
       requested: mode,
       effective: Core,

--- a/editor/viewer/diff_provider/moondiff/semantic_review_plan.mbt
+++ b/editor/viewer/diff_provider/moondiff/semantic_review_plan.mbt
@@ -1,0 +1,490 @@
+///|
+pub(all) enum SemanticReviewStatus {
+  Identical
+  Changed
+  Reordered
+  NoStructuralChanges
+  IgnoredOnly
+} derive(Eq, Debug)
+
+///|
+/// One physical source range owned by a semantic section. Line numbers are
+/// one-based for display; section DiffEditors use local model coordinates.
+pub(all) struct SemanticReviewSourceRange {
+  start_line_number : Int
+  line_count : Int
+} derive(Eq, Debug)
+
+///|
+pub(all) enum SemanticReviewSectionKind {
+  Whole
+  Matched
+  Deleted
+  Inserted
+} derive(Eq, Debug)
+
+///|
+/// The provider used inside one section DiffEditor. Inserted and deleted
+/// declarations use Core because one model is intentionally empty; matched
+/// and whole fragments retain MoonDiff's local intraline result.
+pub(all) enum SemanticReviewDiff {
+  Core
+  Fragment(@diff.DocumentDiff)
+} derive(Eq, Debug)
+
+///|
+/// One independently rendered semantic section. It carries source slices and
+/// a fragment-local diff only; no global two-sided line order is synthesized.
+pub(all) struct SemanticReviewSection {
+  key : String
+  identity : Int?
+  kind : SemanticReviewSectionKind
+  old_range : SemanticReviewSourceRange?
+  new_range : SemanticReviewSourceRange?
+  old_context : String?
+  new_context : String?
+  fallbacks : Array[String]
+  original_source : String
+  modified_source : String
+  diff : SemanticReviewDiff
+} derive(Eq, Debug)
+
+///|
+/// Main sections follow MoonDiff's new-side order. Deleted sections remain a
+/// separate old-side ordered group, so reordered identities never cross in a
+/// single DiffEditor mapping.
+pub(all) struct SectionedSemanticReviewPlan {
+  requested : MoonDiffMode
+  status : SemanticReviewStatus
+  reordered : Bool
+  main_sections : Array[SemanticReviewSection]
+  deleted_sections : Array[SemanticReviewSection]
+} derive(Eq, Debug)
+
+///|
+fn semantic_status(status : @mbtdiff.DiffStatus) -> SemanticReviewStatus {
+  match status {
+    Identical => Identical
+    Changed => Changed
+    Reordered => Reordered
+    NoStructuralChanges => NoStructuralChanges
+    IgnoredOnly => IgnoredOnly
+  }
+}
+
+///|
+fn fallback_stage_text(stage : @mbtdiff.ComputationStage) -> String {
+  match stage {
+    TopLevelAlignment => "top-level alignment"
+    SyntaxMatching => "syntax matching"
+    IntralineMatching => "intraline matching"
+  }
+}
+
+///|
+fn fallback_sides_text(sides : ArrayView[@mbtdiff.DiffSide]) -> String {
+  let names = sides.map(side => {
+    match side {
+      Old => "old"
+      New => "new"
+    }
+  })
+  match names {
+    [] => ""
+    [side] => "the \{side} side"
+    _ => "the \{names.join(" and ")} sides"
+  }
+}
+
+///|
+fn fallback_reason_text(reason : @mbtdiff.FallbackReason) -> String {
+  match reason {
+    ParseError(detail~, ..) => detail
+    SyntaxPositionsOutOfBounds(sides~) => {
+      let sides = fallback_sides_text(sides)
+      if sides.is_empty() {
+        "syntax positions out of bounds"
+      } else {
+        "syntax positions out of bounds on \{sides}"
+      }
+    }
+    GraphLimitExceeded(limit~) => "graph limit exceeded (\{limit})"
+    ComputationLimitExceeded(stage~, limit~) =>
+      "computation limit exceeded (\{limit}) during \{fallback_stage_text(stage)}"
+  }
+}
+
+///|
+fn fallback_texts(
+  fallbacks : ArrayView[@mbtdiff.FallbackReason],
+) -> Array[String] {
+  fallbacks.map(fallback_reason_text)
+}
+
+///|
+/// Normalize LF, CRLF, and CR to local LF-separated model text while keeping
+/// a terminating newline as a final empty line.
+fn normalized_source_lines(source : String) -> Array[String] {
+  let chars = source.to_array()
+  let lines : Array[String] = []
+  let mut line_start = 0
+  let mut index = 0
+  while index < chars.length() {
+    match chars[index] {
+      '\r' => {
+        lines.push(String::from_array(chars[line_start:index].to_owned()))
+        index += 1
+        if index < chars.length() && chars[index] == '\n' {
+          index += 1
+        }
+        line_start = index
+      }
+      '\n' => {
+        lines.push(String::from_array(chars[line_start:index].to_owned()))
+        index += 1
+        line_start = index
+      }
+      _ => index += 1
+    }
+  }
+  lines.push(String::from_array(chars[line_start:chars.length()].to_owned()))
+  lines
+}
+
+///|
+fn normalized_source(source : String) -> String {
+  normalized_source_lines(source).join("\n")
+}
+
+///|
+fn source_range(range : @mbtdiff.LineRange) -> SemanticReviewSourceRange {
+  { start_line_number: range.start + 1, line_count: range.len, }
+}
+
+///|
+fn source_slice(lines : Array[String], range : @mbtdiff.LineRange) -> String? {
+  if range.start < 0 ||
+    range.len < 0 ||
+    range.start > lines.length() ||
+    range.len > lines.length() - range.start {
+    return None
+  }
+  Some(lines[range.start:range.start + range.len].join("\n"))
+}
+
+///|
+fn fragment_has_output(fragment : @mbtdiff.DiffFragment) -> Bool {
+  !fragment.document.hunks.is_empty() || !fragment.fallbacks.is_empty()
+}
+
+///|
+fn section_diff(
+  fragment : @mbtdiff.DiffFragment,
+  original_source : String,
+  modified_source : String,
+  one_sided : Bool,
+) -> SemanticReviewDiff? {
+  if one_sided {
+    return Some(Core)
+  }
+  fragment_document_diff(fragment.document, original_source, modified_source).map(diff => {
+      Fragment(diff)
+    },
+  )
+}
+
+///|
+fn whole_section(
+  fragment : @mbtdiff.DiffFragment,
+  old_source : String,
+  new_source : String,
+) -> SemanticReviewSection? {
+  let original_source = normalized_source(old_source)
+  let modified_source = normalized_source(new_source)
+  guard section_diff(
+      fragment,
+      original_source,
+      modified_source,
+      old_source.is_empty() || new_source.is_empty(),
+    )
+    is Some(diff) else {
+    return None
+  }
+  Some({
+    key: "whole",
+    identity: None,
+    kind: Whole,
+    old_range: None,
+    new_range: None,
+    old_context: None,
+    new_context: None,
+    fallbacks: fallback_texts(fragment.fallbacks),
+    original_source,
+    modified_source,
+    diff,
+  })
+}
+
+///|
+fn top_level_section(
+  identity : Int,
+  section : @mbtdiff.DiffSection,
+  old_lines : Array[String],
+  new_lines : Array[String],
+) -> SemanticReviewSection? {
+  let (kind, old_range, new_range, old_context, new_context, fragment) = match
+    section {
+    Matched(old~, new~, old_context~, new_context~, diff~) =>
+      (
+        SemanticReviewSectionKind::Matched,
+        Some(old),
+        Some(new),
+        old_context,
+        new_context,
+        diff,
+      )
+    Deleted(old~, old_context~, diff~) =>
+      (Deleted, Some(old), None, old_context, None, diff)
+    Inserted(new~, new_context~, diff~) =>
+      (Inserted, None, Some(new), None, new_context, diff)
+  }
+  let original_source = match old_range {
+    Some(range) => {
+      guard source_slice(old_lines, range) is Some(source) else { return None }
+      source
+    }
+    None => ""
+  }
+  let modified_source = match new_range {
+    Some(range) => {
+      guard source_slice(new_lines, range) is Some(source) else { return None }
+      source
+    }
+    None => ""
+  }
+  guard section_diff(
+      fragment,
+      original_source,
+      modified_source,
+      old_range is None || new_range is None,
+    )
+    is Some(diff) else {
+    return None
+  }
+  Some({
+    key: "section-\{identity}",
+    identity: Some(identity),
+    kind,
+    old_range: old_range.map(source_range),
+    new_range: new_range.map(source_range),
+    old_context,
+    new_context,
+    fallbacks: fallback_texts(fragment.fallbacks),
+    original_source,
+    modified_source,
+    diff,
+  })
+}
+
+///|
+fn valid_top_level_orders(top : @mbtdiff.TopLevelDiff) -> Bool {
+  let old_seen = Array::make(top.sections.length(), false)
+  let new_seen = Array::make(top.sections.length(), false)
+  let mut old_end = 0
+  let mut new_end = 0
+  for identity in top.old_order {
+    if identity < 0 || identity >= top.sections.length() || old_seen[identity] {
+      return false
+    }
+    let range = match top.sections[identity] {
+      Matched(old~, ..) | Deleted(old~, ..) => old
+      Inserted(..) => return false
+    }
+    if range.start < old_end || range.len < 0 {
+      return false
+    }
+    old_seen[identity] = true
+    old_end = range.start + range.len
+  }
+  for identity in top.new_order {
+    if identity < 0 || identity >= top.sections.length() || new_seen[identity] {
+      return false
+    }
+    let range = match top.sections[identity] {
+      Matched(new~, ..) | Inserted(new~, ..) => new
+      Deleted(..) => return false
+    }
+    if range.start < new_end || range.len < 0 {
+      return false
+    }
+    new_seen[identity] = true
+    new_end = range.start + range.len
+  }
+  for identity, section in top.sections {
+    match section {
+      Matched(..) =>
+        if !old_seen[identity] || !new_seen[identity] {
+          return false
+        }
+      Deleted(..) =>
+        if !old_seen[identity] || new_seen[identity] {
+          return false
+        }
+      Inserted(..) =>
+        if old_seen[identity] || !new_seen[identity] {
+          return false
+        }
+    }
+  }
+  true
+}
+
+///|
+fn top_level_plan(
+  top : @mbtdiff.TopLevelDiff,
+  old_source : String,
+  new_source : String,
+) -> (Array[SemanticReviewSection], Array[SemanticReviewSection])? {
+  if !valid_top_level_orders(top) {
+    return None
+  }
+  let old_lines = normalized_source_lines(old_source)
+  let new_lines = normalized_source_lines(new_source)
+  let main_sections : Array[SemanticReviewSection] = []
+  for identity in top.new_order {
+    let section = top.sections[identity]
+    let fragment = match section {
+      Matched(diff~, ..) | Inserted(diff~, ..) => diff
+      Deleted(..) => return None
+    }
+    if fragment_has_output(fragment) {
+      guard top_level_section(identity, section, old_lines, new_lines)
+        is Some(projected) else {
+        return None
+      }
+      main_sections.push(projected)
+    }
+  }
+  let deleted_sections : Array[SemanticReviewSection] = []
+  for identity in top.old_order {
+    let section = top.sections[identity]
+    if section is Deleted(diff~, ..) && fragment_has_output(diff) {
+      guard top_level_section(identity, section, old_lines, new_lines)
+        is Some(projected) else {
+        return None
+      }
+      deleted_sections.push(projected)
+    }
+  }
+  Some((main_sections, deleted_sections))
+}
+
+///|
+/// Compute section ownership and fragment-local DiffEditor inputs for Token or
+/// Tree mode. Core remains the ordinary full-file DiffEditor path.
+pub fn compute_sectioned_semantic_review_plan(
+  old_source : String,
+  new_source : String,
+  mode : MoonDiffMode,
+  old_name? : String = "old",
+  new_name? : String = "new",
+  ignore_comments? : Bool = true,
+  ignore_tests? : Bool = true,
+) -> SectionedSemanticReviewPlan? {
+  let diff_mode = match mode {
+    Core => return None
+    Token => @mbtdiff.DiffMode::Lexical
+    Tree => Ast
+  }
+  let result = @mbtdiff.diff(
+    old_source,
+    new_source,
+    old_name~,
+    new_name~,
+    options=DiffOptions(
+      context_lines=3,
+      ignore_comments~,
+      ignore_tests~,
+      mode=diff_mode,
+    ),
+  )
+  let status = semantic_status(result.status())
+  // These statuses formally contain no visible semantic change. Do not ask
+  // an empty/ignored document to satisfy top-level projection invariants: in
+  // a comment-only file MoonDiff may retain section metadata whose filtered
+  // ranges intentionally no longer describe a renderable fragment.
+  if status is Identical ||
+    status is NoStructuralChanges ||
+    status is IgnoredOnly {
+    return Some({
+      requested: mode,
+      status,
+      reordered: false,
+      main_sections: [],
+      deleted_sections: [],
+    })
+  }
+  match result.document() {
+    Whole(fragment) => {
+      guard whole_section(fragment, old_source, new_source) is Some(section) else {
+        return None
+      }
+      Some({
+        requested: mode,
+        status,
+        reordered: false,
+        main_sections: [section],
+        deleted_sections: [],
+      })
+    }
+    TopLevel(top) => {
+      guard top_level_plan(top, old_source, new_source)
+        is Some((main_sections, deleted_sections)) else {
+        return None
+      }
+      Some({
+        requested: mode,
+        status,
+        reordered: top.reordered,
+        main_sections,
+        deleted_sections,
+      })
+    }
+  }
+}
+
+///|
+pub extend SemanticReviewStatus with Eq::{equal, not_equal}
+
+///|
+pub extend SemanticReviewStatus with Debug::{to_repr}
+
+///|
+pub extend SemanticReviewSourceRange with Eq::{equal, not_equal}
+
+///|
+pub extend SemanticReviewSourceRange with Debug::{to_repr}
+
+///|
+pub extend SemanticReviewSectionKind with Eq::{equal, not_equal}
+
+///|
+pub extend SemanticReviewSectionKind with Debug::{to_repr}
+
+///|
+pub extend SemanticReviewDiff with Eq::{equal, not_equal}
+
+///|
+pub extend SemanticReviewDiff with Debug::{to_repr}
+
+///|
+pub extend SemanticReviewSection with Eq::{equal, not_equal}
+
+///|
+pub extend SemanticReviewSection with Debug::{to_repr}
+
+///|
+pub extend SectionedSemanticReviewPlan with Eq::{equal, not_equal}
+
+///|
+pub extend SectionedSemanticReviewPlan with Debug::{to_repr}

--- a/editor/viewer/diff_provider/moondiff/semantic_review_plan_wbtest.mbt
+++ b/editor/viewer/diff_provider/moondiff/semantic_review_plan_wbtest.mbt
@@ -1,0 +1,186 @@
+///|
+fn semantic_plan_or_fail(
+  old_source : String,
+  new_source : String,
+  mode : MoonDiffMode,
+  ignore_comments? : Bool = false,
+  ignore_tests? : Bool = false,
+) -> SectionedSemanticReviewPlan raise {
+  guard compute_sectioned_semantic_review_plan(
+      old_source,
+      new_source,
+      mode,
+      ignore_comments~,
+      ignore_tests~,
+    )
+    is Some(plan) else {
+    fail("expected a sectioned semantic review plan")
+  }
+  plan
+}
+
+///|
+test "Core remains the ordinary full-file DiffEditor path" {
+  assert_eq(
+    compute_sectioned_semantic_review_plan("fn old() {}", "fn new() {}", Core),
+    None,
+  )
+}
+
+///|
+test "top-level reorder is represented by order, never global line mappings" {
+  let plan = semantic_plan_or_fail(
+    "fn first() {}\nfn second() {}",
+    "fn second() {}\nfn first() {}",
+    Tree,
+  )
+  assert_eq(plan.requested, Tree)
+  assert_eq(plan.status, Reordered)
+  assert_true(plan.reordered)
+  assert_true(plan.main_sections.is_empty())
+  assert_true(plan.deleted_sections.is_empty())
+}
+
+///|
+test "insertions and deletions retain separate source slices" {
+  let plan = semantic_plan_or_fail(
+    "fn kept() {}\nfn removed() {}",
+    "fn inserted() {}\nfn kept() {}",
+    Token,
+  )
+  guard plan.main_sections is [inserted] else {
+    fail("expected one inserted section")
+  }
+  assert_eq(inserted.kind, Inserted)
+  assert_eq(inserted.original_source, "")
+  assert_eq(inserted.modified_source, "fn inserted() {}")
+  assert_eq(inserted.old_range, None)
+  assert_eq(inserted.new_range, Some({ start_line_number: 1, line_count: 1, }))
+  assert_true(inserted.diff is Core)
+
+  guard plan.deleted_sections is [deleted] else {
+    fail("expected one deleted section")
+  }
+  assert_eq(deleted.kind, Deleted)
+  assert_eq(deleted.original_source, "fn removed() {}")
+  assert_eq(deleted.modified_source, "")
+  assert_eq(deleted.old_range, Some({ start_line_number: 2, line_count: 1, }))
+  assert_eq(deleted.new_range, None)
+  assert_true(deleted.diff is Core)
+}
+
+///|
+test "changed matched declarations carry only fragment-local DiffEditor data" {
+  let plan = semantic_plan_or_fail(
+    "fn before() {}\nfn target() {\n  old()\n}",
+    "fn before() {}\nfn added() {}\nfn target() {\n  new()\n}",
+    Tree,
+  )
+  guard plan.main_sections.length() == 2 else {
+    fail("expected inserted and changed matched sections")
+  }
+  let target = plan.main_sections[1]
+  assert_eq(target.kind, Matched)
+  assert_eq(target.old_range, Some({ start_line_number: 2, line_count: 3, }))
+  assert_eq(target.new_range, Some({ start_line_number: 3, line_count: 3, }))
+  assert_eq(target.original_source, "fn target() {\n  old()\n}")
+  assert_eq(target.modified_source, "fn target() {\n  new()\n}")
+  guard target.diff is Fragment(diff) else {
+    fail("expected a MoonDiff fragment provider")
+  }
+  guard diff.changes is [change] else {
+    fail("expected one local changed range")
+  }
+  assert_eq(change.original, LineRange(2, 3))
+  assert_eq(change.modified, LineRange(2, 3))
+}
+
+///|
+test "whole fallback retains local diff and renderer-neutral metadata" {
+  let plan = semantic_plan_or_fail("fn broken( {", "fn okay() {}", Tree)
+  guard plan.main_sections is [whole] else {
+    fail("expected one whole-file fallback section")
+  }
+  assert_eq(whole.kind, Whole)
+  assert_false(whole.fallbacks.is_empty())
+  assert_true(whole.diff is Fragment(_))
+}
+
+///|
+test "semantic statuses preserve empty structural outcomes" {
+  let structural = semantic_plan_or_fail(
+    "fn f() { 1 }",
+    "fn f() {\n  1\n}",
+    Tree,
+  )
+  assert_eq(structural.status, NoStructuralChanges)
+  assert_true(structural.main_sections.is_empty())
+
+  let identical = semantic_plan_or_fail("fn same() {}", "fn same() {}", Token)
+  assert_eq(identical.status, Identical)
+}
+
+///|
+test "comment-only matched declarations stay visible inside local DiffEditors" {
+  let old_source =
+    #|/// old documentation
+    #|fn value() -> Int { 1 }
+  let new_source =
+    #|/// new documentation
+    #|fn value() -> Int { 1 }
+
+  let token = semantic_plan_or_fail(old_source, new_source, Token)
+  guard token.main_sections is [token_section] else {
+    fail("expected one token section for comment-only changes")
+  }
+  assert_eq(token_section.original_source, old_source)
+  assert_eq(token_section.modified_source, new_source)
+  guard token_section.diff is Fragment(token_diff) else {
+    fail("expected token comment diff inside the section DiffEditor")
+  }
+  assert_false(token_diff.changes.is_empty())
+
+  let tree = semantic_plan_or_fail(old_source, new_source, Tree)
+  assert_eq(tree.status, Changed)
+  guard tree.main_sections is [tree_section] else {
+    fail("expected one tree-aligned section for comment-only changes")
+  }
+  assert_eq(tree_section.original_source, old_source)
+  assert_eq(tree_section.modified_source, new_source)
+  guard tree_section.diff is Fragment(tree_diff) else {
+    fail("expected tree comment diff inside the section DiffEditor")
+  }
+  assert_false(tree_diff.changes.is_empty())
+
+  let ignored = semantic_plan_or_fail(
+    old_source,
+    new_source,
+    Tree,
+    ignore_comments=true,
+    ignore_tests=true,
+  )
+  assert_eq(ignored.status, IgnoredOnly)
+  assert_true(ignored.main_sections.is_empty())
+  assert_true(ignored.deleted_sections.is_empty())
+}
+
+///|
+test "default semantic filters return explicit empty plans for ignored-only changes" {
+  let comment_only = compute_sectioned_semantic_review_plan(
+    "/// old documentation\nfn value() -> Int { 1 }",
+    "/// new documentation\nfn value() -> Int { 1 }",
+    Token,
+  ).unwrap()
+  assert_eq(comment_only.status, IgnoredOnly)
+  assert_true(comment_only.main_sections.is_empty())
+  assert_true(comment_only.deleted_sections.is_empty())
+
+  let test_only = compute_sectioned_semantic_review_plan(
+    "test \"value\" { inspect(1, content=\"1\") }",
+    "test \"value\" { inspect(2, content=\"2\") }",
+    Tree,
+  ).unwrap()
+  assert_eq(test_only.status, IgnoredOnly)
+  assert_true(test_only.main_sections.is_empty())
+  assert_true(test_only.deleted_sections.is_empty())
+}

--- a/editor/viewer/pkg.generated.mbti
+++ b/editor/viewer/pkg.generated.mbti
@@ -34,8 +34,10 @@ type DiffEditor
 pub fn DiffEditor::create(@dom.Element, services? : ViewerServices, options? : DiffEditorOptions, provider? : &@diff.DocumentDiffProvider) -> Self
 pub fn DiffEditor::dispose(Self) -> Unit
 pub fn DiffEditor::focus(Self) -> Unit
+pub fn DiffEditor::get_content_height(Self) -> Double
 pub fn DiffEditor::get_diff(Self) -> @diff.DocumentDiff?
 pub fn DiffEditor::get_layout(Self) -> DiffEditorLayout
+pub fn DiffEditor::get_max_scroll_left(Self) -> Double
 pub fn DiffEditor::get_model(Self) -> DiffEditorModel?
 pub fn DiffEditor::is_diff_up_to_date(Self) -> Bool
 pub fn DiffEditor::layout(Self) -> Unit
@@ -45,6 +47,7 @@ pub fn DiffEditor::reveal_next_change(Self) -> Bool
 pub fn DiffEditor::reveal_previous_change(Self) -> Bool
 pub fn DiffEditor::set_diff_provider(Self, &@diff.DocumentDiffProvider) -> Unit
 pub fn DiffEditor::set_model(Self, DiffEditorModel?) -> DiffEditorModel?
+pub fn DiffEditor::set_scroll_left(Self, Double) -> Unit
 pub fn DiffEditor::update_options(Self, DiffEditorOptions) -> Unit
 
 pub(all) enum DiffEditorLayout {
@@ -62,7 +65,7 @@ pub(all) struct DiffEditorModel {
 pub fn DiffEditorModel::DiffEditorModel(@model.TextModel, @model.TextModel) -> Self
 
 type DiffEditorOptions
-pub fn DiffEditorOptions::DiffEditorOptions(editor_options? : ViewerOptions, layout? : DiffEditorLayout, automatic_inline? : Bool, automatic_inline_width? : Double, sash_enabled? : Bool, split_ratio? : Double, diff_word_wrap? : DiffWordWrap, overview_ruler? : Bool, render_indicators? : Bool, ignore_trim_whitespace? : Bool) -> Self
+pub fn DiffEditorOptions::DiffEditorOptions(editor_options? : ViewerOptions, layout? : DiffEditorLayout, automatic_inline? : Bool, automatic_inline_width? : Double, sash_enabled? : Bool, split_ratio? : Double, diff_word_wrap? : DiffWordWrap, overview_ruler? : Bool, render_indicators? : Bool, render_markdown_comments? : Bool, handle_mouse_wheel? : Bool, ignore_trim_whitespace? : Bool) -> Self
 pub fn DiffEditorOptions::default() -> Self
 pub fn DiffEditorOptions::layout(Self) -> DiffEditorLayout
 pub fn DiffEditorOptions::with_editor_options(Self, ViewerOptions) -> Self

--- a/editor/viewer/pkg.generated.mbti
+++ b/editor/viewer/pkg.generated.mbti
@@ -43,8 +43,11 @@ pub fn DiffEditor::is_diff_up_to_date(Self) -> Bool
 pub fn DiffEditor::layout(Self) -> Unit
 pub fn DiffEditor::on_did_update_diff(Self, () -> Unit) -> @common.Disposable
 pub fn DiffEditor::reveal_first_diff(Self) -> Unit
+pub fn DiffEditor::reveal_last_diff(Self) -> Unit
 pub fn DiffEditor::reveal_next_change(Self) -> Bool
+pub fn DiffEditor::reveal_next_change_without_wrap(Self) -> Bool
 pub fn DiffEditor::reveal_previous_change(Self) -> Bool
+pub fn DiffEditor::reveal_previous_change_without_wrap(Self) -> Bool
 pub fn DiffEditor::set_diff_provider(Self, &@diff.DocumentDiffProvider) -> Unit
 pub fn DiffEditor::set_model(Self, DiffEditorModel?) -> DiffEditorModel?
 pub fn DiffEditor::set_scroll_left(Self, Double) -> Unit

--- a/editor/viewer/pkg.generated.mbti
+++ b/editor/viewer/pkg.generated.mbti
@@ -41,6 +41,7 @@ pub fn DiffEditor::get_max_scroll_left(Self) -> Double
 pub fn DiffEditor::get_model(Self) -> DiffEditorModel?
 pub fn DiffEditor::is_diff_up_to_date(Self) -> Bool
 pub fn DiffEditor::layout(Self) -> Unit
+pub fn DiffEditor::on_did_change_content_height(Self, (Double) -> Unit) -> @common.Disposable
 pub fn DiffEditor::on_did_update_diff(Self, () -> Unit) -> @common.Disposable
 pub fn DiffEditor::reveal_first_diff(Self) -> Unit
 pub fn DiffEditor::reveal_last_diff(Self) -> Unit


### PR DESCRIPTION
## Summary

- preserve MoonDiff `Whole`/`TopLevel` section identity, order, reorder state, and missing-side ownership instead of flattening Token/Tree into one synthetic document
- render each top-level section with the existing DiffEditor inside a VS Code-shaped MultiDiff surface; Core remains the ordinary full-file DiffEditor
- keep `Ignore comments` and `Ignore tests` enabled by default for Token/Tree, including an explicit empty result when filters remove every visible change
- restore Modified-side Hover, Definition, References, and diagnostics by projecting section-local coordinates onto the live working-tree model
- restore review comments on both Original and Modified semantic panes, projecting local selections back to the correct physical file lines while leaving historical or absent sides disabled
- restore aggregate Previous/Next and F7/Shift+F7 navigation across semantic sections, including automatic expansion of collapsed destinations and correct backward entry at the final change
- publish the DiffEditor's final paired content height after Markdown ViewZone/alignment reconciliation and resize the owning semantic section in that same update batch, so rich-comment expansion no longer waits for an unrelated layout or diff refresh

## Implementation

The semantic-review planner consumes MoonDiff's sectioned result directly. Each renderable section owns local source slices and a fragment-local DiffEditor input; no cross-section padding or fabricated global mappings remain in the provider.

The desktop view owns the MultiDiff chrome, stable mount points, shared scroll plane, sticky/collapsible headers, shared horizontal scrolling, and aggregate navigation. Source rows, decorations, split/unified layout, intraline highlighting, comments, and editor language features remain owned by the existing editor contributions.

Original and historical models never impersonate the live checkout for IDE requests. Working-tree Modified fragments use an explicit section-start projection. Review comments use a separate side-aware projection so Original feedback keeps its original-revision identity and Modified feedback keeps its exact working-tree range.

DiffEditor now exposes a disposable content-height event. It records the new paired height before notifying listeners, after both comment ViewZones and alignment spacers have been committed. Semantic review subscribes per section, updates only the affected host height, and disposes the subscription with the editor; there is no delay or polling fallback.

## Validation

- targeted DiffEditor JS tests: 58/58
- desktop fileeditor JS tests: 160/160
- `just editor-test`: wasm 1078/1078, JS 1868/1868, native 1213/1213
- `just editor-test-browser`: 110/110, including a real-browser Markdown fold test that asserts one final paired-height publication
- `just test`: native 3383/3383, JS 3329/3329, cram 28/28
- `just check`: native/JS deny-warn checks and formatter check
- exact Editor stable CI check: `moon check --target all --warn-list +73 --deny-warn`
- `just build`
- `moon info && moon fmt`
- `git diff --check`

## Packaged QA

Validated the runtime-equivalent pre-final-refresh head `3d31cd83` in the packaged SeekMoon app built with `moon -C desktop run --target native package/macos -- --release --target app --no-open`, then launched the owned Proton/CEF process and attached to `https://proton.localhost/index.html` over CDP port 9347. The final head differs from that packaged build only by the later rebase and removal of one redundant package qualifier in the browser test scenario; runtime/editor code is unchanged.

- exercised a real three-section MoonBit review in Expand view across Core, Token, and Tree, with Line -> Token -> Tree -> Line -> Token round trips
- expanded and collapsed the first Modified rich Markdown comment in both Token and Tree
- the section editor host grew from 174px to its final 367px, the Original pane received the matching 222px alignment spacer, the following section moved from y=332 to y=525, and collapse returned the host to 174px
- Comments/Tests and Previous/Next controls stayed enabled on Token/Tree; Core and semantic hosts switched cleanly
- no page errors, console warnings/errors, native-log error matches, unexpected clipping, document overflow, stale loading state, or visible disconnection
- the temporary QA fixture, owned app process, and debug-port listener were cleaned up

## Rebase note

Rebased the eight PR commits onto `origin/main` at `8ea45b39`. Crossing main's review-toolbar rewrite required conflict resolution that retained the new two-row File/Line/Token/Tree UI, independent Comments/Tests controls, Split/Unified controls, and File-mode disabled behavior while integrating the semantic surface. The final `4347ca9d -> 8ea45b39` refresh was conflict-free and initially patch-equivalent for all eight commits; the only subsequent delta was removing a redundant test-only `@base_common.` qualifier required by Editor stable CI warning 73. The updated branch head is `f3516fc7`.
