### PR TITLE
docs(prompt): fix and fence the mbtx script snippets

### DIFF
--- a/agent_explore/explore_system_prompt.mbt.md
+++ b/agent_explore/explore_system_prompt.mbt.md
@@ -67,7 +67,7 @@ snippet may start and its isolation rules. The `source` argument is a whole
 prompt/default_prompt.mbt.md; the comment is stripped from the generated
 prompt. -->
 
-```mbt nocheck
+```mbtx
 ///|
 import {
   "moonbitlang/async",

--- a/agent_explore/explore_system_prompt.mbt.md
+++ b/agent_explore/explore_system_prompt.mbt.md
@@ -103,7 +103,7 @@ MoonBit here, which also works on Windows, where the binaries do not exist:
 | Command     | Alternatives     |
 |-------------|------------------|
 | ls          | @fs.readdir(dir) |
-| find        | @shell.glob(pattern) |
+| find        | @shell.glob(pattern), spread into args as `[..files]` |
 | cat         | @fs.read_file(p).text() |
 | head/tail   | slice the split text; wc -l → count it |
 | grep        | rg, or .split("\n").filter(...) on captured output |

--- a/agent_explore/generated_explore_system_prompt.mbt
+++ b/agent_explore/generated_explore_system_prompt.mbt
@@ -106,7 +106,7 @@ fn explore_system_prompt() -> String {
     #|| Command     | Alternatives     |
     #||-------------|------------------|
     #|| ls          | @fs.readdir(dir) |
-    #|| find        | @shell.glob(pattern) |
+    #|| find        | @shell.glob(pattern), spread into args as `[..files]` |
     #|| cat         | @fs.read_file(p).text() |
     #|| head/tail   | slice the split text; wc -l → count it |
     #|| grep        | rg, or .split("\n").filter(...) on captured output |

--- a/agent_explore/generated_explore_system_prompt.mbt
+++ b/agent_explore/generated_explore_system_prompt.mbt
@@ -70,7 +70,7 @@ fn explore_system_prompt() -> String {
     #|
     #|
     #|
-    #|```mbt nocheck
+    #|```mbtx
     #|///|
     #|import {
     #|  "moonbitlang/async",

--- a/agent_review/audit_system_prompt.mbt.md
+++ b/agent_review/audit_system_prompt.mbt.md
@@ -53,7 +53,7 @@ snippet may start and its isolation rules. The `source` argument is a whole
 prompt/default_prompt.mbt.md; the comment is stripped from the generated
 prompt. -->
 
-```mbt nocheck
+```mbtx
 ///|
 import {
   "moonbitlang/async",

--- a/agent_review/audit_system_prompt.mbt.md
+++ b/agent_review/audit_system_prompt.mbt.md
@@ -89,7 +89,7 @@ MoonBit here, which also works on Windows, where the binaries do not exist:
 | Command     | Alternatives     |
 |-------------|------------------|
 | ls          | @fs.readdir(dir) |
-| find        | @shell.glob(pattern) |
+| find        | @shell.glob(pattern), spread into args as `[..files]` |
 | cat         | @fs.read_file(p).text() |
 | head/tail   | slice the split text; wc -l → count it |
 | grep        | rg, or .split("\n").filter(...) on captured output |

--- a/agent_review/generated_audit_system_prompt.mbt
+++ b/agent_review/generated_audit_system_prompt.mbt
@@ -92,7 +92,7 @@ fn audit_system_prompt() -> String {
     #|| Command     | Alternatives     |
     #||-------------|------------------|
     #|| ls          | @fs.readdir(dir) |
-    #|| find        | @shell.glob(pattern) |
+    #|| find        | @shell.glob(pattern), spread into args as `[..files]` |
     #|| cat         | @fs.read_file(p).text() |
     #|| head/tail   | slice the split text; wc -l → count it |
     #|| grep        | rg, or .split("\n").filter(...) on captured output |

--- a/agent_review/generated_audit_system_prompt.mbt
+++ b/agent_review/generated_audit_system_prompt.mbt
@@ -56,7 +56,7 @@ fn audit_system_prompt() -> String {
     #|
     #|
     #|
-    #|```mbt nocheck
+    #|```mbtx
     #|///|
     #|import {
     #|  "moonbitlang/async",

--- a/agent_review/generated_review_system_prompt.mbt
+++ b/agent_review/generated_review_system_prompt.mbt
@@ -30,7 +30,7 @@ fn review_system_prompt() -> String {
     #|
     #|
     #|
-    #|```mbt nocheck
+    #|```mbtx
     #|///|
     #|import {
     #|  "moonbitlang/async",

--- a/agent_review/generated_review_system_prompt.mbt
+++ b/agent_review/generated_review_system_prompt.mbt
@@ -66,7 +66,7 @@ fn review_system_prompt() -> String {
     #|| Command     | Alternatives     |
     #||-------------|------------------|
     #|| ls          | @fs.readdir(dir) |
-    #|| find        | @shell.glob(pattern) |
+    #|| find        | @shell.glob(pattern), spread into args as `[..files]` |
     #|| cat         | @fs.read_file(p).text() |
     #|| head/tail   | slice the split text; wc -l → count it |
     #|| grep        | rg, or .split("\n").filter(...) on captured output |

--- a/agent_review/review_system_prompt.mbt.md
+++ b/agent_review/review_system_prompt.mbt.md
@@ -63,7 +63,7 @@ MoonBit here, which also works on Windows, where the binaries do not exist:
 | Command     | Alternatives     |
 |-------------|------------------|
 | ls          | @fs.readdir(dir) |
-| find        | @shell.glob(pattern) |
+| find        | @shell.glob(pattern), spread into args as `[..files]` |
 | cat         | @fs.read_file(p).text() |
 | head/tail   | slice the split text; wc -l → count it |
 | grep        | rg, or .split("\n").filter(...) on captured output |

--- a/agent_review/review_system_prompt.mbt.md
+++ b/agent_review/review_system_prompt.mbt.md
@@ -27,7 +27,7 @@ snippet may start and its isolation rules. The `source` argument is a whole
 prompt/default_prompt.mbt.md; the comment is stripped from the generated
 prompt. -->
 
-```mbt nocheck
+```mbtx
 ///|
 import {
   "moonbitlang/async",

--- a/agent_worker/generated_worker_system_prompt.mbt
+++ b/agent_worker/generated_worker_system_prompt.mbt
@@ -125,7 +125,7 @@ fn worker_system_prompt() -> String {
     #|| Command     | Alternatives     |
     #||-------------|------------------|
     #|| ls          | @fs.readdir(dir) |
-    #|| find        | @shell.glob(pattern) |
+    #|| find        | @shell.glob(pattern), spread into args as `[..files]` |
     #|| cat         | @fs.read_file(p).text() |
     #|| head/tail   | slice the split text; wc -l → count it |
     #|| grep        | rg, or .split("\n").filter(...) on captured output |

--- a/agent_worker/generated_worker_system_prompt.mbt
+++ b/agent_worker/generated_worker_system_prompt.mbt
@@ -89,7 +89,7 @@ fn worker_system_prompt() -> String {
     #|
     #|
     #|
-    #|```mbt nocheck
+    #|```mbtx
     #|///|
     #|import {
     #|  "moonbitlang/async",

--- a/agent_worker/worker_system_prompt.mbt.md
+++ b/agent_worker/worker_system_prompt.mbt.md
@@ -86,7 +86,7 @@ snippet may start and its isolation rules. The `source` argument is a whole
 prompt/default_prompt.mbt.md; the comment is stripped from the generated
 prompt. -->
 
-```mbt nocheck
+```mbtx
 ///|
 import {
   "moonbitlang/async",

--- a/agent_worker/worker_system_prompt.mbt.md
+++ b/agent_worker/worker_system_prompt.mbt.md
@@ -122,7 +122,7 @@ MoonBit here, which also works on Windows, where the binaries do not exist:
 | Command     | Alternatives     |
 |-------------|------------------|
 | ls          | @fs.readdir(dir) |
-| find        | @shell.glob(pattern) |
+| find        | @shell.glob(pattern), spread into args as `[..files]` |
 | cat         | @fs.read_file(p).text() |
 | head/tail   | slice the split text; wc -l → count it |
 | grep        | rg, or .split("\n").filter(...) on captured output |

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -1,4 +1,4 @@
-You are SeekMoon, a MoonBit coding agent focused on implementing user tasks.<!-- prompt-source: this file is a MoonBit blackbox-test file; mbt check blocks are checked by moon check deny-warn mode and moon test with imports in prompt/moon.pkg; mbt nocheck blocks are illustrative. -->
+You are SeekMoon, a MoonBit coding agent focused on implementing user tasks.<!-- prompt-source: this file is a MoonBit blackbox-test file; mbt check blocks are checked by moon check deny-warn mode and moon test with imports in prompt/moon.pkg; mbtx blocks are single-file .mbtx scripts, which moon does not check today, so verify them by running them through the mbtx tool; mbt nocheck blocks are illustrative. -->
 
 Use the native tools to inspect, create, edit, validate, and finish work. If
 work is needed, call a tool. When the task is complete, call `finish`.
@@ -48,7 +48,7 @@ program:
 
 A minimal script can inspect paths without spawning a process:
 
-```mbt nocheck
+```mbtx
 ///|
 import {
   "moonbitlang/async",
@@ -130,7 +130,7 @@ The plain command shape captures both streams and reads them back through
 `Output`'s accessor methods — `out.stdout()`, `out.stderr()`, and
 `out.exit_code()`:
 
-```mbt nocheck
+```mbtx
 ///|
 import {
   "moonbitlang/async",
@@ -161,7 +161,7 @@ matter.
 For compiler feedback, stream the line-delimited JSON from one `moon check`
 rather than collecting it and parsing it afterward:
 
-```mbt nocheck
+```mbtx
 ///|
 import {
   "moonbitlang/async",

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -77,8 +77,11 @@ async fn main {
 interpolating, or `"\{home}/.moon"` renders as `Some(/Users/me)/.moon`.
 
 `@shell.glob` expands `*`, `?`, character sets, and `**` without shell
-parsing; its sorted matches are ordinary `Array[String]` values. A pattern
-that matches nothing returns an empty array.
+parsing; it is `async`, and its sorted matches are ordinary `Array[String]`
+values. A pattern that matches nothing returns an empty array. Spread them
+into a command's arguments — `@shell.Cmd("rg", ["-c", "TODO", ..files])`; a
+bare `@shell.glob(...)` in an argument array is an `Array[String]` where a
+`String` is wanted and does not compile.
 
 Use `@shell.Cmd` to run an external program and capture its output. Only
 these programs can be started:
@@ -107,7 +110,7 @@ where the binaries do not exist:
 | Command     | Alternatives     |
 |-------------|------------------|
 | ls          | @fs.readdir(dir) |
-| find        | @shell.glob(pattern) |
+| find        | @shell.glob(pattern), spread into args as `[..files]` |
 | cat         | @fs.read_file(p).text() |
 | head/tail   | slice the split text; wc -l → count it |
 | grep        | rg, or .split("\n").filter(...) on captured output |

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -53,7 +53,7 @@ fn default_prompt() -> String {
     #|
     #|A minimal script can inspect paths without spawning a process:
     #|
-    #|```mbt nocheck
+    #|```mbtx
     #|///|
     #|import {
     #|  "moonbitlang/async",
@@ -135,7 +135,7 @@ fn default_prompt() -> String {
     #|`Output`'s accessor methods — `out.stdout()`, `out.stderr()`, and
     #|`out.exit_code()`:
     #|
-    #|```mbt nocheck
+    #|```mbtx
     #|///|
     #|import {
     #|  "moonbitlang/async",
@@ -166,7 +166,7 @@ fn default_prompt() -> String {
     #|For compiler feedback, stream the line-delimited JSON from one `moon check`
     #|rather than collecting it and parsing it afterward:
     #|
-    #|```mbt nocheck
+    #|```mbtx
     #|///|
     #|import {
     #|  "moonbitlang/async",

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -82,8 +82,11 @@ fn default_prompt() -> String {
     #|interpolating, or `"\{home}/.moon"` renders as `Some(/Users/me)/.moon`.
     #|
     #|`@shell.glob` expands `*`, `?`, character sets, and `**` without shell
-    #|parsing; its sorted matches are ordinary `Array[String]` values. A pattern
-    #|that matches nothing returns an empty array.
+    #|parsing; it is `async`, and its sorted matches are ordinary `Array[String]`
+    #|values. A pattern that matches nothing returns an empty array. Spread them
+    #|into a command's arguments — `@shell.Cmd("rg", ["-c", "TODO", ..files])`; a
+    #|bare `@shell.glob(...)` in an argument array is an `Array[String]` where a
+    #|`String` is wanted and does not compile.
     #|
     #|Use `@shell.Cmd` to run an external program and capture its output. Only
     #|these programs can be started:
@@ -112,7 +115,7 @@ fn default_prompt() -> String {
     #|| Command     | Alternatives     |
     #||-------------|------------------|
     #|| ls          | @fs.readdir(dir) |
-    #|| find        | @shell.glob(pattern) |
+    #|| find        | @shell.glob(pattern), spread into args as `[..files]` |
     #|| cat         | @fs.read_file(p).text() |
     #|| head/tail   | slice the split text; wc -l → count it |
     #|| grep        | rg, or .split("\n").filter(...) on captured output |


### PR DESCRIPTION
Two related fixes to the `.mbtx` script snippets in the system prompts.

## 1. Show how to pass glob matches to a command

`@shell.glob` returns `Array[String]` and `@shell.Cmd` takes its arguments as `Array[String]`, so a bare `@shell.glob(...)` inside an argument array is an array where a string is wanted, and does not compile:

```
Error: [4014] Expr Type Mismatch
   has type : Array[String]
   wanted   : String
```

Nothing in the prompts said so. Worse, the shell-alternatives table lists `find → @shell.glob(pattern)` two rows above `grep → rg`, which reads as an invitation to write exactly that. The working form spreads the matches — `["-c", "TODO", ..files]` — and was shown nowhere.

This says so where glob is explained, and amends the table row in all five prompts that carry it.

It also notes that `glob` is **`async`** (`pub async fn glob(String, cwd? : String) -> Array[String]`). It reads the filesystem, so a plain `fn` helper calling it fails with errors 4122/4149 — easy to miss for something that looks like pure pattern expansion.

Verified by running each form as a real `.mbtx` script:

| Form | Result |
| --- | --- |
| `Cmd("rg", ["-n", "x", @shell.glob(...)])` | **fails**, error 4014 |
| `Cmd("rg", ["-c", "TODO", ..files])` | runs, `exit=0` |
| `fn helper() { @shell.glob(...) }` (non-async) | **fails**, errors 4122/4149 |
| `@shell.glob("agent_tool/mbtx/*.mbt")` | 5 sorted paths — confirms the existing "sorted `Array[String]`" claim |

## 2. Fence single-file scripts as `mbtx`

The script examples were fenced ` ```mbt nocheck `, which says only "MoonBit we chose not to check" and lumps them in with illustrative fragments. They are a distinct thing: whole single-file programs in the format the mbtx tool's `source` argument takes. They are now fenced ` ```mbtx `, after the extension they actually are.

Seven blocks qualify — an inline `import { … }` block plus a top-level `main` — three in the default prompt and one each in explore, review, audit, and worker. They are only **three distinct programs**; the `rg` capture is byte-identical across five files.

Blocks that are not scripts keep ` ```mbt nocheck `: the checked-error `suberror` sample (package-shaped) and `base_prompt`'s fragments.

### Caveat, stated plainly

**`moon` does not check ` ```mbtx ` blocks today.** I verified this by injecting `let deliberate : Int = "not an int"` into one and watching `moon check --deny-warn` pass clean. `moon check` and `moon build` also ignore a `.mbtx` path entirely ("no work to do"); only `moon run` type-checks one.

So this fence is a **marker to build tooling on, not verification** — the tooling is intended as follow-up. Until it exists, the three programs were each run through `moon run` by hand.

## Audit of the existing snippets

All four distinct `nocheck` examples were extracted and run before any edit — the glob/readdir/env probe, the `rg` capture, the `moon check --output-json` line-streamer, and the checked-error sample. **All four compile and run unchanged**, so none were rewritten. (The `rg` one reports `exit=2` here only because this repo has no `src/` directory; the script itself is correct.)

I also tested converting the checked-error block to ` ```mbt check `. It cannot be: `[4069] Unexpected main function in the non-main package`, plus `unnecessary_annotation` on the `ParseError::` prefixes. Making it compile would mean deleting its `fn main raise` demonstration, which `prompt/moon.pkg` explicitly warns against — prompt text is eval'd, not documentation. So it stays `nocheck`.

## Testing

| Gate | Result |
| --- | --- |
| `moon check --target native --deny-warn` | pass |
| `moon check --target js --deny-warn` | pass |
| `moon test --target native` on `prompt`, `agent`, `agent_explore`, `agent_review`, `agent_worker` | 144/144 pass |
| `moon test --target js` | 3266/3266 pass |
| `moon cram test tests/cram` | 28/28 pass |
| All 3 distinct `mbtx` scripts via `moon run` | all run |

Generated `generated_*_system_prompt.mbt` files are regenerated by the `md_to_mbt_string` dev_build rule and included. The convention comment at the top of the default prompt records all three fence kinds; it is an HTML comment, stripped from the generated prompt, so it costs the model nothing.

Same pre-existing local-toolchain caveats as #1096, both unrelated: whole-workspace native tests cannot complete on moonc `0.10.11` (the graphviz ICE CI's pin to `0.10.10` documents), and `moon fmt --check` flags files this PR does not touch, including a spot already dirty on `main` at `default_prompt.mbt.md:835-841`. Every line this PR adds is format-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tk6HwkrfbJhhQRTHc5fJjE