### PR TITLE
refactor(desktop): separate text and semantic search state

### DIFF
--- a/desktop/frontend/grep_search/request.mbt
+++ b/desktop/frontend/grep_search/request.mbt
@@ -45,12 +45,9 @@ priv enum LoadedReply {
 }
 
 ///|
-fn cancel_search(
-  owner : @interop.ConversationKey,
-  request : SearchRequest,
-) -> Unit {
+fn SearchRequest::cancel(self : SearchRequest, owner : @interop.ConversationKey) -> Unit {
   @js.async_run(() => {
-    match request {
+    match self {
       Text(payload) =>
         ignore(
           @interop.bridge_request(
@@ -179,7 +176,7 @@ fn search_request_loader(
       active = false
       @dom.window().clear_timeout(timer)
       if !settled {
-        cancel_search(owner, request)
+        request.cancel(owner)
       }
     },
     update_tagger: payload => {

--- a/desktop/frontend/grep_search/request.mbt
+++ b/desktop/frontend/grep_search/request.mbt
@@ -23,12 +23,10 @@ struct SearchRequestIdentity {
 ///|
 fn SearchRequest::identity(self : SearchRequest) -> SearchRequestIdentity {
   match self {
-    Text(payload) => { root: payload.root, generation: payload.generation, kind: "text" }
-    Semantic(payload) => {
-      root: payload.root,
-      generation: payload.generation,
-      kind: "semantic",
-    }
+    Text(payload) =>
+      { root: payload.root, generation: payload.generation, kind: "text", }
+    Semantic(payload) =>
+      { root: payload.root, generation: payload.generation, kind: "semantic", }
   }
 }
 
@@ -45,7 +43,10 @@ priv enum LoadedReply {
 }
 
 ///|
-fn SearchRequest::cancel(self : SearchRequest, owner : @interop.ConversationKey) -> Unit {
+fn SearchRequest::cancel(
+  self : SearchRequest,
+  owner : @interop.ConversationKey,
+) -> Unit {
   @js.async_run(() => {
     match self {
       Text(payload) =>
@@ -90,8 +91,8 @@ fn search_request_loader(
   let mut emit = emit
   let mut active = true
   let mut settled = false
-   let identity = request.identity()
-   let request_root = identity.root
+  let identity = request.identity()
+  let request_root = identity.root
   let request_generation = request.generation()
   let timer = @dom.window().set_timeout(
     () => {
@@ -217,7 +218,7 @@ pub fn State::subscription(
   let identity = request.identity()
   let request_root = identity.root
   @sub.custom_sub(
-     "grep-search:\{input.owner.channel.uri_authority()}:\{input.owner.session}:\{request_root}:\{identity.generation}:\{identity.kind}",
+    "grep-search:\{input.owner.channel.uri_authority()}:\{input.owner.session}:\{request_root}:\{identity.generation}:\{identity.kind}",
     Local,
     SearchRequestSub::SearchRequest(input.owner, request, page.delay_ms, emit),
     @sub.SubLoader(search_request_loader),

--- a/desktop/frontend/grep_search/request.mbt
+++ b/desktop/frontend/grep_search/request.mbt
@@ -14,19 +14,27 @@ priv enum SearchRequest {
 }
 
 ///|
-fn SearchRequest::root_string(self : SearchRequest) -> String {
+struct SearchRequestIdentity {
+  root : String
+  generation : Int
+  kind : String
+} derive(Eq)
+
+///|
+fn SearchRequest::identity(self : SearchRequest) -> SearchRequestIdentity {
   match self {
-    Text(payload) => payload.root
-    Semantic(payload) => payload.root
+    Text(payload) => { root: payload.root, generation: payload.generation, kind: "text" }
+    Semantic(payload) => {
+      root: payload.root,
+      generation: payload.generation,
+      kind: "semantic",
+    }
   }
 }
 
 ///|
 fn SearchRequest::generation(self : SearchRequest) -> Int {
-  match self {
-    Text(payload) => payload.generation
-    Semantic(payload) => payload.generation
-  }
+  self.identity().generation
 }
 
 ///|
@@ -85,7 +93,8 @@ fn search_request_loader(
   let mut emit = emit
   let mut active = true
   let mut settled = false
-  let request_root = request.root_string()
+   let identity = request.identity()
+   let request_root = identity.root
   let request_generation = request.generation()
   let timer = @dom.window().set_timeout(
     () => {
@@ -208,9 +217,10 @@ pub fn State::subscription(
       page.semantic_request_payload(input).map(payload => Semantic(payload))
   }
   guard request is Some(request) else { return @sub.none }
-  let request_root = request.root_string()
+  let identity = request.identity()
+  let request_root = identity.root
   @sub.custom_sub(
-    "grep-search:\{input.owner.channel.uri_authority()}:\{input.owner.session}:\{request_root}:\{request.generation()}:\{match page.mode { Text => "text"; Semantic => "semantic" }}",
+     "grep-search:\{input.owner.channel.uri_authority()}:\{input.owner.session}:\{request_root}:\{identity.generation}:\{identity.kind}",
     Local,
     SearchRequestSub::SearchRequest(input.owner, request, page.delay_ms, emit),
     @sub.SubLoader(search_request_loader),

--- a/desktop/frontend/grep_search/state.mbt
+++ b/desktop/frontend/grep_search/state.mbt
@@ -217,17 +217,7 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
       let generation = self.generation + 1
       {
         generation,
-        page: {
-          ..page,
-          text: { ..page.text, matches: [] },
-          semantic: { ..page.semantic, hits: [], partial: false },
-          match_count: 0,
-          file_count: 0,
-          limit_hit: false,
-          visible_lines: InitialVisibleSearchLines,
-          phase: Idle,
-          generation,
-        },
+        page: { ..page.clear_results(), phase: Idle, generation, },
       }
     }
     CollapseAll => {
@@ -288,9 +278,8 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
       {
         ..self,
         page: {
-          ..page,
+          ..page.clear_results(),
           text: { ..page.text, matches: reply.matches },
-          semantic: { ..page.semantic, hits: [], partial: false },
           match_count: reply.match_count,
           file_count: reply.file_count,
           limit_hit: reply.limit_hit,
@@ -447,6 +436,28 @@ fn Page::active_result_count(self : Page) -> Int {
   match self.mode {
     Text => self.text.matches.length()
     Semantic => self.semantic.hits.length()
+  }
+}
+
+///|
+fn Page::clear_results(self : Page) -> Page {
+  {
+    ..self,
+    text: { ..self.text, matches: [] },
+    semantic: { ..self.semantic, hits: [], partial: false },
+    match_count: 0,
+    file_count: 0,
+    limit_hit: false,
+    visible_lines: InitialVisibleSearchLines,
+  }
+}
+
+///|
+fn Page::result_summary(self : Page) -> SearchResultSummary {
+  {
+    match_count: self.match_count,
+    file_count: self.file_count,
+    limit_hit: self.limit_hit,
   }
 }
 

--- a/desktop/frontend/grep_search/state.mbt
+++ b/desktop/frontend/grep_search/state.mbt
@@ -8,20 +8,20 @@ const MaxSearchResults : Int = 20000
 fn fresh_page() -> Page {
   {
     mode: Text,
-    query: "",
-    regex: false,
-    case_sensitive: false,
-    whole_word: false,
+    text: {
+      query: "",
+      regex: false,
+      case_sensitive: false,
+      whole_word: false,
+      matches: [],
+    },
+    semantic: { patterns: [""], hits: [], partial: false },
     details_open: false,
     include_glob: "",
     exclude_glob: "",
-    patterns: [""],
-    matches: [],
-    semantic_hits: [],
     match_count: 0,
     file_count: 0,
     limit_hit: false,
-    partial: false,
     collapsed: Map([]),
     visible_lines: InitialVisibleSearchLines,
     phase: Idle,
@@ -42,7 +42,8 @@ pub fn State::reset_checkout(self : State) -> State {
       ..fresh_page(),
       generation,
       mode: self.page.mode,
-      patterns: self.page.patterns,
+      text: fresh_page().text,
+      semantic: { ..self.page.semantic, hits: [], partial: false },
     },
     generation,
   }
@@ -70,18 +71,18 @@ fn State::schedule(
 ) -> State {
   let generation = self.generation + 1
   let has_query = match page.mode {
-    Text => !page.query.is_empty()
-    Semantic => page.patterns.any(pattern => !pattern.trim().is_empty())
+    Text => !page.text.query.is_empty()
+    Semantic =>
+      page.semantic.patterns.any(pattern => !pattern.trim().is_empty())
   }
   let page = if !has_query || input.root is None {
     {
       ..page,
-      matches: [],
-      semantic_hits: [],
+      text: { ..page.text, matches: [] },
+      semantic: { ..page.semantic, hits: [], partial: false },
       match_count: 0,
       file_count: 0,
       limit_hit: false,
-      partial: false,
       visible_lines: InitialVisibleSearchLines,
       phase: Idle,
       generation,
@@ -89,11 +90,8 @@ fn State::schedule(
   } else {
     {
       ..page,
-      semantic_hits: if page.mode is Semantic {
-        []
-      } else {
-        page.semantic_hits
-      },
+      text: page.text,
+      semantic: { ..page.semantic, hits: [], partial: false },
       match_count: if page.mode is Semantic {
         0
       } else {
@@ -137,18 +135,21 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
   let page = self.page
   match msg {
     QueryChanged(query) =>
-      self.schedule({ ..page, query, }, input, immediate=false)
+      self.schedule(
+        { ..page, text: { ..page.text, query, } },
+        input,
+        immediate=false,
+      )
     ModeChanged(mode) =>
       self.schedule(
         {
           ..page,
           mode,
           details_open: page.details_open,
-          matches: [],
-          semantic_hits: [],
+          text: { ..page.text, matches: [] },
+          semantic: { ..page.semantic, hits: [], partial: false },
           match_count: 0,
           file_count: 0,
-          partial: false,
           collapsed: Map([]),
         },
         input,
@@ -156,18 +157,25 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
       )
     ToggleCaseSensitive =>
       self.schedule(
-        { ..page, case_sensitive: !page.case_sensitive, },
+        {
+          ..page,
+          text: { ..page.text, case_sensitive: !page.text.case_sensitive },
+        },
         input,
         immediate=false,
       )
     ToggleWholeWord =>
       self.schedule(
-        { ..page, whole_word: !page.whole_word, },
+        { ..page, text: { ..page.text, whole_word: !page.text.whole_word } },
         input,
         immediate=false,
       )
     ToggleRegex =>
-      self.schedule({ ..page, regex: !page.regex, }, input, immediate=false)
+      self.schedule(
+        { ..page, text: { ..page.text, regex: !page.text.regex } },
+        input,
+        immediate=false,
+      )
     ToggleDetails =>
       { ..self, page: { ..page, details_open: !page.details_open, }, }
     IncludeChanged(include_glob) =>
@@ -175,19 +183,34 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
     ExcludeChanged(exclude_glob) =>
       self.schedule({ ..page, exclude_glob, }, input, immediate=false)
     PatternChanged(index, value) => {
-      let patterns = page.patterns.copy()
+      let patterns = page.semantic.patterns.copy()
       if index < patterns.length() {
         patterns[index] = value
       }
-      self.schedule({ ..page, patterns, }, input, immediate=false)
+      self.schedule(
+        { ..page, semantic: { ..page.semantic, patterns, } },
+        input,
+        immediate=false,
+      )
     }
-    AddPattern => { ..self, page: { ..page, patterns: page.patterns + [""], }, }
+    AddPattern =>
+      {
+        ..self,
+        page: {
+          ..page,
+          semantic: { ..page.semantic, patterns: page.semantic.patterns + [""] },
+        },
+      }
     RemovePattern(index) => {
-      let patterns = page.patterns.copy()
+      let patterns = page.semantic.patterns.copy()
       if index < patterns.length() && patterns.length() > 1 {
         let _ = patterns.remove(index)
       }
-      self.schedule({ ..page, patterns, }, input, immediate=false)
+      self.schedule(
+        { ..page, semantic: { ..page.semantic, patterns, } },
+        input,
+        immediate=false,
+      )
     }
     Submit | Refresh => self.schedule(page, input, immediate=true)
     ClearResults => {
@@ -196,12 +219,11 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
         generation,
         page: {
           ..page,
-          matches: [],
-          semantic_hits: [],
+          text: { ..page.text, matches: [] },
+          semantic: { ..page.semantic, hits: [], partial: false },
           match_count: 0,
           file_count: 0,
           limit_hit: false,
-          partial: false,
           visible_lines: InitialVisibleSearchLines,
           phase: Idle,
           generation,
@@ -211,8 +233,8 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
     CollapseAll => {
       let collapsed : Map[String, Bool] = Map([])
       let active = match page.mode {
-        Text => page.matches.map(result => result.path)
-        Semantic => page.semantic_hits.map(hit => hit.path)
+        Text => page.text.matches.map(result => result.path)
+        Semantic => page.semantic.hits.map(hit => hit.path)
       }
       for path in active {
         collapsed[path] = true
@@ -267,12 +289,11 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
         ..self,
         page: {
           ..page,
-          matches: reply.matches,
-          semantic_hits: [],
+          text: { ..page.text, matches: reply.matches },
+          semantic: { ..page.semantic, hits: [], partial: false },
           match_count: reply.match_count,
           file_count: reply.file_count,
           limit_hit: reply.limit_hit,
-          partial: false,
           visible_lines: InitialVisibleSearchLines.min(reply.matches.length()),
           phase,
         },
@@ -292,7 +313,7 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
           ..self,
           page: {
             ..page,
-            semantic_hits: [],
+            semantic: { ..page.semantic, hits: [], partial: false },
             match_count: 0,
             file_count: 0,
             phase: Idle,
@@ -307,12 +328,14 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
         ..self,
         page: {
           ..page,
-          matches: [],
-          semantic_hits: reply.matches,
+          semantic: {
+            ..page.semantic,
+            hits: reply.matches,
+            partial: reply.partial,
+          },
           match_count: reply.match_count,
           file_count: reply.file_count,
           limit_hit: reply.limit_hit,
-          partial: reply.partial,
           visible_lines: InitialVisibleSearchLines.min(reply.matches.length()),
           phase,
         },
@@ -341,7 +364,11 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
         ..self,
         page: {
           ..page,
-          semantic_hits: page.semantic_hits + matches,
+          semantic: {
+            ..page.semantic,
+            hits: page.semantic.hits + matches,
+            partial: true,
+          },
           match_count,
           file_count,
         },
@@ -355,12 +382,11 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
           ..self,
           page: {
             ..page,
-            matches: [],
-            semantic_hits: [],
+            text: { ..page.text, matches: [] },
+            semantic: { ..page.semantic, hits: [], partial: false },
             match_count: 0,
             file_count: 0,
             limit_hit: false,
-            partial: false,
             visible_lines: InitialVisibleSearchLines,
             phase: Failed(code~, message~),
           },
@@ -384,7 +410,7 @@ pub fn State::editor_highlights(
   let ranges : Array[@common.Range] = []
   match self.page.mode {
     Text =>
-      for result in self.page.matches {
+      for result in self.page.text.matches {
         if result.path == path {
           for range in result.ranges {
             ranges.push(
@@ -399,7 +425,7 @@ pub fn State::editor_highlights(
         }
       }
     Semantic =>
-      for hit in self.page.semantic_hits {
+      for hit in self.page.semantic.hits {
         if hit.path == path {
           ranges.push(
             @common.Range(
@@ -419,8 +445,8 @@ pub fn State::editor_highlights(
 ///|
 fn Page::active_result_count(self : Page) -> Int {
   match self.mode {
-    Text => self.matches.length()
-    Semantic => self.semantic_hits.length()
+    Text => self.text.matches.length()
+    Semantic => self.semantic.hits.length()
   }
 }
 
@@ -430,13 +456,15 @@ fn Page::text_request_payload(
   input : Input,
 ) -> @protocol.SearchTextPayload? {
   guard self.mode is Text else { return None }
-  guard input.root is Some(root) && !self.query.is_empty() else { return None }
+  guard input.root is Some(root) && !self.text.query.is_empty() else {
+    return None
+  }
   Some({
     root: root.path,
-    query: self.query,
-    regex: self.regex,
-    case_sensitive: self.case_sensitive,
-    whole_word: self.whole_word,
+    query: self.text.query,
+    regex: self.text.regex,
+    case_sensitive: self.text.case_sensitive,
+    whole_word: self.text.whole_word,
     include_glob: self.include_glob,
     exclude_glob: self.exclude_glob,
     session_key: "grep-search:\{input.owner.channel.uri_authority()}:\{input.owner.session}:\{root.path}",
@@ -452,7 +480,9 @@ fn Page::semantic_request_payload(
 ) -> @protocol.SearchSemanticPayload? {
   guard self.mode is Semantic else { return None }
   guard input.root is Some(root) else { return None }
-  let patterns = self.patterns.filter(pattern => !pattern.trim().is_empty())
+  let patterns = self.semantic.patterns.filter(pattern => {
+    !pattern.trim().is_empty()
+  })
   guard !patterns.is_empty() else { return None }
   Some({
     root: root.path,
@@ -474,8 +504,8 @@ test "checkout reset clears results while preserving the generation fence" {
   let state = State::empty().handle(QueryChanged("moon"), input)
   let old_generation = state.page.generation
   let reset = state.reset_checkout()
-  assert_eq(reset.page.query, "")
-  assert_true(reset.page.matches.is_empty())
+  assert_eq(reset.page.text.query, "")
+  assert_true(reset.page.text.matches.is_empty())
   assert_true(reset.page.phase is Idle)
   assert_true(reset.page.generation > old_generation)
 }
@@ -495,8 +525,10 @@ test "mode changes preserve each search input and shared details" {
     .handle(AddPattern, input)
     .handle(PatternChanged(1, "match($x)"), input)
   let switched_back = state.handle(ModeChanged(Text), input)
-  assert_eq(switched_back.page.query, "text query")
-  assert_eq(switched_back.page.patterns, ["inspect($(x:arg))", "match($x)"])
+  assert_eq(switched_back.page.text.query, "text query")
+  assert_eq(switched_back.page.semantic.patterns, [
+    "inspect($(x:arg))", "match($x)",
+  ])
   assert_eq(switched_back.page.include_glob, "src/**")
   assert_eq(switched_back.page.exclude_glob, "generated/**")
   assert_false(switched_back.page.details_open)
@@ -568,7 +600,7 @@ test "semantic progress streams partial hits and late progress is fenced" {
     ),
     input,
   )
-  assert_eq(streamed.page.semantic_hits, [hit])
+  assert_eq(streamed.page.semantic.hits, [hit])
   assert_eq(streamed.page.match_count, 1)
   assert_eq(streamed.page.file_count, 1)
   // A progress frame for a previous generation must not touch the page.
@@ -583,7 +615,7 @@ test "semantic progress streams partial hits and late progress is fenced" {
     ),
     input,
   )
-  assert_true(stale.page.semantic_hits.is_empty())
+  assert_true(stale.page.semantic.hits.is_empty())
 }
 
 ///|
@@ -634,7 +666,7 @@ test "semantic progress batches append only new hits" {
     ),
     input,
   )
-  assert_eq(streamed.page.semantic_hits, [hit, second])
+  assert_eq(streamed.page.semantic.hits, [hit, second])
 }
 
 ///|
@@ -674,12 +706,12 @@ test "new semantic search clears partial results and cancellation clears them" {
     input,
   )
   let next = streamed.handle(PatternChanged(0, "match($x)"), input)
-  assert_true(next.page.semantic_hits.is_empty())
+  assert_true(next.page.semantic.hits.is_empty())
   assert_eq(next.page.match_count, 0)
-  let cancelled = streamed.handle(
-    SemanticLoaded(owner~, root=root.path, generation=page.generation, reply={
+  let cancelled = next.handle(
+    SemanticLoaded(owner~, root=root.path, generation=next.page.generation, reply={
       root: root.path,
-      generation: page.generation,
+      generation: next.page.generation,
       matches: [],
       match_count: 0,
       file_count: 0,
@@ -690,7 +722,7 @@ test "new semantic search clears partial results and cancellation clears them" {
     }),
     input,
   )
-  assert_true(cancelled.page.semantic_hits.is_empty())
+  assert_true(cancelled.page.semantic.hits.is_empty())
   assert_eq(cancelled.page.match_count, 0)
 }
 
@@ -711,7 +743,7 @@ test "parking a checkout keeps its draft and fences the in-flight reply" {
   let suspended = running.park()
   let page = suspended.page
   assert_true(page.phase is Idle)
-  assert_eq(page.query, "moon")
+  assert_eq(page.text.query, "moon")
   assert_true(page.generation > old_generation)
   let stale : @protocol.SearchTextReply = {
     root: root.path,
@@ -779,8 +811,8 @@ test "refresh is immediate and loaded file groups can collapse and clear" {
   assert_false(page.collapsed.get("src/main.mbt").unwrap_or(false))
   let cleared = expanded.handle(ClearResults, input)
   let page = cleared.page
-  assert_eq(page.query, "moon")
-  assert_true(page.matches.is_empty())
+  assert_eq(page.text.query, "moon")
+  assert_true(page.text.matches.is_empty())
   assert_true(page.phase is Idle)
 }
 

--- a/desktop/frontend/grep_search/state.mbt
+++ b/desktop/frontend/grep_search/state.mbt
@@ -222,11 +222,7 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
     }
     CollapseAll => {
       let collapsed : Map[String, Bool] = Map([])
-      let active = match page.mode {
-        Text => page.text.matches.map(result => result.path)
-        Semantic => page.semantic.hits.map(hit => hit.path)
-      }
-      for path in active {
+      for path in page.active_paths() {
         collapsed[path] = true
       }
       { ..self, page: { ..page, collapsed, }, }
@@ -396,10 +392,40 @@ pub fn State::editor_highlights(
   path : String,
 ) -> EditorHighlights? {
   guard self.page.phase is Ready else { return None }
+  self.page.active_highlights(path)
+}
+
+///|
+fn Page::active_result_count(self : Page) -> Int {
+  match self.mode {
+    Text => self.text.matches.length()
+    Semantic => self.semantic.hits.length()
+  }
+}
+
+///|
+fn Page::active_file_count(self : Page) -> Int {
+  let files : Map[String, Bool] = Map([])
+  for path in self.active_paths() {
+    files[path] = true
+  }
+  files.length()
+}
+
+///|
+fn Page::active_paths(self : Page) -> Array[String] {
+  match self.mode {
+    Text => self.text.matches.map(result => result.path)
+    Semantic => self.semantic.hits.map(hit => hit.path)
+  }
+}
+
+///|
+fn Page::active_highlights(self : Page, path : String) -> EditorHighlights? {
   let ranges : Array[@common.Range] = []
-  match self.page.mode {
+  match self.mode {
     Text =>
-      for result in self.page.text.matches {
+      for result in self.text.matches {
         if result.path == path {
           for range in result.ranges {
             ranges.push(
@@ -414,7 +440,7 @@ pub fn State::editor_highlights(
         }
       }
     Semantic =>
-      for hit in self.page.semantic.hits {
+      for hit in self.semantic.hits {
         if hit.path == path {
           ranges.push(
             @common.Range(
@@ -429,14 +455,6 @@ pub fn State::editor_highlights(
   }
   guard !ranges.is_empty() else { return None }
   Some({ ranges, })
-}
-
-///|
-fn Page::active_result_count(self : Page) -> Int {
-  match self.mode {
-    Text => self.text.matches.length()
-    Semantic => self.semantic.hits.length()
-  }
 }
 
 ///|
@@ -735,6 +753,66 @@ test "new semantic search clears partial results and cancellation clears them" {
   )
   assert_true(cancelled.page.semantic.hits.is_empty())
   assert_eq(cancelled.page.match_count, 0)
+}
+
+///|
+test "active result helpers share file grouping and highlight projection" {
+  let owner : @interop.ConversationKey = {
+    channel: @interop.ChannelId::Local,
+    session: "active-results",
+  }
+  let root = @common.Uri::parse("file:///work")
+  let input : Input = { owner, root: Some(root) }
+  let state = State::empty().handle(QueryChanged("moon"), input)
+  let page = state.page
+  let first : @protocol.TextSearchMatch = {
+    path: "src/main.mbt",
+    line_number: 2,
+    preview: "moon moon",
+    preview_start_column: 1,
+    ranges: [
+      { start_column: 1, end_column: 5 },
+      { start_column: 6, end_column: 10 },
+    ],
+  }
+  let second : @protocol.TextSearchMatch = {
+    path: "src/main.mbt",
+    line_number: 4,
+    preview: "moon",
+    preview_start_column: 1,
+    ranges: [{ start_column: 1, end_column: 5 }],
+  }
+  let loaded = state.handle(
+    Loaded(
+      owner~,
+      root=root.path,
+      generation=page.generation,
+      reply={
+        root: root.path,
+        generation: page.generation,
+        matches: [first, second],
+        match_count: 2,
+        file_count: 1,
+        limit_hit: false,
+        cancelled: false,
+        error: None,
+      },
+    ),
+    input,
+  )
+  assert_eq(loaded.page.active_result_count(), 2)
+  assert_eq(loaded.page.active_file_count(), 1)
+  guard loaded.editor_highlights("src/main.mbt") is Some(highlights) else {
+    fail("expected text highlights")
+  }
+  assert_eq(
+    highlights.ranges(),
+    [
+      @common.Range(2, 1, 2, 5),
+      @common.Range(2, 6, 2, 10),
+      @common.Range(4, 1, 4, 5),
+    ],
+  )
 }
 
 ///|

--- a/desktop/frontend/grep_search/state.mbt
+++ b/desktop/frontend/grep_search/state.mbt
@@ -15,7 +15,7 @@ fn fresh_page() -> Page {
       whole_word: false,
       matches: [],
     },
-    semantic: { patterns: [""], hits: [], partial: false },
+    semantic: { patterns: [""], hits: [], partial: false, },
     details_open: false,
     include_glob: "",
     exclude_glob: "",
@@ -43,7 +43,7 @@ pub fn State::reset_checkout(self : State) -> State {
       generation,
       mode: self.page.mode,
       text: fresh_page().text,
-      semantic: { ..self.page.semantic, hits: [], partial: false },
+      semantic: { ..self.page.semantic, hits: [], partial: false, },
     },
     generation,
   }
@@ -78,8 +78,8 @@ fn State::schedule(
   let page = if !has_query || input.root is None {
     {
       ..page,
-      text: { ..page.text, matches: [] },
-      semantic: { ..page.semantic, hits: [], partial: false },
+      text: { ..page.text, matches: [], },
+      semantic: { ..page.semantic, hits: [], partial: false, },
       match_count: 0,
       file_count: 0,
       limit_hit: false,
@@ -91,7 +91,7 @@ fn State::schedule(
     {
       ..page,
       text: page.text,
-      semantic: { ..page.semantic, hits: [], partial: false },
+      semantic: { ..page.semantic, hits: [], partial: false, },
       match_count: if page.mode is Semantic {
         0
       } else {
@@ -136,7 +136,7 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
   match msg {
     QueryChanged(query) =>
       self.schedule(
-        { ..page, text: { ..page.text, query, } },
+        { ..page, text: { ..page.text, query, }, },
         input,
         immediate=false,
       )
@@ -146,8 +146,8 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
           ..page,
           mode,
           details_open: page.details_open,
-          text: { ..page.text, matches: [] },
-          semantic: { ..page.semantic, hits: [], partial: false },
+          text: { ..page.text, matches: [], },
+          semantic: { ..page.semantic, hits: [], partial: false, },
           match_count: 0,
           file_count: 0,
           collapsed: Map([]),
@@ -159,20 +159,20 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
       self.schedule(
         {
           ..page,
-          text: { ..page.text, case_sensitive: !page.text.case_sensitive },
+          text: { ..page.text, case_sensitive: !page.text.case_sensitive, },
         },
         input,
         immediate=false,
       )
     ToggleWholeWord =>
       self.schedule(
-        { ..page, text: { ..page.text, whole_word: !page.text.whole_word } },
+        { ..page, text: { ..page.text, whole_word: !page.text.whole_word, }, },
         input,
         immediate=false,
       )
     ToggleRegex =>
       self.schedule(
-        { ..page, text: { ..page.text, regex: !page.text.regex } },
+        { ..page, text: { ..page.text, regex: !page.text.regex, }, },
         input,
         immediate=false,
       )
@@ -188,7 +188,7 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
         patterns[index] = value
       }
       self.schedule(
-        { ..page, semantic: { ..page.semantic, patterns, } },
+        { ..page, semantic: { ..page.semantic, patterns, }, },
         input,
         immediate=false,
       )
@@ -198,7 +198,10 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
         ..self,
         page: {
           ..page,
-          semantic: { ..page.semantic, patterns: page.semantic.patterns + [""] },
+          semantic: {
+            ..page.semantic,
+            patterns: page.semantic.patterns + [""],
+          },
         },
       }
     RemovePattern(index) => {
@@ -207,7 +210,7 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
         let _ = patterns.remove(index)
       }
       self.schedule(
-        { ..page, semantic: { ..page.semantic, patterns, } },
+        { ..page, semantic: { ..page.semantic, patterns, }, },
         input,
         immediate=false,
       )
@@ -275,7 +278,7 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
         ..self,
         page: {
           ..page.clear_results(),
-          text: { ..page.text, matches: reply.matches },
+          text: { ..page.text, matches: reply.matches, },
           match_count: reply.match_count,
           file_count: reply.file_count,
           limit_hit: reply.limit_hit,
@@ -298,7 +301,7 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
           ..self,
           page: {
             ..page,
-            semantic: { ..page.semantic, hits: [], partial: false },
+            semantic: { ..page.semantic, hits: [], partial: false, },
             match_count: 0,
             file_count: 0,
             phase: Idle,
@@ -367,8 +370,8 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
           ..self,
           page: {
             ..page,
-            text: { ..page.text, matches: [] },
-            semantic: { ..page.semantic, hits: [], partial: false },
+            text: { ..page.text, matches: [], },
+            semantic: { ..page.semantic, hits: [], partial: false, },
             match_count: 0,
             file_count: 0,
             limit_hit: false,
@@ -461,8 +464,8 @@ fn Page::active_highlights(self : Page, path : String) -> EditorHighlights? {
 fn Page::clear_results(self : Page) -> Page {
   {
     ..self,
-    text: { ..self.text, matches: [] },
-    semantic: { ..self.semantic, hits: [], partial: false },
+    text: { ..self.text, matches: [], },
+    semantic: { ..self.semantic, hits: [], partial: false, },
     match_count: 0,
     file_count: 0,
     limit_hit: false,
@@ -762,7 +765,7 @@ test "active result helpers share file grouping and highlight projection" {
     session: "active-results",
   }
   let root = @common.Uri::parse("file:///work")
-  let input : Input = { owner, root: Some(root) }
+  let input : Input = { owner, root: Some(root), }
   let state = State::empty().handle(QueryChanged("moon"), input)
   let page = state.page
   let first : @protocol.TextSearchMatch = {
@@ -771,8 +774,8 @@ test "active result helpers share file grouping and highlight projection" {
     preview: "moon moon",
     preview_start_column: 1,
     ranges: [
-      { start_column: 1, end_column: 5 },
-      { start_column: 6, end_column: 10 },
+      { start_column: 1, end_column: 5, },
+      { start_column: 6, end_column: 10, },
     ],
   }
   let second : @protocol.TextSearchMatch = {
@@ -780,24 +783,19 @@ test "active result helpers share file grouping and highlight projection" {
     line_number: 4,
     preview: "moon",
     preview_start_column: 1,
-    ranges: [{ start_column: 1, end_column: 5 }],
+    ranges: [{ start_column: 1, end_column: 5, }],
   }
   let loaded = state.handle(
-    Loaded(
-      owner~,
-      root=root.path,
-      generation=page.generation,
-      reply={
-        root: root.path,
-        generation: page.generation,
-        matches: [first, second],
-        match_count: 2,
-        file_count: 1,
-        limit_hit: false,
-        cancelled: false,
-        error: None,
-      },
-    ),
+    Loaded(owner~, root=root.path, generation=page.generation, reply={
+      root: root.path,
+      generation: page.generation,
+      matches: [first, second],
+      match_count: 2,
+      file_count: 1,
+      limit_hit: false,
+      cancelled: false,
+      error: None,
+    }),
     input,
   )
   assert_eq(loaded.page.active_result_count(), 2)
@@ -805,14 +803,11 @@ test "active result helpers share file grouping and highlight projection" {
   guard loaded.editor_highlights("src/main.mbt") is Some(highlights) else {
     fail("expected text highlights")
   }
-  assert_eq(
-    highlights.ranges(),
-    [
-      @common.Range(2, 1, 2, 5),
-      @common.Range(2, 6, 2, 10),
-      @common.Range(4, 1, 4, 5),
-    ],
-  )
+  assert_eq(highlights.ranges(), [
+    @common.Range(2, 1, 2, 5),
+    @common.Range(2, 6, 2, 10),
+    @common.Range(4, 1, 4, 5),
+  ])
 }
 
 ///|

--- a/desktop/frontend/grep_search/types.mbt
+++ b/desktop/frontend/grep_search/types.mbt
@@ -31,22 +31,32 @@ enum Mode {
 } derive(Eq, Debug)
 
 ///|
-struct Page {
-  mode : Mode
+struct TextSearchState {
   query : String
   regex : Bool
   case_sensitive : Bool
   whole_word : Bool
+  matches : Array[@protocol.TextSearchMatch]
+} derive(Eq)
+
+///|
+struct SemanticSearchState {
+  patterns : Array[String]
+  hits : Array[@protocol.SemanticSearchHit]
+  partial : Bool
+} derive(Eq)
+
+///|
+struct Page {
+  mode : Mode
+  text : TextSearchState
+  semantic : SemanticSearchState
   details_open : Bool
   include_glob : String
   exclude_glob : String
-  patterns : Array[String]
-  matches : Array[@protocol.TextSearchMatch]
-  semantic_hits : Array[@protocol.SemanticSearchHit]
   match_count : Int
   file_count : Int
   limit_hit : Bool
-  partial : Bool
   collapsed : Map[String, Bool]
   visible_lines : Int
   phase : Phase

--- a/desktop/frontend/grep_search/types.mbt
+++ b/desktop/frontend/grep_search/types.mbt
@@ -47,6 +47,13 @@ struct SemanticSearchState {
 } derive(Eq)
 
 ///|
+struct SearchResultSummary {
+  match_count : Int
+  file_count : Int
+  limit_hit : Bool
+} derive(Eq)
+
+///|
 struct Page {
   mode : Mode
   text : TextSearchState

--- a/desktop/frontend/grep_search/view.mbt
+++ b/desktop/frontend/grep_search/view.mbt
@@ -62,7 +62,7 @@ fn grouped_matches(
 fn visible_file_groups(page : Page) -> Array[FileGroup] {
   let visible : Array[FileGroup] = []
   let mut remaining = page.visible_lines.max(0)
-  for group in grouped_matches(page.matches) {
+  for group in grouped_matches(page.text.matches) {
     guard remaining > 0 else { break }
     let rows : Array[@protocol.TextSearchMatch] = []
     for result in group.matches {
@@ -203,18 +203,18 @@ fn mode_options(page : Page, emit : @cmd.Emit[Msg]) -> @html.Html {
       toggle_button(
         "Aa",
         "Match Case",
-        page.case_sensitive,
+        page.text.case_sensitive,
         emit(ToggleCaseSensitive),
       ),
       whole_word_toggle_button(
         "Match Whole Word",
-        page.whole_word,
+        page.text.whole_word,
         emit(ToggleWholeWord),
       ),
       toggle_button(
         ".*",
         "Use Regular Expression",
-        page.regex,
+        page.text.regex,
         emit(ToggleRegex),
       ),
     ])
@@ -360,7 +360,7 @@ fn search_message(page : Page) -> @html.Html? {
           },
         ),
       )
-    Idle if page.query.is_empty() =>
+    Idle if page.text.query.is_empty() =>
       Some(
         @html.div(
           class="search-empty",
@@ -432,9 +432,9 @@ fn text_search_body(
     for group in visible_file_groups(page) {
       children.push(file_group_view(page, group, emit, open_match))
     }
-    let shown = page.visible_lines.min(page.matches.length())
-    if shown < page.matches.length() {
-      let next = VisibleSearchLineStep.min(page.matches.length() - shown)
+    let shown = page.visible_lines.min(page.text.matches.length())
+    if shown < page.text.matches.length() {
+      let next = VisibleSearchLineStep.min(page.text.matches.length() - shown)
       children.push(
         @html.div(class="search-show-more", [
           @html.button(
@@ -443,7 +443,7 @@ fn text_search_body(
           ),
           @html.div(
             class="search-show-more-detail",
-            "\{shown} of \{page.matches.length()} matching lines rendered",
+            "\{shown} of \{page.text.matches.length()} matching lines rendered",
           ),
         ]),
       )
@@ -486,7 +486,7 @@ fn semantic_grouped_hits(
 fn visible_semantic_file_groups(page : Page) -> Array[SemanticFileGroup] {
   let visible : Array[SemanticFileGroup] = []
   let mut remaining = page.visible_lines.max(0)
-  for group in semantic_grouped_hits(page.semantic_hits) {
+  for group in semantic_grouped_hits(page.semantic.hits) {
     guard remaining > 0 else { break }
     let rows : Array[@protocol.SemanticSearchHit] = []
     for hit in group.hits {
@@ -598,7 +598,7 @@ fn semantic_search_body(
   let children : Array[@html.Html] = []
   let busy = page.phase is Debouncing || page.phase is Loading
   let summary = if busy {
-    if page.semantic_hits.is_empty() {
+    if page.semantic.hits.is_empty() {
       "Searching…"
     } else {
       // The scan is still running; these counts are the partial stream, not
@@ -626,7 +626,7 @@ fn semantic_search_body(
       ),
     )
   }
-  if page.partial {
+  if page.semantic.partial {
     children.push(
       @html.div(
         class="search-truncated",
@@ -641,15 +641,15 @@ fn semantic_search_body(
   for group in visible_semantic_file_groups(page) {
     children.push(semantic_file_group_view(page, group, emit, open_match))
   }
-  let shown = page.visible_lines.min(page.semantic_hits.length())
-  if shown < page.semantic_hits.length() {
-    let next = VisibleSearchLineStep.min(page.semantic_hits.length() - shown)
+  let shown = page.visible_lines.min(page.semantic.hits.length())
+  if shown < page.semantic.hits.length() {
+    let next = VisibleSearchLineStep.min(page.semantic.hits.length() - shown)
     children.push(
       @html.div(class="search-show-more", [
         @html.button(on_click=emit(ShowMore), "Show \{next} more matches"),
         @html.div(
           class="search-show-more-detail",
-          "\{shown} of \{page.semantic_hits.length()} matches rendered",
+          "\{shown} of \{page.semantic.hits.length()} matches rendered",
         ),
       ]),
     )
@@ -701,7 +701,7 @@ fn page_view(
       if page.mode is Text {
         @html.input(
           input_type=@html.InputType::Text,
-          value=page.query,
+          value=page.text.query,
           placeholder="Search",
           on_input=emit.map(value => QueryChanged(value)),
           attrs=query_key_attrs(emit),
@@ -709,7 +709,7 @@ fn page_view(
       } else {
         @html.input(
           input_type=@html.InputType::Text,
-          value=page.patterns[0],
+          value=page.semantic.patterns[0],
           placeholder="inspect($(x:arg))",
           on_input=emit.map(value => PatternChanged(0, value)),
           attrs=@html.Attrs::build()
@@ -733,7 +733,7 @@ fn page_view(
     ]),
     if page.mode is Semantic {
       let patterns : Array[@html.Html] = []
-      for index, pattern in page.patterns {
+      for index, pattern in page.semantic.patterns {
         if index > 0 {
           patterns.push(
             @html.div(class="search-semantic-source", [

--- a/desktop/frontend/grep_search/view.mbt
+++ b/desktop/frontend/grep_search/view.mbt
@@ -404,12 +404,13 @@ fn text_search_body(
   let children : Array[@html.Html] = []
   let busy = page.phase is Debouncing || page.phase is Loading
   let summary = page.result_summary()
+  let file_count = page.active_file_count()
   let summary_text = if busy {
     "Searching…"
   } else if summary.match_count == 1 {
-    "1 result in \{summary.file_count} file"
+    "1 result in \{file_count} file"
   } else {
-    "\{summary.match_count} results in \{summary.file_count} files"
+    "\{summary.match_count} results in \{file_count} files"
   }
   children.push(
     @html.div(
@@ -598,6 +599,8 @@ fn semantic_search_body(
 ) -> @html.Html {
   let children : Array[@html.Html] = []
   let busy = page.phase is Debouncing || page.phase is Loading
+  let summary = page.result_summary()
+  let file_count = page.active_file_count()
   let summary = if busy {
     if page.semantic.hits.is_empty() {
       "Searching…"
@@ -606,10 +609,10 @@ fn semantic_search_body(
       // the final totals the reply will replace.
       "\{page.match_count} matches in \{page.file_count} files so far…"
     }
-  } else if page.match_count == 1 {
-    "1 match in \{page.file_count} file"
+  } else if summary.match_count == 1 {
+    "1 match in \{file_count} file"
   } else {
-    "\{page.match_count} matches in \{page.file_count} files"
+    "\{summary.match_count} matches in \{file_count} files"
   }
   children.push(
     @html.div(

--- a/desktop/frontend/grep_search/view.mbt
+++ b/desktop/frontend/grep_search/view.mbt
@@ -403,21 +403,22 @@ fn text_search_body(
 ) -> @html.Html {
   let children : Array[@html.Html] = []
   let busy = page.phase is Debouncing || page.phase is Loading
-  let summary = if busy {
+  let summary = page.result_summary()
+  let summary_text = if busy {
     "Searching…"
-  } else if page.match_count == 1 {
-    "1 result in \{page.file_count} file"
+  } else if summary.match_count == 1 {
+    "1 result in \{summary.file_count} file"
   } else {
-    "\{page.match_count} results in \{page.file_count} files"
+    "\{summary.match_count} results in \{summary.file_count} files"
   }
   children.push(
     @html.div(
       class="search-summary",
       attrs=@html.Attrs::build().aria_live("polite").aria_busy(busy.to_string()),
-      summary,
+      summary_text,
     ),
   )
-  if page.limit_hit {
+  if summary.limit_hit {
     children.push(
       @html.div(
         class="search-truncated",

--- a/desktop/frontend/grep_search/view.mbt
+++ b/desktop/frontend/grep_search/view.mbt
@@ -599,7 +599,7 @@ fn semantic_search_body(
 ) -> @html.Html {
   let children : Array[@html.Html] = []
   let busy = page.phase is Debouncing || page.phase is Loading
-  let summary = page.result_summary()
+  let result_summary = page.result_summary()
   let file_count = page.active_file_count()
   let summary = if busy {
     if page.semantic.hits.is_empty() {
@@ -607,12 +607,12 @@ fn semantic_search_body(
     } else {
       // The scan is still running; these counts are the partial stream, not
       // the final totals the reply will replace.
-      "\{page.match_count} matches in \{page.file_count} files so far…"
+      "\{result_summary.match_count} matches in \{file_count} files so far…"
     }
-  } else if summary.match_count == 1 {
+  } else if result_summary.match_count == 1 {
     "1 match in \{file_count} file"
   } else {
-    "\{summary.match_count} matches in \{file_count} files"
+    "\{result_summary.match_count} matches in \{file_count} files"
   }
   children.push(
     @html.div(
@@ -621,7 +621,7 @@ fn semantic_search_body(
       summary,
     ),
   )
-  if page.limit_hit {
+  if result_summary.limit_hit {
     children.push(
       @html.div(
         class="search-truncated",


### PR DESCRIPTION
## Summary

Refactor the desktop search frontend to separate Text and Semantic search state while preserving the existing behavior.

## Changes

- Split mode-specific page state into `TextSearchState` and `SemanticSearchState`.
- Centralize shared search state helpers:
  - result clearing
  - result summaries
  - active result counts
  - active file paths
  - editor highlights
- Centralize request identity handling for root, generation, and search kind.
- Bind cancellation behavior directly to `SearchRequest`.
- Keep Text and Semantic search inputs and results isolated when switching modes.
- Preserve stale reply and progress fencing through owner, root, generation, and mode checks.
- Keep common result rendering behavior consistent across both search modes.
- Clarify Semantic search summary state handling.

## Behavior

- Text search behavior is unchanged.
- Semantic search behavior is unchanged.
- Mode switching preserves the independent Text and Semantic inputs.
- Search cancellation continues to cancel the correct backend request.
- Stale replies and progress notifications cannot overwrite the current search state.

## Verification

- `moon check desktop`
- `moon test desktop/frontend/grep_search --target js`
- Result: 14 tests passed
- `git diff --check`

Manual verification covered:

- Text search
- Semantic search
- Mode switching
- Clear Results
- Refresh
- Search cancellation
- Checkout switching
- Result highlighting
- File collapsing