### PR TITLE
fix(desktop): fence stale Codex Git replies

### DIFF
--- a/desktop/frontend/codex/bridge.mbt
+++ b/desktop/frontend/codex/bridge.mbt
@@ -376,25 +376,33 @@ fn State::refresh_git(
   self : State,
   dispatch : @cmd.Emit[Msg],
   channel : @interop.ChannelId,
-) -> @cmd.Cmd {
+) -> (@cmd.Cmd, State) {
   guard self.active_thread() is Some(active) && active.cwd is Some(cwd) else {
-    return @cmd.none
+    return (@cmd.none, self)
   }
   let thread_id = active.id
-  @cmd.custom_cmd(scheduler => {
-    @js.async_run(() => {
-      let reply : @protocol.GitPullRequestReply = @interop.bridge_request(
-        channel,
-        @commands.git_pull_request,
-        { session: thread_id, cwd: Some(cwd), branch_hint: active.branch },
-      ) catch {
-        // Git/gh decoration never blocks the conversation. Keep app-server's
-        // captured branch label when the live lookup is unavailable.
-        _ => return
-      }
-      scheduler.add(dispatch(GitLoaded(thread_id~, reply~)))
-    })
-  })
+  let generation = self.git_request_generation + 1
+  (
+    @cmd.custom_cmd(scheduler => {
+      @js.async_run(() => {
+        let reply : @protocol.GitPullRequestReply = @interop.bridge_request(
+          channel,
+          @commands.git_pull_request,
+          { session: thread_id, cwd: Some(cwd), branch_hint: active.branch },
+        ) catch {
+          // Git/gh decoration never blocks the conversation. Keep app-server's
+          // captured branch label when the live lookup is unavailable.
+          _ => return
+        }
+        scheduler.add(
+          dispatch(
+            GitLoaded(thread_id~, generation~, requested_cwd=cwd, reply~),
+          ),
+        )
+      })
+    }),
+    { ..self, git_request_generation: generation },
+  )
 }
 
 ///|

--- a/desktop/frontend/codex/model.mbt
+++ b/desktop/frontend/codex/model.mbt
@@ -327,7 +327,12 @@ enum Msg {
   ChoosePermission(@protocol.CodexPermissionMode)
   ConfirmFullAccess
   CancelFullAccess
-  GitLoaded(thread_id~ : String, reply~ : @protocol.GitPullRequestReply)
+  GitLoaded(
+    thread_id~ : String,
+    generation~ : Int,
+    requested_cwd~ : String,
+    reply~ : @protocol.GitPullRequestReply
+  )
   ToggleGitDetails
   CloseGitDetails
   ToggleWorktreeMode
@@ -513,6 +518,10 @@ struct State {
   // the same id, so an older request can never replace a newer selection.
   requested_thread : String?
   git_status : CodexGitStatus?
+  // Every live Git lookup carries the number minted here. The counter belongs
+  // to the Codex page rather than a thread or checkout because either can be
+  // replaced while an older request is still in flight.
+  git_request_generation : Int
   git_details_open : Bool
   draft : String
   mentions : Array[@composer.Mention]
@@ -559,6 +568,7 @@ pub fn State::State(loading? : Bool = false) -> State {
     selection: CodexNoTask,
     requested_thread: None,
     git_status: None,
+    git_request_generation: 0,
     git_details_open: false,
     draft: "",
     mentions: [],
@@ -1667,9 +1677,14 @@ fn State::with_created_worktree(
 fn State::with_git_reply(
   self : State,
   thread_id : String,
+  generation : Int,
+  requested_cwd : String,
   reply : @protocol.GitPullRequestReply,
 ) -> State {
-  guard self.active_thread() is Some(active) && active.id == thread_id else {
+  guard self.active_thread() is Some(active) &&
+    active.id == thread_id &&
+    generation == self.git_request_generation &&
+    active.cwd == Some(requested_cwd) else {
     return self
   }
   {
@@ -2907,13 +2922,13 @@ test "Codex Git status starts from app-server and accepts current checkout" {
   })
   assert_eq(state.new_thread_cwd(), "/workspace/project")
   assert_eq(state.git_status.unwrap().branch, Some("captured-branch"))
-  let refreshed = state.with_git_reply("thread-1", {
+  let refreshed = state.with_git_reply("thread-1", 0, "/worktrees/a/project", {
     pull_request: None,
     compare_url: None,
     branch: Some("current-branch"),
   })
   assert_eq(refreshed.git_status.unwrap().branch, Some("current-branch"))
-  let empty = state.with_git_reply("thread-1", {
+  let empty = state.with_git_reply("thread-1", 0, "/worktrees/a/project", {
     pull_request: None,
     compare_url: None,
     branch: None,

--- a/desktop/frontend/codex/update.mbt
+++ b/desktop/frontend/codex/update.mbt
@@ -75,8 +75,11 @@ pub fn update(
           permission_picker: state.permission_picker.cancel_full_access(),
         },
       )
-    GitLoaded(thread_id~, reply~) =>
-      (@cmd.none, state.with_git_reply(thread_id, reply))
+    GitLoaded(thread_id~, generation~, requested_cwd~, reply~) =>
+      (
+        @cmd.none,
+        state.with_git_reply(thread_id, generation, requested_cwd, reply),
+      )
     ToggleGitDetails =>
       (
         @cmd.none,
@@ -265,8 +268,10 @@ pub fn update(
           // place. Only a verified selection may retarget Files/Terminal.
           if next.requested_thread is None {
             next = next.loading_context(false)
+            let (git, refreshed) = next.refresh_git(dispatch, channel)
+            next = refreshed
             cmd = @cmd.batch([
-              next.refresh_git(dispatch, channel),
+              git,
               next.load_skills(dispatch, channel, force_reload=false),
             ])
           }
@@ -278,9 +283,11 @@ pub fn update(
           // notification observes the stored selection. The preserved draft
           // and placement now flow through the ordinary Local/Worktree send.
           next = next.loading_context(false)
+          let (git, refreshed) = next.refresh_git(dispatch, channel)
+          next = refreshed
           cmd = @cmd.batch([
             next.send(dispatch, channel),
-            next.refresh_git(dispatch, channel),
+            git,
             next.load_skills(dispatch, channel, force_reload=false),
           ])
           if next.active_thread() is Some(active) {
@@ -290,15 +297,19 @@ pub fn update(
         CodexTurnReply(_) => next = next.with_turn_reply(value)
         CodexWorktreeTurnReply(_, worktree) => {
           next = next.with_created_worktree(worktree).with_turn_reply(value)
+          let (git, refreshed) = next.refresh_git(dispatch, channel)
+          next = refreshed
           cmd = @cmd.batch([
-            next.refresh_git(dispatch, channel),
+            git,
             next.load_skills(dispatch, channel, force_reload=false),
           ])
         }
         CodexWorktreeRepairReply(_, worktree) => {
           next = next.with_created_worktree(worktree)
+          let (git, refreshed) = next.refresh_git(dispatch, channel)
+          next = refreshed
           cmd = @cmd.batch([
-            next.refresh_git(dispatch, channel),
+            git,
             next.load_skills(dispatch, channel, force_reload=false),
           ])
         }
@@ -479,7 +490,9 @@ pub fn update(
       } else if method_ == "turn/completed" {
         // A turn may check out another branch or create a PR. Refresh the same
         // compact status chip OpenSeek updates at its run boundary.
-        next.refresh_git(dispatch, channel)
+        let (git, refreshed) = next.refresh_git(dispatch, channel)
+        next = refreshed
+        git
       } else {
         @cmd.none
       }
@@ -1102,6 +1115,134 @@ test "Codex missing worktree waits for rebuild or archive confirmation" {
     .map(uri => uri.path),
     Some("/work/project/.worktrees/wt-1"),
   )
+}
+
+///|
+test "Codex Git replies stay with the latest checkout request" {
+  let dispatch : @cmd.Emit[Msg] = @cmd.Emit(_ => @cmd.none)
+  let main_cwd = "/workspace/openseek"
+  let worktree_cwd = "/workspace/.codex/worktrees/wt-3/openseek"
+  let opened = State().with_thread_reply({
+    "thread": {
+      "id": "thread-1",
+      "cwd": main_cwd,
+      "projectRoot": main_cwd,
+      "gitInfo": { "branch": "docs/desktop-ux-guidelines" },
+      "turns": [],
+    },
+  })
+  // Opening the thread starts the lookup against the main checkout.
+  let (_, main_pending) = opened.refresh_git(
+    dispatch,
+    @interop.ChannelId::Local,
+  )
+  assert_eq(main_pending.git_request_generation, 1)
+
+  // Fresh-worktree creation retargets the same thread and starts a newer
+  // lookup. Neither request is executed in this pure update test; their
+  // messages below deliberately arrive in the opposite order.
+  let worktree : CodexWorktree = {
+    name: "wt-3",
+    path: worktree_cwd,
+    present: true,
+  }
+  let retargeted = main_pending.with_created_worktree(worktree)
+  let (_, worktree_pending) = retargeted.refresh_git(
+    dispatch,
+    @interop.ChannelId::Local,
+  )
+  assert_eq(worktree_pending.git_request_generation, 2)
+
+  let worktree_reply = GitLoaded(
+    thread_id="thread-1",
+    generation=2,
+    requested_cwd=worktree_cwd,
+    reply={
+      pull_request: Some({
+        number: 759,
+        title: "Worktree pull request",
+        state: "open",
+        draft: false,
+        url: "https://github.com/moonbitlang/openseek/pull/759",
+        base: "main",
+        additions: 1,
+        deletions: 0,
+        changed_files: 1,
+        checks: None,
+      }),
+      compare_url: None,
+      branch: Some("openseek/wt-3"),
+    },
+  )
+  let (_, applied) = update(
+    dispatch,
+    worktree_reply,
+    worktree_pending,
+    @interop.ChannelId::Local,
+    _ => @cmd.none,
+  )
+  let (_, applied_again) = update(
+    dispatch,
+    worktree_reply,
+    worktree_pending,
+    @interop.ChannelId::Local,
+    _ => @cmd.none,
+  )
+  // The handler is pure: the same state and message produce the same result.
+  assert_true(applied_again == applied)
+  assert_eq(applied.git_status.unwrap().pull_request.unwrap().number, 759)
+
+  let main_reply = GitLoaded(
+    thread_id="thread-1",
+    generation=1,
+    requested_cwd=main_cwd,
+    reply={
+      pull_request: Some({
+        number: 1079,
+        title: "Main checkout pull request",
+        state: "open",
+        draft: false,
+        url: "https://github.com/moonbitlang/openseek/pull/1079",
+        base: "main",
+        additions: 2,
+        deletions: 0,
+        changed_files: 1,
+        checks: None,
+      }),
+      compare_url: None,
+      branch: Some("docs/desktop-ux-guidelines"),
+    },
+  )
+  let (_, stale) = update(
+    dispatch,
+    main_reply,
+    applied,
+    @interop.ChannelId::Local,
+    _ => @cmd.none,
+  )
+  // The main-checkout reply arrives last but cannot replace the worktree's
+  // newer answer.
+  assert_true(stale == applied)
+  assert_eq(stale.git_status.unwrap().pull_request.unwrap().number, 759)
+
+  let wrong_cwd_reply = GitLoaded(
+    thread_id="thread-1",
+    generation=2,
+    requested_cwd=main_cwd,
+    reply={
+      pull_request: None,
+      compare_url: None,
+      branch: Some("wrong-checkout"),
+    },
+  )
+  let (_, wrong_cwd) = update(
+    dispatch,
+    wrong_cwd_reply,
+    worktree_pending,
+    @interop.ChannelId::Local,
+    _ => @cmd.none,
+  )
+  assert_true(wrong_cwd == worktree_pending)
 }
 
 ///|


### PR DESCRIPTION
## Summary

- stamp each Codex Git/PR lookup with a monotonic generation and its requested cwd
- apply replies only when the thread, latest generation, and active checkout all match
- cover reversed main-checkout/worktree reply order and cwd mismatches with a regression test

## Testing

- moon -C desktop test frontend/codex --target js --deny-warn (52 passed)
- just check
- just test (native 3323 passed; JS 3246 passed; cram 28 passed)
- just build
- git diff --check origin/main...HEAD

The frontend/codex generated interface is unchanged.