### PR TITLE
feat(llm): add GLM 5.3 support

### DIFF
--- a/README.mbt.md
+++ b/README.mbt.md
@@ -1,8 +1,9 @@
 # bobzhang/openseek
 
-OpenSeek is a small MoonBit foundation for a DeepSeek-backed coding agent. The
-module is split into pure data, HTTP transport, agent orchestration, and a CLI
-entry point so request encoding can be tested without network access.
+OpenSeek is a small MoonBit foundation for an OpenAI-compatible coding agent
+supporting DeepSeek, Kimi, and Z.AI GLM models. The module is split into pure
+data, HTTP transport, agent orchestration, and a CLI entry point so request
+encoding can be tested without network access.
 
 For a picture of how the pieces fit together — module architecture, the core
 data model, and the life of one agent turn — see
@@ -54,8 +55,8 @@ git submodule update --init editor/vscode     # opt-in performance suite
 | Package | Purpose | Docs |
 | --- | --- | --- |
 | `bobzhang/openseek` | Root package and module overview. | `README.mbt.md` |
-| `bobzhang/openseek/deepseek` | Pure DeepSeek chat data, JSON encoding, and response decoding. | `deepseek/README.mbt.md` |
-| `bobzhang/openseek/deepseek/client` | Native-only HTTP transport for DeepSeek chat completions. | `deepseek/client/README.mbt.md` |
+| `bobzhang/openseek/deepseek` | Pure chat data, provider-aware JSON encoding, and response decoding. | `deepseek/README.mbt.md` |
+| `bobzhang/openseek/deepseek/client` | Native-only HTTP transport for supported chat-completions providers. | `deepseek/client/README.mbt.md` |
 | `bobzhang/openseek/agent_runtime` | Native-only agent task-group and extensible runtime event queue. | `agent_runtime/README.mbt.md` |
 | `bobzhang/openseek/agent_session` | Typed durable conversation state and DeepSeek message projection. | `agent_session/README.mbt.md` |
 | `bobzhang/openseek/agent_session/store` | Native filesystem-backed append-only session store. | `agent_session/store/README.mbt.md` |
@@ -149,11 +150,19 @@ export KIMI=sk-...
 moon run cmd/openseek -- --model kimi-k2.7-code-highspeed run "inspect this project"
 ```
 
+For Z.AI GLM models, set `GLM`:
+
+```bash
+export GLM=...
+moon run cmd/openseek -- --model glm-5.3 run "inspect this project"
+```
+
 `OPENSEEK_MODEL` is optional and defaults to `deepseek-v4-pro`.
 `OPENSEEK_MAX_STEPS` is optional; when omitted, turns are bounded by the
 model's context window (a checkpoint summary carries each turn into the
-next) rather than a step count. Pass `--max-steps` to cap steps for one run. `--thinking no|high|max` controls DeepSeek
-thinking mode and effort (default: max).
+next) rather than a step count. Pass `--max-steps` to cap steps for one run.
+`--thinking no|high|max` controls thinking mode and effort (default: max); GLM
+maps `no` to its lowest supported effort because GLM 5.3 always reasons.
 Pass `--dir <workspace>` to run one-shot commands against another workspace
 while still launching from the current shell. The default is `.`; if the final
 directory component is missing and its parent exists, OpenSeek creates it and

--- a/cmd/openseek/README.md
+++ b/cmd/openseek/README.md
@@ -36,14 +36,15 @@ moon run cmd/openseek -- run [--api-key sk-...] [--model deepseek-v4-pro] [--api
 ```
 
 Runs require `--api-key` or the provider-specific environment variable:
-`DEEPSEEK` for DeepSeek models and `KIMI` for Kimi models. `--model` can also
-be supplied with `OPENSEEK_MODEL`; it accepts `deepseek-v4-flash`,
-`deepseek-v4-pro`, `kimi-k2.7-code`, and `kimi-k2.7-code-highspeed`, and
-defaults to `deepseek-v4-pro`. `--max-steps` can also be supplied with
+`DEEPSEEK` for DeepSeek models, `KIMI` for Kimi models, and `GLM` for Z.AI GLM
+models. `--model` can also be supplied with `OPENSEEK_MODEL`; it accepts
+`deepseek-v4-flash`, `deepseek-v4-pro`, `kimi-k2.7-code`,
+`kimi-k2.7-code-highspeed`, `glm-5.3`, and `glm-5.3-flash`, and defaults to
+`deepseek-v4-pro`. `--max-steps` can also be supplied with
 `OPENSEEK_MAX_STEPS`; when omitted, turns are bounded by the model's context
 window instead of a step count. `--api-url` can also be supplied
-with `OPENSEEK_API_URL`; when omitted, OpenSeek uses the default DeepSeek chat
-completions endpoint, or the Kimi endpoint for Kimi models.
+with `OPENSEEK_API_URL`; when omitted, OpenSeek uses the official endpoint for
+the model's provider.
 `--dir` defaults to `.` and becomes the workspace root for relative prompt
 files, sessions, workspace skills, and agent tools. If the directory itself is
 missing but its parent exists, OpenSeek creates that final component and logs a
@@ -63,7 +64,7 @@ list` / `openseek sessions show <id>` (or the viz server) and resumable with
 `--session` is rejected.
 
 Without an explicit prompt file, the CLI uses the default built-in prompt
-(`prompt/default_prompt.mbt.md`) for the supported DeepSeek and Kimi model
+(`prompt/default_prompt.mbt.md`) for the supported DeepSeek, Kimi, and GLM model
 names. The older base prompt remains in `prompt/base_prompt.mbt.md` for
 comparison and experiments, but it is not selected by default.
 

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -1376,18 +1376,25 @@ test "cli defaults model and max steps" {
 }
 
 ///|
-test "cli uses KIMI only for Kimi models" {
+test "cli uses provider API keys only for their models" {
   let kimi = run_matches(argv=["write", "MoonBit"], env={
     "KIMI": "kimi-key",
     "OPENSEEK_MODEL": "kimi-k2.7-code-highspeed",
   })
   let kimi_model : @deepseek.Model = Kimi(K27CodeHighSpeed)
   assert_eq(kimi_model.api_key(kimi.values), Some("kimi-key"))
+  let glm = run_matches(argv=["write", "MoonBit"], env={
+    "GLM": "glm-key",
+    "OPENSEEK_MODEL": "glm-5.3-flash",
+  })
+  let glm_model : @deepseek.Model = Glm(G53Flash)
+  assert_eq(glm_model.api_key(glm.values), Some("glm-key"))
   let deepseek = run_matches(argv=["write", "MoonBit"], env={
     "KIMI": "kimi-key",
+    "GLM": "glm-key",
   })
-  // KIMI is not a fallback for a DeepSeek model: no arm matches, so the
-  // caller sees `None` and reports it.
+  // Provider keys are not fallbacks for a DeepSeek model: no arm matches, so
+  // the caller sees `None` and reports it.
   let deepseek_model : @deepseek.Model = Deepseek(V4Pro)
   assert_true(deepseek_model.api_key(deepseek.values) is None)
 }

--- a/cmd/tui/README.md
+++ b/cmd/tui/README.md
@@ -43,7 +43,7 @@ startup banner) stores the conversation under `--session-root` (default
 ## Configuration
 
 `--api-key` or a provider-specific key env is required: `DEEPSEEK` for DeepSeek
-models and `KIMI` for Kimi models. `--model`, `--api-url`,
+models, `KIMI` for Kimi models, and `GLM` for Z.AI GLM models. `--model`, `--api-url`,
 `--max-steps`, and `--thinking` mirror the engine's flags and are forwarded to
 it through the environment, alongside the session settings.
 

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -157,6 +157,7 @@ fn engine_extra_env(config : AppConfig) -> Map[String, String] {
   }
   let api_key_env = match config.model {
     Kimi(_) => "KIMI"
+    Glm(_) => "GLM"
     Deepseek(_) => "DEEPSEEK"
   }
   env[api_key_env] = config.api_key
@@ -1027,6 +1028,9 @@ test "engine configuration puts supported placement in argv" {
   let kimi_env = engine_extra_env({ ..config, model: Kimi(K27CodeHighSpeed) })
   assert_true(kimi_env.get("KIMI") == Some(config.api_key))
   assert_true(kimi_env.get("DEEPSEEK") is None)
+  let glm_env = engine_extra_env({ ..config, model: Glm(G53) })
+  assert_true(glm_env.get("GLM") == Some(config.api_key))
+  assert_true(glm_env.get("DEEPSEEK") is None)
   @debug.assert_eq(config.engine_command_args("run", ["--", "task"]), [
     "run", "--session=test", "--session-root=.openseek", "--dir=.", "--", "task",
   ])

--- a/cmd/tui/main.mbt
+++ b/cmd/tui/main.mbt
@@ -34,12 +34,20 @@ pub fn tui_shared_options(global? : Bool = false) -> Array[@argparse.OptionArg] 
       hidden=true,
     ),
     OptionArg(
+      "glm-api-key",
+      long="glm-api-key",
+      env="GLM",
+      default_values=[""],
+      global~,
+      hidden=true,
+    ),
+    OptionArg(
       "model",
       long="model",
       env="OPENSEEK_MODEL",
       default_values=[@deepseek.Deepseek(V4Pro).to_string()],
       global~,
-      about="Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, or kimi-k2.7-code-highspeed.",
+      about="Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, kimi-k2.7-code-highspeed, glm-5.3, or glm-5.3-flash.",
     ),
     OptionArg(
       "api-url",
@@ -47,7 +55,7 @@ pub fn tui_shared_options(global? : Bool = false) -> Array[@argparse.OptionArg] 
       env="OPENSEEK_API_URL",
       default_values=[""],
       global~,
-      about="DeepSeek-compatible chat completions endpoint.",
+      about="OpenAI-compatible chat completions endpoint.",
     ),
     OptionArg(
       "max-steps",
@@ -62,7 +70,7 @@ pub fn tui_shared_options(global? : Bool = false) -> Array[@argparse.OptionArg] 
       env="OPENSEEK_THINKING",
       default_values=["max"],
       global~,
-      about="DeepSeek thinking mode: no, high, or max.",
+      about="Model thinking mode: no, high, or max; GLM maps no to low effort.",
     ),
     OptionArg(
       "session",
@@ -497,7 +505,7 @@ test "cli parses api url" {
 }
 
 ///|
-test "cli uses KIMI only for Kimi models" {
+test "cli uses provider API keys only for their models" {
   let kimi = cli_command().parse(argv=[], env={
     "KIMI": "kimi-key",
     "OPENSEEK_MODEL": "kimi-k2.7-code-highspeed",
@@ -505,16 +513,26 @@ test "cli uses KIMI only for Kimi models" {
   let kimi_config = parse_config(kimi)
   assert_eq(kimi_config.api_key, "kimi-key")
   assert_true(kimi_config.model is Kimi(K27CodeHighSpeed))
-  // KIMI is not a fallback for a DeepSeek model: `Model::api_key` returns
+  let glm = cli_command().parse(argv=[], env={
+    "GLM": "glm-key",
+    "OPENSEEK_MODEL": "glm-5.3",
+  })
+  let glm_config = parse_config(glm)
+  assert_eq(glm_config.api_key, "glm-key")
+  assert_true(glm_config.model is Glm(G53))
+  // Provider keys do not fall back across models: `Model::api_key` returns
   // `None` and this main is the one that turns that into a failure.
-  let deepseek = cli_command().parse(argv=[], env={ "KIMI": "kimi-key" })
+  let deepseek = cli_command().parse(argv=[], env={
+    "KIMI": "kimi-key",
+    "GLM": "glm-key",
+  })
   let _ = parse_config(deepseek) catch {
     error => {
       assert_true("\{error}".contains("an API key is required"))
       return
     }
   }
-  fail("KIMI was accepted for a DeepSeek model")
+  fail("a non-DeepSeek key was accepted for a DeepSeek model")
 }
 
 ///|

--- a/deepseek/README.mbt.md
+++ b/deepseek/README.mbt.md
@@ -2,26 +2,28 @@
 
 This pure package provides strongly typed DeepSeek chat data and JSON
 encoding/decoding. Use it when constructing requests, parsing responses, or
-testing DeepSeek chat behavior without network access. The typed model list
-also covers Kimi K2.7 Code models where their request policy differs from
-DeepSeek's.
+testing compatible chat behavior without network access. The typed model list
+also covers Kimi K2.7 Code and Z.AI GLM 5.3 models where their request policies
+differ from DeepSeek's.
 
 The HTTP client lives in `bobzhang/openseek/deepseek/client`.
 
 ## API Shape
 
-- `Model`: provider-tagged chat models, e.g. `Deepseek(V4Pro)` and
-  `Kimi(K27Code)`, with `Show` for wire strings and `Debug` for inspection.
+- `Model`: provider-tagged chat models, e.g. `Deepseek(V4Pro)`,
+  `Kimi(K27Code)`, and `Glm(G53)`, with `Show` for wire strings and `Debug` for
+  inspection.
 - `Model::api_key(matches)`: resolves the key a command main should send for
   this model — an explicit `--api-key` first, then the provider-specific
-  option (`--deepseek-api-key` / `--kimi-api-key`, which the command tables
-  back with `DEEPSEEK` / `KIMI`), and `None` when neither is set. It is the
+  option (`--deepseek-api-key` / `--kimi-api-key` / `--glm-api-key`, which the
+  command tables back with `DEEPSEEK` / `KIMI` / `GLM`), and `None` when
+  neither is set. It is the
   shared answer to *where a key may come from*; whether a missing one is fatal,
   and what to say about it, is left to each command main. This is the one place
   in the package that reads parsed CLI options, and it lives here because the
   model tag is what decides which provider a key belongs to.
-- `ThinkingMode`: typed control for DeepSeek V4 thinking (`No`, `High`, or
-  `Max`).
+- `ThinkingMode`: typed thinking control (`No`, `High`, or `Max`), translated
+  to each provider's supported request policy.
 - `Role`: `System`, `User`, `Assistant`, and `Tool(tool_call_id)`, with `Show`
   for wire strings and `Debug` for inspection.
 - `ChatMessage(role, content=..., tool_calls?, reasoning_content?)`: one typed
@@ -34,7 +36,8 @@ The HTTP client lives in `bobzhang/openseek/deepseek/client`.
   model?=Deepseek(V4Pro)) <| messages`: builds the full DeepSeek chat completions request
   body. Streaming requests include usage-bearing stream options. Kimi K2.7 Code
   requests omit DeepSeek-specific thinking fields and preserve assistant
-  `reasoning_content`. The per-value
+  `reasoning_content`. GLM requests keep reasoning across tool turns and map
+  `No` to GLM's supported `low` effort. The per-value
   encoders for messages, tool definitions, and tool calls are package-private
   implementation details.
 - `ToolDefinition(name, description, parameters, strict?)`: a native DeepSeek
@@ -55,7 +58,7 @@ flowchart LR
   app["agent / tests"] --> root["deepseek\nmodels, messages, tools, JSON"]
   session["agent_session\nchat projection"] --> root
   client["deepseek/client\nHTTP, retries, SSE"] --> root
-  client --> api["DeepSeek / Kimi chat API"]
+  client --> api["DeepSeek / Kimi / Z.AI GLM chat API"]
 ```
 
 The core API is a set of public data types around chat request and response
@@ -70,6 +73,7 @@ classDiagram
     <<tagged union>>
     Deepseek(DsVariant)
     Kimi(KimiVariant)
+    Glm(GlmVariant)
     +parse(String) Model
   }
 
@@ -84,6 +88,16 @@ classDiagram
     K27Code
     K27CodeHighSpeed
   }
+
+  class GlmVariant {
+    <<enumeration>>
+    G53
+    G53Flash
+  }
+
+  Model --> DsVariant
+  Model --> KimiVariant
+  Model --> GlmVariant
 
   class ThinkingMode {
     <<enumeration>>
@@ -204,7 +218,7 @@ The usual sequence is:
 sequenceDiagram
   participant Caller
   participant Encoder as encode_chat_request
-  participant API as DeepSeek / Kimi API
+  participant API as chat-completions provider
   participant Tool as local tool
 
   Caller->>Encoder: messages + ToolDefinition[]

--- a/deepseek/api_key.mbt
+++ b/deepseek/api_key.mbt
@@ -36,6 +36,8 @@ pub fn Model::api_key(
       Some(k.trim().to_owned())
     (Kimi(_), { "kimi-api-key": [k, ..], .. }) if !k.is_blank() =>
       Some(k.trim().to_owned())
+    (Glm(_), { "glm-api-key": [k, ..], .. }) if !k.is_blank() =>
+      Some(k.trim().to_owned())
     _ => None
   }
 }

--- a/deepseek/client/README.mbt.md
+++ b/deepseek/client/README.mbt.md
@@ -1,10 +1,11 @@
 # DeepSeek Client
 
-This package is the effectful HTTP transport for DeepSeek chat completions. It
-uses `bobzhang/openseek/deepseek` for typed models, messages, tool definitions,
-request JSON encoding, and response JSON decoding.
+This package is the effectful HTTP transport for DeepSeek-, Kimi-, and
+Z.AI-compatible chat completions. It uses `bobzhang/openseek/deepseek` for typed
+models, messages, tool definitions, request JSON encoding, and response JSON
+decoding.
 
-Use this package when code needs to call the real DeepSeek API. Keep pure
+Use this package when code needs to call a supported provider API. Keep pure
 request/response tests in `bobzhang/openseek/deepseek`; use this package for
 transport behavior such as retries, HTTP errors, and streaming.
 
@@ -31,6 +32,8 @@ model is `deepseek-v4-pro`, and `thinking=No` is sent unless a different mode is
 provided. Kimi K2.7 Code models default to
 `https://api.moonshot.cn/v1/chat/completions` and omit DeepSeek-specific
 thinking fields when the request body is encoded.
+Z.AI GLM models default to `https://api.z.ai/api/paas/v4/chat/completions`;
+GLM 5.3 always reasons, so `thinking=No` maps to `reasoning_effort=low`.
 
 Retries cover transient failures: transport errors, HTTP 429, and HTTP 5xx.
 Other HTTP 4xx responses fail immediately. `retry_attempts` counts total tries;
@@ -71,7 +74,7 @@ Without `stream`, `Client::chat` builds the same JSON body as
 configuration, then posts it to `api_url` with `Content-Type:
 application/json` and bearer authorization.
 
-Use `tools=[...]` when the model may request native DeepSeek function calls.
+Use `tools=[...]` when the model may request native function calls.
 Use `response_format=JsonObject` only when the assistant content itself must be
 a JSON object.
 
@@ -215,5 +218,6 @@ The blackbox test suite includes a real DeepSeek API smoke test when `DEEPSEEK`
 is set. Kimi smoke tests are opt-in: set `KIMI` to a Kimi API key. The normal
 Kimi smoke also uses `OPENSEEK_MODEL` to choose the Kimi model; streaming,
 tool-call, and multi-turn reasoning-content smokes use `kimi-k2.7-code`.
+The GLM streaming tool-call smoke test runs when `GLM` is set.
 Without those environment variables, the smoke tests print skip messages and
 return successfully.

--- a/deepseek/client/client.mbt
+++ b/deepseek/client/client.mbt
@@ -5,12 +5,16 @@ const DeepSeekDefaultApiUrl : String = "https://api.deepseek.com/chat/completion
 const KimiDefaultApiUrl : String = "https://api.moonshot.cn/v1/chat/completions"
 
 ///|
+const GlmDefaultApiUrl : String = "https://api.z.ai/api/paas/v4/chat/completions"
+
+///|
 let default_model : @deepseek.Model = Deepseek(V4Pro)
 
 ///|
 fn default_api_url_for_model(model : @deepseek.Model) -> String {
   match model {
     Kimi(_) => KimiDefaultApiUrl
+    Glm(_) => GlmDefaultApiUrl
     Deepseek(_) => DeepSeekDefaultApiUrl
   }
 }

--- a/deepseek/client/client_realworld_test.mbt
+++ b/deepseek/client/client_realworld_test.mbt
@@ -189,3 +189,43 @@ async test "realworld Kimi API multi-turn reasoning-content smoke test" {
   assert_true(second.content.contains("done"))
   assert_true(second.usage.total_tokens > 0)
 }
+
+///|
+async test "realworld GLM streaming tool-call smoke test" {
+  guard @env.get_env_var("GLM") is Some(api_key) && api_key != "" else {
+    println(
+      "GLM environment variable is not set or is empty; skipping realworld GLM streaming tool-call smoke test",
+    )
+    return
+  }
+
+  let client = @client.Client(api_key~, model=Glm(G53), thinking=High)
+  let tool = @deepseek.ToolDefinition(
+    "return_token",
+    "Return the exact token requested by the user.",
+    {
+      "type": "object",
+      "properties": { "token": { "type": "string" } },
+      "required": ["token"],
+    },
+    strict=true,
+  )
+  let response = client.chat(
+    [
+      ChatMessage(
+        System,
+        content=(
+          #|You must call the return_token tool exactly once. Do not answer in text.
+        ),
+      ),
+      ChatMessage(User, content="Call return_token with token pong."),
+    ],
+    tools=[tool],
+    stream=StreamHandler(on_content_delta=_ => ()),
+  )
+  assert_eq(response.tool_calls.length(), 1)
+  assert_eq(response.tool_calls[0].name, "return_token")
+  assert_true(response.tool_calls[0].id != "")
+  assert_true(response.tool_calls[0].arguments.contains("pong"))
+  assert_true(response.usage.total_tokens > 0)
+}

--- a/deepseek/client/client_test.mbt
+++ b/deepseek/client/client_test.mbt
@@ -10,6 +10,8 @@ test "client defaults" {
 test "client endpoint defaults follow selected model" {
   let kimi = @client.Client(api_key="test-key", model=Kimi(K27Code))
   assert_eq(kimi.api_url, "https://api.moonshot.cn/v1/chat/completions")
+  let glm = @client.Client(api_key="test-key", model=Glm(G53))
+  assert_eq(glm.api_url, "https://api.z.ai/api/paas/v4/chat/completions")
   let proxied = @client.Client(
     api_key="test-key",
     model=Kimi(K27CodeHighSpeed),

--- a/deepseek/deepseek.mbt
+++ b/deepseek/deepseek.mbt
@@ -13,10 +13,18 @@ pub(all) enum KimiVariant {
 } derive(Eq, Debug)
 
 ///|
+/// Z.AI GLM chat model variants.
+pub(all) enum GlmVariant {
+  G53
+  G53Flash
+} derive(Eq, Debug)
+
+///|
 /// Supported chat models grouped by provider.
 pub(all) enum Model {
   Deepseek(DsVariant)
   Kimi(KimiVariant)
+  Glm(GlmVariant)
 } derive(Eq, Debug)
 
 ///|
@@ -38,11 +46,21 @@ impl Show for KimiVariant with fn to_string(self : KimiVariant) -> String {
 }
 
 ///|
+/// Returns the wire name for a Z.AI GLM chat model variant.
+impl Show for GlmVariant with fn to_string(self : GlmVariant) -> String {
+  match self {
+    G53 => "glm-5.3"
+    G53Flash => "glm-5.3-flash"
+  }
+}
+
+///|
 /// Returns the wire name for a chat model.
 pub impl Show for Model with fn to_string(self : Model) -> String {
   match self {
     Deepseek(variant) => "\{variant}"
     Kimi(variant) => "\{variant}"
+    Glm(variant) => "\{variant}"
   }
 }
 
@@ -54,6 +72,8 @@ pub fn Model::parse(input : String) -> Model raise {
     "deepseek-v4-pro" => Deepseek(V4Pro)
     "kimi-k2.7-code" => Kimi(K27Code)
     "kimi-k2.7-code-highspeed" => Kimi(K27CodeHighSpeed)
+    "glm-5.3" => Glm(G53)
+    "glm-5.3-flash" => Glm(G53Flash)
     other => fail("unknown model: \{other}")
   }
 }
@@ -71,6 +91,7 @@ pub fn Model::context_window(self : Model) -> Int {
   match self {
     Deepseek(V4Flash | V4Pro) => 1_000_000
     Kimi(K27Code | K27CodeHighSpeed) => 262_144
+    Glm(G53 | G53Flash) => 1_000_000
   }
 }
 
@@ -234,6 +255,12 @@ pub extend KimiVariant with Debug::{to_repr}
 
 ///|
 pub extend KimiVariant with Eq::{equal, not_equal}
+
+///|
+pub extend GlmVariant with Debug::{to_repr}
+
+///|
+pub extend GlmVariant with Eq::{equal, not_equal}
 
 ///|
 pub extend Model with Debug::{to_repr}

--- a/deepseek/deepseek_test.mbt
+++ b/deepseek/deepseek_test.mbt
@@ -21,6 +21,8 @@ test "model parsing" {
   assert_true(
     @deepseek.Model::parse("kimi-k2.7-code-highspeed") is Kimi(K27CodeHighSpeed),
   )
+  assert_true(@deepseek.Model::parse("glm-5.3") is Glm(G53))
+  assert_true(@deepseek.Model::parse("glm-5.3-flash") is Glm(G53Flash))
   assert_eq(
     @deepseek.Model::parse("deepseek-v4-flash").to_string(),
     "deepseek-v4-flash",
@@ -37,6 +39,11 @@ test "model parsing" {
     @deepseek.Model::parse("kimi-k2.7-code-highspeed").to_string(),
     "kimi-k2.7-code-highspeed",
   )
+  assert_eq(@deepseek.Model::parse("glm-5.3").to_string(), "glm-5.3")
+  assert_eq(
+    @deepseek.Model::parse("glm-5.3-flash").to_string(),
+    "glm-5.3-flash",
+  )
 }
 
 ///|
@@ -48,6 +55,8 @@ test "context windows per model" {
     (Kimi(K27CodeHighSpeed) : @deepseek.Model).context_window(),
     262_144,
   )
+  assert_eq((Glm(G53) : @deepseek.Model).context_window(), 1_000_000)
+  assert_eq((Glm(G53Flash) : @deepseek.Model).context_window(), 1_000_000)
 }
 
 ///|

--- a/deepseek/encode_chat_request_test.mbt
+++ b/deepseek/encode_chat_request_test.mbt
@@ -202,6 +202,69 @@ test "kimi highspeed uses the same code-model request policy" {
 }
 
 ///|
+test "glm maps no to low effort and preserves tool-turn reasoning" {
+  let call = @deepseek.ToolCall(
+    id="call_53",
+    name="shell",
+    arguments="{\"cmd\":\"moon test\"}",
+  )
+  let body = @deepseek.encode_chat_request(
+    model=Glm(G53),
+    thinking=No,
+    stream=true,
+  ) <| [
+    ChatMessage(User, content="run tests"),
+    ChatMessage(
+      Assistant,
+      content="",
+      tool_calls=[call],
+      reasoning_content="validate before finishing",
+    ),
+    ChatMessage(Tool("call_53"), content="exit=0\nok"),
+  ]
+  json_inspect(body, content={
+    "model": "glm-5.3",
+    "messages": [
+      { "role": "user", "content": "run tests" },
+      {
+        "role": "assistant",
+        "content": null,
+        "tool_calls": [
+          {
+            "id": "call_53",
+            "type": "function",
+            "function": {
+              "name": "shell",
+              "arguments": "{\"cmd\":\"moon test\"}",
+            },
+          },
+        ],
+        "reasoning_content": "validate before finishing",
+      },
+      { "role": "tool", "content": "exit=0\nok", "tool_call_id": "call_53" },
+    ],
+    "stream": true,
+    "stream_options": { "include_usage": true },
+    "thinking": { "type": "enabled", "clear_thinking": false },
+    "reasoning_effort": "low",
+  })
+}
+
+///|
+test "glm flash enables preserved thinking at max effort" {
+  let body = @deepseek.encode_chat_request(model=Glm(G53Flash), thinking=Max) <| [
+    ChatMessage(User, content="solve"),
+  ]
+  json_inspect(body, content={
+    "model": "glm-5.3-flash",
+    "messages": [{ "role": "user", "content": "solve" }],
+    "stream": false,
+    "thinking": { "type": "enabled", "clear_thinking": false },
+    "reasoning_effort": "max",
+  })
+}
+
+///|
 test "deepseek tool-enabled reasoning and tool result round-trip" {
   let tool = @deepseek.ToolDefinition("shell", "Run a shell command.", {
     "type": "object",

--- a/deepseek/json_encode.mbt
+++ b/deepseek/json_encode.mbt
@@ -1,12 +1,48 @@
 ///|
+/// Provider-specific thinking fields for a chat-completions request.
+///
+/// GLM-5.3 models cannot disable thinking. Map OpenSeek's lowest setting to
+/// GLM's `low` effort and preserve complete reasoning across agent tool turns.
+fn thinking_json_fields(
+  model : Model,
+  thinking : ThinkingMode?,
+) -> Array[(String, Json)] {
+  match (model, thinking) {
+    (Kimi(_), _) | (_, None) => []
+    (Glm(_), Some(mode)) => {
+      let effort = match mode {
+        No => "low"
+        High => "high"
+        Max => "max"
+      }
+      [
+        ("thinking", ({ "type": "enabled", "clear_thinking": false } : Json)),
+        ("reasoning_effort", Json::string(effort)),
+      ]
+    }
+    (_, Some(No)) => [("thinking", ({ "type": "disabled" } : Json))]
+    (_, Some(High)) =>
+      [
+        ("thinking", ({ "type": "enabled" } : Json)),
+        ("reasoning_effort", Json::string("high")),
+      ]
+    (_, Some(Max)) =>
+      [
+        ("thinking", ({ "type": "enabled" } : Json)),
+        ("reasoning_effort", Json::string("max")),
+      ]
+  }
+}
+
+///|
 /// Encodes a `ChatMessage` as a chat-completions `messages[]` entry.
 ///
 /// Assistant messages whose `content` is empty but carry tool calls are
 /// encoded with JSON `content: null`, as the API requires.
 ///
 /// Assistant `reasoning_content` is always replayed: DeepSeek requires it
-/// when tools are enabled and ignores it otherwise, and Kimi K2.7 Code
-/// always requires it.
+/// when tools are enabled and ignores it otherwise, Kimi K2.7 Code always
+/// requires it, and GLM coding-agent requests use preserved thinking.
 ///
 /// See: https://api-docs.deepseek.com/guides/thinking_mode#thinking-mode-with-tool-calls
 /// See: https://platform.kimi.ai/docs/guide/use-kimi-k2-thinking-model#using-the-kimi-k2-7-code-model
@@ -93,23 +129,7 @@ pub fn encode_chat_request(
         ..if tools.length() > 0 {
           [("tools", ([ for tool in tools => tool ] : Json))]
         },
-        // Kimi K2.7 Code documentation says not to pass `thinking`.
-        // https://platform.kimi.ai/docs/guide/use-kimi-k2-thinking-model#using-the-kimi-k2-7-code-model
-        ..if !(model is Kimi(_)) && thinking is Some(mode) {
-          match mode {
-            No => [("thinking", ({ "type": "disabled" } : Json))]
-            High =>
-              [
-                ("thinking", ({ "type": "enabled" } : Json)),
-                ("reasoning_effort", Json::string("high")),
-              ]
-            Max =>
-              [
-                ("thinking", ({ "type": "enabled" } : Json)),
-                ("reasoning_effort", Json::string("max")),
-              ]
-          }
-        },
+        ..thinking_json_fields(model, thinking),
       ],
     ),
   )

--- a/deepseek/pkg.generated.mbti
+++ b/deepseek/pkg.generated.mbti
@@ -39,6 +39,14 @@ pub fn DsVariant::equal(Self, Self) -> Bool
 pub fn DsVariant::not_equal(Self, Self) -> Bool
 pub fn DsVariant::to_repr(Self) -> @debug.Repr
 
+pub(all) enum GlmVariant {
+  G53
+  G53Flash
+} derive(Eq, @debug.Debug)
+pub fn GlmVariant::equal(Self, Self) -> Bool
+pub fn GlmVariant::not_equal(Self, Self) -> Bool
+pub fn GlmVariant::to_repr(Self) -> @debug.Repr
+
 pub(all) enum KimiVariant {
   K27Code
   K27CodeHighSpeed
@@ -50,6 +58,7 @@ pub fn KimiVariant::to_repr(Self) -> @debug.Repr
 pub(all) enum Model {
   Deepseek(DsVariant)
   Kimi(KimiVariant)
+  Glm(GlmVariant)
 } derive(Eq, @debug.Debug)
 pub fn Model::api_key(Self, Map[String, Array[String]]) -> String?
 pub fn Model::context_window(Self) -> Int

--- a/eval/file_edit/cmd/main/main.mbt
+++ b/eval/file_edit/cmd/main/main.mbt
@@ -24,7 +24,7 @@ fn cli_command() -> @argparse.Command {
         "model",
         long="model",
         default_values=[@deepseek.Deepseek(V4Flash).to_string()],
-        about="Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, or kimi-k2.7-code-highspeed.",
+        about="Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, kimi-k2.7-code-highspeed, glm-5.3, or glm-5.3-flash.",
       ),
       OptionArg(
         "runs",

--- a/eval/file_edit/harness/harness.mbt
+++ b/eval/file_edit/harness/harness.mbt
@@ -158,6 +158,7 @@ fn trial_extra_env(
 fn api_key_env_for_model(model : @deepseek.Model) -> String {
   match model {
     Kimi(_) => "KIMI"
+    Glm(_) => "GLM"
     Deepseek(_) => "DEEPSEEK"
   }
 }

--- a/eval/prompt_task/cmd/main/config.mbt
+++ b/eval/prompt_task/cmd/main/config.mbt
@@ -7,8 +7,8 @@ fn config_from_matches(matches : @argparse.Matches) -> @harness.Config raise {
   )
   guard min_successes <= runs else { fail("--min-successes must be <= --runs") }
   // An empty --api-key is allowed: the harness falls back to the provider's
-  // environment variable (DEEPSEEK/KIMI), which is the only way a cross-provider
-  // run authenticates each model with its own key.
+  // environment variable (DEEPSEEK/KIMI/GLM), which is the only way a
+  // cross-provider run authenticates each model with its own key.
   let api_key = @cli.value(matches, "api-key")
   Config(
     api_key~,

--- a/eval/prompt_task/cmd/main/main.mbt
+++ b/eval/prompt_task/cmd/main/main.mbt
@@ -49,7 +49,7 @@ fn cli_command() -> @argparse.Command {
         "model",
         long="model",
         default_values=[@deepseek.Deepseek(V4Flash).to_string()],
-        about="Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, or kimi-k2.7-code-highspeed.",
+        about="Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, kimi-k2.7-code-highspeed, glm-5.3, or glm-5.3-flash.",
       ),
       OptionArg(
         "runs",

--- a/eval/prompt_task/harness/harness.mbt
+++ b/eval/prompt_task/harness/harness.mbt
@@ -116,9 +116,9 @@ fn trial_extra_env(
   // An explicit `api_key` overrides this model's provider key for every trial.
   // An empty one means "let the engine inherit its provider key from the
   // parent environment" — the only way one suite can span providers, since
-  // DeepSeek reads DEEPSEEK and Kimi reads KIMI and a single shared key cannot
-  // authenticate both. Overriding unconditionally would clobber the inherited
-  // KIMI (or DEEPSEEK) of the other provider's trials with the wrong key.
+  // DeepSeek reads DEEPSEEK, Kimi reads KIMI, and GLM reads GLM; a single
+  // shared key cannot authenticate all providers. Overriding unconditionally
+  // would clobber another provider's inherited key with the wrong key.
   if config.api_key != "" {
     env[api_key_env_for_model(config.model)] = config.api_key
   }
@@ -129,6 +129,7 @@ fn trial_extra_env(
 fn api_key_env_for_model(model : @deepseek.Model) -> String {
   match model {
     Kimi(_) => "KIMI"
+    Glm(_) => "GLM"
     Deepseek(_) => "DEEPSEEK"
   }
 }

--- a/eval/prompt_task/harness/harness_wbtest.mbt
+++ b/eval/prompt_task/harness/harness_wbtest.mbt
@@ -19,12 +19,16 @@ test "trial environment configures model and isolated skills" {
   let env = trial_extra_env(config, "/tmp/workspace")
   assert_true(env.get("DEEPSEEK") == Some("key"))
   assert_true(env.get("KIMI") is None)
+  assert_true(env.get("GLM") is None)
   let kimi_env = trial_extra_env(
     { ..config, model: Kimi(K27CodeHighSpeed) },
     "/tmp/workspace",
   )
   assert_true(kimi_env.get("KIMI") == Some("key"))
   assert_true(kimi_env.get("DEEPSEEK") is None)
+  let glm_env = trial_extra_env({ ..config, model: Glm(G53) }, "/tmp/workspace")
+  assert_true(glm_env.get("GLM") == Some("key"))
+  assert_true(glm_env.get("DEEPSEEK") is None)
   guard env.get("OPENSEEK_GLOBAL_SKILLS_DIR") is Some(skills_dir) else {
     fail("expected OPENSEEK_GLOBAL_SKILLS_DIR")
   }
@@ -34,7 +38,7 @@ test "trial environment configures model and isolated skills" {
 ///|
 test "empty api key leaves provider keys to the inherited environment" {
   // A cross-provider suite runs with an empty key so each trial inherits its
-  // own DEEPSEEK/KIMI from the parent env; the harness must not pin either
+  // own DEEPSEEK/KIMI/GLM from the parent env; the harness must not pin a
   // variable to an empty string, which would shadow the inherited key.
   let config = Config(
     api_key="",

--- a/prompt/README.mbt.md
+++ b/prompt/README.mbt.md
@@ -7,15 +7,14 @@ functions through the module-level `md_to_mbt_string` dev-build rule.
 ## Prompt Sources
 
 - `default_prompt.mbt.md`: the default built-in prompt used by the supported
-  DeepSeek and Kimi model names.
+  DeepSeek, Kimi, and GLM model names.
 - `base_prompt.mbt.md`: the older built-in prompt, retained for comparison and
   prompt experiments but not selected by default.
 
 ## API Shape
 
 - `system_prompt_for_model(model)`: return the default built-in prompt for a
-  supported chat model. The supported DeepSeek and Kimi model names all use
-  `default_prompt.mbt.md`.
+  supported chat model. All supported model names use `default_prompt.mbt.md`.
 
 The agent package depends on this package for its default prompt, while the CLI
 can still override or append prompt files for A/B experiments.

--- a/prompt/prompt.mbt
+++ b/prompt/prompt.mbt
@@ -1,7 +1,7 @@
 ///|
 /// Selects the built-in system prompt for a supported chat model.
 ///
-/// Supported DeepSeek and Kimi model names currently share the default
+/// Supported DeepSeek, Kimi, and GLM model names currently share the default
 /// prompt. The older base prompt remains in the package for comparison and
 /// prompt experiments, but it is not selected by default.
 pub fn system_prompt_for_model(_model : @deepseek.Model) -> String {

--- a/tests/cram/cli.md
+++ b/tests/cram/cli.md
@@ -35,10 +35,10 @@ Commands:
 Options:
   -h, --help                     Show help information.
   --api-key <api-key>            API key for the selected chat provider. [default: ]
-  --model <model>                Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, or kimi-k2.7-code-highspeed. [env: OPENSEEK_MODEL] [default: deepseek-v4-pro]
-  --api-url <api-url>            DeepSeek-compatible chat completions endpoint. [env: OPENSEEK_API_URL] [default: ]
+  --model <model>                Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, kimi-k2.7-code-highspeed, glm-5.3, or glm-5.3-flash. [env: OPENSEEK_MODEL] [default: deepseek-v4-pro]
+  --api-url <api-url>            OpenAI-compatible chat completions endpoint. [env: OPENSEEK_API_URL] [default: ]
   --max-steps <max-steps>        Maximum agent steps per turn; omit to bound turns by the model's context window instead (a checkpoint summary carries each turn into the next). [env: OPENSEEK_MAX_STEPS]
-  --thinking <thinking>          DeepSeek thinking mode: no, high, or max. [env: OPENSEEK_THINKING] [default: max]
+  --thinking <thinking>          Model thinking mode: no, high, or max; GLM maps no to low effort. [env: OPENSEEK_THINKING] [default: max]
   --session <session>            Create or resume this durable session id.
   --session-root <session-root>  Directory containing durable OpenSeek sessions. [default: .openseek]
 ```
@@ -131,10 +131,10 @@ Arguments:
 Options:
   -h, --help                                                   Show help information.
   --api-key <api-key>                                          API key for the selected chat provider. [default: ]
-  --model <model>                                              Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, or kimi-k2.7-code-highspeed. [env: OPENSEEK_MODEL] [default: deepseek-v4-pro]
-  --api-url <api-url>                                          DeepSeek-compatible chat completions endpoint. [env: OPENSEEK_API_URL] [default: ]
+  --model <model>                                              Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, kimi-k2.7-code-highspeed, glm-5.3, or glm-5.3-flash. [env: OPENSEEK_MODEL] [default: deepseek-v4-pro]
+  --api-url <api-url>                                          OpenAI-compatible chat completions endpoint. [env: OPENSEEK_API_URL] [default: ]
   --max-steps <max-steps>                                      Maximum agent steps per turn; omit to bound turns by the model's context window instead (a checkpoint summary carries each turn into the next). [env: OPENSEEK_MAX_STEPS]
-  --thinking <thinking>                                        DeepSeek thinking mode: no, high, or max. [env: OPENSEEK_THINKING] [default: max]
+  --thinking <thinking>                                        Model thinking mode: no, high, or max; GLM maps no to low effort. [env: OPENSEEK_THINKING] [default: max]
   --session <session>                                          Create or resume this durable session id.
   --session-root <session-root>                                Directory containing durable OpenSeek sessions. [default: .openseek]
   --no-session                                                 Run ephemerally: do not record this run to a durable session.

--- a/tests/cram/tui.md
+++ b/tests/cram/tui.md
@@ -24,10 +24,10 @@ OpenSeek terminal UI.
 Options:
   -h, --help                     Show help information.
   --api-key <api-key>            API key for the selected chat provider. [default: ]
-  --model <model>                Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, or kimi-k2.7-code-highspeed. [env: OPENSEEK_MODEL] [default: deepseek-v4-pro]
-  --api-url <api-url>            DeepSeek-compatible chat completions endpoint. [env: OPENSEEK_API_URL] [default: ]
+  --model <model>                Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, kimi-k2.7-code-highspeed, glm-5.3, or glm-5.3-flash. [env: OPENSEEK_MODEL] [default: deepseek-v4-pro]
+  --api-url <api-url>            OpenAI-compatible chat completions endpoint. [env: OPENSEEK_API_URL] [default: ]
   --max-steps <max-steps>        Maximum agent steps per turn; omit to bound turns by the model's context window instead (a checkpoint summary carries each turn into the next). [env: OPENSEEK_MAX_STEPS]
-  --thinking <thinking>          DeepSeek thinking mode: no, high, or max. [env: OPENSEEK_THINKING] [default: max]
+  --thinking <thinking>          Model thinking mode: no, high, or max; GLM maps no to low effort. [env: OPENSEEK_THINKING] [default: max]
   --session <session>            Create or resume this durable session id.
   --session-root <session-root>  Directory containing durable OpenSeek sessions. [default: .openseek]
   --continue                     Resume the most recently active session in --session-root.


### PR DESCRIPTION
## Summary

- add typed glm-5.3 and glm-5.3-flash models backed by the Z.AI chat-completions endpoint
- route credentials through the GLM environment variable and expose both models in the CLI, TUI, and eval harnesses
- map OpenSeek thinking levels to GLM low/high/max thinking and retain reasoning_content across assistant turns
- add request snapshots, endpoint/key routing coverage, a guarded live streaming tool-call smoke test, help snapshots, and documentation

## Validation

- live glm-5.3 strict streaming tool-call smoke: passed 1/1 in 6.7 seconds
- just check
- env -u GLM just test: native 3326/3326, JS 3248/3248, cram 28/28
- just build: native and JS
- moon info and moon fmt
- git diff --check

## Effectiveness trial

A real OpenSeek prompt-task run using glm-5.3-flash with low thinking built a MoonBit TOML-subset parser and CLI. The independent evaluator passed all five probes: native check, native tests, file input, stdin dotted keys, and duplicate-key rejection. The generated project passed 10/10 model-authored tests.

The trial took 22m15s, 116 agent steps, and recorded 40 tool errors, so it was capable but inefficient. An additional adversarial probe found that its generated parser silently accepts an unterminated quoted string; that artifact is not included in this PR.

A glm-5.3 max-thinking trial streamed reasoning but made no first tool call after 7m43s and was stopped. High thinking has request-level coverage but has not been run end-to-end.