### PR TITLE
feat(prompt): move mbtx onto moonbitlang/async/shell

### DIFF
--- a/README.mbt.md
+++ b/README.mbt.md
@@ -132,7 +132,7 @@ engine; `mcp` to validate MCP configuration). `openseek run` parses arguments
 and runs the agent package. The agent sends DeepSeek native function tools and
 supports eleven local tools: `mbtx` — both the scripting surface and the
 command runner, spawning processes through the shell-free
-[`bobzhang/myshell`](https://mooncakes.io/docs/bobzhang/myshell) EDSL, with
+`moonbitlang/async/shell` API, with
 `job_output` and `job_stop` watching anything it detaches as a background job —
 plus `read`, `edit`, `multi_edit`, `write`, `remove`, `plan`, `goal`, and
 `finish`. There is no shell tool, so no command ever goes through a shell.

--- a/agent/README.mbt.md
+++ b/agent/README.mbt.md
@@ -106,7 +106,7 @@ calls `@agent.run`, but that decision lives outside the `agent` package.
 - `mbtx`: compile and run a self-contained MoonBit program — both the
   scripting surface (transform files, parse JSON, compute, probe the language)
   and the command runner, since processes are spawned from the program through
-  the shell-free `bobzhang/myshell` EDSL. Supports `run_in_background`;
+  the shell-free `moonbitlang/async/shell` API. Supports `run_in_background`;
 - `job_output` / `job_stop`: read or stop a background job;
 - `read`: read a text file;
 - `edit`: replace exact text in a file;
@@ -119,7 +119,7 @@ calls `@agent.run`, but that decision lives outside the `agent` package.
 - `finish`: end the task with a final answer.
 
 There is no shell tool: every command the agent runs is an argument vector
-handed to `@myshell.Cmd`, so no command text is ever parsed by a shell.
+handed to `@shell.Cmd`, so no command text is ever parsed by a shell.
 
 File-oriented tools capture `runtime.workspace_root()` when the registry is
 built. The registry also receives the runtime and task scope for stateful

--- a/agent/tool_definition.mbt
+++ b/agent/tool_definition.mbt
@@ -25,7 +25,7 @@ fn background_notice_text(snapshot : @bgjobs.BgJobSnapshot) -> String {
 /// `multi_edit`, `write`, `remove`, `plan`, `goal`, `mbtx`, `job_output`,
 /// `job_stop`, and `finish`. Commands are `mbtx`'s job — it compiles and
 /// runs a MoonBit program that spawns processes through the shell-free
-/// `bobzhang/myshell` EDSL, so there is no shell tool and no shell parsing
+/// `moonbitlang/async/shell` API, so there is no shell tool and no shell parsing
 /// anywhere in the registry. A snippet that would outlast the foreground bound
 /// is detached as a background job, which `job_output` and `job_stop` then
 /// watch.
@@ -160,9 +160,6 @@ async test "the registry has no shell tool family" {
     assert_false(names.contains("shell_output"))
     assert_false(names.contains("shell_stop"))
     guard tools.find("mbtx") is Some(mbtx) else { fail("mbtx tool missing") }
-    // The command surface teaches the process EDSL rather than deferring to a
-    // shell tool that is no longer there.
-    assert_true(mbtx.description.contains("bobzhang/myshell"))
     // A job runtime is wired here, so the background argument must be OFFERED:
     // the schema is what decides whether the model can make the call at all.
     let JsonSchema(schema) = mbtx.schema

--- a/agent_explore/README.mbt.md
+++ b/agent_explore/README.mbt.md
@@ -14,7 +14,7 @@ Contract highlights:
 
 - Child toolset: `read` + `mbtx` + `submit_answer` — no edit tools, no
   nested subagent tools. Commands run from a `mbtx` snippet through the
-  shell-free `bobzhang/myshell` EDSL, and the source-write sandbox denies
+  shell-free `moonbitlang/async/shell` API, and the source-write sandbox denies
   writes to the workspace's own sources. A per-child scratch lab (temp dir) is
   the one writable place: the scout may scaffold throwaway projects and run any
   moon command there to verify claims empirically.

--- a/agent_explore/explore_system_prompt.mbt.md
+++ b/agent_explore/explore_system_prompt.mbt.md
@@ -50,7 +50,69 @@ Rules:
 ## Running Commands
 
 There is no shell tool. Every command — `moon`, `git`, anything else — is
-spawned from a `mbtx` snippet; that tool's description carries the shape
-of a snippet and the list of programs one may start. A snippet is bound by the
-same rule as the rest of your work: the scratch lab is the one place it may
-write.
+spawned from a `mbtx` snippet through the shell-free
+`moonbitlang/async/shell` API; the tool's description lists the programs a
+snippet may start and its isolation rules. The `source` argument is a whole
+`.mbtx` program:
+
+- Import every package it uses separately: `"moonbitlang/async"` alone brings
+  in neither `fs` nor `shell`.
+- Keep `async fn main` for async IO.
+- Helpers that run a command or do IO are `async fn` too, without `noraise`;
+  a plain `fn` cannot call them.
+- There is no `await`: async calls are written normally.
+- There is no `print`.
+
+<!-- Keep this block in sync with the Running Commands section of
+prompt/default_prompt.mbt.md; the comment is stripped from the generated
+prompt. -->
+
+```mbt nocheck
+///|
+import {
+  "moonbitlang/async",
+  "moonbitlang/async/shell",
+}
+
+///|
+async fn main {
+  let out = @shell.Cmd("rg", [
+    "-n", "protect_from_cancel\\(", "-g", "*.mbt", "src",
+  ]).output()
+  println(out.stdout())
+  println(out.stderr())
+  println("exit=\{out.exit_code()}")
+}
+```
+
+`Output` is opaque: `out.stdout()`, `out.stderr()`, and `out.exit_code()` are
+calls, never fields. `.output()` reports the program's exit code instead of
+raising on it (`rg` exits 1 when nothing matched); `.status()` returns just
+the exit code. A regex needle is one ordinary string element: double the
+backslashes MoonBit needs (`"\\("`) or pass `-F` for a literal match.
+`@shell.Cmd(program, arguments)` passes its argument vector literally — `|`,
+`>`, `&&`, `$()`, and `*` receive no shell interpretation — so run dependent
+commands as ordinary MoonBit statements and branch on their exit codes. Bulky
+output goes to a file under `@fs.tmpdir(prefix="run-")` through
+`stdout=ToFile(...)` (the label is required) and is read back in part.
+
+Shell utilities such as `ls`, `cat`, and `sh` are refused; each is a line of
+MoonBit here, which also works on Windows, where the binaries do not exist:
+
+| Command     | Alternatives     |
+|-------------|------------------|
+| ls          | @fs.readdir(dir) |
+| find        | @shell.glob(pattern) |
+| cat         | @fs.read_file(p).text() |
+| head/tail   | slice the split text; wc -l → count it |
+| grep        | rg, or .split("\n").filter(...) on captured output |
+| sort/uniq   | .sort(), a Set, or a Map |
+| pwd         | @env.current_dir(); printenv → @env.get_env_var(name) |
+| mkdir -p    | @fs.mkdir(d, recursive=true) |
+| test -f     | @fs.exists(p); test -d → @fs.kind(p) is Directory |
+| echo/printf | println |
+| rm/mv/cp    | the `remove` and `write` tools; a snippet cannot write the workspace, and `remove` refuses files it did not create — a refusal there is an answer, not an obstacle to route past |
+| sh -c, xargs, make | write the logic as MoonBit statements |
+
+A snippet is bound by the same rule as the rest of your work: the scratch lab
+is the one place it may write.

--- a/agent_explore/explore_system_prompt.mbt.md
+++ b/agent_explore/explore_system_prompt.mbt.md
@@ -94,7 +94,8 @@ backslashes MoonBit needs (`"\\("`) or pass `-F` for a literal match.
 `>`, `&&`, `$()`, and `*` receive no shell interpretation — so run dependent
 commands as ordinary MoonBit statements and branch on their exit codes. Bulky
 output goes to a file under `@fs.tmpdir(prefix="run-")` through
-`stdout=ToFile(...)` (the label is required) and is read back in part.
+`stdout=ToFile(...)` (the label is required; that directory is the one place a
+snippet may write — `/tmp` itself is refused) and is read back in part.
 
 Shell utilities such as `ls`, `cat`, and `sh` are refused; each is a line of
 MoonBit here, which also works on Windows, where the binaries do not exist:

--- a/agent_explore/generated_explore_system_prompt.mbt
+++ b/agent_explore/generated_explore_system_prompt.mbt
@@ -55,10 +55,70 @@ fn explore_system_prompt() -> String {
     #|## Running Commands
     #|
     #|There is no shell tool. Every command — `moon`, `git`, anything else — is
-    #|spawned from a `mbtx` snippet; that tool's description carries the shape
-    #|of a snippet and the list of programs one may start. A snippet is bound by the
-    #|same rule as the rest of your work: the scratch lab is the one place it may
-    #|write.
+    #|spawned from a `mbtx` snippet through the shell-free
+    #|`moonbitlang/async/shell` API; the tool's description lists the programs a
+    #|snippet may start and its isolation rules. The `source` argument is a whole
+    #|`.mbtx` program:
+    #|
+    #|- Import every package it uses separately: `"moonbitlang/async"` alone brings
+    #|  in neither `fs` nor `shell`.
+    #|- Keep `async fn main` for async IO.
+    #|- Helpers that run a command or do IO are `async fn` too, without `noraise`;
+    #|  a plain `fn` cannot call them.
+    #|- There is no `await`: async calls are written normally.
+    #|- There is no `print`.
+    #|
+    #|
+    #|
+    #|```mbt nocheck
+    #|///|
+    #|import {
+    #|  "moonbitlang/async",
+    #|  "moonbitlang/async/shell",
+    #|}
+    #|
+    #|///|
+    #|async fn main {
+    #|  let out = @shell.Cmd("rg", [
+    #|    "-n", "protect_from_cancel\\(", "-g", "*.mbt", "src",
+    #|  ]).output()
+    #|  println(out.stdout())
+    #|  println(out.stderr())
+    #|  println("exit=\{out.exit_code()}")
+    #|}
+    #|```
+    #|
+    #|`Output` is opaque: `out.stdout()`, `out.stderr()`, and `out.exit_code()` are
+    #|calls, never fields. `.output()` reports the program's exit code instead of
+    #|raising on it (`rg` exits 1 when nothing matched); `.status()` returns just
+    #|the exit code. A regex needle is one ordinary string element: double the
+    #|backslashes MoonBit needs (`"\\("`) or pass `-F` for a literal match.
+    #|`@shell.Cmd(program, arguments)` passes its argument vector literally — `|`,
+    #|`>`, `&&`, `$()`, and `*` receive no shell interpretation — so run dependent
+    #|commands as ordinary MoonBit statements and branch on their exit codes. Bulky
+    #|output goes to a file under `@fs.tmpdir(prefix="run-")` through
+    #|`stdout=ToFile(...)` (the label is required) and is read back in part.
+    #|
+    #|Shell utilities such as `ls`, `cat`, and `sh` are refused; each is a line of
+    #|MoonBit here, which also works on Windows, where the binaries do not exist:
+    #|
+    #|| Command     | Alternatives     |
+    #||-------------|------------------|
+    #|| ls          | @fs.readdir(dir) |
+    #|| find        | @shell.glob(pattern) |
+    #|| cat         | @fs.read_file(p).text() |
+    #|| head/tail   | slice the split text; wc -l → count it |
+    #|| grep        | rg, or .split("\n").filter(...) on captured output |
+    #|| sort/uniq   | .sort(), a Set, or a Map |
+    #|| pwd         | @env.current_dir(); printenv → @env.get_env_var(name) |
+    #|| mkdir -p    | @fs.mkdir(d, recursive=true) |
+    #|| test -f     | @fs.exists(p); test -d → @fs.kind(p) is Directory |
+    #|| echo/printf | println |
+    #|| rm/mv/cp    | the `remove` and `write` tools; a snippet cannot write the workspace, and `remove` refuses files it did not create — a refusal there is an answer, not an obstacle to route past |
+    #|| sh -c, xargs, make | write the logic as MoonBit statements |
+    #|
+    #|A snippet is bound by the same rule as the rest of your work: the scratch lab
+    #|is the one place it may write.
     #|
   )
 }

--- a/agent_explore/generated_explore_system_prompt.mbt
+++ b/agent_explore/generated_explore_system_prompt.mbt
@@ -97,7 +97,8 @@ fn explore_system_prompt() -> String {
     #|`>`, `&&`, `$()`, and `*` receive no shell interpretation — so run dependent
     #|commands as ordinary MoonBit statements and branch on their exit codes. Bulky
     #|output goes to a file under `@fs.tmpdir(prefix="run-")` through
-    #|`stdout=ToFile(...)` (the label is required) and is read back in part.
+    #|`stdout=ToFile(...)` (the label is required; that directory is the one place a
+    #|snippet may write — `/tmp` itself is refused) and is read back in part.
     #|
     #|Shell utilities such as `ls`, `cat`, and `sh` are refused; each is a line of
     #|MoonBit here, which also works on Windows, where the binaries do not exist:

--- a/agent_review/audit_system_prompt.mbt.md
+++ b/agent_review/audit_system_prompt.mbt.md
@@ -80,7 +80,8 @@ backslashes MoonBit needs (`"\\("`) or pass `-F` for a literal match.
 `>`, `&&`, `$()`, and `*` receive no shell interpretation — so run dependent
 commands as ordinary MoonBit statements and branch on their exit codes. Bulky
 output goes to a file under `@fs.tmpdir(prefix="run-")` through
-`stdout=ToFile(...)` (the label is required) and is read back in part.
+`stdout=ToFile(...)` (the label is required; that directory is the one place a
+snippet may write — `/tmp` itself is refused) and is read back in part.
 
 Shell utilities such as `ls`, `cat`, and `sh` are refused; each is a line of
 MoonBit here, which also works on Windows, where the binaries do not exist:

--- a/agent_review/audit_system_prompt.mbt.md
+++ b/agent_review/audit_system_prompt.mbt.md
@@ -36,5 +36,67 @@ Principles:
 ## Running Commands
 
 There is no shell tool. Every command — `moon`, `git`, anything else — is
-spawned from a `mbtx` snippet; that tool's description carries the shape
-of a snippet and the list of programs one may start.
+spawned from a `mbtx` snippet through the shell-free
+`moonbitlang/async/shell` API; the tool's description lists the programs a
+snippet may start and its isolation rules. The `source` argument is a whole
+`.mbtx` program:
+
+- Import every package it uses separately: `"moonbitlang/async"` alone brings
+  in neither `fs` nor `shell`.
+- Keep `async fn main` for async IO.
+- Helpers that run a command or do IO are `async fn` too, without `noraise`;
+  a plain `fn` cannot call them.
+- There is no `await`: async calls are written normally.
+- There is no `print`.
+
+<!-- Keep this block in sync with the Running Commands section of
+prompt/default_prompt.mbt.md; the comment is stripped from the generated
+prompt. -->
+
+```mbt nocheck
+///|
+import {
+  "moonbitlang/async",
+  "moonbitlang/async/shell",
+}
+
+///|
+async fn main {
+  let out = @shell.Cmd("rg", [
+    "-n", "protect_from_cancel\\(", "-g", "*.mbt", "src",
+  ]).output()
+  println(out.stdout())
+  println(out.stderr())
+  println("exit=\{out.exit_code()}")
+}
+```
+
+`Output` is opaque: `out.stdout()`, `out.stderr()`, and `out.exit_code()` are
+calls, never fields. `.output()` reports the program's exit code instead of
+raising on it (`rg` exits 1 when nothing matched); `.status()` returns just
+the exit code. A regex needle is one ordinary string element: double the
+backslashes MoonBit needs (`"\\("`) or pass `-F` for a literal match.
+`@shell.Cmd(program, arguments)` passes its argument vector literally — `|`,
+`>`, `&&`, `$()`, and `*` receive no shell interpretation — so run dependent
+commands as ordinary MoonBit statements and branch on their exit codes. Bulky
+output goes to a file under `@fs.tmpdir(prefix="run-")` through
+`stdout=ToFile(...)` (the label is required) and is read back in part.
+
+Shell utilities such as `ls`, `cat`, and `sh` are refused; each is a line of
+MoonBit here, which also works on Windows, where the binaries do not exist:
+
+| Command     | Alternatives     |
+|-------------|------------------|
+| ls          | @fs.readdir(dir) |
+| find        | @shell.glob(pattern) |
+| cat         | @fs.read_file(p).text() |
+| head/tail   | slice the split text; wc -l → count it |
+| grep        | rg, or .split("\n").filter(...) on captured output |
+| sort/uniq   | .sort(), a Set, or a Map |
+| pwd         | @env.current_dir(); printenv → @env.get_env_var(name) |
+| mkdir -p    | @fs.mkdir(d, recursive=true) |
+| test -f     | @fs.exists(p); test -d → @fs.kind(p) is Directory |
+| echo/printf | println |
+| rm/mv/cp    | the `remove` and `write` tools; a snippet cannot write the workspace, and `remove` refuses files it did not create — a refusal there is an answer, not an obstacle to route past |
+| sh -c, xargs, make | write the logic as MoonBit statements |
+

--- a/agent_review/generated_audit_system_prompt.mbt
+++ b/agent_review/generated_audit_system_prompt.mbt
@@ -41,8 +41,68 @@ fn audit_system_prompt() -> String {
     #|## Running Commands
     #|
     #|There is no shell tool. Every command — `moon`, `git`, anything else — is
-    #|spawned from a `mbtx` snippet; that tool's description carries the shape
-    #|of a snippet and the list of programs one may start.
+    #|spawned from a `mbtx` snippet through the shell-free
+    #|`moonbitlang/async/shell` API; the tool's description lists the programs a
+    #|snippet may start and its isolation rules. The `source` argument is a whole
+    #|`.mbtx` program:
+    #|
+    #|- Import every package it uses separately: `"moonbitlang/async"` alone brings
+    #|  in neither `fs` nor `shell`.
+    #|- Keep `async fn main` for async IO.
+    #|- Helpers that run a command or do IO are `async fn` too, without `noraise`;
+    #|  a plain `fn` cannot call them.
+    #|- There is no `await`: async calls are written normally.
+    #|- There is no `print`.
+    #|
+    #|
+    #|
+    #|```mbt nocheck
+    #|///|
+    #|import {
+    #|  "moonbitlang/async",
+    #|  "moonbitlang/async/shell",
+    #|}
+    #|
+    #|///|
+    #|async fn main {
+    #|  let out = @shell.Cmd("rg", [
+    #|    "-n", "protect_from_cancel\\(", "-g", "*.mbt", "src",
+    #|  ]).output()
+    #|  println(out.stdout())
+    #|  println(out.stderr())
+    #|  println("exit=\{out.exit_code()}")
+    #|}
+    #|```
+    #|
+    #|`Output` is opaque: `out.stdout()`, `out.stderr()`, and `out.exit_code()` are
+    #|calls, never fields. `.output()` reports the program's exit code instead of
+    #|raising on it (`rg` exits 1 when nothing matched); `.status()` returns just
+    #|the exit code. A regex needle is one ordinary string element: double the
+    #|backslashes MoonBit needs (`"\\("`) or pass `-F` for a literal match.
+    #|`@shell.Cmd(program, arguments)` passes its argument vector literally — `|`,
+    #|`>`, `&&`, `$()`, and `*` receive no shell interpretation — so run dependent
+    #|commands as ordinary MoonBit statements and branch on their exit codes. Bulky
+    #|output goes to a file under `@fs.tmpdir(prefix="run-")` through
+    #|`stdout=ToFile(...)` (the label is required) and is read back in part.
+    #|
+    #|Shell utilities such as `ls`, `cat`, and `sh` are refused; each is a line of
+    #|MoonBit here, which also works on Windows, where the binaries do not exist:
+    #|
+    #|| Command     | Alternatives     |
+    #||-------------|------------------|
+    #|| ls          | @fs.readdir(dir) |
+    #|| find        | @shell.glob(pattern) |
+    #|| cat         | @fs.read_file(p).text() |
+    #|| head/tail   | slice the split text; wc -l → count it |
+    #|| grep        | rg, or .split("\n").filter(...) on captured output |
+    #|| sort/uniq   | .sort(), a Set, or a Map |
+    #|| pwd         | @env.current_dir(); printenv → @env.get_env_var(name) |
+    #|| mkdir -p    | @fs.mkdir(d, recursive=true) |
+    #|| test -f     | @fs.exists(p); test -d → @fs.kind(p) is Directory |
+    #|| echo/printf | println |
+    #|| rm/mv/cp    | the `remove` and `write` tools; a snippet cannot write the workspace, and `remove` refuses files it did not create — a refusal there is an answer, not an obstacle to route past |
+    #|| sh -c, xargs, make | write the logic as MoonBit statements |
+    #|
     #|
   )
 }

--- a/agent_review/generated_audit_system_prompt.mbt
+++ b/agent_review/generated_audit_system_prompt.mbt
@@ -83,7 +83,8 @@ fn audit_system_prompt() -> String {
     #|`>`, `&&`, `$()`, and `*` receive no shell interpretation — so run dependent
     #|commands as ordinary MoonBit statements and branch on their exit codes. Bulky
     #|output goes to a file under `@fs.tmpdir(prefix="run-")` through
-    #|`stdout=ToFile(...)` (the label is required) and is read back in part.
+    #|`stdout=ToFile(...)` (the label is required; that directory is the one place a
+    #|snippet may write — `/tmp` itself is refused) and is read back in part.
     #|
     #|Shell utilities such as `ls`, `cat`, and `sh` are refused; each is a line of
     #|MoonBit here, which also works on Windows, where the binaries do not exist:

--- a/agent_review/generated_review_system_prompt.mbt
+++ b/agent_review/generated_review_system_prompt.mbt
@@ -15,8 +15,68 @@ fn review_system_prompt() -> String {
     #|## Running Commands
     #|
     #|There is no shell tool. Every command — `moon`, `git`, anything else — is
-    #|spawned from a `mbtx` snippet; that tool's description carries the shape
-    #|of a snippet and the list of programs one may start.
+    #|spawned from a `mbtx` snippet through the shell-free
+    #|`moonbitlang/async/shell` API; the tool's description lists the programs a
+    #|snippet may start and its isolation rules. The `source` argument is a whole
+    #|`.mbtx` program:
+    #|
+    #|- Import every package it uses separately: `"moonbitlang/async"` alone brings
+    #|  in neither `fs` nor `shell`.
+    #|- Keep `async fn main` for async IO.
+    #|- Helpers that run a command or do IO are `async fn` too, without `noraise`;
+    #|  a plain `fn` cannot call them.
+    #|- There is no `await`: async calls are written normally.
+    #|- There is no `print`.
+    #|
+    #|
+    #|
+    #|```mbt nocheck
+    #|///|
+    #|import {
+    #|  "moonbitlang/async",
+    #|  "moonbitlang/async/shell",
+    #|}
+    #|
+    #|///|
+    #|async fn main {
+    #|  let out = @shell.Cmd("rg", [
+    #|    "-n", "protect_from_cancel\\(", "-g", "*.mbt", "src",
+    #|  ]).output()
+    #|  println(out.stdout())
+    #|  println(out.stderr())
+    #|  println("exit=\{out.exit_code()}")
+    #|}
+    #|```
+    #|
+    #|`Output` is opaque: `out.stdout()`, `out.stderr()`, and `out.exit_code()` are
+    #|calls, never fields. `.output()` reports the program's exit code instead of
+    #|raising on it (`rg` exits 1 when nothing matched); `.status()` returns just
+    #|the exit code. A regex needle is one ordinary string element: double the
+    #|backslashes MoonBit needs (`"\\("`) or pass `-F` for a literal match.
+    #|`@shell.Cmd(program, arguments)` passes its argument vector literally — `|`,
+    #|`>`, `&&`, `$()`, and `*` receive no shell interpretation — so run dependent
+    #|commands as ordinary MoonBit statements and branch on their exit codes. Bulky
+    #|output goes to a file under `@fs.tmpdir(prefix="run-")` through
+    #|`stdout=ToFile(...)` (the label is required) and is read back in part.
+    #|
+    #|Shell utilities such as `ls`, `cat`, and `sh` are refused; each is a line of
+    #|MoonBit here, which also works on Windows, where the binaries do not exist:
+    #|
+    #|| Command     | Alternatives     |
+    #||-------------|------------------|
+    #|| ls          | @fs.readdir(dir) |
+    #|| find        | @shell.glob(pattern) |
+    #|| cat         | @fs.read_file(p).text() |
+    #|| head/tail   | slice the split text; wc -l → count it |
+    #|| grep        | rg, or .split("\n").filter(...) on captured output |
+    #|| sort/uniq   | .sort(), a Set, or a Map |
+    #|| pwd         | @env.current_dir(); printenv → @env.get_env_var(name) |
+    #|| mkdir -p    | @fs.mkdir(d, recursive=true) |
+    #|| test -f     | @fs.exists(p); test -d → @fs.kind(p) is Directory |
+    #|| echo/printf | println |
+    #|| rm/mv/cp    | the `remove` and `write` tools; a snippet cannot write the workspace, and `remove` refuses files it did not create — a refusal there is an answer, not an obstacle to route past |
+    #|| sh -c, xargs, make | write the logic as MoonBit statements |
+    #|
     #|
   )
 }

--- a/agent_review/generated_review_system_prompt.mbt
+++ b/agent_review/generated_review_system_prompt.mbt
@@ -57,7 +57,8 @@ fn review_system_prompt() -> String {
     #|`>`, `&&`, `$()`, and `*` receive no shell interpretation — so run dependent
     #|commands as ordinary MoonBit statements and branch on their exit codes. Bulky
     #|output goes to a file under `@fs.tmpdir(prefix="run-")` through
-    #|`stdout=ToFile(...)` (the label is required) and is read back in part.
+    #|`stdout=ToFile(...)` (the label is required; that directory is the one place a
+    #|snippet may write — `/tmp` itself is refused) and is read back in part.
     #|
     #|Shell utilities such as `ls`, `cat`, and `sh` are refused; each is a line of
     #|MoonBit here, which also works on Windows, where the binaries do not exist:

--- a/agent_review/review_system_prompt.mbt.md
+++ b/agent_review/review_system_prompt.mbt.md
@@ -10,5 +10,67 @@ Principles:
 ## Running Commands
 
 There is no shell tool. Every command — `moon`, `git`, anything else — is
-spawned from a `mbtx` snippet; that tool's description carries the shape
-of a snippet and the list of programs one may start.
+spawned from a `mbtx` snippet through the shell-free
+`moonbitlang/async/shell` API; the tool's description lists the programs a
+snippet may start and its isolation rules. The `source` argument is a whole
+`.mbtx` program:
+
+- Import every package it uses separately: `"moonbitlang/async"` alone brings
+  in neither `fs` nor `shell`.
+- Keep `async fn main` for async IO.
+- Helpers that run a command or do IO are `async fn` too, without `noraise`;
+  a plain `fn` cannot call them.
+- There is no `await`: async calls are written normally.
+- There is no `print`.
+
+<!-- Keep this block in sync with the Running Commands section of
+prompt/default_prompt.mbt.md; the comment is stripped from the generated
+prompt. -->
+
+```mbt nocheck
+///|
+import {
+  "moonbitlang/async",
+  "moonbitlang/async/shell",
+}
+
+///|
+async fn main {
+  let out = @shell.Cmd("rg", [
+    "-n", "protect_from_cancel\\(", "-g", "*.mbt", "src",
+  ]).output()
+  println(out.stdout())
+  println(out.stderr())
+  println("exit=\{out.exit_code()}")
+}
+```
+
+`Output` is opaque: `out.stdout()`, `out.stderr()`, and `out.exit_code()` are
+calls, never fields. `.output()` reports the program's exit code instead of
+raising on it (`rg` exits 1 when nothing matched); `.status()` returns just
+the exit code. A regex needle is one ordinary string element: double the
+backslashes MoonBit needs (`"\\("`) or pass `-F` for a literal match.
+`@shell.Cmd(program, arguments)` passes its argument vector literally — `|`,
+`>`, `&&`, `$()`, and `*` receive no shell interpretation — so run dependent
+commands as ordinary MoonBit statements and branch on their exit codes. Bulky
+output goes to a file under `@fs.tmpdir(prefix="run-")` through
+`stdout=ToFile(...)` (the label is required) and is read back in part.
+
+Shell utilities such as `ls`, `cat`, and `sh` are refused; each is a line of
+MoonBit here, which also works on Windows, where the binaries do not exist:
+
+| Command     | Alternatives     |
+|-------------|------------------|
+| ls          | @fs.readdir(dir) |
+| find        | @shell.glob(pattern) |
+| cat         | @fs.read_file(p).text() |
+| head/tail   | slice the split text; wc -l → count it |
+| grep        | rg, or .split("\n").filter(...) on captured output |
+| sort/uniq   | .sort(), a Set, or a Map |
+| pwd         | @env.current_dir(); printenv → @env.get_env_var(name) |
+| mkdir -p    | @fs.mkdir(d, recursive=true) |
+| test -f     | @fs.exists(p); test -d → @fs.kind(p) is Directory |
+| echo/printf | println |
+| rm/mv/cp    | the `remove` and `write` tools; a snippet cannot write the workspace, and `remove` refuses files it did not create — a refusal there is an answer, not an obstacle to route past |
+| sh -c, xargs, make | write the logic as MoonBit statements |
+

--- a/agent_review/review_system_prompt.mbt.md
+++ b/agent_review/review_system_prompt.mbt.md
@@ -54,7 +54,8 @@ backslashes MoonBit needs (`"\\("`) or pass `-F` for a literal match.
 `>`, `&&`, `$()`, and `*` receive no shell interpretation — so run dependent
 commands as ordinary MoonBit statements and branch on their exit codes. Bulky
 output goes to a file under `@fs.tmpdir(prefix="run-")` through
-`stdout=ToFile(...)` (the label is required) and is read back in part.
+`stdout=ToFile(...)` (the label is required; that directory is the one place a
+snippet may write — `/tmp` itself is refused) and is read back in part.
 
 Shell utilities such as `ls`, `cat`, and `sh` are refused; each is a line of
 MoonBit here, which also works on Windows, where the binaries do not exist:

--- a/agent_tool/run_moonbit/run_moonbit.mbt
+++ b/agent_tool/run_moonbit/run_moonbit.mbt
@@ -989,9 +989,12 @@ fn schema(background~ : Bool, escalation~ : Bool) -> Json {
 ///|
 /// The `mbtx` tool description.
 ///
-/// Holds the tool-local contract every role must see: the admitted child
-/// processes, refusal and escalation behavior, isolation, limits, and the
-/// arguments this build actually supports. The default system prompt owns the
+/// Holds the tool-local contract every role must see: what a shell's utilities
+/// are in MoonBit, the admitted child processes, refusal and escalation
+/// behavior, isolation, limits, and the arguments this build actually
+/// supports. The utility table comes before the allowlist on purpose: it is
+/// how a snippet does its work, read before reaching for `ls`, not advice
+/// handed out after a refusal. The default system prompt owns the
 /// `moonbitlang/async/shell` tutorial and worked examples; those teach one
 /// role's workflow rather than describing what the tool enforces.
 ///
@@ -1023,19 +1026,15 @@ fn description(background~ : Bool, escalation~ : Bool) -> String {
     (
       #|Anything else is REFUSED, including the obvious ones. When a refused command
       #|is genuinely what the task needs, two answers are legitimate: reach for the
-      #|MoonBit replacement below, or — when no replacement is faithful and the
+      #|MoonBit replacement above, or — when no replacement is faithful and the
       #|refused program IS the task — retry that one snippet with escalated=true and
       #|let the user decide. Reconstructing the refused command out of allowed parts
-      #|without saying so is the answer that is not. Read the table rather than
-      #|finding this out one command at a time — each is a line of MoonBit that also
-      #|works on Windows, where these binaries do not exist:
+      #|without saying so is the answer that is not.
     )
   } else {
     (
       #|Anything else is REFUSED, including the obvious ones; if a refused command is
-      #|genuinely what the task needs, say so rather than working around it. Reach for
-      #|the replacement rather than finding this out one command at a time — each is a
-      #|line of MoonBit that also works on Windows, where these binaries do not exist:
+      #|genuinely what the task needs, say so rather than working around it.
     )
   }
   let base_head =
@@ -1049,6 +1048,26 @@ fn description(background~ : Bool, escalation~ : Bool) -> String {
     #|
     #|`source` is the whole program. Diagnostics are rewritten to `source:LINE:COL`
     #|about your input; `target` defaults to wasm, the sandboxed backend.
+    #|
+    #|## What a shell's utilities are here
+    #|
+    #|Each is a line of MoonBit that also works on Windows, where these binaries
+    #|do not exist:
+    #|
+    #|    ls          → @fs.readdir(dir)
+    #|    find        → rg --files, or recurse @fs.readdir + @fs.kind
+    #|    cat         → @fs.read_file(p).text()
+    #|    head/tail   → slice the split text; wc -l → count it
+    #|    grep        → rg, or .split("\n").filter(...) on captured output
+    #|    sort/uniq   → .sort(), a Set, or a Map
+    #|    pwd         → @env.current_dir(); printenv → @env.get_env_var(name)
+    #|    mkdir -p    → @fs.mkdir(d, recursive=true)
+    #|    test -f     → @fs.exists(p); test -d → @fs.kind(p) is Directory
+    #|    echo/printf → println
+    #|    rm/mv/cp    → the `remove` and `write` tools; a snippet cannot write the
+    #|                  workspace, and `remove` refuses files it did not create —
+    #|                  a refusal there is an answer, not an obstacle to route past
+    #|    sh -c, xargs, make → write the logic as MoonBit statements
     #|
     #|## Which programs a snippet may start
     #|
@@ -1070,21 +1089,6 @@ fn description(background~ : Bool, escalation~ : Bool) -> String {
     #|- `gh` — pr, issue, run, `repo view`, api, `auth status`.
     #|- `rg` and `diff`.
   let base_tail =
-    #|    ls          → @fs.readdir(dir)
-    #|    find        → rg --files, or recurse @fs.readdir + @fs.kind
-    #|    cat         → @fs.read_file(p).text()
-    #|    head/tail   → slice the split text; wc -l → count it
-    #|    grep        → rg, or .split("\n").filter(...) on captured output
-    #|    sort/uniq   → .sort(), a Set, or a Map
-    #|    pwd         → @env.current_dir(); printenv → @env.get_env_var(name)
-    #|    mkdir -p    → @fs.mkdir(d, recursive=true)
-    #|    test -f     → @fs.exists(p); test -d → @fs.kind(p) is Directory
-    #|    echo/printf → println
-    #|    rm/mv/cp    → the `remove` and `write` tools; a snippet cannot write the
-    #|                  workspace, and `remove` refuses files it did not create —
-    #|                  a refusal there is an answer, not an obstacle to route past
-    #|    sh -c, xargs, make → write the logic as MoonBit statements
-    #|
     #|## Isolation and limits
     #|
     #|- A snippet runs with the workspace as its working directory, so RELATIVE paths

--- a/agent_tool/run_moonbit/run_moonbit.mbt
+++ b/agent_tool/run_moonbit/run_moonbit.mbt
@@ -989,12 +989,12 @@ fn schema(background~ : Bool, escalation~ : Bool) -> Json {
 ///|
 /// The `mbtx` tool description.
 ///
-/// Holds the tool-local contract every role must see: what a shell's utilities
-/// are in MoonBit, the admitted child processes, refusal and escalation
-/// behavior, isolation, limits, and the arguments this build actually
-/// supports. The utility table comes before the allowlist on purpose: it is
-/// how a snippet does its work, read before reaching for `ls`, not advice
-/// handed out after a refusal. The default system prompt owns the
+/// Holds the tool-local contract every role must see: the admitted child
+/// processes, refusal and escalation behavior, isolation, limits, and the
+/// arguments this build actually supports. What a shell's utilities are in
+/// MoonBit is the system prompt's to teach — it is how a snippet does its
+/// work, not advice handed out after a refusal — so the refusal text below
+/// names no table. The default system prompt owns the
 /// `moonbitlang/async/shell` tutorial and worked examples; those teach one
 /// role's workflow rather than describing what the tool enforces.
 ///
@@ -1026,7 +1026,7 @@ fn description(background~ : Bool, escalation~ : Bool) -> String {
     (
       #|Anything else is REFUSED, including the obvious ones. When a refused command
       #|is genuinely what the task needs, two answers are legitimate: reach for the
-      #|MoonBit replacement above, or — when no replacement is faithful and the
+      #|MoonBit replacement, or — when no replacement is faithful and the
       #|refused program IS the task — retry that one snippet with escalated=true and
       #|let the user decide. Reconstructing the refused command out of allowed parts
       #|without saying so is the answer that is not.
@@ -1048,26 +1048,6 @@ fn description(background~ : Bool, escalation~ : Bool) -> String {
     #|
     #|`source` is the whole program. Diagnostics are rewritten to `source:LINE:COL`
     #|about your input; `target` defaults to wasm, the sandboxed backend.
-    #|
-    #|## What a shell's utilities are here
-    #|
-    #|Each is a line of MoonBit that also works on Windows, where these binaries
-    #|do not exist:
-    #|
-    #|    ls          → @fs.readdir(dir)
-    #|    find        → rg --files, or recurse @fs.readdir + @fs.kind
-    #|    cat         → @fs.read_file(p).text()
-    #|    head/tail   → slice the split text; wc -l → count it
-    #|    grep        → rg, or .split("\n").filter(...) on captured output
-    #|    sort/uniq   → .sort(), a Set, or a Map
-    #|    pwd         → @env.current_dir(); printenv → @env.get_env_var(name)
-    #|    mkdir -p    → @fs.mkdir(d, recursive=true)
-    #|    test -f     → @fs.exists(p); test -d → @fs.kind(p) is Directory
-    #|    echo/printf → println
-    #|    rm/mv/cp    → the `remove` and `write` tools; a snippet cannot write the
-    #|                  workspace, and `remove` refuses files it did not create —
-    #|                  a refusal there is an answer, not an obstacle to route past
-    #|    sh -c, xargs, make → write the logic as MoonBit statements
     #|
     #|## Which programs a snippet may start
     #|

--- a/agent_tool/run_moonbit/run_moonbit.mbt
+++ b/agent_tool/run_moonbit/run_moonbit.mbt
@@ -989,12 +989,11 @@ fn schema(background~ : Bool, escalation~ : Bool) -> Json {
 ///|
 /// The `mbtx` tool description.
 ///
-/// Holds the whole command surface: every role that registers this tool gets it
-/// and nothing else does. The five system prompts carried this text for one
-/// revision and had already drifted apart within a single commit, while the
-/// prompt-versus-tool A/B that motivated the move showed no effect either way.
-/// What stays in a prompt is what varies by role — which file tools exist, and
-/// whether the role may commit.
+/// Holds the tool-local contract every role must see: the admitted child
+/// processes, refusal and escalation behavior, isolation, limits, and the
+/// arguments this build actually supports. The default system prompt owns the
+/// `moonbitlang/async/shell` tutorial and worked examples; those teach one
+/// role's workflow rather than describing what the tool enforces.
 ///
 /// The spawn list is prose about `spawnable_commands`, kept by hand so the
 /// groupings survive; adding an entry there means editing this text too.
@@ -1042,102 +1041,14 @@ fn description(background~ : Bool, escalation~ : Bool) -> String {
   let base_head =
     #|Compile and run a self-contained MoonBit program and return its merged
     #|stdout/stderr and exit status. This is BOTH your command runner and your
-    #|scripting surface: there is no shell tool, so commands are spawned from MoonBit
-    #|with the `bobzhang/myshell` EDSL.
+    #|scripting surface: there is no shell tool, so commands, IO, and computation
+    #|happen inside the submitted MoonBit program.
     #|
     #|This tool was previously named `run_moonbit` — a resumed session's older
     #|history may still call it that.
     #|
     #|`source` is the whole program. Diagnostics are rewritten to `source:LINE:COL`
     #|about your input; `target` defaults to wasm, the sandboxed backend.
-    #|
-    #|```
-    #|import { "bobzhang/myshell", "moonbitlang/async", "moonbitlang/async/fs" }
-    #|
-    #|async fn main {
-    #|  let out = @myshell.Cmd("moon", ["check", "--diagnostic-limit", "5"]).output()
-    #|  println(out.stdout)
-    #|  println(out.stderr)
-    #|  println("exit=\{out.exit_code}")
-    #|  for name in @fs.readdir(".") {
-    #|    println(name)
-    #|  }
-    #|}
-    #|```
-    #|
-    #|- Every `@pkg` is imported SEPARATELY, as `@fs` is above: `"moonbitlang/async"`
-    #|  alone does not bring in `fs` or `stdio`, and the failure reads
-    #|  `Package "fs" not found`.
-    #|- Keep `async fn main`: a plain `fn main` may not call anything that raises,
-    #|  which nearly every `@fs`/`@myshell` call does.
-    #|- ALWAYS `println` each command's stdout, stderr and exit code — what you do not
-    #|  print is invisible to you. But a run that prints more than ~48KB is STOPPED
-    #|  mid-print, so filter before printing, or park the bulk with
-    #|  `stdout=ToFile("\{@fs.tmpdir(prefix="run-")}/out.log")` and read back the part
-    #|  you need. `prefix~` is required and the call CREATES the directory. A snippet
-    #|  may write ONLY inside its own `@fs.tmpdir`, so that redirect cannot target the
-    #|  workspace.
-    #|- `Cmd(program, args)` passes the argument VECTOR literally: no shell parsing, no
-    #|  quoting, and `|`, `>`, `&&`, `$()`, `*` mean nothing. Other labels: `cwd`,
-    #|  `env`, `stdin=Text(...)`. Run several commands as sequential statements in ONE
-    #|  snippet and branch on `out.exit_code`; do NOT reach for `@myshell.Pipeline` —
-    #|  filter captured output in MoonBit instead.
-    #|
-    #|## Two worked examples
-    #|
-    #|A scoped check, reduced to the `path:line` list the next edit needs.
-    #|`--output-json` prints one diagnostic per line ON STDOUT — only the
-    #|`Failed with N errors` summary goes to stderr, so reading `out.stderr` here
-    #|finds nothing and looks like a clean build. `NO_COLOR` keeps ANSI escapes out
-    #|of the captured text, which otherwise break every `contains`/`has_prefix`:
-    #|
-    #|```
-    #|import { "bobzhang/myshell", "moonbitlang/async", "moonbitlang/core/json" }
-    #|
-    #|async fn main {
-    #|  let out = @myshell.Cmd("moon", ["check", "--output-json"], cwd="agent_tool",
-    #|    env={ "NO_COLOR": "1" }).output()
-    #|  let mut errors = 0
-    #|  for line in out.stdout.split("\n") {
-    #|    let d = @json.parse(line.to_owned()) catch { _ => continue }
-    #|    guard d is { "level": String("error"), "path": String(p), "loc": String(loc),
-    #|                 "message": String(msg), .. } else { continue }
-    #|    errors += 1
-    #|    if errors <= 20 {
-    #|      println("\{p}:\{loc}  \{msg.split("\n").head().unwrap_or("")}")
-    #|    }
-    #|  }
-    #|  println("exit=\{out.exit_code} errors=\{errors}")
-    #|}
-    #|```
-    #|
-    #|Several commands in one snippet, with the bulk parked instead of printed —
-    #|this is what `&&` and `| head` used to do, except the branch can inspect WHAT
-    #|failed, not just whether something did:
-    #|
-    #|```
-    #|import { "bobzhang/myshell", "moonbitlang/async", "moonbitlang/async/fs" }
-    #|
-    #|async fn main {
-    #|  if @myshell.Cmd("moon", ["check"]).output().exit_code != 0 {
-    #|    println("check failed; not running tests")
-    #|    return
-    #|  }
-    #|  let log = "\{@fs.tmpdir(prefix="run-")}/test.log"
-    #|  let out = @myshell.Cmd("moon", ["test"], stdout=ToFile(log)).output()
-    #|  let lines = [..@fs.read_file(log).text().split("\n")]
-    #|  let failed = lines.filter(l => l.contains("FAILED"))
-    #|  println("exit=\{out.exit_code} lines=\{lines.length()} failed=\{failed.length()}")
-    #|  for i, l in failed {
-    #|    if i >= 20 { break }
-    #|    println(l)
-    #|  }
-    #|}
-    #|```
-    #|
-    #|A redirected stream is NOT captured, so `out.stdout` is empty above and the
-    #|file holds everything — that is the only safe way to handle output over ~64KB.
-    #|Slice with a bounded loop, not `failed[:20]`: a view past the end PANICS.
     #|
     #|## Which programs a snippet may start
     #|
@@ -1181,7 +1092,7 @@ fn description(background~ : Bool, escalation~ : Bool) -> String {
     #|  stay in a temp dir — your `_build` is untouched.
     #|- A snippet's imports resolve against the REGISTRY, not your uncommitted edits.
     #|  To exercise working-tree code, add a `*_test.mbt` to that package and run
-    #|  `moon test` through a `@myshell.Cmd`.
+    #|  `moon test` as an admitted child process.
     #|- A snippet READS anywhere and WRITES only its own `@fs.tmpdir()`. Changing a
     #|  workspace file is the file tools' job, or a command's — `moon fmt`, `git
     #|  checkout` and friends are child processes and run normally. A write refusal

--- a/agent_tool/run_moonbit/run_moonbit_test.mbt
+++ b/agent_tool/run_moonbit/run_moonbit_test.mbt
@@ -559,7 +559,6 @@ async test "a worker's snippet writes neither its own tree nor a sibling's" {
 test "a definition without a job runtime does not advertise background runs" {
   let definition = @run_moonbit.definition(workspace_root=".")
   assert_false(definition.description.contains("run_in_background"))
-  assert_true(definition.description.contains("bobzhang/myshell"))
   let JsonSchema(schema) = definition.schema
   assert_false(schema.stringify().contains("run_in_background"))
 }
@@ -740,24 +739,101 @@ async test "error diagnostics name `source`, not the throwaway temp path" {
 }
 
 ///|
-/// Spawning processes is what this tool is for now — the refusal that used to
-/// send commands to the shell tool would make the registry unable to run any.
+/// The system prompt's minimal shell example exercises the library without
+/// spawning a child process: glob expansion itself is useful MoonBit IO.
+async test "moonbitlang/async/shell glob lists workspace paths" {
+  @vfs.with_tmpdir(prefix="mbtx-glob-", ws => {
+    @fs.write_file("\{ws}/main.mbt", "fn main {}", create_mode=CreateOrTruncate)
+    let out = run_in(ws, {
+      "source": (
+        #|import { "moonbitlang/async", "moonbitlang/async/shell" }
+        #|
+        #|async fn main {
+        #|  for path in @shell.glob("*.mbt") {
+        #|    println(path)
+        #|  }
+        #|}
+      ),
+    })
+    assert_false(out.is_error)
+    assert_true(out.content.contains("main.mbt"))
+  })
+}
+
+///|
+/// The system prompt's plain command example reads a captured run back through
+/// `Output`'s accessor methods: the type is opaque, so field access does not
+/// compile, and a non-zero exit is reported rather than raised.
 #cfg(not(platform="windows"))
-async test "runs a command through the myshell EDSL" {
+async test "reads a captured command through Output accessors" {
   let out = run(
     (
-      #|import { "bobzhang/myshell", "moonbitlang/async" }
+      #|import { "moonbitlang/async", "moonbitlang/async/shell" }
       #|
       #|async fn main {
-      #|  let result = @myshell.Cmd("git", ["--version"]).output()
-      #|  println("out=\{result.stdout}")
-      #|  println("exit=\{result.exit_code}")
+      #|  let out = @shell.Cmd("git", ["--version"]).output()
+      #|  println(out.stdout())
+      #|  println(out.stderr())
+      #|  println("exit=\{out.exit_code()}")
+      #|  let missing = @shell.Cmd("git", ["rev-parse", "--verify", "no-such-ref"]).output()
+      #|  println("missing exit=\{missing.exit_code()}")
       #|}
     ),
   )
   assert_false(out.is_error)
-  assert_true(out.content.contains("out=git version"))
+  assert_true(out.content.contains("git version"))
   assert_true(out.content.contains("exit=0"))
+  assert_true(out.content.contains("missing exit=128"))
+}
+
+///|
+/// The system prompt's compiler example combines structured diagnostics with
+/// incremental stdout handling instead of teaching two `moon check` shapes.
+#cfg(not(platform="windows"))
+async test "streams structured moon check diagnostics with async shell" {
+  @vfs.with_tmpdir(prefix="mbtx-json-check-", ws => {
+    @fs.write_file(
+      "\{ws}/moon.mod",
+      "name = \"tmp/mbtx_json_check\"\n",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file(
+      "\{ws}/main.mbt",
+      "pub fn broken() -> Int { \"not an int\" }\n",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file("\{ws}/moon.pkg", "", create_mode=CreateOrTruncate)
+    let out = run_in(ws, {
+      "source": (
+        #|import { "moonbitlang/async", "moonbitlang/async/shell", "moonbitlang/core/json" }
+        #|
+        #|async fn main {
+        #|  let mut errors = 0
+        #|  let exit_code = @shell.Cmd(
+        #|    "moon",
+        #|    ["check", "--output-json", "--diagnostic-limit", "5"],
+        #|    env={ "NO_COLOR": "1" },
+        #|  ).each_line() <| line => {
+        #|    let diagnostic = @json.parse(line) catch { _ => return }
+        #|    if diagnostic is {
+        #|      "level": String("error"),
+        #|      "path": String(path),
+        #|      "loc": String(loc),
+        #|      "message": String(message),
+        #|      ..
+        #|    } {
+        #|      errors += 1
+        #|      println("\{path}:\{loc}  \{message}")
+        #|    }
+        #|  }
+        #|  println("exit=\{exit_code} errors=\{errors}")
+        #|}
+      ),
+    })
+    assert_false(out.is_error)
+    assert_true(out.content.contains("main.mbt:"))
+    assert_true(out.content.contains("errors=1"))
+  })
 }
 
 ///|

--- a/agent_tool/run_moonbit/run_moonbit_test.mbt
+++ b/agent_tool/run_moonbit/run_moonbit_test.mbt
@@ -746,11 +746,14 @@ async test "moonbitlang/async/shell glob lists workspace paths" {
     @fs.write_file("\{ws}/main.mbt", "fn main {}", create_mode=CreateOrTruncate)
     let out = run_in(ws, {
       "source": (
-        #|import { "moonbitlang/async", "moonbitlang/async/shell" }
+        #|import { "moonbitlang/async", "moonbitlang/async/fs", "moonbitlang/async/shell" }
         #|
         #|async fn main {
         #|  for path in @shell.glob("*.mbt") {
         #|    println(path)
+        #|  }
+        #|  for name in @fs.readdir(".") {
+        #|    println(name)
         #|  }
         #|}
       ),
@@ -1087,10 +1090,6 @@ test "the description offers asking as an answer where it exists" {
   // The stance survives the fork: reconstructing the command out of allowed
   // parts without saying so is still the answer that is not.
   assert_true(asking.contains("Reconstructing the refused command"))
-  // The utility table is shared by both spellings and sits before the
-  // allowlist rather than hanging off the refusal advice.
-  assert_true(plain.contains("ls          → @fs.readdir(dir)"))
-  assert_true(asking.contains("ls          → @fs.readdir(dir)"))
 }
 
 ///|

--- a/agent_tool/run_moonbit/run_moonbit_test.mbt
+++ b/agent_tool/run_moonbit/run_moonbit_test.mbt
@@ -746,7 +746,7 @@ async test "moonbitlang/async/shell glob lists workspace paths" {
     @fs.write_file("\{ws}/main.mbt", "fn main {}", create_mode=CreateOrTruncate)
     let out = run_in(ws, {
       "source": (
-        #|import { "moonbitlang/async", "moonbitlang/async/fs", "moonbitlang/async/shell" }
+        #|import { "moonbitlang/async", "moonbitlang/async/fs", "moonbitlang/async/shell", "moonbitlang/core/env" }
         #|
         #|async fn main {
         #|  for path in @shell.glob("*.mbt") {
@@ -755,11 +755,17 @@ async test "moonbitlang/async/shell glob lists workspace paths" {
         #|  for name in @fs.readdir(".") {
         #|    println(name)
         #|  }
+        #|  guard @env.get_env_var("HOME") is Some(home) else {
+        #|    println("HOME is not set")
+        #|    return
+        #|  }
+        #|  println("\{home}/.moon exists: \{@fs.exists("\{home}/.moon")}")
         #|}
       ),
     })
     assert_false(out.is_error)
     assert_true(out.content.contains("main.mbt"))
+    assert_true(out.content.contains(".moon exists: "))
   })
 }
 

--- a/agent_tool/run_moonbit/run_moonbit_test.mbt
+++ b/agent_tool/run_moonbit/run_moonbit_test.mbt
@@ -765,7 +765,6 @@ async test "moonbitlang/async/shell glob lists workspace paths" {
     })
     assert_false(out.is_error)
     assert_true(out.content.contains("main.mbt"))
-    assert_true(out.content.contains(".moon exists: "))
   })
 }
 

--- a/agent_tool/run_moonbit/run_moonbit_test.mbt
+++ b/agent_tool/run_moonbit/run_moonbit_test.mbt
@@ -1087,7 +1087,8 @@ test "the description offers asking as an answer where it exists" {
   // The stance survives the fork: reconstructing the command out of allowed
   // parts without saying so is still the answer that is not.
   assert_true(asking.contains("Reconstructing the refused command"))
-  // Both spellings still lead into the replacement table.
+  // The utility table is shared by both spellings and sits before the
+  // allowlist rather than hanging off the refusal advice.
   assert_true(plain.contains("ls          → @fs.readdir(dir)"))
   assert_true(asking.contains("ls          → @fs.readdir(dir)"))
 }

--- a/agent_tool/run_moonbit/wasm_policy.mbt
+++ b/agent_tool/run_moonbit/wasm_policy.mbt
@@ -17,9 +17,10 @@
 /// A prefix matches whole argument tokens from the front, so `moon` with
 /// `["test"]` allows `moon test --filter x` but not `moon build`.
 ///
-/// The mbtx tool description carries this list in prose. Admitting a command
-/// here without adding it there costs a turn steps: the model never learns it
-/// may use it.
+/// The mbtx tool description and the default system prompt
+/// (`prompt/default_prompt.mbt.md`, "Only these programs can be started")
+/// both carry this list in prose. Admitting a command here without adding it
+/// to both costs a turn steps: the model never learns it may use it.
 let spawnable_commands : Array[(String, Array[String])] = [
   // The MoonBit toolchain, which is most of what a turn runs. Listed per
   // subcommand rather than as a bare `moon` so the set is reviewable, and so

--- a/agent_tool/run_moonbit/wasm_policy.mbt
+++ b/agent_tool/run_moonbit/wasm_policy.mbt
@@ -17,7 +17,7 @@
 /// A prefix matches whole argument tokens from the front, so `moon` with
 /// `["test"]` allows `moon test --filter x` but not `moon build`.
 ///
-/// Each role's system prompt carries this list in prose. Admitting a command
+/// The mbtx tool description carries this list in prose. Admitting a command
 /// here without adding it there costs a turn steps: the model never learns it
 /// may use it.
 let spawnable_commands : Array[(String, Array[String])] = [

--- a/agent_worker/generated_worker_system_prompt.mbt
+++ b/agent_worker/generated_worker_system_prompt.mbt
@@ -116,7 +116,8 @@ fn worker_system_prompt() -> String {
     #|`>`, `&&`, `$()`, and `*` receive no shell interpretation — so run dependent
     #|commands as ordinary MoonBit statements and branch on their exit codes. Bulky
     #|output goes to a file under `@fs.tmpdir(prefix="run-")` through
-    #|`stdout=ToFile(...)` (the label is required) and is read back in part.
+    #|`stdout=ToFile(...)` (the label is required; that directory is the one place a
+    #|snippet may write — `/tmp` itself is refused) and is read back in part.
     #|
     #|Shell utilities such as `ls`, `cat`, and `sh` are refused; each is a line of
     #|MoonBit here, which also works on Windows, where the binaries do not exist:

--- a/agent_worker/generated_worker_system_prompt.mbt
+++ b/agent_worker/generated_worker_system_prompt.mbt
@@ -74,9 +74,69 @@ fn worker_system_prompt() -> String {
     #|## Running Commands
     #|
     #|There is no shell tool. Every command — `moon`, `git`, anything else — is
-    #|spawned from a `mbtx` snippet; that tool's description carries the shape
-    #|of a snippet and the list of programs one may start. Two narrowings are yours,
-    #|per the confinement above:
+    #|spawned from a `mbtx` snippet through the shell-free
+    #|`moonbitlang/async/shell` API; the tool's description lists the programs a
+    #|snippet may start and its isolation rules. The `source` argument is a whole
+    #|`.mbtx` program:
+    #|
+    #|- Import every package it uses separately: `"moonbitlang/async"` alone brings
+    #|  in neither `fs` nor `shell`.
+    #|- Keep `async fn main` for async IO.
+    #|- Helpers that run a command or do IO are `async fn` too, without `noraise`;
+    #|  a plain `fn` cannot call them.
+    #|- There is no `await`: async calls are written normally.
+    #|- There is no `print`.
+    #|
+    #|
+    #|
+    #|```mbt nocheck
+    #|///|
+    #|import {
+    #|  "moonbitlang/async",
+    #|  "moonbitlang/async/shell",
+    #|}
+    #|
+    #|///|
+    #|async fn main {
+    #|  let out = @shell.Cmd("rg", [
+    #|    "-n", "protect_from_cancel\\(", "-g", "*.mbt", "src",
+    #|  ]).output()
+    #|  println(out.stdout())
+    #|  println(out.stderr())
+    #|  println("exit=\{out.exit_code()}")
+    #|}
+    #|```
+    #|
+    #|`Output` is opaque: `out.stdout()`, `out.stderr()`, and `out.exit_code()` are
+    #|calls, never fields. `.output()` reports the program's exit code instead of
+    #|raising on it (`rg` exits 1 when nothing matched); `.status()` returns just
+    #|the exit code. A regex needle is one ordinary string element: double the
+    #|backslashes MoonBit needs (`"\\("`) or pass `-F` for a literal match.
+    #|`@shell.Cmd(program, arguments)` passes its argument vector literally — `|`,
+    #|`>`, `&&`, `$()`, and `*` receive no shell interpretation — so run dependent
+    #|commands as ordinary MoonBit statements and branch on their exit codes. Bulky
+    #|output goes to a file under `@fs.tmpdir(prefix="run-")` through
+    #|`stdout=ToFile(...)` (the label is required) and is read back in part.
+    #|
+    #|Shell utilities such as `ls`, `cat`, and `sh` are refused; each is a line of
+    #|MoonBit here, which also works on Windows, where the binaries do not exist:
+    #|
+    #|| Command     | Alternatives     |
+    #||-------------|------------------|
+    #|| ls          | @fs.readdir(dir) |
+    #|| find        | @shell.glob(pattern) |
+    #|| cat         | @fs.read_file(p).text() |
+    #|| head/tail   | slice the split text; wc -l → count it |
+    #|| grep        | rg, or .split("\n").filter(...) on captured output |
+    #|| sort/uniq   | .sort(), a Set, or a Map |
+    #|| pwd         | @env.current_dir(); printenv → @env.get_env_var(name) |
+    #|| mkdir -p    | @fs.mkdir(d, recursive=true) |
+    #|| test -f     | @fs.exists(p); test -d → @fs.kind(p) is Directory |
+    #|| echo/printf | println |
+    #|| rm/mv/cp    | the `remove` and `write` tools; a snippet cannot write the workspace, and `remove` refuses files it did not create — a refusal there is an answer, not an obstacle to route past |
+    #|| sh -c, xargs, make | write the logic as MoonBit statements |
+    #|
+    #|Two narrowings are yours, per the confinement above:
     #|
     #|- Of the git commands that description lists, use only the reading ones and the
     #|  WORKING-TREE-ONLY ones (`restore <path>`, `checkout -- <path>`). `add`,

--- a/agent_worker/worker_system_prompt.mbt.md
+++ b/agent_worker/worker_system_prompt.mbt.md
@@ -69,9 +69,71 @@ plain-text finish):
 ## Running Commands
 
 There is no shell tool. Every command — `moon`, `git`, anything else — is
-spawned from a `mbtx` snippet; that tool's description carries the shape
-of a snippet and the list of programs one may start. Two narrowings are yours,
-per the confinement above:
+spawned from a `mbtx` snippet through the shell-free
+`moonbitlang/async/shell` API; the tool's description lists the programs a
+snippet may start and its isolation rules. The `source` argument is a whole
+`.mbtx` program:
+
+- Import every package it uses separately: `"moonbitlang/async"` alone brings
+  in neither `fs` nor `shell`.
+- Keep `async fn main` for async IO.
+- Helpers that run a command or do IO are `async fn` too, without `noraise`;
+  a plain `fn` cannot call them.
+- There is no `await`: async calls are written normally.
+- There is no `print`.
+
+<!-- Keep this block in sync with the Running Commands section of
+prompt/default_prompt.mbt.md; the comment is stripped from the generated
+prompt. -->
+
+```mbt nocheck
+///|
+import {
+  "moonbitlang/async",
+  "moonbitlang/async/shell",
+}
+
+///|
+async fn main {
+  let out = @shell.Cmd("rg", [
+    "-n", "protect_from_cancel\\(", "-g", "*.mbt", "src",
+  ]).output()
+  println(out.stdout())
+  println(out.stderr())
+  println("exit=\{out.exit_code()}")
+}
+```
+
+`Output` is opaque: `out.stdout()`, `out.stderr()`, and `out.exit_code()` are
+calls, never fields. `.output()` reports the program's exit code instead of
+raising on it (`rg` exits 1 when nothing matched); `.status()` returns just
+the exit code. A regex needle is one ordinary string element: double the
+backslashes MoonBit needs (`"\\("`) or pass `-F` for a literal match.
+`@shell.Cmd(program, arguments)` passes its argument vector literally — `|`,
+`>`, `&&`, `$()`, and `*` receive no shell interpretation — so run dependent
+commands as ordinary MoonBit statements and branch on their exit codes. Bulky
+output goes to a file under `@fs.tmpdir(prefix="run-")` through
+`stdout=ToFile(...)` (the label is required) and is read back in part.
+
+Shell utilities such as `ls`, `cat`, and `sh` are refused; each is a line of
+MoonBit here, which also works on Windows, where the binaries do not exist:
+
+| Command     | Alternatives     |
+|-------------|------------------|
+| ls          | @fs.readdir(dir) |
+| find        | @shell.glob(pattern) |
+| cat         | @fs.read_file(p).text() |
+| head/tail   | slice the split text; wc -l → count it |
+| grep        | rg, or .split("\n").filter(...) on captured output |
+| sort/uniq   | .sort(), a Set, or a Map |
+| pwd         | @env.current_dir(); printenv → @env.get_env_var(name) |
+| mkdir -p    | @fs.mkdir(d, recursive=true) |
+| test -f     | @fs.exists(p); test -d → @fs.kind(p) is Directory |
+| echo/printf | println |
+| rm/mv/cp    | the `remove` and `write` tools; a snippet cannot write the workspace, and `remove` refuses files it did not create — a refusal there is an answer, not an obstacle to route past |
+| sh -c, xargs, make | write the logic as MoonBit statements |
+
+Two narrowings are yours, per the confinement above:
 
 - Of the git commands that description lists, use only the reading ones and the
   WORKING-TREE-ONLY ones (`restore <path>`, `checkout -- <path>`). `add`,

--- a/agent_worker/worker_system_prompt.mbt.md
+++ b/agent_worker/worker_system_prompt.mbt.md
@@ -113,7 +113,8 @@ backslashes MoonBit needs (`"\\("`) or pass `-F` for a literal match.
 `>`, `&&`, `$()`, and `*` receive no shell interpretation — so run dependent
 commands as ordinary MoonBit statements and branch on their exit codes. Bulky
 output goes to a file under `@fs.tmpdir(prefix="run-")` through
-`stdout=ToFile(...)` (the label is required) and is read back in part.
+`stdout=ToFile(...)` (the label is required; that directory is the one place a
+snippet may write — `/tmp` itself is refused) and is read back in part.
 
 Shell utilities such as `ls`, `cat`, and `sh` are refused; each is a line of
 MoonBit here, which also works on Windows, where the binaries do not exist:

--- a/eval/prompt_tasks/toml_parser_cli.md
+++ b/eval/prompt_tasks/toml_parser_cli.md
@@ -1,8 +1,5 @@
-You are running a MoonBit prompt A/B eval.
-
-Workspace: {{WORKSPACE}}
-
-Build a small MoonBit TOML parser library and native CLI in that workspace.
+Build a small MoonBit TOML parser library and native CLI in the current
+workspace.
 
 Requirements:
 

--- a/moon.mod
+++ b/moon.mod
@@ -4,7 +4,7 @@ version = "0.2.2"
 
 import {
   "moonbit-community/tty@0.3.0",
-  "moonbitlang/async@0.21.0",
+  "moonbitlang/async@0.21.1",
   "moonbitlang/x@0.4.50",
   "moonbit-community/displaytext@0.1.5",
   "tonyfettes/xlog@0.4.0",

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -34,8 +34,15 @@ full diagnostics.
 There is no shell tool. Every command — `moon`, `git`, anything else — is
 spawned from a `mbtx` snippet through the shell-free
 `moonbitlang/async/shell` API. The `source` argument is a whole `.mbtx`
-program: import every package it uses separately and keep `async fn main` for
-async IO.
+program:
+
+- Import every package it uses separately.
+- Keep `async fn main` for async IO.
+- Helpers that run a command or do IO are `async fn` too, without `noraise`;
+  a plain `fn` cannot call them.
+- There is no `await`: async calls are written normally, and async functions
+  and tests are marked `async`.
+- There is no `print`.
 
 A minimal script can inspect paths without spawning a process:
 
@@ -43,6 +50,7 @@ A minimal script can inspect paths without spawning a process:
 ///|
 import {
   "moonbitlang/async",
+  "moonbitlang/async/fs",
   "moonbitlang/async/shell",
 }
 
@@ -51,6 +59,9 @@ async fn main {
   for path in @shell.glob("*.mbt") {
     println(path)
   }
+  for name in @fs.readdir(".") {
+    println(name)
+  }
 }
 ```
 
@@ -58,11 +69,52 @@ async fn main {
 parsing; its sorted matches are ordinary `Array[String]` values. A pattern
 that matches nothing returns an empty array.
 
+Use `@shell.Cmd` to run an external program and capture its output. Only
+these programs can be started:
+
+- `moon` — check, test, build, bench, run, fmt, info, add, remove, update,
+  install, tree, clean, new, ide, doc, explain, coverage, cram, package,
+  version, plus `publish --dry-run`. (Not plain `publish`, `login` or
+  `register`.)
+- `proton_cli` — `--version`, `--help`, new, dev, build, package, doctor,
+  cef, and updater. Set `Cmd.cwd` for the project directory; the global
+  `-C`/`--cwd` options before the subcommand are refused.
+- `git` — status, log, diff, show, blame, describe, rev-parse, rev-list,
+  show-ref, for-each-ref, cat-file, check-ignore, merge-base, range-diff,
+  ls-files, ls-tree, ls-remote, shortlog, grep, branch, tag, remote, reflog,
+  add, commit, checkout, switch, restore, reset, revert, rm, init, fetch,
+  push, rebase; plus `submodule update|status`, `worktree list|add|prune`,
+  `stash list|show`. Not `config`. A global option BEFORE the subcommand
+  (`-c`, `-C`, `--git-dir`, `--work-tree`) is refused.
+- `gh` — pr, issue, run, `repo view`, api, `auth status`.
+- `rg` and `diff`.
+
+Anything else is refused, including the obvious ones such as `ls`, `cat`, and
+`sh`. Each of those is a line of MoonBit here, which also works on Windows,
+where the binaries do not exist:
+
+| Command     | Alternatives     |
+|-------------|------------------|
+| ls          | @fs.readdir(dir) |
+| find        | @shell.glob(pattern) |
+| cat         | @fs.read_file(p).text() |
+| head/tail   | slice the split text; wc -l → count it |
+| grep        | rg, or .split("\n").filter(...) on captured output |
+| sort/uniq   | .sort(), a Set, or a Map |
+| pwd         | @env.current_dir(); printenv → @env.get_env_var(name) |
+| mkdir -p    | @fs.mkdir(d, recursive=true) |
+| test -f     | @fs.exists(p); test -d → @fs.kind(p) is Directory |
+| echo/printf | println |
+| rm/mv/cp    | the `remove` and `write` tools; a snippet cannot write the workspace, and `remove` refuses files it did not create — a refusal there is an answer, not an obstacle to route past |
+| sh -c, xargs, make | write the logic as MoonBit statements |
+
+If a refused command is genuinely what the task needs, say so rather than
+working around it — the `mbtx` tool description states the refusal and
+escalation rules.
+
 The plain command shape captures both streams and reads them back through
 `Output`'s accessor methods — `out.stdout()`, `out.stderr()`, and
-`out.exit_code()`. Running a `Cmd` (`.output()`, `.status()`, `.each_line()`)
-is async and may raise, so it lives in `async fn main` or an `async fn`
-helper without `noraise` — a plain `fn` wrapper cannot call it:
+`out.exit_code()`:
 
 ```mbt nocheck
 ///|
@@ -440,9 +492,7 @@ import {
 
 supported_targets = "+native"
 
-options(
-  "is-main": true,
-)
+pkgtype(kind: "executable")
 ```
 
 ## Proton CLI Workflow
@@ -486,8 +536,6 @@ options(
   file.mbt:line:col` for types.
 - Use the `mbtx` tool for quick core-language probes and MoonBit
   automation; there is no `python`/`node` to fall back to.
-- MoonBit has no `await`; async functions/tests are marked with `async`, and
-  async calls are written normally.
 - Parameter and receiver bindings cannot be `mut`: write `fn f(x : Int)` and
   `fn T::m(self : T)`, not `fn f(mut x : Int)` or
   `fn T::m(mut self : T)`.
@@ -503,6 +551,31 @@ options(
 test {
   let n : Int = @string.from_str("123")
   debug_inspect(n, content="123")
+}
+```
+
+- Write lambdas as arrow functions, `x => ...` or `(a, b) => { ... }`, not
+  `fn(x) { ... }`. One parameter needs no parentheses and an expression body
+  needs no braces; several parameters are parenthesized and a body with
+  statements takes braces. A lambda that must be async is spelled
+  `async fn(x) { ... }`; `async (x) => ...` does not parse:
+
+```mbt check
+///|
+test {
+  let words = ["moon", "bit", "shell"]
+  let lengths = words.map(w => w.length())
+  let pairs = words.map(w => (w, w.length()))
+  pairs.sort_by((a, b) => {
+    let by_length = a.1.compare(b.1)
+    if by_length != 0 {
+      by_length
+    } else {
+      a.0.compare(b.0)
+    }
+  })
+  debug_inspect(lengths, content="[4, 3, 5]")
+  debug_inspect(pairs, content="[(\"bit\", 3), (\"moon\", 4), (\"shell\", 5)]")
 }
 ```
 

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -36,7 +36,9 @@ spawned from a `mbtx` snippet through the shell-free
 `moonbitlang/async/shell` API. The `source` argument is a whole `.mbtx`
 program:
 
-- Import every package it uses separately.
+- Import every package it uses separately, core packages included and by
+  their real path: `moonbitlang/core/encoding/base64`, not
+  `moonbitlang/core/base64` — `moon ide doc "@base64"` prints the path.
 - Keep `async fn main` for async IO.
 - Helpers that run a command or do IO are `async fn` too, without `noraise`;
   a plain `fn` cannot call them.
@@ -52,6 +54,7 @@ import {
   "moonbitlang/async",
   "moonbitlang/async/fs",
   "moonbitlang/async/shell",
+  "moonbitlang/core/env",
 }
 
 ///|
@@ -62,8 +65,16 @@ async fn main {
   for name in @fs.readdir(".") {
     println(name)
   }
+  guard @env.get_env_var("HOME") is Some(home) else {
+    println("HOME is not set")
+    return
+  }
+  println("\{home}/.moon exists: \{@fs.exists("\{home}/.moon")}")
 }
 ```
+
+`@env.get_env_var` and `@env.current_dir` return `String?`: unwrap before
+interpolating, or `"\{home}/.moon"` renders as `Some(/Users/me)/.moon`.
 
 `@shell.glob` expands `*`, `?`, character sets, and `**` without shell
 parsing; its sorted matches are ordinary `Array[String]` values. A pattern
@@ -101,7 +112,7 @@ where the binaries do not exist:
 | head/tail   | slice the split text; wc -l → count it |
 | grep        | rg, or .split("\n").filter(...) on captured output |
 | sort/uniq   | .sort(), a Set, or a Map |
-| pwd         | @env.current_dir(); printenv → @env.get_env_var(name) |
+| pwd         | @env.current_dir(); printenv → @env.get_env_var(name) — both `String?` |
 | mkdir -p    | @fs.mkdir(d, recursive=true) |
 | test -f     | @fs.exists(p); test -d → @fs.kind(p) is Directory |
 | echo/printf | println |
@@ -139,9 +150,9 @@ exits 1 when nothing matched, so read `exit_code()` rather than treating the
 call as failed. A regex needle is one ordinary string element: double the
 backslashes MoonBit needs (`"\\("`) or pass `-F` for a literal match. For
 bulky output, redirect with `stdout=ToFile(...)` to a file under
-`@fs.tmpdir(prefix="run-")` — the label is required and the call creates the
-directory, the one place a snippet may write — and read only the needed
-excerpt; `.status()` returns just the exit code when the output does not
+`@fs.tmpdir(prefix="run-")` — the label is required, the call creates the
+directory, and that directory is the one place a snippet may write (`/tmp`
+itself is refused) — and read only the needed excerpt; `.status()` returns just the exit code when the output does not
 matter.
 
 For compiler feedback, stream the line-delimited JSON from one `moon check`
@@ -219,7 +230,8 @@ tools that rewrite source as their job (`moon fmt`, `moon info`,
   structured alternative to commenting it out.
 - `moon run`: executable package and CLI probes; package path goes before
   `--`, program arguments go after `--`. Example:
-  `moon run --target native cmd/tomljson -- /tmp/input.toml`.
+  `moon run --target native cmd/tomljson -- input.toml` (a file the `write` tool
+  put in the workspace).
 - `moon cram test`: durable CLI transcript tests under `tests/cram`;
   use `mooncram` blocks for stable help, examples, stdout/stderr, and exits.
   Example: `moon cram test tests/cram`.
@@ -831,7 +843,8 @@ fn config_from_matches(matches : @argparse.Matches) -> Config raise {
 
 - In `moon run`, the package path goes before `--`; program arguments go after
   `--`. Example file probe:
-  `moon run --target native cmd/tomljson -- /tmp/input.toml`.
+  `moon run --target native cmd/tomljson -- input.toml` (a file the `write` tool
+  put in the workspace).
 - Example stdin probe (no pipes — feed stdin directly):
   `@shell.Cmd("moon", ["run", "--target", "native", "cmd/tomljson", "--",
   "--stdin"], stdin=Text("a.b = 1\n"))`.

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -32,13 +32,166 @@ full diagnostics.
 ## Running Commands
 
 There is no shell tool. Every command — `moon`, `git`, anything else — is
-spawned from a `mbtx` snippet; that tool's description carries the shape
-of a snippet and the list of programs one may start.
+spawned from a `mbtx` snippet through the shell-free
+`moonbitlang/async/shell` API. The `source` argument is a whole `.mbtx`
+program: import every package it uses separately and keep `async fn main` for
+async IO.
+
+A minimal script can inspect paths without spawning a process:
+
+```mbt nocheck
+///|
+import {
+  "moonbitlang/async",
+  "moonbitlang/async/shell",
+}
+
+///|
+async fn main {
+  for path in @shell.glob("*.mbt") {
+    println(path)
+  }
+}
+```
+
+`@shell.glob` expands `*`, `?`, character sets, and `**` without shell
+parsing; its sorted matches are ordinary `Array[String]` values. A pattern
+that matches nothing returns an empty array.
+
+The plain command shape captures both streams and reads them back through
+`Output`'s accessor methods — `out.stdout()`, `out.stderr()`, and
+`out.exit_code()`. Running a `Cmd` (`.output()`, `.status()`, `.each_line()`)
+is async and may raise, so it lives in `async fn main` or an `async fn`
+helper without `noraise` — a plain `fn` wrapper cannot call it:
+
+```mbt nocheck
+///|
+import {
+  "moonbitlang/async",
+  "moonbitlang/async/shell",
+}
+
+///|
+async fn main {
+  let out = @shell.Cmd("rg", [
+    "-n", "protect_from_cancel\\(", "-g", "*.mbt", "src",
+  ]).output()
+  println(out.stdout())
+  println(out.stderr())
+  println("exit=\{out.exit_code()}")
+}
+```
+
+`.output()` reports the program's exit code instead of raising on it; `rg`
+exits 1 when nothing matched, so read `exit_code()` rather than treating the
+call as failed. A regex needle is one ordinary string element: double the
+backslashes MoonBit needs (`"\\("`) or pass `-F` for a literal match. For
+bulky output, redirect with `stdout=ToFile(...)` to a file under
+`@fs.tmpdir(prefix="run-")` — the label is required and the call creates the
+directory, the one place a snippet may write — and read only the needed
+excerpt; `.status()` returns just the exit code when the output does not
+matter.
+
+For compiler feedback, stream the line-delimited JSON from one `moon check`
+rather than collecting it and parsing it afterward:
+
+```mbt nocheck
+///|
+import {
+  "moonbitlang/async",
+  "moonbitlang/async/shell",
+  "moonbitlang/core/json",
+}
+
+///|
+async fn main {
+  let mut errors = 0
+  let exit_code = @shell.Cmd(
+    "moon",
+    ["check", "--output-json", "--diagnostic-limit", "5"],
+    env={ "NO_COLOR": "1" },
+  ).each_line() <| line => {
+    let diagnostic = @json.parse(line) catch { _ => return }
+    if diagnostic
+      is {
+        "level": String("error"),
+        "path": String(path),
+        "loc": String(loc),
+        "message": String(message),
+        ..
+      } {
+      errors += 1
+      println("\{path}:\{loc}  \{message}")
+    }
+  }
+  println("exit=\{exit_code} errors=\{errors}")
+}
+```
+
+`each_line` hands each stdout line to an async callback as it arrives and
+returns the exit code, so bind that `Int` (or `ignore` it): a bare statement
+does not compile. Its callback is async too. Completed lines are not
+retained. Stderr is inherited, so `mbtx` still
+includes Moon's summary in its merged output.
+
+`@shell.Cmd(program, arguments)` passes its argument vector literally: `|`,
+`>`, `&&`, `$()`, and `*` receive no shell interpretation. Run dependent
+commands as ordinary MoonBit statements and branch on their exit codes.
+
+`mbtx` is both the command runner (via `@shell.Cmd`) and the scripting surface
+for reading and transforming files, parsing JSON, computing, and running quick
+language or API probes. Its tool description owns the enforced process and
+isolation contract; the examples above own the working syntax. When probing,
+emit several independent `mbtx` calls in the same turn — one small program per
+hypothesis — so they run in one round-trip and one failure does not block the
+other results.
 
 Make your own source edits with `edit`/`multi_edit`/`write`, which are
 line-anchored and reviewable — not by having a snippet rewrite files. The
 tools that rewrite source as their job (`moon fmt`, `moon info`,
 `moon test --update`, `git checkout`) do run normally.
+
+### Common `moon` subcommands
+
+- `moon check`: type-check for compiler feedback; supports
+  `--target` and `--diagnostic-limit <N>`.
+- `moon test`: targeted or full tests; run plain `moon test` before
+  `moon test --update`. Example: `moon test parser --filter "Parser::*"
+  --diagnostic-limit 5`. Filters support glob syntax. This is THE way to
+  exercise local package code: write a black-box `_test.mbt` test and run it
+  with `--filter` — never probe local packages through `moon run -e` (see
+  below). To keep a test but not run it, annotate it `#skip("reason")`: still
+  type-checked, but run only with `--include-skipped` (or `-i <index>`, which
+  implies it) — plain `moon test --filter` will not run it. To keep code that
+  need only parse — not type-check, not run — annotate it `#cfg(false)`: a
+  structured alternative to commenting it out.
+- `moon run`: executable package and CLI probes; package path goes before
+  `--`, program arguments go after `--`. Example:
+  `moon run --target native cmd/tomljson -- /tmp/input.toml`.
+- `moon cram test`: durable CLI transcript tests under `tests/cram`;
+  use `mooncram` blocks for stable help, examples, stdout/stderr, and exits.
+  Example: `moon cram test tests/cram`.
+- `moon info`: regenerate and inspect `.mbti` interface files.
+- `moon fmt`: format MoonBit sources before finishing. Example:
+  `moon fmt --check parser`.
+- `moon build`: check build artifacts or backend-specific builds. Example:
+  `moon build --target native cmd/tool --diagnostic-limit 5`.
+- `moon doc` and `moon explain`: documentation and diagnostic help.
+- `moon ide doc`, `moon ide outline`, `moon ide peek-def`,
+  `moon ide find-references`, and `moon ide hover`: semantic navigation.
+  Verified examples: `moon ide doc "@json.parse"`,
+  `moon ide outline parser`, `moon ide peek-def parse --loc
+  src/parser.mbt:42:9`, `moon ide find-references parse --loc
+  src/parser.mbt:42:9`, and `moon ide hover parse --loc src/parser.mbt:42:9`.
+- `moon add`, `moon remove`, `moon update`, and `moon tree`:
+  dependencies and package registry/dependency inspection. Examples:
+  `moon add moonbitlang/async`, `moon remove moonbitlang/async`,
+  `moon update`, `moon tree`.
+- `moon clean`: clear `_build` when stale build output is suspected.
+  Example: `moon clean`.
+- `moon bench`: run benchmarks, e.g. `moon bench lib/parser`.
+- `moon coverage analyze`: inspect test coverage when coverage matters.
+  Example: `moon coverage analyze --package user/project/parser`.
 
 ## Tool Protocol
 
@@ -77,7 +230,7 @@ tools that rewrite source as their job (`moon fmt`, `moon info`,
     matter in MoonBit, and an append cannot mismatch an anchor. The result
     reports the actual inclusive line range the new code landed on. Insert
     mid-file only when grouping related code.
-  - `mbtx` with `@myshell.Cmd` for all Moon commands, including
+  - `mbtx` with `@shell.Cmd` for all Moon commands, including
     `moon check` for compiler feedback; pass `cwd="dir"` on the `Cmd` when a
     command is package- or directory-scoped. If a run reports that source file
     writes are blocked, retry compiler feedback fixes with line-anchored `edit`
@@ -122,31 +275,8 @@ tools that rewrite source as their job (`moon fmt`, `moon info`,
       ])
 - Keep reads focused. Use bounded reads for large files and logs.
 
-Common `moon` subcommands:
+### Review And Delegation Tools
 
-- `moon check`: type-check for compiler feedback; supports
-  `--target` and `--diagnostic-limit <N>`.
-- `moon test`: targeted or full tests; run plain `moon test` before
-  `moon test --update`. Example: `moon test parser --filter "Parser::*"
-  --diagnostic-limit 5`. Filters support glob syntax. This is THE way to
-  exercise local package code: write a black-box `_test.mbt` test and run it
-  with `--filter` — never probe local packages through `moon run -e` (see
-  below). To keep a test but not run it, annotate it `#skip("reason")`: still
-  type-checked, but run only with `--include-skipped` (or `-i <index>`, which
-  implies it) — plain `moon test --filter` will not run it. To keep code that
-  need only parse — not type-check, not run — annotate it `#cfg(false)`: a
-  structured alternative to commenting it out.
-- `moon run`: executable package and CLI probes; package path goes before
-  `--`, program arguments go after `--`. Example:
-  `moon run --target native cmd/tomljson -- /tmp/input.toml`.
-- `mbtx` tool: BOTH your command runner (via `@myshell.Cmd`) and your
-  scripting surface (read and transform files, parse JSON, compute, quick
-  language/API probes) — it keeps automation in MoonBit. Its own description is
-  the full contract. When probing, emit several independent
-  `mbtx` calls in the SAME turn — one small program per hypothesis —
-  rather than one probe per turn or one mega-program: batched probes come back
-  together, cost one round-trip, and a failing hypothesis never blocks the
-  others from answering.
 - `review` tool: before declaring substantial work or a standing goal
   complete, request an independent worktree audit — a review subagent reads
   the files, runs the project's own checks, hunts for vacuous success, and
@@ -192,6 +322,9 @@ Common `moon` subcommands:
   diagnostic; group by error code (a small script), derive each group's
   file list, and give each worker one group with those files as
   `allowed_paths`. Not for work you can do yourself in a few edits.
+
+## Git Authorship And Shipping
+
 - Attribute Git work you author:
   - End every commit message you write with
     `Co-Authored-By: SeekMoon <noreply@moonbitlang.cn>` as its own final
@@ -241,30 +374,6 @@ Common `moon` subcommands:
     timeouts, flaky runners): rerun once, and if it repeats, say so plainly
     instead of papering over it. A red check you cannot explain is a
     finding to report, not a detail to omit.
-- `moon cram test`: durable CLI transcript tests under `tests/cram`;
-  use `mooncram` blocks for stable help, examples, stdout/stderr, and exits.
-  Example: `moon cram test tests/cram`.
-- `moon info`: regenerate and inspect `.mbti` interface files.
-- `moon fmt`: format MoonBit sources before finishing. Example:
-  `moon fmt --check parser`.
-- `moon build`: check build artifacts or backend-specific builds. Example:
-  `moon build --target native cmd/tool --diagnostic-limit 5`.
-- `moon doc` and `moon explain`: documentation and diagnostic help.
-- `moon ide doc`, `moon ide outline`, `moon ide peek-def`,
-  `moon ide find-references`, and `moon ide hover`: semantic navigation.
-  Verified examples: `moon ide doc "@json.parse"`,
-  `moon ide outline parser`, `moon ide peek-def parse --loc
-  src/parser.mbt:42:9`, `moon ide find-references parse --loc
-  src/parser.mbt:42:9`, and `moon ide hover parse --loc src/parser.mbt:42:9`.
-- `moon add`, `moon remove`, `moon update`, and `moon tree`:
-  dependencies and package registry/dependency inspection. Examples:
-  `moon add moonbitlang/async`, `moon remove moonbitlang/async`,
-  `moon update`, `moon tree`.
-- `moon clean`: clear `_build` when stale build output is suspected.
-  Example: `moon clean`.
-- `moon bench`: run benchmarks, e.g. `moon bench lib/parser`.
-- `moon coverage analyze`: inspect test coverage when coverage matters.
-  Example: `moon coverage analyze --package user/project/parser`.
 
 ## MoonBit Project Setup
 
@@ -647,7 +756,7 @@ fn config_from_matches(matches : @argparse.Matches) -> Config raise {
   `--`. Example file probe:
   `moon run --target native cmd/tomljson -- /tmp/input.toml`.
 - Example stdin probe (no pipes — feed stdin directly):
-  `@myshell.Cmd("moon", ["run", "--target", "native", "cmd/tomljson", "--",
+  `@shell.Cmd("moon", ["run", "--target", "native", "cmd/tomljson", "--",
   "--stdin"], stdin=Text("a.b = 1\n"))`.
 - Implement stdin mode with `@stdio.stdin.read_all().text()`, not
   `/dev/stdin` or C FFI.

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -543,6 +543,10 @@ pkgtype(kind: "executable")
   parse. Use it only for local rebinding — mutable maps/arrays are updated
   without rebinding — and use `mut field : T` only on struct fields that you
   assign, e.g. `self.field = value`.
+- Keywords are not identifiers: `test`, `suberror`, `type`, `method`, `ref`,
+  `opaque`, and `member` cannot name a variable, parameter, or field —
+  `let test = 0` is a parse error (`unexpected token `test``). Write
+  `test_count`, `suberror_lines`, `method_`.
 - Empty no-op expression is `()`. Do not write `{ }`; that is an empty map.
 - Match arms are separated by newlines or semicolons, not `|`:
 

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -817,13 +817,13 @@ fn config_from_matches(matches : @argparse.Matches) -> Config raise {
     {
       values: { "input"? : Some([input, ..]), .. },
       flags: { "stdin"? : Some(stdin), .. },
-      ..
-    } => { input, stdin, }
+      ..,
+    } => { input, stdin }
     {
       values: { "input"? : Some([input, ..]), .. },
       flags: { "stdin"? : None, .. },
-      ..
-    } => { input, stdin: false, }
+      ..,
+    } => { input, stdin: false }
     _ => fail("missing parsed argument: input")
   }
 }

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -817,13 +817,13 @@ fn config_from_matches(matches : @argparse.Matches) -> Config raise {
     {
       values: { "input"? : Some([input, ..]), .. },
       flags: { "stdin"? : Some(stdin), .. },
-      ..,
-    } => { input, stdin }
+      ..
+    } => { input, stdin, }
     {
       values: { "input"? : Some([input, ..]), .. },
       flags: { "stdin"? : None, .. },
-      ..,
-    } => { input, stdin: false }
+      ..
+    } => { input, stdin: false, }
     _ => fail("missing parsed argument: input")
   }
 }

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -548,6 +548,10 @@ fn default_prompt() -> String {
     #|  parse. Use it only for local rebinding — mutable maps/arrays are updated
     #|  without rebinding — and use `mut field : T` only on struct fields that you
     #|  assign, e.g. `self.field = value`.
+    #|- Keywords are not identifiers: `test`, `suberror`, `type`, `method`, `ref`,
+    #|  `opaque`, and `member` cannot name a variable, parameter, or field —
+    #|  `let test = 0` is a parse error (`unexpected token `test``). Write
+    #|  `test_count`, `suberror_lines`, `method_`.
     #|- Empty no-op expression is `()`. Do not write `{ }`; that is an empty map.
     #|- Match arms are separated by newlines or semicolons, not `|`:
     #|

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -39,8 +39,15 @@ fn default_prompt() -> String {
     #|There is no shell tool. Every command — `moon`, `git`, anything else — is
     #|spawned from a `mbtx` snippet through the shell-free
     #|`moonbitlang/async/shell` API. The `source` argument is a whole `.mbtx`
-    #|program: import every package it uses separately and keep `async fn main` for
-    #|async IO.
+    #|program:
+    #|
+    #|- Import every package it uses separately.
+    #|- Keep `async fn main` for async IO.
+    #|- Helpers that run a command or do IO are `async fn` too, without `noraise`;
+    #|  a plain `fn` cannot call them.
+    #|- There is no `await`: async calls are written normally, and async functions
+    #|  and tests are marked `async`.
+    #|- There is no `print`.
     #|
     #|A minimal script can inspect paths without spawning a process:
     #|
@@ -48,6 +55,7 @@ fn default_prompt() -> String {
     #|///|
     #|import {
     #|  "moonbitlang/async",
+    #|  "moonbitlang/async/fs",
     #|  "moonbitlang/async/shell",
     #|}
     #|
@@ -56,6 +64,9 @@ fn default_prompt() -> String {
     #|  for path in @shell.glob("*.mbt") {
     #|    println(path)
     #|  }
+    #|  for name in @fs.readdir(".") {
+    #|    println(name)
+    #|  }
     #|}
     #|```
     #|
@@ -63,11 +74,52 @@ fn default_prompt() -> String {
     #|parsing; its sorted matches are ordinary `Array[String]` values. A pattern
     #|that matches nothing returns an empty array.
     #|
+    #|Use `@shell.Cmd` to run an external program and capture its output. Only
+    #|these programs can be started:
+    #|
+    #|- `moon` — check, test, build, bench, run, fmt, info, add, remove, update,
+    #|  install, tree, clean, new, ide, doc, explain, coverage, cram, package,
+    #|  version, plus `publish --dry-run`. (Not plain `publish`, `login` or
+    #|  `register`.)
+    #|- `proton_cli` — `--version`, `--help`, new, dev, build, package, doctor,
+    #|  cef, and updater. Set `Cmd.cwd` for the project directory; the global
+    #|  `-C`/`--cwd` options before the subcommand are refused.
+    #|- `git` — status, log, diff, show, blame, describe, rev-parse, rev-list,
+    #|  show-ref, for-each-ref, cat-file, check-ignore, merge-base, range-diff,
+    #|  ls-files, ls-tree, ls-remote, shortlog, grep, branch, tag, remote, reflog,
+    #|  add, commit, checkout, switch, restore, reset, revert, rm, init, fetch,
+    #|  push, rebase; plus `submodule update|status`, `worktree list|add|prune`,
+    #|  `stash list|show`. Not `config`. A global option BEFORE the subcommand
+    #|  (`-c`, `-C`, `--git-dir`, `--work-tree`) is refused.
+    #|- `gh` — pr, issue, run, `repo view`, api, `auth status`.
+    #|- `rg` and `diff`.
+    #|
+    #|Anything else is refused, including the obvious ones such as `ls`, `cat`, and
+    #|`sh`. Each of those is a line of MoonBit here, which also works on Windows,
+    #|where the binaries do not exist:
+    #|
+    #|| Command     | Alternatives     |
+    #||-------------|------------------|
+    #|| ls          | @fs.readdir(dir) |
+    #|| find        | @shell.glob(pattern) |
+    #|| cat         | @fs.read_file(p).text() |
+    #|| head/tail   | slice the split text; wc -l → count it |
+    #|| grep        | rg, or .split("\n").filter(...) on captured output |
+    #|| sort/uniq   | .sort(), a Set, or a Map |
+    #|| pwd         | @env.current_dir(); printenv → @env.get_env_var(name) |
+    #|| mkdir -p    | @fs.mkdir(d, recursive=true) |
+    #|| test -f     | @fs.exists(p); test -d → @fs.kind(p) is Directory |
+    #|| echo/printf | println |
+    #|| rm/mv/cp    | the `remove` and `write` tools; a snippet cannot write the workspace, and `remove` refuses files it did not create — a refusal there is an answer, not an obstacle to route past |
+    #|| sh -c, xargs, make | write the logic as MoonBit statements |
+    #|
+    #|If a refused command is genuinely what the task needs, say so rather than
+    #|working around it — the `mbtx` tool description states the refusal and
+    #|escalation rules.
+    #|
     #|The plain command shape captures both streams and reads them back through
     #|`Output`'s accessor methods — `out.stdout()`, `out.stderr()`, and
-    #|`out.exit_code()`. Running a `Cmd` (`.output()`, `.status()`, `.each_line()`)
-    #|is async and may raise, so it lives in `async fn main` or an `async fn`
-    #|helper without `noraise` — a plain `fn` wrapper cannot call it:
+    #|`out.exit_code()`:
     #|
     #|```mbt nocheck
     #|///|
@@ -445,9 +497,7 @@ fn default_prompt() -> String {
     #|
     #|supported_targets = "+native"
     #|
-    #|options(
-    #|  "is-main": true,
-    #|)
+    #|pkgtype(kind: "executable")
     #|```
     #|
     #|## Proton CLI Workflow
@@ -491,8 +541,6 @@ fn default_prompt() -> String {
     #|  file.mbt:line:col` for types.
     #|- Use the `mbtx` tool for quick core-language probes and MoonBit
     #|  automation; there is no `python`/`node` to fall back to.
-    #|- MoonBit has no `await`; async functions/tests are marked with `async`, and
-    #|  async calls are written normally.
     #|- Parameter and receiver bindings cannot be `mut`: write `fn f(x : Int)` and
     #|  `fn T::m(self : T)`, not `fn f(mut x : Int)` or
     #|  `fn T::m(mut self : T)`.
@@ -508,6 +556,31 @@ fn default_prompt() -> String {
     #|test {
     #|  let n : Int = @string.from_str("123")
     #|  debug_inspect(n, content="123")
+    #|}
+    #|```
+    #|
+    #|- Write lambdas as arrow functions, `x => ...` or `(a, b) => { ... }`, not
+    #|  `fn(x) { ... }`. One parameter needs no parentheses and an expression body
+    #|  needs no braces; several parameters are parenthesized and a body with
+    #|  statements takes braces. A lambda that must be async is spelled
+    #|  `async fn(x) { ... }`; `async (x) => ...` does not parse:
+    #|
+    #|```mbt check
+    #|///|
+    #|test {
+    #|  let words = ["moon", "bit", "shell"]
+    #|  let lengths = words.map(w => w.length())
+    #|  let pairs = words.map(w => (w, w.length()))
+    #|  pairs.sort_by((a, b) => {
+    #|    let by_length = a.1.compare(b.1)
+    #|    if by_length != 0 {
+    #|      by_length
+    #|    } else {
+    #|      a.0.compare(b.0)
+    #|    }
+    #|  })
+    #|  debug_inspect(lengths, content="[4, 3, 5]")
+    #|  debug_inspect(pairs, content="[(\"bit\", 3), (\"moon\", 4), (\"shell\", 5)]")
     #|}
     #|```
     #|

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -822,13 +822,13 @@ fn default_prompt() -> String {
     #|    {
     #|      values: { "input"? : Some([input, ..]), .. },
     #|      flags: { "stdin"? : Some(stdin), .. },
-    #|      ..,
-    #|    } => { input, stdin }
+    #|      ..
+    #|    } => { input, stdin, }
     #|    {
     #|      values: { "input"? : Some([input, ..]), .. },
     #|      flags: { "stdin"? : None, .. },
-    #|      ..,
-    #|    } => { input, stdin: false }
+    #|      ..
+    #|    } => { input, stdin: false, }
     #|    _ => fail("missing parsed argument: input")
     #|  }
     #|}

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -822,13 +822,13 @@ fn default_prompt() -> String {
     #|    {
     #|      values: { "input"? : Some([input, ..]), .. },
     #|      flags: { "stdin"? : Some(stdin), .. },
-    #|      ..
-    #|    } => { input, stdin, }
+    #|      ..,
+    #|    } => { input, stdin }
     #|    {
     #|      values: { "input"? : Some([input, ..]), .. },
     #|      flags: { "stdin"? : None, .. },
-    #|      ..
-    #|    } => { input, stdin: false, }
+    #|      ..,
+    #|    } => { input, stdin: false }
     #|    _ => fail("missing parsed argument: input")
     #|  }
     #|}

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -37,13 +37,166 @@ fn default_prompt() -> String {
     #|## Running Commands
     #|
     #|There is no shell tool. Every command — `moon`, `git`, anything else — is
-    #|spawned from a `mbtx` snippet; that tool's description carries the shape
-    #|of a snippet and the list of programs one may start.
+    #|spawned from a `mbtx` snippet through the shell-free
+    #|`moonbitlang/async/shell` API. The `source` argument is a whole `.mbtx`
+    #|program: import every package it uses separately and keep `async fn main` for
+    #|async IO.
+    #|
+    #|A minimal script can inspect paths without spawning a process:
+    #|
+    #|```mbt nocheck
+    #|///|
+    #|import {
+    #|  "moonbitlang/async",
+    #|  "moonbitlang/async/shell",
+    #|}
+    #|
+    #|///|
+    #|async fn main {
+    #|  for path in @shell.glob("*.mbt") {
+    #|    println(path)
+    #|  }
+    #|}
+    #|```
+    #|
+    #|`@shell.glob` expands `*`, `?`, character sets, and `**` without shell
+    #|parsing; its sorted matches are ordinary `Array[String]` values. A pattern
+    #|that matches nothing returns an empty array.
+    #|
+    #|The plain command shape captures both streams and reads them back through
+    #|`Output`'s accessor methods — `out.stdout()`, `out.stderr()`, and
+    #|`out.exit_code()`. Running a `Cmd` (`.output()`, `.status()`, `.each_line()`)
+    #|is async and may raise, so it lives in `async fn main` or an `async fn`
+    #|helper without `noraise` — a plain `fn` wrapper cannot call it:
+    #|
+    #|```mbt nocheck
+    #|///|
+    #|import {
+    #|  "moonbitlang/async",
+    #|  "moonbitlang/async/shell",
+    #|}
+    #|
+    #|///|
+    #|async fn main {
+    #|  let out = @shell.Cmd("rg", [
+    #|    "-n", "protect_from_cancel\\(", "-g", "*.mbt", "src",
+    #|  ]).output()
+    #|  println(out.stdout())
+    #|  println(out.stderr())
+    #|  println("exit=\{out.exit_code()}")
+    #|}
+    #|```
+    #|
+    #|`.output()` reports the program's exit code instead of raising on it; `rg`
+    #|exits 1 when nothing matched, so read `exit_code()` rather than treating the
+    #|call as failed. A regex needle is one ordinary string element: double the
+    #|backslashes MoonBit needs (`"\\("`) or pass `-F` for a literal match. For
+    #|bulky output, redirect with `stdout=ToFile(...)` to a file under
+    #|`@fs.tmpdir(prefix="run-")` — the label is required and the call creates the
+    #|directory, the one place a snippet may write — and read only the needed
+    #|excerpt; `.status()` returns just the exit code when the output does not
+    #|matter.
+    #|
+    #|For compiler feedback, stream the line-delimited JSON from one `moon check`
+    #|rather than collecting it and parsing it afterward:
+    #|
+    #|```mbt nocheck
+    #|///|
+    #|import {
+    #|  "moonbitlang/async",
+    #|  "moonbitlang/async/shell",
+    #|  "moonbitlang/core/json",
+    #|}
+    #|
+    #|///|
+    #|async fn main {
+    #|  let mut errors = 0
+    #|  let exit_code = @shell.Cmd(
+    #|    "moon",
+    #|    ["check", "--output-json", "--diagnostic-limit", "5"],
+    #|    env={ "NO_COLOR": "1" },
+    #|  ).each_line() <| line => {
+    #|    let diagnostic = @json.parse(line) catch { _ => return }
+    #|    if diagnostic
+    #|      is {
+    #|        "level": String("error"),
+    #|        "path": String(path),
+    #|        "loc": String(loc),
+    #|        "message": String(message),
+    #|        ..
+    #|      } {
+    #|      errors += 1
+    #|      println("\{path}:\{loc}  \{message}")
+    #|    }
+    #|  }
+    #|  println("exit=\{exit_code} errors=\{errors}")
+    #|}
+    #|```
+    #|
+    #|`each_line` hands each stdout line to an async callback as it arrives and
+    #|returns the exit code, so bind that `Int` (or `ignore` it): a bare statement
+    #|does not compile. Its callback is async too. Completed lines are not
+    #|retained. Stderr is inherited, so `mbtx` still
+    #|includes Moon's summary in its merged output.
+    #|
+    #|`@shell.Cmd(program, arguments)` passes its argument vector literally: `|`,
+    #|`>`, `&&`, `$()`, and `*` receive no shell interpretation. Run dependent
+    #|commands as ordinary MoonBit statements and branch on their exit codes.
+    #|
+    #|`mbtx` is both the command runner (via `@shell.Cmd`) and the scripting surface
+    #|for reading and transforming files, parsing JSON, computing, and running quick
+    #|language or API probes. Its tool description owns the enforced process and
+    #|isolation contract; the examples above own the working syntax. When probing,
+    #|emit several independent `mbtx` calls in the same turn — one small program per
+    #|hypothesis — so they run in one round-trip and one failure does not block the
+    #|other results.
     #|
     #|Make your own source edits with `edit`/`multi_edit`/`write`, which are
     #|line-anchored and reviewable — not by having a snippet rewrite files. The
     #|tools that rewrite source as their job (`moon fmt`, `moon info`,
     #|`moon test --update`, `git checkout`) do run normally.
+    #|
+    #|### Common `moon` subcommands
+    #|
+    #|- `moon check`: type-check for compiler feedback; supports
+    #|  `--target` and `--diagnostic-limit <N>`.
+    #|- `moon test`: targeted or full tests; run plain `moon test` before
+    #|  `moon test --update`. Example: `moon test parser --filter "Parser::*"
+    #|  --diagnostic-limit 5`. Filters support glob syntax. This is THE way to
+    #|  exercise local package code: write a black-box `_test.mbt` test and run it
+    #|  with `--filter` — never probe local packages through `moon run -e` (see
+    #|  below). To keep a test but not run it, annotate it `#skip("reason")`: still
+    #|  type-checked, but run only with `--include-skipped` (or `-i <index>`, which
+    #|  implies it) — plain `moon test --filter` will not run it. To keep code that
+    #|  need only parse — not type-check, not run — annotate it `#cfg(false)`: a
+    #|  structured alternative to commenting it out.
+    #|- `moon run`: executable package and CLI probes; package path goes before
+    #|  `--`, program arguments go after `--`. Example:
+    #|  `moon run --target native cmd/tomljson -- /tmp/input.toml`.
+    #|- `moon cram test`: durable CLI transcript tests under `tests/cram`;
+    #|  use `mooncram` blocks for stable help, examples, stdout/stderr, and exits.
+    #|  Example: `moon cram test tests/cram`.
+    #|- `moon info`: regenerate and inspect `.mbti` interface files.
+    #|- `moon fmt`: format MoonBit sources before finishing. Example:
+    #|  `moon fmt --check parser`.
+    #|- `moon build`: check build artifacts or backend-specific builds. Example:
+    #|  `moon build --target native cmd/tool --diagnostic-limit 5`.
+    #|- `moon doc` and `moon explain`: documentation and diagnostic help.
+    #|- `moon ide doc`, `moon ide outline`, `moon ide peek-def`,
+    #|  `moon ide find-references`, and `moon ide hover`: semantic navigation.
+    #|  Verified examples: `moon ide doc "@json.parse"`,
+    #|  `moon ide outline parser`, `moon ide peek-def parse --loc
+    #|  src/parser.mbt:42:9`, `moon ide find-references parse --loc
+    #|  src/parser.mbt:42:9`, and `moon ide hover parse --loc src/parser.mbt:42:9`.
+    #|- `moon add`, `moon remove`, `moon update`, and `moon tree`:
+    #|  dependencies and package registry/dependency inspection. Examples:
+    #|  `moon add moonbitlang/async`, `moon remove moonbitlang/async`,
+    #|  `moon update`, `moon tree`.
+    #|- `moon clean`: clear `_build` when stale build output is suspected.
+    #|  Example: `moon clean`.
+    #|- `moon bench`: run benchmarks, e.g. `moon bench lib/parser`.
+    #|- `moon coverage analyze`: inspect test coverage when coverage matters.
+    #|  Example: `moon coverage analyze --package user/project/parser`.
     #|
     #|## Tool Protocol
     #|
@@ -82,7 +235,7 @@ fn default_prompt() -> String {
     #|    matter in MoonBit, and an append cannot mismatch an anchor. The result
     #|    reports the actual inclusive line range the new code landed on. Insert
     #|    mid-file only when grouping related code.
-    #|  - `mbtx` with `@myshell.Cmd` for all Moon commands, including
+    #|  - `mbtx` with `@shell.Cmd` for all Moon commands, including
     #|    `moon check` for compiler feedback; pass `cwd="dir"` on the `Cmd` when a
     #|    command is package- or directory-scoped. If a run reports that source file
     #|    writes are blocked, retry compiler feedback fixes with line-anchored `edit`
@@ -127,31 +280,8 @@ fn default_prompt() -> String {
     #|      ])
     #|- Keep reads focused. Use bounded reads for large files and logs.
     #|
-    #|Common `moon` subcommands:
+    #|### Review And Delegation Tools
     #|
-    #|- `moon check`: type-check for compiler feedback; supports
-    #|  `--target` and `--diagnostic-limit <N>`.
-    #|- `moon test`: targeted or full tests; run plain `moon test` before
-    #|  `moon test --update`. Example: `moon test parser --filter "Parser::*"
-    #|  --diagnostic-limit 5`. Filters support glob syntax. This is THE way to
-    #|  exercise local package code: write a black-box `_test.mbt` test and run it
-    #|  with `--filter` — never probe local packages through `moon run -e` (see
-    #|  below). To keep a test but not run it, annotate it `#skip("reason")`: still
-    #|  type-checked, but run only with `--include-skipped` (or `-i <index>`, which
-    #|  implies it) — plain `moon test --filter` will not run it. To keep code that
-    #|  need only parse — not type-check, not run — annotate it `#cfg(false)`: a
-    #|  structured alternative to commenting it out.
-    #|- `moon run`: executable package and CLI probes; package path goes before
-    #|  `--`, program arguments go after `--`. Example:
-    #|  `moon run --target native cmd/tomljson -- /tmp/input.toml`.
-    #|- `mbtx` tool: BOTH your command runner (via `@myshell.Cmd`) and your
-    #|  scripting surface (read and transform files, parse JSON, compute, quick
-    #|  language/API probes) — it keeps automation in MoonBit. Its own description is
-    #|  the full contract. When probing, emit several independent
-    #|  `mbtx` calls in the SAME turn — one small program per hypothesis —
-    #|  rather than one probe per turn or one mega-program: batched probes come back
-    #|  together, cost one round-trip, and a failing hypothesis never blocks the
-    #|  others from answering.
     #|- `review` tool: before declaring substantial work or a standing goal
     #|  complete, request an independent worktree audit — a review subagent reads
     #|  the files, runs the project's own checks, hunts for vacuous success, and
@@ -197,6 +327,9 @@ fn default_prompt() -> String {
     #|  diagnostic; group by error code (a small script), derive each group's
     #|  file list, and give each worker one group with those files as
     #|  `allowed_paths`. Not for work you can do yourself in a few edits.
+    #|
+    #|## Git Authorship And Shipping
+    #|
     #|- Attribute Git work you author:
     #|  - End every commit message you write with
     #|    `Co-Authored-By: SeekMoon <noreply@moonbitlang.cn>` as its own final
@@ -246,30 +379,6 @@ fn default_prompt() -> String {
     #|    timeouts, flaky runners): rerun once, and if it repeats, say so plainly
     #|    instead of papering over it. A red check you cannot explain is a
     #|    finding to report, not a detail to omit.
-    #|- `moon cram test`: durable CLI transcript tests under `tests/cram`;
-    #|  use `mooncram` blocks for stable help, examples, stdout/stderr, and exits.
-    #|  Example: `moon cram test tests/cram`.
-    #|- `moon info`: regenerate and inspect `.mbti` interface files.
-    #|- `moon fmt`: format MoonBit sources before finishing. Example:
-    #|  `moon fmt --check parser`.
-    #|- `moon build`: check build artifacts or backend-specific builds. Example:
-    #|  `moon build --target native cmd/tool --diagnostic-limit 5`.
-    #|- `moon doc` and `moon explain`: documentation and diagnostic help.
-    #|- `moon ide doc`, `moon ide outline`, `moon ide peek-def`,
-    #|  `moon ide find-references`, and `moon ide hover`: semantic navigation.
-    #|  Verified examples: `moon ide doc "@json.parse"`,
-    #|  `moon ide outline parser`, `moon ide peek-def parse --loc
-    #|  src/parser.mbt:42:9`, `moon ide find-references parse --loc
-    #|  src/parser.mbt:42:9`, and `moon ide hover parse --loc src/parser.mbt:42:9`.
-    #|- `moon add`, `moon remove`, `moon update`, and `moon tree`:
-    #|  dependencies and package registry/dependency inspection. Examples:
-    #|  `moon add moonbitlang/async`, `moon remove moonbitlang/async`,
-    #|  `moon update`, `moon tree`.
-    #|- `moon clean`: clear `_build` when stale build output is suspected.
-    #|  Example: `moon clean`.
-    #|- `moon bench`: run benchmarks, e.g. `moon bench lib/parser`.
-    #|- `moon coverage analyze`: inspect test coverage when coverage matters.
-    #|  Example: `moon coverage analyze --package user/project/parser`.
     #|
     #|## MoonBit Project Setup
     #|
@@ -652,7 +761,7 @@ fn default_prompt() -> String {
     #|  `--`. Example file probe:
     #|  `moon run --target native cmd/tomljson -- /tmp/input.toml`.
     #|- Example stdin probe (no pipes — feed stdin directly):
-    #|  `@myshell.Cmd("moon", ["run", "--target", "native", "cmd/tomljson", "--",
+    #|  `@shell.Cmd("moon", ["run", "--target", "native", "cmd/tomljson", "--",
     #|  "--stdin"], stdin=Text("a.b = 1\n"))`.
     #|- Implement stdin mode with `@stdio.stdin.read_all().text()`, not
     #|  `/dev/stdin` or C FFI.

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -41,7 +41,9 @@ fn default_prompt() -> String {
     #|`moonbitlang/async/shell` API. The `source` argument is a whole `.mbtx`
     #|program:
     #|
-    #|- Import every package it uses separately.
+    #|- Import every package it uses separately, core packages included and by
+    #|  their real path: `moonbitlang/core/encoding/base64`, not
+    #|  `moonbitlang/core/base64` — `moon ide doc "@base64"` prints the path.
     #|- Keep `async fn main` for async IO.
     #|- Helpers that run a command or do IO are `async fn` too, without `noraise`;
     #|  a plain `fn` cannot call them.
@@ -57,6 +59,7 @@ fn default_prompt() -> String {
     #|  "moonbitlang/async",
     #|  "moonbitlang/async/fs",
     #|  "moonbitlang/async/shell",
+    #|  "moonbitlang/core/env",
     #|}
     #|
     #|///|
@@ -67,8 +70,16 @@ fn default_prompt() -> String {
     #|  for name in @fs.readdir(".") {
     #|    println(name)
     #|  }
+    #|  guard @env.get_env_var("HOME") is Some(home) else {
+    #|    println("HOME is not set")
+    #|    return
+    #|  }
+    #|  println("\{home}/.moon exists: \{@fs.exists("\{home}/.moon")}")
     #|}
     #|```
+    #|
+    #|`@env.get_env_var` and `@env.current_dir` return `String?`: unwrap before
+    #|interpolating, or `"\{home}/.moon"` renders as `Some(/Users/me)/.moon`.
     #|
     #|`@shell.glob` expands `*`, `?`, character sets, and `**` without shell
     #|parsing; its sorted matches are ordinary `Array[String]` values. A pattern
@@ -106,7 +117,7 @@ fn default_prompt() -> String {
     #|| head/tail   | slice the split text; wc -l → count it |
     #|| grep        | rg, or .split("\n").filter(...) on captured output |
     #|| sort/uniq   | .sort(), a Set, or a Map |
-    #|| pwd         | @env.current_dir(); printenv → @env.get_env_var(name) |
+    #|| pwd         | @env.current_dir(); printenv → @env.get_env_var(name) — both `String?` |
     #|| mkdir -p    | @fs.mkdir(d, recursive=true) |
     #|| test -f     | @fs.exists(p); test -d → @fs.kind(p) is Directory |
     #|| echo/printf | println |
@@ -144,9 +155,9 @@ fn default_prompt() -> String {
     #|call as failed. A regex needle is one ordinary string element: double the
     #|backslashes MoonBit needs (`"\\("`) or pass `-F` for a literal match. For
     #|bulky output, redirect with `stdout=ToFile(...)` to a file under
-    #|`@fs.tmpdir(prefix="run-")` — the label is required and the call creates the
-    #|directory, the one place a snippet may write — and read only the needed
-    #|excerpt; `.status()` returns just the exit code when the output does not
+    #|`@fs.tmpdir(prefix="run-")` — the label is required, the call creates the
+    #|directory, and that directory is the one place a snippet may write (`/tmp`
+    #|itself is refused) — and read only the needed excerpt; `.status()` returns just the exit code when the output does not
     #|matter.
     #|
     #|For compiler feedback, stream the line-delimited JSON from one `moon check`
@@ -224,7 +235,8 @@ fn default_prompt() -> String {
     #|  structured alternative to commenting it out.
     #|- `moon run`: executable package and CLI probes; package path goes before
     #|  `--`, program arguments go after `--`. Example:
-    #|  `moon run --target native cmd/tomljson -- /tmp/input.toml`.
+    #|  `moon run --target native cmd/tomljson -- input.toml` (a file the `write` tool
+    #|  put in the workspace).
     #|- `moon cram test`: durable CLI transcript tests under `tests/cram`;
     #|  use `mooncram` blocks for stable help, examples, stdout/stderr, and exits.
     #|  Example: `moon cram test tests/cram`.
@@ -836,7 +848,8 @@ fn default_prompt() -> String {
     #|
     #|- In `moon run`, the package path goes before `--`; program arguments go after
     #|  `--`. Example file probe:
-    #|  `moon run --target native cmd/tomljson -- /tmp/input.toml`.
+    #|  `moon run --target native cmd/tomljson -- input.toml` (a file the `write` tool
+    #|  put in the workspace).
     #|- Example stdin probe (no pipes — feed stdin directly):
     #|  `@shell.Cmd("moon", ["run", "--target", "native", "cmd/tomljson", "--",
     #|  "--stdin"], stdin=Text("a.b = 1\n"))`.


### PR DESCRIPTION
## Summary

- The default prompt now owns the `mbtx` tutorial and teaches the shell-free `moonbitlang/async/shell` API (`@shell.glob`, `.output()` read through `Output`'s accessor methods, `each_line` for streaming `moon check --output-json`); the tool description keeps only the enforced contract.
- `moonbitlang/async` 0.21.0 → 0.21.1.
- Mirror tests in `agent_tool/run_moonbit` run the prompt's example shapes through the real `mbtx` runner (`Output` accessors, streamed diagnostics, `@shell.glob`).
- The explore, review, audit, and worker prompts carry the same Running Commands block (checklist, `.output()` example with `Output` accessors, literal argument vectors, `@fs.tmpdir(prefix=)`, coreutils table) ahead of each role's own narrowing, since the tool description no longer teaches the snippet shape; READMEs that still said `bobzhang/myshell` now say `moonbitlang/async/shell`.
- The system prompt now also states the mbtx checklist (separate imports, `async fn main`, async helpers, no `await`/`print`), the program allowlist, and the coreutils-to-MoonBit table right after it; the tool description keeps the allowlist plus refusal/escalation rules and no longer carries the table. Arrow-lambda rule with a checked example; `pkgtype(kind: "executable")` in the moon.pkg example.

## Eval (deepseek-v4-flash, 10 trials per arm)

Arms are separately built binaries: **baseline** = `main` (`bobzhang/myshell` examples in the tool description), **draft** = first version of this prompt, **shipped** = this PR.

| task | metric | baseline | draft | shipped |
|---|---|---:|---:|---:|
| corpus audit (rg through `@shell.Cmd`, 6 graded sections) | audits fully correct | 10/10 | 9/10 | 10/10 |
| | rg calls whose first diagnostic sits on the `Cmd` line | 4/82 | 7/81 | **0/57** |
| | mean steps | 12.1 | 10.5 | 9.9 |
| TOML parser CLI (harness-validated) | validated trials | 10/10 | 9/10\* | 10/10 |
| | mean steps (finished) | 47.9 | 39.8 | 46.0 |

\* the one miss died at step 2 on `TlsError("bad decrypt")` mid-stream; the other nine validated.

The draft's seven Cmd-line failures were all in the `each_line` shape it taught: `Output` is opaque in `async/shell` (`out.stdout` → E4028), Cmd execution is async/raising so a plain `fn` or `noraise` helper cannot call it (E4122/E4014), and `each_line` returns the exit code (E4139 when ignored). The shipped text adds a plain `.output()` example with `out.stdout()`/`stderr()`/`exit_code()`, states the async-helper rule for every execution method, notes regex-needle escaping (`"\\("` or `-F`), and spells `@fs.tmpdir(prefix="run-")` (the label is required). The `Cmd("rg", [...], needle)` shape that motivated the check never appeared in any arm.

Full report (per-trial data, failure taxonomy, method): https://claude.ai/code/artifact/a68f3165-168a-4542-8512-c392fb8b7c43

## Test plan

- [x] `moon check --target native agent agent_tool/run_moonbit prompt --deny-warn`
- [x] `moon test --target native agent_tool/run_moonbit --filter "*Output accessors*"` / `"*async shell*"` / `"*glob*"`
- [x] `moon test --target native prompt` (19/19), `moon test --target native agent --filter "*shell tool family*"`
- [x] `moon fmt --check`; no `pkg.generated.mbti` drift
- [x] TOML regression run for the shipped prompt: 10/10 validated (two batches of 5 after a 402-truncated first attempt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
