### PR TITLE
refactor(desktop): manage bridge connections as subscriptions

### DIFF
--- a/desktop/frontend/boot.mbt
+++ b/desktop/frontend/boot.mbt
@@ -363,6 +363,10 @@ pub fn boot() -> Unit {
             emit.map(viewport => ViewportResized(width=viewport.width)),
           ),
           app_shortcut_subscription(emit),
+          // Host event sources follow the device roster. Removing a device
+          // therefore unloads its WebSocket immediately; advancing its retry
+          // identity replaces only that device's connection.
+          model.bridge_subscriptions(emit),
         ]
         // The project picker's Enter/Escape/paste surface, only while its
         // modal is open — same lifetime rule as the dismissal listeners.

--- a/desktop/frontend/bridge.mbt
+++ b/desktop/frontend/bridge.mbt
@@ -6,54 +6,11 @@
 // decoders below.
 
 ///|
-/// Decode one host notification into the owner that consumes it. Raw terminal
-/// output goes straight to the terminal package's emulator command: it changes
-/// neither terminal state nor application state, so sending it through either
-/// Rabbita update loop would only redraw unrelated UI. Terminal lifecycle
-/// events still use the terminal emitter because they do change its root-owned
-/// state; everything else uses the app emitter.
-fn host_notification(
-  terminal : @cmd.Emit[@terminal.Msg],
-  app_emit : @cmd.Emit[Msg],
-  channel : @interop.ChannelId,
-  notification : @protocol.Notification,
-) -> @cmd.Cmd {
-  match notification {
-    TerminalOutput(payload) =>
-      @terminal.output(channel, payload.id, payload.sequence, payload.data)
-    TerminalExit(payload) =>
-      match terminal_exit_msg(channel, payload) {
-        Some(msg) => terminal(msg)
-        None => @cmd.none
-      }
-    _ =>
-      match bridge_msg(channel, notification) {
-        Some(msg) => app_emit(msg)
-        None => @cmd.none
-      }
-  }
-}
-
-///|
-/// Wire a host's notification stream into messages, once, over the
-/// channel's transport.
-fn install_bridge(
-  app_emit : @cmd.Emit[Msg],
-  terminal : @cmd.Emit[@terminal.Msg],
-  channel : @interop.ChannelId,
-  websocket_epoch : Int,
-) -> @cmd.Cmd {
-  match channel {
-    Local => install_proton_bridge(app_emit, terminal, 0)
-    Remote(device) => connect_ws(app_emit, terminal, device, websocket_epoch)
-  }
-}
-
-///|
-/// Route one notification to its decoder, stamped with the channel it
-/// arrived on. Device-scoped notifications wrap as `FromDevice`; the rest
-/// back page-global or focused-scoped state and stay root messages.
-fn bridge_msg(
+/// Purely decode one non-terminal host notification, retaining the channel it
+/// arrived on. Device-scoped notifications wrap as `FromDevice`; page-global
+/// and focused-scoped notifications stay root messages. Terminal notifications
+/// return `None` because `bridge_event` sends their commands directly.
+fn notification_msg(
   channel : @interop.ChannelId,
   notification : @protocol.Notification,
 ) -> Msg? {
@@ -278,111 +235,86 @@ fn session_changed_msg(
 }
 
 // ---------------------------------------------------------------------------
-// The desktop window: the injected proton bridge.
+// Adapt the bridge package's transport-neutral events into this application's
+// root messages and direct terminal commands.
 
 ///|
-let bridge_events_wired : Ref[Bool] = Ref(false)
-
-///|
-/// Wait for proton to inject the bridge (it loads alongside this bundle),
-/// wire the notification events into messages once, and open the host
-/// connection. The 25ms retries add up to ~3 seconds before the bridge is
-/// declared unavailable.
-fn install_proton_bridge(
-  dispatch : @cmd.Emit[Msg],
-  terminal : @cmd.Emit[@terminal.Msg],
-  attempt : Int,
-) -> @cmd.Cmd {
-  @cmd.custom_cmd(scheduler => {
-    // The request API and the two event actors are separate injected objects.
-    // Do not wire a partially initialized page; retry until every method used
-    // below is available.
-    guard @interop.openseek_api() is Some(request_api) &&
-      @interop.moonbit_bridge_root() is Some(root) &&
-      @interop.js_prop(root, "events") is Some(extension_events) &&
-      @interop.js_prop(root, "app") is Some(application_events) &&
-      @interop.js_prop(request_api, "host.connect") is Some(_) &&
-      @interop.js_prop(request_api, "agent.start") is Some(_) &&
-      @interop.js_prop(extension_events, "on") is Some(_) &&
-      @interop.js_prop(application_events, "on") is Some(_) else {
-      if attempt > 120 {
-        scheduler.add(
-          dispatch(FromDevice(Local, BridgeUnavailable("Bridge unavailable"))),
-        )
+/// Turn one event emitted by a local or remote bridge subscription into a
+/// command understood by the root application. Raw terminal output bypasses
+/// application dispatch to avoid an unrelated redraw; other notifications are
+/// decoded into root messages here alongside connection and window events.
+fn bridge_event(dispatch : @cmd.Emit[Msg], event : @bridge.Event) -> @cmd.Cmd {
+  match event {
+    @bridge.Event::Notification(channel~, notification~) =>
+      match notification {
+        TerminalOutput(payload) =>
+          @terminal.output(channel, payload.id, payload.sequence, payload.data)
+        TerminalExit(payload) =>
+          @terminal.SessionExited(channel~, id=payload.id, code=payload.code)
+          |> Terminal
+          |> dispatch
+        _ =>
+          if notification_msg(channel, notification) is Some(msg) {
+            dispatch(msg)
+          } else {
+            @cmd.none
+          }
+      }
+    @bridge.Event::Unavailable(channel~, message~) =>
+      dispatch(FromDevice(channel, BridgeUnavailable(message)))
+    @bridge.Event::ChannelDown(channel~, websocket_epoch~) =>
+      dispatch(FromDevice(channel, ChannelDown(websocket_epoch~)))
+    @bridge.Event::BrowserEvent(payload~) =>
+      match browser_event_msg(payload) {
+        Some(msg) => dispatch(msg)
+        None => @cmd.none
+      }
+    @bridge.Event::MenuCommand(command_id~) =>
+      if command_id == @commands.app_open_devtools.name() {
+        dispatch(AppDeveloperToolsRequested)
       } else {
-        scheduler.add(
-          @cmd.delay(install_proton_bridge(dispatch, terminal, attempt + 1), 25),
-        )
+        @cmd.none
       }
-      return
-    }
-    if !bridge_events_wired.val {
-      bridge_events_wired.val = true
-      wire_proton_events(
-        scheduler, dispatch, terminal, extension_events, application_events,
-      )
-      open_host_connection(scheduler, dispatch, request_api)
-    }
-  })
+    @bridge.Event::NotificationClicked(run_id~) =>
+      dispatch(NotificationClicked(run_id~))
+  }
 }
 
 ///|
-/// Attach this page to the host's app-lifetime notification actor. The call
-/// resolves once the actor has emitted its readiness event; a rejection means
-/// the page could not attach to the native bridge.
-fn open_host_connection(
-  scheduler : &@cmd.Scheduler,
+fn DeviceState::bridge_subscription(
+  self : DeviceState,
   dispatch : @cmd.Emit[Msg],
-  api : @js.Value,
-) -> Unit {
-  @js.async_run(() => {
-    let _ : @js.Value = @interop.js_method_promise(
-      api,
-      "host.connect",
-      @js.Object::new().to_value(),
-    ).wait() catch {
-      error => {
-        scheduler.add(
-          dispatch(
-            FromDevice(
-              Local,
-              BridgeUnavailable(@interop.bridge_error_text(error)),
-            ),
-          ),
-        )
-        return
-      }
-    }
-  })
+) -> @sub.Sub {
+  let bridge_dispatch : @cmd.Emit[@bridge.Event] = event => {
+    bridge_event(dispatch, event)
+  }
+  match self.channel {
+    Local => @bridge.local_connection(bridge_dispatch)
+    Remote(device) =>
+      @bridge.remote_connection(
+        device_id=device,
+        websocket_epoch=self.websocket_epoch,
+        reconnect_attempt=self.reconnect_attempt,
+        dispatch=bridge_dispatch,
+      )
+  }
 }
 
 ///|
-/// Notification kinds exposed by the host extension. Proton requires an
-/// explicit listener for each one, unlike the WebSocket transport's generic
-/// notification callback, so the listeners derive from the shared catalog.
-fn proton_event_methods() -> Array[@protocol.NotificationKind] {
-  @protocol.NotificationKind::all()
+/// Declare one host notification source per device in the model. Rabbita
+/// owns installation and cleanup from here; request/reply commands remain
+/// independent one-shot effects.
+fn Model::bridge_subscriptions(
+  self : Model,
+  dispatch : @cmd.Emit[Msg],
+) -> @sub.Sub {
+  @sub.batch(self.devices.map(dev => dev.bridge_subscription(dispatch)))
 }
 
 ///|
-test "proton subscribes to all Codex app-server events" {
+test "Codex app-server notifications route to Codex state" {
   assert_true(
-    proton_event_methods().contains(
-      @protocol.NotificationKind::CodexStatusChanged,
-    ),
-  )
-  assert_true(
-    proton_event_methods().contains(
-      @protocol.NotificationKind::CodexNotification,
-    ),
-  )
-  assert_true(
-    proton_event_methods().contains(
-      @protocol.NotificationKind::CodexServerRequest,
-    ),
-  )
-  assert_true(
-    bridge_msg(
+    notification_msg(
       Local,
       @protocol.Notification::CodexNotification({
         "method": "turn/completed",
@@ -395,26 +327,17 @@ test "proton subscribes to all Codex app-server events" {
 }
 
 ///|
-test "proton subscribes to remote-access status changes" {
-  assert_true(proton_event_methods().contains(AuthChanged))
-}
-
-///|
 test "skill invalidations are device-scoped catalog events" {
-  assert_true(proton_event_methods().contains(SkillsChanged))
   assert_true(
-    bridge_msg(Remote("d1"), @protocol.Notification::SkillsChanged)
+    notification_msg(Remote("d1"), @protocol.Notification::SkillsChanged)
     is Some(FromDevice(Remote("d1"), SkillsChanged)),
   )
 }
 
 ///|
 test "update download notifications control only the local desktop flow" {
-  assert_true(proton_event_methods().contains(UpdateDownloadProgress))
-  assert_true(proton_event_methods().contains(UpdateDownloaded))
-  assert_true(proton_event_methods().contains(UpdateDownloadFailed))
   assert_true(
-    bridge_msg(
+    notification_msg(
       Local,
       @protocol.Notification::UpdateDownloadProgress({
         downloaded_bytes: 42,
@@ -424,14 +347,14 @@ test "update download notifications control only the local desktop flow" {
     is Some(UpdateDownloadProgress(downloaded_bytes=42, total_bytes=Some(100))),
   )
   assert_true(
-    bridge_msg(
+    notification_msg(
       Local,
       @protocol.Notification::UpdateDownloaded({ version: "test" }),
     )
     is Some(UpdateDownloaded),
   )
   assert_true(
-    bridge_msg(
+    notification_msg(
       Local,
       @protocol.Notification::UpdateDownloadFailed({
         message: "digest mismatch",
@@ -440,7 +363,7 @@ test "update download notifications control only the local desktop flow" {
     is Some(UpdateFailed(message="digest mismatch")),
   )
   assert_true(
-    bridge_msg(
+    notification_msg(
       Local,
       @protocol.Notification::UpdateDownloadProgress({
         downloaded_bytes: -1,
@@ -450,7 +373,7 @@ test "update download notifications control only the local desktop flow" {
     is None,
   )
   assert_true(
-    bridge_msg(
+    notification_msg(
       Remote("d1"),
       @protocol.Notification::UpdateDownloadProgress({
         downloaded_bytes: 42,
@@ -460,7 +383,7 @@ test "update download notifications control only the local desktop flow" {
     is None,
   )
   assert_true(
-    bridge_msg(
+    notification_msg(
       Remote("d1"),
       @protocol.Notification::UpdateDownloaded({ version: "test" }),
     )
@@ -472,7 +395,7 @@ test "update download notifications control only the local desktop flow" {
 test "file-panel pushes carry their channel; auth.changed is Local-only" {
   let channel : @interop.ChannelId = Remote("d1")
   assert_true(
-    bridge_msg(
+    notification_msg(
       channel,
       @protocol.Notification::FsChanged({
         root: "/work/project",
@@ -489,7 +412,7 @@ test "file-panel pushes carry their channel; auth.changed is Local-only" {
     ),
   )
   assert_true(
-    bridge_msg(
+    notification_msg(
       channel,
       @protocol.Notification::FsChanged({
         root: "/work/project",
@@ -526,9 +449,8 @@ test "file-panel pushes carry their channel; auth.changed is Local-only" {
       )
     ),
   )
-  assert_true(proton_event_methods().contains(FsWatchFailed))
   assert_true(
-    bridge_msg(
+    notification_msg(
       channel,
       @protocol.Notification::FsWatchFailed({
         root: "/work/project",
@@ -552,7 +474,7 @@ test "file-panel pushes carry their channel; auth.changed is Local-only" {
   )
   // A remote device's relay registration is its host's business.
   assert_true(
-    bridge_msg(
+    notification_msg(
       channel,
       @protocol.Notification::AuthChanged({
         connected: false,
@@ -566,96 +488,6 @@ test "file-panel pushes carry their channel; auth.changed is Local-only" {
   )
 }
 
-///|
-test "terminal lifecycle pushes retain the channel that owns their host session" {
-  let payload : @protocol.TerminalExitPayload = { id: 1, code: 0 }
-  assert_true(
-    terminal_exit_msg(Local, payload)
-    is Some(SessionExited(channel=Local, id=1, code=0)),
-  )
-  assert_true(
-    terminal_exit_msg(Remote("d1"), payload)
-    is Some(SessionExited(channel=Remote("d1"), id=1, code=0)),
-  )
-}
-
-///|
-fn wire_proton_events(
-  scheduler : &@cmd.Scheduler,
-  dispatch : @cmd.Emit[Msg],
-  terminal : @cmd.Emit[@terminal.Msg],
-  extension_events : @js.Value,
-  application_events : @js.Value,
-) -> Unit {
-  fn on(name : String, decode : (Map[String, Json]) -> Msg?) -> Unit {
-    let handler = (event : @js.Value) => {
-      guard event_payload(event) is Some(payload) else { return }
-      guard decode(payload) is Some(msg) else { return }
-      scheduler.add(dispatch(msg))
-    }
-    let _ : @js.Value = extension_events.apply_with_string("on", [
-      @js.Value::cast_from(name),
-      @js.Value::cast_from(handler),
-    ])
-  }
-
-  for kind_ in proton_event_methods() {
-    let method_ = kind_.wire_name()
-    let handler = (event : @js.Value) => {
-      guard event_payload(event) is Some(payload) &&
-        @protocol.Notification::from_wire(method_, Json::object(payload))
-        is Some(notification) else {
-        return
-      }
-      scheduler.add(host_notification(terminal, dispatch, Local, notification))
-    }
-    let _ : @js.Value = extension_events.apply_with_string("on", [
-      @js.Value::cast_from("openseek." + method_),
-      @js.Value::cast_from(handler),
-    ])
-  }
-  // Native view events describe this window's own browser tabs. Like
-  // `notification.click` below, the event is window-local: it has no
-  // `NotificationKind` because the shared wire catalog must never carry it
-  // to a relay client, which has no native views.
-  on("openseek.browser.event", browser_event_msg)
-  // Proton forwards native menu commands as application events.
-  // Application events use `__MoonBit__.app.on`; the shared event hub above
-  // is reserved for extension events. Ignore unknown ids so another menu
-  // item cannot accidentally map to developer tools.
-  let menu_handler = (event : @js.Value) => {
-    guard event_payload(event) is Some(payload) &&
-      @jsonx.json_text(payload, "command_id") ==
-      Some(@commands.app_open_devtools.name()) else {
-      return
-    }
-    scheduler.add(dispatch(AppDeveloperToolsRequested))
-  }
-  let _ : @js.Value = application_events.apply_with_string("on", [
-    @js.Value::cast_from("menu.command"),
-    @js.Value::cast_from(menu_handler),
-  ])
-  // Emitted by the notification extension when the user clicks a system
-  // notification; the payload is the run id this frontend stamped on it.
-  // Desktop-only by nature.
-  on("notification.click", notification_clicked_msg)
-}
-
-///|
-/// A proton event's payload as JSON fields. Payloads cross the bridge as
-/// structured clones of the host's JSON, so the round trip back through
-/// JSON is lossless; an event without a decodable payload is dropped —
-/// except a payload-less notification, which reads as empty fields
-/// and is then accepted only if that notification's typed payload permits it.
-fn event_payload(event : @js.Value) -> Map[String, Json]? {
-  guard @interop.js_prop(event, "payload") is Some(payload) else {
-    return Some(Map([]))
-  }
-  let json = payload.to_json() catch { _ => return None }
-  guard json is Object(fields) else { return None }
-  Some(fields)
-}
-
 // ---------------------------------------------------------------------------
 // A browser: JSON-RPC over the page's WebSocket, with reconnection.
 
@@ -664,43 +496,6 @@ fn event_payload(event : @js.Value) -> Map[String, Json]? {
 /// unreachable. The loop keeps reconnecting regardless; the next
 /// `agent.connected` restores the UI.
 const WsLostAfter = 3
-
-///|
-/// Open a device's WebSocket once. Reconnection is model-driven: the socket
-/// closing dispatches `ChannelDown`, whose handler counts the loss and
-/// schedules `ReconnectDue` with backoff — so a device dropped from the
-/// model (revoked, signed out) stops reconnecting by itself, and a
-/// successful connection (the host's `agent.connected`) resets the count.
-fn connect_ws(
-  dispatch : @cmd.Emit[Msg],
-  terminal : @cmd.Emit[@terminal.Msg],
-  device : String,
-  websocket_epoch : Int,
-) -> @cmd.Cmd {
-  @cmd.custom_cmd(scheduler => {
-    let channel : @interop.ChannelId = Remote(device)
-    @interop.ws_connect(
-      device,
-      on_notification=notification => {
-        scheduler.add(
-          host_notification(terminal, dispatch, channel, notification),
-        )
-      },
-      on_down=() => {
-        scheduler.add(
-          dispatch(FromDevice(channel, ChannelDown(websocket_epoch~))),
-        )
-      },
-    )
-  })
-}
-
-///|
-/// Close a channel's socket and forget it, as a command — the roster
-/// reconcile retires channels from inside `update`, which stays pure.
-fn close_channel(channel : @interop.ChannelId) -> @cmd.Cmd {
-  @cmd.custom_cmd(_scheduler => @interop.ws_close(channel))
-}
 
 ///|
 /// Reconnect backoff: quick first retries, settling at 15s so an
@@ -1006,26 +801,6 @@ fn diagnostics_msg(
   Some(
     DiagnosticsPublished(channel~, absolute~, diagnostics=payload.diagnostics),
   )
-}
-
-///|
-fn terminal_exit_msg(
-  channel : @interop.ChannelId,
-  payload : @protocol.TerminalExitPayload,
-) -> @terminal.Msg? {
-  Some(SessionExited(channel~, id=payload.id, code=payload.code))
-}
-
-///|
-/// A clicked notification's payload is the run id `system_notification.mbt`
-/// stamped on it; an empty payload is dropped (a stale notification from an
-/// older build, or a payload another surface posted).
-fn notification_clicked_msg(payload : Map[String, Json]) -> Msg? {
-  guard @jsonx.json_text(payload, "payload") is Some(run_id) &&
-    !run_id.is_empty() else {
-    return None
-  }
-  Some(NotificationClicked(run_id~))
 }
 
 ///|

--- a/desktop/frontend/bridge.mbt
+++ b/desktop/frontend/bridge.mbt
@@ -2,8 +2,8 @@
 // notifications (docs/remote-protocol.md). Methods go through
 // `@interop.bridge_request`; notifications arrive either as `openseek.*`
 // proton events (the desktop window) or as JSON-RPC notifications on the
-// page's WebSocket (a browser through the relay), and both feed the same
-// decoders below.
+// page's WebSocket (a browser through the relay). `frontend/bridge` owns both
+// transports; both feed the same decoders below.
 
 ///|
 /// Purely decode one non-terminal host notification, retaining the channel it
@@ -265,9 +265,10 @@ fn bridge_event(dispatch : @cmd.Emit[Msg], event : @bridge.Event) -> @cmd.Cmd {
     @bridge.Event::ChannelDown(channel~, websocket_epoch~) =>
       dispatch(FromDevice(channel, ChannelDown(websocket_epoch~)))
     @bridge.Event::BrowserEvent(payload~) =>
-      match browser_event_msg(payload) {
-        Some(msg) => dispatch(msg)
-        None => @cmd.none
+      if browser_event_msg(payload) is Some(msg) {
+        dispatch(msg)
+      } else {
+        @cmd.none
       }
     @bridge.Event::MenuCommand(command_id~) =>
       if command_id == @commands.app_open_devtools.name() {

--- a/desktop/frontend/bridge/event.mbt
+++ b/desktop/frontend/bridge/event.mbt
@@ -1,0 +1,18 @@
+// Events emitted by a live engine-host connection. This package owns the
+// transport lifecycle and wire-facing payload extraction; the parent
+// frontend decides how each event changes application state.
+
+///|
+/// One event observed from a local Proton host or remote relay device. The
+/// parent frontend pattern-matches this value to apply application policy.
+pub enum Event {
+  Notification(
+    channel~ : @interop.ChannelId,
+    notification~ : @protocol.Notification
+  )
+  Unavailable(channel~ : @interop.ChannelId, message~ : String)
+  ChannelDown(channel~ : @interop.ChannelId, websocket_epoch~ : Int)
+  BrowserEvent(payload~ : Map[String, Json])
+  MenuCommand(command_id~ : String)
+  NotificationClicked(run_id~ : String)
+}

--- a/desktop/frontend/bridge/local.mbt
+++ b/desktop/frontend/bridge/local.mbt
@@ -17,9 +17,7 @@ fn LocalBridgeSub::LocalBridgeSub(
 }
 
 ///|
-fn LocalBridgeSub::subscription_key() -> String {
-  "host-bridge:local"
-}
+const LocalBridgeKey = "host-bridge:local"
 
 ///|
 /// Wait for Proton to inject the bridge, wire this connection's events, and
@@ -102,20 +100,9 @@ fn LocalBridgeSub::subscribe(
 }
 
 ///|
-/// Notification kinds exposed by the host extension. Proton needs one
-/// listener per kind, so this derives directly from the shared catalog.
-fn LocalBridgeSub::notification_kinds() -> Array[@protocol.NotificationKind] {
-  @protocol.NotificationKind::all()
-}
-
-///|
 /// Decode a Proton event's structured-clone payload back into JSON fields.
 /// A payload-less event reads as empty fields; malformed values are dropped.
-fn LocalBridgeSub::event_payload(
-  self : LocalBridgeSub,
-  event : @js.Value,
-) -> Map[String, Json]? {
-  guard self.active else { return None }
+fn event_payload(event : @js.Value) -> Map[String, Json]? {
   guard @interop.js_prop(event, "payload") is Some(payload) else {
     return Some(Map([]))
   }
@@ -131,10 +118,12 @@ fn LocalBridgeSub::wire(
   extension_events : @js.Value,
   application_events : @js.Value,
 ) -> Unit {
-  for kind_ in LocalBridgeSub::notification_kinds() {
+  // Proton needs one listener per notification kind, so the listeners derive
+  // directly from the shared catalog.
+  for kind_ in @protocol.NotificationKind::all() {
     let method_ = kind_.wire_name()
     let handler = (event : @js.Value) => {
-      guard self.event_payload(event) is Some(payload) &&
+      guard event_payload(event) is Some(payload) &&
         @protocol.Notification::from_wire(method_, Json::object(payload))
         is Some(notification) else {
         return
@@ -150,13 +139,13 @@ fn LocalBridgeSub::wire(
   // Native browser-view events are intentionally window-local rather than
   // shared protocol notifications. The parent frontend owns their UI decode.
   self.subscribe(extension_events, "openseek.browser.event", event => {
-    guard self.event_payload(event) is Some(payload) else { return }
+    guard event_payload(event) is Some(payload) else { return }
     scheduler.add((self.dispatch)(Event::BrowserEvent(payload~)))
   })
   // Application events use `__MoonBit__.app.on`; keep their command id typed
   // while leaving command policy to the parent frontend.
   self.subscribe(application_events, "menu.command", event => {
-    guard self.event_payload(event) is Some(payload) &&
+    guard event_payload(event) is Some(payload) &&
       payload.get("command_id") is Some(String(command_id)) else {
       return
     }
@@ -164,7 +153,7 @@ fn LocalBridgeSub::wire(
   })
   // The notification extension stamps the owning run id in `payload`.
   self.subscribe(extension_events, "notification.click", event => {
-    guard self.event_payload(event) is Some(payload) &&
+    guard event_payload(event) is Some(payload) &&
       payload.get("payload") is Some(String(run_id)) &&
       !run_id.is_empty() else {
       return
@@ -188,23 +177,4 @@ fn LocalBridgeSub::unload(self : LocalBridgeSub) -> Unit {
   for unsubscribe in self.unsubscribers {
     let _ : @js.Value = unsubscribe.apply(([] : Array[@js.Value]))
   }
-}
-
-///|
-test "local bridge listens to the shared host notification catalog" {
-  let kinds = LocalBridgeSub::notification_kinds()
-  assert_true(kinds.contains(@protocol.NotificationKind::CodexStatusChanged))
-  assert_true(kinds.contains(@protocol.NotificationKind::CodexNotification))
-  assert_true(kinds.contains(@protocol.NotificationKind::CodexServerRequest))
-  assert_true(kinds.contains(@protocol.NotificationKind::AuthChanged))
-  assert_true(kinds.contains(@protocol.NotificationKind::SkillsChanged))
-  assert_true(kinds.contains(@protocol.NotificationKind::FsWatchFailed))
-  assert_true(kinds.contains(@protocol.NotificationKind::SessionEvent))
-  assert_true(kinds.contains(@protocol.NotificationKind::WorkspaceChanged))
-  assert_true(kinds.contains(@protocol.NotificationKind::WorktreeChanged))
-  assert_true(kinds.contains(@protocol.NotificationKind::UpdateDownloaded))
-  assert_true(
-    kinds.contains(@protocol.NotificationKind::UpdateDownloadProgress),
-  )
-  assert_true(kinds.contains(@protocol.NotificationKind::UpdateDownloadFailed))
 }

--- a/desktop/frontend/bridge/local.mbt
+++ b/desktop/frontend/bridge/local.mbt
@@ -1,0 +1,210 @@
+// The desktop window's injected Proton connection. The request API and event
+// actors appear independently, so installation waits for the complete surface
+// before registering listeners or attaching to the host notification actor.
+
+///|
+priv struct LocalBridgeSub {
+  mut dispatch : @cmd.Emit[Event]
+  mut active : Bool
+  unsubscribers : Array[@js.Value]
+}
+
+///|
+fn LocalBridgeSub::LocalBridgeSub(
+  dispatch : @cmd.Emit[Event],
+) -> LocalBridgeSub {
+  { dispatch, active: true, unsubscribers: [] }
+}
+
+///|
+fn LocalBridgeSub::subscription_key() -> String {
+  "host-bridge:local"
+}
+
+///|
+/// Wait for Proton to inject the bridge, wire this connection's events, and
+/// attach to the host. The 25ms retries add up to roughly three seconds.
+/// Unloading makes every already queued retry harmless.
+fn LocalBridgeSub::install(self : LocalBridgeSub, attempt : Int) -> @cmd.Cmd {
+  @cmd.custom_cmd(scheduler => {
+    guard self.active else { return }
+    guard @interop.openseek_api() is Some(request_api) &&
+      @interop.moonbit_bridge_root() is Some(root) &&
+      @interop.js_prop(root, "events") is Some(extension_events) &&
+      @interop.js_prop(root, "app") is Some(application_events) &&
+      @interop.js_prop(request_api, "host.connect") is Some(_) &&
+      @interop.js_prop(request_api, "agent.start") is Some(_) &&
+      @interop.js_prop(extension_events, "on") is Some(_) &&
+      @interop.js_prop(application_events, "on") is Some(_) else {
+      if attempt > 120 {
+        scheduler.add(
+          (self.dispatch)(
+            Event::Unavailable(
+              channel=@interop.ChannelId::Local,
+              message="Bridge unavailable",
+            ),
+          ),
+        )
+      } else {
+        scheduler.add(@cmd.delay(self.install(attempt + 1), 25))
+      }
+      return
+    }
+    self.wire(scheduler, extension_events, application_events)
+    self.open_host_connection(scheduler, request_api)
+  })
+}
+
+///|
+/// Attach this page to the host's app-lifetime notification actor. The call
+/// resolves after the actor emits its readiness event.
+fn LocalBridgeSub::open_host_connection(
+  self : LocalBridgeSub,
+  scheduler : &@cmd.Scheduler,
+  api : @js.Value,
+) -> Unit {
+  @js.async_run(() => {
+    let _ : @js.Value = @interop.js_method_promise(
+      api,
+      "host.connect",
+      @js.Object::new().to_value(),
+    ).wait() catch {
+      error => {
+        guard self.active else { return }
+        scheduler.add(
+          (self.dispatch)(
+            Event::Unavailable(
+              channel=@interop.ChannelId::Local,
+              message=@interop.bridge_error_text(error),
+            ),
+          ),
+        )
+        return
+      }
+    }
+  })
+}
+
+///|
+/// Register one injected event listener and retain its unsubscribe function
+/// for this connection's unload boundary.
+fn LocalBridgeSub::subscribe(
+  self : LocalBridgeSub,
+  events : @js.Value,
+  name : String,
+  handler : (@js.Value) -> Unit,
+) -> Unit {
+  let unsubscribe : @js.Value = events.apply_with_string("on", [
+    @js.Value::cast_from(name),
+    @js.Value::cast_from(handler),
+  ])
+  self.unsubscribers.push(unsubscribe)
+}
+
+///|
+/// Notification kinds exposed by the host extension. Proton needs one
+/// listener per kind, so this derives directly from the shared catalog.
+fn LocalBridgeSub::notification_kinds() -> Array[@protocol.NotificationKind] {
+  @protocol.NotificationKind::all()
+}
+
+///|
+/// Decode a Proton event's structured-clone payload back into JSON fields.
+/// A payload-less event reads as empty fields; malformed values are dropped.
+fn LocalBridgeSub::event_payload(
+  self : LocalBridgeSub,
+  event : @js.Value,
+) -> Map[String, Json]? {
+  guard self.active else { return None }
+  guard @interop.js_prop(event, "payload") is Some(payload) else {
+    return Some(Map([]))
+  }
+  let json = payload.to_json() catch { _ => return None }
+  guard json is Object(fields) else { return None }
+  Some(fields)
+}
+
+///|
+fn LocalBridgeSub::wire(
+  self : LocalBridgeSub,
+  scheduler : &@cmd.Scheduler,
+  extension_events : @js.Value,
+  application_events : @js.Value,
+) -> Unit {
+  for kind_ in LocalBridgeSub::notification_kinds() {
+    let method_ = kind_.wire_name()
+    let handler = (event : @js.Value) => {
+      guard self.event_payload(event) is Some(payload) &&
+        @protocol.Notification::from_wire(method_, Json::object(payload))
+        is Some(notification) else {
+        return
+      }
+      scheduler.add(
+        (self.dispatch)(
+          Event::Notification(channel=@interop.ChannelId::Local, notification~),
+        ),
+      )
+    }
+    self.subscribe(extension_events, "openseek." + method_, handler)
+  }
+  // Native browser-view events are intentionally window-local rather than
+  // shared protocol notifications. The parent frontend owns their UI decode.
+  self.subscribe(extension_events, "openseek.browser.event", event => {
+    guard self.event_payload(event) is Some(payload) else { return }
+    scheduler.add((self.dispatch)(Event::BrowserEvent(payload~)))
+  })
+  // Application events use `__MoonBit__.app.on`; keep their command id typed
+  // while leaving command policy to the parent frontend.
+  self.subscribe(application_events, "menu.command", event => {
+    guard self.event_payload(event) is Some(payload) &&
+      payload.get("command_id") is Some(String(command_id)) else {
+      return
+    }
+    scheduler.add((self.dispatch)(Event::MenuCommand(command_id~)))
+  })
+  // The notification extension stamps the owning run id in `payload`.
+  self.subscribe(extension_events, "notification.click", event => {
+    guard self.event_payload(event) is Some(payload) &&
+      payload.get("payload") is Some(String(run_id)) &&
+      !run_id.is_empty() else {
+      return
+    }
+    scheduler.add((self.dispatch)(Event::NotificationClicked(run_id~)))
+  })
+}
+
+///|
+fn LocalBridgeSub::update_dispatch(
+  self : LocalBridgeSub,
+  dispatch : @cmd.Emit[Event],
+) -> Unit {
+  self.dispatch = dispatch
+}
+
+///|
+/// Retire every Proton listener and make queued injection retries inert.
+fn LocalBridgeSub::unload(self : LocalBridgeSub) -> Unit {
+  self.active = false
+  for unsubscribe in self.unsubscribers {
+    let _ : @js.Value = unsubscribe.apply(([] : Array[@js.Value]))
+  }
+}
+
+///|
+test "local bridge listens to the shared host notification catalog" {
+  let kinds = LocalBridgeSub::notification_kinds()
+  assert_true(kinds.contains(@protocol.NotificationKind::CodexStatusChanged))
+  assert_true(kinds.contains(@protocol.NotificationKind::CodexNotification))
+  assert_true(kinds.contains(@protocol.NotificationKind::CodexServerRequest))
+  assert_true(kinds.contains(@protocol.NotificationKind::AuthChanged))
+  assert_true(kinds.contains(@protocol.NotificationKind::SkillsChanged))
+  assert_true(kinds.contains(@protocol.NotificationKind::FsWatchFailed))
+  assert_true(kinds.contains(@protocol.NotificationKind::SessionEvent))
+  assert_true(kinds.contains(@protocol.NotificationKind::WorkspaceChanged))
+  assert_true(kinds.contains(@protocol.NotificationKind::WorktreeChanged))
+  assert_true(kinds.contains(@protocol.NotificationKind::UpdateDownloaded))
+  assert_true(
+    kinds.contains(@protocol.NotificationKind::UpdateDownloadProgress),
+  )
+  assert_true(kinds.contains(@protocol.NotificationKind::UpdateDownloadFailed))
+}

--- a/desktop/frontend/bridge/moon.pkg
+++ b/desktop/frontend/bridge/moon.pkg
@@ -1,5 +1,4 @@
 import {
-  "moonbitlang/core/json",
   "moonbit-community/rabbita/cmd",
   "moonbit-community/rabbita/js",
   "moonbit-community/rabbita/sub",

--- a/desktop/frontend/bridge/moon.pkg
+++ b/desktop/frontend/bridge/moon.pkg
@@ -1,0 +1,10 @@
+import {
+  "moonbitlang/core/json",
+  "moonbit-community/rabbita/cmd",
+  "moonbit-community/rabbita/js",
+  "moonbit-community/rabbita/sub",
+  "openseek_desktop/internal/protocol",
+  "openseek_desktop/frontend/interop",
+}
+
+supported_targets = "js"

--- a/desktop/frontend/bridge/pkg.generated.mbti
+++ b/desktop/frontend/bridge/pkg.generated.mbti
@@ -1,0 +1,30 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "openseek_desktop/frontend/bridge"
+
+import {
+  "moonbit-community/rabbita/cmd",
+  "moonbit-community/rabbita/sub",
+  "openseek_desktop/frontend/interop",
+  "openseek_desktop/internal/protocol",
+}
+
+// Values
+pub fn local_connection(@cmd.Emit[Event]) -> @sub.Sub
+
+pub fn remote_connection(device_id~ : String, websocket_epoch~ : Int, reconnect_attempt~ : Int, dispatch~ : @cmd.Emit[Event]) -> @sub.Sub
+
+// Errors
+
+// Types and methods
+pub enum Event {
+  Notification(channel~ : @interop.ChannelId, notification~ : @protocol.Notification)
+  Unavailable(channel~ : @interop.ChannelId, message~ : String)
+  ChannelDown(channel~ : @interop.ChannelId, websocket_epoch~ : Int)
+  BrowserEvent(payload~ : Map[String, Json])
+  MenuCommand(command_id~ : String)
+  NotificationClicked(run_id~ : String)
+}
+
+// Type aliases
+
+// Traits

--- a/desktop/frontend/bridge/remote.mbt
+++ b/desktop/frontend/bridge/remote.mbt
@@ -1,0 +1,77 @@
+// A browser page's connection to one named relay device. Reconnection policy
+// remains in the parent model; changing the declared resource identity causes
+// Rabbita to unload this socket and install the next generation.
+
+///|
+priv struct RemoteBridgeSub {
+  device_id : String
+  channel : @interop.ChannelId
+  websocket_epoch : Int
+  mut dispatch : @cmd.Emit[Event]
+}
+
+///|
+fn RemoteBridgeSub::RemoteBridgeSub(
+  device_id : String,
+  websocket_epoch : Int,
+  dispatch : @cmd.Emit[Event],
+) -> RemoteBridgeSub {
+  {
+    device_id,
+    channel: @interop.ChannelId::Remote(device_id),
+    websocket_epoch,
+    dispatch,
+  }
+}
+
+///|
+fn RemoteBridgeSub::subscription_key(
+  device_id : String,
+  websocket_epoch : Int,
+  reconnect_attempt : Int,
+) -> String {
+  let channel : @interop.ChannelId = @interop.ChannelId::Remote(device_id)
+  "host-bridge:\{channel.uri_authority()}:\{websocket_epoch}:\{reconnect_attempt}"
+}
+
+///|
+fn RemoteBridgeSub::install(
+  self : RemoteBridgeSub,
+  scheduler : &@cmd.Scheduler,
+) -> Unit {
+  @interop.ws_connect(
+    self.device_id,
+    on_notification=notification => {
+      scheduler.add(
+        (self.dispatch)(
+          Event::Notification(channel=self.channel, notification~),
+        ),
+      )
+    },
+    on_down=() => {
+      scheduler.add(
+        (self.dispatch)(
+          Event::ChannelDown(
+            channel=self.channel,
+            websocket_epoch=self.websocket_epoch,
+          ),
+        ),
+      )
+    },
+  )
+}
+
+///|
+fn RemoteBridgeSub::update_dispatch(
+  self : RemoteBridgeSub,
+  dispatch : @cmd.Emit[Event],
+) -> Unit {
+  self.dispatch = dispatch
+}
+
+///|
+/// Close the current socket without emitting a down event. Removing the device
+/// or replacing its declared generation therefore cannot start another retry.
+fn RemoteBridgeSub::unload(self : RemoteBridgeSub) -> Unit {
+  @interop.ws_close(self.channel)
+}

--- a/desktop/frontend/bridge/subscription.mbt
+++ b/desktop/frontend/bridge/subscription.mbt
@@ -16,7 +16,7 @@ priv suberror BridgeSubscription {
 /// Declare the desktop window's injected Proton connection.
 pub fn local_connection(dispatch : @cmd.Emit[Event]) -> @sub.Sub {
   @sub.custom_sub(
-    LocalBridgeSub::subscription_key(),
+    LocalBridgeKey,
     @sub.Global,
     LocalBridge(dispatch~),
     bridge_sub_loader,
@@ -82,10 +82,6 @@ fn bridge_sub_loader(
 test "bridge identity changes only when its resource must restart" {
   let remote = RemoteBridgeSub::subscription_key("device-a", 0, 0)
   assert_eq(RemoteBridgeSub::subscription_key("device-a", 0, 0), remote)
-  assert_false(RemoteBridgeSub::subscription_key("device-a", 0, 1) == remote)
-  assert_false(RemoteBridgeSub::subscription_key("device-a", 1, 0) == remote)
-  assert_eq(
-    LocalBridgeSub::subscription_key(),
-    LocalBridgeSub::subscription_key(),
-  )
+  assert_not_eq(RemoteBridgeSub::subscription_key("device-a", 0, 1), remote)
+  assert_not_eq(RemoteBridgeSub::subscription_key("device-a", 1, 0), remote)
 }

--- a/desktop/frontend/bridge/subscription.mbt
+++ b/desktop/frontend/bridge/subscription.mbt
@@ -1,0 +1,91 @@
+// Rabbita resource declarations for local Proton and remote WebSocket host
+// connections. The payload carries only transport identity and an Event
+// emitter, never parent-frontend model or message types.
+
+///|
+priv suberror BridgeSubscription {
+  LocalBridge(dispatch~ : @cmd.Emit[Event])
+  RemoteBridge(
+    dispatch~ : @cmd.Emit[Event],
+    device_id~ : String,
+    websocket_epoch~ : Int
+  )
+}
+
+///|
+/// Declare the desktop window's injected Proton connection.
+pub fn local_connection(dispatch : @cmd.Emit[Event]) -> @sub.Sub {
+  @sub.custom_sub(
+    LocalBridgeSub::subscription_key(),
+    @sub.Global,
+    LocalBridge(dispatch~),
+    bridge_sub_loader,
+  )
+}
+
+///|
+/// Declare one remote device connection. Advancing either generation replaces
+/// the socket; ordinary model changes only refresh the event emitter.
+pub fn remote_connection(
+  device_id~ : String,
+  websocket_epoch~ : Int,
+  reconnect_attempt~ : Int,
+  dispatch~ : @cmd.Emit[Event],
+) -> @sub.Sub {
+  @sub.custom_sub(
+    RemoteBridgeSub::subscription_key(
+      device_id, websocket_epoch, reconnect_attempt,
+    ),
+    @sub.Global,
+    RemoteBridge(dispatch~, device_id~, websocket_epoch~),
+    bridge_sub_loader,
+  )
+}
+
+///|
+fn bridge_sub_loader(
+  payload : Error,
+  scheduler : &@cmd.Scheduler,
+) -> @sub.RunningSub? {
+  match payload {
+    LocalBridge(dispatch~) => {
+      let running = LocalBridgeSub(dispatch)
+      scheduler.add(running.install(0))
+      Some({
+        unload: _ => running.unload(),
+        update_tagger: payload => {
+          match payload {
+            LocalBridge(dispatch=next) => running.update_dispatch(next)
+            _ => ()
+          }
+        },
+      })
+    }
+    RemoteBridge(dispatch~, device_id~, websocket_epoch~) => {
+      let running = RemoteBridgeSub(device_id, websocket_epoch, dispatch)
+      running.install(scheduler)
+      Some({
+        unload: _ => running.unload(),
+        update_tagger: payload => {
+          match payload {
+            RemoteBridge(dispatch=next, ..) => running.update_dispatch(next)
+            _ => ()
+          }
+        },
+      })
+    }
+    _ => None
+  }
+}
+
+///|
+test "bridge identity changes only when its resource must restart" {
+  let remote = RemoteBridgeSub::subscription_key("device-a", 0, 0)
+  assert_eq(RemoteBridgeSub::subscription_key("device-a", 0, 0), remote)
+  assert_false(RemoteBridgeSub::subscription_key("device-a", 0, 1) == remote)
+  assert_false(RemoteBridgeSub::subscription_key("device-a", 1, 0) == remote)
+  assert_eq(
+    LocalBridgeSub::subscription_key(),
+    LocalBridgeSub::subscription_key(),
+  )
+}

--- a/desktop/frontend/component_terminal.mbt
+++ b/desktop/frontend/component_terminal.mbt
@@ -15,6 +15,6 @@ fn Model::terminal_input(self : Model) -> @terminal.Input {
         }
       })
       .to_array(),
-    devices=self.devices.map(dev => dev.channel),
+    has_devices=!self.devices.is_empty(),
   )
 }

--- a/desktop/frontend/component_terminal.mbt
+++ b/desktop/frontend/component_terminal.mbt
@@ -15,12 +15,6 @@ fn Model::terminal_input(self : Model) -> @terminal.Input {
         }
       })
       .to_array(),
-    connections=self.devices.map(dev => {
-      @terminal.Connection(
-        channel=dev.channel,
-        websocket_epoch=dev.websocket_epoch,
-        attempt=dev.reconnect_attempt,
-      )
-    }),
+    devices=self.devices.map(dev => dev.channel),
   )
 }

--- a/desktop/frontend/console.mbt
+++ b/desktop/frontend/console.mbt
@@ -221,8 +221,9 @@ fn apply_roster(
     @interop.ChannelId::Remote(id)
   })
   // Retire first: anything other than this page's target, or a target the
-  // roster no longer grants, closes its socket (a command — update stays
-  // pure), drops its state and conversations, and disposes its PTYs.
+  // roster no longer grants, drops its state and conversations and disposes
+  // its PTYs. Removing the device also removes its root subscription, whose
+  // unload closes the socket before update's commands run.
   let devices : Array[DeviceState] = []
   for dev in model.devices {
     let granted = if dev.channel is Remote(id) {
@@ -230,9 +231,7 @@ fn apply_roster(
     } else {
       false
     }
-    if Some(dev.channel) != page_channel || !granted {
-      commands.push(close_channel(dev.channel))
-    } else {
+    if Some(dev.channel) == page_channel && granted {
       devices.push(dev)
     }
   }
@@ -804,12 +803,8 @@ fn console_signed_out(
   model : Model,
   console : ConsoleState,
 ) -> (@cmd.Cmd, Model) {
-  let commands : Array[@cmd.Cmd] = []
-  for dev in model.devices {
-    commands.push(close_channel(dev.channel))
-  }
   (
-    @cmd.batch(commands),
+    @cmd.none,
     {
       ..model,
       devices: [],

--- a/desktop/frontend/moon.pkg
+++ b/desktop/frontend/moon.pkg
@@ -16,6 +16,7 @@ import {
   "openseek_desktop/frontend/pathx",
   "openseek_desktop/internal/protocol",
   "openseek_desktop/internal/commands",
+  "openseek_desktop/frontend/bridge",
   "openseek_desktop/frontend/dock",
   "openseek_desktop/frontend/codex",
   "openseek_desktop/frontend/composer",

--- a/desktop/frontend/terminal/component.mbt
+++ b/desktop/frontend/terminal/component.mbt
@@ -4,18 +4,19 @@
 struct Input {
   ctx : Ctx
   live_channels : Array[@interop.ChannelId]
-  // Retained even while a channel reconnects. An empty device set closes the
-  // panel, while `live_channels` separately retires the dead PTY generation.
-  devices : Array[@interop.ChannelId]
+  // Stays true while a channel reconnects; only a device-less (signed-out)
+  // console closes the panel. `live_channels` separately retires the dead PTY
+  // generation.
+  has_devices : Bool
 } derive(Eq)
 
 ///|
 pub fn Input::Input(
   ctx~ : Ctx,
   live_channels~ : Array[@interop.ChannelId],
-  devices~ : Array[@interop.ChannelId],
+  has_devices~ : Bool,
 ) -> Input {
-  { ctx, live_channels, devices }
+  { ctx, live_channels, has_devices }
 }
 
 ///|
@@ -23,11 +24,11 @@ pub fn Input::Input(
 /// boundary, but preserve the user's visibility choice while retained devices
 /// reconnect; their old PTYs are still retired through `live_channels`
 /// reconciliation.
-fn State::close_without_devices(self : State, device_count : Int) -> State {
-  if device_count == 0 {
-    { ..self, open: false }
-  } else {
+fn State::close_without_devices(self : State, has_devices : Bool) -> State {
+  if has_devices {
     self
+  } else {
+    { ..self, open: false }
   }
 }
 
@@ -49,7 +50,7 @@ pub fn State::reconcile(
       state = next
     }
   }
-  state = state.close_without_devices(input.devices.length())
+  state = state.close_without_devices(input.has_devices)
   let (state, sync_command) = sync(dispatch, state, input.ctx)
   commands.push(sync_command)
   // Output bypasses Rabbita, so refresh the terminal package's imperative
@@ -72,9 +73,9 @@ pub fn component(
 ///|
 test "terminal visibility distinguishes disconnect from device removal" {
   let open = { ..State::empty(), open: true }
-  let disconnected = open.close_without_devices(1)
+  let disconnected = open.close_without_devices(true)
   assert_true(disconnected.open)
-  let signed_out = open.close_without_devices(0)
+  let signed_out = open.close_without_devices(false)
   assert_false(signed_out.open)
 }
 

--- a/desktop/frontend/terminal/component.mbt
+++ b/desktop/frontend/terminal/component.mbt
@@ -56,10 +56,7 @@ pub fn State::reconcile(
   // session-to-emulator routing after the low-frequency state transition that
   // can change it. This is a projection of `State`, not a second state owner.
   commands.push(state.sync_host_routes())
-  (
-    { ..state, live_channels: input.live_channels, devices: input.devices },
-    @cmd.batch(commands),
-  )
+  ({ ..state, live_channels: input.live_channels }, @cmd.batch(commands))
 }
 
 ///|

--- a/desktop/frontend/terminal/component.mbt
+++ b/desktop/frontend/terminal/component.mbt
@@ -4,35 +4,18 @@
 struct Input {
   ctx : Ctx
   live_channels : Array[@interop.ChannelId]
-  connections : Array[Connection]
+  // Retained even while a channel reconnects. An empty device set closes the
+  // panel, while `live_channels` separately retires the dead PTY generation.
+  devices : Array[@interop.ChannelId]
 } derive(Eq)
-
-///|
-/// One device's current host transport generation. The entry remains while
-/// its socket is temporarily down and disappears only when the device itself
-/// is removed; `attempt` advances when reconnect backoff expires.
-struct Connection {
-  channel : @interop.ChannelId
-  websocket_epoch : Int
-  attempt : Int
-} derive(Eq)
-
-///|
-pub fn Connection::Connection(
-  channel~ : @interop.ChannelId,
-  websocket_epoch~ : Int,
-  attempt~ : Int,
-) -> Connection {
-  { channel, websocket_epoch, attempt }
-}
 
 ///|
 pub fn Input::Input(
   ctx~ : Ctx,
   live_channels~ : Array[@interop.ChannelId],
-  connections~ : Array[Connection],
+  devices~ : Array[@interop.ChannelId],
 ) -> Input {
-  { ctx, live_channels, connections }
+  { ctx, live_channels, devices }
 }
 
 ///|
@@ -50,13 +33,12 @@ fn State::close_without_devices(self : State, device_count : Int) -> State {
 
 ///|
 /// Reconcile parent-owned inputs after every root update. Channel retirement,
-/// transport installation, conversation switches, and theme changes are all
-/// ordinary state transitions; no rendered marker or DOM observer is needed.
+/// conversation switches, and theme changes are ordinary state transitions;
+/// the root bridge subscriptions own transport installation separately.
 pub fn State::reconcile(
   self : State,
   dispatch : @cmd.Emit[Msg],
   input : Input,
-  connect : (@interop.ChannelId, Int) -> @cmd.Cmd,
 ) -> (State, @cmd.Cmd) {
   let commands : Array[@cmd.Cmd] = []
   let mut state = self
@@ -67,12 +49,7 @@ pub fn State::reconcile(
       state = next
     }
   }
-  for connection in input.connections {
-    if !self.connections.contains(connection) {
-      commands.push(connect(connection.channel, connection.websocket_epoch))
-    }
-  }
-  state = state.close_without_devices(input.connections.length())
+  state = state.close_without_devices(input.devices.length())
   let (state, sync_command) = sync(dispatch, state, input.ctx)
   commands.push(sync_command)
   // Output bypasses Rabbita, so refresh the terminal package's imperative
@@ -80,11 +57,7 @@ pub fn State::reconcile(
   // can change it. This is a projection of `State`, not a second state owner.
   commands.push(state.sync_host_routes())
   (
-    {
-      ..state,
-      live_channels: input.live_channels,
-      connections: input.connections,
-    },
+    { ..state, live_channels: input.live_channels, devices: input.devices },
     @cmd.batch(commands),
   )
 }
@@ -107,9 +80,6 @@ test "terminal visibility distinguishes disconnect from device removal" {
   let signed_out = open.close_without_devices(0)
   assert_false(signed_out.open)
 }
-
-///|
-pub extend Connection with Eq::{equal, not_equal}
 
 ///|
 pub extend Input with Eq::{equal, not_equal}

--- a/desktop/frontend/terminal/pkg.generated.mbti
+++ b/desktop/frontend/terminal/pkg.generated.mbti
@@ -32,7 +32,7 @@ pub fn Ctx::equal(Self, Self) -> Bool
 pub fn Ctx::not_equal(Self, Self) -> Bool
 
 type Input derive(Eq)
-pub fn Input::Input(ctx~ : Ctx, live_channels~ : Array[@interop.ChannelId], devices~ : Array[@interop.ChannelId]) -> Self
+pub fn Input::Input(ctx~ : Ctx, live_channels~ : Array[@interop.ChannelId], has_devices~ : Bool) -> Self
 pub fn Input::equal(Self, Self) -> Bool
 pub fn Input::not_equal(Self, Self) -> Bool
 

--- a/desktop/frontend/terminal/pkg.generated.mbti
+++ b/desktop/frontend/terminal/pkg.generated.mbti
@@ -20,9 +20,6 @@ pub fn output(@interop.ChannelId, Int, Int, String) -> @cmd.Cmd
 // Errors
 
 // Types and methods
-type Connection derive(Eq)
-pub fn Connection::Connection(channel~ : @interop.ChannelId, websocket_epoch~ : Int, attempt~ : Int) -> Self
-
 pub struct Ctx {
   channel : @interop.ChannelId
   session : String
@@ -31,9 +28,13 @@ pub struct Ctx {
   connected : Bool
 } derive(Eq)
 pub fn Ctx::Ctx(channel~ : @interop.ChannelId, session~ : String, placement~ : @interop.CheckoutPlacement?, dark_mode~ : Bool, connected~ : Bool) -> Self
+pub fn Ctx::equal(Self, Self) -> Bool
+pub fn Ctx::not_equal(Self, Self) -> Bool
 
 type Input derive(Eq)
-pub fn Input::Input(ctx~ : Ctx, live_channels~ : Array[@interop.ChannelId], connections~ : Array[Connection]) -> Self
+pub fn Input::Input(ctx~ : Ctx, live_channels~ : Array[@interop.ChannelId], devices~ : Array[@interop.ChannelId]) -> Self
+pub fn Input::equal(Self, Self) -> Bool
+pub fn Input::not_equal(Self, Self) -> Bool
 
 pub(all) enum Msg {
   ToggleTerminal
@@ -55,9 +56,11 @@ pub struct State {
   // private fields
 } derive(Eq)
 pub fn State::empty() -> Self
+pub fn State::equal(Self, Self) -> Bool
 pub fn State::handle(Self, @cmd.Emit[Msg], Msg, Input) -> (@cmd.Cmd, Self)
 pub fn State::is_open(Self) -> Bool
-pub fn State::reconcile(Self, @cmd.Emit[Msg], Input, (@interop.ChannelId, Int) -> @cmd.Cmd) -> (Self, @cmd.Cmd)
+pub fn State::not_equal(Self, Self) -> Bool
+pub fn State::reconcile(Self, @cmd.Emit[Msg], Input) -> (Self, @cmd.Cmd)
 
 // Type aliases
 

--- a/desktop/frontend/terminal/state.mbt
+++ b/desktop/frontend/terminal/state.mbt
@@ -74,11 +74,9 @@ pub struct State {
   /// model state lets `sync` refresh existing xterm instances exactly once
   /// when the application switches between light and dark mode.
   priv synced_dark_mode : Bool?
-  /// Root-owned input snapshots used to retire dead channels and distinguish
-  /// a temporarily reconnecting device from a signed-out device. Keeping them
+  /// Root-owned input snapshot used to retire dead channels. Keeping it
   /// beside the tabs makes input reconciliation a normal state transition.
   priv live_channels : Array[@interop.ChannelId]
-  priv devices : Array[@interop.ChannelId]
 } derive(Eq)
 
 ///|
@@ -92,7 +90,6 @@ pub fn State::empty() -> State {
     exited_before_open: [],
     synced_dark_mode: None,
     live_channels: [],
-    devices: [],
   }
 }
 

--- a/desktop/frontend/terminal/state.mbt
+++ b/desktop/frontend/terminal/state.mbt
@@ -74,12 +74,11 @@ pub struct State {
   /// model state lets `sync` refresh existing xterm instances exactly once
   /// when the application switches between light and dark mode.
   priv synced_dark_mode : Bool?
-  /// Root-owned input snapshots used to retire dead channels and install each
-  /// transport generation exactly once. Keeping them beside the tabs makes
-  /// input reconciliation a normal state transition instead of a DOM
-  /// MutationObserver callback.
+  /// Root-owned input snapshots used to retire dead channels and distinguish
+  /// a temporarily reconnecting device from a signed-out device. Keeping them
+  /// beside the tabs makes input reconciliation a normal state transition.
   priv live_channels : Array[@interop.ChannelId]
-  priv connections : Array[Connection]
+  priv devices : Array[@interop.ChannelId]
 } derive(Eq)
 
 ///|
@@ -93,7 +92,7 @@ pub fn State::empty() -> State {
     exited_before_open: [],
     synced_dark_mode: None,
     live_channels: [],
-    connections: [],
+    devices: [],
   }
 }
 

--- a/desktop/frontend/terminal/terminal_xxtest.mbt
+++ b/desktop/frontend/terminal/terminal_xxtest.mbt
@@ -177,7 +177,6 @@ test "a disconnected channel retires only its terminal tabs" {
     exited_before_open: [(remote, 9), (local_channel, 9)],
     synced_dark_mode: Some(false),
     live_channels: [local_channel, remote],
-    devices: [local_channel, remote],
   }
   let (_, disconnected) = disconnect(state, remote)
   inspect(disconnected.tabs.length(), content="1")

--- a/desktop/frontend/terminal/terminal_xxtest.mbt
+++ b/desktop/frontend/terminal/terminal_xxtest.mbt
@@ -177,7 +177,7 @@ test "a disconnected channel retires only its terminal tabs" {
     exited_before_open: [(remote, 9), (local_channel, 9)],
     synced_dark_mode: Some(false),
     live_channels: [local_channel, remote],
-    connections: [],
+    devices: [local_channel, remote],
   }
   let (_, disconnected) = disconnect(state, remote)
   inspect(disconnected.tabs.length(), content="1")

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1726,16 +1726,12 @@ fn update(
     model
   }
   // Terminal input changes are reconciled as part of the root transition.
-  // This replaces the component's rendered marker and MutationObserver while
-  // preserving one installation per connection generation.
+  // Host transport installation is declared separately by the root
+  // subscriptions, so terminal reconciliation owns only terminal state.
   let terminal_emit = dispatch.map(msg => Terminal(msg))
   let terminal_input = model.terminal_input()
   let (terminal, terminal_cmd) = model.terminal.reconcile(
-    terminal_emit,
-    terminal_input,
-    (channel, websocket_epoch) => {
-      install_bridge(dispatch, terminal_emit, channel, websocket_epoch)
-    },
+    terminal_emit, terminal_input,
   )
   let model = { ..model, terminal, }
   let (model, browser_cmd) = sync_browser_view(dispatch, model)

--- a/desktop/frontend/workspace_settings.mbt
+++ b/desktop/frontend/workspace_settings.mbt
@@ -589,7 +589,7 @@ test "a straggler reply for a detached workspace is rejected" {
 
 ///|
 test "settings commit decoder carries the workspace identity" {
-  guard bridge_msg(
+  guard notification_msg(
       @interop.ChannelId::Local,
       @protocol.Notification::WorkspaceSettingsChanged({
         workspace: "/proj",

--- a/desktop/frontend/workspaces.mbt
+++ b/desktop/frontend/workspaces.mbt
@@ -425,7 +425,7 @@ test "a workspace commit broadcast supersedes list replies and refreshes session
 
 ///|
 test "workspace commit decoder carries the canonical registry list" {
-  guard bridge_msg(
+  guard notification_msg(
       @interop.ChannelId::Local,
       @protocol.Notification::WorkspaceChanged({ workspaces: ["/one", "/two"] }),
     )
@@ -434,13 +434,6 @@ test "workspace commit decoder carries the canonical registry list" {
   }
   inspect(paths.length(), content="2")
   assert_eq(paths[1].path, "/two")
-}
-
-///|
-test "proton subscribes to canonical durable and workspace notifications" {
-  let methods = proton_event_methods()
-  assert_true(methods.contains(@protocol.NotificationKind::SessionEvent))
-  assert_true(methods.contains(@protocol.NotificationKind::WorkspaceChanged))
 }
 
 ///|

--- a/desktop/frontend/worktrees.mbt
+++ b/desktop/frontend/worktrees.mbt
@@ -663,7 +663,7 @@ test "worktree commit decoder carries the workspace and its rows" {
     is Some(notification) else {
     fail("known notification was rejected")
   }
-  guard bridge_msg(@interop.ChannelId::Local, notification)
+  guard notification_msg(@interop.ChannelId::Local, notification)
     is Some(FromDevice(_, WorktreesChanged(rows, workspace~))) else {
     fail("expected a worktree change")
   }
@@ -678,11 +678,6 @@ test "worktree commit decoder carries the workspace and its rows" {
     @protocol.Notification::from_wire("worktree.changed", { "worktrees": [] })
     is None,
   )
-}
-
-///|
-test "proton subscribes to the worktree commit notification" {
-  assert_true(proton_event_methods().contains(WorktreeChanged))
 }
 
 ///|


### PR DESCRIPTION
## Summary

- move local Proton and remote WebSocket connection lifecycles into the `desktop/frontend/bridge` package
- declare each device connection as a Rabbita subscription with generation-based replacement and unload cleanup
- keep terminal reconciliation focused on terminal state while the root frontend adapts bridge events into application messages

## Validation

- `just check`
- `just test` — native: 3325 passed; JS: 3244 passed; cram: 28 passed