### PR TITLE
fix(deepseek): make streaming connections resilient

### DIFF
--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -255,7 +255,9 @@ pub async fn[X] run_turn_in_scope(
   on_goal_met? : async (String, @agent_session.GoalBaseline?) -> String?,
 ) -> @agent_session.Session {
   let client = @client.Client(api_key~, model~, thinking~, api_url?)
+  defer client.close()
   let summary_client = @client.Client(api_key~, model~, api_url?, thinking=No)
+  defer summary_client.close()
   let session = session |> append_item(User(UserMessage(task, submission_id?)))
   let tools = try {
     match tools {

--- a/agent_session/compact/compact.mbt
+++ b/agent_session/compact/compact.mbt
@@ -93,6 +93,7 @@ pub async fn compact_session(
   }
   @emit.emit(CompactionStarted(from_sequence~, to_sequence~))
   let client = @client.Client(api_key~, model~, api_url?, thinking=No)
+  defer client.close()
   let summary = generate_compaction_summary(client~, session)
   let next = append_compaction_summary(
     store?,

--- a/deepseek/client/README.mbt.md
+++ b/deepseek/client/README.mbt.md
@@ -13,12 +13,15 @@ The package depends on `moonbitlang/async/http` and is native-only.
 ## API Shape
 
 - `Client(api_key~, model?, api_url?, thinking?, retry_attempts?,
-  retry_backoff_ms?)`: configure the API key, endpoint, model, thinking mode,
-  and retry budget.
+  retry_backoff_ms?, connect_retry_window_ms?, idle_timeout_ms?)`: configure
+  the API key, endpoint, model, thinking mode, retry budgets, and streaming
+  idle bound.
 - `Client::chat(messages, tools?, response_format?, stream?)`: send a request
   and decode the response as `@deepseek.ChatResponse`. Without `stream`, this
   is a normal JSON response. With `stream=StreamHandler(...)`, it uses SSE and
   still returns the accumulated response.
+- `Client::close()`: close the retained keep-alive connection. Agent turns do
+  this automatically; long-lived direct users should call it when finished.
 - `StreamHandler(on_content_delta~, on_reasoning_delta?)`: receive non-empty
   content and reasoning deltas while a streaming chat request is in progress.
 
@@ -35,7 +38,36 @@ thinking fields when the request body is encoded.
 Retries cover transient failures: transport errors, HTTP 429, and HTTP 5xx.
 Other HTTP 4xx responses fail immediately. `retry_attempts` counts total tries;
 `retry_backoff_ms` is the first exponential-backoff delay, capped internally at
-60 seconds.
+60 seconds. Their defaults remain three total tries and a 500ms initial delay.
+A streaming request stops replaying as soon as the first complete SSE event
+arrives, so partial model output and tool calls are never duplicated
+automatically. The ordinary three-attempt policy still applies when a request
+was sent but no SSE event came back; as with the previous client behavior, an
+upstream that accepted such a request before the connection failed could bill
+more than one completion. Set `retry_attempts=1` if that tradeoff is not
+acceptable.
+
+New streaming connections have a separate 65-second retry-start window,
+`connect_retry_window_ms`. It applies only to DNS/TCP/TLS setup, before any HTTP
+request bytes are sent, so it can cross a short-lived DNS or edge-routing cache
+entry safely. The separate connection window itself never repeats a completion
+because none has been requested yet. Eligible fast failures retry through its
+deadline; an in-progress OS connect may finish after it. An actively refused
+port instead uses the ordinary short `retry_attempts` policy so invalid
+endpoints fail promptly. Pass `0` to disable only the separate long window.
+
+Successful sequential streaming calls on the same `Client` reuse one healthy
+HTTP/1.1 connection, avoiding another DNS lookup, TCP connect, and TLS
+handshake for every tool-call round. A connection is retained only after
+`[DONE]` and the remaining HTTP response framing have both been consumed.
+Transport failures, `Connection: close`, incomplete body framing, and stale
+connections all cause that socket to be discarded; a later retry reconnects.
+
+When transport retries are exhausted, the error includes the attempt count and
+the I/O phase (for example, DNS/TCP/TLS setup or waiting for response headers).
+This turns an otherwise context-free TLS `ConnectionClosed` into a diagnostic
+without claiming that a particular proxy, DNS resolver, or network is always
+responsible.
 
 ```moonbit check
 ///|
@@ -57,6 +89,7 @@ test "construct DeepSeek client configuration" {
       #|  thinking: Max,
       #|  retry_attempts: 5,
       #|  retry_backoff_ms: 200,
+      #|  connect_retry_window_ms: 65000,
       #|  idle_timeout_ms: 120000,
       #|}
     ),
@@ -80,6 +113,7 @@ At runtime:
 ```moonbit nocheck
 ///|
 let client = @client.Client(api_key~, thinking=Max)
+defer client.close()
 
 ///|
 let response = client.chat(

--- a/deepseek/client/client.mbt
+++ b/deepseek/client/client.mbt
@@ -19,16 +19,77 @@ fn default_api_url_for_model(model : @deepseek.Model) -> String {
 type API_KEY = String
 
 ///|
+priv struct ConnectionPool {
+  mut idle : @http.Client?
+  mut closed : Bool
+}
+
+///|
+fn ConnectionPool::ConnectionPool() -> ConnectionPool {
+  { idle: None, closed: false }
+}
+
+///|
+/// Synchronous checkout is atomic with respect to MoonBit's cooperative task
+/// scheduling. Concurrent chats therefore take separate connections instead
+/// of trying to multiplex HTTP/1.1; at most one healthy idle connection is
+/// retained afterwards.
+fn ConnectionPool::checkout(self : ConnectionPool) -> @http.Client? raise {
+  guard !self.closed else { fail("DeepSeek client is closed") }
+  let connection = self.idle
+  self.idle = None
+  connection
+}
+
+///|
+fn ConnectionPool::checkin(
+  self : ConnectionPool,
+  connection : @http.Client,
+) -> Unit {
+  if self.closed || self.idle is Some(_) {
+    connection.close()
+  } else {
+    self.idle = Some(connection)
+  }
+}
+
+///|
+fn ConnectionPool::close(self : ConnectionPool) -> Unit {
+  self.closed = true
+  if self.idle is Some(connection) {
+    self.idle = None
+    connection.close()
+  }
+}
+
+///|
 /// HTTP client for the DeepSeek chat completions API.
 pub struct Client {
   priv api_key : API_KEY
+  priv connections : ConnectionPool
   model : @deepseek.Model
   api_url : String
   thinking : @deepseek.ThinkingMode
   retry_attempts : Int
   retry_backoff_ms : Int
+  connect_retry_window_ms : Int
   idle_timeout_ms : Int
-} derive(Debug(ignore=API_KEY))
+}
+
+///|
+/// Keep credentials and the live connection pool out of debug output.
+pub impl Debug for Client with fn to_repr(self) {
+  Repr::record({
+    "api_key": Repr::omitted(),
+    "model": Repr(self.model),
+    "api_url": Repr(self.api_url),
+    "thinking": Repr(self.thinking),
+    "retry_attempts": Repr(self.retry_attempts),
+    "retry_backoff_ms": Repr(self.retry_backoff_ms),
+    "connect_retry_window_ms": Repr(self.connect_retry_window_ms),
+    "idle_timeout_ms": Repr(self.idle_timeout_ms),
+  })
+}
 
 ///|
 /// Constructs a DeepSeek HTTP client.
@@ -39,9 +100,16 @@ pub struct Client {
 ///
 /// Transient failures — transport errors, HTTP 429, and 5xx — are retried up
 /// to `retry_attempts` total tries with exponential backoff starting at
-/// `retry_backoff_ms` (doubling per retry, capped at 60s). Client errors
-/// other than 429 never retry, and a streaming call never retries once the
-/// stream has produced any event — text, tool-call, or usage alike.
+/// `retry_backoff_ms` (doubling per retry, capped at 60s). Client errors other
+/// than 429 never retry, and a streaming call never retries once the stream has
+/// produced any event — text, tool-call, or usage alike.
+///
+/// Before any HTTP request bytes are sent, new streaming connections get a
+/// separate `connect_retry_window_ms` retry-start window. Its 65s default can
+/// cross one short-lived DNS or edge-routing cache entry without replaying a
+/// request that DeepSeek may already have received or billed. Pass `0` (or
+/// less) to disable this separate window. An actively refused port remains on
+/// the ordinary `retry_attempts` budget so invalid endpoints fail promptly.
 ///
 /// `idle_timeout_ms` bounds how long a streaming request may sit with no
 /// progress: it caps both the wait for response headers and the wait between
@@ -64,17 +132,28 @@ pub fn Client::Client(
   thinking? : @deepseek.ThinkingMode = No,
   retry_attempts? : Int = 3,
   retry_backoff_ms? : Int = 500,
+  connect_retry_window_ms? : Int = 65_000,
   idle_timeout_ms? : Int = 120_000,
 ) -> Client {
   {
     api_key,
+    connections: ConnectionPool(),
     model,
     api_url,
     thinking,
     retry_attempts,
     retry_backoff_ms,
+    connect_retry_window_ms,
     idle_timeout_ms,
   }
+}
+
+///|
+/// Close the client's retained HTTP connection. This is idempotent. A request
+/// already in flight is allowed to finish, then its connection is discarded
+/// instead of being returned to the pool.
+pub fn Client::close(self : Client) -> Unit {
+  self.connections.close()
 }
 
 ///|
@@ -115,6 +194,80 @@ priv suberror RetryableApiError {
 }
 
 ///|
+/// A network failure annotated at the exact I/O boundary where it surfaced.
+/// The underlying async TLS error often contains only `ConnectionClosed`, so
+/// retaining the phase here is what lets the exhausted-retry message say
+/// whether the failure happened while connecting, sending, or reading.
+priv suberror RetryableTransportError {
+  RetryableTransportError(phase~ : String, reason~ : String)
+}
+
+///|
+/// Only errors known to represent a transient socket/stream condition are
+/// replayable. TLS validation/configuration errors and unknown parser or user
+/// callback errors propagate immediately instead of being guessed retryable.
+fn retryable_transport_error(error : Error) -> Bool {
+  error is @os_error.OSError(_) ||
+  error is @socket.ResolveHostnameError(_) ||
+  error is @tls.ConnectionClosed ||
+  error is @io.ReaderClosed
+}
+
+///|
+/// TLS backends do not agree on how a peer disappearing during the handshake
+/// is typed: OpenSSL may report `ConnectionClosed` or `TlsError`, while
+/// Schannel reports its socket failures as `TlsError`. Retrying either is safe
+/// during setup because no HTTP bytes exist yet. A permanent certificate error
+/// is therefore bounded by the same setup window rather than retried after a
+/// request might have been accepted.
+fn retryable_connection_setup_error(error : Error) -> Bool {
+  retryable_transport_error(error) || error is @tls.TlsError(_)
+}
+
+///|
+/// An actively refused port is a deterministic endpoint/configuration result,
+/// not the slow bad-edge failure the connect window is meant to outlive. Keep
+/// it on the ordinary short request retry budget so invalid local/custom URLs
+/// still fail promptly.
+fn connection_refused(error : Error) -> Bool {
+  match error {
+    @os_error.OSError(_) as os_error => os_error.is_ECONNREFUSED()
+    _ => false
+  }
+}
+
+///|
+fn retryable_attempt_error(error : Error) -> Bool {
+  error is RetryableApiError(_) ||
+  error is RetryableTransportError(..) ||
+  retryable_transport_error(error)
+}
+
+///|
+/// Add transport phase information without swallowing cancellation, caller
+/// failures, malformed endpoint errors, or an already classified API error.
+/// Schannel uses `TlsError` for established-socket failures as well as setup
+/// failures, so streaming callers opt into retrying it only after setup has
+/// completed; this keeps certificate and TLS configuration errors fatal.
+async fn[T] transport_io(
+  phase : String,
+  operation : async () -> T,
+  retry_tls_error? : Bool = false,
+) -> T {
+  operation() catch {
+    error if @async.is_cancellation_error(error) => raise error
+    error if error is Failure::Failure(_) => raise error
+    error if error is RetryableApiError(_) => raise error
+    error if error is @http.URIParseError::InvalidFormat => raise error
+    error if error is @http.URIParseError::UnsupportedProtocol(_) => raise error
+    error if retryable_transport_error(error) ||
+      (retry_tls_error && error is @tls.TlsError(_)) =>
+      raise RetryableTransportError(phase~, reason="\{error}")
+    error => raise error
+  }
+}
+
+///|
 /// Ceiling on a single backoff sleep. The doubling sequence from
 /// `retry_backoff_ms` stops growing here, so a generous retry budget cannot
 /// accumulate minutes-long sleeps between attempts.
@@ -125,15 +278,13 @@ let max_backoff_ms : Int = 60_000
 /// (exponential backoff doubling from `retry_backoff_ms`, capped at
 /// `max_backoff_ms`; `max_retry` counts restarts, hence the -1).
 ///
-/// The `fatal_error` classification: cancellations, plain failures (our own
-/// final verdicts — non-retryable HTTP statuses, malformed response bodies,
-/// truncated streams), and malformed-api_url parse errors (which fail
-/// identically every time, before any network I/O) propagate immediately;
-/// anything else is transport-shaped (connect refused, reset, DNS) and
-/// retries within budget. `bail` lets an attempt declare later retries
-/// pointless — streaming chat sets it once the stream has produced any event,
-/// since replaying a half-consumed completion would duplicate content (or
-/// regenerate tool calls) downstream.
+/// The `fatal_error` classification is deliberately positive: only marked API
+/// failures and known socket/stream errors retry. Cancellations, plain
+/// failures (our own final verdicts), malformed URLs, TLS validation failures,
+/// parser failures, and callback failures propagate immediately. `bail` lets
+/// an attempt declare later retries pointless — streaming chat sets it once
+/// the stream has produced any event, since replaying a half-consumed
+/// completion would duplicate content (or regenerate tool calls) downstream.
 ///
 /// A `RetryableApiError` that survives the budget (or bail) re-raises as a
 /// plain failure carrying the same text a non-retrying client would have
@@ -142,7 +293,9 @@ async fn[T] Client::with_retries(
   self : Client,
   attempt : async () -> T,
   bail : () -> Bool,
+  streaming? : Bool = false,
 ) -> T {
+  let mut attempts = 0
   @async.retry(
     ExponentialDelay(
       initial=self.retry_backoff_ms,
@@ -155,11 +308,31 @@ async fn[T] Client::with_retries(
       @async.is_cancellation_error(error) ||
       error is Failure::Failure(_) ||
       error is @http.URIParseError::InvalidFormat ||
-      error is @http.URIParseError::UnsupportedProtocol(_)
+      error is @http.URIParseError::UnsupportedProtocol(_) ||
+      !retryable_attempt_error(error)
     },
-    attempt,
+    () => {
+      attempts = attempts + 1
+      attempt()
+    },
   ) catch {
     RetryableApiError(message) => fail(message)
+    RetryableTransportError(phase~, reason~) =>
+      if streaming {
+        if bail() {
+          fail(
+            "DeepSeek stream connection failed after the response started during \{phase} (attempt \{attempts}; not retried to avoid duplicate output): \{reason}",
+          )
+        } else {
+          fail(
+            "DeepSeek connection failed before any response event after \{attempts} attempts during \{phase}: \{reason}",
+          )
+        }
+      } else {
+        fail(
+          "DeepSeek request failed after \{attempts} attempts during \{phase}: \{reason}",
+        )
+      }
     error => raise error
   }
 }
@@ -206,6 +379,7 @@ pub async fn Client::chat(
           )
         },
         () => streamed,
+        streaming=true,
       )
     }
   }
@@ -216,10 +390,12 @@ async fn Client::chat_attempt(
   self : Client,
   body : Json,
 ) -> @deepseek.ChatResponse {
-  let (resp, data) = @http.post(self.api_url, body, headers={
-    "Content-Type": "application/json",
-    "Authorization": "Bearer \{self.api_key}",
-  })
+  let (resp, data) = transport_io("sending request and reading response") <| () => {
+    @http.post(self.api_url, body, headers={
+      "Content-Type": "application/json",
+      "Authorization": "Bearer \{self.api_key}",
+    })
+  }
   let text = data.text()
   guard resp.code >= 200 && resp.code < 300 else {
     let message = "DeepSeek API error \{resp.code}: \{text}"
@@ -241,34 +417,199 @@ async fn Client::chat_attempt(
 }
 
 ///|
+/// Split a full API endpoint into the origin accepted by `@http.Client` and
+/// the request target sent on a reusable connection. Keep this deliberately in
+/// step with async/http's URL parser: lowercase HTTP(S), first slash or query
+/// after the authority, and `/` when no request target is present.
+fn split_api_endpoint(url : String) -> (String, String) raise {
+  guard url.find("://") is Some(protocol_len) else {
+    fail("invalid DeepSeek API URL: \{url}")
+  }
+  match url[:protocol_len] {
+    "http" | "https" => ()
+    protocol => fail("unsupported DeepSeek API URL protocol: \{protocol}")
+  }
+  let authority_start = protocol_len + 3
+  let rest = url[authority_start:]
+  guard !rest.is_empty() else { fail("invalid DeepSeek API URL: \{url}") }
+  let relative_path_start = rest.find("/")
+  let relative_query_start = rest.find("?")
+  let relative_target_start = match
+    (relative_path_start, relative_query_start) {
+    (Some(path), Some(query)) => Some(path.min(query))
+    (Some(path), None) => Some(path)
+    (None, Some(query)) => Some(query)
+    (None, None) => None
+  }
+  match relative_target_start {
+    Some(relative_target_start) => {
+      let target_start = authority_start + relative_target_start
+      let target = url[target_start:].to_owned()
+      (
+        url[:target_start].to_owned(),
+        if relative_query_start == Some(relative_target_start) {
+          "/\{target}"
+        } else {
+          target
+        },
+      )
+    }
+    None => (url, "/")
+  }
+}
+
+///|
+/// A response can only leave a reusable HTTP/1.1 connection when its body has
+/// explicit framing and the peer did not request connection close. Otherwise
+/// EOF itself delimits the body, so there is no live socket to retain.
+fn response_allows_reuse(response : @http.Response) -> Bool {
+  let closes = response.headers
+    .get("connection")
+    .map_or(false, value => value.to_lower().contains("close"))
+  !closes &&
+  (
+    response.headers.contains("content-length") ||
+    response.headers.contains("transfer-encoding")
+  )
+}
+
+///|
+/// Bound the next connect backoff by the wall-clock deadline. When a fast
+/// failure reaches the end of the exponential schedule, sleeping the exact
+/// remainder produces one final attempt at the deadline instead of stopping
+/// early merely because the attempt count was exhausted.
+fn connect_retry_sleep_ms(
+  now : Int64,
+  deadline : Int64,
+  backoff_ms : Int,
+) -> Int? {
+  let remaining = (deadline - now).to_int()
+  if remaining <= 0 {
+    None
+  } else {
+    Some(remaining.min(backoff_ms.max(1)))
+  }
+}
+
+///|
+/// Establish DNS/TCP/TLS before any HTTP request bytes are sent. Only this
+/// unambiguously safe phase receives the long retry window: failures after
+/// `.request` may mean DeepSeek already accepted and billed the completion.
+async fn Client::open_stream_connection(
+  self : Client,
+  origin : String,
+) -> @http.Client {
+  let started = @async.now()
+  let deadline = started + self.connect_retry_window_ms.to_int64()
+  let mut attempts = 0
+  let mut backoff_ms = self.retry_backoff_ms.max(1)
+  for ;; {
+    attempts = attempts + 1
+    try {
+      return Client(origin, headers={
+        "Content-Type": "application/json",
+        "Authorization": "Bearer \{self.api_key}",
+        // Without an explicit Accept-Encoding the HTTP client advertises gzip and
+        // transparently decompresses. A gzip-compressing intermediary buffers
+        // whole compression blocks, which would re-batch the SSE deltas this
+        // request exists to stream — so pin the identity encoding.
+        "Accept-Encoding": "identity",
+      })
+    } catch {
+      error if @async.is_cancellation_error(error) => raise error
+      error if connection_refused(error) =>
+        raise RetryableTransportError(
+          phase="DNS/TCP/TLS setup",
+          reason="\{error}",
+        )
+      error if !retryable_connection_setup_error(error) =>
+        fail(
+          "DeepSeek connection setup failed before sending the request during DNS/TCP/TLS setup: \{error}",
+        )
+      error if self.connect_retry_window_ms <= 0 =>
+        raise RetryableTransportError(
+          phase="DNS/TCP/TLS setup",
+          reason="\{error}",
+        )
+      error =>
+        match connect_retry_sleep_ms(@async.now(), deadline, backoff_ms) {
+          Some(sleep_ms) => {
+            @async.sleep(sleep_ms)
+            backoff_ms = max_backoff_ms.min(backoff_ms * 2)
+          }
+          _ => {
+            let elapsed_ms = (@async.now() - started).to_int()
+            fail(
+              "DeepSeek connection failed before sending the request after \{attempts} attempts over \{elapsed_ms}ms during DNS/TCP/TLS setup: \{error}",
+            )
+          }
+        }
+    }
+  }
+}
+
+///|
+/// `[DONE]` ends the SSE protocol before the HTTP reader necessarily consumes
+/// the final chunk marker. Drain that framing under a short bound before
+/// pooling. Failure merely forfeits reuse: the model response is already
+/// complete and must not be turned into a retry or user-visible error.
+async fn drain_completed_response(client : @http.Client) -> Bool {
+  try (
+    @async.with_timeout_opt(1_000, () => client.skip_response_body()) is Some(_)
+  ) catch {
+    error if @async.is_cancellation_error(error) => raise error
+    _ => false
+  }
+}
+
+///|
 async fn Client::chat_stream_attempt(
   self : Client,
   body : Json,
   on_stream_event~ : () -> Unit,
   stream : StreamHandler,
 ) -> @deepseek.ChatResponse {
-  let client = @http.post_stream(self.api_url, headers={
-    "Content-Type": "application/json",
-    "Authorization": "Bearer \{self.api_key}",
-    // Without an explicit Accept-Encoding the HTTP client advertises gzip and
-    // transparently decompresses. A gzip-compressing intermediary buffers
-    // whole compression blocks, which would re-batch the SSE deltas this
-    // request exists to stream — so pin the identity encoding.
-    "Accept-Encoding": "identity",
+  let (origin, path) = split_api_endpoint(self.api_url)
+  let client = match self.connections.checkout() {
+    Some(connection) => connection
+    None => self.open_stream_connection(origin)
+  }
+  let mut reusable = false
+  defer (if reusable {
+    self.connections.checkin(client)
+  } else {
+    client.close()
   })
-  defer client.close()
-  client.write(body.stringify())
+  transport_io(
+    "starting HTTP request",
+    () => client.request(Post, path),
+    retry_tls_error=true,
+  )
+  transport_io(
+    "sending request body",
+    () => client.write(body.stringify()),
+    retry_tls_error=true,
+  )
   // Bound the wait for response headers the same way the SSE loop bounds the
   // wait between events: a peer that accepts the connection then never sends a
   // status line would otherwise block here forever, before any event, with no
   // error for the retry loop to see.
-  let resp = with_idle_timeout(
-    self.idle_timeout_ms,
-    "DeepSeek response headers",
-    () => client.end_request(),
+  let resp = transport_io(
+    "waiting for response headers",
+    () => {
+      with_idle_timeout(self.idle_timeout_ms, "DeepSeek response headers", () => {
+        client.end_request()
+      })
+    },
+    retry_tls_error=true,
   )
   guard resp.code >= 200 && resp.code < 300 else {
-    let text = client.read_all().text()
+    let text = transport_io(
+      "reading error response body",
+      () => client.read_all().text(),
+      retry_tls_error=true,
+    )
+    reusable = response_allows_reuse(resp)
     let message = "DeepSeek API error \{resp.code}: \{text}"
     if retryable_status(resp.code) {
       raise RetryableApiError(message)
@@ -279,13 +620,17 @@ async fn Client::chat_stream_attempt(
   // (see decode_sse_data in stream.mbt), so a mid-stream transport error
   // reaches the retry loop with its own type and the delivered-event bail
   // decides whether retrying is allowed.
-  read_chat_stream(
+  let response = read_chat_stream(
     client,
     idle_timeout_ms=self.idle_timeout_ms,
     on_stream_event~,
     on_content_delta=stream.on_content_delta,
     on_reasoning_delta=stream.on_reasoning_delta,
   )
+  if response_allows_reuse(resp) && drain_completed_response(client) {
+    reusable = true
+  }
+  response
 }
 
 ///|

--- a/deepseek/client/client_realworld_test.mbt
+++ b/deepseek/client/client_realworld_test.mbt
@@ -8,6 +8,7 @@ async test "realworld DeepSeek API smoke test" {
   }
 
   let client = @client.Client(api_key~, model=Deepseek(V4Pro), thinking=High)
+  defer client.close()
   let response = client.chat(
     [
       ChatMessage(
@@ -49,6 +50,7 @@ async test "realworld Kimi API smoke test" {
 
   let model = @deepseek.Model::parse(model_name)
   let client = @client.Client(api_key~, model~)
+  defer client.close()
   let response = client.chat([
     ChatMessage(
       System,
@@ -71,6 +73,7 @@ async test "realworld Kimi API streaming smoke test" {
 
   let model = @deepseek.Kimi(K27Code)
   let client = @client.Client(api_key~, model~)
+  defer client.close()
   let deltas : Array[String] = []
   let response = client.chat(
     [
@@ -98,6 +101,7 @@ async test "realworld Kimi API tool-call smoke test" {
 
   let model = @deepseek.Kimi(K27Code)
   let client = @client.Client(api_key~, model~)
+  defer client.close()
   let tool = @deepseek.ToolDefinition(
     "return_token",
     "Return the exact token requested by the user.",
@@ -137,6 +141,7 @@ async test "realworld Kimi API multi-turn reasoning-content smoke test" {
 
   let model = @deepseek.Kimi(K27Code)
   let client = @client.Client(api_key~, model~)
+  defer client.close()
   let tool = @deepseek.ToolDefinition(
     "return_token",
     "Return the exact token requested by the user.",

--- a/deepseek/client/client_retry_test.mbt
+++ b/deepseek/client/client_retry_test.mbt
@@ -123,6 +123,7 @@ async test "streaming chat retries a pre-stream 429 and then streams" {
       retry_attempts=3,
       retry_backoff_ms=1,
     )
+    defer client.close()
     let deltas : Array[String] = []
     let response = client.chat(
       [ChatMessage(User, content="hello")],
@@ -148,6 +149,7 @@ async test "streaming Kimi chat retries a pre-stream 502 and then streams" {
       retry_attempts=3,
       retry_backoff_ms=1,
     )
+    defer client.close()
     let deltas : Array[String] = []
     let response = client.chat(
       [ChatMessage(User, content="hello")],
@@ -195,12 +197,182 @@ async test "streaming chat retries a pre-delta stream drop" {
       retry_attempts=3,
       retry_backoff_ms=1,
     )
+    defer client.close()
     let response = client.chat(
       [ChatMessage(User, content="hello")],
       stream=StreamHandler(on_content_delta=_ => ()),
     )
     assert_eq(response.content, "ok")
     assert_eq(hits.val, 2)
+  }
+}
+
+///|
+/// An actively refused port is deterministic and should fail on the ordinary
+/// attempt budget rather than consume the long bad-edge retry window. Reserve
+/// and close a loopback port first to produce `ECONNREFUSED` reliably.
+async test "streaming TCP refusal does not consume the long connect window" {
+  @async.with_task_group() <| _ => {
+    let server = @socket.TcpServer(@socket.Addr::parse("127.0.0.1:0")) catch {
+      _ => {
+        println("local TCP bind unavailable; skipping retry test")
+        return
+      }
+    }
+    let port = server.addr.port()
+    server.close()
+    let url = "https://127.0.0.1:\{port}/chat/completions"
+    let client = @client.Client(
+      api_key="test-key",
+      api_url=url,
+      retry_attempts=2,
+      retry_backoff_ms=1,
+      connect_retry_window_ms=100,
+    )
+    let _ = client.chat(
+      [ChatMessage(User, content="hello")],
+      stream=StreamHandler(on_content_delta=_ => ()),
+    ) catch {
+      error => {
+        let message = "\{error}"
+        assert_true(message.contains("before any response event"))
+        assert_true(message.contains("after 2 attempts"))
+        assert_true(message.contains("DNS/TCP/TLS setup"))
+        assert_true(message.contains("OSError"))
+        assert_false(message.contains("attempts over"))
+        return
+      }
+    }
+    fail("expected exhausted connection retries")
+  }
+}
+
+///|
+/// TLS implementations classify an EOF during the handshake differently.
+/// Regardless of whether it surfaces as `ConnectionClosed` or `TlsError`, the
+/// client can retry it safely because the HTTP request has not started.
+async test "streaming TLS handshake close retries before sending the request" {
+  @async.with_task_group() <| group => {
+    let server = @socket.TcpServer(@socket.Addr::parse("127.0.0.1:0")) catch {
+      _ => {
+        println("local TCP bind unavailable; skipping retry test")
+        return
+      }
+    }
+    let hits : Ref[Int] = { val: 0 }
+    group.spawn_bg(no_wait=true) <| () => {
+      server.run_forever((_, _) => hits.val = hits.val + 1, max_connections=8)
+    }
+    let url = "https://127.0.0.1:\{server.addr.port()}/chat/completions"
+    let client = @client.Client(
+      api_key="test-key",
+      api_url=url,
+      retry_attempts=1,
+      retry_backoff_ms=1,
+      connect_retry_window_ms=100,
+    )
+    let _ = client.chat(
+      [ChatMessage(User, content="hello")],
+      stream=StreamHandler(on_content_delta=_ => ()),
+    ) catch {
+      error => {
+        let message = "\{error}"
+        assert_true(message.contains("before sending the request"))
+        assert_true(message.contains("DNS/TCP/TLS setup"))
+        assert_true(message.contains("attempts over"))
+        assert_true(hits.val > 1)
+        return
+      }
+    }
+    fail("expected exhausted TLS connection retries")
+  }
+}
+
+///|
+/// Disabling the separate setup window must leave the ordinary request retry
+/// policy intact. Each outer attempt gets one setup try, so two configured
+/// attempts should produce two accepted and immediately closed connections.
+async test "disabled setup window falls back to ordinary retries" {
+  @async.with_task_group() <| group => {
+    let server = @socket.TcpServer(@socket.Addr::parse("127.0.0.1:0")) catch {
+      _ => {
+        println("local TCP bind unavailable; skipping retry test")
+        return
+      }
+    }
+    let hits : Ref[Int] = { val: 0 }
+    group.spawn_bg(no_wait=true) <| () => {
+      server.run_forever((_, _) => hits.val = hits.val + 1, max_connections=8)
+    }
+    let url = "https://127.0.0.1:\{server.addr.port()}/chat/completions"
+    let client = @client.Client(
+      api_key="test-key",
+      api_url=url,
+      retry_attempts=2,
+      retry_backoff_ms=1,
+      connect_retry_window_ms=0,
+    )
+    let _ = client.chat(
+      [ChatMessage(User, content="hello")],
+      stream=StreamHandler(on_content_delta=_ => ()),
+    ) catch {
+      error => {
+        let message = "\{error}"
+        assert_true(message.contains("before any response event"))
+        assert_true(message.contains("after 2 attempts"))
+        assert_true(message.contains("DNS/TCP/TLS setup"))
+        assert_false(message.contains("attempts over"))
+        assert_eq(hits.val, 2)
+        return
+      }
+    }
+    fail("expected exhausted ordinary retries")
+  }
+}
+
+///|
+/// Bare async transport errors such as TLS `ConnectionClosed` do not say at
+/// which request stage they occurred. Preserve the I/O phase and attempt count
+/// when retries are exhausted so the user sees an actionable failure instead
+/// of only the low-level error name.
+async test "exhausted pre-event transport error reports phase and attempts" {
+  @async.with_task_group() <| group => {
+    guard bind_test_server("local TCP bind unavailable; skipping retry test")
+      is Some(server) else {
+      return
+    }
+    let hits : Ref[Int] = { val: 0 }
+    group.spawn_bg(no_wait=true) <| () => {
+      server.run_forever(
+        (_request, body, conn) => {
+          let _ = body.read_all()
+          hits.val = hits.val + 1
+          conn.close()
+        },
+        max_connections=4,
+      )
+    }
+    let url = "http://127.0.0.1:\{server.addr.port()}/chat/completions"
+    let client = @client.Client(
+      api_key="test-key",
+      api_url=url,
+      retry_attempts=2,
+      retry_backoff_ms=1,
+    )
+    let _ = client.chat(
+      [ChatMessage(User, content="hello")],
+      stream=StreamHandler(on_content_delta=_ => ()),
+    ) catch {
+      error => {
+        let message = "\{error}"
+        assert_true(message.contains("before any response event"))
+        assert_true(message.contains("after 2 attempts"))
+        assert_true(message.contains("waiting for response headers"))
+        assert_eq(hits.val, 2)
+        return
+      }
+    }
+    fail("expected exhausted transport retries")
   }
 }
 

--- a/deepseek/client/client_stream_test.mbt
+++ b/deepseek/client/client_stream_test.mbt
@@ -57,6 +57,7 @@ async test "chat stream handler accumulates SSE content, tool calls, and usage" 
   @async.with_task_group() <| group => {
     guard stream_test_server(group) is Some(url) else { return }
     let client = @client.Client(api_key="test-key", api_url=url)
+    defer client.close()
     let deltas : Array[String] = []
     let reasoning_deltas : Array[String] = []
     let callbacks : Array[String] = []
@@ -94,6 +95,227 @@ async test "chat stream handler accumulates SSE content, tool calls, and usage" 
 }
 
 ///|
+/// Sequential model rounds (especially tool-call loops) should reuse one
+/// healthy HTTP/1.1 connection. Reconnecting every round repeats DNS, TCP, and
+/// TLS setup and needlessly exposes the agent to a transient bad edge route.
+async test "sequential streaming chats reuse a healthy connection" {
+  @async.with_task_group() <| group => {
+    let server = @socket.TcpServer(@socket.Addr::parse("127.0.0.1:0")) catch {
+      _ => {
+        println("local TCP bind unavailable; skipping stream test")
+        return
+      }
+    }
+    let connections : Ref[Int] = { val: 0 }
+    group.spawn_bg(no_wait=true) <| () => {
+      server.run_forever(
+        (tcp, _peer) => {
+          connections.val = connections.val + 1
+          let conn = @http.ServerConnection::new(tcp)
+          for ;; {
+            let _request = conn.read_request()
+            let _ = conn.read_all()
+            conn.send_response(200, "OK", extra_headers={
+              "Content-Type": "text/event-stream",
+            })
+            conn.write(
+              "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\n",
+            )
+            conn.write("data: [DONE]\n\n")
+            conn.end_response()
+          }
+        },
+        max_connections=2,
+      )
+    }
+    let url = "http://127.0.0.1:\{server.addr.port()}/chat/completions"
+    let client = @client.Client(api_key="test-key", api_url=url)
+    defer client.close()
+    for _ in 0..<2 {
+      let response = client.chat(
+        [ChatMessage(User, content="hello")],
+        stream=StreamHandler(on_content_delta=_ => ()),
+      )
+      assert_eq(response.content, "ok")
+    }
+    assert_eq(connections.val, 1)
+  }
+}
+
+///|
+/// A peer's explicit `Connection: close` wins over otherwise valid response
+/// framing. With one retry attempt, the second chat can only succeed if the
+/// first socket was discarded proactively rather than checked back in.
+async test "streaming chats do not retain Connection close responses" {
+  @async.with_task_group() <| group => {
+    let server = @socket.TcpServer(@socket.Addr::parse("127.0.0.1:0")) catch {
+      _ => {
+        println("local TCP bind unavailable; skipping stream test")
+        return
+      }
+    }
+    let connections : Ref[Int] = { val: 0 }
+    group.spawn_bg(no_wait=true) <| () => {
+      server.run_forever(
+        (tcp, _peer) => {
+          connections.val = connections.val + 1
+          let conn = @http.ServerConnection::new(tcp)
+          let _request = conn.read_request()
+          let _ = conn.read_all()
+          conn.send_response(200, "OK", extra_headers={
+            "Content-Type": "text/event-stream",
+            "Connection": "close",
+          })
+          conn.write("data: [DONE]\n\n")
+          conn.end_response()
+          conn.close()
+        },
+        max_connections=2,
+      )
+    }
+    let url = "http://127.0.0.1:\{server.addr.port()}/chat/completions"
+    let client = @client.Client(
+      api_key="test-key",
+      api_url=url,
+      retry_attempts=1,
+    )
+    defer client.close()
+    for _ in 0..<2 {
+      let response = client.chat(
+        [ChatMessage(User, content="hello")],
+        stream=StreamHandler(on_content_delta=_ => ()),
+      )
+      assert_eq(response.content, "")
+    }
+    assert_eq(connections.val, 2)
+  }
+}
+
+///|
+/// `[DONE]` alone is not enough to pool a socket: the terminating HTTP chunk
+/// must also arrive. The first peer deliberately omits it, so the drain times
+/// out and the next chat opens a fresh connection.
+async test "streaming chats discard incomplete response framing" {
+  @async.with_task_group() <| group => {
+    let server = @socket.TcpServer(@socket.Addr::parse("127.0.0.1:0")) catch {
+      _ => {
+        println("local TCP bind unavailable; skipping stream test")
+        return
+      }
+    }
+    let connections : Ref[Int] = { val: 0 }
+    group.spawn_bg(no_wait=true) <| () => {
+      server.run_forever(
+        (tcp, _peer) => {
+          connections.val = connections.val + 1
+          let connection_number = connections.val
+          let conn = @http.ServerConnection::new(tcp)
+          let _request = conn.read_request()
+          let _ = conn.read_all()
+          conn.send_response(200, "OK", extra_headers={
+            "Content-Type": "text/event-stream",
+          })
+          conn.write("data: [DONE]\n\n")
+          if connection_number == 1 {
+            conn.flush()
+            @async.sleep(1_500)
+          } else {
+            conn.end_response()
+          }
+          conn.close()
+        },
+        max_connections=2,
+      )
+    }
+    let url = "http://127.0.0.1:\{server.addr.port()}/chat/completions"
+    let client = @client.Client(
+      api_key="test-key",
+      api_url=url,
+      retry_attempts=1,
+    )
+    defer client.close()
+    for _ in 0..<2 {
+      let response = client.chat(
+        [ChatMessage(User, content="hello")],
+        stream=StreamHandler(on_content_delta=_ => ()),
+      )
+      assert_eq(response.content, "")
+    }
+    assert_eq(connections.val, 2)
+  }
+}
+
+///|
+/// A socket can become stale after it was validly pooled. Retrying the next
+/// pre-event request must discard that socket, reconnect, and recover.
+async test "streaming chat reconnects after a pooled socket becomes stale" {
+  @async.with_task_group() <| group => {
+    let server = @socket.TcpServer(@socket.Addr::parse("127.0.0.1:0")) catch {
+      _ => {
+        println("local TCP bind unavailable; skipping stream test")
+        return
+      }
+    }
+    let connections : Ref[Int] = { val: 0 }
+    let requests : Ref[Int] = { val: 0 }
+    group.spawn_bg(no_wait=true) <| () => {
+      server.run_forever(
+        (tcp, _peer) => {
+          connections.val = connections.val + 1
+          let conn = @http.ServerConnection::new(tcp)
+          let _request = conn.read_request()
+          let _ = conn.read_all()
+          requests.val = requests.val + 1
+          conn.send_response(200, "OK", extra_headers={
+            "Content-Type": "text/event-stream",
+          })
+          conn.write("data: [DONE]\n\n")
+          conn.end_response()
+          conn.close()
+        },
+        max_connections=2,
+      )
+    }
+    let url = "http://127.0.0.1:\{server.addr.port()}/chat/completions"
+    let client = @client.Client(
+      api_key="test-key",
+      api_url=url,
+      retry_attempts=2,
+      retry_backoff_ms=1,
+    )
+    defer client.close()
+    for _ in 0..<2 {
+      let response = client.chat(
+        [ChatMessage(User, content="hello")],
+        stream=StreamHandler(on_content_delta=_ => ()),
+      )
+      assert_eq(response.content, "")
+    }
+    assert_eq(connections.val, 2)
+    assert_eq(requests.val, 2)
+  }
+}
+
+///|
+/// Closing is idempotent and prevents a new streaming request from opening a
+/// connection. This also makes accidental use-after-close fail locally.
+async test "closed client rejects new streaming chats" {
+  let client = @client.Client(api_key="test-key")
+  client.close()
+  client.close()
+  let _ = client.chat(
+    [ChatMessage(User, content="hello")],
+    stream=StreamHandler(on_content_delta=_ => ()),
+  ) catch {
+    error => {
+      assert_true("\{error}".contains("DeepSeek client is closed"))
+      return
+    }
+  }
+  fail("expected closed client failure")
+}
+
+///|
 async test "chat stream handler accumulates Kimi stream_options usage" {
   @async.with_task_group() <| group => {
     guard stream_test_server(group, kimi_usage=true) is Some(url) else {
@@ -104,6 +326,7 @@ async test "chat stream handler accumulates Kimi stream_options usage" {
       model=Kimi(K27Code),
       api_url=url,
     )
+    defer client.close()
     let response = client.chat(
       [ChatMessage(User, content="hello")],
       stream=StreamHandler(on_content_delta=_ => ()),
@@ -161,6 +384,7 @@ async test "streaming chat retries an idle stall before any event" {
       retry_backoff_ms=1,
       idle_timeout_ms=100,
     )
+    defer client.close()
     let response = client.chat(
       [ChatMessage(User, content="hello")],
       stream=StreamHandler(on_content_delta=_ => ()),

--- a/deepseek/client/client_test.mbt
+++ b/deepseek/client/client_test.mbt
@@ -4,6 +4,8 @@ test "client defaults" {
   inspect(client.model, content="deepseek-v4-pro")
   assert_eq(client.api_url, "https://api.deepseek.com/chat/completions")
   assert_true(client.thinking is No)
+  assert_eq(client.retry_attempts, 3)
+  assert_eq(client.connect_retry_window_ms, 65_000)
 }
 
 ///|
@@ -31,6 +33,7 @@ test "client debug redacts api key" {
       #|  thinking: Max,
       #|  retry_attempts: 3,
       #|  retry_backoff_ms: 500,
+      #|  connect_retry_window_ms: 65000,
       #|  idle_timeout_ms: 120000,
       #|}
     ),

--- a/deepseek/client/client_wbtest.mbt
+++ b/deepseek/client/client_wbtest.mbt
@@ -1,0 +1,40 @@
+///|
+/// Fast failures must not exhaust an attempt count before the DNS/edge retry
+/// window expires. The bounded final sleep puts one last connect exactly at
+/// the 65s deadline: 0, .5, 1.5, 3.5, 7.5, 15.5, 31.5, 63.5, 65 seconds.
+test "connect retry schedule reaches the wall-clock deadline" {
+  let deadline : Int64 = 65_000
+  let starts : Array[Int64] = [0]
+  let mut now : Int64 = 0
+  let mut backoff_ms = 500
+  for ;; {
+    match connect_retry_sleep_ms(now, deadline, backoff_ms) {
+      None => break
+      Some(sleep_ms) => {
+        now = now + sleep_ms.to_int64()
+        starts.push(now)
+        backoff_ms = max_backoff_ms.min(backoff_ms * 2)
+      }
+    }
+  }
+  debug_inspect(
+    starts,
+    content="[0, 500, 1500, 3500, 7500, 15500, 31500, 63500, 65000]",
+  )
+  assert_eq(connect_retry_sleep_ms(deadline, deadline, 500), None)
+}
+
+///|
+/// A query can begin the request target even when the endpoint has no explicit
+/// slash after its authority. The reusable client must retain that query and
+/// normalize the target to origin-form with a leading slash.
+test "query-only API endpoints preserve their request target" {
+  assert_eq(
+    split_api_endpoint("https://api.example?api-version=1"),
+    ("https://api.example", "/?api-version=1"),
+  )
+  assert_eq(
+    split_api_endpoint("https://api.example/chat?api-version=1"),
+    ("https://api.example", "/chat?api-version=1"),
+  )
+}

--- a/deepseek/client/moon.pkg
+++ b/deepseek/client/moon.pkg
@@ -3,6 +3,9 @@ import {
   "moonbitlang/async",
   "moonbitlang/async/http",
   "moonbitlang/async/io",
+  "moonbitlang/async/os_error",
+  "moonbitlang/async/socket",
+  "moonbitlang/async/tls",
   "moonbitlang/core/json",
 }
 

--- a/deepseek/client/pkg.generated.mbti
+++ b/deepseek/client/pkg.generated.mbti
@@ -17,12 +17,15 @@ pub struct Client {
   thinking : @deepseek.ThinkingMode
   retry_attempts : Int
   retry_backoff_ms : Int
+  connect_retry_window_ms : Int
   idle_timeout_ms : Int
   // private fields
-} derive(@debug.Debug)
-pub fn Client::Client(api_key~ : String, model? : @deepseek.Model, api_url? : String, thinking? : @deepseek.ThinkingMode, retry_attempts? : Int, retry_backoff_ms? : Int, idle_timeout_ms? : Int) -> Self
+}
+pub fn Client::Client(api_key~ : String, model? : @deepseek.Model, api_url? : String, thinking? : @deepseek.ThinkingMode, retry_attempts? : Int, retry_backoff_ms? : Int, connect_retry_window_ms? : Int, idle_timeout_ms? : Int) -> Self
 pub async fn Client::chat(Self, Array[@deepseek.ChatMessage], tools? : Array[@deepseek.ToolDefinition], response_format? : @deepseek.ResponseFormat, stream? : StreamHandler) -> @deepseek.ChatResponse
+pub fn Client::close(Self) -> Unit
 pub fn Client::to_repr(Self) -> @debug.Repr
+pub impl @debug.Debug for Client
 
 pub struct StreamHandler {
   // private fields

--- a/deepseek/client/stream.mbt
+++ b/deepseek/client/stream.mbt
@@ -235,9 +235,21 @@ async fn read_stream_line(
   idle_timeout_ms : Int,
 ) -> String?? {
   if idle_timeout_ms <= 0 {
-    Some(reader.read_until("\n"))
+    Some(
+      transport_io(
+        "reading SSE stream",
+        () => reader.read_until("\n"),
+        retry_tls_error=true,
+      ),
+    )
   } else {
-    @async.with_timeout_opt(idle_timeout_ms, () => reader.read_until("\n"))
+    @async.with_timeout_opt(idle_timeout_ms, () => {
+      transport_io(
+        "reading SSE stream",
+        () => reader.read_until("\n"),
+        retry_tls_error=true,
+      )
+    })
   }
 }
 


### PR DESCRIPTION
## Summary

- reuse one healthy HTTP/1.1 connection across sequential streaming model and tool-call rounds
- add a configurable 65-second connection-setup retry window that ends before HTTP request bytes are sent
- discard stale, explicitly closed, or incompletely framed responses instead of returning those sockets to the pool
- report transport phase and attempt count, add explicit client lifecycle cleanup, and cover the behavior with regression tests

## Why

Streaming rounds previously created a fresh DNS, TCP, and TLS connection for every model step. That unnecessary connection churn made transient setup failures more visible during multi-step agent turns. Reusing a healthy connection removes the repeated setup while preserving the existing Chat Completions API and normal SSE termination behavior.

## Correctness and scope

- the longer setup retry cannot replay or rebill a completion because it ends before request transmission
- the existing ordinary retry policy remains after a request was sent but before the first SSE event; callers can set retry_attempts=1 when replay ambiguity is unacceptable
- failures are not retried after any complete SSE event
- only responses with reusable framing, no Connection: close header, and a successfully drained body return their socket to the pool
- the change is limited to connection lifecycle, retry classification, diagnostics, and the tests and documentation needed for those behaviors