### PR TITLE
fix(desktop): keep live work from stalling the editor

### DIFF
--- a/desktop/frontend/boot.mbt
+++ b/desktop/frontend/boot.mbt
@@ -65,6 +65,55 @@ fn app_shortcut_subscription(emit : @cmd.Emit[Msg]) -> @sub.Sub {
 }
 
 ///|
+/// Route high-frequency live reasoning directly to the transcript component.
+/// Every other message keeps the root application emitter. Step, run, and
+/// transport boundaries additionally clear the matching provisional state so
+/// an abnormal end cannot leave component-owned text behind.
+priv struct AppDispatcher {
+  root : @cmd.Emit[Msg]
+  live_reasoning : @transcript_component.LiveReasoning
+}
+
+///|
+fn AppDispatcher::emit(self : AppDispatcher, msg : Msg) -> @cmd.Cmd {
+  match msg {
+    FromDevice(
+      channel,
+      Engine(run_id, ReasoningDelta(content), session=Some(session)),
+    ) =>
+      self.live_reasoning.delta(channel~, session~, run_id~, content~)
+    FromDevice(
+      channel,
+      Engine(run_id, ReasoningMessage(_), session=Some(session)),
+    ) => self.live_reasoning.finish(channel~, session~, run_id~)
+    FromDevice(
+      channel,
+      Engine(run_id, AgentStep(_), session=Some(session)),
+    ) =>
+      @cmd.batch([
+        self.live_reasoning.finish(channel~, session~, run_id~),
+        (self.root)(msg),
+      ])
+    FromDevice(channel, Error(run_id=Some(run_id), ..))
+    | FromDevice(channel, Finished(run_id~, ..)) =>
+      @cmd.batch([
+        self.live_reasoning.finish_run(channel~, run_id~), (self.root)(msg),
+      ])
+    FromDevice(channel, BridgeReady)
+    | FromDevice(channel, ChannelDown(..)) =>
+      @cmd.batch([
+        self.live_reasoning.reset_channel(channel), (self.root)(msg),
+      ])
+    _ => (self.root)(msg)
+  }
+}
+
+///|
+fn AppDispatcher::as_emit(self : AppDispatcher) -> @cmd.Emit[Msg] {
+  @cmd.Emit(msg => self.emit(msg))
+}
+
+///|
 /// Browser platform label used to select Cmd on Apple systems and Ctrl
 /// elsewhere, leaving Ctrl chords available to terminal programs on Apple.
 fn app_shortcut_browser_platform() -> String {
@@ -345,12 +394,17 @@ fn SidebarDispatcher::actions(self : SidebarDispatcher) -> @sidebar.Actions {
 pub fn boot() -> Unit {
   @crash_page.install()
   let app = @rabbita.new(() => {
+    let live_reasoning = @transcript_component.LiveReasoning()
     let (state, emit) = @rabbita.create_state_with_init(
       // Init flows through `update` like any other message, as
       // `with_init(dispatch(Init))` did before the 0.13 migration.
       init=emit => (initial_model(), emit(Init)),
       update=(model, msg, emit) => {
-        let (cmd, next) = update(emit, msg, model)
+        let dispatch : @cmd.Emit[Msg] = AppDispatcher::{
+          root: emit,
+          live_reasoning,
+        }.as_emit()
+        let (cmd, next) = update(dispatch, msg, model)
         (next, cmd)
       },
       // The narrow-layout flag must track the window: rotating a phone or
@@ -497,17 +551,21 @@ pub fn boot() -> Unit {
       terminal_input, terminal_state, terminal_emit,
     )
     let transcript_input = state.map(model => model.transcript_input())
-    let transcript_html = @transcript_component.component(transcript_input, {
-      open: emit.map(path => OpenFile(path)),
-      jump: emit.map(target => {
-        JumpToLocation(
-          path=target.file,
-          range=target.range,
-          annotation=target.annotation,
-        )
-      }),
-      open_session: emit.map(session => OpenSessionHere(session)),
-    })
+    let transcript_html = @transcript_component.component(
+      transcript_input,
+      live_reasoning,
+      {
+        open: emit.map(path => OpenFile(path)),
+        jump: emit.map(target => {
+          JumpToLocation(
+            path=target.file,
+            range=target.range,
+            annotation=target.annotation,
+          )
+        }),
+        open_session: emit.map(session => OpenSessionHere(session)),
+      },
+    )
     let composer_input = state.map(model => model.composer_input())
     let composer_html = @composer.component(
       composer_input,

--- a/desktop/frontend/boot.mbt
+++ b/desktop/frontend/boot.mbt
@@ -65,55 +65,6 @@ fn app_shortcut_subscription(emit : @cmd.Emit[Msg]) -> @sub.Sub {
 }
 
 ///|
-/// Route high-frequency live reasoning directly to the transcript component.
-/// Every other message keeps the root application emitter. Step, run, and
-/// transport boundaries additionally clear the matching provisional state so
-/// an abnormal end cannot leave component-owned text behind.
-priv struct AppDispatcher {
-  root : @cmd.Emit[Msg]
-  live_reasoning : @transcript_component.LiveReasoning
-}
-
-///|
-fn AppDispatcher::emit(self : AppDispatcher, msg : Msg) -> @cmd.Cmd {
-  match msg {
-    FromDevice(
-      channel,
-      Engine(run_id, ReasoningDelta(content), session=Some(session)),
-    ) =>
-      self.live_reasoning.delta(channel~, session~, run_id~, content~)
-    FromDevice(
-      channel,
-      Engine(run_id, ReasoningMessage(_), session=Some(session)),
-    ) => self.live_reasoning.finish(channel~, session~, run_id~)
-    FromDevice(
-      channel,
-      Engine(run_id, AgentStep(_), session=Some(session)),
-    ) =>
-      @cmd.batch([
-        self.live_reasoning.finish(channel~, session~, run_id~),
-        (self.root)(msg),
-      ])
-    FromDevice(channel, Error(run_id=Some(run_id), ..))
-    | FromDevice(channel, Finished(run_id~, ..)) =>
-      @cmd.batch([
-        self.live_reasoning.finish_run(channel~, run_id~), (self.root)(msg),
-      ])
-    FromDevice(channel, BridgeReady)
-    | FromDevice(channel, ChannelDown(..)) =>
-      @cmd.batch([
-        self.live_reasoning.reset_channel(channel), (self.root)(msg),
-      ])
-    _ => (self.root)(msg)
-  }
-}
-
-///|
-fn AppDispatcher::as_emit(self : AppDispatcher) -> @cmd.Emit[Msg] {
-  @cmd.Emit(msg => self.emit(msg))
-}
-
-///|
 /// Browser platform label used to select Cmd on Apple systems and Ctrl
 /// elsewhere, leaving Ctrl chords available to terminal programs on Apple.
 fn app_shortcut_browser_platform() -> String {
@@ -400,11 +351,7 @@ pub fn boot() -> Unit {
       // `with_init(dispatch(Init))` did before the 0.13 migration.
       init=emit => (initial_model(), emit(Init)),
       update=(model, msg, emit) => {
-        let dispatch : @cmd.Emit[Msg] = AppDispatcher::{
-          root: emit,
-          live_reasoning,
-        }.as_emit()
-        let (cmd, next) = update(dispatch, msg, model)
+        let (cmd, next) = update(emit, msg, model)
         (next, cmd)
       },
       // The narrow-layout flag must track the window: rotating a phone or
@@ -420,7 +367,7 @@ pub fn boot() -> Unit {
           // Host event sources follow the device roster. Removing a device
           // therefore unloads its WebSocket immediately; advancing its retry
           // identity replaces only that device's connection.
-          model.bridge_subscriptions(emit),
+          model.bridge_subscriptions(emit, live_reasoning),
         ]
         // The project picker's Enter/Escape/paste surface, only while its
         // modal is open — same lifetime rule as the dismissal listeners.
@@ -551,21 +498,21 @@ pub fn boot() -> Unit {
       terminal_input, terminal_state, terminal_emit,
     )
     let transcript_input = state.map(model => model.transcript_input())
-    let transcript_html = @transcript_component.component(
-      transcript_input,
-      live_reasoning,
-      {
-        open: emit.map(path => OpenFile(path)),
-        jump: emit.map(target => {
-          JumpToLocation(
-            path=target.file,
-            range=target.range,
-            annotation=target.annotation,
-          )
-        }),
-        open_session: emit.map(session => OpenSessionHere(session)),
+    let transcript_html = @transcript_component.component(transcript_input, {
+      open: emit.map(path => OpenFile(path)),
+      jump: emit.map(target => {
+        JumpToLocation(
+          path=target.file,
+          range=target.range,
+          annotation=target.annotation,
+        )
+      }),
+      open_session: emit.map(session => OpenSessionHere(session)),
+      focus_live_reasoning: (input, pinned) => {
+        live_reasoning.focus(input, pinned)
       },
-    )
+      live_reasoning_pinned: pinned => live_reasoning.set_pinned(pinned),
+    })
     let composer_input = state.map(model => model.composer_input())
     let composer_html = @composer.component(
       composer_input,

--- a/desktop/frontend/bridge.mbt
+++ b/desktop/frontend/bridge.mbt
@@ -261,45 +261,106 @@ fn session_changed_msg(
 // root messages and direct terminal commands.
 
 ///|
-/// Turn one event emitted by a local or remote bridge subscription into a
-/// command understood by the root application. Raw terminal output bypasses
-/// application dispatch to avoid an unrelated redraw; other notifications are
-/// decoded into root messages here alongside connection and window events.
-fn bridge_event(dispatch : @cmd.Emit[Msg], event : @bridge.Event) -> @cmd.Cmd {
+/// Turn one event emitted by a local or remote bridge subscription into an
+/// optional root command. Raw terminal output bypasses application dispatch;
+/// live reasoning updates its transcript-owned preview directly and returns
+/// `None`, so neither path redraws unrelated application UI.
+fn bridge_event(
+  dispatch : @cmd.Emit[Msg],
+  live_reasoning : @transcript_component.LiveReasoning,
+  event : @bridge.Event,
+) -> @cmd.Cmd? {
   match event {
-    @bridge.Event::Notification(channel~, notification~) =>
+    @bridge.Event::Notification(channel~, websocket_epoch~, notification~) =>
       match notification {
         TerminalOutput(payload) =>
-          @terminal.output(channel, payload.id, payload.sequence, payload.data)
+          Some(
+            @terminal.output(
+              channel, payload.id, payload.sequence, payload.data,
+            ),
+          )
         TerminalExit(payload) =>
-          @terminal.SessionExited(channel~, id=payload.id, code=payload.code)
-          |> Terminal
-          |> dispatch
-        _ =>
-          if notification_msg(channel, notification) is Some(msg) {
-            dispatch(msg)
-          } else {
-            @cmd.none
+          Some(
+            @terminal.SessionExited(channel~, id=payload.id, code=payload.code)
+            |> Terminal
+            |> dispatch,
+          )
+        AgentConnected(_) => {
+          live_reasoning.connection_opened(channel, websocket_epoch)
+          notification_msg(channel, notification).map(msg => dispatch(msg))
+        }
+        AgentEvent(payload) =>
+          match engine_msg(payload) {
+            Some(
+              Engine(run_id, ReasoningDelta(content), session=Some(session)),
+            ) => {
+              live_reasoning.delta(
+                channel~,
+                websocket_epoch~,
+                session~,
+                run_id~,
+                content~,
+              )
+              None
+            }
+            Some(
+              Engine(run_id, ReasoningMessage(_), session=Some(session)),
+            ) => {
+              live_reasoning.finish(
+                channel~, websocket_epoch~, session~, run_id~,
+              )
+              None
+            }
+            Some(Engine(run_id, AgentStep(_), session=Some(session)) as msg) => {
+              live_reasoning.finish(
+                channel~, websocket_epoch~, session~, run_id~,
+              )
+              Some(dispatch(FromDevice(channel, msg)))
+            }
+            Some(msg) => Some(dispatch(FromDevice(channel, msg)))
+            None => None
           }
+        AgentError(payload) =>
+          match error_msg(payload) {
+            Some(Error(run_id=Some(run_id), ..) as msg) => {
+              live_reasoning.finish_run(
+                channel~, websocket_epoch~, run_id~,
+              )
+              Some(dispatch(FromDevice(channel, msg)))
+            }
+            Some(msg) => Some(dispatch(FromDevice(channel, msg)))
+            None => None
+          }
+        AgentFinished(payload) =>
+          match finished_msg(payload) {
+            Some(Finished(run_id~, ..) as msg) => {
+              live_reasoning.finish_run(
+                channel~, websocket_epoch~, run_id~,
+              )
+              Some(dispatch(FromDevice(channel, msg)))
+            }
+            Some(msg) => Some(dispatch(FromDevice(channel, msg)))
+            None => None
+          }
+        _ =>
+          notification_msg(channel, notification).map(msg => dispatch(msg))
       }
     @bridge.Event::Unavailable(channel~, message~) =>
-      dispatch(FromDevice(channel, BridgeUnavailable(message)))
-    @bridge.Event::ChannelDown(channel~, websocket_epoch~) =>
-      dispatch(FromDevice(channel, ChannelDown(websocket_epoch~)))
+      Some(dispatch(FromDevice(channel, BridgeUnavailable(message))))
+    @bridge.Event::ChannelDown(channel~, websocket_epoch~) => {
+      live_reasoning.connection_closed(channel, websocket_epoch)
+      Some(dispatch(FromDevice(channel, ChannelDown(websocket_epoch~))))
+    }
     @bridge.Event::BrowserEvent(payload~) =>
-      if browser_event_msg(payload) is Some(msg) {
-        dispatch(msg)
-      } else {
-        @cmd.none
-      }
+      browser_event_msg(payload).map(msg => dispatch(msg))
     @bridge.Event::MenuCommand(command_id~) =>
       if command_id == @commands.app_open_devtools.name() {
-        dispatch(AppDeveloperToolsRequested)
+        Some(dispatch(AppDeveloperToolsRequested))
       } else {
-        @cmd.none
+        None
       }
     @bridge.Event::NotificationClicked(run_id~) =>
-      dispatch(NotificationClicked(run_id~))
+      Some(dispatch(NotificationClicked(run_id~)))
   }
 }
 
@@ -307,18 +368,19 @@ fn bridge_event(dispatch : @cmd.Emit[Msg], event : @bridge.Event) -> @cmd.Cmd {
 fn DeviceState::bridge_subscription(
   self : DeviceState,
   dispatch : @cmd.Emit[Msg],
+  live_reasoning : @transcript_component.LiveReasoning,
 ) -> @sub.Sub {
-  let bridge_dispatch : @cmd.Emit[@bridge.Event] = event => {
-    bridge_event(dispatch, event)
-  }
+  let events = @bridge.EventHandler::new(event => {
+    bridge_event(dispatch, live_reasoning, event)
+  })
   match self.channel {
-    Local => @bridge.local_connection(bridge_dispatch)
+    Local => @bridge.local_connection(events)
     Remote(device) =>
       @bridge.remote_connection(
         device_id=device,
         websocket_epoch=self.websocket_epoch,
         reconnect_attempt=self.reconnect_attempt,
-        dispatch=bridge_dispatch,
+        events~,
       )
   }
 }
@@ -330,8 +392,11 @@ fn DeviceState::bridge_subscription(
 fn Model::bridge_subscriptions(
   self : Model,
   dispatch : @cmd.Emit[Msg],
+  live_reasoning : @transcript_component.LiveReasoning,
 ) -> @sub.Sub {
-  @sub.batch(self.devices.map(dev => dev.bridge_subscription(dispatch)))
+  @sub.batch(
+    self.devices.map(dev => dev.bridge_subscription(dispatch, live_reasoning)),
+  )
 }
 
 ///|

--- a/desktop/frontend/bridge.mbt
+++ b/desktop/frontend/bridge.mbt
@@ -276,7 +276,10 @@ fn bridge_event(
         TerminalOutput(payload) =>
           Some(
             @terminal.output(
-              channel, payload.id, payload.sequence, payload.data,
+              channel,
+              payload.id,
+              payload.sequence,
+              payload.data,
             ),
           )
         TerminalExit(payload) =>
@@ -291,9 +294,7 @@ fn bridge_event(
         }
         AgentEvent(payload) =>
           match engine_msg(payload) {
-            Some(
-              Engine(run_id, ReasoningDelta(content), session=Some(session)),
-            ) => {
+            Some(Engine(run_id, ReasoningDelta(content), session=Some(session))) => {
               live_reasoning.delta(
                 channel~,
                 websocket_epoch~,
@@ -303,17 +304,21 @@ fn bridge_event(
               )
               None
             }
-            Some(
-              Engine(run_id, ReasoningMessage(_), session=Some(session)),
-            ) => {
+            Some(Engine(run_id, ReasoningMessage(_), session=Some(session))) => {
               live_reasoning.finish(
-                channel~, websocket_epoch~, session~, run_id~,
+                channel~,
+                websocket_epoch~,
+                session~,
+                run_id~,
               )
               None
             }
             Some(Engine(run_id, AgentStep(_), session=Some(session)) as msg) => {
               live_reasoning.finish(
-                channel~, websocket_epoch~, session~, run_id~,
+                channel~,
+                websocket_epoch~,
+                session~,
+                run_id~,
               )
               Some(dispatch(FromDevice(channel, msg)))
             }
@@ -323,9 +328,7 @@ fn bridge_event(
         AgentError(payload) =>
           match error_msg(payload) {
             Some(Error(run_id=Some(run_id), ..) as msg) => {
-              live_reasoning.finish_run(
-                channel~, websocket_epoch~, run_id~,
-              )
+              live_reasoning.finish_run(channel~, websocket_epoch~, run_id~)
               Some(dispatch(FromDevice(channel, msg)))
             }
             Some(msg) => Some(dispatch(FromDevice(channel, msg)))
@@ -334,16 +337,13 @@ fn bridge_event(
         AgentFinished(payload) =>
           match finished_msg(payload) {
             Some(Finished(run_id~, ..) as msg) => {
-              live_reasoning.finish_run(
-                channel~, websocket_epoch~, run_id~,
-              )
+              live_reasoning.finish_run(channel~, websocket_epoch~, run_id~)
               Some(dispatch(FromDevice(channel, msg)))
             }
             Some(msg) => Some(dispatch(FromDevice(channel, msg)))
             None => None
           }
-        _ =>
-          notification_msg(channel, notification).map(msg => dispatch(msg))
+        _ => notification_msg(channel, notification).map(msg => dispatch(msg))
       }
     @bridge.Event::Unavailable(channel~, message~) =>
       Some(dispatch(FromDevice(channel, BridgeUnavailable(message))))

--- a/desktop/frontend/bridge/event.mbt
+++ b/desktop/frontend/bridge/event.mbt
@@ -35,7 +35,7 @@ fn EventHandler::enqueue(
   scheduler : &@cmd.Scheduler,
   event : Event,
 ) -> Unit {
-  if self.0(event) is Some(command) {
+  if (self.0)(event) is Some(command) {
     scheduler.add(command)
   }
 }

--- a/desktop/frontend/bridge/event.mbt
+++ b/desktop/frontend/bridge/event.mbt
@@ -8,6 +8,7 @@
 pub enum Event {
   Notification(
     channel~ : @interop.ChannelId,
+    websocket_epoch~ : Int,
     notification~ : @protocol.Notification
   )
   Unavailable(channel~ : @interop.ChannelId, message~ : String)
@@ -15,4 +16,26 @@ pub enum Event {
   BrowserEvent(payload~ : Map[String, Json])
   MenuCommand(command_id~ : String)
   NotificationClicked(run_id~ : String)
+}
+
+///|
+/// Decide whether a transport event needs a Rabbita command. High-frequency
+/// events handled directly by a component return `None`, so the connection
+/// does not enqueue an empty command and trigger an unrelated root render.
+pub struct EventHandler((Event) -> @cmd.Cmd?)
+
+///|
+pub fn EventHandler::new(handle : (Event) -> @cmd.Cmd?) -> EventHandler {
+  EventHandler(handle)
+}
+
+///|
+fn EventHandler::enqueue(
+  self : EventHandler,
+  scheduler : &@cmd.Scheduler,
+  event : Event,
+) -> Unit {
+  if self.0(event) is Some(command) {
+    scheduler.add(command)
+  }
 }

--- a/desktop/frontend/bridge/local.mbt
+++ b/desktop/frontend/bridge/local.mbt
@@ -10,9 +10,7 @@ priv struct LocalBridgeSub {
 }
 
 ///|
-fn LocalBridgeSub::LocalBridgeSub(
-  events : EventHandler,
-) -> LocalBridgeSub {
+fn LocalBridgeSub::LocalBridgeSub(events : EventHandler) -> LocalBridgeSub {
   { events, active: true, unsubscribers: [], }
 }
 

--- a/desktop/frontend/bridge/local.mbt
+++ b/desktop/frontend/bridge/local.mbt
@@ -4,16 +4,16 @@
 
 ///|
 priv struct LocalBridgeSub {
-  mut dispatch : @cmd.Emit[Event]
+  mut events : EventHandler
   mut active : Bool
   unsubscribers : Array[@js.Value]
 }
 
 ///|
 fn LocalBridgeSub::LocalBridgeSub(
-  dispatch : @cmd.Emit[Event],
+  events : EventHandler,
 ) -> LocalBridgeSub {
-  { dispatch, active: true, unsubscribers: [], }
+  { events, active: true, unsubscribers: [], }
 }
 
 ///|
@@ -35,12 +35,11 @@ fn LocalBridgeSub::install(self : LocalBridgeSub, attempt : Int) -> @cmd.Cmd {
       @interop.js_prop(extension_events, "on") is Some(_) &&
       @interop.js_prop(application_events, "on") is Some(_) else {
       if attempt > 120 {
-        scheduler.add(
-          (self.dispatch)(
-            Unavailable(
-              channel=@interop.ChannelId::Local,
-              message="Bridge unavailable",
-            ),
+        self.events.enqueue(
+          scheduler,
+          Unavailable(
+            channel=@interop.ChannelId::Local,
+            message="Bridge unavailable",
           ),
         )
       } else {
@@ -69,12 +68,11 @@ fn LocalBridgeSub::open_host_connection(
     ).wait() catch {
       error => {
         guard self.active else { return }
-        scheduler.add(
-          (self.dispatch)(
-            Unavailable(
-              channel=@interop.ChannelId::Local,
-              message=@interop.bridge_error_text(error),
-            ),
+        self.events.enqueue(
+          scheduler,
+          Unavailable(
+            channel=@interop.ChannelId::Local,
+            message=@interop.bridge_error_text(error),
           ),
         )
         return
@@ -128,9 +126,12 @@ fn LocalBridgeSub::wire(
         is Some(notification) else {
         return
       }
-      scheduler.add(
-        (self.dispatch)(
-          Notification(channel=@interop.ChannelId::Local, notification~),
+      self.events.enqueue(
+        scheduler,
+        Notification(
+          channel=@interop.ChannelId::Local,
+          websocket_epoch=0,
+          notification~,
         ),
       )
     }
@@ -140,7 +141,7 @@ fn LocalBridgeSub::wire(
   // shared protocol notifications. The parent frontend owns their UI decode.
   self.subscribe(extension_events, "openseek.browser.event", event => {
     guard event_payload(event) is Some(payload) else { return }
-    scheduler.add((self.dispatch)(BrowserEvent(payload~)))
+    self.events.enqueue(scheduler, BrowserEvent(payload~))
   })
   // Application events use `__MoonBit__.app.on`; keep their command id typed
   // while leaving command policy to the parent frontend.
@@ -149,7 +150,7 @@ fn LocalBridgeSub::wire(
       payload.get("command_id") is Some(String(command_id)) else {
       return
     }
-    scheduler.add((self.dispatch)(MenuCommand(command_id~)))
+    self.events.enqueue(scheduler, MenuCommand(command_id~))
   })
   // The notification extension stamps the owning run id in `payload`.
   self.subscribe(extension_events, "notification.click", event => {
@@ -158,16 +159,16 @@ fn LocalBridgeSub::wire(
       !run_id.is_empty() else {
       return
     }
-    scheduler.add((self.dispatch)(NotificationClicked(run_id~)))
+    self.events.enqueue(scheduler, NotificationClicked(run_id~))
   })
 }
 
 ///|
-fn LocalBridgeSub::update_dispatch(
+fn LocalBridgeSub::update_events(
   self : LocalBridgeSub,
-  dispatch : @cmd.Emit[Event],
+  events : EventHandler,
 ) -> Unit {
-  self.dispatch = dispatch
+  self.events = events
 }
 
 ///|

--- a/desktop/frontend/bridge/pkg.generated.mbti
+++ b/desktop/frontend/bridge/pkg.generated.mbti
@@ -9,21 +9,24 @@ import {
 }
 
 // Values
-pub fn local_connection(@cmd.Emit[Event]) -> @sub.Sub
+pub fn local_connection(EventHandler) -> @sub.Sub
 
-pub fn remote_connection(device_id~ : String, websocket_epoch~ : Int, reconnect_attempt~ : Int, dispatch~ : @cmd.Emit[Event]) -> @sub.Sub
+pub fn remote_connection(device_id~ : String, websocket_epoch~ : Int, reconnect_attempt~ : Int, events~ : EventHandler) -> @sub.Sub
 
 // Errors
 
 // Types and methods
 pub enum Event {
-  Notification(channel~ : @interop.ChannelId, notification~ : @protocol.Notification)
+  Notification(channel~ : @interop.ChannelId, websocket_epoch~ : Int, notification~ : @protocol.Notification)
   Unavailable(channel~ : @interop.ChannelId, message~ : String)
   ChannelDown(channel~ : @interop.ChannelId, websocket_epoch~ : Int)
   BrowserEvent(payload~ : Map[String, Json])
   MenuCommand(command_id~ : String)
   NotificationClicked(run_id~ : String)
 }
+
+pub struct EventHandler((Event) -> @cmd.Cmd?)
+pub fn EventHandler::new((Event) -> @cmd.Cmd?) -> Self
 
 // Type aliases
 

--- a/desktop/frontend/bridge/remote.mbt
+++ b/desktop/frontend/bridge/remote.mbt
@@ -54,10 +54,7 @@ fn RemoteBridgeSub::install(
     on_down=() => {
       self.events.enqueue(
         scheduler,
-        ChannelDown(
-          channel=self.channel,
-          websocket_epoch=self.websocket_epoch,
-        ),
+        ChannelDown(channel=self.channel, websocket_epoch=self.websocket_epoch),
       )
     },
   )

--- a/desktop/frontend/bridge/remote.mbt
+++ b/desktop/frontend/bridge/remote.mbt
@@ -7,20 +7,20 @@ priv struct RemoteBridgeSub {
   device_id : String
   channel : @interop.ChannelId
   websocket_epoch : Int
-  mut dispatch : @cmd.Emit[Event]
+  mut events : EventHandler
 }
 
 ///|
 fn RemoteBridgeSub::RemoteBridgeSub(
   device_id : String,
   websocket_epoch : Int,
-  dispatch : @cmd.Emit[Event],
+  events : EventHandler,
 ) -> RemoteBridgeSub {
   {
     device_id,
     channel: @interop.ChannelId::Remote(device_id),
     websocket_epoch,
-    dispatch,
+    events,
   }
 }
 
@@ -42,17 +42,21 @@ fn RemoteBridgeSub::install(
   @interop.ws_connect(
     self.device_id,
     on_notification=notification => {
-      scheduler.add(
-        (self.dispatch)(Notification(channel=self.channel, notification~)),
+      self.events.enqueue(
+        scheduler,
+        Notification(
+          channel=self.channel,
+          websocket_epoch=self.websocket_epoch,
+          notification~,
+        ),
       )
     },
     on_down=() => {
-      scheduler.add(
-        (self.dispatch)(
-          ChannelDown(
-            channel=self.channel,
-            websocket_epoch=self.websocket_epoch,
-          ),
+      self.events.enqueue(
+        scheduler,
+        ChannelDown(
+          channel=self.channel,
+          websocket_epoch=self.websocket_epoch,
         ),
       )
     },
@@ -60,11 +64,11 @@ fn RemoteBridgeSub::install(
 }
 
 ///|
-fn RemoteBridgeSub::update_dispatch(
+fn RemoteBridgeSub::update_events(
   self : RemoteBridgeSub,
-  dispatch : @cmd.Emit[Event],
+  events : EventHandler,
 ) -> Unit {
-  self.dispatch = dispatch
+  self.events = events
 }
 
 ///|

--- a/desktop/frontend/bridge/subscription.mbt
+++ b/desktop/frontend/bridge/subscription.mbt
@@ -1,12 +1,12 @@
 // Rabbita resource declarations for local Proton and remote WebSocket host
 // connections. The payload carries only transport identity and an Event
-// emitter, never parent-frontend model or message types.
+// handler, never parent-frontend model or message types.
 
 ///|
 priv suberror BridgeSubscription {
-  LocalBridge(dispatch~ : @cmd.Emit[Event])
+  LocalBridge(events~ : EventHandler)
   RemoteBridge(
-    dispatch~ : @cmd.Emit[Event],
+    events~ : EventHandler,
     device_id~ : String,
     websocket_epoch~ : Int
   )
@@ -14,11 +14,11 @@ priv suberror BridgeSubscription {
 
 ///|
 /// Declare the desktop window's injected Proton connection.
-pub fn local_connection(dispatch : @cmd.Emit[Event]) -> @sub.Sub {
+pub fn local_connection(events : EventHandler) -> @sub.Sub {
   @sub.custom_sub(
     LocalBridgeKey,
     @sub.Global,
-    LocalBridge(dispatch~),
+    LocalBridge(events~),
     bridge_sub_loader,
   )
 }
@@ -30,14 +30,14 @@ pub fn remote_connection(
   device_id~ : String,
   websocket_epoch~ : Int,
   reconnect_attempt~ : Int,
-  dispatch~ : @cmd.Emit[Event],
+  events~ : EventHandler,
 ) -> @sub.Sub {
   @sub.custom_sub(
     RemoteBridgeSub::subscription_key(
       device_id, websocket_epoch, reconnect_attempt,
     ),
     @sub.Global,
-    RemoteBridge(dispatch~, device_id~, websocket_epoch~),
+    RemoteBridge(events~, device_id~, websocket_epoch~),
     bridge_sub_loader,
   )
 }
@@ -48,27 +48,27 @@ fn bridge_sub_loader(
   scheduler : &@cmd.Scheduler,
 ) -> @sub.RunningSub? {
   match payload {
-    LocalBridge(dispatch~) => {
-      let running = LocalBridgeSub(dispatch)
+    LocalBridge(events~) => {
+      let running = LocalBridgeSub(events)
       scheduler.add(running.install(0))
       Some({
         unload: _ => running.unload(),
         update_tagger: payload => {
           match payload {
-            LocalBridge(dispatch=next) => running.update_dispatch(next)
+            LocalBridge(events=next) => running.update_events(next)
             _ => ()
           }
         },
       })
     }
-    RemoteBridge(dispatch~, device_id~, websocket_epoch~) => {
-      let running = RemoteBridgeSub(device_id, websocket_epoch, dispatch)
+    RemoteBridge(events~, device_id~, websocket_epoch~) => {
+      let running = RemoteBridgeSub(device_id, websocket_epoch, events)
       running.install(scheduler)
       Some({
         unload: _ => running.unload(),
         update_tagger: payload => {
           match payload {
-            RemoteBridge(dispatch=next, ..) => running.update_dispatch(next)
+            RemoteBridge(events=next, ..) => running.update_events(next)
             _ => ()
           }
         },

--- a/desktop/frontend/component_transcript.mbt
+++ b/desktop/frontend/component_transcript.mbt
@@ -36,19 +36,21 @@ fn Model::transcript_input(self : Model) -> @transcript_component.Input {
             streaming_identity="",
           )
         Some(conversation) => {
-          let (streaming_reasoning, reasoning_complete) = conversation.reasoning_for_render()
+          let active_run_id = match conversation.run {
+            Open(run_id~, ..) => Some(run_id)
+            _ => None
+          }
           @transcript_component.Input(
             source=@transcript_component.OpenSeek,
             focused=self.focused,
             active_session=self.active_session,
+            active_run_id?,
             root=self
               .conversation_placement(conversation)
               .bind(value => value.checkout_root()),
             submission_generation=self.submission_sequence,
             items=conversation.visible_transcript_rows(),
             streaming_response=conversation.turn.streaming_response,
-            streaming_reasoning?,
-            reasoning_complete~,
             streaming_identity=conversation.streaming_render_identity(),
           )
         }

--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -200,8 +200,14 @@ fn editor_surface_host_visible(host_id : String) -> Bool {
   guard @dom.document().get_element_by_id(host_id).to_option() is Some(host) else {
     return false
   }
-  let rect = host.get_bounding_client_rect()
-  rect.get_width() > 0.0 && rect.get_height() > 0.0
+  // Rabbita owns the stable host classes. Reading that state avoids forcing
+  // three synchronous layout measurements on every resize animation frame.
+  for class_name in host.get_attribute("class").unwrap_or("").split(" ") {
+    if class_name == "moonbit-viewer-surface-hidden" {
+      return false
+    }
+  }
+  true
 }
 
 ///|
@@ -214,7 +220,7 @@ fn active_editor_surface() -> ActiveEditorSurface? {
 }
 
 ///|
-fn layout_active_editor_surface() -> Unit {
+fn layout_active_editor_surface(layout_observed_diff? : Bool = true) -> Unit {
   match active_editor_surface() {
     Some(CodeEditorSurface) =>
       match mounted_viewer() {
@@ -227,11 +233,36 @@ fn layout_active_editor_surface() -> Unit {
         None => ()
       }
     Some(DiffEditorSurface) =>
-      match mounted_diff_editor() {
-        Some(viewer) => viewer.layout()
-        None => ()
+      if layout_observed_diff {
+        match mounted_diff_editor() {
+          Some(viewer) => viewer.layout()
+          None => ()
+        }
       }
     None => ()
+  }
+}
+
+///|
+/// Tell the active code surface whether a continuous width drag is in
+/// progress. Code lines continue to lay out at every width; derived diff
+/// geometry, overview rulers, and offscreen Markdown measures wait for mouseup.
+fn ViewerHost::set_continuous_width_resize(
+  self : ViewerHost,
+  active : Bool,
+) -> Unit {
+  match active_editor_surface() {
+    Some(CodeEditorSurface) =>
+      match self.viewer {
+        Some(viewer) => viewer.set_continuous_width_resize(active)
+        None => ()
+      }
+    Some(DiffEditorSurface) =>
+      match self.diff_editor {
+        Some(editor) => editor.set_continuous_width_resize(active)
+        None => ()
+      }
+    Some(MarkdownEditorSurface) | None => ()
   }
 }
 

--- a/desktop/frontend/fileeditor/editor_resize.mbt
+++ b/desktop/frontend/fileeditor/editor_resize.mbt
@@ -1,9 +1,10 @@
 // Drag-to-resize for the editor side-panel. The panel's width is a CSS custom
-// property `--editor-width` on the document element, set imperatively as the
-// user drags a handle on the panel's left edge — never through the model, so a
-// drag never re-renders the (possibly large) transcript. The grid in
-// `index.html` reads the property through a `clamp(...)`, so the bounds live in
-// CSS and survive a window resize on their own.
+// property `--editor-width` on the document element, committed when a drag
+// ends — never through the model, so a drag never re-renders the (possibly
+// large) transcript. During the drag, the `.content` grid is written directly:
+// changing an inherited root custom property on every move would invalidate
+// styles across the whole transcript. The CSS `clamp(...)` remains the durable
+// layout and survives a later window resize on its own.
 
 ///|
 /// The id of the grab strip the view renders on the editor's left edge.
@@ -26,6 +27,24 @@ const MinEditorWidth = 360
 /// excluded), so it holds whether or not the sidebar is collapsed. Mirrors the
 /// CSS `clamp` ceiling, `calc(100% - 240px)`.
 const MinChatWidth = 240
+
+///|
+/// A completed editor width owns both CSS spellings used by the drag. Keeping
+/// the concrete track here makes the live value testable: malformed CSS is
+/// otherwise silently ignored and the pane appears frozen until mouseup.
+priv struct EditorWidth {
+  pixels : Int
+}
+
+///|
+fn EditorWidth::grid_template(self : EditorWidth) -> String {
+  "minmax(0, 1fr) \{self.pixels}px"
+}
+
+///|
+fn EditorWidth::custom_property(self : EditorWidth) -> String {
+  "\{self.pixels}px"
+}
 
 ///|
 /// Whether the drag listeners have been installed yet (once, after first paint).
@@ -80,6 +99,7 @@ fn start_resize(event : @dom.Event) -> Unit {
   // Stop the press from starting a text selection in the viewer underneath.
   event.prevent_default()
   resizing.val = true
+  viewer_state.set_continuous_width_resize(true)
   set_root_class(ResizingClass)
 }
 
@@ -127,8 +147,24 @@ fn drag_size(raw : Double, floor~ : Double, max~ : Double) -> Int {
 /// drag flag of whichever resizer is ending — see `resizing` / `tree_resizing`.
 fn end_drag(active : Ref[Bool]) -> Unit {
   guard active.val else { return }
+  let editor_drag_ended = resizing.val
   active.val = false
   set_root_class("")
+  if editor_drag_ended {
+    // Commit the final width once, then return ownership of the grid template
+    // to CSS. This one root-style invalidation happens after pointer tracking,
+    // not once per live frame.
+    sync_root_style()
+    if @dom.document().query_selector(".content").to_option() is Some(content) {
+      let style : @js.Value = @js.Value::cast_from(content).get_with_string(
+        "style",
+      )
+      let _ : @js.Value = style.apply_with_string("removeProperty", [
+        @js.Value::cast_from("grid-template-columns"),
+      ])
+    }
+  }
+  viewer_state.set_continuous_width_resize(false)
   layout_active_editor_surface()
 }
 
@@ -136,7 +172,7 @@ fn end_drag(active : Ref[Bool]) -> Unit {
 /// The dragged sizes, kept so the resizers (editor width, tree height, tree
 /// width) can rewrite the shared root `style` attribute without erasing each
 /// other's property.
-let editor_width : Ref[Int?] = Ref(None)
+let editor_width : Ref[EditorWidth?] = Ref(None)
 
 ///|
 let tree_height : Ref[Int?] = Ref(None)
@@ -155,7 +191,7 @@ fn sync_root_style() -> Unit {
   if editor_width.val is Some(width) {
     let _ : @js.Value = style.apply_with_string("setProperty", [
       @js.Value::cast_from("--editor-width"),
-      @js.Value::cast_from("\{width}px"),
+      @js.Value::cast_from(width.custom_property()),
     ])
   }
   if tree_height.val is Some(height) {
@@ -174,8 +210,23 @@ fn sync_root_style() -> Unit {
 
 ///|
 fn set_editor_width(width : Int) -> Unit {
-  editor_width.val = Some(width)
-  sync_root_style()
+  let value : EditorWidth = { pixels: width }
+  editor_width.val = Some(value)
+  if resizing.val &&
+    @dom.document().query_selector(".content").to_option() is Some(content) {
+    // The value has already been clamped against the live content box. Write
+    // the concrete grid track instead of an inherited variable so the browser
+    // only invalidates the layout that actually changed.
+    let style : @js.Value = @js.Value::cast_from(content).get_with_string(
+      "style",
+    )
+    let _ : @js.Value = style.apply_with_string("setProperty", [
+      @js.Value::cast_from("grid-template-columns"),
+      @js.Value::cast_from(value.grid_template()),
+    ])
+  } else {
+    sync_root_style()
+  }
 }
 
 ///|
@@ -204,9 +255,9 @@ fn document_element() -> @dom.Element? {
 }
 
 ///|
-/// Re-measure the viewer at most once per animation frame while dragging, so a
-/// flood of `mousemove`s does not thrash its layout (the viewer fills its host
-/// with absolutely-positioned layers and cannot see a CSS width change itself).
+/// Re-measure an active code or Markdown viewer at most once per animation
+/// frame while dragging. DiffEditor owns a ResizeObserver on the same host, so
+/// calling its layout here as well would render both panes twice for one width.
 fn schedule_remeasure() -> Unit {
   if remeasure_pending.val ||
     (
@@ -219,7 +270,7 @@ fn schedule_remeasure() -> Unit {
   remeasure_pending.val = true
   @dom.window().request_animation_frame(_ => {
     remeasure_pending.val = false
-    layout_active_editor_surface()
+    layout_active_editor_surface(layout_observed_diff=false)
   })
   |> ignore
 }

--- a/desktop/frontend/fileeditor/editor_resize.mbt
+++ b/desktop/frontend/fileeditor/editor_resize.mbt
@@ -210,7 +210,7 @@ fn sync_root_style() -> Unit {
 
 ///|
 fn set_editor_width(width : Int) -> Unit {
-  let value : EditorWidth = { pixels: width }
+  let value : EditorWidth = { pixels: width, }
   editor_width.val = Some(value)
   if resizing.val &&
     @dom.document().query_selector(".content").to_option() is Some(content) {

--- a/desktop/frontend/fileeditor/editor_resize_wbtest.mbt
+++ b/desktop/frontend/fileeditor/editor_resize_wbtest.mbt
@@ -1,7 +1,15 @@
 // `drag_size` is shared by three drags (editor width, tree width, tree
 // height), so its rules are pinned once here rather than in any one of them.
 // The DOM-driven halves of the resizers (`end_drag`, the listener install)
-// need a browser and are covered by using the app, not by these tests.
+// need a browser. The live grid value is pure and pinned here because a browser
+// silently ignores malformed CSS, which otherwise looks like a frozen drag.
+
+///|
+test "a live editor width produces a valid concrete grid track" {
+  let width : EditorWidth = { pixels: 504 }
+  assert_eq(width.grid_template(), "minmax(0, 1fr) 504px")
+  assert_eq(width.custom_property(), "504px")
+}
 
 ///|
 test "a dragged size passes through inside its range and saturates outside" {

--- a/desktop/frontend/fileeditor/editor_resize_wbtest.mbt
+++ b/desktop/frontend/fileeditor/editor_resize_wbtest.mbt
@@ -6,7 +6,7 @@
 
 ///|
 test "a live editor width produces a valid concrete grid track" {
-  let width : EditorWidth = { pixels: 504 }
+  let width : EditorWidth = { pixels: 504, }
   assert_eq(width.grid_template(), "minmax(0, 1fr) 504px")
   assert_eq(width.custom_property(), "504px")
 }

--- a/desktop/frontend/fileeditor/tree_resize.mbt
+++ b/desktop/frontend/fileeditor/tree_resize.mbt
@@ -90,6 +90,7 @@ fn start_tree_resize(event : @dom.Event) -> Unit {
   }
   event.prevent_default()
   tree_resizing.val = true
+  viewer_state.set_continuous_width_resize(true)
   set_root_class(
     if tree_docked_right() {
       ColResizingClass

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -698,11 +698,7 @@ priv struct RunState {
 /// The state a turn starts from. A conversation with no run open holds one
 /// too: every field means "nothing observed".
 fn RunState::empty() -> RunState {
-  {
-    streaming_response: None,
-    subruns: [],
-    usage_tokens: 0,
-  }
+  { streaming_response: None, subruns: [], usage_tokens: 0 }
 }
 
 ///|
@@ -3455,10 +3451,7 @@ fn Conversation::run_heartbeat(self : Conversation) -> @composer.RunHeartbeat? {
 
 ///|
 fn Conversation::clear_streams(self : Conversation) -> Conversation {
-  {
-    ..self,
-    turn: { ..self.turn, streaming_response: None },
-  }
+  { ..self, turn: { ..self.turn, streaming_response: None } }
 }
 
 ///|

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -672,21 +672,12 @@ fn Workspace::worktree_name(self : Workspace) -> String? {
 }
 
 ///|
-/// Reasoning visible before its durable assistant event lands.
-priv struct LiveReasoning {
-  content : String
-  complete : Bool
-} derive(Eq, Debug)
-
-///|
 /// Everything that belongs to one turn and to nothing outside it.
 ///
 /// It is replaced wholesale when a run opens, so a fragment or token count
 /// left by the previous turn cannot survive into this one by being forgotten -
 /// the reset is one assignment rather than three. Only the `agent.*` lifecycle
-/// and stream events write it. Durable commits are deliberately not allowed to
-/// mutate it: they carry no run or step identity, so a delayed older commit
-/// cannot safely settle a newer stream.
+/// and stream events write it.
 priv struct RunState {
   // Live text of the in-flight assistant turn, accumulated from
   // `assistant_delta` events and cleared by ordered full semantic, step,
@@ -696,15 +687,6 @@ priv struct RunState {
   // has not committed yet, and the only reason it is a separate field from
   // `messages` rather than a row inside it.
   streaming_response : String?
-  // Provisional reasoning assembled from `reasoning_delta`. The completed
-  // semantic event seals the buffer. The durable Assistant commit remains the
-  // sole history; rendering de-duplicates an equal completed preview without
-  // letting the untagged commit mutate this run-scoped state.
-  live_reasoning : LiveReasoning?
-  // Highest durable event already known when this run opened. Only reasoning
-  // committed after this frontier can visually de-duplicate this run's sealed
-  // preview; identical text from an earlier turn is unrelated.
-  reasoning_frontier : Int
   // Sub-runs this turn has in flight, in the order they started. Live-only:
   // nothing persists a sub-run's progress, so a reload mid-turn shows the
   // tool call pending with no lane under it.
@@ -718,16 +700,14 @@ priv struct RunState {
 fn RunState::empty() -> RunState {
   {
     streaming_response: None,
-    live_reasoning: None,
-    reasoning_frontier: 0,
     subruns: [],
     usage_tokens: 0,
   }
 }
 
 ///|
-fn RunState::for_run(reasoning_frontier : Int) -> RunState {
-  { ..RunState::empty(), reasoning_frontier, }
+fn RunState::for_run() -> RunState {
+  RunState::empty()
 }
 
 ///|
@@ -3477,27 +3457,7 @@ fn Conversation::run_heartbeat(self : Conversation) -> @composer.RunHeartbeat? {
 fn Conversation::clear_streams(self : Conversation) -> Conversation {
   {
     ..self,
-    turn: { ..self.turn, streaming_response: None, live_reasoning: None, },
-  }
-}
-
-///|
-fn Conversation::clear_response(self : Conversation) -> Conversation {
-  { ..self, turn: { ..self.turn, streaming_response: None, }, }
-}
-
-///|
-fn Conversation::complete_reasoning(self : Conversation) -> Conversation {
-  match self.turn.live_reasoning {
-    Some(reasoning) if !reasoning.complete =>
-      {
-        ..self,
-        turn: {
-          ..self.turn,
-          live_reasoning: Some({ ..reasoning, complete: true, }),
-        },
-      }
-    _ => self
+    turn: { ..self.turn, streaming_response: None },
   }
 }
 

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -698,7 +698,7 @@ priv struct RunState {
 /// The state a turn starts from. A conversation with no run open holds one
 /// too: every field means "nothing observed".
 fn RunState::empty() -> RunState {
-  { streaming_response: None, subruns: [], usage_tokens: 0 }
+  { streaming_response: None, subruns: [], usage_tokens: 0, }
 }
 
 ///|
@@ -3451,7 +3451,7 @@ fn Conversation::run_heartbeat(self : Conversation) -> @composer.RunHeartbeat? {
 
 ///|
 fn Conversation::clear_streams(self : Conversation) -> Conversation {
-  { ..self, turn: { ..self.turn, streaming_response: None } }
+  { ..self, turn: { ..self.turn, streaming_response: None, }, }
 }
 
 ///|

--- a/desktop/frontend/transcript/component/component.mbt
+++ b/desktop/frontend/transcript/component/component.mbt
@@ -115,63 +115,346 @@ fn LiveReasoningKey::matches_input(
 }
 
 ///|
+fn LiveReasoningKey::wire(self : LiveReasoningKey) -> String {
+  self.channel.uri_authority() +
+  "\u{0}" +
+  self.session +
+  "\u{0}" +
+  self.run_id.unwrap_or("")
+}
+
+///|
 priv struct LiveReasoningPreview {
   key : LiveReasoningKey
-  content : String
+  // Keep provider fragments separate. Appending is O(1); the full string is
+  // materialized only when a durable render or remount asks to hydrate the
+  // visible DOM widget.
+  chunks : @vector.Vector[String]
+} derive(Eq)
+
+///|
+fn LiveReasoningPreview::content(self : LiveReasoningPreview) -> String {
+  let out = StringBuilder()
+  for chunk in self.chunks {
+    out.write_string(chunk)
+  }
+  out.to_string()
+}
+
+///|
+/// The OpenSeek conversation currently allowed to use the one visible host.
+/// `step_label` is presentation data derived from durable transcript rows; it
+/// does not participate in routing provider fragments.
+priv struct LiveReasoningTarget {
+  key : LiveReasoningKey
+  step_label : String
+} derive(Eq)
+
+///|
+fn Input::live_reasoning_target(self : Input) -> LiveReasoningTarget? {
+  guard self.source is OpenSeek else { return None }
+  Some({
+    key: {
+      channel: self.focused,
+      session: self.active_session,
+      run_id: self.active_run_id,
+    },
+    step_label: "#\{durable_step_ordinals(self.items).length() + 1}",
+  })
+}
+
+///|
+/// Whether this component may still accept transient events from one concrete
+/// bridge connection. Keeping the last epoch after a close prevents callbacks
+/// already queued by that connection from recreating a cleared preview.
+priv enum LiveReasoningConnectionPhase {
+  Receiving
+  Closed
+} derive(Eq)
+
+///|
+/// The latest bridge connection observed for one device channel. Epochs are
+/// monotonic within a channel; a replacement connection therefore fences both
+/// late reasoning fragments and a late close callback from its predecessor.
+priv struct LiveReasoningConnection {
+  channel : @interop.ChannelId
+  websocket_epoch : Int
+  phase : LiveReasoningConnectionPhase
 } derive(Eq)
 
 ///|
 /// Component-owned previews for every concurrently running conversation.
-/// The persistent vector makes each update a new value, so a background run
-/// cannot mutate a state snapshot currently being rendered for the foreground.
-priv struct LiveReasoningState(
-  @vector.Vector[LiveReasoningPreview]
-) derive(Eq)
+/// Both vectors are persistent, so a background connection or run cannot
+/// mutate a state snapshot currently being rendered for the foreground.
+priv struct LiveReasoningState {
+  connections : @vector.Vector[LiveReasoningConnection]
+  previews : @vector.Vector[LiveReasoningPreview]
+  active : LiveReasoningTarget?
+} derive(Eq)
 
 ///|
 priv enum LiveReasoningMsg {
-  Delta(LiveReasoningKey, String)
-  Finished(LiveReasoningKey)
-  RunFinished(@interop.ChannelId, String)
-  ChannelReset(@interop.ChannelId)
+  Focused(LiveReasoningTarget?)
+  ConnectionOpened(@interop.ChannelId, websocket_epoch~ : Int)
+  Delta(LiveReasoningKey, websocket_epoch~ : Int, String)
+  Finished(LiveReasoningKey, websocket_epoch~ : Int)
+  RunFinished(@interop.ChannelId, websocket_epoch~ : Int, String)
+  ConnectionClosed(@interop.ChannelId, websocket_epoch~ : Int)
+}
+
+///|
+/// The only effects allowed out of the live state machine. They update one
+/// browser-owned text node and never produce a Rabbita `Val[Html]`.
+priv enum LiveReasoningEffect {
+  None
+  Sync(target~ : String, step_label~ : String, content~ : String)
+  Append(target~ : String, content~ : String)
+  Hide(target~ : String)
+  Reset
+} derive(Eq, Debug)
+
+///|
+fn LiveReasoningEffect::apply(
+  self : LiveReasoningEffect,
+  preview : @live_preview.LivePreview,
+) -> Unit {
+  match self {
+    None => ()
+    Sync(target~, step_label~, content~) =>
+      preview.sync(target, step_label, content)
+    Append(target~, content~) => preview.append(target, content)
+    Hide(target~) => preview.hide(target)
+    Reset => preview.reset()
+  }
+}
+
+///|
+fn LiveReasoningState::preview_for(
+  self : LiveReasoningState,
+  key : LiveReasoningKey,
+) -> LiveReasoningPreview? {
+  for preview in self.previews {
+    if preview.key == key {
+      return Some(preview)
+    }
+  }
+  None
+}
+
+///|
+fn LiveReasoningState::sync_effect(
+  self : LiveReasoningState,
+  target : LiveReasoningTarget?,
+) -> LiveReasoningEffect {
+  match target {
+    None => Reset
+    Some(target) =>
+      Sync(
+        target=target.key.wire(),
+        step_label=target.step_label,
+        content=self
+          .preview_for(target.key)
+          .map(preview => preview.content())
+          .unwrap_or(""),
+      )
+  }
+}
+
+///|
+fn LiveReasoningState::accepts(
+  self : LiveReasoningState,
+  channel : @interop.ChannelId,
+  websocket_epoch : Int,
+) -> Bool {
+  for connection in self.connections {
+    if connection.channel == channel {
+      return connection.websocket_epoch == websocket_epoch &&
+        connection.phase is Receiving
+    }
+  }
+  false
 }
 
 ///|
 fn LiveReasoningState::update(
   self : LiveReasoningState,
   msg : LiveReasoningMsg,
-) -> LiveReasoningState {
+) -> (LiveReasoningState, LiveReasoningEffect) {
   match msg {
-    Delta(key, content) => {
-      if content.is_empty() {
-        return self
-      }
-      for index in 0..<self.0.length() {
-        if self.0[index].key == key {
-          return LiveReasoningState(
-            self.0.set(index, {
-              key,
-              content: self.0[index].content + content,
+    Focused(target) => {
+      let next = { ..self, active: target }
+      // Always re-sync, even when the logical target is unchanged: the host
+      // may have been remounted while another application screen was visible.
+      (next, next.sync_effect(target))
+    }
+    ConnectionOpened(channel, websocket_epoch~) => {
+      for index in 0..<self.connections.length() {
+        let current = self.connections[index]
+        if current.channel == channel {
+          // A connection command can finish after its replacement was
+          // installed. Never move this component's fence backwards.
+          if websocket_epoch < current.websocket_epoch {
+            return (self, None)
+          }
+          let next = {
+            ..self,
+            connections: self.connections.set(index, {
+              channel,
+              websocket_epoch,
+              phase: Receiving,
             }),
+            // `agent.connected` can repeat without a WebSocket replacement
+            // when the engine pump restarts. Its transient fragments are no
+            // more replayable than fragments across a transport reconnect.
+            previews: self.previews.filter(preview => {
+              preview.key.channel != channel
+            }),
+          }
+          return (
+            next,
+            if self.active is Some(active) && active.key.channel == channel {
+              Hide(target=active.key.wire())
+            } else {
+              None
+            },
           )
         }
       }
-      LiveReasoningState(self.0.push({ key, content }))
+      let next = {
+        ..self,
+        connections: self.connections.push({
+          channel,
+          websocket_epoch,
+          phase: Receiving,
+        }),
+        previews: self.previews.filter(preview => preview.key.channel != channel),
+      }
+      (
+        next,
+        if self.active is Some(active) && active.key.channel == channel {
+          Hide(target=active.key.wire())
+        } else {
+          None
+        },
+      )
     }
-    Finished(key) =>
-      LiveReasoningState(self.0.filter(preview => preview.key != key))
-    RunFinished(channel, run_id) =>
-      LiveReasoningState(
-        self.0.filter(preview =>
-          preview.key.channel != channel ||
-          preview.key.run_id != Some(run_id)
-        ),
+    Delta(key, websocket_epoch~, content) => {
+      if !self.accepts(key.channel, websocket_epoch) || content.is_empty() {
+        return (self, None)
+      }
+      for index in 0..<self.previews.length() {
+        if self.previews[index].key == key {
+          let next = {
+            ..self,
+            previews: self.previews.set(index, {
+              key,
+              chunks: self.previews[index].chunks.push(content),
+            }),
+          }
+          return (
+            next,
+            if self.active is Some(active) && active.key == key {
+              Append(target=key.wire(), content~)
+            } else {
+              None
+            },
+          )
+        }
+      }
+      let next = {
+        ..self,
+        previews: self.previews.push({
+          key,
+          chunks: @vector.new().push(content),
+        }),
+      }
+      (
+        next,
+        if self.active is Some(active) && active.key == key {
+          Append(target=key.wire(), content~)
+        } else {
+          None
+        },
       )
-    ChannelReset(channel) =>
-      LiveReasoningState(
-        self.0.filter(preview => preview.key.channel != channel),
-      )
+    }
+    Finished(key, websocket_epoch~) =>
+      if self.accepts(key.channel, websocket_epoch) {
+        (
+          {
+            ..self,
+            previews: self.previews.filter(preview => preview.key != key),
+          },
+          if self.active is Some(active) && active.key == key {
+            Hide(target=key.wire())
+          } else {
+            None
+          },
+        )
+      } else {
+        (self, None)
+      }
+    RunFinished(channel, websocket_epoch~, run_id) =>
+      if self.accepts(channel, websocket_epoch) {
+        let next = {
+          ..self,
+          previews: self.previews.filter(preview => {
+            preview.key.channel != channel || preview.key.run_id != Some(run_id)
+          }),
+        }
+        (
+          next,
+          if self.active is Some(active) &&
+            active.key.channel == channel &&
+            active.key.run_id == Some(run_id) {
+            Hide(target=active.key.wire())
+          } else {
+            None
+          },
+        )
+      } else {
+        (self, None)
+      }
+    ConnectionClosed(channel, websocket_epoch~) => {
+      for index in 0..<self.connections.length() {
+        let current = self.connections[index]
+        if current.channel == channel &&
+          current.websocket_epoch == websocket_epoch {
+          if current.phase is Closed {
+            return (self, None)
+          }
+          let next = {
+            ..self,
+            connections: self.connections.set(index, {
+              ..current,
+              phase: Closed,
+            }),
+            previews: self.previews.filter(preview => {
+              preview.key.channel != channel
+            }),
+          }
+          return (
+            next,
+            if self.active is Some(active) && active.key.channel == channel {
+              Hide(target=active.key.wire())
+            } else {
+              None
+            },
+          )
+        }
+      }
+      (self, None)
+    }
   }
+}
+
+///|
+/// State-only projection used by reducer tests that are not inspecting the DOM
+/// effect of a transition.
+fn LiveReasoningState::transition(
+  self : LiveReasoningState,
+  msg : LiveReasoningMsg,
+) -> LiveReasoningState {
+  self.update(msg).0
 }
 
 ///|
@@ -179,30 +462,78 @@ fn LiveReasoningState::content_for(
   self : LiveReasoningState,
   input : Input,
 ) -> String? {
-  for preview in self.0 {
+  for preview in self.previews {
     if preview.key.matches_input(input) {
-      return Some(preview.content)
+      return Some(preview.content())
     }
   }
   None
 }
 
 ///|
-/// The transcript component's live-reasoning controller. It is constructed
-/// beside the root Rabbita state so bridge notifications can target this
-/// component without storing an emitter or callback in the application model.
+/// The transcript component's live-reasoning controller. It deliberately is
+/// not a Rabbita state: Rabbita flushes the root VDOM after every scheduled
+/// command, even when no rendered value depends on that state. Bridge callbacks
+/// mutate this controller directly so a delta cannot schedule a root diff.
 struct LiveReasoning {
-  state : @rabbita.Val[LiveReasoningState]
-  emit : @cmd.Emit[LiveReasoningMsg]
+  mut state : LiveReasoningState
+  preview : @live_preview.LivePreview
 }
 
 ///|
 pub fn LiveReasoning::LiveReasoning() -> LiveReasoning {
-  let (state, emit) = @rabbita.create_pure_state(
-    LiveReasoningState(@vector.new()),
-    update=(state, msg) => state.update(msg),
+  {
+    state: { connections: @vector.new(), previews: @vector.new(), active: None },
+    preview: @live_preview.LivePreview(),
+  }
+}
+
+///|
+/// Apply one bridge event synchronously on the browser main thread. WebSocket,
+/// Proton, and animation-frame callbacks are all serialized by that thread, so
+/// this mutable controller needs no second queue or Rabbita emitter.
+fn LiveReasoning::apply(self : LiveReasoning, msg : LiveReasoningMsg) -> Unit {
+  let (state, effect) = self.state.update(msg)
+  self.state = state
+  effect.apply(self.preview)
+}
+
+///|
+/// Select the conversation allowed to occupy the stable preview host. The
+/// command also rehydrates a newly mounted host from stored fragments and
+/// synchronizes the transcript's current scroll ownership before observing
+/// that content.
+pub fn LiveReasoning::focus(
+  self : LiveReasoning,
+  input : Input,
+  pinned : Bool,
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(
+    _ => {
+      self.preview.set_pinned(pinned)
+      self.apply(Focused(input.live_reasoning_target()))
+    },
+    kind=@cmd.after_render,
   )
-  { state, emit }
+}
+
+///|
+/// Cache a real transcript scroll transition without scheduling a Rabbita
+/// render. This is called by the transcript's capture-phase scroll listener.
+pub fn LiveReasoning::set_pinned(self : LiveReasoning, pinned : Bool) -> Unit {
+  self.preview.set_pinned(pinned)
+}
+
+///|
+/// Start accepting transient events from this concrete bridge connection.
+/// Repeating the same epoch is also the engine-pump restart boundary, so its
+/// pre-restart preview is discarded before new fragments arrive.
+pub fn LiveReasoning::connection_opened(
+  self : LiveReasoning,
+  channel : @interop.ChannelId,
+  websocket_epoch : Int,
+) -> Unit {
+  self.apply(ConnectionOpened(channel, websocket_epoch~))
 }
 
 ///|
@@ -210,11 +541,12 @@ pub fn LiveReasoning::LiveReasoning() -> LiveReasoning {
 pub fn LiveReasoning::delta(
   self : LiveReasoning,
   channel~ : @interop.ChannelId,
+  websocket_epoch~ : Int,
   session~ : String,
   run_id~ : String?,
   content~ : String,
-) -> @cmd.Cmd {
-  (self.emit)(Delta({ channel, session, run_id }, content))
+) -> Unit {
+  self.apply(Delta({ channel, session, run_id }, websocket_epoch~, content))
 }
 
 ///|
@@ -223,10 +555,11 @@ pub fn LiveReasoning::delta(
 pub fn LiveReasoning::finish(
   self : LiveReasoning,
   channel~ : @interop.ChannelId,
+  websocket_epoch~ : Int,
   session~ : String,
   run_id~ : String?,
-) -> @cmd.Cmd {
-  (self.emit)(Finished({ channel, session, run_id }))
+) -> Unit {
+  self.apply(Finished({ channel, session, run_id }, websocket_epoch~))
 }
 
 ///|
@@ -234,19 +567,21 @@ pub fn LiveReasoning::finish(
 pub fn LiveReasoning::finish_run(
   self : LiveReasoning,
   channel~ : @interop.ChannelId,
+  websocket_epoch~ : Int,
   run_id~ : String,
-) -> @cmd.Cmd {
-  (self.emit)(RunFinished(channel, run_id))
+) -> Unit {
+  self.apply(RunFinished(channel, websocket_epoch~, run_id))
 }
 
 ///|
-/// A transport restart cannot replay live fragments, so discard that
-/// channel's previews and let durable session snapshots restore history.
-pub fn LiveReasoning::reset_channel(
+/// Stop accepting events from this exact connection and discard its previews.
+/// A stale close is ignored after a newer epoch has taken ownership.
+pub fn LiveReasoning::connection_closed(
   self : LiveReasoning,
   channel : @interop.ChannelId,
-) -> @cmd.Cmd {
-  (self.emit)(ChannelReset(channel))
+  websocket_epoch : Int,
+) -> Unit {
+  self.apply(ConnectionClosed(channel, websocket_epoch~))
 }
 
 ///|
@@ -258,6 +593,27 @@ pub(all) struct Actions {
   /// Open another session's transcript. Used by a sub-run tool card to reach
   /// the child transcript it names.
   open_session : @cmd.Emit[String]
+  // Reconcile the browser-owned preview only after the transcript reports its
+  // durable DOM. The callback computes a small target before creating a Cmd;
+  // the full `Input` is never stored in live state.
+  focus_live_reasoning : (Input, Bool) -> @cmd.Cmd
+  // Scroll events are already browser effects. Feed their settled state to
+  // the browser-owned preview directly so delta frames only append text.
+  live_reasoning_pinned : (Bool) -> Unit
+}
+
+///|
+/// Apply an explicit component pin transition after its Html has settled.
+/// Scroll events use the direct callback above; buttons and remounts use this
+/// command so Model::update remains pure.
+fn Actions::pin_live_reasoning_after_render(
+  self : Actions,
+  pinned : Bool,
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(
+    _ => (self.live_reasoning_pinned)(pinned),
+    kind=@cmd.after_render,
+  )
 }
 
 ///|
@@ -289,6 +645,8 @@ fn Model::update(
   input : Input,
   msg : Msg,
   emit : @cmd.Emit[Msg],
+  focus_live_reasoning? : (Input, Bool) -> @cmd.Cmd = (_, _) => @cmd.none,
+  pin_live_reasoning? : (Bool) -> @cmd.Cmd = _ => @cmd.none,
 ) -> (Model, @cmd.Cmd) {
   // A conversation switch can reach the component through input before its
   // DOM mutation notification. Never project the previous owner's data URLs
@@ -305,6 +663,7 @@ fn Model::update(
       (
         { ..self, pinned: true, },
         @cmd.batch([
+          pin_live_reasoning(true),
           scroll_after_render(),
           report_visible_turn_after_render(emit, skip_unchanged=true),
         ]),
@@ -349,6 +708,12 @@ fn Model::update(
         report_visible_turn_after_render(emit, skip_unchanged=!navigated),
       )
       commands.push(self.images.apply_after_render())
+      if mounted {
+        // Durable rows, target identity, and host remounts all arrive through
+        // this one notification. Live DOM mutations are excluded from the
+        // observer below, so a reasoning delta cannot feed back into update.
+        commands.push(focus_live_reasoning(input, next.pinned))
+      }
       (next, @cmd.batch(commands))
     }
     ImageRequested(path) => {
@@ -370,7 +735,13 @@ fn Model::update(
         // The clicked tick is already under the pointer. Revealing it could
         // move the rail beneath the pointer and transfer hover to a neighbor.
         Clicked(key) =>
-          ({ ..next, pinned: false, }, scroll_turn_into_view(emit, key))
+          (
+            { ..next, pinned: false },
+            @cmd.batch([
+              pin_live_reasoning(false),
+              scroll_turn_into_view(emit, key),
+            ]),
+          )
         // A transcript scroll may activate a tick outside the rail's visible
         // window. Reveal only an actual active-turn change so rail scrolling
         // itself cannot feed back into another write.
@@ -390,7 +761,6 @@ fn Model::update(
 /// Build the transcript state and return its independently updating Html.
 pub fn component(
   input : @rabbita.Val[Input],
-  live_reasoning : LiveReasoning,
   actions : Actions,
 ) -> @rabbita.Val[@html.Html] {
   let (state, emit) = @rabbita.create_state_with_input(
@@ -411,13 +781,24 @@ pub fn component(
         @cmd.none,
       )
     },
-    update=(state, input, msg, emit) => state.update(input, msg, emit),
-    subscriptions=(_, _, emit) => transcript_subscription(emit),
+    update=(state, input, msg, emit) => {
+      state.update(
+        input,
+        msg,
+        emit,
+        focus_live_reasoning=actions.focus_live_reasoning,
+        pin_live_reasoning=pinned => {
+          actions.pin_live_reasoning_after_render(pinned)
+        },
+      )
+    },
+    subscriptions=(_, _, emit) => {
+      transcript_subscription(emit, actions.live_reasoning_pinned)
+    },
   )
-  state.view3(input, live_reasoning.state, (state, input, live_state) => {
+  state.view2(input, (state, input) => {
     transcript_view(
       input,
-      live_reasoning?=live_state.content_for(input),
       pinned=state.pinned,
       overview=state.overview,
       overview_emit=emit.map(msg => Overview(msg)),
@@ -568,18 +949,21 @@ fn report_visible_turn_after_render(
 
 ///|
 priv suberror TranscriptSubscription {
-  TranscriptSubscription(@cmd.Emit[Msg])
+  TranscriptSubscription(@cmd.Emit[Msg], (Bool) -> Unit)
 }
 
 ///|
 /// Scroll position and rendered-content growth are DOM signals owned by the
 /// transcript. Keeping both in this component means the application no longer
 /// forwards a synthetic "content changed" message into child state.
-fn transcript_subscription(emit : @cmd.Emit[Msg]) -> @sub.Sub {
+fn transcript_subscription(
+  emit : @cmd.Emit[Msg],
+  live_reasoning_pinned : (Bool) -> Unit,
+) -> @sub.Sub {
   @sub.custom_sub(
     "transcript-dom",
     @sub.Local,
-    TranscriptSubscription(emit),
+    TranscriptSubscription(emit, live_reasoning_pinned),
     transcript_sub_loader,
   )
 }
@@ -590,8 +974,9 @@ fn transcript_sub_loader(
   scheduler : &@cmd.Scheduler,
 ) -> @sub.RunningSub? {
   match payload {
-    TranscriptSubscription(emit) => {
+    TranscriptSubscription(emit, live_reasoning_pinned) => {
       let mut emit = emit
+      let mut live_reasoning_pinned = live_reasoning_pinned
       let target = @dom.document().as_event_target()
       let listener : @dom.Listener = event => {
         guard event.target().to_element() is Some(element) &&
@@ -603,6 +988,10 @@ fn transcript_sub_loader(
           element.get_scroll_top() -
           client_height <=
           4.0
+        // This callback updates only the browser-owned preview controller. It
+        // must run before any Rabbita message so a queued delta observes the
+        // user's latest decision to follow or read history.
+        live_reasoning_pinned(pinned)
         if pinned != transcript_pinned_watch.val {
           transcript_pinned_watch.val = pinned
           scheduler.add(emit(Pinned(pinned)))
@@ -629,8 +1018,11 @@ fn transcript_sub_loader(
           observers.disconnect()
         },
         update_tagger: payload => {
-          guard payload is TranscriptSubscription(next) else { return }
+          guard payload is TranscriptSubscription(next, next_pinned) else {
+            return
+          }
           emit = next
+          live_reasoning_pinned = next_pinned
         },
       })
     }
@@ -722,17 +1114,21 @@ fn TranscriptDomMount::observe_content(
   observer : @dom.MutationObserver,
 ) -> Unit {
   if self.element is Some(element) {
-    observer.observe(
-      element.as_node(),
-      attributes=true,
-      child_list=true,
-      character_data=true,
-      subtree=true,
-      attribute_filter=[
-        "data-transcript-source", "data-transcript-channel", "data-transcript-session",
-        "data-transcript-root", "data-transcript-submission",
-      ],
-    )
+    // Observe identity on the transcript root, but observe content only below
+    // the durable `#stream`. The sibling live-preview host is mutated for each
+    // delta and must never emit `ContentRendered` back into this component.
+    observer.observe(element.as_node(), attributes=true, attribute_filter=[
+      "data-transcript-source", "data-transcript-channel", "data-transcript-session",
+      "data-transcript-run", "data-transcript-root", "data-transcript-submission",
+    ])
+    if element.query_selector("#stream") is Some(stream) {
+      observer.observe(
+        stream.as_node(),
+        child_list=true,
+        character_data=true,
+        subtree=true,
+      )
+    }
   }
 }
 
@@ -742,7 +1138,14 @@ fn TranscriptDomMount::observe_resize(
   observer : @dom.ResizeObserver,
 ) -> Unit {
   if self.element is Some(element) {
-    observer.observe(element)
+    // The live-reasoning host is a sibling of `#stream`. Observing the whole
+    // transcript would turn each preview line wrap into `ContentRendered`,
+    // feeding transient DOM growth back through the component render loop.
+    // Durable rows, images, and diagrams all live under `#stream`, so it is
+    // the resize boundary this component actually owns.
+    if element.query_selector("#stream") is Some(stream) {
+      observer.observe(stream)
+    }
   }
 }
 
@@ -938,6 +1341,7 @@ test "a conversation switch clears component-owned overview state" {
 
 ///|
 test "live reasoning appends by owner and semantic finish deletes it" {
+  let epoch = 7
   let key : LiveReasoningKey = {
     channel: @interop.ChannelId::Local,
     session: "desktop-test",
@@ -954,27 +1358,52 @@ test "live reasoning appends by owner and semantic finish deletes it" {
     streaming_response=None,
     streaming_identity="r7",
   )
-  let empty = LiveReasoningState(@vector.new())
-  let first = empty.update(Delta(key, "think"))
-  let live = first.update(Delta(key, "ing"))
+  let empty = LiveReasoningState::{
+    connections: @vector.new(),
+    previews: @vector.new(),
+    active: None,
+  }
+  let connected = empty.transition(
+    ConnectionOpened(@interop.ChannelId::Local, websocket_epoch=epoch),
+  )
+  let target = input.live_reasoning_target()
+  let (focused, focus_effect) = connected.update(Focused(target))
+  assert_eq(focus_effect, Sync(target=key.wire(), step_label="#1", content=""))
+  let (first, first_effect) = focused.update(
+    Delta(key, websocket_epoch=epoch, "think"),
+  )
+  assert_eq(first_effect, Append(target=key.wire(), content="think"))
+  let (live, second_effect) = first.update(
+    Delta(key, websocket_epoch=epoch, "ing"),
+  )
+  assert_eq(second_effect, Append(target=key.wire(), content="ing"))
   assert_eq(live.content_for(input), Some("thinking"))
+  let (_, hydrate_effect) = live.update(Focused(target))
+  assert_eq(
+    hydrate_effect,
+    Sync(target=key.wire(), step_label="#1", content="thinking"),
+  )
 
   // The full reasoning event is a semantic boundary, not a durable commit.
   // Removing the preview here makes both commit-first and finish-first delivery
   // converge without comparing the reasoning text with transcript history.
-  let finished = live.update(Finished(key))
+  let (finished, finish_effect) = live.update(
+    Finished(key, websocket_epoch=epoch),
+  )
   assert_eq(finished.content_for(input), None)
+  assert_eq(finish_effect, Hide(target=key.wire()))
 
   // Updating the same immutable snapshot twice must produce the same result;
   // an emitter may replay a state transition while scheduling a render.
   assert_true(
-    empty.update(Delta(key, "think")) ==
-    empty.update(Delta(key, "think")),
+    focused.update(Delta(key, websocket_epoch=epoch, "think")) ==
+    focused.update(Delta(key, websocket_epoch=epoch, "think")),
   )
 }
 
 ///|
 test "live reasoning keeps concurrent conversations and runs isolated" {
+  let epoch = 7
   let local_r7 : LiveReasoningKey = {
     channel: @interop.ChannelId::Local,
     session: "shared",
@@ -990,10 +1419,23 @@ test "live reasoning keeps concurrent conversations and runs isolated" {
     session: "shared",
     run_id: Some("r7"),
   }
-  let state = LiveReasoningState(@vector.new())
-    .update(Delta(local_r7, "local-old"))
-    .update(Delta(local_r8, "local-current"))
-    .update(Delta(remote_r7, "remote"))
+  let state = LiveReasoningState::{
+      connections: @vector.new(),
+      previews: @vector.new(),
+      active: None,
+    }
+    .transition(
+      ConnectionOpened(@interop.ChannelId::Local, websocket_epoch=epoch),
+    )
+    .transition(
+      ConnectionOpened(
+        @interop.ChannelId::Remote("device-b"),
+        websocket_epoch=epoch,
+      ),
+    )
+    .transition(Delta(local_r7, websocket_epoch=epoch, "local-old"))
+    .transition(Delta(local_r8, websocket_epoch=epoch, "local-current"))
+    .transition(Delta(remote_r7, websocket_epoch=epoch, "remote"))
   let local_input = Input(
     source=OpenSeek,
     focused=@interop.ChannelId::Local,
@@ -1019,17 +1461,90 @@ test "live reasoning keeps concurrent conversations and runs isolated" {
   assert_eq(state.content_for(local_input), Some("local-current"))
   assert_eq(state.content_for(remote_input), Some("remote"))
 
-  let after_run = state.update(
-    RunFinished(@interop.ChannelId::Local, "r7"),
+  let (focused, focus_effect) = state.update(
+    Focused(local_input.live_reasoning_target()),
+  )
+  assert_eq(
+    focus_effect,
+    Sync(target=local_r8.wire(), step_label="#1", content="local-current"),
+  )
+  let (with_background, background_effect) = focused.update(
+    Delta(remote_r7, websocket_epoch=epoch, "-more"),
+  )
+  assert_eq(background_effect, None)
+  assert_eq(with_background.content_for(remote_input), Some("remote-more"))
+
+  let after_run = with_background.transition(
+    RunFinished(@interop.ChannelId::Local, websocket_epoch=epoch, "r7"),
   )
   assert_eq(after_run.content_for(local_input), Some("local-current"))
-  assert_eq(after_run.content_for(remote_input), Some("remote"))
+  assert_eq(after_run.content_for(remote_input), Some("remote-more"))
 
-  let after_channel = after_run.update(
-    ChannelReset(@interop.ChannelId::Remote("device-b")),
+  let after_channel = after_run.transition(
+    ConnectionClosed(
+      @interop.ChannelId::Remote("device-b"),
+      websocket_epoch=epoch,
+    ),
   )
   assert_eq(after_channel.content_for(local_input), Some("local-current"))
   assert_eq(after_channel.content_for(remote_input), None)
+}
+
+///|
+test "live reasoning rejects stale connection callbacks" {
+  let channel = @interop.ChannelId::Remote("device-b")
+  let key : LiveReasoningKey = {
+    channel,
+    session: "desktop-test",
+    run_id: Some("r7"),
+  }
+  let input = Input(
+    source=OpenSeek,
+    focused=channel,
+    active_session="desktop-test",
+    active_run_id="r7",
+    root=None,
+    submission_generation=0,
+    items=[],
+    streaming_response=None,
+    streaming_identity="r7",
+  )
+  let empty = LiveReasoningState::{
+    connections: @vector.new(),
+    previews: @vector.new(),
+    active: None,
+  }
+  let current = empty
+    .transition(ConnectionOpened(channel, websocket_epoch=1))
+    .transition(Delta(key, websocket_epoch=1, "old"))
+    .transition(ConnectionOpened(channel, websocket_epoch=2))
+    .transition(Delta(key, websocket_epoch=2, "current"))
+
+  // Both callbacks belong to the replaced socket. Neither may change the
+  // current preview, even if JavaScript queued them before the replacement.
+  let after_stale = current
+    .transition(ConnectionOpened(channel, websocket_epoch=1))
+    .transition(Delta(key, websocket_epoch=1, "-stale"))
+    .transition(ConnectionClosed(channel, websocket_epoch=1))
+  assert_eq(after_stale.content_for(input), Some("current"))
+
+  // The current close clears once and keeps the epoch fenced, so a delta
+  // already queued by the closed socket cannot recreate the preview.
+  let closed = after_stale
+    .transition(ConnectionClosed(channel, websocket_epoch=2))
+    .transition(Delta(key, websocket_epoch=2, "late"))
+  assert_eq(closed.content_for(input), None)
+  assert_true(
+    after_stale.transition(ConnectionClosed(channel, websocket_epoch=2)) ==
+    after_stale.transition(ConnectionClosed(channel, websocket_epoch=2)),
+  )
+
+  // `agent.connected` can reopen the engine pump without replacing the
+  // WebSocket. The same epoch becomes receiving again, starting from empty.
+  let reopened = closed
+    .transition(ConnectionOpened(channel, websocket_epoch=2))
+    .transition(Delta(key, websocket_epoch=2, "fresh"))
+  assert_eq(reopened.content_for(input), Some("fresh"))
 }
 
 ///|

--- a/desktop/frontend/transcript/component/component.mbt
+++ b/desktop/frontend/transcript/component/component.mbt
@@ -282,7 +282,7 @@ fn LiveReasoningState::update(
 ) -> (LiveReasoningState, LiveReasoningEffect) {
   match msg {
     Focused(target) => {
-      let next = { ..self, active: target }
+      let next = { ..self, active: target, }
       // Always re-sync, even when the logical target is unchanged: the host
       // may have been remounted while another application screen was visible.
       (next, next.sync_effect(target))
@@ -483,7 +483,11 @@ struct LiveReasoning {
 ///|
 pub fn LiveReasoning::LiveReasoning() -> LiveReasoning {
   {
-    state: { connections: @vector.new(), previews: @vector.new(), active: None },
+    state: {
+      connections: @vector.new(),
+      previews: @vector.new(),
+      active: None,
+    },
     preview: @live_preview.LivePreview(),
   }
 }
@@ -546,7 +550,7 @@ pub fn LiveReasoning::delta(
   run_id~ : String?,
   content~ : String,
 ) -> Unit {
-  self.apply(Delta({ channel, session, run_id }, websocket_epoch~, content))
+  self.apply(Delta({ channel, session, run_id, }, websocket_epoch~, content))
 }
 
 ///|
@@ -559,7 +563,7 @@ pub fn LiveReasoning::finish(
   session~ : String,
   run_id~ : String?,
 ) -> Unit {
-  self.apply(Finished({ channel, session, run_id }, websocket_epoch~))
+  self.apply(Finished({ channel, session, run_id, }, websocket_epoch~))
 }
 
 ///|
@@ -754,7 +758,7 @@ fn Model::update(
         // move the rail beneath the pointer and transfer hover to a neighbor.
         Clicked(key) =>
           (
-            { ..next, pinned: false },
+            { ..next, pinned: false, },
             @cmd.batch([
               pin_live_reasoning(false),
               scroll_turn_into_view(emit, key),

--- a/desktop/frontend/transcript/component/component.mbt
+++ b/desktop/frontend/transcript/component/component.mbt
@@ -47,12 +47,16 @@ pub fn VisibleRow::history(
 
 ///|
 /// The conversation data rendered by the component. The application computes
-/// durable chronology and active-run ownership; this package owns only the
-/// transcript subtree and its scroll behavior.
+/// durable chronology and active-run ownership; this package owns the live
+/// reasoning preview, transcript subtree, and scroll behavior.
 struct Input {
   source : Source
   focused : @interop.ChannelId
   active_session : String
+  // The open engine run whose live reasoning this transcript may render.
+  // Durable rows need no run id; this identity only keeps concurrent live
+  // previews on separate conversations from replacing one another.
+  active_run_id : String?
   // The concrete project or worktree root sent alongside relative Markdown
   // image paths so the owning host, rather than the frontend, resolves them.
   root : @common.Uri?
@@ -62,10 +66,6 @@ struct Input {
   // when nothing is streaming. It is deliberately not a `VisibleRow`: the
   // rows are the durable record and this is not durable yet.
   streaming_response : String?
-  // Live reasoning is likewise provisional. It is plain text until complete;
-  // the durable reasoning row replaces it and renders Markdown once.
-  streaming_reasoning : String?
-  reasoning_complete : Bool
   streaming_identity : String
 } derive(Eq)
 
@@ -74,26 +74,179 @@ pub fn Input::Input(
   source~ : Source,
   focused~ : @interop.ChannelId,
   active_session~ : String,
+  active_run_id? : String,
   root~ : @common.Uri?,
   submission_generation~ : Int,
   items~ : Array[VisibleRow],
   streaming_response~ : String?,
-  streaming_reasoning? : String,
-  reasoning_complete? : Bool = false,
   streaming_identity~ : String,
 ) -> Input {
   {
     source,
     focused,
     active_session,
+    active_run_id,
     root,
     submission_generation,
     items,
     streaming_response,
-    streaming_reasoning,
-    reasoning_complete,
     streaming_identity,
   }
+}
+
+///|
+/// One live reasoning stream's exact owner. Session ids are scoped by their
+/// device channel, and separate runs of one session must never share text.
+priv struct LiveReasoningKey {
+  channel : @interop.ChannelId
+  session : String
+  run_id : String?
+} derive(Eq)
+
+///|
+fn LiveReasoningKey::matches_input(
+  self : LiveReasoningKey,
+  input : Input,
+) -> Bool {
+  input.source is OpenSeek &&
+  self.channel == input.focused &&
+  self.session == input.active_session &&
+  self.run_id == input.active_run_id
+}
+
+///|
+priv struct LiveReasoningPreview {
+  key : LiveReasoningKey
+  content : String
+} derive(Eq)
+
+///|
+/// Component-owned previews for every concurrently running conversation.
+/// The persistent vector makes each update a new value, so a background run
+/// cannot mutate a state snapshot currently being rendered for the foreground.
+priv struct LiveReasoningState(
+  @vector.Vector[LiveReasoningPreview]
+) derive(Eq)
+
+///|
+priv enum LiveReasoningMsg {
+  Delta(LiveReasoningKey, String)
+  Finished(LiveReasoningKey)
+  RunFinished(@interop.ChannelId, String)
+  ChannelReset(@interop.ChannelId)
+}
+
+///|
+fn LiveReasoningState::update(
+  self : LiveReasoningState,
+  msg : LiveReasoningMsg,
+) -> LiveReasoningState {
+  match msg {
+    Delta(key, content) => {
+      if content.is_empty() {
+        return self
+      }
+      for index in 0..<self.0.length() {
+        if self.0[index].key == key {
+          return LiveReasoningState(
+            self.0.set(index, {
+              key,
+              content: self.0[index].content + content,
+            }),
+          )
+        }
+      }
+      LiveReasoningState(self.0.push({ key, content }))
+    }
+    Finished(key) =>
+      LiveReasoningState(self.0.filter(preview => preview.key != key))
+    RunFinished(channel, run_id) =>
+      LiveReasoningState(
+        self.0.filter(preview =>
+          preview.key.channel != channel ||
+          preview.key.run_id != Some(run_id)
+        ),
+      )
+    ChannelReset(channel) =>
+      LiveReasoningState(
+        self.0.filter(preview => preview.key.channel != channel),
+      )
+  }
+}
+
+///|
+fn LiveReasoningState::content_for(
+  self : LiveReasoningState,
+  input : Input,
+) -> String? {
+  for preview in self.0 {
+    if preview.key.matches_input(input) {
+      return Some(preview.content)
+    }
+  }
+  None
+}
+
+///|
+/// The transcript component's live-reasoning controller. It is constructed
+/// beside the root Rabbita state so bridge notifications can target this
+/// component without storing an emitter or callback in the application model.
+struct LiveReasoning {
+  state : @rabbita.Val[LiveReasoningState]
+  emit : @cmd.Emit[LiveReasoningMsg]
+}
+
+///|
+pub fn LiveReasoning::LiveReasoning() -> LiveReasoning {
+  let (state, emit) = @rabbita.create_pure_state(
+    LiveReasoningState(@vector.new()),
+    update=(state, msg) => state.update(msg),
+  )
+  { state, emit }
+}
+
+///|
+/// Append one ordered provider fragment to its conversation's preview.
+pub fn LiveReasoning::delta(
+  self : LiveReasoning,
+  channel~ : @interop.ChannelId,
+  session~ : String,
+  run_id~ : String?,
+  content~ : String,
+) -> @cmd.Cmd {
+  (self.emit)(Delta({ channel, session, run_id }, content))
+}
+
+///|
+/// The full semantic reasoning event closes the preview unconditionally.
+/// Its durable Assistant commit, whenever observed, is the only history row.
+pub fn LiveReasoning::finish(
+  self : LiveReasoning,
+  channel~ : @interop.ChannelId,
+  session~ : String,
+  run_id~ : String?,
+) -> @cmd.Cmd {
+  (self.emit)(Finished({ channel, session, run_id }))
+}
+
+///|
+/// Clear an abnormally closed run even when no semantic finish was emitted.
+pub fn LiveReasoning::finish_run(
+  self : LiveReasoning,
+  channel~ : @interop.ChannelId,
+  run_id~ : String,
+) -> @cmd.Cmd {
+  (self.emit)(RunFinished(channel, run_id))
+}
+
+///|
+/// A transport restart cannot replay live fragments, so discard that
+/// channel's previews and let durable session snapshots restore history.
+pub fn LiveReasoning::reset_channel(
+  self : LiveReasoning,
+  channel : @interop.ChannelId,
+) -> @cmd.Cmd {
+  (self.emit)(ChannelReset(channel))
 }
 
 ///|
@@ -237,6 +390,7 @@ fn Model::update(
 /// Build the transcript state and return its independently updating Html.
 pub fn component(
   input : @rabbita.Val[Input],
+  live_reasoning : LiveReasoning,
   actions : Actions,
 ) -> @rabbita.Val[@html.Html] {
   let (state, emit) = @rabbita.create_state_with_input(
@@ -260,9 +414,10 @@ pub fn component(
     update=(state, input, msg, emit) => state.update(input, msg, emit),
     subscriptions=(_, _, emit) => transcript_subscription(emit),
   )
-  state.view2(input, (state, input) => {
+  state.view3(input, live_reasoning.state, (state, input, live_state) => {
     transcript_view(
       input,
+      live_reasoning?=live_state.content_for(input),
       pinned=state.pinned,
       overview=state.overview,
       overview_emit=emit.map(msg => Overview(msg)),
@@ -779,6 +934,102 @@ test "a conversation switch clears component-owned overview state" {
   assert_true(remounted.pinned)
   @debug.assert_eq(remounted.overview.hover, None)
   @debug.assert_eq(remounted.overview.active, None)
+}
+
+///|
+test "live reasoning appends by owner and semantic finish deletes it" {
+  let key : LiveReasoningKey = {
+    channel: @interop.ChannelId::Local,
+    session: "desktop-test",
+    run_id: Some("r7"),
+  }
+  let input = Input(
+    source=OpenSeek,
+    focused=@interop.ChannelId::Local,
+    active_session="desktop-test",
+    active_run_id="r7",
+    root=None,
+    submission_generation=0,
+    items=[],
+    streaming_response=None,
+    streaming_identity="r7",
+  )
+  let empty = LiveReasoningState(@vector.new())
+  let first = empty.update(Delta(key, "think"))
+  let live = first.update(Delta(key, "ing"))
+  assert_eq(live.content_for(input), Some("thinking"))
+
+  // The full reasoning event is a semantic boundary, not a durable commit.
+  // Removing the preview here makes both commit-first and finish-first delivery
+  // converge without comparing the reasoning text with transcript history.
+  let finished = live.update(Finished(key))
+  assert_eq(finished.content_for(input), None)
+
+  // Updating the same immutable snapshot twice must produce the same result;
+  // an emitter may replay a state transition while scheduling a render.
+  assert_true(
+    empty.update(Delta(key, "think")) ==
+    empty.update(Delta(key, "think")),
+  )
+}
+
+///|
+test "live reasoning keeps concurrent conversations and runs isolated" {
+  let local_r7 : LiveReasoningKey = {
+    channel: @interop.ChannelId::Local,
+    session: "shared",
+    run_id: Some("r7"),
+  }
+  let local_r8 : LiveReasoningKey = {
+    channel: @interop.ChannelId::Local,
+    session: "shared",
+    run_id: Some("r8"),
+  }
+  let remote_r7 : LiveReasoningKey = {
+    channel: @interop.ChannelId::Remote("device-b"),
+    session: "shared",
+    run_id: Some("r7"),
+  }
+  let state = LiveReasoningState(@vector.new())
+    .update(Delta(local_r7, "local-old"))
+    .update(Delta(local_r8, "local-current"))
+    .update(Delta(remote_r7, "remote"))
+  let local_input = Input(
+    source=OpenSeek,
+    focused=@interop.ChannelId::Local,
+    active_session="shared",
+    active_run_id="r8",
+    root=None,
+    submission_generation=0,
+    items=[],
+    streaming_response=None,
+    streaming_identity="r8",
+  )
+  let remote_input = Input(
+    source=OpenSeek,
+    focused=@interop.ChannelId::Remote("device-b"),
+    active_session="shared",
+    active_run_id="r7",
+    root=None,
+    submission_generation=0,
+    items=[],
+    streaming_response=None,
+    streaming_identity="r7",
+  )
+  assert_eq(state.content_for(local_input), Some("local-current"))
+  assert_eq(state.content_for(remote_input), Some("remote"))
+
+  let after_run = state.update(
+    RunFinished(@interop.ChannelId::Local, "r7"),
+  )
+  assert_eq(after_run.content_for(local_input), Some("local-current"))
+  assert_eq(after_run.content_for(remote_input), Some("remote"))
+
+  let after_channel = after_run.update(
+    ChannelReset(@interop.ChannelId::Remote("device-b")),
+  )
+  assert_eq(after_channel.content_for(local_input), Some("local-current"))
+  assert_eq(after_channel.content_for(remote_input), None)
 }
 
 ///|

--- a/desktop/frontend/transcript/component/component.mbt
+++ b/desktop/frontend/transcript/component/component.mbt
@@ -620,6 +620,10 @@ fn Actions::pin_live_reasoning_after_render(
 priv struct Model {
   pinned : Bool
   overview : @transcript_overview.State
+  // Closed activity disclosures retain only their summary DOM. Keys are
+  // scoped by transcript identity, so equal durable rows in another session
+  // never inherit an open body during the intermediate input render.
+  expanded_activities : @vector.Vector[String]
   source : Source
   focused : @interop.ChannelId
   active_session : String
@@ -633,6 +637,7 @@ priv struct Model {
 priv enum Msg {
   Pinned(Bool)
   JumpToLatest
+  ToggleActivity(String)
   ContentRendered(mounted~ : Bool)
   ImageRequested(String)
   ImageResolved(ImageOwner, String, ImageReadResult)
@@ -668,6 +673,14 @@ fn Model::update(
           report_visible_turn_after_render(emit, skip_unchanged=true),
         ]),
       )
+    ToggleActivity(key) => {
+      let expanded_activities = if self.expanded_activities.contains(key) {
+        self.expanded_activities.filter(current => current != key)
+      } else {
+        self.expanded_activities.push(key)
+      }
+      ({ ..self, expanded_activities, }, @cmd.none)
+    }
     ContentRendered(mounted~) => {
       // The component outlives the Chat DOM while Skills, Settings, or the
       // signed-out console gate is shown. A newly mounted scroller therefore
@@ -691,6 +704,11 @@ fn Model::update(
           @transcript_overview.State::empty()
         } else {
           self.overview
+        },
+        expanded_activities: if navigated {
+          @vector.new()
+        } else {
+          self.expanded_activities
         },
         source: input.source,
         focused: input.focused,
@@ -770,6 +788,7 @@ pub fn component(
         {
           pinned: true,
           overview: @transcript_overview.State::empty(),
+          expanded_activities: @vector.new(),
           source: input.source,
           focused: input.focused,
           active_session: input.active_session,
@@ -802,6 +821,8 @@ pub fn component(
       pinned=state.pinned,
       overview=state.overview,
       overview_emit=emit.map(msg => Overview(msg)),
+      expanded_activity_keys=state.expanded_activities,
+      on_toggle_activity=key => emit(ToggleActivity(key)),
       path => (actions.open)(path),
       target => (actions.jump)(target),
       session => (actions.open_session)(session),
@@ -1212,6 +1233,7 @@ test "local pinned transitions are pure" {
   let state : Model = {
     pinned: true,
     overview: @transcript_overview.State::empty(),
+    expanded_activities: @vector.new(),
     source: OpenSeek,
     focused: Local,
     active_session: "desktop-test",
@@ -1249,6 +1271,12 @@ test "local pinned transitions are pure" {
   assert_true(submitted.pinned)
   let (jumped, _) = grown.update(input, JumpToLatest, emit)
   assert_true(jumped.pinned)
+  let (opened, _) = state.update(input, ToggleActivity("activity-a"), emit)
+  let (replayed, _) = state.update(input, ToggleActivity("activity-a"), emit)
+  assert_true(opened.expanded_activities.contains("activity-a"))
+  @debug.assert_eq(opened.expanded_activities, replayed.expanded_activities)
+  let (closed, _) = opened.update(input, ToggleActivity("activity-a"), emit)
+  assert_false(closed.expanded_activities.contains("activity-a"))
   let (navigated, _) = grown.update(
     { ..input, active_session: "another-session", },
     ContentRendered(mounted=true),
@@ -1273,6 +1301,7 @@ test "an overview click unpins and highlights inside the component" {
   let state : Model = {
     pinned: true,
     overview: @transcript_overview.State::empty(),
+    expanded_activities: @vector.new(),
     source: OpenSeek,
     focused: Local,
     active_session: "desktop-test",
@@ -1309,6 +1338,7 @@ test "a conversation switch clears component-owned overview state" {
       }),
       active: Some(@transcript_overview.Durable(3)),
     },
+    expanded_activities: @vector.singleton("activity-a"),
     source: OpenSeek,
     focused: Local,
     active_session: "desktop-test",
@@ -1326,6 +1356,7 @@ test "a conversation switch clears component-owned overview state" {
   assert_true(next.pinned)
   @debug.assert_eq(next.overview.hover, None)
   @debug.assert_eq(next.overview.active, None)
+  assert_true(next.expanded_activities.is_empty())
   let (removed, _) = state.update(input, ContentRendered(mounted=false), emit)
   let (remounted, _) = removed.update(
     input,

--- a/desktop/frontend/transcript/component/moon.pkg
+++ b/desktop/frontend/transcript/component/moon.pkg
@@ -9,6 +9,7 @@ import {
   "moonbit-community/rabbita/js",
   "moonbit-community/rabbita/sub",
   "moonbitlang/core/debug",
+  "moonbitlang/core/immut/vector",
   "moonbitlang/core/json",
   "moonbitlang/editor/base/common",
   "moonbitlang/editor/viewer/html" @syntax_html,

--- a/desktop/frontend/transcript/component/moon.pkg
+++ b/desktop/frontend/transcript/component/moon.pkg
@@ -23,6 +23,7 @@ import {
   "openseek_desktop/frontend/plan",
   "openseek_desktop/frontend/resource",
   "openseek_desktop/frontend/transcript",
+  "openseek_desktop/frontend/transcript/live_preview",
   "openseek_desktop/frontend/transcript_overview",
 }
 

--- a/desktop/frontend/transcript/component/pkg.generated.mbti
+++ b/desktop/frontend/transcript/component/pkg.generated.mbti
@@ -12,7 +12,7 @@ import {
 }
 
 // Values
-pub fn component(@rabbita.Val[Input], LiveReasoning, Actions) -> @rabbita.Val[@html.Html]
+pub fn component(@rabbita.Val[Input], Actions) -> @rabbita.Val[@html.Html]
 
 // Errors
 
@@ -21,6 +21,8 @@ pub(all) struct Actions {
   open : @cmd.Emit[String]
   jump : @cmd.Emit[@mention_context.Target]
   open_session : @cmd.Emit[String]
+  focus_live_reasoning : (Input, Bool) -> @cmd.Cmd
+  live_reasoning_pinned : (Bool) -> Unit
 }
 
 type Input derive(Eq)
@@ -30,10 +32,13 @@ pub fn Input::not_equal(Self, Self) -> Bool
 
 type LiveReasoning
 pub fn LiveReasoning::LiveReasoning() -> Self
-pub fn LiveReasoning::delta(Self, channel~ : @interop.ChannelId, session~ : String, run_id~ : String?, content~ : String) -> @cmd.Cmd
-pub fn LiveReasoning::finish(Self, channel~ : @interop.ChannelId, session~ : String, run_id~ : String?) -> @cmd.Cmd
-pub fn LiveReasoning::finish_run(Self, channel~ : @interop.ChannelId, run_id~ : String) -> @cmd.Cmd
-pub fn LiveReasoning::reset_channel(Self, @interop.ChannelId) -> @cmd.Cmd
+pub fn LiveReasoning::connection_closed(Self, @interop.ChannelId, Int) -> Unit
+pub fn LiveReasoning::connection_opened(Self, @interop.ChannelId, Int) -> Unit
+pub fn LiveReasoning::delta(Self, channel~ : @interop.ChannelId, websocket_epoch~ : Int, session~ : String, run_id~ : String?, content~ : String) -> Unit
+pub fn LiveReasoning::finish(Self, channel~ : @interop.ChannelId, websocket_epoch~ : Int, session~ : String, run_id~ : String?) -> Unit
+pub fn LiveReasoning::finish_run(Self, channel~ : @interop.ChannelId, websocket_epoch~ : Int, run_id~ : String) -> Unit
+pub fn LiveReasoning::focus(Self, Input, Bool) -> @cmd.Cmd
+pub fn LiveReasoning::set_pinned(Self, Bool) -> Unit
 
 pub(all) enum Source {
   OpenSeek

--- a/desktop/frontend/transcript/component/pkg.generated.mbti
+++ b/desktop/frontend/transcript/component/pkg.generated.mbti
@@ -12,7 +12,7 @@ import {
 }
 
 // Values
-pub fn component(@rabbita.Val[Input], Actions) -> @rabbita.Val[@html.Html]
+pub fn component(@rabbita.Val[Input], LiveReasoning, Actions) -> @rabbita.Val[@html.Html]
 
 // Errors
 
@@ -24,9 +24,16 @@ pub(all) struct Actions {
 }
 
 type Input derive(Eq)
-pub fn Input::Input(source~ : Source, focused~ : @interop.ChannelId, active_session~ : String, root~ : @common.Uri?, submission_generation~ : Int, items~ : Array[VisibleRow], streaming_response~ : String?, streaming_reasoning? : String, reasoning_complete? : Bool, streaming_identity~ : String) -> Self
+pub fn Input::Input(source~ : Source, focused~ : @interop.ChannelId, active_session~ : String, active_run_id? : String, root~ : @common.Uri?, submission_generation~ : Int, items~ : Array[VisibleRow], streaming_response~ : String?, streaming_identity~ : String) -> Self
 pub fn Input::equal(Self, Self) -> Bool
 pub fn Input::not_equal(Self, Self) -> Bool
+
+type LiveReasoning
+pub fn LiveReasoning::LiveReasoning() -> Self
+pub fn LiveReasoning::delta(Self, channel~ : @interop.ChannelId, session~ : String, run_id~ : String?, content~ : String) -> @cmd.Cmd
+pub fn LiveReasoning::finish(Self, channel~ : @interop.ChannelId, session~ : String, run_id~ : String?) -> @cmd.Cmd
+pub fn LiveReasoning::finish_run(Self, channel~ : @interop.ChannelId, run_id~ : String) -> @cmd.Cmd
+pub fn LiveReasoning::reset_channel(Self, @interop.ChannelId) -> @cmd.Cmd
 
 pub(all) enum Source {
   OpenSeek

--- a/desktop/frontend/transcript/component/rendering.mbt
+++ b/desktop/frontend/transcript/component/rendering.mbt
@@ -98,7 +98,7 @@ fn TranscriptSectionKey::jump_latest() -> TranscriptSectionKey {
 
 ///|
 fn TranscriptSectionKey::live_reasoning() -> TranscriptSectionKey {
-  { value: "live-reasoning" }
+  { value: "live-reasoning", }
 }
 
 ///|

--- a/desktop/frontend/transcript/component/rendering.mbt
+++ b/desktop/frontend/transcript/component/rendering.mbt
@@ -126,6 +126,15 @@ fn TranscriptRenderer::subrun_link(self : TranscriptRenderer) -> SubrunLink? {
 }
 
 ///|
+/// Scope component-owned disclosure state to the stream as well as the row.
+fn TranscriptRenderer::activity_state_key(
+  self : TranscriptRenderer,
+  render_key : String,
+) -> String {
+  TranscriptSectionKey::stream(self.input).wire() + "\u{0}" + render_key
+}
+
+///|
 /// Insert one non-activity transcript row. Activity rows are handled by the
 /// step-aware grouping pass below; keeping this path singular ensures user turn
 /// anchors and assistant/error rendering cannot drift between durable steps
@@ -168,6 +177,8 @@ fn TranscriptRenderer::insert_row(
 /// order determines visual order; the strings only determine node identity.
 fn TranscriptRenderer::stream_children(
   self : TranscriptRenderer,
+  expanded_activity_keys? : @vector.Vector[String],
+  on_toggle_activity? : (String) -> @cmd.Cmd,
 ) -> Map[String, @html.Html] {
   let visible = self.input.items
   let items : Map[String, @html.Html] = Map([])
@@ -224,13 +235,19 @@ fn TranscriptRenderer::stream_children(
           index += 1
         }
         if !activity.is_empty() {
+          let render_key = TranscriptRenderKey::activity_after(left_boundary).wire()
+          let state_key = self.activity_state_key(render_key)
           items.set(
-            TranscriptRenderKey::activity_after(left_boundary).wire(),
+            render_key,
             activity_view(
               activity,
               self.on_open,
               step_label="#\{step_number}",
               subrun?=self.subrun_link(),
+              expanded?=expanded_activity_keys.map(keys => {
+                keys.contains(state_key)
+              }),
+              on_toggle?=on_toggle_activity.map(toggle => toggle(state_key)),
             ),
           )
         }
@@ -275,9 +292,17 @@ fn TranscriptRenderer::stream_children(
         run.push(visible[index].item)
         index += 1
       }
+      let render_key = TranscriptRenderKey::activity_after(left_boundary).wire()
+      let state_key = self.activity_state_key(render_key)
       items.set(
-        TranscriptRenderKey::activity_after(left_boundary).wire(),
-        activity_view(run, self.on_open, subrun?=self.subrun_link()),
+        render_key,
+        activity_view(
+          run,
+          self.on_open,
+          subrun?=self.subrun_link(),
+          expanded?=expanded_activity_keys.map(keys => keys.contains(state_key)),
+          on_toggle?=on_toggle_activity.map(toggle => toggle(state_key)),
+        ),
       )
       left_boundary = Some(visible[index - 1].identity)
     }
@@ -307,6 +332,8 @@ fn TranscriptRenderer::section_children(
   pinned : Bool,
   overview : @transcript_overview.State,
   overview_emit : @cmd.Emit[@transcript_overview.Msg],
+  expanded_activity_keys : @vector.Vector[String],
+  on_toggle_activity : (String) -> @cmd.Cmd,
   on_jump_latest : @cmd.Cmd,
 ) -> Map[String, @html.Html] {
   let visible_items = self.input.items.map(row => row.item)
@@ -330,7 +357,11 @@ fn TranscriptRenderer::section_children(
   )
   children.set(
     TranscriptSectionKey::stream(self.input).wire(),
-    @html.div(id="stream", class="stream", self.stream_children()),
+    @html.div(
+      id="stream",
+      class="stream",
+      self.stream_children(expanded_activity_keys~, on_toggle_activity~),
+    ),
   )
   // Rabbita owns this stable node but deliberately owns no descendants. The
   // live-preview package writes a small activity card beneath it, so frequent

--- a/desktop/frontend/transcript/component/rendering.mbt
+++ b/desktop/frontend/transcript/component/rendering.mbt
@@ -102,6 +102,9 @@ fn TranscriptSectionKey::jump_latest() -> TranscriptSectionKey {
 /// a child by key while moving, inserting, or removing its siblings.
 priv struct TranscriptRenderer {
   input : Input
+  // Present only while the component-owned reasoning stream is open. A
+  // completed preview is deleted, so durable rows need no content matching.
+  live_reasoning : String?
   on_open : (String) -> @cmd.Cmd
   on_jump : (@mention_context.Target) -> @cmd.Cmd
   on_open_session : (String) -> @cmd.Cmd
@@ -176,7 +179,7 @@ fn TranscriptRenderer::stream_children(
   // grouping pass. Live semantic events never synthesize durable-looking
   // items here; their store commits populate the transcript.
   if visible.is_empty() &&
-    self.input.streaming_reasoning is None &&
+    self.live_reasoning is None &&
     self.input.streaming_response is None {
     items.set(
       TranscriptRenderKey::empty().wire(),
@@ -279,18 +282,17 @@ fn TranscriptRenderer::stream_children(
       left_boundary = Some(visible[index - 1].identity)
     }
   }
-  // Durable commits are untagged and cannot prove ownership of an in-flight
-  // preview. Keep ambiguous live reasoning visible as a provisional next step;
-  // `Conversation::reasoning_for_render` suppresses only an exact, completed
-  // duplicate after it has durably committed.
-  if self.input.streaming_reasoning is Some(reasoning) {
+  // The preview exists only while its ordered `reasoning_delta` stream is
+  // open. A commit may therefore make this temporarily duplicate a durable
+  // card, or a semantic finish may remove it briefly before the commit lands;
+  // either order converges to the durable transcript without correlation.
+  if self.live_reasoning is Some(reasoning) {
     items.set(
       TranscriptRenderKey::activity_after(left_boundary).wire(),
       activity_view(
         [],
         self.on_open,
         live_reasoning=reasoning,
-        reasoning_complete=self.input.reasoning_complete,
         step_label=if self.input.source is OpenSeek {
           "#\{step_ordinals.length() + 1}"
         } else {

--- a/desktop/frontend/transcript/component/rendering.mbt
+++ b/desktop/frontend/transcript/component/rendering.mbt
@@ -97,14 +97,16 @@ fn TranscriptSectionKey::jump_latest() -> TranscriptSectionKey {
 }
 
 ///|
+fn TranscriptSectionKey::live_reasoning() -> TranscriptSectionKey {
+  { value: "live-reasoning" }
+}
+
+///|
 /// Pure rendering context for one transcript component. Its child-building
 /// methods return `Map[String, Html]`, which is the Rabbita API that preserves
 /// a child by key while moving, inserting, or removing its siblings.
 priv struct TranscriptRenderer {
   input : Input
-  // Present only while the component-owned reasoning stream is open. A
-  // completed preview is deleted, so durable rows need no content matching.
-  live_reasoning : String?
   on_open : (String) -> @cmd.Cmd
   on_jump : (@mention_context.Target) -> @cmd.Cmd
   on_open_session : (String) -> @cmd.Cmd
@@ -178,9 +180,7 @@ fn TranscriptRenderer::stream_children(
   // The durable transcript plus client-local notices, rendered through one
   // grouping pass. Live semantic events never synthesize durable-looking
   // items here; their store commits populate the transcript.
-  if visible.is_empty() &&
-    self.live_reasoning is None &&
-    self.input.streaming_response is None {
+  if visible.is_empty() && self.input.streaming_response is None {
     items.set(
       TranscriptRenderKey::empty().wire(),
       @html.div(class="empty", [
@@ -282,25 +282,6 @@ fn TranscriptRenderer::stream_children(
       left_boundary = Some(visible[index - 1].identity)
     }
   }
-  // The preview exists only while its ordered `reasoning_delta` stream is
-  // open. A commit may therefore make this temporarily duplicate a durable
-  // card, or a semantic finish may remove it briefly before the commit lands;
-  // either order converges to the durable transcript without correlation.
-  if self.live_reasoning is Some(reasoning) {
-    items.set(
-      TranscriptRenderKey::activity_after(left_boundary).wire(),
-      activity_view(
-        [],
-        self.on_open,
-        live_reasoning=reasoning,
-        step_label=if self.input.source is OpenSeek {
-          "#\{step_ordinals.length() + 1}"
-        } else {
-          ""
-        },
-      ),
-    )
-  }
   if self.input.streaming_response is Some(streaming) {
     items.set(
       TranscriptRenderKey::streaming(self.input.streaming_identity).wire(),
@@ -350,6 +331,17 @@ fn TranscriptRenderer::section_children(
   children.set(
     TranscriptSectionKey::stream(self.input).wire(),
     @html.div(id="stream", class="stream", self.stream_children()),
+  )
+  // Rabbita owns this stable node but deliberately owns no descendants. The
+  // live-preview package writes a small activity card beneath it, so frequent
+  // reasoning fragments cannot invalidate transcript or application Html.
+  children.set(
+    TranscriptSectionKey::live_reasoning().wire(),
+    @html.div(
+      id="live-reasoning-host",
+      class="live-reasoning-host",
+      ([] : Array[@html.Html]),
+    ),
   )
   // Reading history unpins auto-follow (see `watch_transcript_scroll`); the
   // floating button is the way back to the live tail. Sticky inside the

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -135,9 +135,7 @@ fn activity_view(
       class="msg-content activity-thinking activity-thinking-live",
       @html.text(content),
     )
-    rows.push(
-      thought_fold("Thinking…", prose, true),
-    )
+    rows.push(thought_fold("Thinking…", prose, true))
   }
   @html.div(class="activity-row", rows)
 }

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -6,9 +6,11 @@
 /// hiding them. Only reasoning stays behind a fold: a step that opens with a
 /// thought carries the ordinal and commit instant on that fold's summary
 /// ("#2 14:32:10 · Thought"), and a step that goes straight to tools puts
-/// the same columns on a plain heading line instead. The open state of every
-/// disclosure is the browser's (`<details>`), so a reader's toggle survives
-/// re-renders and the run growing while live.
+/// the same columns on a plain heading line instead. When the transcript
+/// component supplies disclosure state, a closed reasoning fold omits its
+/// body DOM entirely; stable activity keys preserve the body while the run
+/// grows. Focused rendering tests may omit that state and retain native
+/// `<details>` behavior.
 ///
 /// Failures need no badge up here: a failed call's own row is visible and
 /// carries its own literal `failed` marker. Its potentially large arguments
@@ -23,6 +25,8 @@ fn activity_view(
   live_reasoning? : String,
   step_label? : String = "",
   subrun? : SubrunLink,
+  expanded? : Bool,
+  on_toggle? : @cmd.Cmd,
 ) -> @html.Html {
   // The step ordinal is its own span so it can carry the accent and a fixed
   // numeral column, then the instant in a second fixed column: the run reads
@@ -73,12 +77,27 @@ fn activity_view(
     } else {
       text.push(@html.text(label))
     }
-    @html.details(class="activity", open=unfolded, [
-      @html.summary(class="activity-summary", [
+    let controlled = expanded is Some(_)
+    let open = unfolded || expanded.unwrap_or(false)
+    let summary_attrs = match (controlled, on_toggle) {
+      (true, Some(toggle)) =>
+        @html.Attrs::build()
+        .class("activity-summary")
+        .on_click(event => {
+          event.prevent_default()
+          toggle
+        })
+      _ => @html.Attrs::build().class("activity-summary")
+    }
+    let children : Array[@html.Html] = [
+      @html.summary(attrs=summary_attrs, [
         @html.span(class="activity-text", text),
       ]),
-      @html.div(class="activity-body", [prose]),
-    ])
+    ]
+    if !controlled || open {
+      children.push(@html.div(class="activity-body", [prose]))
+    }
+    @html.details(class="activity", open~, children)
   }
 
   let mut index = 0
@@ -881,6 +900,8 @@ fn transcript_view(
   pinned~ : Bool,
   overview~ : @transcript_overview.State,
   overview_emit~ : @cmd.Emit[@transcript_overview.Msg],
+  expanded_activity_keys? : @vector.Vector[String] = @vector.new(),
+  on_toggle_activity? : (String) -> @cmd.Cmd = _ => @cmd.none,
   on_open : (String) -> @cmd.Cmd,
   on_jump : (@mention_context.Target) -> @cmd.Cmd,
   on_open_session : (String) -> @cmd.Cmd,
@@ -893,7 +914,8 @@ fn transcript_view(
     on_open_session,
   }
   let children = renderer.section_children(
-    pinned, overview, overview_emit, on_jump_latest,
+    pinned, overview, overview_emit, expanded_activity_keys, on_toggle_activity,
+    on_jump_latest,
   )
   // These identity attributes make conversation and root changes observable
   // even when the rendered children stay identical. The component subscription

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -878,7 +878,6 @@ fn streaming_response_view(
 ///|
 fn transcript_view(
   input : Input,
-  live_reasoning? : String,
   pinned~ : Bool,
   overview~ : @transcript_overview.State,
   overview_emit~ : @cmd.Emit[@transcript_overview.Msg],
@@ -889,7 +888,6 @@ fn transcript_view(
 ) -> @html.Html {
   let renderer : TranscriptRenderer = {
     input,
-    live_reasoning,
     on_open,
     on_jump,
     on_open_session,
@@ -908,6 +906,7 @@ fn transcript_view(
       .data_set("transcript-source", input.source.wire())
       .data_set("transcript-channel", input.focused.uri_authority())
       .data_set("transcript-session", input.active_session)
+      .data_set("transcript-run", input.active_run_id.unwrap_or(""))
       .data_set(
         "transcript-root",
         input.root.map(uri => uri.to_string()).unwrap_or(""),

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -21,7 +21,6 @@ fn activity_view(
   items : Array[@transcript.TranscriptItem],
   on_open : (String) -> @cmd.Cmd,
   live_reasoning? : String,
-  reasoning_complete? : Bool = false,
   step_label? : String = "",
   subrun? : SubrunLink,
 ) -> @html.Html {
@@ -110,31 +109,15 @@ fn activity_view(
     }
   }
   if live_reasoning is Some(content) {
-    let prose = if reasoning_complete {
-      // The semantic completion supplies one whole document, so Markdown is
-      // safe and cheap now. The durable item will take over the same card.
-      @html.div(
-        class="msg-content markdown activity-thinking",
-        @markdown.markdown_nodes(content, open_file=on_open),
-      )
-    } else {
-      // Do not parse an unfinished Markdown document on every provider token.
-      // Newlines are preserved by CSS while fragments are still arriving.
-      @html.div(
-        class="msg-content activity-thinking activity-thinking-live",
-        @html.text(content),
-      )
-    }
+    // Do not parse an unfinished Markdown document on every provider token.
+    // Newlines are preserved by CSS while fragments are still arriving. The
+    // semantic finish deletes this preview; only the durable row uses Markdown.
+    let prose = @html.div(
+      class="msg-content activity-thinking activity-thinking-live",
+      @html.text(content),
+    )
     rows.push(
-      thought_fold(
-        if reasoning_complete {
-          "Thought"
-        } else {
-          "Thinking…"
-        },
-        prose,
-        true,
-      ),
+      thought_fold("Thinking…", prose, true),
     )
   }
   @html.div(class="activity-row", rows)
@@ -895,6 +878,7 @@ fn streaming_response_view(
 ///|
 fn transcript_view(
   input : Input,
+  live_reasoning? : String,
   pinned~ : Bool,
   overview~ : @transcript_overview.State,
   overview_emit~ : @cmd.Emit[@transcript_overview.Msg],
@@ -905,6 +889,7 @@ fn transcript_view(
 ) -> @html.Html {
   let renderer : TranscriptRenderer = {
     input,
+    live_reasoning,
     on_open,
     on_jump,
     on_open_session,

--- a/desktop/frontend/transcript/component/view_tests.mbt
+++ b/desktop/frontend/transcript/component/view_tests.mbt
@@ -753,6 +753,39 @@ test "a mixed activity keeps its call on display beside the thought fold" {
 
 ///|
 #warnings("-alert_unstable")
+test "a controlled closed thought omits its body DOM" {
+  let items : Array[@transcript.TranscriptItem] = [
+    {
+      kind: Reasoning,
+      content: "large historical reasoning",
+      ts: None,
+      sequence: Some(2),
+    },
+  ]
+  let render = expanded => {
+    @rabbita.render_to_string(() => {
+      @rabbita.Val::constant(
+        activity_view(
+          items,
+          _ => @cmd.none,
+          expanded~,
+          on_toggle=@cmd.none,
+        ),
+      )
+    })
+  }
+  let closed = render(false)
+  assert_true(closed.contains("activity-summary"))
+  assert_false(closed.contains("activity-body"))
+  assert_false(closed.contains("large historical reasoning"))
+
+  let opened = render(true)
+  assert_true(opened.contains("activity-body"))
+  assert_true(opened.contains("large historical reasoning"))
+}
+
+///|
+#warnings("-alert_unstable")
 test "the turn rule dates itself only from a real stamp" {
   let render = rule => {
     @rabbita.render_to_string(() => @rabbita.Val::constant(rule))

--- a/desktop/frontend/transcript/component/view_tests.mbt
+++ b/desktop/frontend/transcript/component/view_tests.mbt
@@ -125,6 +125,7 @@ test "transcript stream children use stable typed keys in display order" {
   )
   let renderer : TranscriptRenderer = {
     input,
+    live_reasoning: None,
     on_open: _ => @cmd.none,
     on_jump: _ => @cmd.none,
     on_open_session: _ => @cmd.none,
@@ -266,6 +267,7 @@ test "durable assistant sequences render as separate foldable steps" {
   )
   let renderer : TranscriptRenderer = {
     input,
+    live_reasoning: None,
     on_open: _ => @cmd.none,
     on_jump: _ => @cmd.none,
     on_open_session: _ => @cmd.none,
@@ -328,11 +330,11 @@ test "live step hands off to its durable assistant card key" {
     submission_generation=1,
     items=[user, first],
     streaming_response=None,
-    streaming_reasoning="next thought",
     streaming_identity="r7",
   )
   let live_renderer : TranscriptRenderer = {
     input: live_input,
+    live_reasoning: Some("next thought"),
     on_open: _ => @cmd.none,
     on_jump: _ => @cmd.none,
     on_open_session: _ => @cmd.none,
@@ -381,9 +383,12 @@ test "live step hands off to its durable assistant card key" {
         identity: "s4\u{0}o1",
       },
     ],
-    streaming_reasoning: None,
   }
-  let settled = { ..live_renderer, input: settled_input, }.stream_children()
+  let settled = {
+    ..live_renderer,
+    input: settled_input,
+    live_reasoning: None,
+  }.stream_children()
   assert_true(settled.get(handoff_key) is Some(_))
   let settled_markup = @rabbita.render_to_string(() => {
     @rabbita.Val::constant(settled[handoff_key])
@@ -395,7 +400,7 @@ test "live step hands off to its durable assistant card key" {
 
 ///|
 #warnings("-alert_unstable")
-test "an ambiguous commit-first prefix keeps live reasoning visible" {
+test "commit-first reasoning may temporarily show durable and live cards" {
   let rows : Array[VisibleRow] = [
     {
       item: { kind: User, content: "question", ts: None, sequence: Some(1), },
@@ -462,12 +467,12 @@ test "an ambiguous commit-first prefix keeps live reasoning visible" {
     submission_generation=1,
     items=rows,
     streaming_response=None,
-    streaming_reasoning="complete",
     streaming_identity="r7",
   )
   let children = (
     {
       input,
+      live_reasoning: Some("complete"),
       on_open: _ => @cmd.none,
       on_jump: _ => @cmd.none,
       on_open_session: _ => @cmd.none,
@@ -516,11 +521,11 @@ test "live reasoning is plain text and keeps the durable activity key" {
     submission_generation=1,
     items=[user],
     streaming_response=None,
-    streaming_reasoning="*unfinished*\nnext",
     streaming_identity="r7",
   )
   let live_renderer : TranscriptRenderer = {
     input: live_input,
+    live_reasoning: Some("*unfinished*\nnext"),
     on_open: _ => @cmd.none,
     on_jump: _ => @cmd.none,
     on_open_session: _ => @cmd.none,
@@ -533,17 +538,6 @@ test "live reasoning is plain text and keeps the durable activity key" {
   assert_true(live_markup.contains("*unfinished*\nnext"))
   assert_false(live_markup.contains("<em>unfinished</em>"))
   assert_true(live_markup.contains("<details class=\"activity\" open"))
-
-  let complete_renderer = {
-    ..live_renderer,
-    input: { ..live_input, reasoning_complete: true, },
-  }
-  let complete_markup = @rabbita.render_to_string(() => {
-    @rabbita.Val::constant(
-      complete_renderer.stream_children()["activity\u{0}after\u{0}s1\u{0}o0"],
-    )
-  })
-  assert_true(complete_markup.contains("<em>unfinished</em>"))
 
   let settled = {
     ..live_input,
@@ -568,9 +562,12 @@ test "live reasoning is plain text and keeps the durable activity key" {
         identity: "s2\u{0}o1",
       },
     ],
-    streaming_reasoning: None,
   }
-  let settled_renderer = { ..live_renderer, input: settled, }
+  let settled_renderer = {
+    ..live_renderer,
+    input: settled,
+    live_reasoning: None,
+  }
   let settled_children = settled_renderer.stream_children()
   assert_true(
     settled_children.get("activity\u{0}after\u{0}s1\u{0}o0") is Some(_),
@@ -1438,6 +1435,7 @@ fn subrun_step(session~ : String, source~ : Source) -> Map[String, @html.Html] {
   (
     {
       input,
+      live_reasoning: None,
       on_open: _ => @cmd.none,
       on_jump: _ => @cmd.none,
       on_open_session: _ => @cmd.none,
@@ -1507,6 +1505,7 @@ test "an ordinary tool card carries no sub-run link" {
   let children = (
     {
       input,
+      live_reasoning: None,
       on_open: _ => @cmd.none,
       on_jump: _ => @cmd.none,
       on_open_session: _ => @cmd.none,
@@ -1559,6 +1558,7 @@ test "a subtask launch card links every worker it started" {
   let children = (
     {
       input,
+      live_reasoning: None,
       on_open: _ => @cmd.none,
       on_jump: _ => @cmd.none,
       on_open_session: _ => @cmd.none,

--- a/desktop/frontend/transcript/component/view_tests.mbt
+++ b/desktop/frontend/transcript/component/view_tests.mbt
@@ -65,6 +65,7 @@ test "transcript markup exposes conversation identity" {
     source=OpenSeek,
     focused=@interop.ChannelId::Remote("relay-a"),
     active_session="same-markup-chat",
+    active_run_id="run-a",
     root=Some(root),
     submission_generation=7,
     items=[],
@@ -84,12 +85,15 @@ test "transcript markup exposes conversation identity" {
   let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
   assert_true(markup.contains("data-transcript-channel=\"remote.relay-a\""))
   assert_true(markup.contains("data-transcript-session=\"same-markup-chat\""))
+  assert_true(markup.contains("data-transcript-run=\"run-a\""))
   assert_true(
     markup.contains(
       "data-transcript-root=\"openseek://remote.relay-a/work/project\"",
     ),
   )
   assert_true(markup.contains("data-transcript-submission=\"7\""))
+  assert_true(markup.contains("id=\"live-reasoning-host\""))
+  assert_false(markup.contains("activity-thinking-live"))
 }
 
 ///|
@@ -125,7 +129,6 @@ test "transcript stream children use stable typed keys in display order" {
   )
   let renderer : TranscriptRenderer = {
     input,
-    live_reasoning: None,
     on_open: _ => @cmd.none,
     on_jump: _ => @cmd.none,
     on_open_session: _ => @cmd.none,
@@ -267,7 +270,6 @@ test "durable assistant sequences render as separate foldable steps" {
   )
   let renderer : TranscriptRenderer = {
     input,
-    live_reasoning: None,
     on_open: _ => @cmd.none,
     on_jump: _ => @cmd.none,
     on_open_session: _ => @cmd.none,
@@ -301,7 +303,7 @@ test "durable assistant sequences render as separate foldable steps" {
 
 ///|
 #warnings("-alert_unstable")
-test "live step hands off to its durable assistant card key" {
+test "a committed reasoning step takes the next durable activity key" {
   let user : VisibleRow = {
     item: { kind: User, content: "question", ts: None, sequence: Some(1), },
     identity: "s1\u{0}o0",
@@ -332,14 +334,13 @@ test "live step hands off to its durable assistant card key" {
     streaming_response=None,
     streaming_identity="r7",
   )
-  let live_renderer : TranscriptRenderer = {
+  let renderer : TranscriptRenderer = {
     input: live_input,
-    live_reasoning: Some("next thought"),
     on_open: _ => @cmd.none,
     on_jump: _ => @cmd.none,
     on_open_session: _ => @cmd.none,
   }
-  let live = live_renderer.stream_children()
+  let live = renderer.stream_children()
   let first_markup = @rabbita.render_to_string(() => {
     @rabbita.Val::constant(live["activity\u{0}after\u{0}s1\u{0}o0"])
   })
@@ -352,13 +353,6 @@ test "live step hands off to its durable assistant card key" {
   )
   assert_false(first_markup.contains("<details class=\"activity\""))
   let handoff_key = "activity\u{0}after\u{0}s2\u{0}o0"
-  assert_true(live.get(handoff_key) is Some(_))
-  let live_markup = @rabbita.render_to_string(() => {
-    @rabbita.Val::constant(live[handoff_key])
-  })
-  assert_true(live_markup.contains(step_summary(2, "Thinking…")))
-  assert_true(live_markup.contains("<details class=\"activity\" open"))
-
   let settled_input = {
     ..live_input,
     items: [
@@ -384,11 +378,7 @@ test "live step hands off to its durable assistant card key" {
       },
     ],
   }
-  let settled = {
-    ..live_renderer,
-    input: settled_input,
-    live_reasoning: None,
-  }.stream_children()
+  let settled = { ..renderer, input: settled_input }.stream_children()
   assert_true(settled.get(handoff_key) is Some(_))
   let settled_markup = @rabbita.render_to_string(() => {
     @rabbita.Val::constant(settled[handoff_key])
@@ -400,7 +390,7 @@ test "live step hands off to its durable assistant card key" {
 
 ///|
 #warnings("-alert_unstable")
-test "commit-first reasoning may temporarily show durable and live cards" {
+test "durable transcript never synthesizes a live reasoning card" {
   let rows : Array[VisibleRow] = [
     {
       item: { kind: User, content: "question", ts: None, sequence: Some(1), },
@@ -472,7 +462,6 @@ test "commit-first reasoning may temporarily show durable and live cards" {
   let children = (
     {
       input,
-      live_reasoning: Some("complete"),
       on_open: _ => @cmd.none,
       on_jump: _ => @cmd.none,
       on_open_session: _ => @cmd.none,
@@ -481,7 +470,6 @@ test "commit-first reasoning may temporarily show durable and live cards" {
   assert_eq(keys, [
     "row\u{0}s1\u{0}o0", "rule\u{0}s1\u{0}o0", "activity\u{0}after\u{0}s1\u{0}o0",
     "row\u{0}s2\u{0}o1", "activity\u{0}after\u{0}s2\u{0}o1", "row\u{0}s3\u{0}o1",
-    "activity\u{0}after\u{0}s3\u{0}o1",
   ])
   let markup = @rabbita.render_to_string(() => {
     @rabbita.Val::constant(children["activity\u{0}after\u{0}s1\u{0}o0"])
@@ -498,17 +486,11 @@ test "commit-first reasoning may temporarily show durable and live cards" {
   assert_true(later_markup.contains("later thought"))
   assert_false(later_markup.contains("activity-thinking-live"))
   assert_false(later_markup.contains("#3"))
-  let live_markup = @rabbita.render_to_string(() => {
-    @rabbita.Val::constant(children["activity\u{0}after\u{0}s3\u{0}o1"])
-  })
-  assert_true(live_markup.contains(step_summary(3, "Thinking…")))
-  assert_true(live_markup.contains("complete"))
-  assert_true(live_markup.contains("activity-thinking-live"))
 }
 
 ///|
 #warnings("-alert_unstable")
-test "live reasoning is plain text and keeps the durable activity key" {
+test "committed reasoning uses Markdown in its durable activity card" {
   let user : VisibleRow = {
     item: { kind: User, content: "question", ts: None, sequence: Some(1), },
     identity: "s1\u{0}o0",
@@ -523,22 +505,6 @@ test "live reasoning is plain text and keeps the durable activity key" {
     streaming_response=None,
     streaming_identity="r7",
   )
-  let live_renderer : TranscriptRenderer = {
-    input: live_input,
-    live_reasoning: Some("*unfinished*\nnext"),
-    on_open: _ => @cmd.none,
-    on_jump: _ => @cmd.none,
-    on_open_session: _ => @cmd.none,
-  }
-  let live_children = live_renderer.stream_children()
-  assert_true(live_children.get("activity\u{0}after\u{0}s1\u{0}o0") is Some(_))
-  let live_markup = @rabbita.render_to_string(() => {
-    @rabbita.Val::constant(live_children["activity\u{0}after\u{0}s1\u{0}o0"])
-  })
-  assert_true(live_markup.contains("*unfinished*\nnext"))
-  assert_false(live_markup.contains("<em>unfinished</em>"))
-  assert_true(live_markup.contains("<details class=\"activity\" open"))
-
   let settled = {
     ..live_input,
     items: [
@@ -563,10 +529,11 @@ test "live reasoning is plain text and keeps the durable activity key" {
       },
     ],
   }
-  let settled_renderer = {
-    ..live_renderer,
+  let settled_renderer : TranscriptRenderer = {
     input: settled,
-    live_reasoning: None,
+    on_open: _ => @cmd.none,
+    on_jump: _ => @cmd.none,
+    on_open_session: _ => @cmd.none,
   }
   let settled_children = settled_renderer.stream_children()
   assert_true(
@@ -1435,7 +1402,6 @@ fn subrun_step(session~ : String, source~ : Source) -> Map[String, @html.Html] {
   (
     {
       input,
-      live_reasoning: None,
       on_open: _ => @cmd.none,
       on_jump: _ => @cmd.none,
       on_open_session: _ => @cmd.none,
@@ -1505,7 +1471,6 @@ test "an ordinary tool card carries no sub-run link" {
   let children = (
     {
       input,
-      live_reasoning: None,
       on_open: _ => @cmd.none,
       on_jump: _ => @cmd.none,
       on_open_session: _ => @cmd.none,
@@ -1558,7 +1523,6 @@ test "a subtask launch card links every worker it started" {
   let children = (
     {
       input,
-      live_reasoning: None,
       on_open: _ => @cmd.none,
       on_jump: _ => @cmd.none,
       on_open_session: _ => @cmd.none,

--- a/desktop/frontend/transcript/component/view_tests.mbt
+++ b/desktop/frontend/transcript/component/view_tests.mbt
@@ -378,7 +378,7 @@ test "a committed reasoning step takes the next durable activity key" {
       },
     ],
   }
-  let settled = { ..renderer, input: settled_input }.stream_children()
+  let settled = { ..renderer, input: settled_input, }.stream_children()
   assert_true(settled.get(handoff_key) is Some(_))
   let settled_markup = @rabbita.render_to_string(() => {
     @rabbita.Val::constant(settled[handoff_key])
@@ -765,12 +765,7 @@ test "a controlled closed thought omits its body DOM" {
   let render = expanded => {
     @rabbita.render_to_string(() => {
       @rabbita.Val::constant(
-        activity_view(
-          items,
-          _ => @cmd.none,
-          expanded~,
-          on_toggle=@cmd.none,
-        ),
+        activity_view(items, _ => @cmd.none, expanded~, on_toggle=@cmd.none),
       )
     })
   }

--- a/desktop/frontend/transcript/live_preview/live_preview.mbt
+++ b/desktop/frontend/transcript/live_preview/live_preview.mbt
@@ -1,0 +1,339 @@
+///|
+/// Keep rewrites bounded while avoiding one DOM node per rendered frame. A
+/// long provider fragment may occupy its own larger node; later fragments
+/// start a fresh bounded chunk instead of repeatedly copying that large text.
+const LIVE_TEXT_CHUNK_LIMIT = 8192
+
+///|
+/// Imperative DOM state for the childless live-reasoning host. This object is
+/// captured by the component's private update closure; it is never stored in
+/// a Rabbita model or exposed to the root view.
+struct LivePreview {
+  mut target : String?
+  mut step_label : String
+  mut pinned : Bool
+  mut host : @dom.Element?
+  mut reasoning : @dom.Element?
+  mut text_chunk : @dom.Element?
+  mut text_chunk_content : String
+  pending : Array[String]
+  mut frame : Double?
+  mut resize : @dom.ResizeObserver?
+}
+
+///|
+pub fn LivePreview::LivePreview() -> LivePreview {
+  {
+    target: None,
+    step_label: "",
+    pinned: true,
+    host: None,
+    reasoning: None,
+    text_chunk: None,
+    text_chunk_content: "",
+    pending: [],
+    frame: None,
+    resize: None,
+  }
+}
+
+///|
+/// Cancel a queued frame before changing ownership. Clearing the fragments at
+/// the same time prevents a callback from one conversation from appending to
+/// a replacement conversation's card.
+fn LivePreview::cancel_pending(self : LivePreview) -> Unit {
+  match self.frame {
+    Some(frame) => {
+      @dom.window().cancel_animation_frame(frame)
+      self.frame = None
+    }
+    None => ()
+  }
+  self.pending.clear()
+}
+
+///|
+/// Remove only the descendants owned by this widget. The host itself belongs
+/// to Rabbita and remains a stable childless virtual-DOM node.
+fn LivePreview::clear_host(self : LivePreview, host : @dom.Element?) -> Unit {
+  if self.resize is Some(resize) {
+    resize.disconnect()
+  }
+  match host {
+    Some(host) =>
+      while host.get_child_count() > 0 {
+        host.remove_child(host.get_child(0))
+      }
+    None => ()
+  }
+  self.host = host
+  self.reasoning = None
+  self.text_chunk = None
+  self.text_chunk_content = ""
+}
+
+///|
+/// Follow live growth only after ResizeObserver reports the browser's completed
+/// layout. Reading scrollHeight here therefore consumes the layout that already
+/// happened instead of forcing one synchronously in the delta append path.
+fn LivePreview::follow_tail_after_layout(self : LivePreview) -> Unit {
+  if !self.pinned {
+    return
+  }
+  if @dom.document().get_element_by_id("transcript").to_option()
+    is Some(transcript) {
+    transcript.set_scroll_top(transcript.get_scroll_height())
+  }
+}
+
+///|
+/// Observe only the small live text element. The observer is reused across
+/// cards but disconnected before Rabbita replaces or clears the stable host.
+fn LivePreview::observe_reasoning(
+  self : LivePreview,
+  reasoning : @dom.Element,
+) -> Unit {
+  let resize = match self.resize {
+    Some(resize) => resize
+    None => {
+      let resize = @dom.ResizeObserver::new((_, _) => {
+        self.follow_tail_after_layout()
+      })
+      self.resize = Some(resize)
+      resize
+    }
+  }
+  resize.disconnect()
+  resize.observe(reasoning)
+}
+
+///|
+/// Append into a bounded current chunk. Updating one unbounded text node would
+/// copy the whole preview every frame; appending one node per frame instead
+/// leaves thousands of layout objects. Bounded chunks avoid both growth modes.
+fn LivePreview::append_text(
+  self : LivePreview,
+  reasoning : @dom.Element,
+  content : String,
+) -> Unit {
+  if self.text_chunk is Some(text_chunk) {
+    let combined = self.text_chunk_content + content
+    if combined.length() <= LIVE_TEXT_CHUNK_LIMIT {
+      text_chunk.set_node_value(@js.Nullable::from_option(Some(combined)))
+      self.text_chunk_content = combined
+      return
+    }
+  }
+  let text_chunk = @dom.document().create_text_node(content)
+  reasoning.append_child(text_chunk.as_node())
+  if content.length() <= LIVE_TEXT_CHUNK_LIMIT {
+    self.text_chunk = Some(text_chunk)
+    self.text_chunk_content = content
+  } else {
+    self.text_chunk = None
+    self.text_chunk_content = ""
+  }
+}
+
+///|
+/// Build one activity card using Rabbita's typed DOM package. Returning the
+/// reasoning element gives later frames one narrow append target.
+fn LivePreview::build_card(
+  self : LivePreview,
+  host : @dom.Element,
+  initial_content : String,
+) -> @dom.Element {
+  self.clear_host(Some(host))
+  let document = @dom.document()
+  let row = document.create_element("div")
+  row.set_attribute("class", "activity-row")
+  let details = document.create_element("details")
+  details.set_attribute("class", "activity")
+  details.set_attribute("open", "")
+  let summary = document.create_element("summary")
+  summary.set_attribute("class", "activity-summary")
+  let summary_text = document.create_element("span")
+  summary_text.set_attribute("class", "activity-text")
+  if self.step_label.is_empty() {
+    summary_text.append_child(
+      document.create_text_node("Thinking…").as_node(),
+    )
+  } else {
+    let step = document.create_element("span")
+    step.set_attribute("class", "activity-step")
+    step.append_child(document.create_text_node(self.step_label).as_node())
+    summary_text.append_child(step.as_node())
+    summary_text.append_child(
+      document.create_text_node(" · Thinking…").as_node(),
+    )
+  }
+  summary.append_child(summary_text.as_node())
+  let body = document.create_element("div")
+  body.set_attribute("class", "activity-body")
+  let reasoning = document.create_element("div")
+  reasoning.set_attribute(
+    "class", "msg-content activity-thinking activity-thinking-live",
+  )
+  body.append_child(reasoning.as_node())
+  details.append_child(summary.as_node())
+  details.append_child(body.as_node())
+  row.append_child(details.as_node())
+  host.append_child(row.as_node())
+  self.host = Some(host)
+  self.reasoning = Some(reasoning)
+  if !initial_content.is_empty() {
+    self.append_text(reasoning, initial_content)
+  }
+  self.observe_reasoning(reasoning)
+  reasoning
+}
+
+///|
+/// Drain all fragments received during one browser frame. Updating one bounded
+/// text chunk keeps the cost of a frame independent of the full reasoning
+/// length.
+fn LivePreview::flush(self : LivePreview, target : String) -> Unit {
+  self.frame = None
+  if self.target != Some(target) {
+    self.pending.clear()
+    return
+  }
+  let content = StringBuilder()
+  for fragment in self.pending {
+    content.write_string(fragment)
+  }
+  self.pending.clear()
+  let content = content.to_string()
+  if content.is_empty() {
+    return
+  }
+  let document = @dom.document()
+  guard document.get_element_by_id("live-reasoning-host").to_option()
+    is Some(host) else {
+    self.host = None
+    self.reasoning = None
+    return
+  }
+  let reasoning = match (self.host, self.reasoning) {
+    (Some(previous_host), Some(reasoning)) =>
+      if previous_host.is_same_node(host.as_node()) {
+        reasoning
+      } else {
+        self.build_card(host, "")
+      }
+    _ => self.build_card(host, "")
+  }
+  self.append_text(reasoning, content)
+}
+
+///|
+fn LivePreview::apply_sync(
+  self : LivePreview,
+  target : String,
+  step_label : String,
+  content : String,
+) -> Unit {
+  self.cancel_pending()
+  self.target = Some(target)
+  self.step_label = step_label
+  let host = @dom.document()
+    .get_element_by_id("live-reasoning-host")
+    .to_option()
+  if content.is_empty() {
+    self.clear_host(host)
+  } else {
+    match host {
+      Some(host) => {
+        let _ = self.build_card(host, content)
+      }
+      None => {
+        self.host = None
+        self.reasoning = None
+      }
+    }
+  }
+}
+
+///|
+fn LivePreview::enqueue(
+  self : LivePreview,
+  target : String,
+  content : String,
+) -> Unit {
+  if content.is_empty() || self.target != Some(target) {
+    return
+  }
+  self.pending.push(content)
+  if self.frame is None {
+    self.frame = Some(
+      @dom.window().request_animation_frame(_ => self.flush(target)),
+    )
+  }
+}
+
+///|
+fn LivePreview::apply_hide(self : LivePreview, target : String) -> Unit {
+  if self.target != Some(target) {
+    return
+  }
+  self.cancel_pending()
+  self.clear_host(
+    @dom.document().get_element_by_id("live-reasoning-host").to_option(),
+  )
+}
+
+///|
+fn LivePreview::apply_reset(self : LivePreview) -> Unit {
+  self.cancel_pending()
+  self.target = None
+  self.step_label = ""
+  self.clear_host(
+    @dom.document().get_element_by_id("live-reasoning-host").to_option(),
+  )
+}
+
+///|
+/// Replace the visible live-reasoning widget with one complete state. Callers
+/// invoke this only from a bridge callback or an after-render command. Empty
+/// content arms the target without showing a card.
+pub fn LivePreview::sync(
+  self : LivePreview,
+  target : String,
+  step_label : String,
+  content : String,
+) -> Unit {
+  self.apply_sync(target, step_label, content)
+}
+
+///|
+/// Queue one ordered reasoning fragment. All fragments received before the
+/// next browser frame become one text-node append.
+pub fn LivePreview::append(
+  self : LivePreview,
+  target : String,
+  content : String,
+) -> Unit {
+  self.enqueue(target, content)
+}
+
+///|
+/// Cache the transcript's real scroll state. The transcript capture listener
+/// calls this only for scroll events; delta frames never query layout merely
+/// to rediscover the same value.
+pub fn LivePreview::set_pinned(self : LivePreview, pinned : Bool) -> Unit {
+  self.pinned = pinned
+}
+
+///|
+/// Remove a finished step's card while retaining its target. A later fragment
+/// for the same run can therefore create the next card without a root render.
+pub fn LivePreview::hide(self : LivePreview, target : String) -> Unit {
+  self.apply_hide(target)
+}
+
+///|
+/// Remove the card and disarm its target when no OpenSeek conversation owns
+/// the host. A later target must arrive through `sync` before deltas are shown.
+pub fn LivePreview::reset(self : LivePreview) -> Unit {
+  self.apply_reset()
+}

--- a/desktop/frontend/transcript/live_preview/moon.pkg
+++ b/desktop/frontend/transcript/live_preview/moon.pkg
@@ -1,0 +1,6 @@
+import {
+  "moonbit-community/rabbita/dom",
+  "moonbit-community/rabbita/js",
+}
+
+supported_targets = "js"

--- a/desktop/frontend/transcript_rendering.mbt
+++ b/desktop/frontend/transcript_rendering.mbt
@@ -58,6 +58,7 @@ fn Conversation::streaming_render_identity(self : Conversation) -> String {
   }
 }
 
+///|
 test "transcript row identities include event ordinals" {
   let conv = {
     ..test_conversation(),

--- a/desktop/frontend/transcript_rendering.mbt
+++ b/desktop/frontend/transcript_rendering.mbt
@@ -58,35 +58,6 @@ fn Conversation::streaming_render_identity(self : Conversation) -> String {
   }
 }
 
-///|
-/// The provisional reasoning to render. A sealed preview equal to reasoning
-/// committed during this step is already present in the durable activity card,
-/// so hide only that visual duplicate. Never hide an in-flight prefix and never
-/// mutate the preview from a commit: session commits carry no run/step identity,
-/// and an older delayed commit must not truncate a newer stream.
-fn Conversation::reasoning_for_render(self : Conversation) -> (String?, Bool) {
-  guard self.turn.live_reasoning is Some(live) && !live.content.is_empty() else {
-    return (None, false)
-  }
-  let candidate = live.content.trim()
-  if live.complete && !candidate.is_empty() {
-    let mut index = self.messages.length()
-    while index > 0 {
-      index -= 1
-      if self.messages[index].kind is Reasoning {
-        if self.messages[index].sequence is Some(sequence) &&
-          sequence > self.turn.reasoning_frontier &&
-          self.messages[index].content.trim() == candidate {
-          return (None, live.complete)
-        }
-        break
-      }
-    }
-  }
-  (Some(live.content), live.complete)
-}
-
-///|
 test "transcript row identities include event ordinals" {
   let conv = {
     ..test_conversation(),

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1045,13 +1045,9 @@ fn apply_engine_event(
 ) -> (String?, Conversation) {
   match event {
     AgentStep(step) => {
-      // The next model request starts after every durable commit this page
-      // already knows, including commits buffered during a reload. Advancing
-      // the frontier per step prevents an earlier step's identical reasoning
-      // from being mistaken for this step's commit.
-      let reasoning_frontier = conv.durable_frontier()
-      let cleared = conv.clear_streams()
-      let conv = { ..cleared, turn: { ..cleared.turn, reasoning_frontier, }, }
+      // The transcript component clears its provisional reasoning through the
+      // bridge dispatcher. Root state retains only streamed assistant prose.
+      let conv = conv.clear_streams()
       (
         None,
         // A step can only advance an open, uncancelled turn: after a Stop the
@@ -1069,7 +1065,6 @@ fn apply_engine_event(
       if content.is_empty() {
         (None, conv)
       } else {
-        let conv = conv.complete_reasoning()
         let carried = conv.turn.streaming_response.unwrap_or("")
         (
           None,
@@ -1079,57 +1074,11 @@ fn apply_engine_event(
           },
         )
       }
-    ReasoningDelta(content) =>
-      if content.is_empty() ||
-        conv.turn.live_reasoning is Some({ complete: true, .. }) {
-        // A completed semantic event is the boundary. A delayed fragment must
-        // not resurrect or mutate the finished preview.
-        (None, conv)
-      } else {
-        let carried = match conv.turn.live_reasoning {
-          Some(reasoning) => reasoning.content
-          None => ""
-        }
-        (
-          None,
-          {
-            ..conv,
-            turn: {
-              ..conv.turn,
-              live_reasoning: Some({
-                content: carried + content,
-                complete: false,
-              }),
-            },
-          },
-        )
-      }
-    // Full semantic events never append transcript items: the store commit is
-    // the sole durable source. The complete reasoning payload replaces any
-    // accumulated fragments and seals their transient presentation.
-    ReasoningMessage(content) => {
-      let normalized = content.trim().to_owned()
-      if normalized.is_empty() {
-        // Remote delivery strips the complete payload because the durable
-        // session event carries it. A remote client may have joined midway
-        // through the stream, so its accumulated deltas can be only a suffix;
-        // discard that provisional text at settlement and let the canonical
-        // commit supply the complete Markdown card.
-        (None, { ..conv, turn: { ..conv.turn, live_reasoning: None, }, })
-      } else {
-        (
-          None,
-          {
-            ..conv,
-            turn: {
-              ..conv.turn,
-              live_reasoning: Some({ content, complete: true, }),
-            },
-          },
-        )
-      }
-    }
-    AssistantMessage(_) => (None, conv.complete_reasoning().clear_response())
+    // Production bridge dispatch sends these straight to the transcript
+    // component. Keep the root fold total for direct tests and legacy callers
+    // without recreating component-owned state here.
+    ReasoningDelta(_) | ReasoningMessage(_) => (None, conv)
+    AssistantMessage(_) => (None, conv.clear_streams())
     RuntimeUpdate(content) => {
       let update = @transcript.parse_runtime_update(content)
       (None, { ..conv, watcher_status: update.status, })
@@ -3406,7 +3355,7 @@ fn update_msg(
           // floor: the store may have advanced through an external CLI while
           // this page was idle, so only the real Started seam's causal
           // snapshot may establish this run's predecessor terminal.
-          turn: RunState::for_run(conv.durable_frontier()),
+          turn: RunState::for_run(),
           // The submit is the moment this run began as far as the user is
           // concerned: the wait they are watching starts here, not at the
           // host's `started`.
@@ -6601,7 +6550,7 @@ fn update_device_msg(
       let turn : RunState = if stale_terminal || same_open {
         conv.turn
       } else {
-        RunState::for_run(conv.durable_frontier())
+        RunState::for_run()
       }
       // `foreign` is exactly the question the elapsed span needs answered: a
       // run this page did not submit and wait for has an age that started
@@ -8013,293 +7962,21 @@ test "deltas from an unknown run are dropped" {
 }
 
 ///|
-test "reasoning message waits for its durable commit" {
+test "reasoning stream events do not mutate root conversation state" {
   let dispatch = test_dispatch()
   let model = running_model()
-  let (_, next) = update_dev(
+  let (_, delta) = update_dev(
     dispatch,
-    Engine(Some("r7"), ReasoningMessage("full thought"), session=None),
+    Engine(Some("r7"), ReasoningDelta("thinking"), session=None),
     model,
   )
-  inspect(next.active().messages.length(), content="0")
-  assert_eq(
-    next.active().turn.live_reasoning,
-    Some({ content: "full thought", complete: true, }),
-  )
-}
-
-///|
-test "reasoning deltas accumulate and answer output closes the live stream" {
-  let dispatch = test_dispatch()
-  let (_, first) = update_dev(
+  let (_, finished) = update_dev(
     dispatch,
-    Engine(Some("r7"), ReasoningDelta("first"), session=None),
-    running_model(),
-  )
-  let (_, second) = update_dev(
-    dispatch,
-    Engine(Some("r7"), ReasoningDelta(" line"), session=None),
-    first,
-  )
-  assert_eq(
-    second.active().turn.live_reasoning,
-    Some({ content: "first line", complete: false, }),
-  )
-  let (_, answered) = update_dev(
-    dispatch,
-    Engine(Some("r7"), AssistantDelta("answer"), session=None),
-    second,
-  )
-  assert_eq(
-    answered.active().turn.live_reasoning,
-    Some({ content: "first line", complete: true, }),
-  )
-  // Once the stream is semantically complete, a delayed delta cannot revive
-  // or extend it.
-  let (_, late) = update_dev(
-    dispatch,
-    Engine(Some("r7"), ReasoningDelta(" late"), session=None),
-    answered,
-  )
-  assert_eq(
-    late.active().turn.live_reasoning,
-    answered.active().turn.live_reasoning,
-  )
-}
-
-///|
-test "an empty remote reasoning settlement clears the partial preview" {
-  let dispatch = test_dispatch()
-  let (_, partial) = update_dev(
-    dispatch,
-    Engine(Some("r7"), ReasoningDelta("first line"), session=None),
-    running_model(),
-  )
-  let (_, settled) = update_dev(
-    dispatch,
-    Engine(Some("r7"), ReasoningMessage(""), session=None),
-    partial,
-  )
-  assert_eq(settled.active().turn.live_reasoning, None)
-  assert_eq(settled.active().reasoning_for_render(), (None, false))
-}
-
-///|
-test "a matching durable commit de-duplicates without mutating the preview" {
-  let dispatch = test_dispatch()
-  let live = running_model().replace_conversation({
-    ..running_conversation(),
-    turn: {
-      ..running_conversation().turn,
-      live_reasoning: Some({ content: "think", complete: true, }),
-    },
-  })
-  let (_, committed) = update_dev(
-    dispatch,
-    SessionCommitted(
-      session="desktop-test",
-      sequence=1,
-      ts=None,
-      item=@protocol.Assistant({
-        content: "answer",
-        tool_calls: None,
-        reasoning_content: Some("think"),
-        is_replay: None,
-      }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
-    ),
-    live,
-  )
-  assert_eq(
-    committed.active().turn.live_reasoning,
-    Some({ content: "think", complete: true, }),
-  )
-  assert_eq(committed.active().reasoning_for_render(), (None, true))
-  assert_eq(committed.active().messages.length(), 2)
-  assert_true(committed.active().messages[0].kind is Reasoning)
-}
-
-///|
-test "commit-first reasoning keeps late prefixes and de-duplicates when sealed" {
-  let dispatch = test_dispatch()
-  let commit = SessionCommitted(
-    session="desktop-test",
-    sequence=1,
-    ts=None,
-    item=@protocol.Assistant({
-      content: "answer",
-      tool_calls: None,
-      reasoning_content: Some("complete thought"),
-      is_replay: None,
-    }),
-    session_root=@interop.ChannelId::Local.test_store_root(),
-  )
-  let (_, committed) = update_dev(dispatch, commit, running_model())
-  let (_, partial) = update_dev(
-    dispatch,
-    Engine(Some("r7"), ReasoningDelta("complete"), session=None),
-    committed,
-  )
-  assert_eq(partial.active().reasoning_for_render(), (Some("complete"), false))
-  let (_, completed) = update_dev(
-    dispatch,
-    Engine(Some("r7"), ReasoningMessage("complete thought"), session=None),
-    partial,
-  )
-  assert_eq(
-    completed.active().turn.live_reasoning,
-    Some({ content: "complete thought", complete: true, }),
-  )
-  assert_eq(completed.active().reasoning_for_render(), (None, true))
-}
-
-///|
-test "a delayed untagged commit cannot truncate a newer reasoning stream" {
-  let dispatch = test_dispatch()
-  let (_, partial) = update_dev(
-    dispatch,
-    Engine(Some("r7"), ReasoningDelta("shared"), session=None),
-    running_model(),
-  )
-  let (_, committed) = update_dev(
-    dispatch,
-    SessionCommitted(
-      session="desktop-test",
-      sequence=1,
-      ts=None,
-      item=@protocol.Assistant({
-        content: "older answer",
-        tool_calls: None,
-        reasoning_content: Some("shared"),
-        is_replay: None,
-      }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
-    ),
-    partial,
-  )
-  assert_eq(
-    committed.active().turn.live_reasoning,
-    Some({ content: "shared", complete: false, }),
-  )
-  assert_eq(committed.active().reasoning_for_render(), (Some("shared"), false))
-  let (_, continued) = update_dev(
-    dispatch,
-    Engine(Some("r7"), ReasoningDelta(" future"), session=None),
-    committed,
-  )
-  assert_eq(
-    continued.active().turn.live_reasoning,
-    Some({ content: "shared future", complete: false, }),
-  )
-}
-
-///|
-test "a later run does not confuse identical historical reasoning for its commit" {
-  let dispatch = test_dispatch()
-  let historical = {
-    ..running_conversation(),
-    messages: [
-      {
-        kind: Reasoning,
-        content: "shared opening",
-        ts: None,
-        sequence: Some(2),
-      },
-      {
-        kind: Assistant(is_danger=false),
-        content: "older answer",
-        ts: None,
-        sequence: Some(2),
-      },
-    ],
-    watermark: 3,
-    turn: RunState::for_run(3),
-  }
-  let model = running_model().replace_conversation(historical)
-  let (_, partial) = update_dev(
-    dispatch,
-    Engine(Some("r7"), ReasoningDelta("shared opening"), session=None),
+    Engine(Some("r7"), ReasoningMessage("thinking"), session=None),
     model,
   )
-  assert_eq(
-    partial.active().reasoning_for_render(),
-    (Some("shared opening"), false),
-  )
-  let (_, complete) = update_dev(
-    dispatch,
-    Engine(Some("r7"), ReasoningMessage("shared opening"), session=None),
-    partial,
-  )
-  assert_eq(
-    complete.active().turn.live_reasoning,
-    Some({ content: "shared opening", complete: true, }),
-  )
-}
-
-///|
-test "a new model step advances past identical reasoning from the prior step" {
-  let previous_step = {
-    ..running_conversation(),
-    messages: [
-      {
-        kind: Reasoning,
-        content: "shared opening",
-        ts: None,
-        sequence: Some(2),
-      },
-    ],
-    watermark: 2,
-    turn: {
-      ..RunState::for_run(0),
-      live_reasoning: Some({ content: "old live", complete: true, }),
-    },
-  }
-  let (_, next_step) = apply_engine_event(
-    previous_step,
-    AgentStep(Some(2)),
-    Some("r7"),
-  )
-  assert_eq(next_step.turn.live_reasoning, None)
-  assert_eq(next_step.turn.reasoning_frontier, 2)
-  let (_, live) = apply_engine_event(
-    next_step,
-    ReasoningDelta("shared opening"),
-    Some("r7"),
-  )
-  assert_eq(live.reasoning_for_render(), (Some("shared opening"), false))
-}
-
-///|
-test "a new run frontier includes commits already buffered by reload" {
-  let dispatch = test_dispatch()
-  let buffered : BufferedCommit = {
-    sequence: 3,
-    ts: None,
-    item: @protocol.Assistant({
-      content: "older answer",
-      tool_calls: None,
-      reasoning_content: Some("shared opening"),
-      is_replay: None,
-    }),
-  }
-  let conv = {
-    ..test_conversation(),
-    watermark: 1,
-    sync: test_reloading([buffered]),
-  }
-  let (_, started) = update_dev(
-    dispatch,
-    Started(
-      run_id="r7",
-      session="desktop-test",
-      model=High,
-      max_steps=1000,
-      session_root=None,
-      submission_id=None,
-    ),
-    test_model().replace_conversation(conv),
-  )
-  assert_eq(started.active().turn.reasoning_frontier, 3)
+  assert_true(delta.active().turn == model.active().turn)
+  assert_true(finished.active().turn == model.active().turn)
 }
 
 ///|
@@ -10582,7 +10259,7 @@ test "started places a conversation before the registry arrives" {
 }
 
 ///|
-test "a run boundary discards the previous turn's live state whole" {
+test "a run boundary discards the previous turn's transient state whole" {
   let dispatch = test_dispatch()
   let lane : @subrun.Lane = {
     id: "sub-1",
@@ -10597,8 +10274,6 @@ test "a run boundary discards the previous turn's live state whole" {
     run: Open(run_id="r-old", stage=AtStep(Some(3))),
     turn: {
       streaming_response: Some("old answer fragment"),
-      live_reasoning: None,
-      reasoning_frontier: 0,
       subruns: [lane],
       usage_tokens: 4200,
     },
@@ -17634,10 +17309,6 @@ test "a delayed assistant commit never clears a newer live delta" {
     turn: {
       ..running_conversation().turn,
       streaming_response: Some("newer turn fragment"),
-      live_reasoning: Some({
-        content: "newer reasoning fragment",
-        complete: false,
-      }),
     },
   })
   let (_, committed) = update_dev(
@@ -17659,10 +17330,6 @@ test "a delayed assistant commit never clears a newer live delta" {
   assert_eq(
     committed.active().turn.streaming_response,
     Some("newer turn fragment"),
-  )
-  assert_eq(
-    committed.active().turn.live_reasoning,
-    Some({ content: "newer reasoning fragment", complete: false, }),
   )
 }
 

--- a/desktop/styles/base.css
+++ b/desktop/styles/base.css
@@ -407,8 +407,10 @@ html {
 }
 
 /* Open: the conversation and the editor share the content area. The
-   editor's width is `--editor-width`, set as the user drags the handle on
-   its left edge (see editor_resize.mbt); it defaults to half and is
+   editor's completed width is stored in `--editor-width`; while the pointer
+   is down, editor_resize.mbt writes this grid template directly so changing
+   an inherited variable does not invalidate the transcript on every move.
+   It defaults to half and is
    clamped against the content area (`100%`, sidebar excluded) so the
    editor floors at 360px while the conversation keeps at least 240px. The
    clamp also re-fits the panel on window resize without any script. */

--- a/desktop/styles/transcript.css
+++ b/desktop/styles/transcript.css
@@ -27,6 +27,19 @@
   margin: 0 auto;
 }
 
+/* Rabbita owns this stable, childless host; the live-reasoning command package
+   owns the one activity row beneath it. Match `.stream` explicitly because the
+   host is its sibling, kept outside durable transcript reconciliation. */
+.live-reasoning-host {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  max-width: 820px;
+  margin: 20px auto 0;
+}
+.live-reasoning-host:empty {
+  display: none;
+}
+
 /* Floating "jump to latest" over the transcript's bottom edge, shown
    only while auto-follow is unpinned. Sticky inside the scroller; zero
    height so it never adds scroll length, the transform lifts the button

--- a/editor/internal/viewer/code_editor_widget/markdown_comments_contribution.mbt
+++ b/editor/internal/viewer/code_editor_widget/markdown_comments_contribution.mbt
@@ -10,23 +10,40 @@ let markdown_comment_contribution_id : String = "editor.contrib.markdownComments
 let markdown_comment_hidden_source : String = "markdown-comments"
 
 ///|
+/// Hidden comments keep their last measured height during a continuous width
+/// drag. Their complete geometry is refreshed once the viewport width settles;
+/// visible comments still update immediately through their own ResizeObserver.
+const MarkdownCommentWidthSettleMs = 120
+
+///|
 priv struct MarkdownCommentContributionState {
   mut presentation_enabled : Bool
+  // A host can resize continuously for many frames. While it does, retain the
+  // last offscreen heights and let visible comments keep using their ordinary
+  // ResizeObservers; one explicit release refreshes every hidden comment.
+  mut viewport_measure_deferred : Bool
   mut generation : Int
   rendered : Map[String, RenderedMarkdownComment]
   listeners : Array[@base_common.Disposable]
   mut viewport_observer : @markdown_comments_browser.MarkdownCommentViewportObserver?
+  viewport_measure_scheduler : @base_browser.RunOnceScheduler
   mut geometry_lease : @base_common.Disposable?
 }
 
 ///|
-fn MarkdownCommentContributionState::MarkdownCommentContributionState() -> MarkdownCommentContributionState {
+fn MarkdownCommentContributionState::MarkdownCommentContributionState(
+  viewport_measure_scheduler? : @base_browser.RunOnceScheduler = @base_browser.RunOnceScheduler(
+    MarkdownCommentWidthSettleMs,
+  ),
+) -> MarkdownCommentContributionState {
   {
     presentation_enabled: true,
+    viewport_measure_deferred: false,
     generation: 0,
     rendered: Map([]),
     listeners: [],
     viewport_observer: None,
+    viewport_measure_scheduler,
     geometry_lease: None,
   }
 }
@@ -110,6 +127,35 @@ fn MarkdownCommentContributionState::request_all_measures(
 }
 
 ///|
+fn MarkdownCommentContributionState::schedule_all_measures(
+  self : MarkdownCommentContributionState,
+) -> Unit {
+  if self.viewport_measure_deferred {
+    return
+  }
+  self.viewport_measure_scheduler.schedule(() => self.request_all_measures())
+}
+
+///|
+/// Hold expensive offscreen measurements across a continuous host-width
+/// change. Releasing the hold measures every retained comment exactly once at
+/// the final width, even when the last ResizeObserver notification was dropped.
+fn MarkdownCommentContributionState::set_viewport_measure_deferred(
+  self : MarkdownCommentContributionState,
+  deferred : Bool,
+) -> Unit {
+  if self.viewport_measure_deferred == deferred {
+    return
+  }
+  self.viewport_measure_deferred = deferred
+  if deferred {
+    self.viewport_measure_scheduler.cancel()
+  } else {
+    self.request_all_measures()
+  }
+}
+
+///|
 fn CodeEditorWidget::sync_markdown_comment_fold_lane_width(
   self : CodeEditorWidget,
 ) -> Unit {
@@ -127,7 +173,7 @@ fn MarkdownCommentContributionState::ensure_viewport_observer(
 ) -> Unit {
   if self.viewport_observer is None {
     self.viewport_observer = Some(
-      dom.observe_viewport_width(() => self.request_all_measures()),
+      dom.observe_viewport_width(() => self.schedule_all_measures()),
     )
   }
 }
@@ -136,6 +182,7 @@ fn MarkdownCommentContributionState::ensure_viewport_observer(
 fn MarkdownCommentContributionState::dispose_viewport_observer(
   self : MarkdownCommentContributionState,
 ) -> Unit {
+  self.viewport_measure_scheduler.cancel()
   match self.viewport_observer {
     Some(observer) => observer.dispose()
     None => ()
@@ -731,6 +778,24 @@ pub fn CodeEditorWidget::set_markdown_comment_presentation_enabled(
 }
 
 ///|
+/// Mark a continuous host-width resize. Code lines keep laying out at every
+/// observed width, while offscreen Markdown measurements and overview-ruler
+/// projection wait for the final width.
+pub fn CodeEditorWidget::set_continuous_width_resize(
+  self : CodeEditorWidget,
+  active : Bool,
+) -> Unit {
+  guard !self.disposed else { return }
+  match self.markdown_comment_contribution() {
+    Some(state) => state.set_viewport_measure_deferred(active)
+    None => ()
+  }
+  for ruler in self.overview_rulers {
+    ruler.set_continuous_width_resize(active)
+  }
+}
+
+///|
 fn CodeEditorWidget::markdown_comments_on_theme_changed(
   self : CodeEditorWidget,
   viewer_theme : String,
@@ -822,6 +887,7 @@ fn MarkdownCommentContributionState::dispose(
   viewer : CodeEditorWidget,
 ) -> Unit {
   viewer.clear_markdown_comment_model_state()
+  self.viewport_measure_scheduler.dispose()
   for listener in self.listeners {
     listener.dispose()
   }

--- a/editor/internal/viewer/code_editor_widget/markdown_comments_contribution.mbt
+++ b/editor/internal/viewer/code_editor_widget/markdown_comments_contribution.mbt
@@ -32,7 +32,7 @@ priv struct MarkdownCommentContributionState {
 
 ///|
 fn MarkdownCommentContributionState::MarkdownCommentContributionState(
-  viewport_measure_scheduler? : @base_browser.RunOnceScheduler = @base_browser.RunOnceScheduler(
+  viewport_measure_scheduler? : @base_browser.RunOnceScheduler = RunOnceScheduler(
     MarkdownCommentWidthSettleMs,
   ),
 ) -> MarkdownCommentContributionState {

--- a/editor/internal/viewer/code_editor_widget/markdown_comments_contribution_wbtest.mbt
+++ b/editor/internal/viewer/code_editor_widget/markdown_comments_contribution_wbtest.mbt
@@ -3,6 +3,48 @@
 // the retained Playwright Markdown-comment suite.
 
 ///|
+test "Markdown comment width measurements wait for the settled viewport" {
+  let callbacks : Array[() -> Unit] = []
+  let delays : Array[Int] = []
+  let canceled = Ref(0)
+  let scheduler = @base_browser.RunOnceScheduler::new_with_timer(
+    MarkdownCommentWidthSettleMs,
+    (callback, delay_ms) => {
+      delays.push(delay_ms)
+      callbacks.push(callback)
+      let active = Ref(true)
+      @base_common.Disposable::from(() => {
+        if active.val {
+          active.val = false
+          canceled.val += 1
+        }
+      })
+    },
+  )
+  let state = MarkdownCommentContributionState(
+    viewport_measure_scheduler=scheduler,
+  )
+  state.schedule_all_measures()
+  state.schedule_all_measures()
+  assert_eq(callbacks.length(), 2)
+  assert_eq(delays, [MarkdownCommentWidthSettleMs, MarkdownCommentWidthSettleMs])
+  assert_eq(canceled.val, 1)
+  assert_true(state.viewport_measure_scheduler.is_scheduled())
+  guard callbacks.get(1) is Some(settled) else {
+    fail("expected the replacement settle callback")
+  }
+  settled()
+  assert_false(state.viewport_measure_scheduler.is_scheduled())
+
+  state.set_viewport_measure_deferred(true)
+  state.schedule_all_measures()
+  assert_eq(callbacks.length(), 2)
+  assert_false(state.viewport_measure_scheduler.is_scheduled())
+  state.set_viewport_measure_deferred(false)
+  assert_false(state.viewport_measure_scheduler.is_scheduled())
+}
+
+///|
 test "Markdown comments mark only exact mermaid fences and keep safe fallback source" {
   let exact = @markdown_core.render_markdown(
     (

--- a/editor/internal/viewer/code_editor_widget/overview_ruler.mbt
+++ b/editor/internal/viewer/code_editor_widget/overview_ruler.mbt
@@ -215,6 +215,12 @@ pub struct CodeEditorOverviewRuler {
   mut entries : Array[CodeEditorOverviewRulerEntry]
   mut bands : Array[CodeEditorOverviewRulerBand]
   mut generation : Int
+  /// Scroll, ViewZone, and ResizeObserver events often arrive several times in
+  /// one editor frame. Keep only one canvas redraw queued for that frame.
+  priv mut render_frame : Double?
+  /// The code lines still resize continuously, but the overview projection is
+  /// derived decoration and may wait until the host releases a width drag.
+  priv mut continuous_width_resize : Bool
   mut disposed : Bool
 }
 
@@ -300,6 +306,11 @@ fn CodeEditorOverviewRuler::render(self : CodeEditorOverviewRuler) -> Unit {
   if self.disposed {
     return
   }
+  match self.render_frame {
+    Some(frame) => @rdom.window().cancel_animation_frame(frame)
+    None => ()
+  }
+  self.render_frame = None
   self.root.set_attribute(
     "data-overview-ruler-generation",
     self.generation.to_string(),
@@ -359,6 +370,45 @@ fn CodeEditorOverviewRuler::render(self : CodeEditorOverviewRuler) -> Unit {
     "data-overview-ruler-band-count",
     render_bands.length().to_string(),
   )
+}
+
+///|
+/// Coalesces geometry-driven redraws without delaying semantic `set_entries`
+/// updates, which still call `render` synchronously.
+fn CodeEditorOverviewRuler::request_render(
+  self : CodeEditorOverviewRuler,
+) -> Unit {
+  if self.disposed ||
+    self.continuous_width_resize ||
+    self.render_frame is Some(_) {
+    return
+  }
+  self.render_frame = Some(
+    @rdom.window().request_animation_frame(_ => {
+      self.render_frame = None
+      self.render()
+    }),
+  )
+}
+
+///|
+fn CodeEditorOverviewRuler::set_continuous_width_resize(
+  self : CodeEditorOverviewRuler,
+  active : Bool,
+) -> Unit {
+  if self.disposed || self.continuous_width_resize == active {
+    return
+  }
+  self.continuous_width_resize = active
+  if active {
+    match self.render_frame {
+      Some(frame) => @rdom.window().cancel_animation_frame(frame)
+      None => ()
+    }
+    self.render_frame = None
+  } else {
+    self.request_render()
+  }
 }
 
 ///|
@@ -449,6 +499,8 @@ pub fn CodeEditorWidget::create_overview_ruler(
     entries: [],
     bands: [],
     generation: 0,
+    render_frame: None,
+    continuous_width_resize: false,
     disposed: false,
   }
   let pointer_down = event => ruler.handle_pointer_down(event)
@@ -464,12 +516,16 @@ pub fn CodeEditorWidget::create_overview_ruler(
   ruler.listeners.push(
     self.on_did_change_model_content(_ => ruler.clear_for_content_change()),
   )
-  ruler.listeners.push(self.on_did_scroll_change(_ => ruler.render()))
-  ruler.listeners.push(self.on_did_change_view_zones(() => ruler.render()))
-  ruler.listeners.push(self.on_did_change_hidden_areas(() => ruler.render()))
+  ruler.listeners.push(self.on_did_scroll_change(_ => ruler.request_render()))
+  ruler.listeners.push(
+    self.on_did_change_view_zones(() => ruler.request_render()),
+  )
+  ruler.listeners.push(
+    self.on_did_change_hidden_areas(() => ruler.request_render()),
+  )
   ruler.resize_observer = @base_browser.observe_element_resize(
     self.get_container_dom_node(),
-    () => ruler.render(),
+    () => ruler.request_render(),
   )
   if self.disposed {
     ruler.dispose()
@@ -550,7 +606,7 @@ fn CodeEditorWidget::refresh_managed_overview_rulers(
   self : CodeEditorWidget,
 ) -> Unit {
   for ruler in self.overview_rulers {
-    ruler.render()
+    ruler.request_render()
   }
 }
 
@@ -570,6 +626,11 @@ pub fn CodeEditorOverviewRuler::dispose(self : CodeEditorOverviewRuler) -> Unit 
     return
   }
   self.disposed = true
+  match self.render_frame {
+    Some(frame) => @rdom.window().cancel_animation_frame(frame)
+    None => ()
+  }
+  self.render_frame = None
   match self.resize_observer {
     Some(observer) => observer.dispose()
     None => ()

--- a/editor/internal/viewer/code_editor_widget/overview_ruler_wbtest.mbt
+++ b/editor/internal/viewer/code_editor_widget/overview_ruler_wbtest.mbt
@@ -42,6 +42,8 @@ fn overview_ruler_eof_offset_entry(
     entries: [{ id: 1, range, color: "red", lane: Full, }],
     bands: [],
     generation: 0,
+    render_frame: None,
+    continuous_width_resize: false,
     disposed: false,
   }
   ruler.model_offset_entries()[0]
@@ -214,6 +216,8 @@ fn overview_ruler_disposal_test_handle(
     entries: [{ id: 1, range: LineRange(1, 2), color: "red", lane: Full, }],
     bands: [{ id: 1, from: 0, to: 4, color: "red", lane: Full, }],
     generation: 3,
+    render_frame: None,
+    continuous_width_resize: false,
     disposed: false,
   }
 }

--- a/editor/internal/viewer/code_editor_widget/pkg.generated.mbti
+++ b/editor/internal/viewer/code_editor_widget/pkg.generated.mbti
@@ -101,6 +101,7 @@ pub struct CodeEditorOverviewRuler {
   mut bands : Array[CodeEditorOverviewRulerBand]
   mut generation : Int
   mut disposed : Bool
+  // private fields
 }
 pub fn CodeEditorOverviewRuler::clear(Self, Int) -> Unit
 pub fn CodeEditorOverviewRuler::dispose(Self) -> Unit
@@ -273,6 +274,7 @@ pub fn CodeEditorWidget::reveal_range_in_center_if_outside_viewport(Self, @commo
 pub fn CodeEditorWidget::reveal_range_near_top(Self, @common.Range) -> Unit
 pub fn CodeEditorWidget::reveal_range_near_top_if_outside_viewport(Self, @common.Range) -> Unit
 pub fn CodeEditorWidget::save_view_state(Self) -> CodeEditorViewState?
+pub fn CodeEditorWidget::set_continuous_width_resize(Self, Bool) -> Unit
 pub fn CodeEditorWidget::set_hidden_areas(Self, Array[@common.Range], source? : String, force_update? : Bool) -> Unit
 pub fn CodeEditorWidget::set_markdown_comment_presentation_enabled(Self, Bool) -> Unit
 pub fn CodeEditorWidget::set_model(Self, @model.TextModel?) -> Unit

--- a/editor/internal/viewer/diff_editor/editors.mbt
+++ b/editor/internal/viewer/diff_editor/editors.mbt
@@ -213,6 +213,37 @@ fn DiffEditorEditors::layout(
 }
 
 ///|
+/// During a continuous outer resize, lay out one pane per animation frame.
+/// Both pane hosts already have their live CSS widths; alternating the costly
+/// code rewrap keeps either pane at most one frame behind that boundary.
+fn DiffEditorEditors::layout_continuous_pane(
+  self : DiffEditorEditors,
+  original : Bool,
+) -> Unit {
+  if !self.disposed {
+    if original {
+      self.original.layout()
+    } else {
+      self.modified.layout()
+    }
+  }
+}
+
+///|
+/// Apply one continuous-width-resize policy to both code-editor kernels. In
+/// SideBySide both may own rich comments; in Inline the disabled original is a
+/// no-op while both panes continue rendering code at the live width.
+fn DiffEditorEditors::set_continuous_width_resize(
+  self : DiffEditorEditors,
+  active : Bool,
+) -> Unit {
+  if !self.disposed {
+    self.original.set_continuous_width_resize(active)
+    self.modified.set_continuous_width_resize(active)
+  }
+}
+
+///|
 fn DiffEditorEditors::focus(self : DiffEditorEditors) -> Unit {
   if !self.disposed {
     self.modified.focus()

--- a/editor/internal/viewer/diff_editor/pkg.generated.mbti
+++ b/editor/internal/viewer/diff_editor/pkg.generated.mbti
@@ -145,6 +145,7 @@ pub struct DiffEditorWidget {
   mut resize_observer_disposed : Bool
   mut overview_ruler_disposed : Bool
   mut disposed : Bool
+  // private fields
 }
 pub fn DiffEditorWidget::create(@dom.Element, services? : @code_editor_widget.CodeEditorServices, editor_options? : @code_editor_widget.CodeEditorOptions, options? : DiffEditorOptions, &@diff.DocumentDiffProvider) -> Self
 pub fn DiffEditorWidget::dispose(Self) -> Unit
@@ -159,6 +160,7 @@ pub fn DiffEditorWidget::on_did_update_diff(Self, () -> Unit) -> @common.Disposa
 pub fn DiffEditorWidget::reveal_first_diff(Self) -> Unit
 pub fn DiffEditorWidget::reveal_next_change(Self) -> Bool
 pub fn DiffEditorWidget::reveal_previous_change(Self) -> Bool
+pub fn DiffEditorWidget::set_continuous_width_resize(Self, Bool) -> Unit
 pub fn DiffEditorWidget::set_diff_provider(Self, &@diff.DocumentDiffProvider) -> Unit
 pub fn DiffEditorWidget::set_model(Self, DiffEditorModelData?) -> DiffEditorModelData?
 pub fn DiffEditorWidget::update_options(Self, @code_editor_widget.CodeEditorOptions, DiffEditorOptions) -> Unit

--- a/editor/internal/viewer/diff_editor/reconcile_transaction.mbt
+++ b/editor/internal/viewer/diff_editor/reconcile_transaction.mbt
@@ -46,8 +46,10 @@ fn same_alignment_geometry(
   left : PaneGeometrySnapshot,
   right : PaneGeometrySnapshot,
 ) -> Bool {
+  // Viewport width is an observation source, not an alignment input. Wrapped
+  // line heights and foreign-zone heights already carry every width-dependent
+  // geometry change that can alter the paired vertical axis.
   left.line_height == right.line_height &&
-  left.viewport_width == right.viewport_width &&
   left.line_heights == right.line_heights &&
   left.line_max_columns == right.line_max_columns &&
   left.foreign_zone_heights == right.foreign_zone_heights &&

--- a/editor/internal/viewer/diff_editor/reconcile_transaction_wbtest.mbt
+++ b/editor/internal/viewer/diff_editor/reconcile_transaction_wbtest.mbt
@@ -70,14 +70,14 @@ test "viewport width alone does not invalidate vertical alignment" {
   let narrow = PaneGeometrySnapshot(
     3,
     18.0,
-    foreign_zone_heights=[{ after_line_number: 2, height_in_px: 9.0 }],
+    foreign_zone_heights=[{ after_line_number: 2, height_in_px: 9.0, }],
     line_max_columns=[2, 2, 2],
     viewport_width=320.0,
   )
   let wide = PaneGeometrySnapshot(
     3,
     18.0,
-    foreign_zone_heights=[{ after_line_number: 2, height_in_px: 9.0 }],
+    foreign_zone_heights=[{ after_line_number: 2, height_in_px: 9.0, }],
     line_max_columns=[2, 2, 2],
     viewport_width=640.0,
   )

--- a/editor/internal/viewer/diff_editor/reconcile_transaction_wbtest.mbt
+++ b/editor/internal/viewer/diff_editor/reconcile_transaction_wbtest.mbt
@@ -64,3 +64,29 @@ test "owned-zone-excluded geometry does not self-trigger another reconcile" {
     ),
   )
 }
+
+///|
+test "viewport width alone does not invalidate vertical alignment" {
+  let narrow = PaneGeometrySnapshot(
+    3,
+    18.0,
+    foreign_zone_heights=[{ after_line_number: 2, height_in_px: 9.0 }],
+    line_max_columns=[2, 2, 2],
+    viewport_width=320.0,
+  )
+  let wide = PaneGeometrySnapshot(
+    3,
+    18.0,
+    foreign_zone_heights=[{ after_line_number: 2, height_in_px: 9.0 }],
+    line_max_columns=[2, 2, 2],
+    viewport_width=640.0,
+  )
+  assert_false(
+    alignment_geometry_pair_changed(
+      Some(wide),
+      Some(wide),
+      Some(narrow),
+      Some(narrow),
+    ),
+  )
+}

--- a/editor/internal/viewer/diff_editor/widget.mbt
+++ b/editor/internal/viewer/diff_editor/widget.mbt
@@ -50,6 +50,13 @@ pub struct DiffEditorWidget {
   layout_render_waiters : Array[@base_common.Disposable]
   mut layout_render_generation : Int
   mut layout_render_remaining : Int
+  /// During a host drag, code panes still render each observed width. Derived
+  /// diff geometry, viewport restoration, and overview projection reconcile
+  /// once after mouseup instead of being rebuilt for every intermediate width.
+  priv mut continuous_width_resize : Bool
+  /// The two expensive code-pane rewraps alternate while the outer boundary
+  /// moves. Both hosts still receive every live width through `apply_layout_dom`.
+  priv mut continuous_layout_original_next : Bool
   /// Model-relative modified viewport captured before an outer layout mutates
   /// pane widths/options. Modified is the canonical viewport: keep this anchor
   /// across the first render and every follow-up Markdown/ViewZone measurement
@@ -210,6 +217,8 @@ pub fn DiffEditorWidget::create(
     layout_render_waiters: [],
     layout_render_generation: 0,
     layout_render_remaining: 0,
+    continuous_width_resize: false,
+    continuous_layout_original_next: true,
     pending_layout_modified_viewport: None,
     has_valid_layout_box: false,
     inline_original_strip_width: -1.0,
@@ -283,14 +292,19 @@ fn DiffEditorWidget::complete_layout_pane_render(
     return
   }
   self.cancel_layout_render_barrier()
+  if self.continuous_width_resize {
+    return
+  }
   if !self.host_has_positive_layout_box() {
     self.has_valid_layout_box = false
     self.pending_layout_modified_viewport = None
     return
   }
   self.has_valid_layout_box = true
-  // Every outer layout, including height-only resizes, gets exactly one
-  // reconcile using geometry from the completed pane render(s).
+  // A completed ordinary layout is also the synchronization point for
+  // semantic diffs and option changes that may have arrived before either pane
+  // painted. Continuous host drags bypass this barrier and reconcile once on
+  // their final non-continuous layout instead.
   self.reconcile_view_model()
   match self.pending_layout_modified_viewport {
     Some(state) => self.restore_modified_viewport_and_sync_original(state)
@@ -307,6 +321,11 @@ fn DiffEditorWidget::layout_editors_after_render(
   if !self.has_valid_layout_box || !self.host_has_positive_layout_box() {
     self.has_valid_layout_box = false
     self.pending_layout_modified_viewport = None
+    return
+  }
+  if self.continuous_width_resize {
+    self.editors.layout_continuous_pane(self.continuous_layout_original_next)
+    self.continuous_layout_original_next = !self.continuous_layout_original_next
     return
   }
   self.layout_render_generation += 1
@@ -677,7 +696,9 @@ fn DiffEditorWidget::relayout_inline_strip(self : DiffEditorWidget) -> Unit {
     !self.host_has_positive_layout_box() {
     return
   }
-  self.capture_layout_modified_viewport_if_absent()
+  if !self.continuous_width_resize {
+    self.capture_layout_modified_viewport_if_absent()
+  }
   self.apply_layout_dom()
   self.layout_editors_after_render()
 }
@@ -1210,6 +1231,7 @@ fn DiffEditorWidget::reconcile_geometry_if_changed(
   self : DiffEditorWidget,
 ) -> Unit {
   if self.disposed ||
+    self.continuous_width_resize ||
     self.editors.is_committing_model_pair() ||
     self.is_reconciling ||
     self.diff_state is None ||
@@ -1715,18 +1737,46 @@ pub fn DiffEditorWidget::layout(self : DiffEditorWidget) -> Unit {
     return
   }
   self.has_valid_layout_box = true
-  self.capture_layout_modified_viewport_if_absent()
-  self.layout_state.layout(width) |> ignore
-  self.editors.update_options(
-    self.editor_options,
-    self.options.diff_word_wrap,
-    self.layout_state.actual_layout,
-  )
-  self.apply_layout_dom()
-  self.editors.sync_markdown_comment_presentations(
-    self.layout_state.actual_layout,
-  )
+  if !self.continuous_width_resize {
+    self.capture_layout_modified_viewport_if_absent()
+  }
+  let layout_changed = self.layout_state.layout(width)
+  if layout_changed {
+    self.editors.update_options(
+      self.editor_options,
+      self.options.diff_word_wrap,
+      self.layout_state.actual_layout,
+    )
+    self.editors.sync_markdown_comment_presentations(
+      self.layout_state.actual_layout,
+    )
+  }
+  // SideBySide panes use stable percentage flex bases, so their hosts follow
+  // an outer width change without rewriting identical class/ARIA/style
+  // attributes. Inline owns a clipped pixel strip and must recompute it.
+  if layout_changed || self.layout_state.actual_layout == Inline {
+    self.apply_layout_dom()
+  }
   self.layout_editors_after_render()
+}
+
+///|
+/// Keep code layout live during a continuous host-width resize while deferring
+/// derived diff geometry, overview projection, and offscreen Markdown measures
+/// until the host releases the drag.
+pub fn DiffEditorWidget::set_continuous_width_resize(
+  self : DiffEditorWidget,
+  active : Bool,
+) -> Unit {
+  if self.disposed || self.continuous_width_resize == active {
+    return
+  }
+  self.continuous_width_resize = active
+  if active {
+    self.pending_layout_modified_viewport = None
+    self.continuous_layout_original_next = true
+  }
+  self.editors.set_continuous_width_resize(active)
 }
 
 ///|

--- a/editor/viewer/diff_editor_facade.mbt
+++ b/editor/viewer/diff_editor_facade.mbt
@@ -273,6 +273,16 @@ pub fn DiffEditor::layout(self : DiffEditor) -> Unit {
 }
 
 ///|
+/// Keep code panes live during a continuous host-width resize while deferring
+/// derived diff, Markdown, and overview work until the host passes `false`.
+pub fn DiffEditor::set_continuous_width_resize(
+  self : DiffEditor,
+  active : Bool,
+) -> Unit {
+  self.widget.set_continuous_width_resize(active)
+}
+
+///|
 pub fn DiffEditor::focus(self : DiffEditor) -> Unit {
   self.widget.focus()
 }

--- a/editor/viewer/pkg.generated.mbti
+++ b/editor/viewer/pkg.generated.mbti
@@ -43,6 +43,7 @@ pub fn DiffEditor::on_did_update_diff(Self, () -> Unit) -> @common.Disposable
 pub fn DiffEditor::reveal_first_diff(Self) -> Unit
 pub fn DiffEditor::reveal_next_change(Self) -> Bool
 pub fn DiffEditor::reveal_previous_change(Self) -> Bool
+pub fn DiffEditor::set_continuous_width_resize(Self, Bool) -> Unit
 pub fn DiffEditor::set_diff_provider(Self, &@diff.DocumentDiffProvider) -> Unit
 pub fn DiffEditor::set_model(Self, DiffEditorModel?) -> DiffEditorModel?
 pub fn DiffEditor::update_options(Self, DiffEditorOptions) -> Unit
@@ -214,6 +215,7 @@ pub fn Viewer::reveal_range_in_center_if_outside_viewport(Self, @common.Range) -
 pub fn Viewer::reveal_range_near_top(Self, @common.Range) -> Unit
 pub fn Viewer::reveal_range_near_top_if_outside_viewport(Self, @common.Range) -> Unit
 pub fn Viewer::save_view_state(Self) -> ViewerViewState?
+pub fn Viewer::set_continuous_width_resize(Self, Bool) -> Unit
 pub fn Viewer::set_model(Self, @model.TextModel?) -> Unit
 pub fn Viewer::set_position(Self, @common.Position, source? : String) -> Unit
 pub fn Viewer::set_scroll_left(Self, Double) -> Unit

--- a/editor/viewer/viewer_facade_forwarding.mbt
+++ b/editor/viewer/viewer_facade_forwarding.mbt
@@ -35,6 +35,16 @@ pub fn Viewer::layout(self : Viewer) -> Unit {
 }
 
 ///|
+/// Keep code layout live during a continuous host-width resize while deferring
+/// derived Markdown and overview work until the host passes `false`.
+pub fn Viewer::set_continuous_width_resize(
+  self : Viewer,
+  active : Bool,
+) -> Unit {
+  self.widget.set_continuous_width_resize(active)
+}
+
+///|
 pub fn Viewer::focus(self : Viewer) -> Unit {
   self.widget.focus()
 }


### PR DESCRIPTION
## Summary

- route live reasoning deltas and semantic completion directly into a transcript-owned preview controller, without scheduling a Rabbita root update per delta
- render the preview inside one stable childless DOM host, coalesce text fragments once per animation frame, and follow the tail without synchronous `scrollHeight` reads
- omit durable activity bodies while their disclosures are closed, so old tool/reasoning text does not remain in the DOM and participate in every style invalidation
- resize the editor with a concrete `.content` grid track while the pointer is down, then commit `--editor-width` once on mouseup
- keep both code panes visibly resizing while deferring diff alignment, overview projection, and offscreen Markdown measurements until the drag ends

## Motivation

Live reasoning previously caused Rabbita to flush the root VDOM. A large transcript therefore invalidated unrelated UI work, including the right-side file editor. The direct preview path removed the root update, but synchronous scroll geometry and the durable transcript's retained closed bodies still made the document expensive.

The editor divider also wrote an inherited root custom property on every move. That invalidated styles throughout the transcript and caused the diff editor to rebuild alignment zones, Markdown measurements, and overview geometry at intermediate widths.

The new paths keep high-frequency work local: live preview updates one small host, closed activity bodies do not exist in the DOM, and divider moves update only the content grid plus live code-pane layouts. Mouseup performs one complete diff/Markdown reconciliation and persists the final editor width.

## Validation

- `just check` (native, JS, and stable formatter passed)
- `just test`: native 3322/3322, JS 3244/3244, cram 28/28
- `just build` (native and JS passed)
- `just editor-test`: wasm 1082/1082, JS 1864/1864, native 1215/1215
- `just editor-test-browser`: 107/107 passed
- focused JS tests: diff editor 57/57; desktop file editor 144/144
- Playwright/CDP against the long SeekMoon Development transcript confirmed that editor width and both internal diff panes change before mouseup (714 -> 790 -> 870 -> 630 px for the sampled drag), with zero transcript DOM mutations during the drag
- the sampled heavy diff had 33-42 ms worst frame gaps during three scripted 20-move drags; this is a diagnostic result, not a 60 fps claim
- no new `extern "js"` declarations
