### PR TITLE
ci: pin the stable MoonBit toolchain to 0.10.10+f8a486b6f

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,14 @@ jobs:
         target: [native, js]
         include:
           - moonbit-channel: stable
-            moonbit-version: latest
+            # Pinned, not `latest`: stable 0.10.11 (moon 0.1.20260827) crashes
+            # the native backend on moonbit-community/graphviz@0.1.3
+            # ("Machine_of_clam_lower.lower_break: break value is required for
+            # scalar loop"), which the editor pulls in through kokic/uml, so
+            # every `moon test --target native` dies before running. Its
+            # formatter also changed (trailing commas in struct literals), so
+            # unpinning means reformatting the workspace in the same change.
+            moonbit-version: "0.10.10+f8a486b6f"
             deny-warn: "--deny-warn"
     steps:
       - name: Checkout code

--- a/.github/workflows/editor.yml
+++ b/.github/workflows/editor.yml
@@ -49,7 +49,9 @@ jobs:
           if [ "${{ matrix.channel }}" = "nightly" ]; then
             curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s nightly
           else
-            curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
+            # Same pin as ci.yml: stable 0.10.11 ICEs on graphviz under
+            # `moon test --target native`.
+            curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s -- '0.10.10+f8a486b6f'
           fi
           echo "$HOME/.moon/bin" >> $GITHUB_PATH
 
@@ -88,7 +90,7 @@ jobs:
 
       - name: Install MoonBit (stable)
         run: |
-          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s -- '0.10.10+f8a486b6f'
           echo "$HOME/.moon/bin" >> $GITHUB_PATH
 
       - name: Update dependencies


### PR DESCRIPTION
## Summary

- Stable moved to `moon 0.1.20260827` / `moonc v0.10.11` today. Its native backend crashes on `moonbit-community/graphviz@0.1.3` (pulled in by the editor via `kokic/uml@0.1.5`): `Machine_of_clam_lower.lower_break: break value is required for scalar loop`. Every `moon test --target native` in the workspace links those packages, so CI and the editor workflow fail on every branch, `main` included (#1083, #1089); nightly crashes the same way.
- `ci.yml` and `editor.yml` install `0.10.10+f8a486b6f` instead of `latest`: the version `main`'s last green run used, the one `desktop/.moonbit-version` already pins, and under which the crashing package passes (`editor/internal/viewer/contrib/hover`: 52/52).
- The two formatters disagree (0.10.11 writes trailing commas in multi-line struct literals; 0.10.10 rejects them), so this pin and the 0.10.11 reformat in #1089 are mutually exclusive — #1089 is closed until the ICE is fixed upstream, and unpinning must reformat the workspace in the same change.

Not touched: `desktop-release.yml` and `copilot-setup-steps.yml` still install `latest`; the release build may hit the same crash and should be pinned the same way if it does.

Repro of the crash with 0.10.11: `cd editor && moon test --target native internal/viewer/contrib/hover`.

## Test plan

- [x] `moon test --target native internal/viewer/contrib/hover` passes under `0.10.10+f8a486b6f` (isolated install)
- [x] YAML parses
- [ ] CI (stable, native/js) and Editor green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)