### PR TITLE
feat(desktop): separate tool calls from results

### DIFF
--- a/desktop/frontend/transcript/component/edit_diff_tests.mbt
+++ b/desktop/frontend/transcript/component/edit_diff_tests.mbt
@@ -83,7 +83,7 @@ test "a payload with no readable change decodes to nothing" {
 
 ///|
 #warnings("-alert_unstable")
-test "an edit row tabs its change, payload, and result" {
+test "an edit row tabs its change and payload apart from its result" {
   let arguments =
     #|{"path":"lib/parser.mbt","start_line":12,"old_string":"args.length()","new_string":"args.len()"}
   let rendered = tool_call_view({
@@ -105,19 +105,20 @@ test "an edit row tabs its change, payload, and result" {
   assert_true(markup.contains("diff-add\">+ args.len()"))
   assert_true(markup.contains("tool-card-chip\">path: lib/parser.mbt"))
   assert_true(markup.contains("class=\"tool-call-tabs\""))
-  assert_eq(markup.split("class=\"tool-call-tab-input\"").length(), 4)
+  assert_eq(markup.split("class=\"tool-call-tab-input\"").length(), 3)
   assert_true(markup.contains(">Change</label>"))
   assert_true(markup.contains(">Original JSON</label>"))
-  assert_true(markup.contains(">Output</label>"))
+  assert_false(markup.contains(">Output</label>"))
   assert_true(markup.contains("edited 1 occurrence"))
   // The synthesized diff stands in for the arguments dump, not beside it.
   assert_false(markup.contains("tool-call-arguments"))
-  assert_false(markup.contains("tool-call-section-label\">Output"))
+  assert_true(markup.contains("tool-call-section-label\">Output"))
+  assert_true(markup.contains("class=\"tool-result\""))
 }
 
 ///|
 #warnings("-alert_unstable")
-test "a multi_edit row tabs its anchored changes, payload, and result" {
+test "a multi_edit row tabs its changes and payload apart from its result" {
   let arguments =
     #|{"edits":[{"file":"a.mbt","start_line":3,"old_string":"one","new_string":"1"},{"file":"b.mbt","start_line":9,"old_string":"two","new_string":"2"}],"revert_when_errors_above":0}
   let rendered = tool_call_view({
@@ -140,11 +141,13 @@ test "a multi_edit row tabs its anchored changes, payload, and result" {
   assert_true(markup.contains("diff-add\">+ 1"))
   assert_true(markup.contains("diff-add\">+ 2"))
   assert_true(markup.contains("class=\"tool-call-tabs\""))
-  assert_eq(markup.split("class=\"tool-call-tab-input\"").length(), 4)
+  assert_eq(markup.split("class=\"tool-call-tab-input\"").length(), 3)
   assert_true(markup.contains(">Changes</label>"))
   assert_true(markup.contains(">Original JSON</label>"))
-  assert_true(markup.contains(">Output</label>"))
+  assert_false(markup.contains(">Output</label>"))
   assert_true(markup.contains("applied 2 edits"))
+  assert_true(markup.contains("tool-call-section-label\">Output"))
+  assert_true(markup.contains("class=\"tool-result\""))
   assert_false(markup.contains("tool-call-arguments"))
 }
 

--- a/desktop/frontend/transcript/component/mbtx_tests.mbt
+++ b/desktop/frontend/transcript/component/mbtx_tests.mbt
@@ -123,18 +123,20 @@ test "a failed mbtx row still reads as a program, not escaped JSON" {
   assert_true(markup.contains("target: js"))
   // The program reads as lines rather than as one JSON-escaped string.
   assert_true(markup.contains("println(1 / 0)"))
-  // The three large views share one tab set, with Program selected first.
+  // Program and the exact payload share the request's tab set. Output stays in
+  // the distinct result row, matching the viz HTML render.
   assert_true(markup.contains("class=\"tool-call-tabs\""))
-  assert_eq(markup.split("class=\"tool-call-tab-input\"").length(), 4)
+  assert_eq(markup.split("class=\"tool-call-tab-input\"").length(), 3)
   assert_true(markup.contains(">Program</label>"))
   assert_true(markup.contains(">Original JSON</label>"))
-  assert_true(markup.contains(">Output</label>"))
+  assert_false(markup.contains(">Output</label>"))
   // The payload as the model sent it stays available in its own tab.
   assert_true(markup.contains("Original JSON"))
   assert_true(markup.contains("\\n"))
-  // The run's own output stays present without adding a stacked section.
+  // The run's own output stays present in the result row.
   assert_true(markup.contains("boom"))
-  assert_false(markup.contains("tool-call-section-label\">Output"))
+  assert_true(markup.contains("tool-call-section-label\">Output"))
+  assert_true(markup.contains("class=\"tool-result error\""))
 }
 
 ///|

--- a/desktop/frontend/transcript/component/tool_card.mbt
+++ b/desktop/frontend/transcript/component/tool_card.mbt
@@ -108,17 +108,6 @@ fn original_json_content(arguments : String) -> @html.Html {
 }
 
 ///|
-/// The read tool's exact numbered protocol behind a closed disclosure. The
-/// friendly view may drop protocol separators, but debugging can still inspect
-/// the unmodified output and status footer.
-fn original_output_view(content : String) -> @html.Html {
-  @html.details(class="tool-card-original", [
-    @html.summary(class="tool-card-original-summary", "Original output"),
-    @html.pre(class="tool-card-original-json", content),
-  ])
-}
-
-///|
 /// Ceiling on a recorded payload worth decoding for a custom card, in UTF-16
 /// code units.
 ///

--- a/desktop/frontend/transcript/component/tool_tabs.mbt
+++ b/desktop/frontend/transcript/component/tool_tabs.mbt
@@ -1,4 +1,4 @@
-// A compact, state-free tab set for the large views inside one tool call.
+// A compact, state-free tab set for alternate views of one tool-call payload.
 //
 // Native radio buttons own the selection. Rabbita therefore does not need to
 // lift a transient viewing choice into the conversation model, while the
@@ -67,19 +67,19 @@ fn tool_call_tabs_key(call_id : String, sequence : Int?) -> String {
 }
 
 ///|
-/// Build the compact detail tabs shared by every ordinary tool call. A custom
-/// card supplies the first semantic view for tools such as `mbtx` and
+/// Build the compact argument tabs shared by every ordinary tool call. A
+/// custom card supplies the first semantic view for tools such as `mbtx` and
 /// `edit`; other tools use the readable generic arguments view. Exact JSON is
 /// a separate tab only when the first view is a derived reading rather than
-/// the recording itself.
+/// the recording itself. The result deliberately does not join this tab set:
+/// like the viz HTML renderer, the transcript renders it as its own row.
 ///
 /// `None` when there is only one useful view: the existing labeled fallback is
 /// clearer than a one-entry tab strip.
-fn tool_call_tabbed_view(
+fn tool_arguments_tabbed_view(
   key : String,
   name : String,
   arguments : String?,
-  output : String,
 ) -> @html.Html? {
   let tabs : Array[ToolCallTab] = []
   if arguments is Some(arguments) {
@@ -106,13 +106,27 @@ fn tool_call_tabbed_view(
       }
     }
   }
-  for tab in tool_output_tabs(name, arguments, output) {
-    tabs.push(tab)
-  }
   if tabs.length() < 2 {
     return None
   }
   Some(tool_call_tabs(key, tabs))
+}
+
+///|
+/// Render alternate semantic and original views of one result as tabs. A
+/// result with only one useful view stays a plain labeled section in its own
+/// result row instead of gaining a one-entry tab strip.
+fn tool_result_tabbed_view(
+  key : String,
+  name : String,
+  arguments : String?,
+  output : String,
+) -> @html.Html? {
+  let tabs = tool_output_tabs(name, arguments, output)
+  if tabs.length() < 2 {
+    return None
+  }
+  Some(tool_call_tabs("\{key}-result", tabs))
 }
 
 ///|

--- a/desktop/frontend/transcript/component/tool_tabs.mbt
+++ b/desktop/frontend/transcript/component/tool_tabs.mbt
@@ -113,23 +113,6 @@ fn tool_arguments_tabbed_view(
 }
 
 ///|
-/// Render alternate semantic and original views of one result as tabs. A
-/// result with only one useful view stays a plain labeled section in its own
-/// result row instead of gaining a one-entry tab strip.
-fn tool_result_tabbed_view(
-  key : String,
-  name : String,
-  arguments : String?,
-  output : String,
-) -> @html.Html? {
-  let tabs = tool_output_tabs(name, arguments, output)
-  if tabs.length() < 2 {
-    return None
-  }
-  Some(tool_call_tabs("\{key}-result", tabs))
-}
-
-///|
 /// Result views for a tool call. A decoded MoonBit `read` gets a readable,
 /// highlighted Output plus the exact numbered protocol in Original output;
 /// every other result is already its own faithful display.

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -179,7 +179,7 @@ fn tool_run_views(
       }
     }
     for index, item in items {
-      if item.kind is Tool(has_result=true, ..) {
+      if tool_result_row_is_visible(item) {
         rows[tool_run_row_key(item, index, "result")] = tool_result_view(
           item,
           subrun?,
@@ -191,7 +191,7 @@ fn tool_run_views(
       if item.kind is Tool(arguments=Some(_), ..) {
         rows[tool_run_row_key(item, index, "request")] = tool_request_view(item)
       }
-      if item.kind is Tool(has_result=true, ..) {
+      if tool_result_row_is_visible(item) {
         rows[tool_run_row_key(item, index, "result")] = tool_result_view(
           item,
           subrun?,
@@ -280,8 +280,18 @@ fn append_tool_result(
   item : @transcript.TranscriptItem,
   subrun? : SubrunLink,
 ) -> Unit {
-  guard item.kind is Tool(has_result=true, ..) else { return }
+  guard tool_result_row_is_visible(item) else { return }
   rows.push(tool_result_view(item, subrun?))
+}
+
+///|
+/// A completed result always gets its own row, including an empty one. Codex
+/// command items can also accumulate output while still in progress; surface
+/// that stream immediately, but let `has_result` keep the row labelled pending
+/// until the completed item arrives.
+fn tool_result_row_is_visible(item : @transcript.TranscriptItem) -> Bool {
+  guard item.kind is Tool(has_result~, ..) else { return false }
+  has_result || !item.content.is_blank()
 }
 
 ///|
@@ -370,24 +380,27 @@ fn tool_request_view(item : @transcript.TranscriptItem) -> @html.Html {
 }
 
 ///|
-/// One completed tool result, separate from the request that produced it as in
-/// the viz HTML renderer. The row remains visible even for an empty result so
-/// pending and completed calls are distinguishable without opening anything.
+/// One tool result, separate from the request that produced it as in the viz
+/// HTML renderer. A completed row remains visible even when empty; a pending
+/// Codex command gets a row only after it has streamed output, and its label
+/// deliberately says "output" rather than claiming completion.
 fn tool_result_view(
   item : @transcript.TranscriptItem,
   subrun? : SubrunLink,
 ) -> @html.Html {
   guard item.kind
-    is Tool(call_id~, name~, arguments~, has_result=true, is_error~, brief~) else {
+    is Tool(call_id~, name~, arguments~, has_result~, is_error~, brief~) else {
     return @html.nothing
   }
-  let label = match (arguments, brief) {
-    (None, Some(brief)) if !brief.is_blank() => capitalize(brief)
-    (None, _) => capitalize(name)
+  let label = match (arguments, brief, has_result) {
+    (None, Some(brief), _) if !brief.is_blank() => capitalize(brief)
+    (None, _, _) => capitalize(name)
+    (_, _, false) => "Tool output · \{name}"
     _ if is_error => "Tool error · \{name}"
     _ => "Tool result · \{name}"
   }
   let error_class = if is_error { " error" } else { "" }
+  let pending_class = if has_result { "" } else { " pending" }
   let line : Array[@html.Html] = [
     @html.span(class="tool-flow", "←"),
     @html.span(class="tool-result-text", capitalize(label)),
@@ -427,10 +440,10 @@ fn tool_result_view(
     }
   }
   if body.is_empty() {
-    @html.div(class="tool-result-label" + error_class, line)
+    @html.div(class="tool-result-label" + error_class + pending_class, line)
   } else {
     @html.details(
-      class="tool-result" + error_class,
+      class="tool-result" + error_class + pending_class,
       [@html.summary(class="tool-result-summary", title=label, line), ..body],
     )
   }

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -97,12 +97,14 @@ fn activity_view(
   let mut index = 0
   while index < items.length() {
     if items[index].kind is Tool(..) {
-      let calls : Array[@html.Html] = []
+      let tools : Array[@transcript.TranscriptItem] = []
       while index < items.length() && items[index].kind is Tool(..) {
-        calls.push(tool_call_view(items[index], subrun?))
+        tools.push(items[index])
         index = index + 1
       }
-      rows.push(@html.div(class="activity-work", calls))
+      rows.push(
+        @html.div(class="activity-work", tool_run_views(tools, subrun?)),
+      )
     } else {
       // Reasoning; callers never pass user messages, assistant prose, or
       // error bubbles.
@@ -151,6 +153,42 @@ fn activity_view(
 }
 
 ///|
+/// Render one consecutive run of tool-shaped transcript items. Calls emitted
+/// by the same durable Assistant event share a sequence: show every request
+/// first and every result after it, exactly as the viz HTML renderer's
+/// Assistant card followed by result cards makes a parallel burst readable.
+/// Different or absent sequences cannot prove a burst, so keep each request
+/// beside its own result instead of implying concurrency.
+fn tool_run_views(
+  items : Array[@transcript.TranscriptItem],
+  subrun? : SubrunLink,
+) -> Array[@html.Html] {
+  let rows : Array[@html.Html] = []
+  let same_assistant_event = match items {
+    [first, ..] if items.length() > 1 && first.sequence is Some(sequence) =>
+      items.all(item => {
+        item.sequence == Some(sequence) &&
+        item.kind is Tool(arguments=Some(_), ..)
+      })
+    _ => false
+  }
+  if same_assistant_event {
+    for item in items {
+      append_tool_request(rows, item)
+    }
+    for item in items {
+      append_tool_result(rows, item, subrun?)
+    }
+  } else {
+    for item in items {
+      append_tool_request(rows, item)
+      append_tool_result(rows, item, subrun?)
+    }
+  }
+  rows
+}
+
+///|
 /// What a sub-run tool card needs to offer its child transcript: the session
 /// this card is being rendered under (an `sr-N` is only unique within its own
 /// engine, so the child id cannot be derived without it), and the way to open
@@ -182,20 +220,47 @@ fn subrun_chip(child : String, open : (String) -> @cmd.Cmd) -> @html.Html {
 }
 
 ///|
-/// One tool call, always on display as its own row: its brief ("Read
-/// moon.mod", or the tool name when the engine sent none), expandable to the
-/// original arguments and the later result. Failed calls stay folded by
-/// default like every other call, read red, and carry a literal `failed`
-/// marker so the state never rests on color alone. A `plan` call's row also
-/// carries the compact progress meter, so the checklist's fill reads without
-/// unfolding anything. Calls from older sessions may have no recorded
-/// arguments; unmatched results keep their old output-only presentation.
+/// A complete tool exchange for focused rendering tests and the unreachable
+/// one-item fallback. Activity runs use `tool_run_views` directly so calls
+/// from one Assistant event can precede all of their distinct result rows.
 fn tool_call_view(
   item : @transcript.TranscriptItem,
   subrun? : SubrunLink,
 ) -> @html.Html {
-  guard item.kind is Tool(call_id~, name~, arguments~, is_error~, brief~, ..) else {
-    return @html.text("")
+  let rows : Array[@html.Html] = []
+  append_tool_request(rows, item)
+  append_tool_result(rows, item, subrun?)
+  @html.div(class="tool-exchange", rows)
+}
+
+///|
+fn append_tool_request(
+  rows : Array[@html.Html],
+  item : @transcript.TranscriptItem,
+) -> Unit {
+  guard item.kind is Tool(arguments=Some(_), ..) else { return }
+  rows.push(tool_request_view(item))
+}
+
+///|
+fn append_tool_result(
+  rows : Array[@html.Html],
+  item : @transcript.TranscriptItem,
+  subrun? : SubrunLink,
+) -> Unit {
+  guard item.kind is Tool(has_result=true, ..) else { return }
+  rows.push(tool_result_view(item, subrun?))
+}
+
+///|
+/// One recorded tool request, always on display as its own row. Its brief is
+/// the result-derived caption the viz renderer also promotes onto the call;
+/// expanding reveals only what the model sent. Failed calls read red and carry
+/// a literal marker, while their separate result row owns the output.
+fn tool_request_view(item : @transcript.TranscriptItem) -> @html.Html {
+  guard item.kind
+    is Tool(call_id~, name~, arguments=Some(arguments), is_error~, brief~, ..) else {
+    return @html.nothing
   }
   let label = capitalize(
     if brief is Some(brief) && !brief.is_blank() {
@@ -209,29 +274,15 @@ fn tool_call_view(
   // the result errored (the row's red must not carry the state alone), and —
   // for an applied `plan` call — the compact progress meter. `fold_progress`
   // renders nothing for every other call.
-  let line : Array[@html.Html] = [@html.span(class="tool-call-text", label)]
+  let line : Array[@html.Html] = [
+    @html.span(class="tool-flow", "→"),
+    @html.span(class="tool-call-text", label),
+  ]
   if is_error {
     line.push(@html.span(class="tool-call-failed", "failed"))
   }
   line.push(@plan.fold_progress([item]))
   let body : Array[@html.Html] = []
-  let mut content_in_tabs = false
-  // A sub-run result names the child session it spawned in its brief. The
-  // child's transcript is the only account of what the subagent actually did —
-  // this card holds its report, not its work — so the card leads with the way
-  // to go and read it.
-  if subrun is Some(link) && brief is Some(brief) {
-    // One launch can start several workers and name them all in one brief, so
-    // this is a chip each rather than a single link.
-    for
-      child in @transcript.subrun_child_sessions(
-        name,
-        brief,
-        parent=link.parent,
-      ) {
-      body.push(subrun_chip(child, link.open))
-    }
-  }
   // A `plan` call shows the checklist it recorded rather than its JSON, in
   // every state where that checklist is what the model asked for. A pending
   // call qualifies: the card is a record of the call, and the missing Output
@@ -240,17 +291,14 @@ fn tool_call_view(
   // checklist would report a plan that never took effect.
   if @plan.classify(item) is Some(Applied(steps) | Pending(steps)) {
     body.push(@html.div(class="tool-call-section", [@plan.card(steps)]))
-  } else if tool_call_tabbed_view(
+  } else if tool_arguments_tabbed_view(
       tool_call_tabs_key(call_id, item.sequence),
       name,
-      arguments,
-      item.content,
+      Some(arguments),
     )
     is Some(tabs) {
-    content_in_tabs = true
     body.push(@html.div(class="tool-call-section", [tabs]))
-  } else if arguments is Some(arguments) &&
-    custom_card(name, arguments) is Some((label, card)) {
+  } else if custom_card(name, arguments) is Some((label, card)) {
     // Some tools' arguments have a shape JSON hides, such as an `edit` split
     // across two blobs whose difference is the whole point. Those get a card.
     // A payload the card cannot read falls through to the generic rendering
@@ -261,7 +309,7 @@ fn tool_call_view(
         card,
       ]),
     )
-  } else if arguments is Some(arguments) {
+  } else {
     let trimmed = arguments.trim()
     if !trimmed.is_empty() && trimmed != "{}" {
       body.push(
@@ -272,27 +320,6 @@ fn tool_call_view(
       )
     }
   }
-  if !content_in_tabs && !item.content.is_blank() {
-    let content = truncate_output(item.content)
-    let output = match (name, arguments) {
-      ("read", Some(arguments)) =>
-        match @read_html.moonbit_output(arguments, item.content) {
-          Some(rendered) =>
-            [
-              @html.pre(class="tool-call-output", [rendered]),
-              original_output_view(item.content),
-            ]
-          None => [@html.pre(class="tool-call-output", content)]
-        }
-      _ => [@html.pre(class="tool-call-output", content)]
-    }
-    body.push(
-      @html.div(
-        class="tool-call-section",
-        [@html.div(class="tool-call-section-label", "Output"), ..output],
-      ),
-    )
-  }
   if body.is_empty() {
     @html.div(class="tool-call-label" + error_class, line)
   } else {
@@ -301,11 +328,75 @@ fn tool_call_view(
       [
         // The full label as the row's tooltip: a brief longer than the pane
         // is ellipsized by the stylesheet, and the body holds the arguments
-        // and output, not the brief — hover (or opening the row, which the
+        // but not the brief — hover (or opening the row, which the
         // stylesheet un-clamps) is how the whole text stays reachable.
         @html.summary(class="tool-call-summary", title=label, line),
         ..body,
       ],
+    )
+  }
+}
+
+///|
+/// One completed tool result, separate from the request that produced it as in
+/// the viz HTML renderer. The row remains visible even for an empty result so
+/// pending and completed calls are distinguishable without opening anything.
+fn tool_result_view(
+  item : @transcript.TranscriptItem,
+  subrun? : SubrunLink,
+) -> @html.Html {
+  guard item.kind
+    is Tool(call_id~, name~, arguments~, has_result=true, is_error~, brief~) else {
+    return @html.nothing
+  }
+  let label = match (arguments, brief) {
+    (None, Some(brief)) if !brief.is_blank() => capitalize(brief)
+    _ if is_error => "Tool error · \{name}"
+    _ => "Tool result · \{name}"
+  }
+  let error_class = if is_error { " error" } else { "" }
+  let line : Array[@html.Html] = [
+    @html.span(class="tool-flow", "←"),
+    @html.span(class="tool-result-text", capitalize(label)),
+  ]
+  if is_error {
+    line.push(@html.span(class="tool-call-failed", "failed"))
+  }
+  let body : Array[@html.Html] = []
+  // A sub-run result names the child session it spawned in its brief. The
+  // result owns the child report and therefore owns the way into its transcript.
+  if subrun is Some(link) && brief is Some(brief) {
+    for
+      child in @transcript.subrun_child_sessions(
+        name,
+        brief,
+        parent=link.parent,
+      ) {
+      body.push(subrun_chip(child, link.open))
+    }
+  }
+  if !item.content.is_blank() {
+    let key = tool_call_tabs_key(call_id, item.sequence)
+    if tool_result_tabbed_view(key, name, arguments, item.content) is Some(tabs) {
+      body.push(@html.div(class="tool-call-section", [tabs]))
+    } else {
+      let output = tool_output_tabs(name, arguments, item.content)
+      if output is [tab] {
+        body.push(
+          @html.div(class="tool-call-section", [
+            @html.div(class="tool-call-section-label", tab.label),
+            tab.body,
+          ]),
+        )
+      }
+    }
+  }
+  if body.is_empty() {
+    @html.div(class="tool-result-label" + error_class, line)
+  } else {
+    @html.details(
+      class="tool-result" + error_class,
+      [@html.summary(class="tool-result-summary", title=label, line), ..body],
     )
   }
 }

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -162,8 +162,8 @@ fn activity_view(
 fn tool_run_views(
   items : Array[@transcript.TranscriptItem],
   subrun? : SubrunLink,
-) -> Array[@html.Html] {
-  let rows : Array[@html.Html] = []
+) -> Map[String, @html.Html] {
+  let rows : Map[String, @html.Html] = Map([])
   let same_assistant_event = match items {
     [first, ..] if items.length() > 1 && first.sequence is Some(sequence) =>
       items.all(item => {
@@ -173,19 +173,51 @@ fn tool_run_views(
     _ => false
   }
   if same_assistant_event {
-    for item in items {
-      append_tool_request(rows, item)
+    for index, item in items {
+      if item.kind is Tool(arguments=Some(_), ..) {
+        rows[tool_run_row_key(item, index, "request")] = tool_request_view(item)
+      }
     }
-    for item in items {
-      append_tool_result(rows, item, subrun?)
+    for index, item in items {
+      if item.kind is Tool(has_result=true, ..) {
+        rows[tool_run_row_key(item, index, "result")] = tool_result_view(
+          item,
+          subrun?,
+        )
+      }
     }
   } else {
-    for item in items {
-      append_tool_request(rows, item)
-      append_tool_result(rows, item, subrun?)
+    for index, item in items {
+      if item.kind is Tool(arguments=Some(_), ..) {
+        rows[tool_run_row_key(item, index, "request")] = tool_request_view(item)
+      }
+      if item.kind is Tool(has_result=true, ..) {
+        rows[tool_run_row_key(item, index, "result")] = tool_result_view(
+          item,
+          subrun?,
+        )
+      }
     }
   }
   rows
+}
+
+///|
+/// Stable VDOM identity for one side of a tool exchange. Results can arrive
+/// after later calls are already visible, so keyed children keep browser-owned
+/// disclosure and radio state attached to the same call instead of the same
+/// array position. The index disambiguates malformed logs with duplicate ids;
+/// call order itself is stable in the transcript projection.
+fn tool_run_row_key(
+  item : @transcript.TranscriptItem,
+  index : Int,
+  side : String,
+) -> String {
+  guard item.kind is Tool(call_id~, name~, ..) else {
+    return "\{side}\u{0}\{index}"
+  }
+  let identity = if call_id.is_empty() { name } else { call_id }
+  "\{side}\u{0}\{identity}\u{0}\{index}"
 }
 
 ///|
@@ -351,6 +383,7 @@ fn tool_result_view(
   }
   let label = match (arguments, brief) {
     (None, Some(brief)) if !brief.is_blank() => capitalize(brief)
+    (None, _) => capitalize(name)
     _ if is_error => "Tool error · \{name}"
     _ => "Tool result · \{name}"
   }
@@ -377,18 +410,20 @@ fn tool_result_view(
   }
   if !item.content.is_blank() {
     let key = tool_call_tabs_key(call_id, item.sequence)
-    if tool_result_tabbed_view(key, name, arguments, item.content) is Some(tabs) {
-      body.push(@html.div(class="tool-call-section", [tabs]))
-    } else {
-      let output = tool_output_tabs(name, arguments, item.content)
-      if output is [tab] {
-        body.push(
-          @html.div(class="tool-call-section", [
-            @html.div(class="tool-call-section-label", tab.label),
-            tab.body,
-          ]),
-        )
-      }
+    let output = tool_output_tabs(name, arguments, item.content)
+    if output is [tab] {
+      body.push(
+        @html.div(class="tool-call-section", [
+          @html.div(class="tool-call-section-label", tab.label),
+          tab.body,
+        ]),
+      )
+    } else if output.length() > 1 {
+      body.push(
+        @html.div(class="tool-call-section", [
+          tool_call_tabs("\{key}-result", output),
+        ]),
+      )
     }
   }
   if body.is_empty() {

--- a/desktop/frontend/transcript/component/view_tests.mbt
+++ b/desktop/frontend/transcript/component/view_tests.mbt
@@ -719,6 +719,33 @@ test "a synthetic runtime update keeps its notice label" {
 }
 
 ///|
+/// Codex command executions stream output before their completed item arrives.
+/// Keep that feedback visible as a distinct pending row without claiming the
+/// tool has produced its final result.
+#warnings("-alert_unstable")
+test "a pending tool keeps its streamed output visible" {
+  let rendered = tool_call_view({
+    kind: Tool(
+      call_id="command-1",
+      name="shell",
+      arguments=Some("{\"command\":\"moon test\"}"),
+      has_result=false,
+      is_error=false,
+      brief=Some("moon test"),
+    ),
+    content: "package core: 12/20 tests passed",
+    ts: None,
+    sequence: None,
+  })
+  let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
+  assert_true(markup.contains("Moon test"))
+  assert_true(markup.contains("Tool output · shell"))
+  assert_true(markup.contains("package core: 12/20 tests passed"))
+  assert_true(markup.contains("<details class=\"tool-result pending\">"))
+  assert_false(markup.contains("Tool result · shell"))
+}
+
+///|
 #warnings("-alert_unstable")
 test "a mixed activity keeps its call on display beside the thought fold" {
   let rendered = activity_view(

--- a/desktop/frontend/transcript/component/view_tests.mbt
+++ b/desktop/frontend/transcript/component/view_tests.mbt
@@ -632,13 +632,16 @@ test "every tool request and result of a run is on display as its own row" {
 /// precede either result row.
 #warnings("-alert_unstable")
 test "one assistant event renders its call burst before its results" {
-  let rendered = activity_view(
-    [
-      { ..tool_item("alpha", brief="first request"), sequence: Some(21), },
-      { ..tool_item("beta", brief="second request"), sequence: Some(21), },
-    ],
-    _ => @cmd.none,
-  )
+  let tools = [
+    { ..tool_item("alpha", brief="first request"), sequence: Some(21), },
+    { ..tool_item("beta", brief="second request"), sequence: Some(21), },
+  ]
+  let rows = tool_run_views(tools)
+  assert_eq(rows.to_array().map(entry => entry.0), [
+    "request\u{0}alpha\u{0}0", "request\u{0}beta\u{0}1", "result\u{0}alpha\u{0}0",
+    "result\u{0}beta\u{0}1",
+  ])
+  let rendered = activity_view(tools, _ => @cmd.none)
   let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
   guard (
       markup.find("First request"),
@@ -690,6 +693,29 @@ test "different assistant events keep each result beside its request" {
   assert_true(first_call < first_result)
   assert_true(first_result < second_call)
   assert_true(second_call < second_result)
+}
+
+///|
+/// Background runtime updates are result-shaped for layout, but they are not
+/// responses to model tool calls and must retain their standalone status name.
+#warnings("-alert_unstable")
+test "a synthetic runtime update keeps its notice label" {
+  let rendered = tool_call_view({
+    kind: Tool(
+      call_id="",
+      name="moon_check passed",
+      arguments=None,
+      has_result=true,
+      is_error=false,
+      brief=None,
+    ),
+    content: "Finished.",
+    ts: None,
+    sequence: Some(21),
+  })
+  let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
+  assert_true(markup.contains("Moon_check passed"))
+  assert_false(markup.contains("Tool result"))
 }
 
 ///|

--- a/desktop/frontend/transcript/component/view_tests.mbt
+++ b/desktop/frontend/transcript/component/view_tests.mbt
@@ -6,9 +6,9 @@ fn tool_item(
 ) -> @transcript.TranscriptItem {
   {
     kind: Tool(
-      call_id="",
+      call_id=name,
       name~,
-      arguments=None,
+      arguments=Some("{\"fixture\":true}"),
       has_result=true,
       is_error~,
       brief~,
@@ -595,7 +595,7 @@ test "transcript stream section key scopes equal session ids by channel" {
 
 ///|
 #warnings("-alert_unstable")
-test "every tool call of a run is on display as its own row" {
+test "every tool request and result of a run is on display as its own row" {
   let rendered = activity_view(
     [
       tool_item("shell", brief="moon test"),
@@ -605,22 +605,91 @@ test "every tool call of a run is on display as its own row" {
     _ => @cmd.none,
   )
   let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
-  // One always-visible row per call, no fold around the run, no synthetic
-  // category sentence standing in for the briefs.
+  // One always-visible request and result row per exchange, no fold around the
+  // run, and no synthetic category sentence standing in for the briefs.
   assert_true(markup.contains("activity-work"))
   assert_true(markup.contains("Moon test"))
   assert_true(markup.contains("Read moon.mod"))
   assert_true(markup.contains("Edit view.mbt"))
   assert_false(markup.contains("activity-summary"))
   assert_false(markup.contains("Ran 1 command"))
-  // The failed call stays folded like every other call, and its state is a
-  // literal word rather than the row's red alone.
+  assert_eq(markup.split("<details class=\"tool-call").length(), 4)
+  assert_eq(markup.split("<details class=\"tool-result").length(), 4)
+  // The failed request and result stay folded like the other expandable rows,
+  // and their state is a literal word rather than the red color alone.
   assert_true(markup.contains("<details class=\"tool-call error\">"))
+  assert_true(markup.contains("<details class=\"tool-result error\">"))
   assert_false(markup.contains("<details class=\"tool-call error\" open"))
   assert_true(markup.contains("<span class=\"tool-call-failed\">failed</span>"))
   // Each summary carries its full label as a tooltip, so a brief the
   // stylesheet ellipsizes on a narrow pane stays reachable.
   assert_true(markup.contains("title=\"Moon test\""))
+}
+
+///|
+/// One Assistant event owns both requests, so its sequence is positive proof
+/// that this is a parallel burst. As in the viz HTML renderer, both call rows
+/// precede either result row.
+#warnings("-alert_unstable")
+test "one assistant event renders its call burst before its results" {
+  let rendered = activity_view(
+    [
+      { ..tool_item("alpha", brief="first request"), sequence: Some(21), },
+      { ..tool_item("beta", brief="second request"), sequence: Some(21), },
+    ],
+    _ => @cmd.none,
+  )
+  let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
+  guard (
+      markup.find("First request"),
+      markup.find("Second request"),
+      markup.find("Tool result · alpha"),
+      markup.find("Tool result · beta"),
+    )
+    is (
+      Some(first_call),
+      Some(second_call),
+      Some(first_result),
+      Some(second_result),
+    ) else {
+    fail("expected both request and result rows")
+  }
+  assert_true(first_call < second_call)
+  assert_true(second_call < first_result)
+  assert_true(first_result < second_result)
+}
+
+///|
+/// Different Assistant sequences are sequential calls even when a fallback
+/// activity run places them next to each other. Keep each result beside its
+/// request rather than visually turning them into a burst.
+#warnings("-alert_unstable")
+test "different assistant events keep each result beside its request" {
+  let rendered = activity_view(
+    [
+      { ..tool_item("alpha", brief="first request"), sequence: Some(21), },
+      { ..tool_item("beta", brief="second request"), sequence: Some(22), },
+    ],
+    _ => @cmd.none,
+  )
+  let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
+  guard (
+      markup.find("First request"),
+      markup.find("Tool result · alpha"),
+      markup.find("Second request"),
+      markup.find("Tool result · beta"),
+    )
+    is (
+      Some(first_call),
+      Some(first_result),
+      Some(second_call),
+      Some(second_result),
+    ) else {
+    fail("expected both request and result rows")
+  }
+  assert_true(first_call < first_result)
+  assert_true(first_result < second_call)
+  assert_true(second_call < second_result)
 }
 
 ///|
@@ -648,6 +717,7 @@ test "a mixed activity keeps its call on display beside the thought fold" {
     ),
   )
   assert_true(markup.contains("<pre class=\"tool-call-output\">output</pre>"))
+  assert_true(markup.contains("class=\"tool-result-summary\""))
 }
 
 ///|
@@ -918,7 +988,7 @@ test "user message URLs are clickable but inline code stays inert" {
 
 ///|
 #warnings("-alert_unstable")
-test "an ordinary tool tabs readable arguments, the recording, and its result" {
+test "an ordinary tool keeps its result out of the argument tabs" {
   let rendered = tool_call_view({
     kind: Tool(
       call_id="c1",
@@ -934,15 +1004,16 @@ test "an ordinary tool tabs readable arguments, the recording, and its result" {
   })
   let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
   assert_true(markup.contains("class=\"tool-call-tabs\""))
-  assert_eq(markup.split("class=\"tool-call-tab-input\"").length(), 4)
+  assert_eq(markup.split("class=\"tool-call-tab-input\"").length(), 3)
   assert_true(markup.contains(">Arguments</label>"))
   assert_true(markup.contains(">Original JSON</label>"))
-  assert_true(markup.contains(">Output</label>"))
+  assert_false(markup.contains(">Output</label>"))
   assert_true(markup.contains("cmd"))
   assert_true(markup.contains("moon test"))
   assert_true(markup.contains("test failed"))
-  assert_false(markup.contains("tool-call-section-label\">Output"))
+  assert_true(markup.contains("tool-call-section-label\">Output"))
   assert_true(markup.contains("<details class=\"tool-call error\">"))
+  assert_true(markup.contains("<details class=\"tool-result error\">"))
   assert_false(markup.contains("<details class=\"tool-call error\" open>"))
 }
 
@@ -1138,9 +1209,12 @@ test "tabbed reads from one event keep independent radio groups" {
   let first_group = "tool-call-tabs-call-\{"read-a".hash()}"
   let second_group = "tool-call-tabs-call-\{"read-b".hash()}"
   assert_true(first_group != second_group)
-  // Four tabs per read, all belonging to that read and no other one.
-  assert_eq(markup.split("name=\"\{first_group}\"").length(), 5)
-  assert_eq(markup.split("name=\"\{second_group}\"").length(), 5)
+  // Two request tabs and two result tabs per read, isolated from both the
+  // other call and the other half of this exchange.
+  assert_eq(markup.split("name=\"\{first_group}\"").length(), 3)
+  assert_eq(markup.split("name=\"\{first_group}-result\"").length(), 3)
+  assert_eq(markup.split("name=\"\{second_group}\"").length(), 3)
+  assert_eq(markup.split("name=\"\{second_group}-result\"").length(), 3)
 }
 
 ///|

--- a/desktop/styles/transcript.css
+++ b/desktop/styles/transcript.css
@@ -661,13 +661,15 @@
 }
 
 .activity-summary,
-.tool-call-summary {
+.tool-call-summary,
+.tool-result-summary {
   cursor: pointer;
   list-style: none;
   user-select: none;
 }
 .activity-summary::-webkit-details-marker,
-.tool-call-summary::-webkit-details-marker {
+.tool-call-summary::-webkit-details-marker,
+.tool-result-summary::-webkit-details-marker {
   display: none;
 }
 
@@ -818,7 +820,9 @@
   overflow-wrap: anywhere;
 }
 
-/* A step's tool calls, always on display: one row per call, hanging behind
+/* A step's tool exchanges, always on display: one row per request and result,
+   with every request in a proven parallel burst preceding its result rows.
+   They hang behind
    the same quiet guide line an expanded fold used to draw, so the step still
    reads as one block under its heading or thought fold. */
 .activity-work {
@@ -829,18 +833,32 @@
   border-left: 2px solid var(--color-border);
 }
 
-/* One tool call's row: its brief, expandable to recorded arguments and the
-   result output. Same muted line treatment as the summaries above it —
+.tool-exchange {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 4px;
+}
+
+/* One tool request/result row: the request expands to recorded arguments and
+   the result expands to output. Same muted line treatment as the summaries —
    depth is carried by the guide line, not a size step. */
 .tool-call-label,
-.tool-call-summary {
+.tool-call-summary,
+.tool-result-label,
+.tool-result-summary {
   display: flex;
   align-items: baseline;
   gap: 10px;
   color: var(--color-text-muted);
   font-size: var(--font-size-sm);
 }
-.tool-call-summary:hover {
+.tool-flow {
+  flex: 0 0 1em;
+  color: var(--color-text-faint);
+  text-align: center;
+}
+.tool-call-summary:hover,
+.tool-result-summary:hover {
   color: var(--color-text-secondary);
 }
 /* One line per expandable call, whatever the brief's length: a long brief
@@ -850,7 +868,8 @@
    Only summaries get this: a bodyless `.tool-call-label` row (a goal
    notice, a pending call) holds the sole copy of its text, so it wraps
    rather than losing what an ellipsis would clip. */
-.tool-call-summary .tool-call-text {
+.tool-call-summary .tool-call-text,
+.tool-result-summary .tool-result-text {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -861,7 +880,8 @@
    keeps a clipped brief reachable — including where there is no hover.
    `anywhere` breaks an unbroken token (a Codex command string), so the
    revealed text wraps instead of painting past the pane. */
-.tool-call[open] > .tool-call-summary .tool-call-text {
+.tool-call[open] > .tool-call-summary .tool-call-text,
+.tool-result[open] > .tool-result-summary .tool-result-text {
   white-space: normal;
   overflow: visible;
   overflow-wrap: anywhere;
@@ -869,7 +889,8 @@
 /* A bodyless label wraps its whole text (see above — it is the sole copy),
    and the same `anywhere` break keeps an unbroken token, such as a long URL
    in a one-line goal, from pushing the transcript wide. */
-.tool-call-label .tool-call-text {
+.tool-call-label .tool-call-text,
+.tool-result-label .tool-result-text {
   min-width: 0;
   overflow-wrap: anywhere;
 }
@@ -877,14 +898,18 @@
    rows have nothing to disclose and stay bare. It is the summary's own last
    flex item rather than part of the text span, so a truncated brief cannot
    ellipsize it away. */
-.tool-call-summary::after {
+.tool-call-summary::after,
+.tool-result-summary::after {
   content: "▸";
 }
-.tool-call[open] > .tool-call-summary::after {
+.tool-call[open] > .tool-call-summary::after,
+.tool-result[open] > .tool-result-summary::after {
   content: "▾";
 }
 .tool-call-label.error,
-.tool-call.error > .tool-call-summary {
+.tool-call.error > .tool-call-summary,
+.tool-result-label.error,
+.tool-result.error > .tool-result-summary {
   color: var(--color-danger);
 }
 /* The literal word beside a failed call's brief: the state must not rest on
@@ -936,7 +961,8 @@
   border-color: var(--color-accent);
 }
 
-.tool-call pre {
+.tool-call pre,
+.tool-result pre {
   margin: 6px 0 8px;
   padding: 10px 12px;
   border-radius: var(--radius-sm);
@@ -947,14 +973,13 @@
   white-space: pre-wrap;
   overflow-wrap: anywhere;
 }
-.tool-call.error .tool-call-output {
+.tool-result.error .tool-call-output {
   background: var(--color-danger-soft);
 }
 
-/* A tool's readable arguments/card, exact payload, and output share one compact
-   radio-backed tab set. Native radios retain keyboard arrow navigation and
-   keep the viewing choice out of conversation state; only the selected panel
-   participates in layout. */
+/* Alternate views of one request or one result share a compact radio-backed
+   tab set. Requests and results never share a strip: the separate rows retain
+   the call/result chronology exposed by the viz HTML renderer. */
 .tool-call-tabs {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary

- render tool requests and results as distinct transcript rows, matching the viz HTML renderer
- group requests before results only when multiple calls share the same durable Assistant event sequence; keep sequential calls paired request/result
- keep request argument tabs and result output tabs independent, including stable radio groups for multi-call events
- key request/result DOM rows so late results preserve disclosure and tab state
- keep streamed output visible for pending Codex commands as a distinct `Tool output` row without claiming completion

## Independent Codex review

A first fresh Codex CLI review identified three P2 findings; this PR addresses all three with keyed late-result reconciliation, preserved synthetic runtime-notice labels, and single-pass result view construction. A second fresh review found one P1 lifecycle regression where pending command output disappeared; that is fixed and covered by a regression test. A final fresh Codex CLI review against commit `ecc2d65bb` found no actionable issues.

## Verification

- `moon info && moon fmt`
- focused transcript component tests: 56/56
- `just check`
- `just test` (native 3327/3327, JS 3273/3273, cram 28/28)
- `just build`
- native desktop visual QA against a recorded session: confirmed two- and three-call bursts render all request rows before result rows; expanded requests show Arguments / Original JSON while expanded results show Output separately