### PR TITLE
Show background task activity in the desktop sidebar

### DIFF
--- a/desktop/frontend/codex/activity.mbt
+++ b/desktop/frontend/codex/activity.mbt
@@ -1,0 +1,163 @@
+///|
+/// One task's ordered running-state evidence.
+priv struct CodexActivityEntry {
+  running : Bool
+  revision : Int
+} derive(Eq)
+
+///|
+/// The request-time cut carried by every app-server snapshot. Reserving a cut
+/// orders concurrent requests as well as live lifecycle notifications, so a
+/// newer snapshot wins even when its reply arrives first.
+priv struct CodexActivityFrontier {
+  connection_epoch : Int
+  revision : Int
+}
+
+///|
+/// Ordered frontend-local running evidence for Codex tasks. The map mirrors
+/// the catalog's per-task runtime bit and adds only the revision needed to
+/// reject stale snapshots. Protocol detail stays here; the shared sidebar sees
+/// only the semantic `presentation` projection.
+priv struct CodexActivityLedger {
+  entries : Map[String, CodexActivityEntry]
+  revision : Int
+  connection_epoch : Int
+} derive(Eq)
+
+///|
+fn CodexActivityLedger::empty() -> CodexActivityLedger {
+  { entries: Map([]), revision: 0, connection_epoch: 0, }
+}
+
+///|
+fn CodexActivityLedger::frontier(
+  self : CodexActivityLedger,
+) -> CodexActivityFrontier {
+  { connection_epoch: self.connection_epoch, revision: self.revision, }
+}
+
+///|
+/// Reserve a distinct causal cut before launching a list/read request.
+fn CodexActivityLedger::reserve_snapshot(
+  self : CodexActivityLedger,
+) -> (CodexActivityFrontier, CodexActivityLedger) {
+  let revision = self.revision + 1
+  (
+    { connection_epoch: self.connection_epoch, revision, },
+    { ..self, revision, },
+  )
+}
+
+///|
+fn CodexActivityLedger::entry(
+  self : CodexActivityLedger,
+  thread_id : String,
+) -> CodexActivityEntry {
+  self.entries.get(thread_id).unwrap_or({ running: false, revision: 0, })
+}
+
+///|
+/// Replace one entry and advance the causal revision in the same operation.
+/// Keeping the mutable Map copy here prevents any lifecycle caller from
+/// aliasing an earlier State snapshot or forgetting the ordering fence.
+fn CodexActivityLedger::record(
+  self : CodexActivityLedger,
+  thread_id : String,
+  running : Bool,
+) -> CodexActivityLedger {
+  let revision = self.revision + 1
+  let entries = self.entries.copy()
+  entries[thread_id] = { running, revision, }
+  { ..self, entries, revision, }
+}
+
+///|
+fn CodexActivityLedger::started(
+  self : CodexActivityLedger,
+  thread_id : String,
+) -> CodexActivityLedger {
+  self.record(thread_id, true)
+}
+
+///|
+fn CodexActivityLedger::completed(
+  self : CodexActivityLedger,
+  thread_id : String,
+) -> CodexActivityLedger {
+  // Keep an idle tombstone even if this frontend missed turn/started: it must
+  // still beat an active snapshot requested before the completion arrived.
+  self.record(thread_id, false)
+}
+
+///|
+fn CodexActivityLedger::status_changed(
+  self : CodexActivityLedger,
+  thread_id : String,
+  runtime : CodexThreadRuntime?,
+) -> CodexActivityLedger {
+  guard runtime is Some(runtime) else { return self }
+  self.record(thread_id, runtime is ThreadActive)
+}
+
+///|
+/// Retiring a task fences an older snapshot only when this frontend had
+/// catalog or live activity for it.
+fn CodexActivityLedger::retired(
+  self : CodexActivityLedger,
+  thread_id : String,
+) -> CodexActivityLedger {
+  guard self.entries.get(thread_id) is Some(_) else { return self }
+  self.record(thread_id, false)
+}
+
+///|
+/// A new app-server connection owns a new runtime epoch. Running evidence from
+/// the dead process is retired; a fresh snapshot will recover any work that is
+/// still active on the new connection.
+fn CodexActivityLedger::disconnected(
+  self : CodexActivityLedger,
+) -> CodexActivityLedger {
+  { ..self, entries: Map([]), connection_epoch: self.connection_epoch + 1, }
+}
+
+///|
+/// Merge a list/read snapshot only for tasks untouched by newer evidence.
+fn CodexActivityLedger::reconcile_snapshot(
+  self : CodexActivityLedger,
+  statuses : Array[(String, CodexThreadRuntime?)],
+  frontier : CodexActivityFrontier,
+) -> CodexActivityLedger {
+  guard frontier.connection_epoch == self.connection_epoch else { return self }
+  let entries = self.entries.copy()
+  let mut accepted = false
+  for status in statuses {
+    let (thread_id, runtime) = status
+    guard runtime is Some(runtime) else { continue }
+    let current = self.entry(thread_id)
+    guard current.revision <= frontier.revision else { continue }
+    entries[thread_id] = {
+      running: runtime is ThreadActive,
+      revision: frontier.revision,
+    }
+    accepted = true
+  }
+  if accepted {
+    { ..self, entries, }
+  } else {
+    self
+  }
+}
+
+///|
+fn CodexActivityLedger::presentation(
+  self : CodexActivityLedger,
+  thread_id : String,
+) -> @conversation.RunMark {
+  let entry = self.entry(thread_id)
+  if entry.running {
+    @conversation.RunningMark
+  } else {
+    @conversation.NoRunMark
+  }
+}

--- a/desktop/frontend/codex/activity_wbtest.mbt
+++ b/desktop/frontend/codex/activity_wbtest.mbt
@@ -1,0 +1,122 @@
+///|
+test "Codex activity retires running evidence on disconnect" {
+  let activity = CodexActivityLedger::empty().started("thread-1")
+  assert_true(activity.presentation("thread-1") is @conversation.RunningMark)
+  let disconnected = activity.disconnected()
+  assert_true(disconnected.presentation("thread-1") is @conversation.NoRunMark)
+}
+
+///|
+test "Codex activity accepts snapshot-only running evidence" {
+  let activity = CodexActivityLedger::empty()
+  let recovered = activity.reconcile_snapshot(
+    [("thread-1", Some(ThreadActive))],
+    activity.frontier(),
+  )
+  assert_true(recovered.presentation("thread-1") is @conversation.RunningMark)
+}
+
+///|
+test "Codex activity accepts idle catalog evidence without a run mark" {
+  let activity = CodexActivityLedger::empty()
+  let (frontier, pending) = activity.reserve_snapshot()
+  let reconciled = pending.reconcile_snapshot(
+    [("thread-1", Some(ThreadInactive)), ("thread-2", Some(ThreadInactive))],
+    frontier,
+  )
+  assert_true(reconciled != pending)
+  assert_true(reconciled.presentation("thread-1") is @conversation.NoRunMark)
+  assert_true(reconciled.retired("thread-3") == reconciled)
+}
+
+///|
+test "Codex activity rejects active snapshot older than completion" {
+  let activity = CodexActivityLedger::empty()
+  let frontier = activity.frontier()
+  let completed = activity.started("thread-1").completed("thread-1")
+  let reconciled = completed.reconcile_snapshot(
+    [("thread-1", Some(ThreadActive))],
+    frontier,
+  )
+  assert_true(reconciled.presentation("thread-1") is @conversation.NoRunMark)
+}
+
+///|
+test "Codex activity rejects active snapshot older than idle notification" {
+  let activity = CodexActivityLedger::empty()
+  let frontier = activity.frontier()
+  let idle = activity.status_changed("thread-1", Some(ThreadInactive))
+  let reconciled = idle.reconcile_snapshot(
+    [("thread-1", Some(ThreadActive))],
+    frontier,
+  )
+  assert_true(reconciled.presentation("thread-1") is @conversation.NoRunMark)
+}
+
+///|
+test "newer idle history snapshot fences older active Codex catalog" {
+  let activity = CodexActivityLedger::empty()
+  let (catalog_frontier, catalog_pending) = activity.reserve_snapshot()
+  let (read_frontier, read_pending) = catalog_pending.reserve_snapshot()
+  let idle = read_pending.reconcile_snapshot(
+    [("thread-1", Some(ThreadInactive))],
+    read_frontier,
+  )
+  let reconciled = idle.reconcile_snapshot(
+    [("thread-1", Some(ThreadActive))],
+    catalog_frontier,
+  )
+  assert_true(reconciled.presentation("thread-1") is @conversation.NoRunMark)
+}
+
+///|
+test "newer active Codex catalog fences older idle history snapshot" {
+  let activity = CodexActivityLedger::empty()
+  let (read_frontier, read_pending) = activity.reserve_snapshot()
+  let (catalog_frontier, catalog_pending) = read_pending.reserve_snapshot()
+  let running = catalog_pending.reconcile_snapshot(
+    [("thread-1", Some(ThreadActive))],
+    catalog_frontier,
+  )
+  let reconciled = running.reconcile_snapshot(
+    [("thread-1", Some(ThreadInactive))],
+    read_frontier,
+  )
+  assert_true(reconciled.presentation("thread-1") is @conversation.RunningMark)
+}
+
+///|
+test "failed newer Codex snapshot does not fence older catalog evidence" {
+  let activity = CodexActivityLedger::empty()
+  let (catalog_frontier, catalog_pending) = activity.reserve_snapshot()
+  let (_, read_pending) = catalog_pending.reserve_snapshot()
+  let reconciled = read_pending.reconcile_snapshot(
+    [("thread-1", Some(ThreadActive))],
+    catalog_frontier,
+  )
+  assert_true(reconciled.presentation("thread-1") is @conversation.RunningMark)
+}
+
+///|
+test "Codex activity rejects idle snapshot older than start" {
+  let activity = CodexActivityLedger::empty()
+  let frontier = activity.frontier()
+  let running = activity.started("thread-1")
+  let reconciled = running.reconcile_snapshot(
+    [("thread-1", Some(ThreadInactive))],
+    frontier,
+  )
+  assert_true(reconciled.presentation("thread-1") is @conversation.RunningMark)
+}
+
+///|
+test "Codex activity rejects snapshots from an earlier connection" {
+  let activity = CodexActivityLedger::empty()
+  let frontier = activity.frontier()
+  let reconnected = activity.disconnected()
+  let reconciled = reconnected.reconcile_snapshot(
+    [("thread-1", Some(ThreadActive))],
+    frontier,
+  )
+  assert_true(reconciled.presentation("thread-1") is @conversation.NoRunMark)
+}

--- a/desktop/frontend/codex/bridge.mbt
+++ b/desktop/frontend/codex/bridge.mbt
@@ -29,14 +29,8 @@ fn[Payload : ToJson, Response : FromJson + ToJson] CodexReplyKind::request(
 /// Read one complete active or archived catalog. App-server deliberately
 /// pages `thread/list`; the sidebar must follow `nextCursor` instead of making
 /// old tasks disappear once an account has more than one page.
-priv struct CodexThreadCatalogRequest {
-  archived : Bool
-  generation : Int
-}
-
-///|
-fn CodexThreadCatalogRequest::run(
-  self : CodexThreadCatalogRequest,
+fn CodexCatalogReplyContext::run(
+  self : CodexCatalogReplyContext,
   dispatch : @cmd.Emit[Msg],
   channel : @interop.ChannelId,
 ) -> @cmd.Cmd {
@@ -55,7 +49,7 @@ fn CodexThreadCatalogRequest::run(
             scheduler.add(
               dispatch(
                 Failed(
-                  kind=CodexThreadsReply(self.archived, self.generation),
+                  kind=CodexThreadsReply(self),
                   message=@interop.bridge_error_text(error),
                 ),
               ),
@@ -75,7 +69,7 @@ fn CodexThreadCatalogRequest::run(
           scheduler.add(
             dispatch(
               Failed(
-                kind=CodexThreadsReply(self.archived, self.generation),
+                kind=CodexThreadsReply(self),
                 message="Codex thread list repeated cursor " + next,
               ),
             ),
@@ -86,11 +80,7 @@ fn CodexThreadCatalogRequest::run(
         cursor = Some(next)
       }
       scheduler.add(
-        dispatch(
-          Reply(kind=CodexThreadsReply(self.archived, self.generation), value={
-            "data": rows,
-          }),
-        ),
+        dispatch(Reply(kind=CodexThreadsReply(self), value={ "data": rows })),
       )
     })
   })
@@ -104,20 +94,24 @@ fn State::refresh_catalog(
   dispatch : @cmd.Emit[Msg],
   channel : @interop.ChannelId,
 ) -> (@cmd.Cmd, State) {
+  let (activity_frontier, activity) = self.activity.reserve_snapshot()
   let next = {
     ..self,
+    activity,
     live_catalog_generation: self.live_catalog_generation + 1,
     archived_catalog_generation: self.archived_catalog_generation + 1,
   }
   (
     @cmd.batch([
-      CodexThreadCatalogRequest::{
+      CodexCatalogReplyContext::{
         archived: false,
         generation: next.live_catalog_generation,
+        activity_frontier,
       }.run(dispatch, channel),
-      CodexThreadCatalogRequest::{
+      CodexCatalogReplyContext::{
         archived: true,
         generation: next.archived_catalog_generation,
+        activity_frontier,
       }.run(dispatch, channel),
     ]),
     next,
@@ -333,19 +327,24 @@ fn State::start_draft_thread(
 
 ///|
 fn State::open_thread(
-  _self : State,
+  self : State,
   dispatch : @cmd.Emit[Msg],
   channel : @interop.ChannelId,
   thread_id : String,
-) -> @cmd.Cmd {
+) -> (@cmd.Cmd, CodexActivityFrontier, State) {
   // The host keeps this read-only across both legacy inline histories and
   // paginated histories. Selecting a row never resumes the task or claims its
   // writer merely to render the transcript.
-  CodexThreadReply(thread_id).request(
-    dispatch,
-    channel,
-    @commands.codex_thread_history_read,
-    { thread_id, },
+  let (activity_frontier, activity) = self.activity.reserve_snapshot()
+  (
+    CodexThreadReply(thread_id, activity_frontier).request(
+      dispatch,
+      channel,
+      @commands.codex_thread_history_read,
+      { thread_id, },
+    ),
+    activity_frontier,
+    { ..self, activity, },
   )
 }
 

--- a/desktop/frontend/codex/model.mbt
+++ b/desktop/frontend/codex/model.mbt
@@ -126,10 +126,19 @@ priv struct CodexThreadRow {
   cwd : String?
   project_root : String?
   worktree : CodexWorktree?
+  runtime : CodexThreadRuntime?
   // App-server last-activity stamp, converted to milliseconds so it is
   // directly comparable with OpenSeek's session mtimes when the shared
   // sidebar interleaves the two sources by recency.
   updated_at_ms : Double?
+} derive(Eq)
+
+///|
+/// App-server's durable thread status, reduced to the distinction the sidebar
+/// needs. Unknown future variants remain absent instead of being guessed idle.
+priv enum CodexThreadRuntime {
+  ThreadActive
+  ThreadInactive
 } derive(Eq)
 
 ///|
@@ -201,6 +210,7 @@ priv struct CodexThread {
   // composer an immediate label while the host verifies the current checkout
   // and asks GitHub for its pull request.
   branch : String?
+  runtime : CodexThreadRuntime?
   turns : Array[CodexTurn]
 } derive(Eq)
 
@@ -280,14 +290,34 @@ priv enum CodexSteerDelivery {
 } derive(Eq)
 
 ///|
+/// The request-time identity and activity cut for one half of the paged
+/// sidebar catalog. Keeping these fields together prevents a reply from
+/// accidentally pairing one generation with another request's frontier.
+priv struct CodexCatalogReplyContext {
+  archived : Bool
+  generation : Int
+  activity_frontier : CodexActivityFrontier
+}
+
+///|
+/// Why one complete thread snapshot is entering State. History reads carry
+/// the request-time activity cut and expected id; thread creation and the
+/// public test boundary are authoritative local transitions.
+priv enum CodexThreadSnapshotOrigin {
+  CodexHistoryRead(String, CodexActivityFrontier)
+  CodexThreadStart
+  CodexImportedSnapshot
+}
+
+///|
 /// The typed operation associated with one app-server reply.
 priv enum CodexReplyKind {
   CodexStatusReply
   CodexRequestsReply
   CodexAccountReply
   CodexModelsReply
-  CodexThreadsReply(Bool, Int)
-  CodexThreadReply(String)
+  CodexThreadsReply(CodexCatalogReplyContext)
+  CodexThreadReply(String, CodexActivityFrontier)
   CodexResumeReply(String)
   CodexDraftOpenReply(String)
   CodexDraftThreadReply(String)
@@ -553,6 +583,10 @@ struct State {
   permission_picker : CodexPermissionPicker
   threads : Array[CodexThreadRow]
   archived_threads : Array[CodexThreadRow]
+  // Ordered lifecycle evidence remains available when a task's transcript is
+  // not selected. Request frontiers prevent older snapshots from overwriting
+  // notifications that arrived while those requests were in flight.
+  activity : CodexActivityLedger
   // Live and archived pagination are independent requests. Each refresh
   // advances both generations so a slower older walk cannot overwrite a
   // newer catalog after reconnect, archive, or device focus changes.
@@ -614,6 +648,7 @@ pub fn State::State(loading? : Bool = false) -> State {
     permission_picker: CodexPermissionClosed(@protocol.AutoReview),
     threads: [],
     archived_threads: [],
+    activity: CodexActivityLedger::empty(),
     live_catalog_generation: 0,
     archived_catalog_generation: 0,
     selection: CodexNoTask,
@@ -670,7 +705,7 @@ fn State::can_choose_permission(self : State) -> Bool {
 /// The shell's black-box workspace tests use the same boundary as production
 /// instead of constructing Codex's private thread representation.
 pub fn State::from_thread_snapshot(value : Json) -> State {
-  State().with_thread_reply(value)
+  State().with_thread_reply(value, CodexImportedSnapshot)
 }
 
 ///|
@@ -887,11 +922,15 @@ fn State::accepts_thread_reply(self : State, requested_thread : String) -> Bool 
 /// so an overtaken draft/turn reply is inert rather than partly applied.
 fn State::accepts_reply(self : State, kind : CodexReplyKind) -> Bool {
   match kind {
-    CodexThreadsReply(false, generation) =>
-      generation == self.live_catalog_generation
-    CodexThreadsReply(true, generation) =>
-      generation == self.archived_catalog_generation
-    CodexThreadReply(thread_id) => self.accepts_thread_reply(thread_id)
+    CodexThreadsReply(context) =>
+      if context.archived {
+        context.generation == self.archived_catalog_generation
+      } else {
+        context.generation == self.live_catalog_generation
+      }
+    CodexThreadReply(thread_id, frontier) =>
+      frontier.connection_epoch == self.activity.connection_epoch &&
+      self.accepts_thread_reply(thread_id)
     CodexResumeReply(thread_id) =>
       self
       .active_thread()
@@ -922,7 +961,7 @@ fn State::accepts_reply(self : State, kind : CodexReplyKind) -> Bool {
 fn CodexReplyKind::foreground(self : CodexReplyKind) -> CodexForeground? {
   match self {
     CodexDraftOpenReply(id) => Some(CodexDraftOpenForeground(id))
-    CodexThreadReply(id) => Some(CodexThreadForeground(id))
+    CodexThreadReply(id, _) => Some(CodexThreadForeground(id))
     CodexResumeReply(id) => Some(CodexResumeForeground(id))
     CodexDraftThreadReply(id) => Some(CodexDraftStartForeground(id))
     CodexTurnStartReply(id)
@@ -940,7 +979,7 @@ fn CodexReplyKind::foreground(self : CodexReplyKind) -> CodexForeground? {
     | CodexRequestsReply
     | CodexAccountReply
     | CodexModelsReply
-    | CodexThreadsReply(_, _)
+    | CodexThreadsReply(_)
     | CodexInterruptReply
     | CodexApprovalReply => None
   }
@@ -1249,6 +1288,19 @@ fn CodexWorktree::decode(value : Json) -> CodexWorktree? {
 }
 
 ///|
+fn CodexThreadRuntime::decode(value : Json?) -> CodexThreadRuntime? {
+  guard value is Some(Object(fields)) &&
+    @jsonx.json_text(fields, "type") is Some(type_) else {
+    return None
+  }
+  match type_ {
+    "active" => Some(ThreadActive)
+    "idle" | "notLoaded" | "systemError" => Some(ThreadInactive)
+    _ => None
+  }
+}
+
+///|
 /// Select the exact registry row created or rebuilt for this Codex owner.
 /// The host reply is authoritative; name alone is insufficient because the
 /// same workspace can contain worktrees owned by OpenSeek conversations.
@@ -1280,6 +1332,11 @@ fn CodexThread::decode(value : Json) -> CodexThread? {
       }
     }
   }
+  let runtime = match CodexThreadRuntime::decode(fields.get("status")) {
+    Some(runtime) => Some(runtime)
+    None if turns.iter().any(turn => turn.is_running()) => Some(ThreadActive)
+    None => None
+  }
   Some({
     id,
     title: CodexThreadRow::title(fields),
@@ -1287,6 +1344,7 @@ fn CodexThread::decode(value : Json) -> CodexThread? {
     project_root: @jsonx.json_text(fields, "projectRoot"),
     worktree: fields.get("openseekWorktree").bind(CodexWorktree::decode),
     branch: CodexThreadRow::branch(fields),
+    runtime,
     turns,
   })
 }
@@ -1369,9 +1427,20 @@ fn CodexThreadRow::branch(fields : Map[String, Json]) -> String? {
 
 ///|
 fn State::with_status(self : State, value : Json) -> State {
-  guard value is Object(fields) &&
-    @jsonx.json_text(fields, "status") is Some(status) else {
-    return { ..self, connection: CodexUnavailable("Malformed status reply"), }
+  let connection = match value {
+    Object(fields) =>
+      match @jsonx.json_text(fields, "status") {
+        Some("ready") => CodexReady
+        Some("starting") => CodexStarting
+        Some(_) =>
+          CodexUnavailable(
+            @jsonx.json_text(fields, "message").unwrap_or(
+              "Codex is unavailable",
+            ),
+          )
+        None => CodexUnavailable("Malformed status reply")
+      }
+    _ => CodexUnavailable("Malformed status reply")
   }
   {
     ..self
@@ -1384,13 +1453,14 @@ fn State::with_status(self : State, value : Json) -> State {
     } else {
       self.loading
     },
-    connection: match status {
-      "ready" => CodexReady
-      "starting" => CodexStarting
-      _ =>
-        CodexUnavailable(
-          @jsonx.json_text(fields, "message").unwrap_or("Codex is unavailable"),
-        )
+    connection,
+    // A disconnect ends running work owned by that process.
+    // Advance the connection epoch only on the ready-to-disconnected edge so
+    // repeated starting/unavailable reports do not invalidate fresh requests.
+    activity: if self.connection is CodexReady && !(connection is CodexReady) {
+      self.activity.disconnected()
+    } else {
+      self.activity
     },
   }
 }
@@ -1471,7 +1541,12 @@ fn State::with_models(self : State, value : Json) -> State {
 }
 
 ///|
-fn State::with_threads(self : State, value : Json, archived : Bool) -> State {
+fn State::with_threads(
+  self : State,
+  value : Json,
+  archived : Bool,
+  activity_frontier : CodexActivityFrontier,
+) -> State {
   guard value is Object(fields) && fields.get("data") is Some(Array(values)) else {
     return { ..self, notice: "Malformed Codex thread list", }
   }
@@ -1486,12 +1561,17 @@ fn State::with_threads(self : State, value : Json, archived : Bool) -> State {
     // missed while disconnected. Remove matching live rows in either reply
     // order, and settle a selected task through the same removal transition as
     // a live `thread/archived` notification.
+    let mut activity = self.activity
+    for thread in threads {
+      activity = activity.retired(thread.id)
+    }
     let next = {
       ..self,
       threads: self.threads.filter(live => {
         !threads.iter().any(archived => archived.id == live.id)
       }),
       archived_threads: threads,
+      activity,
       notice: "",
     }
     if next.active_thread() is Some(active) &&
@@ -1524,6 +1604,7 @@ fn State::with_threads(self : State, value : Json, archived : Bool) -> State {
         cwd: active.cwd,
         project_root: active.project_root,
         worktree: active.worktree,
+        runtime: active.runtime,
         updated_at_ms: carried_ms,
       },
     ]
@@ -1534,7 +1615,15 @@ fn State::with_threads(self : State, value : Json, archived : Bool) -> State {
   } else {
     threads
   }
-  { ..self, threads: visible, notice: "", }
+  // Only rows returned by this list response carry new runtime evidence. The
+  // selected row may be carried forward solely for navigation continuity, and
+  // its cached runtime must not overwrite a newer lifecycle notification.
+  let statuses = threads.map(thread => (thread.id, thread.runtime))
+  let next = { ..self, threads: visible, notice: "", }
+  {
+    ..next,
+    activity: next.activity.reconcile_snapshot(statuses, activity_frontier),
+  }
 }
 
 ///|
@@ -1553,6 +1642,7 @@ fn CodexThreadRow::decode(value : Json) -> CodexThreadRow? {
     cwd: @jsonx.json_text(thread, "cwd"),
     project_root: @jsonx.json_text(thread, "projectRoot"),
     worktree: thread.get("openseekWorktree").bind(CodexWorktree::decode),
+    runtime: CodexThreadRuntime::decode(thread.get("status")),
     updated_at_ms,
   })
 }
@@ -1595,8 +1685,12 @@ fn State::with_requests(self : State, value : Json) -> State {
 fn State::with_thread_reply(
   self : State,
   value : Json,
-  requested_thread? : String,
+  origin : CodexThreadSnapshotOrigin,
 ) -> State {
+  let (requested_thread, activity_frontier) = match origin {
+    CodexHistoryRead(thread_id, frontier) => (Some(thread_id), frontier)
+    CodexThreadStart | CodexImportedSnapshot => (None, self.activity.frontier())
+  }
   guard value is Object(fields) &&
     fields.get("thread") is Some(thread) &&
     CodexThread::decode(thread) is Some(active) else {
@@ -1625,6 +1719,7 @@ fn State::with_thread_reply(
     cwd: active.cwd,
     project_root: active.project_root,
     worktree: active.worktree,
+    runtime: active.runtime,
     updated_at_ms: reply_stamp_ms,
   }
   let threads : Array[CodexThreadRow] = []
@@ -1654,7 +1749,7 @@ fn State::with_thread_reply(
     }
     visible
   }
-  {
+  let next = {
     ..self,
     threads: visible,
     selection: CodexStoredTask(active),
@@ -1692,6 +1787,13 @@ fn State::with_thread_reply(
       None => @composer.LocalCheckout
     },
     notice: "",
+  }
+  {
+    ..next,
+    activity: next.activity.reconcile_snapshot(
+      [(active.id, active.runtime)],
+      activity_frontier,
+    ),
   }
 }
 
@@ -1821,6 +1923,7 @@ fn State::without_thread(self : State, thread_id : String) -> State {
   {
     ..self,
     threads: self.threads.filter(thread => thread.id != thread_id),
+    activity: self.activity.retired(thread_id),
     selection: if removing_active {
       CodexNoTask
     } else {
@@ -2121,30 +2224,46 @@ fn State::with_notification(
     @jsonx.json_text(fields, "threadId") is Some(thread_id) {
     return self.without_archived_thread(thread_id)
   }
-  guard self.active_thread() is Some(active) &&
-    @jsonx.json_text(fields, "threadId").unwrap_or(active.id) == active.id else {
-    return self
+  let thread_id = @jsonx.json_text(fields, "threadId")
+  let observed = match (method_, thread_id, fields.get("turn")) {
+    ("turn/started", Some(thread_id), Some(Object(_))) =>
+      { ..self, activity: self.activity.started(thread_id), }
+    ("turn/completed", Some(thread_id), Some(Object(_))) =>
+      { ..self, activity: self.activity.completed(thread_id), }
+    ("thread/status/changed", Some(thread_id), _) =>
+      {
+        ..self,
+        activity: self.activity.status_changed(
+          thread_id,
+          CodexThreadRuntime::decode(fields.get("status")),
+        ),
+      }
+    _ => self
+  }
+  guard observed.active_thread() is Some(active) &&
+    thread_id.unwrap_or(active.id) == active.id else {
+    return observed
   }
   let next = match method_ {
     "thread/name/updated" =>
       if @jsonx.json_text(fields, "name") is Some(title) {
-        { ..self, selection: CodexStoredTask({ ..active, title, }), }
+        { ..observed, selection: CodexStoredTask({ ..active, title, }), }
       } else {
-        self
+        observed
       }
     "turn/started" | "turn/completed" =>
       if fields.get("turn") is Some(value) &&
         CodexTurn::decode(value) is Some(turn) {
-        { ..self, selection: CodexStoredTask(active.with_turn(turn)), }
+        { ..observed, selection: CodexStoredTask(active.with_turn(turn)), }
       } else {
-        self
+        observed
       }
     "item/started" | "item/completed" =>
       if @jsonx.json_text(fields, "turnId") is Some(turn_id) &&
         fields.get("item") is Some(value) &&
         CodexItem::decode(value) is Some(item) {
         {
-          ..self,
+          ..observed,
           selection: CodexStoredTask(
             active.with_item(
               turn_id,
@@ -2154,7 +2273,7 @@ fn State::with_notification(
           ),
         }
       } else {
-        self
+        observed
       }
     "item/agentMessage/delta"
     | "item/plan/delta"
@@ -2165,26 +2284,26 @@ fn State::with_notification(
         @jsonx.json_text(fields, "itemId") is Some(item_id) &&
         @jsonx.json_text(fields, "delta") is Some(delta) {
         {
-          ..self,
+          ..observed,
           selection: CodexStoredTask(active.with_delta(turn_id, item_id, delta)),
         }
       } else {
-        self
+        observed
       }
     "error" =>
       if fields.get("error") is Some(Object(error)) &&
         @jsonx.json_text(error, "message") is Some(message) {
-        { ..self, notice: message, }
+        { ..observed, notice: message, }
       } else {
-        self
+        observed
       }
     "warning" =>
       if @jsonx.json_text(fields, "message") is Some(message) {
-        { ..self, notice: message, }
+        { ..observed, notice: message, }
       } else {
-        self
+        observed
       }
-    _ => self
+    _ => observed
   }
   next.with_observed_first_prompt()
 }
@@ -2802,7 +2921,10 @@ test "a summary turn/completed keeps the streamed user message" {
   // user and agent messages arrive only as items, and turn/completed's
   // "summary" view lists the agent message alone.
   let state = State()
-    .with_thread_reply({ "thread": { "id": "thread-1", "turns": [] } })
+    .with_thread_reply(
+      { "thread": { "id": "thread-1", "turns": [] } },
+      CodexImportedSnapshot,
+    )
     .with_notification(
       "turn/started",
       {
@@ -2879,9 +3001,10 @@ test "a summary turn/completed keeps the streamed user message" {
 
 ///|
 test "Codex archive notification closes the active thread" {
-  let state = State().with_thread_reply({
-    "thread": { "id": "thread-1", "turns": [] },
-  })
+  let state = State().with_thread_reply(
+    { "thread": { "id": "thread-1", "turns": [] } },
+    CodexImportedSnapshot,
+  )
   let settled = state.with_notification(
     "thread/archived",
     { "threadId": "thread-1" },
@@ -2897,10 +3020,12 @@ test "Codex active and archived catalogs remain independent" {
     .with_threads(
       { "data": [{ "id": "thread-live", "preview": "Live" }] },
       false,
+      State().activity.frontier(),
     )
     .with_threads(
       { "data": [{ "id": "thread-archived", "preview": "Archived" }] },
       true,
+      State().activity.frontier(),
     )
   assert_eq(state.threads.map(thread => thread.id), ["thread-live"])
   assert_eq(state.archived_threads.map(thread => thread.id), ["thread-archived"])
@@ -2915,35 +3040,80 @@ test "Codex active and archived catalogs remain independent" {
 
 ///|
 test "Codex thread replies are visible before catalog refresh" {
-  let state = State().with_thread_reply({
-    "thread": {
-      "id": "thread-1",
-      "cwd": "/project",
-      "projectRoot": "/project",
-      "preview": "Smoke test",
-      "turns": [],
+  let state = State().with_thread_reply(
+    {
+      "thread": {
+        "id": "thread-1",
+        "cwd": "/project",
+        "projectRoot": "/project",
+        "preview": "Smoke test",
+        "turns": [],
+      },
     },
-  })
+    CodexThreadStart,
+  )
   assert_eq(state.threads.length(), 1)
   assert_eq(state.threads[0].id, "thread-1")
   assert_eq(state.threads[0].title, "Smoke test")
   assert_eq(state.threads[0].project_root, Some("/project"))
   assert_eq(state.worktree_launch_workspace(@interop.ChannelId::Local), None)
-  let external_worktree = State().with_thread_reply({
-    "thread": {
-      "id": "thread-external",
-      "cwd": "/external/worktree",
-      "projectRoot": "/project",
-      "turns": [],
+  let external_worktree = State().with_thread_reply(
+    {
+      "thread": {
+        "id": "thread-external",
+        "cwd": "/external/worktree",
+        "projectRoot": "/project",
+        "turns": [],
+      },
     },
-  })
+    CodexImportedSnapshot,
+  )
   assert_eq(
     external_worktree.worktree_launch_workspace(@interop.ChannelId::Local),
     None,
   )
-  let refreshed = state.with_threads({ "data": [] }, false)
+  let refreshed = state.with_threads(
+    { "data": [] },
+    false,
+    state.activity.frontier(),
+  )
   assert_eq(refreshed.threads.length(), 1)
   assert_eq(refreshed.threads[0].id, "thread-1")
+}
+
+///|
+test "carried Codex rows do not revive running after completion" {
+  let started = State().with_thread_reply(
+    {
+      "thread": {
+        "id": "thread-1",
+        "status": { "type": "active" },
+        "turns": [{ "id": "turn-1", "status": "inProgress", "items": [] }],
+      },
+    },
+    CodexThreadStart,
+  )
+  let completed = started.with_notification(
+    "turn/completed",
+    {
+      "threadId": "thread-1",
+      "turn": { "id": "turn-1", "status": "completed", "items": [] },
+    },
+    0,
+  )
+  assert_true(
+    completed.activity.presentation("thread-1") is @conversation.NoRunMark,
+  )
+  let (frontier, activity) = completed.activity.reserve_snapshot()
+  let refreshed = { ..completed, activity, }.with_threads(
+    { "data": [] },
+    false,
+    frontier,
+  )
+  assert_eq(refreshed.threads.map(thread => thread.id), ["thread-1"])
+  assert_true(
+    refreshed.activity.presentation("thread-1") is @conversation.NoRunMark,
+  )
 }
 
 ///|
@@ -2957,14 +3127,18 @@ test "opening a Codex conversation preserves its catalog position" {
       ],
     },
     false,
+    State().activity.frontier(),
   )
-  let opened = listed.with_thread_reply({
-    "thread": {
-      "id": "thread-middle",
-      "preview": "Middle refreshed",
-      "turns": [],
+  let opened = listed.with_thread_reply(
+    {
+      "thread": {
+        "id": "thread-middle",
+        "preview": "Middle refreshed",
+        "turns": [],
+      },
     },
-  })
+    CodexHistoryRead("thread-middle", listed.activity.frontier()),
+  )
   assert_eq(opened.threads.map(thread => thread.id), [
     "thread-new", "thread-middle", "thread-old",
   ])
@@ -2973,15 +3147,18 @@ test "opening a Codex conversation preserves its catalog position" {
 
 ///|
 test "Codex Git status starts from app-server and accepts current checkout" {
-  let state = State().with_thread_reply({
-    "thread": {
-      "id": "thread-1",
-      "cwd": "/worktrees/a/project",
-      "projectRoot": "/workspace/project",
-      "gitInfo": { "branch": "captured-branch" },
-      "turns": [],
+  let state = State().with_thread_reply(
+    {
+      "thread": {
+        "id": "thread-1",
+        "cwd": "/worktrees/a/project",
+        "projectRoot": "/workspace/project",
+        "gitInfo": { "branch": "captured-branch" },
+        "turns": [],
+      },
     },
-  })
+    CodexImportedSnapshot,
+  )
   assert_eq(state.new_thread_cwd(), "/workspace/project")
   assert_eq(state.git_status.unwrap().branch, Some("captured-branch"))
   let refreshed = state.with_git_reply("thread-1", 0, "/worktrees/a/project", {
@@ -3018,6 +3195,7 @@ test "Codex worktree conversations share their main project key" {
       ],
     },
     false,
+    State().activity.frontier(),
   )
   assert_eq(state.threads.length(), 2)
   assert_eq(

--- a/desktop/frontend/codex/update.mbt
+++ b/desktop/frontend/codex/update.mbt
@@ -170,16 +170,17 @@ pub fn update(
         // any foreground Stop authority.
         (@cmd.none, state)
       } else {
-        let commands : Array[@cmd.Cmd] = [
-          state.open_thread(dispatch, channel, thread_id),
-        ]
+        let (read, activity_frontier, reading) = state.open_thread(
+          dispatch, channel, thread_id,
+        )
+        let commands : Array[@cmd.Cmd] = [read]
         if state.active_draft() is Some(draft) {
           commands.push(state.close_draft(channel, draft.id))
         }
         (
           @cmd.batch(commands),
           {
-            ..state,
+            ..reading,
             git_details_open: false,
             requested_thread: Some(thread_id),
             // These fields are the adapter's last canonical submission snapshot.
@@ -190,7 +191,7 @@ pub fn update(
             submitted_first_prompt: None,
             pending_steers: [],
             notice: "",
-          }.begin_foreground(CodexThreadReply(thread_id)),
+          }.begin_foreground(CodexThreadReply(thread_id, activity_frontier)),
         )
       }
     ArchiveThread(thread_id) =>
@@ -275,19 +276,28 @@ pub fn update(
         CodexRequestsReply => next = next.with_requests(value)
         CodexAccountReply => next = next.with_account(value)
         CodexModelsReply => next = next.with_models(value)
-        CodexThreadsReply(archived, _) =>
-          next = next.with_threads(value, archived)
+        CodexThreadsReply(context) =>
+          next = next.with_threads(
+            value,
+            context.archived,
+            context.activity_frontier,
+          )
         CodexDraftOpenReply(draft_id) => {
           next = next.with_open_draft(draft_id, value).loading_context(false)
           cmd = @cmd.batch([
             next.load_skills(dispatch, channel, force_reload=false),
           ])
         }
-        CodexThreadReply(requested_thread) => {
-          next = next.with_thread_reply(value, requested_thread~)
+        CodexThreadReply(requested_thread, activity_frontier) => {
+          next = next.with_thread_reply(
+            value,
+            CodexHistoryRead(requested_thread, activity_frontier),
+          )
           // A malformed or mismatched snapshot leaves the requested id in
           // place. Only a verified selection may retarget Files/Terminal.
-          if next.requested_thread is None {
+          if next.requested_thread is None &&
+            next.active_thread() is Some(active) &&
+            active.id == requested_thread {
             next = next.loading_context(false)
             let (git, refreshed) = next.refresh_git(dispatch, channel)
             next = refreshed
@@ -299,7 +309,7 @@ pub fn update(
         }
         CodexResumeReply(_) => ()
         CodexDraftThreadReply(_) => {
-          next = next.with_thread_reply(value)
+          next = next.with_thread_reply(value, CodexThreadStart)
           // Install the real id before starting the turn so every app-server
           // notification observes the stored selection. The preserved draft
           // and placement now flow through the ordinary Local/Worktree send.
@@ -405,10 +415,14 @@ pub fn update(
         CodexRequestsReply => "Codex requests"
         CodexAccountReply => "Codex account"
         CodexModelsReply => "Codex models"
-        CodexThreadsReply(false, _) => "Codex threads"
-        CodexThreadsReply(true, _) => "Archived Codex threads"
+        CodexThreadsReply(context) =>
+          if context.archived {
+            "Archived Codex threads"
+          } else {
+            "Codex threads"
+          }
         CodexDraftOpenReply(_) => "Codex draft"
-        CodexThreadReply(_) | CodexDraftThreadReply(_) => "Codex thread"
+        CodexThreadReply(_, _) | CodexDraftThreadReply(_) => "Codex thread"
         CodexTurnStartReply(_)
         | CodexTurnSteerReply(_)
         | CodexWorktreeTurnReply(_, _) => "Codex turn"
@@ -462,8 +476,23 @@ pub fn update(
       let cmd = if next.connection is CodexReady {
         let (refresh, refreshed) = next.refresh(dispatch, channel)
         current = refreshed
-        if next.active_thread() is Some(active) {
-          @cmd.batch([refresh, next.open_thread(dispatch, channel, active.id)])
+        // A disconnect invalidates the old history request's activity epoch.
+        // Retry its pending target before refreshing the still-rendered prior
+        // selection; `open_thread` captures the new epoch in the reply kind.
+        if next.requested_thread is Some(thread_id) {
+          let (read, _, reading) = current.open_thread(
+            dispatch, channel, thread_id,
+          )
+          current = reading
+          @cmd.batch([refresh, read])
+        } else if next.active_thread() is Some(active) {
+          let (read, _, reading) = current.open_thread(
+            dispatch,
+            channel,
+            active.id,
+          )
+          current = reading
+          @cmd.batch([refresh, read])
         } else if next.active_draft() is Some(draft) && !draft.cwd.is_empty() {
           @cmd.batch([
             refresh,
@@ -538,6 +567,11 @@ fn State::with_turn_start_reply(self : State, value : Json) -> State {
     { ..self, selection: CodexStoredTask(active.with_turn(turn)), draft: "", }
   } else {
     { ..self, draft: "", }
+  }
+  let next = match next.active_thread() {
+    Some(active) if active.turns.iter().any(turn => turn.is_running()) =>
+      { ..next, activity: next.activity.started(active.id), }
+    _ => next
   }
   { ..next, mentions: [], submission_sequence: next.submission_sequence + 1, }.with_observed_first_prompt()
 }
@@ -1362,9 +1396,23 @@ test "Codex update handlers are pure and idempotent" {
       "account": Json::null(),
     }),
     Reply(kind=CodexModelsReply, value={ "data": [] }),
-    Reply(kind=CodexThreadsReply(false, 0), value={ "data": [] }),
-    Reply(kind=CodexThreadsReply(true, 0), value={ "data": [] }),
-    Reply(kind=CodexThreadReply("thread-1"), value={
+    Reply(
+      kind=CodexThreadsReply({
+        archived: false,
+        generation: 0,
+        activity_frontier: State().activity.frontier(),
+      }),
+      value={ "data": [] },
+    ),
+    Reply(
+      kind=CodexThreadsReply({
+        archived: true,
+        generation: 0,
+        activity_frontier: State().activity.frontier(),
+      }),
+      value={ "data": [] },
+    ),
+    Reply(kind=CodexThreadReply("thread-1", State().activity.frontier()), value={
       "thread": { "id": "thread-1", "turns": [] },
     }),
     Reply(kind=CodexDraftThreadReply("desktop-test"), value={
@@ -1557,15 +1605,18 @@ test "Codex Git replies stay with the latest checkout request" {
   let dispatch : @cmd.Emit[Msg] = @cmd.Emit(_ => @cmd.none)
   let main_cwd = "/workspace/openseek"
   let worktree_cwd = "/workspace/.codex/worktrees/wt-3/openseek"
-  let opened = State().with_thread_reply({
-    "thread": {
-      "id": "thread-1",
-      "cwd": main_cwd,
-      "projectRoot": main_cwd,
-      "gitInfo": { "branch": "docs/desktop-ux-guidelines" },
-      "turns": [],
+  let opened = State().with_thread_reply(
+    {
+      "thread": {
+        "id": "thread-1",
+        "cwd": main_cwd,
+        "projectRoot": main_cwd,
+        "gitInfo": { "branch": "docs/desktop-ux-guidelines" },
+        "turns": [],
+      },
     },
-  })
+    CodexImportedSnapshot,
+  )
   // Opening the thread starts the lookup against the main checkout.
   let (_, main_pending) = opened.refresh_git(
     dispatch,
@@ -1691,6 +1742,7 @@ test "Codex history replies stay with the latest selected thread" {
       ],
     },
     false,
+    State().activity.frontier(),
   )
   let (_, waiting_a) = update(
     dispatch,
@@ -1712,7 +1764,7 @@ test "Codex history replies stay with the latest selected thread" {
   // neither may settle B's loading state or replace its pending target.
   let (_, stale_success) = update(
     dispatch,
-    Reply(kind=CodexThreadReply("thread-a"), value={
+    Reply(kind=CodexThreadReply("thread-a", listed.activity.frontier()), value={
       "thread": { "id": "thread-a", "turns": [] },
     }),
     waiting_b,
@@ -1722,7 +1774,10 @@ test "Codex history replies stay with the latest selected thread" {
   assert_true(stale_success == waiting_b)
   let (_, stale_failure) = update(
     dispatch,
-    Failed(kind=CodexThreadReply("thread-a"), message="late failure"),
+    Failed(
+      kind=CodexThreadReply("thread-a", listed.activity.frontier()),
+      message="late failure",
+    ),
     waiting_b,
     @interop.ChannelId::Local,
     _ => @cmd.none,
@@ -1731,7 +1786,7 @@ test "Codex history replies stay with the latest selected thread" {
 
   let (_, selected_b) = update(
     dispatch,
-    Reply(kind=CodexThreadReply("thread-b"), value={
+    Reply(kind=CodexThreadReply("thread-b", listed.activity.frontier()), value={
       "thread": { "id": "thread-b", "turns": [] },
     }),
     waiting_b,
@@ -1745,7 +1800,7 @@ test "Codex history replies stay with the latest selected thread" {
   // Once B is selected, even an A response arriving after B cannot rewind it.
   let (_, late_a) = update(
     dispatch,
-    Reply(kind=CodexThreadReply("thread-a"), value={
+    Reply(kind=CodexThreadReply("thread-a", listed.activity.frontier()), value={
       "thread": { "id": "thread-a", "turns": [] },
     }),
     selected_b,
@@ -1753,6 +1808,80 @@ test "Codex history replies stay with the latest selected thread" {
     _ => @cmd.none,
   )
   assert_true(late_a == selected_b)
+}
+
+///|
+test "Codex reconnect preserves a pending history target for a new epoch" {
+  let dispatch : @cmd.Emit[Msg] = @cmd.Emit(_ => @cmd.none)
+  let selected = State()
+    .with_threads(
+      {
+        "data": [
+          { "id": "thread-a", "preview": "Thread A" },
+          { "id": "thread-b", "preview": "Thread B" },
+        ],
+      },
+      false,
+      State().activity.frontier(),
+    )
+    .with_thread_reply(
+      { "thread": { "id": "thread-a", "turns": [] } },
+      CodexImportedSnapshot,
+    )
+  let ready = { ..selected, connection: CodexReady, }
+  let old_frontier = ready.activity.frontier()
+  let (_, opening) = update(
+    dispatch,
+    OpenThread("thread-b"),
+    ready,
+    @interop.ChannelId::Local,
+    _ => @cmd.none,
+  )
+  let (_, disconnected) = update(
+    dispatch,
+    StatusChanged({ "status": "starting" }),
+    opening,
+    @interop.ChannelId::Local,
+    _ => @cmd.none,
+  )
+  assert_eq(disconnected.requested_thread, Some("thread-b"))
+  assert_true(
+    disconnected.activity.frontier().connection_epoch !=
+    old_frontier.connection_epoch,
+  )
+
+  // The dead connection's reply is inert. Ready retries thread-b with the
+  // new frontier, whose reply can settle the pending selection normally.
+  let reply : Json = { "thread": { "id": "thread-b", "turns": [] } }
+  let (_, stale) = update(
+    dispatch,
+    Reply(kind=CodexThreadReply("thread-b", old_frontier), value=reply),
+    disconnected,
+    @interop.ChannelId::Local,
+    _ => @cmd.none,
+  )
+  assert_true(stale == disconnected)
+  let (_, reconnected) = update(
+    dispatch,
+    StatusChanged({ "status": "ready" }),
+    disconnected,
+    @interop.ChannelId::Local,
+    _ => @cmd.none,
+  )
+  assert_eq(reconnected.requested_thread, Some("thread-b"))
+  let (_, opened) = update(
+    dispatch,
+    Reply(
+      kind=CodexThreadReply("thread-b", reconnected.activity.frontier()),
+      value=reply,
+    ),
+    reconnected,
+    @interop.ChannelId::Local,
+    _ => @cmd.none,
+  )
+  assert_eq(opened.active_id(), Some("thread-b"))
+  assert_eq(opened.requested_thread, None)
+  assert_false(opened.loading)
 }
 
 ///|
@@ -2147,9 +2276,14 @@ test "newer Codex catalog refresh rejects an older pagination result" {
   )
   let (_, stale) = update(
     dispatch,
-    Reply(kind=CodexThreadsReply(false, 1), value={
-      "data": [{ "id": "stale", "preview": "Stale" }],
-    }),
+    Reply(
+      kind=CodexThreadsReply({
+        archived: false,
+        generation: 1,
+        activity_frontier: first.activity.frontier(),
+      }),
+      value={ "data": [{ "id": "stale", "preview": "Stale" }] },
+    ),
     second,
     @interop.ChannelId::Local,
     _ => @cmd.none,
@@ -2157,9 +2291,14 @@ test "newer Codex catalog refresh rejects an older pagination result" {
   assert_true(stale == second)
   let (_, current) = update(
     dispatch,
-    Reply(kind=CodexThreadsReply(false, 2), value={
-      "data": [{ "id": "current", "preview": "Current" }],
-    }),
+    Reply(
+      kind=CodexThreadsReply({
+        archived: false,
+        generation: 2,
+        activity_frontier: second.activity.frontier(),
+      }),
+      value={ "data": [{ "id": "current", "preview": "Current" }] },
+    ),
     stale,
     @interop.ChannelId::Local,
     _ => @cmd.none,
@@ -2168,15 +2307,128 @@ test "newer Codex catalog refresh rejects an older pagination result" {
 }
 
 ///|
+test "Codex list and history snapshots follow request order" {
+  let dispatch : @cmd.Emit[Msg] = @cmd.Emit(_ => @cmd.none)
+  let listed = State().with_threads(
+    { "data": [{ "id": "thread-a", "preview": "Thread A" }] },
+    false,
+    State().activity.frontier(),
+  )
+  let (_, refreshing) = update(
+    dispatch,
+    Refresh,
+    listed,
+    @interop.ChannelId::Local,
+    _ => @cmd.none,
+  )
+  let catalog_frontier = refreshing.activity.frontier()
+  let (_, opening) = update(
+    dispatch,
+    OpenThread("thread-a"),
+    refreshing,
+    @interop.ChannelId::Local,
+    _ => @cmd.none,
+  )
+  let read_frontier = opening.activity.frontier()
+  let (_, idle) = update(
+    dispatch,
+    Reply(kind=CodexThreadReply("thread-a", read_frontier), value={
+      "thread": { "id": "thread-a", "status": { "type": "idle" }, "turns": [] },
+    }),
+    opening,
+    @interop.ChannelId::Local,
+    _ => @cmd.none,
+  )
+  let (_, stale_active) = update(
+    dispatch,
+    Reply(
+      kind=CodexThreadsReply({
+        archived: false,
+        generation: 1,
+        activity_frontier: catalog_frontier,
+      }),
+      value={
+        "data": [
+          {
+            "id": "thread-a",
+            "preview": "Thread A",
+            "status": { "type": "active" },
+          },
+        ],
+      },
+    ),
+    idle,
+    @interop.ChannelId::Local,
+    _ => @cmd.none,
+  )
+  assert_true(
+    stale_active.activity.presentation("thread-a") is @conversation.NoRunMark,
+  )
+
+  // A subsequently requested catalog is newer than the history read and may
+  // authoritatively recover running state even if no notification was seen.
+  let (_, reloading) = update(
+    dispatch,
+    Refresh,
+    stale_active,
+    @interop.ChannelId::Local,
+    _ => @cmd.none,
+  )
+  let (_, current_active) = update(
+    dispatch,
+    Reply(
+      kind=CodexThreadsReply({
+        archived: false,
+        generation: 2,
+        activity_frontier: reloading.activity.frontier(),
+      }),
+      value={
+        "data": [
+          {
+            "id": "thread-a",
+            "preview": "Thread A",
+            "status": { "type": "active" },
+          },
+        ],
+      },
+    ),
+    reloading,
+    @interop.ChannelId::Local,
+    _ => @cmd.none,
+  )
+  assert_true(
+    current_active.activity.presentation("thread-a")
+    is @conversation.RunningMark,
+  )
+}
+
+///|
 test "archived Codex catalog removes a selected task in either reply order" {
   let dispatch : @cmd.Emit[Msg] = @cmd.Emit(_ => @cmd.none)
-  let selected = State::from_thread_snapshot({
+  let snapshot = State::from_thread_snapshot({
     "thread": { "id": "thread-a", "cwd": "/work/a", "turns": [] },
-  }).begin_foreground(CodexThreadReply("thread-a"))
-  let live = Reply(kind=CodexThreadsReply(false, 0), value={ "data": [] })
-  let archived = Reply(kind=CodexThreadsReply(true, 0), value={
-    "data": [{ "id": "thread-a", "cwd": "/work/a", "preview": "Archived A" }],
   })
+  let selected = snapshot.begin_foreground(
+    CodexThreadReply("thread-a", snapshot.activity.frontier()),
+  )
+  let live = Reply(
+    kind=CodexThreadsReply({
+      archived: false,
+      generation: 0,
+      activity_frontier: selected.activity.frontier(),
+    }),
+    value={ "data": [] },
+  )
+  let archived = Reply(
+    kind=CodexThreadsReply({
+      archived: true,
+      generation: 0,
+      activity_frontier: selected.activity.frontier(),
+    }),
+    value={
+      "data": [{ "id": "thread-a", "cwd": "/work/a", "preview": "Archived A" }],
+    },
+  )
   let (_, live_first) = update(
     dispatch,
     live,

--- a/desktop/frontend/codex/view.mbt
+++ b/desktop/frontend/codex/view.mbt
@@ -311,7 +311,7 @@ fn CodexThreadRow::sidebar_input(
 ) -> @conversation.Input {
   let selected = context.selected &&
     state.active_thread().map(item => item.id == self.id).unwrap_or(false)
-  let running = selected && state.is_running()
+  let run_mark = state.activity.presentation(self.id)
   {
     id: @conversation.Id(
       source="codex.live",
@@ -324,21 +324,13 @@ fn CodexThreadRow::sidebar_input(
     nested,
     subrun: false,
     active: selected,
-    running,
+    running: run_mark is @conversation.RunningMark,
     openable: true,
     worktree: self.worktree
     .filter(worktree => worktree.present)
     .map(worktree => worktree.name),
-    run_mark: if running {
-      @conversation.RunningMark
-    } else {
-      @conversation.NoRunMark
-    },
-    trailing: if running {
-      []
-    } else {
-      [@conversation.Archive(title="Archive Codex conversation")]
-    },
+    run_mark,
+    trailing: [@conversation.Archive(title="Archive Codex conversation")],
     children: [],
   }
 }
@@ -534,6 +526,7 @@ test "Codex archived catalog contributes restore inputs" {
   let state = State().with_threads(
     { "data": [{ "id": "thread-archived", "preview": "Archived task" }] },
     true,
+    State().activity.frontier(),
   )
   let entries = state.archived_sidebar_entries(@interop.ChannelId::Local)
   assert_eq(entries.length(), 1)
@@ -555,7 +548,11 @@ test "Codex threads join their registered project's shared row" {
       "preview": "Codex task \{number}",
     })
   }
-  let state = State().with_threads({ "data": data }, false)
+  let state = State().with_threads(
+    { "data": data },
+    false,
+    State().activity.frontier(),
+  )
   let context : SidebarContext = {
     channel: @interop.ChannelId::Local,
     selected: true,
@@ -566,4 +563,181 @@ test "Codex threads join their registered project's shared row" {
   assert_true(conversations[0].input.nested)
   assert_eq(state.project_conversations(context, "/work/other").length(), 0)
   assert_eq(state.loose_entries(context).length(), 0)
+}
+
+///|
+test "Codex snapshots preserve running activity across task switches" {
+  let context : SidebarContext = {
+    channel: @interop.ChannelId::Local,
+    selected: true,
+    registered_projects: ["/work/openseek"],
+  }
+  let listed = State().with_threads(
+    {
+      "data": [
+        {
+          "id": "thread-running",
+          "projectRoot": "/work/openseek",
+          "cwd": "/work/openseek",
+          "preview": "Running task",
+          "status": { "type": "active", "activeFlags": [] },
+        },
+        {
+          "id": "thread-selected",
+          "projectRoot": "/work/openseek",
+          "cwd": "/work/openseek",
+          "preview": "Selected task",
+          "status": { "type": "idle" },
+        },
+      ],
+    },
+    false,
+    State().activity.frontier(),
+  )
+  let listed_rows = listed.project_conversations(context, "/work/openseek")
+  assert_true(listed_rows[0].input.run_mark is @conversation.RunningMark)
+  assert_true(listed_rows[0].input.trailing is [@conversation.Archive(..)])
+
+  // Older app-server snapshots may omit thread status. A full read still
+  // carries the active turn and must survive after another task is selected.
+  let read = State()
+    .with_threads(
+      {
+        "data": [
+          {
+            "id": "thread-running",
+            "projectRoot": "/work/openseek",
+            "cwd": "/work/openseek",
+            "preview": "Running task",
+          },
+          {
+            "id": "thread-selected",
+            "projectRoot": "/work/openseek",
+            "cwd": "/work/openseek",
+            "preview": "Selected task",
+          },
+        ],
+      },
+      false,
+      State().activity.frontier(),
+    )
+    .with_thread_reply(
+      {
+        "thread": {
+          "id": "thread-running",
+          "projectRoot": "/work/openseek",
+          "cwd": "/work/openseek",
+          "preview": "Running task",
+          "turns": [{ "id": "turn-1", "status": "inProgress", "items": [] }],
+        },
+      },
+      CodexHistoryRead("thread-running", State().activity.frontier()),
+    )
+  assert_true(
+    read.activity.presentation("thread-running") is @conversation.RunningMark,
+  )
+  let switched = read.with_thread_reply(
+    {
+      "thread": {
+        "id": "thread-selected",
+        "projectRoot": "/work/openseek",
+        "cwd": "/work/openseek",
+        "preview": "Selected task",
+        "turns": [],
+      },
+    },
+    CodexHistoryRead("thread-selected", read.activity.frontier()),
+  )
+  let switched_rows = switched.project_conversations(context, "/work/openseek")
+  assert_true(switched_rows[0].input.run_mark is @conversation.RunningMark)
+  assert_true(switched_rows[0].input.trailing is [@conversation.Archive(..)])
+
+  let notified = State().with_notification(
+    "thread/status/changed",
+    {
+      "threadId": "thread-running",
+      "status": { "type": "active", "activeFlags": [] },
+    },
+    1,
+  )
+  assert_true(
+    notified.activity.presentation("thread-running")
+    is @conversation.RunningMark,
+  )
+  let idle = notified.with_notification(
+    "thread/status/changed",
+    { "threadId": "thread-running", "status": { "type": "idle" } },
+    2,
+  )
+  assert_true(
+    idle.activity.presentation("thread-running") is @conversation.NoRunMark,
+  )
+}
+
+///|
+test "background Codex activity follows its thread instead of selection" {
+  let state = State()
+    .with_threads(
+      {
+        "data": [
+          {
+            "id": "thread-background",
+            "projectRoot": "/work/openseek",
+            "cwd": "/work/openseek",
+            "preview": "Background task",
+          },
+          {
+            "id": "thread-selected",
+            "projectRoot": "/work/openseek",
+            "cwd": "/work/openseek",
+            "preview": "Selected task",
+          },
+        ],
+      },
+      false,
+      State().activity.frontier(),
+    )
+    .with_thread_reply(
+      {
+        "thread": {
+          "id": "thread-selected",
+          "projectRoot": "/work/openseek",
+          "cwd": "/work/openseek",
+          "preview": "Selected task",
+          "turns": [],
+        },
+      },
+      CodexHistoryRead("thread-selected", State().activity.frontier()),
+    )
+  let running = state.with_notification(
+    "turn/started",
+    {
+      "threadId": "thread-background",
+      "turn": { "id": "turn-1", "status": "inProgress", "items": [] },
+    },
+    1,
+  )
+  assert_eq(running.active_id(), Some("thread-selected"))
+  let context : SidebarContext = {
+    channel: @interop.ChannelId::Local,
+    selected: true,
+    registered_projects: ["/work/openseek"],
+  }
+  let rows = running.project_conversations(context, "/work/openseek")
+  assert_eq(rows.length(), 2)
+  assert_true(rows[0].input.run_mark is @conversation.RunningMark)
+  assert_true(rows[0].input.trailing is [@conversation.Archive(..)])
+  assert_true(rows[1].input.run_mark is @conversation.NoRunMark)
+
+  let completed = running.with_notification(
+    "turn/completed",
+    {
+      "threadId": "thread-background",
+      "turn": { "id": "turn-1", "status": "completed", "items": [] },
+    },
+    2,
+  )
+  let settled = completed.project_conversations(context, "/work/openseek")
+  assert_true(settled[0].input.run_mark is @conversation.NoRunMark)
+  assert_true(settled[0].input.trailing is [@conversation.Archive(..)])
 }

--- a/desktop/frontend/sidebar/conversation/conversation.mbt
+++ b/desktop/frontend/sidebar/conversation/conversation.mbt
@@ -209,18 +209,36 @@ pub fn component(
     }
     match input.run_mark {
       NoRunMark => ()
-      RunningMark => status.push(@html.span(class="run-dot accent pulse", ""))
+      RunningMark =>
+        status.push(
+          @html.span(
+            class="run-dot running",
+            attrs=@html.Attrs::build()
+              .role("status")
+              .aria_live("polite")
+              .aria_label("Running"),
+            "",
+          ),
+        )
       CompletedMark => status.push(@html.span(class="run-dot accent", ""))
       FailedMark => status.push(@html.span(class="run-dot warn", ""))
     }
-    if !status.is_empty() || !input.trailing.is_empty() {
+    // Runtime callers advertise the row's durable actions. The shared row
+    // owns the safety rule that none of them are actionable during a run, so a
+    // caller cannot accidentally pair a running mark with Archive.
+    let trailing_actions = if input.run_mark is RunningMark {
+      []
+    } else {
+      input.trailing
+    }
+    if !status.is_empty() || !trailing_actions.is_empty() {
       let trailing : Array[@html.Html] = []
       if !status.is_empty() {
         trailing.push(@html.span(class="row-status", status))
       }
-      if !input.trailing.is_empty() {
+      if !trailing_actions.is_empty() {
         let buttons : Array[@html.Html] = []
-        for action in input.trailing {
+        for action in trailing_actions {
           let (title, button_class, image) = match action {
             Archive(title~) => (title, "row-archive", @icons.icon_archive)
             Restore(title~) => (title, "row-archive", @icons.icon_arrow_up)

--- a/desktop/styles/base.css
+++ b/desktop/styles/base.css
@@ -241,6 +241,12 @@ samp,
     box-shadow: 0 0 0 0 transparent;
   }
 }
+
+@keyframes spinRunDot {
+  to {
+    transform: rotate(360deg);
+  }
+}
 @keyframes riseIn {
   from {
     opacity: 0;

--- a/desktop/styles/main_header.css
+++ b/desktop/styles/main_header.css
@@ -107,6 +107,7 @@ main {
 .run-dot {
   width: 7px;
   height: 7px;
+  box-sizing: border-box;
   border-radius: var(--radius-pill);
   background: var(--color-text-muted);
   flex: 0 0 auto;
@@ -122,6 +123,12 @@ main {
 }
 .run-dot.accent {
   background: var(--color-text-secondary);
+}
+.run-dot.running {
+  border: 2px solid var(--color-text-secondary);
+  border-right-color: transparent;
+  background: transparent;
+  animation: spinRunDot 0.9s linear infinite;
 }
 .run-dot.pulse {
   animation: pulseDot 1.6s ease-out infinite;

--- a/desktop/styles/responsive.css
+++ b/desktop/styles/responsive.css
@@ -159,7 +159,7 @@
 }
 
 /* Keep status changes visible without forcing motion on users who disable it
-   at the operating-system level. Static color and text still show each state. */
+   at the operating-system level. Static shape and color still show each state. */
 @media (prefers-reduced-motion: reduce) {
   .pending-steer-state,
   .subrun-mark,
@@ -170,7 +170,8 @@
   .msg.streaming .msg-content::after,
   .activity-row,
   .browser-nav-button.loading .icon svg,
-  .run-dot.pulse {
+  .run-dot.pulse,
+  .run-dot.running {
     animation: none;
   }
 }


### PR DESCRIPTION
## Why

Background Codex work was visible only while its task occupied the main pane. After switching tasks or reloading, an active task could look idle and expose Archive even though work was still in flight.

## What changed

- Reuse the existing OpenSeek sidebar run-mark contract. OpenSeek keeps its current running, completed, and failed behavior; Codex projects only running or no mark.
- Render running as an accessible spinning ring, with a static broken-ring fallback for reduced-motion users, and suppress durable row actions while any runtime reports work in flight.
- Keep ordered per-task Codex running evidence from live turn/status notifications and decoded catalog rows.
- Recover Codex running state from accepted `thread/list` and `thread/read` snapshots, including an `inProgress` turn when an older app-server omits thread status.
- Fence snapshots with per-task revisions, request order, and connection epochs so delayed replies cannot overwrite newer starts, completions, snapshots, or disconnects.
- Retry a pending history target with the new epoch after reconnect, and return Codex rows to idle on completion, idle status, disconnect, or archive.

## Why this is correct and minimal

This PR does not add Codex unread/completion semantics, read acknowledgements, backend polling, or protocol changes. OpenSeek retains its existing completion marks, while both runtimes share the same running presentation. The frontend-local Codex ledger mirrors only the runtime bit for tasks already decoded from the catalog, plus a revision for ordering; failed or malformed snapshots add no evidence. Cross-instance state sharing remains separate in #1098.
