### PR TITLE
chore(editor): upgrade kokic/uml to 0.1.10

### DIFF
--- a/editor/internal/viewer/markdown/moon.pkg
+++ b/editor/internal/viewer/markdown/moon.pkg
@@ -1,7 +1,7 @@
 import {
   "Milky2018/diago",
   "kokic/uml/api" @uml,
-  "kokic/uml/core/style" @uml_style,
+  "kokic/uml/style" @uml_style,
   "moonbit-community/cmark/cmark_base",
   "moonbit-community/cmark/cmark",
   "moonbit-community/cmark/cmark_html",

--- a/editor/moon.mod
+++ b/editor/moon.mod
@@ -25,7 +25,7 @@ import {
   "moonbit-community/rabbita@0.14.3",
   "Milky2018/diago@0.3.0",
   "moonbitlang/x@0.4.50",
-  "kokic/uml@0.1.5",
+  "kokic/uml@0.1.10",
 }
 
 options(


### PR DESCRIPTION
## Summary

Upgrade `kokic/uml` from 0.1.5 to 0.1.10 in the editor module (just released;
required `moon update` to refresh the registry index).

## Changes

- `editor/moon.mod`: `kokic/uml@0.1.5` -> `kokic/uml@0.1.10`
- `editor/internal/viewer/markdown/moon.pkg`: 0.1.10 moves `ColorScheme`
  from `kokic/uml/core/style` to `kokic/uml/style`, so the import path is
  updated. `render_svg` stays in `kokic/uml/api`; it now raises instead of
  returning `String?`, and the existing call sites already use `catch`, so
  no code changes were needed there.

## Verification

- `moon check` (editor module): clean
- `moon check` (root workspace, 871 tasks): clean
- `moon test internal/viewer/markdown`: 60/60
- `moon test editor/viewer --filter "*UML*"`: 1/1
- `moon test desktop/frontend/markdown --target js`: 21/21
- `moon fmt --check editor`: clean

Not verified: browser (Playwright) tests and the visual output of the
rendered UML SVG, which this change does not cover.

Generated with SeekMoon