### PR TITLE
refactor(deepseek): always replay assistant reasoning_content

### DIFF
--- a/deepseek/json_encode.mbt
+++ b/deepseek/json_encode.mbt
@@ -1,36 +1,16 @@
 ///|
-/// Keep assistant reasoning_content when the provider requires it.
-///
-/// DeepSeek requires every historical assistant reasoning trace to be sent
-/// back when tools are enabled. Kimi K2.7 Code always requires the reasoning
-/// from every historical assistant message to be preserved.
-///
-/// See: https://api-docs.deepseek.com/guides/thinking_mode#thinking-mode-with-tool-calls
-/// See: https://platform.kimi.ai/docs/guide/use-kimi-k2-thinking-model#using-the-kimi-k2-7-code-model
-fn ChatMessage::reasoning_json_fields(
-  message : ChatMessage,
-  model : Model,
-  preserve_deepseek_reasoning : Bool,
-) -> Array[(String, Json)] {
-  match (model, message.role, message.reasoning_content) {
-    (Deepseek(_), Assistant, Some(reasoning)) if preserve_deepseek_reasoning =>
-      [("reasoning_content", Json::string(reasoning))]
-    (Kimi(_), Assistant, Some(reasoning)) =>
-      [("reasoning_content", Json::string(reasoning))]
-    _ => []
-  }
-}
-
-///|
-/// Encodes a `ChatMessage` for a selected chat-completions model.
+/// Encodes a `ChatMessage` as a chat-completions `messages[]` entry.
 ///
 /// Assistant messages whose `content` is empty but carry tool calls are
 /// encoded with JSON `content: null`, as the API requires.
-fn ChatMessage::to_json_for_model(
-  message : ChatMessage,
-  model : Model,
-  preserve_deepseek_reasoning? : Bool = false,
-) -> Json {
+///
+/// Assistant `reasoning_content` is always replayed: DeepSeek requires it
+/// when tools are enabled and ignores it otherwise, and Kimi K2.7 Code
+/// always requires it.
+///
+/// See: https://api-docs.deepseek.com/guides/thinking_mode#thinking-mode-with-tool-calls
+/// See: https://platform.kimi.ai/docs/guide/use-kimi-k2-thinking-model#using-the-kimi-k2-7-code-model
+impl ToJson for ChatMessage with fn to_json(message : ChatMessage) -> Json {
   let content = match message.role {
     Assistant if message.tool_calls.length() > 0 && message.content == "" =>
       Json::null()
@@ -47,7 +27,10 @@ fn ChatMessage::to_json_for_model(
         ..if message.tool_calls.length() > 0 {
           [("tool_calls", ([ for call in message.tool_calls => call ] : Json))]
         },
-        ..message.reasoning_json_fields(model, preserve_deepseek_reasoning),
+        ..if message.role is Assistant &&
+          message.reasoning_content is Some(reasoning) {
+          [("reasoning_content", Json::string(reasoning))]
+        },
       ],
     ),
   )
@@ -99,17 +82,7 @@ pub fn encode_chat_request(
     Map(
       [
         ("model", Json::string(Show::to_string(model))),
-        (
-          "messages",
-          [
-            for message in messages => {
-              message.to_json_for_model(
-                model,
-                preserve_deepseek_reasoning=tools.length() > 0,
-              )
-            }
-          ],
-        ),
+        ("messages", ([ for message in messages => message ] : Json)),
         ("stream", Json::boolean(stream)),
         ..if response_format is Some(format) {
           [("response_format", ({ "type": "\{format}" } : Json))]
@@ -145,7 +118,7 @@ pub fn encode_chat_request(
 ///|
 test "tool messages include tool call id" {
   let body = ChatMessage(Tool("call_123"), content="tool result")
-  json_inspect(body.to_json_for_model(Deepseek(V4Pro)), content={
+  json_inspect(body, content={
     "role": "tool",
     "content": "tool result",
     "tool_call_id": "call_123",
@@ -180,7 +153,7 @@ test "tool definitions encode as native DeepSeek tools" {
 }
 
 ///|
-test "deepseek assistant tool calls preserve reasoning content" {
+test "assistant tool calls preserve reasoning content" {
   let body = ChatMessage(
     Assistant,
     content="",
@@ -193,62 +166,7 @@ test "deepseek assistant tool calls preserve reasoning content" {
     ],
     reasoning_content="checked available tools",
   )
-  json_inspect(
-    body.to_json_for_model(Deepseek(V4Pro), preserve_deepseek_reasoning=true),
-    content={
-      "role": "assistant",
-      "content": null,
-      "tool_calls": [
-        {
-          "id": "call_123",
-          "type": "function",
-          "function": {
-            "name": "get_weather",
-            "arguments": "{\"location\":\"Hangzhou\"}",
-          },
-        },
-      ],
-      "reasoning_content": "checked available tools",
-    },
-  )
-}
-
-///|
-test "deepseek reasoning follows tool availability" {
-  let body = ChatMessage(
-    Assistant,
-    content="The tests pass.",
-    reasoning_content="checked the test output",
-  )
-  json_inspect(body.to_json_for_model(Deepseek(V4Pro)), content={
-    "role": "assistant",
-    "content": "The tests pass.",
-  })
-  json_inspect(
-    body.to_json_for_model(Deepseek(V4Pro), preserve_deepseek_reasoning=true),
-    content={
-      "role": "assistant",
-      "content": "The tests pass.",
-      "reasoning_content": "checked the test output",
-    },
-  )
-}
-
-///|
-test "kimi assistant messages preserve reasoning content" {
-  let body = ChatMessage(
-    Assistant,
-    content="",
-    tool_calls=[
-      ToolCall(
-        id="call_123",
-        name="get_weather",
-        arguments="{\"location\":\"Hangzhou\"}",
-      ),
-    ],
-    reasoning_content="checked available tools",
-  )
-  json_inspect(body.to_json_for_model(Kimi(K27Code)), content={
+  json_inspect(body, content={
     "role": "assistant",
     "content": null,
     "tool_calls": [
@@ -266,6 +184,20 @@ test "kimi assistant messages preserve reasoning content" {
 }
 
 ///|
+test "assistant reasoning content is always replayed" {
+  let body = ChatMessage(
+    Assistant,
+    content="The tests pass.",
+    reasoning_content="checked the test output",
+  )
+  json_inspect(body, content={
+    "role": "assistant",
+    "content": "The tests pass.",
+    "reasoning_content": "checked the test output",
+  })
+}
+
+///|
 test "assistant tool call messages preserve content when present" {
   let body = ChatMessage(Assistant, content="I will check that now.", tool_calls=[
     ToolCall(
@@ -274,7 +206,7 @@ test "assistant tool call messages preserve content when present" {
       arguments="{\"location\":\"Hangzhou\"}",
     ),
   ])
-  json_inspect(body.to_json_for_model(Deepseek(V4Pro)), content={
+  json_inspect(body, content={
     "role": "assistant",
     "content": "I will check that now.",
     "tool_calls": [
@@ -298,7 +230,7 @@ test "tool call arguments pass through as opaque strings" {
     arguments="not even valid json{",
   )
   let body = ChatMessage(Assistant, content="", tool_calls=[call])
-  json_inspect(body.to_json_for_model(Deepseek(V4Pro)), content={
+  json_inspect(body, content={
     "role": "assistant",
     "content": null,
     "tool_calls": [


### PR DESCRIPTION
## Summary

Simplifies message encoding by always including assistant `reasoning_content` when replaying conversation history, instead of gating it on model and request-level tools. `ChatMessage::to_json_for_model(model, tools~)` collapses into a plain `impl ToJson for ChatMessage`, and `encode_chat_request` no longer threads `tools` into per-message encoding (net −68 lines).

## What the provider docs say

Checked each provider's docs on replaying `reasoning_content` in input history:

| Provider | Replaying assistant `reasoning_content` in history |
|---|---|
| DeepSeek | **Required when tools are enabled** — "the intermediate assistant's reasoning_content must … be passed back to the API in all subsequent requests — even for turns where the model did not perform a tool call." Without tools: "If passed to the API in subsequent turns, it will be ignored" (no 400, unlike the old R1 endpoint). [Thinking mode guide](https://api-docs.deepseek.com/guides/thinking_mode#thinking-mode-with-tool-calls) |
| Kimi K2.7 Code | **Always required** for every historical assistant message. [Kimi guide](https://platform.kimi.ai/docs/guide/use-kimi-k2-thinking-model#using-the-kimi-k2-7-code-model) |
| GLM (Z.ai) | **Always required**: "Remember to return the historical reasoning_content to keep the reasoning coherent" / "you must return the complete, unmodified reasoning_content back to the API." [Thinking mode guide](https://docs.z.ai/guides/capabilities/thinking-mode.md) |

Since every provider either requires or ignores replayed reasoning, per-message encoding is model-independent — the strictest behavior (always send) is safe everywhere. This also means a future `Glm(...)` model variant would not touch the message encoder; GLM-specific handling (`thinking: {type: enabled}` without `reasoning_effort`, plus its `clear_thinking` knob) belongs in the request-level `encode_chat_request` match where Kimi is already special-cased.

## Behavior change

Non-tool DeepSeek requests now include `reasoning_content` on historical assistant messages. Per the DeepSeek docs this is ignored server-side; the only cost is the extra bytes in the payload.

## Testing

- `moon check` clean, `moon fmt` applied, `moon info` produced no interface change (trait impls aren't listed in `.mbti`).
- All 2060 tests pass. The now-redundant per-model tests merged: DeepSeek/Kimi tool-call reasoning tests became one "assistant tool calls preserve reasoning content"; "deepseek reasoning follows tool availability" became "assistant reasoning content is always replayed".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZ9BYUZxaL9usinbe4Vw9a