### PR TITLE
fix(desktop): report stat failures as failures, not deletions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,16 @@ You can browse and install extra skills here:
 - Try to keep deprecated blocks in file called `deprecated.mbt` in each
   directory.
 
+- Never encode absence or failure as a sentinel value of the payload's own
+  type: no `""` for "no file", no `0`/`-1` for "unknown", no helper that
+  aborts when a value is missing. Absence is `T?` (or a dedicated enum
+  variant), and every caller handles it as its own branch. This applies on
+  the wire too: a JSON field that can be absent is optional or a tagged
+  variant, never an empty string the decoder has to recognize. Do not fold
+  unrelated errors into the "missing" case either — a stat that fails for any
+  reason other than the file being absent must not read as "deleted"; carry
+  the failure so the UI can tell the two apart.
+
 ## Tooling
 
 - `moon fmt` is used to format your code properly.

--- a/desktop/frontend/fileeditor/files.mbt
+++ b/desktop/frontend/fileeditor/files.mbt
@@ -276,14 +276,7 @@ fn stat_files(
           @resource.relative_to(absolute, root) is Some(path) else {
           continue
         }
-        stats.push({
-          path,
-          sig: if stat.sig.is_empty() {
-            None
-          } else {
-            Some(stat.sig)
-          },
-        })
+        stats.push({ path, signature: stat.signature, })
       }
       scheduler.add(dispatch(StatsLoaded(owner~, epoch~, stats~)))
     })

--- a/desktop/frontend/fileeditor/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/pkg.generated.mbti
@@ -167,7 +167,7 @@ pub fn FileIndex::not_equal(Self, Self) -> Bool
 
 pub(all) struct FileStat {
   path : @pathx.Relative
-  sig : String?
+  signature : @protocol.FileSignature
 }
 
 pub(all) enum GitCommitFiles {

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -154,10 +154,11 @@ pub(all) struct Doc {
 
 ///|
 /// One file's decoded `fs.stat_files` result: its current mtime signature,
-/// absent when the file is missing.
+/// or why the host has none — the file is missing, or it could not be
+/// inspected at all.
 pub(all) struct FileStat {
   path : @pathx.Relative
-  sig : String?
+  signature : @protocol.FileSignature
 }
 
 ///|
@@ -946,9 +947,9 @@ pub(all) enum Msg {
   // the one cheap signal that covers them. `owner` fences a background
   // conversation's finish.
   RunSettled(owner~ : @interop.ConversationKey)
-  // A `stat_files` reply: each open tab's current mtime signature (`""` =
-  // the file is gone). Owner plus request epoch fence a request that outlived
-  // either its conversation or checkout.
+  // A `stat_files` reply: each open tab's current mtime signature, or that
+  // the file is gone or could not be inspected. Owner plus request epoch
+  // fence a request that outlived either its conversation or checkout.
   StatsLoaded(
     owner~ : @interop.ConversationKey,
     epoch~ : Int,

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -3360,37 +3360,98 @@ pub fn update(
         let mut active_reloading = false
         for stat in stats {
           guard docs.get(stat.path) is Some(doc) else { continue }
-          guard stat.sig is Some(current_sig) else {
-            // The file is gone. The tab stays as the user's bookmark; the
-            // notice replaces the document if it is the one on screen. A tab
-            // already reviewing a textual HEAD side instead switches to that
-            // deleted-file preview.
-            if !(doc.state is (TabDeleted | TabUnavailable(_))) {
-              let review = match doc.review {
-                Some(review) if review.selected.has_working_tree_file() => {
-                  // The missing signature is newer than any tagged read that
-                  // was already in flight. Advance its token so an older
-                  // successful read cannot resurrect deleted working text.
-                  review_generation = review_generation + 1
-                  Some({ ..review, working_generation: review_generation, })
+          let current_sig = match stat.signature {
+            Missing => {
+              // The file is gone. The tab stays as the user's bookmark; the
+              // notice replaces the document if it is the one on screen. A
+              // tab already reviewing a textual HEAD side instead switches
+              // to that deleted-file preview.
+              if !(doc.state is (TabDeleted | TabUnavailable(_))) {
+                let review = match doc.review {
+                  Some(review) if review.selected.has_working_tree_file() => {
+                    // The missing signature is newer than any tagged read
+                    // that was already in flight. Advance its token so an
+                    // older successful read cannot resurrect deleted working
+                    // text.
+                    review_generation = review_generation + 1
+                    Some({ ..review, working_generation: review_generation, })
+                  }
+                  _ => doc.review
                 }
-                _ => doc.review
+                let deleted = {
+                  ..doc,
+                  state: TabDeleted,
+                  review,
+                  stale: false,
+                }
+                docs[stat.path] = deleted
+                if ctx.active_file == Some(stat.path) {
+                  cmds.push(
+                    show_tab(
+                      dispatch,
+                      ctx,
+                      state.editor_search_highlights(stat.path),
+                      stat.path,
+                      deleted,
+                    ),
+                  )
+                }
               }
-              let deleted = { ..doc, state: TabDeleted, review, stale: false, }
-              docs[stat.path] = deleted
-              if ctx.active_file == Some(stat.path) {
-                cmds.push(
-                  show_tab(
-                    dispatch,
-                    ctx,
-                    state.editor_search_highlights(stat.path),
-                    stat.path,
-                    deleted,
-                  ),
-                )
-              }
+              continue
             }
-            continue
+            Failed(message) => {
+              // The host could not inspect the file — permissions, a sharing
+              // violation, a path it could not resolve. That is not a
+              // deletion, but the text on screen is now of unknown
+              // freshness, so the tab keeps its place and shows the failure
+              // exactly as a failed read would, until a later stat proves
+              // the path readable and the ordinary retry reloads it. A read
+              // still in flight settles the document by itself, withheld
+              // documents have no baseline to invalidate, and a selected
+              // deletion row reviews HEAD rather than whatever now sits at
+              // its path.
+              let affected = match doc.state {
+                TabLoaded(..) | TabReadFailed(_) => true
+                TabDeleted =>
+                  doc.review
+                  .map(review => review.selected.has_working_tree_file())
+                  .unwrap_or(true)
+                TabLoading | TabBinary | TabOversized | TabUnavailable(_) =>
+                  false
+              }
+              if affected {
+                let review = match doc.review {
+                  Some(review) if review.selected.has_working_tree_file() => {
+                    // Like a deletion, the failure is newer than any tagged
+                    // read still in flight: an older success must not settle
+                    // text the host can no longer vouch for.
+                    review_generation = review_generation + 1
+                    Some({ ..review, working_generation: review_generation, })
+                  }
+                  _ => doc.review
+                }
+                let failed = {
+                  ..doc,
+                  state: TabReadFailed(message),
+                  review,
+                  stale: false,
+                }
+                docs[stat.path] = failed
+                if ctx.active_file == Some(stat.path) {
+                  cmds.push(
+                    show_tab(
+                      dispatch,
+                      ctx,
+                      state.editor_search_highlights(stat.path),
+                      stat.path,
+                      failed,
+                    ),
+                  )
+                }
+              }
+              continue
+            }
+            Present(current_sig) => current_sig
           }
           let changed = match doc.state {
             // The loaded baseline says whether the disk moved on.
@@ -4741,7 +4802,7 @@ test "FileLoaded settles content into its document, active or not" {
   let (_, old_epoch) = update(
     emit,
     StatsLoaded(owner=test_ctx().owner, epoch=1, stats=[
-      { path: Relative("a.mbt"), sig: None, },
+      { path: Relative("a.mbt"), signature: Missing, },
     ]),
     epoch_state,
     ctx,
@@ -6127,7 +6188,7 @@ test "a settled Changes snapshot re-stats loaded reviews whose rows disappeared"
   // a committed deletion must replace the cached working source.
   let (_, deleted) = update(
     test_emit(),
-    StatsLoaded(owner=ctx.owner, epoch=0, stats=[{ path, sig: None, }]),
+    StatsLoaded(owner=ctx.owner, epoch=0, stats=[{ path, signature: Missing, }]),
     settled,
     ctx,
   )
@@ -6176,7 +6237,7 @@ test "a review that becomes a symlink clears its cached regular-file source" {
   )
   let (_, missing_unavailable) = update(
     test_emit(),
-    StatsLoaded(owner=ctx.owner, epoch=0, stats=[{ path, sig: None, }]),
+    StatsLoaded(owner=ctx.owner, epoch=0, stats=[{ path, signature: Missing, }]),
     unavailable,
     ctx,
   )
@@ -6185,7 +6246,9 @@ test "a review that becomes a symlink clears its cached regular-file source" {
   // source that preceded it. An explicit ordinary reopen remains the retry.
   let (_, still_unavailable) = update(
     test_emit(),
-    StatsLoaded(owner=ctx.owner, epoch=0, stats=[{ path, sig: Some("4:0"), }]),
+    StatsLoaded(owner=ctx.owner, epoch=0, stats=[
+      { path, signature: Present("4:0"), },
+    ]),
     missing_unavailable,
     ctx,
   )
@@ -6271,7 +6334,9 @@ test "a disappearing review row hands an active reload to an ordinary read" {
   }
   let (_, reloading) = update(
     test_emit(),
-    StatsLoaded(owner=ctx.owner, epoch=0, stats=[{ path, sig: Some("2:1"), }]),
+    StatsLoaded(owner=ctx.owner, epoch=0, stats=[
+      { path, signature: Present("2:1"), },
+    ]),
     state,
     ctx,
   )
@@ -6363,7 +6428,9 @@ test "a newer review reload fences an older working-tree reply" {
   // flight. It receives its own token without invalidating the HEAD request.
   let (_, reloading) = update(
     test_emit(),
-    StatsLoaded(owner=ctx.owner, epoch=0, stats=[{ path, sig: Some("2:0"), }]),
+    StatsLoaded(owner=ctx.owner, epoch=0, stats=[
+      { path, signature: Present("2:0"), },
+    ]),
     state,
     ctx,
   )
@@ -6430,7 +6497,7 @@ test "a newer review reload fences an older working-tree reply" {
   // that captured the file just before it disappeared cannot resurrect it.
   let (_, deleted) = update(
     test_emit(),
-    StatsLoaded(owner=ctx.owner, epoch=0, stats=[{ path, sig: None, }]),
+    StatsLoaded(owner=ctx.owner, epoch=0, stats=[{ path, signature: Missing, }]),
     newest,
     ctx,
   )
@@ -7752,11 +7819,11 @@ test "StatsLoaded marks deletions, reloads the active change, stales the rest" {
     StatsLoaded(owner=test_ctx().owner, epoch=0, stats=[
       // The active file changed: reloaded eagerly, so its document stays
       // loaded (the baseline the scroll-keeping reload compares against).
-      { path: Relative("a.mbt"), sig: Some("9:0"), },
+      { path: Relative("a.mbt"), signature: Present("9:0"), },
       // A background file changed: only marked stale.
-      { path: Relative("b.mbt"), sig: Some("9:0"), },
+      { path: Relative("b.mbt"), signature: Present("9:0"), },
       // Deleted: the document flips to the deleted notice state.
-      { path: Relative("c.mbt"), sig: None, },
+      { path: Relative("c.mbt"), signature: Missing, },
     ]),
     state,
     ctx,
@@ -7776,7 +7843,7 @@ test "StatsLoaded marks deletions, reloads the active change, stales the rest" {
   let (_, same) = update(
     emit,
     StatsLoaded(owner=test_ctx().owner, epoch=0, stats=[
-      { path: Relative("b.mbt"), sig: Some("9:0"), },
+      { path: Relative("b.mbt"), signature: Present("9:0"), },
     ]),
     { ..next, docs: solo, },
     { ..ctx, active_file: None, },
@@ -7804,7 +7871,7 @@ test "StatsLoaded marks deletions, reloads the active change, stales the rest" {
   let (_, retryable) = update(
     emit,
     StatsLoaded(owner=test_ctx().owner, epoch=0, stats=[
-      { path: failed_path, sig: Some("10:0"), },
+      { path: failed_path, signature: Present("10:0"), },
     ]),
     { ..owned_state(), docs: failed_docs, },
     { ..ctx, active_file: None, },
@@ -7822,7 +7889,7 @@ test "StatsLoaded marks deletions, reloads the active change, stales the rest" {
         session: "desktop-test",
       },
       epoch=0,
-      stats=[{ path: Relative("a.mbt"), sig: None, }],
+      stats=[{ path: Relative("a.mbt"), signature: Missing, }],
     ),
     state,
     ctx,
@@ -7830,6 +7897,125 @@ test "StatsLoaded marks deletions, reloads the active change, stales the rest" {
   assert_true(
     other.docs.get(Relative("a.mbt")) is Some({ state: TabLoaded(..), .. }),
   )
+}
+
+///|
+test "a stat the host could not complete reads as a failed read, never a deletion" {
+  let emit = test_emit()
+  let gone_path = @pathx.Relative("gone.mbt")
+  let reviewed_path = @pathx.Relative("reviewed.mbt")
+  let deletion_row : ChangedFile = {
+    path: gone_path,
+    original_path: None,
+    index_status: "D",
+    worktree_status: " ",
+    kind: ChangeDeleted,
+  }
+  let docs : Map[@pathx.Relative, Doc] = Map([])
+  docs[Relative("a.mbt")] = loaded_doc("a.mbt")
+  docs[Relative("b.mbt")] = {
+    name: "b.mbt",
+    state: TabLoading,
+    review: None,
+    stale: false,
+  }
+  docs[Relative("c.mbt")] = {
+    name: "c.mbt",
+    state: TabDeleted,
+    review: None,
+    stale: false,
+  }
+  docs[gone_path] = {
+    name: "gone.mbt",
+    state: TabDeleted,
+    review: Some({
+      generation: 3,
+      working_generation: 3,
+      baseline: ReviewContent("HEAD source"),
+      view_mode: ReviewSource,
+      selected: deletion_row,
+    }),
+    stale: false,
+  }
+  docs[reviewed_path] = {
+    ..loaded_doc("reviewed.mbt"),
+    review: Some({
+      generation: 7,
+      working_generation: 7,
+      baseline: ReviewContent("HEAD source"),
+      view_mode: ReviewSource,
+      selected: test_modified_change(reviewed_path),
+    }),
+  }
+  let ctx = {
+    ..test_ctx(),
+    open_files: [
+      Relative("a.mbt"),
+      Relative("b.mbt"),
+      Relative("c.mbt"),
+      gone_path,
+      reviewed_path,
+    ],
+    active_file: Some(Relative("a.mbt")),
+  }
+  let failed : @protocol.FileSignature = Failed("permission denied")
+  let (_, next) = update(
+    emit,
+    StatsLoaded(owner=test_ctx().owner, epoch=0, stats=[
+      { path: Relative("a.mbt"), signature: failed, },
+      { path: Relative("b.mbt"), signature: failed, },
+      { path: Relative("c.mbt"), signature: failed, },
+      { path: gone_path, signature: failed, },
+      { path: reviewed_path, signature: failed, },
+    ]),
+    { ..owned_state(), docs, review_generation: 7, },
+    ctx,
+  )
+  // A loaded document, active or not, shows the failure where the deleted
+  // notice would otherwise have appeared.
+  assert_true(
+    next.docs.get(Relative("a.mbt"))
+    is Some({ state: TabReadFailed("permission denied"), stale: false, .. }),
+  )
+  // A read in flight settles the document itself.
+  assert_true(
+    next.docs.get(Relative("b.mbt")) is Some({ state: TabLoading, .. }),
+  )
+  // Something the host cannot inspect sits where a deleted file was: that is
+  // a failed read of a present path, not a confirmed deletion.
+  assert_true(
+    next.docs.get(Relative("c.mbt"))
+    is Some({ state: TabReadFailed("permission denied"), .. }),
+  )
+  // A selected deletion row keeps its HEAD preview: the object at the path
+  // belongs to a separate untracked row.
+  assert_true(
+    next.docs.get(gone_path)
+    is Some(
+      { state: TabDeleted, review: Some({ working_generation: 3, .. }), .. }
+    ),
+  )
+  // A reviewed working file fences the tagged read that may still be in
+  // flight, like a deletion does.
+  assert_true(
+    next.docs.get(reviewed_path)
+    is Some(
+      {
+        state: TabReadFailed("permission denied"),
+        review: Some(
+          {
+            generation: 7,
+            working_generation: 8,
+            baseline: ReviewContent("HEAD source"),
+            ..
+          }
+        ),
+        stale: false,
+        ..
+      }
+    ),
+  )
+  assert_eq(next.review_generation, 8)
 }
 
 ///|
@@ -7849,7 +8035,9 @@ test "StatsLoaded preserves a settled HEAD preview when its active file disappea
   let docs : Map[@pathx.Relative, Doc] = Map([(path, doc)])
   let (_, next) = update(
     emit,
-    StatsLoaded(owner=test_ctx().owner, epoch=0, stats=[{ path, sig: None, }]),
+    StatsLoaded(owner=test_ctx().owner, epoch=0, stats=[
+      { path, signature: Missing, },
+    ]),
     { ..owned_state(), docs, },
     { ..test_ctx(), open_files: [path], active_file: Some(path), },
   )
@@ -7882,7 +8070,7 @@ test "a deleted document whose file reappears reloads on the next stats" {
   let (_, next) = update(
     emit,
     StatsLoaded(owner=test_ctx().owner, epoch=0, stats=[
-      { path: Relative("a.mbt"), sig: Some("3:0"), },
+      { path: Relative("a.mbt"), signature: Present("3:0"), },
     ]),
     state,
     { ..test_ctx(), open_files: [Relative("a.mbt")], },
@@ -7922,7 +8110,7 @@ test "a selected deletion hands a clean restoration to an ordinary read" {
   let (_, reviewed) = update(
     emit,
     StatsLoaded(owner=test_ctx().owner, epoch=0, stats=[
-      { path, sig: Some("3:0"), },
+      { path, signature: Present("3:0"), },
     ]),
     { ..owned_state(), docs, },
     ctx,
@@ -7976,7 +8164,9 @@ test "a selected deletion hands a clean restoration to an ordinary read" {
   )
   let (_, reloading) = update(
     emit,
-    StatsLoaded(owner=ctx.owner, epoch=0, stats=[{ path, sig: Some("3:0"), }]),
+    StatsLoaded(owner=ctx.owner, epoch=0, stats=[
+      { path, signature: Present("3:0"), },
+    ]),
     ordinary,
     ctx,
   )
@@ -8059,7 +8249,9 @@ test "a vanished review retries a failed ordinary read" {
   )
   let (_, reloading) = update(
     emit,
-    StatsLoaded(owner=ctx.owner, epoch=0, stats=[{ path, sig: Some("4:0"), }]),
+    StatsLoaded(owner=ctx.owner, epoch=0, stats=[
+      { path, signature: Present("4:0"), },
+    ]),
     ordinary,
     ctx,
   )

--- a/desktop/internal/host/fs_ops.mbt
+++ b/desktop/internal/host/fs_ops.mbt
@@ -118,27 +118,35 @@ async test "binary file reads expose only recognized raster signatures" {
 
 ///|
 /// The mtime signatures of the open tabs' files (see `StatFilesPayload`).
-/// A path that can no longer be stat'ed reads as missing rather than an error:
-/// to the panel, the file was deleted.
+/// Each path answers for itself: one file the host cannot inspect neither
+/// fails the whole reply nor reads as deleted — it is reported as exactly
+/// that.
 async fn stat_files_op(payload : StatFilesPayload) -> StatFilesReply {
   let stats : Array[FileStat] = []
   for path in payload.paths {
     let file = WirePath::parse(path).absolute
-    let sig = file_signature(file.to_string())
-    stats.push({ path, sig: sig.unwrap_or(""), })
+    stats.push({ path, signature: file_signature(file.to_string()), })
   }
   { stats, }
 }
 
 ///|
-/// `"{seconds}:{nanos}"` of the file's mtime, or None when it cannot be
-/// stat'ed — a missing file, by far the common case; any other stat failure
-/// reads the same way, and the panel's read-on-change then surfaces the real
-/// error if the file actually exists.
-async fn file_signature(absolute : String) -> String? {
+/// `Present("{seconds}:{nanos}")` of the file's mtime. `Missing` is the path
+/// no longer resolving to a file — deleted, or an ancestor that stopped being
+/// a directory — by far the common failure. Every other stat error is
+/// `Failed` with the OS message: the panel then re-reads the file so the
+/// read's own error (or the content) replaces the guess, and the log keeps
+/// the stat's.
+async fn file_signature(absolute : String) -> FileSignature {
   let (seconds, nanos) = @fs.mtime(absolute) catch {
     error if @async.is_being_cancelled() => raise error
-    _ => return None
+    @os_error.OSError(_) as error if error.is_ENOENT() || error.is_ENOTDIR() =>
+      return Missing
+    error => {
+      @xlog.warn(category="filesystem") <?
+        { "event": "stat_failed", "path": absolute, "error": "\{error}" }
+      return Failed("\{error}")
+    }
   }
-  Some("\{seconds}:\{nanos}")
+  Present("\{seconds}:\{nanos}")
 }

--- a/desktop/internal/host/fs_watch.mbt
+++ b/desktop/internal/host/fs_watch.mbt
@@ -559,6 +559,13 @@ test "filesystem payloads carry absolute target paths" {
 }
 
 ///|
-async test "file_signature reads a missing file as absent" {
-  assert_true(file_signature("/nonexistent/openseek-fs-watch-test") is None)
+async test "file_signature reads a missing path as absent, not as a failure" {
+  assert_true(file_signature("/nonexistent/openseek-fs-watch-test") is Missing)
+  // A path through a regular file fails with ENOTDIR rather than ENOENT and
+  // is just as absent.
+  let dir = @fs.tmpdir(prefix="openseek-file-signature-")
+  defer @async.protect_from_cancel(() => @fs.rmdir(dir, recursive=true))
+  @fs.write_file("\{dir}/plain", b"x", create_mode=CreateOrTruncate)
+  assert_true(file_signature("\{dir}/plain/child") is Missing)
+  assert_true(file_signature("\{dir}/plain") is Present(_))
 }

--- a/desktop/internal/host/protocol.mbt
+++ b/desktop/internal/host/protocol.mbt
@@ -195,25 +195,14 @@ type ReadFileReply = @protocol.ReadFileReply
 type StatFilesPayload = @protocol.StatFilesPayload
 
 ///|
-/// One file's signature: `"{seconds}:{nanos}"` of its mtime, absent internally
-/// when the file is missing (deleted, or the path stopped resolving). The
-/// bundled desktop predates optional signatures and recognizes `""` as its
-/// deleted-file sentinel, so the manual encoder preserves that wire contract.
-/// The frontend only ever compares signatures for equality, so the shape stays
-/// opaque text — no Int64 crossing JSON.
+/// One file's stat outcome: `Present("{seconds}:{nanos}")` of its mtime,
+/// `Missing` when the path no longer resolves to a file, or `Failed` with the
+/// OS error for anything else. The frontend only ever compares signatures for
+/// equality, so the shape stays opaque text — no Int64 crossing JSON.
 type FileStat = @protocol.FileStat
 
 ///|
-test "file stat keeps the legacy missing-file sentinel on the wire" {
-  assert_eq(ToJson::to_json(({ path: "deleted.mbt", sig: "", } : FileStat)), {
-    "path": "deleted.mbt",
-    "sig": "",
-  })
-  assert_eq(
-    ToJson::to_json(({ path: "present.mbt", sig: "12:34", } : FileStat)),
-    { "path": "present.mbt", "sig": "12:34" },
-  )
-}
+type FileSignature = @protocol.FileSignature
 
 ///|
 type StatFilesReply = @protocol.StatFilesReply

--- a/desktop/internal/protocol/desktop_replies.mbt
+++ b/desktop/internal/protocol/desktop_replies.mbt
@@ -1361,15 +1361,96 @@ pub impl FromJson for ReadFileReply with fn from_json(json, path) {
 }
 
 ///|
+/// One `fs.stat_files` outcome. `Present` carries the opaque mtime signature
+/// `"{seconds}:{nanos}"`; `Missing` is a path that does not resolve to a file;
+/// `Failed` is every other stat error with the host's message. The three stay
+/// distinct on the wire so a file the host cannot inspect never reads as one
+/// that is gone.
+pub(all) enum FileSignature {
+  Missing
+  Present(String)
+  Failed(String)
+} derive(Debug, Eq)
+
+///|
+pub impl ToJson for FileSignature with fn to_json(self) {
+  match self {
+    Missing => { "kind": "missing" }
+    Present(sig) => { "kind": "present", "sig": sig }
+    Failed(message) => { "kind": "failed", "message": message }
+  }
+}
+
+///|
+pub impl FromJson for FileSignature with fn from_json(json, path) {
+  guard json is Object(fields) && fields.get("kind") is Some(String(kind_)) else {
+    raise JsonDecodeError((path, "expected file signature"))
+  }
+  match kind_ {
+    "missing" => Missing
+    "present" => {
+      guard fields.get("sig") is Some(String(sig)) else {
+        raise JsonDecodeError((path.add_key("sig"), "expected string"))
+      }
+      Present(sig)
+    }
+    "failed" => {
+      guard fields.get("message") is Some(String(message)) else {
+        raise JsonDecodeError((path.add_key("message"), "expected string"))
+      }
+      Failed(message)
+    }
+    _ =>
+      raise JsonDecodeError(
+        (path.add_key("kind"), "unknown file signature kind"),
+      )
+  }
+}
+
+///|
 pub(all) struct FileStat {
   path : String
-  sig : String
-} derive(Debug, Eq, FromJson, ToJson)
+  signature : FileSignature
+} derive(Debug, Eq)
+
+///|
+pub impl ToJson for FileStat with fn to_json(self) {
+  { "path": self.path, "signature": self.signature.to_json() }
+}
+
+///|
+pub impl FromJson for FileStat with fn from_json(json, path) {
+  let object = JsonObject::decode(json, path, "file stat")
+  {
+    path: object.required_string("path"),
+    signature: @json.from_json(
+      object.required_json("signature"),
+      path=path.add_key("signature"),
+    ),
+  }
+}
 
 ///|
 pub(all) struct StatFilesReply {
   stats : Array[FileStat]
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(Debug, Eq)
+
+///|
+pub impl ToJson for StatFilesReply with fn to_json(self) {
+  { "stats": self.stats }
+}
+
+///|
+pub impl FromJson for StatFilesReply with fn from_json(json, path) {
+  let object = JsonObject::decode(json, path, "stat files reply")
+  let stats : Array[FileStat] = []
+  for index, raw in object.required_array("stats") {
+    stats.push(
+      @json.from_json(raw, path=path.add_key("stats").add_index(index)),
+    )
+  }
+  { stats, }
+}
 
 ///|
 /// One directory listing (`parent` is `None` at a filesystem root), the
@@ -1842,6 +1923,18 @@ pub extend EmptyReply with Eq::{equal, not_equal}
 
 ///|
 pub extend EmptyReply with ToJson::{to_json}
+
+///|
+pub extend FileSignature with Debug::{to_repr}
+
+///|
+pub extend FileSignature with FromJson::{from_json}
+
+///|
+pub extend FileSignature with Eq::{equal, not_equal}
+
+///|
+pub extend FileSignature with ToJson::{to_json}
 
 ///|
 pub extend FileStat with Debug::{to_repr}

--- a/desktop/internal/protocol/desktop_replies_test.mbt
+++ b/desktop/internal/protocol/desktop_replies_test.mbt
@@ -1407,3 +1407,38 @@ test "a reconnect settlement is refused unless it names run, session and outcome
     assert_true(refused)
   }
 }
+
+///|
+test "file stats keep missing, present, and failed distinct on the wire" {
+  let reply : @protocol.StatFilesReply = {
+    stats: [
+      { path: "/work/gone.mbt", signature: Missing, },
+      { path: "/work/here.mbt", signature: Present("12:34"), },
+      { path: "/work/locked.mbt", signature: Failed("permission denied"), },
+    ],
+  }
+  let wire : Json = {
+    "stats": [
+      { "path": "/work/gone.mbt", "signature": { "kind": "missing" } },
+      {
+        "path": "/work/here.mbt",
+        "signature": { "kind": "present", "sig": "12:34" },
+      },
+      {
+        "path": "/work/locked.mbt",
+        "signature": { "kind": "failed", "message": "permission denied" },
+      },
+    ],
+  }
+  @debug.assert_eq(reply.to_json(), wire)
+  let decoded : @protocol.StatFilesReply = @json.from_json(wire)
+  @debug.assert_eq(decoded, reply)
+  // An empty signature string is not a deleted-file sentinel any more; a
+  // reply spelled that way is malformed rather than silently "deleted".
+  let legacy : @protocol.StatFilesReply = @json.from_json({
+    "stats": [{ "path": "/work/gone.mbt", "sig": "" }],
+  }) catch {
+    _ => return
+  }
+  fail("an empty signature must not decode: \{Repr(legacy)}")
+}

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -824,15 +824,30 @@ pub fn ExternalLinkPayload::not_equal(Self, Self) -> Bool
 pub fn ExternalLinkPayload::to_json(Self) -> Json
 pub fn ExternalLinkPayload::to_repr(Self) -> @debug.Repr
 
+pub(all) enum FileSignature {
+  Missing
+  Present(String)
+  Failed(String)
+} derive(Eq, @debug.Debug)
+pub fn FileSignature::equal(Self, Self) -> Bool
+pub fn FileSignature::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn FileSignature::not_equal(Self, Self) -> Bool
+pub fn FileSignature::to_json(Self) -> Json
+pub fn FileSignature::to_repr(Self) -> @debug.Repr
+pub impl ToJson for FileSignature
+pub impl @json.FromJson for FileSignature
+
 pub(all) struct FileStat {
   path : String
-  sig : String
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+  signature : FileSignature
+} derive(Eq, @debug.Debug)
 pub fn FileStat::equal(Self, Self) -> Bool
 pub fn FileStat::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn FileStat::not_equal(Self, Self) -> Bool
 pub fn FileStat::to_json(Self) -> Json
 pub fn FileStat::to_repr(Self) -> @debug.Repr
+pub impl ToJson for FileStat
+pub impl @json.FromJson for FileStat
 
 pub(all) struct FinishedPayload {
   run_id : String
@@ -2077,12 +2092,14 @@ pub fn StatFilesPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct StatFilesReply {
   stats : Array[FileStat]
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+} derive(Eq, @debug.Debug)
 pub fn StatFilesReply::equal(Self, Self) -> Bool
 pub fn StatFilesReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn StatFilesReply::not_equal(Self, Self) -> Bool
 pub fn StatFilesReply::to_json(Self) -> Json
 pub fn StatFilesReply::to_repr(Self) -> @debug.Repr
+pub impl ToJson for StatFilesReply
+pub impl @json.FromJson for StatFilesReply
 
 pub(all) struct SteerPayload {
   text : String

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -237,9 +237,7 @@ readiness resync follows the same idempotent, race-tolerant rules.
 
 `params` is always a JSON object; `{}` when a method takes nothing.
 Optional fields (`?`) are absent when unset — the protocol never encodes
-request-side absence as `""`, `0`, or another in-band sentinel. The one
-reply-side compatibility exception is a missing file's
-`fs.stat_files.stats[].sig: ""`.
+absence as `""`, `0`, or another in-band sentinel, on either side.
 
 ### agent.* — runs
 
@@ -496,7 +494,7 @@ picker-specific starting-point behavior.
 | `fs.clear_file_search_cache` | `{cache_key}` | `{}` — retires one search cache session and its outstanding work |
 | `fs.search_text` | `{root, query, regex, case_sensitive, whole_word, include_glob, exclude_glob, session_key, generation, max_results}` (`root` absolute; include/exclude are comma-separated VS Code-style globs) | `{root, generation, matches: [{path, line_number, preview, preview_start_column, ranges: [{start_column, end_column}]}], match_count, file_count, limit_hit, cancelled, error_code?, error_message?}` — bounded workspace grep using bundled ripgrep; paths are root-relative, line/preview columns and exclusive range ends are one-based UTF-16. Success omits both error fields; failures include both, and `error_code` distinguishes `invalid_regex`, `invalid_glob`, `permission_denied`, `rg_unavailable`, `invalid_request`, and `search_failed` |
 | `fs.cancel_search_text` | `{session_key, generation}` | `{}` — cancels that generation and records a bounded recent monotonic cancellation frontier; a newer generation in the same session automatically cancels its predecessor |
-| `fs.stat_files` | `{paths}` (absolute) | `{stats: [{path, sig}]}` — each `path` echoes its absolute input; `sig` is the opaque mtime signature `"{seconds}:{nanos}"`; `""` means the file is missing, retained for client compatibility |
+| `fs.stat_files` | `{paths}` (absolute) | `{stats: [{path, signature}]}` — each `path` echoes its absolute input; `signature` is `{kind: "present", sig}` with the opaque mtime signature `"{seconds}:{nanos}"`, `{kind: "missing"}` when the path no longer resolves to a file, or `{kind: "failed", message}` for any other stat error |
 | `fs.watch` | `{path, files, directories, recursive?, generation}` (`path` absolute; `generation` string) | `{}` — replaces the connection's single watcher; success means the native watcher has scanned its initial tree and emitted its baseline, while setup failure rejects this request; `files` and `directories` are relative to `path`, each directory keeps its immediate children observable, `recursive=true` additionally watches every non-pruned descendant, and clients use a page-unique namespace plus a monotonically increasing counter for `generation` |
 | `fs.unwatch` | `{}` | `{}` — stops watching when the panel is closed and it has no open tabs |
 | `fs.browse` | `{path?}` (absent = home; leading `~` expands) | `{path, parent?, entries}` — subdirectory names, sorted, dotfiles skipped |


### PR DESCRIPTION
## Problem

A user's screenshot showed an open tab struck through with "`tzif.mbt` was deleted and has no review baseline to preview." while the Changes list still listed the same path as `?` (untracked — git had just seen it on disk).

For an untracked row the only live producer of `TabDeleted` is a `fs.stat_files` reply with an empty signature, and the host emitted `""` for **every** `@fs.mtime` error, not only a missing file (`desktop/internal/host/fs_ops.mbt` `file_signature`). A file the host could not inspect — permissions, a sharing violation, a path it could not resolve — therefore read as deleted, and the real error was discarded before anyone could see it. The `""` sentinel was kept on purpose "for the bundled desktop", which contradicts the lockstep rule in `desktop/AGENTS.md`.

## Change

- **Protocol**: `FileStat.sig : String` → `signature : FileSignature`, a three-state enum `Missing | Present(sig) | Failed(message)` encoded as `{kind: "missing"}` / `{kind: "present", sig}` / `{kind: "failed", message}`. Explicit `ToJson`/`FromJson` for `FileSignature`, `FileStat`, and `StatFilesReply` (the derived codecs are gone, per `desktop/AGENTS.md`). Round-trip test added; the legacy `{"sig": ""}` is now a malformed reply, not a deletion.
- **Host**: `file_signature` maps `ENOENT`/`ENOTDIR` to `Missing` and every other error to `Failed(message)`, logging a `stat_failed` warning (`category="filesystem"`) so the next occurrence is diagnosable.
- **Frontend**: `StatsLoaded` handles the three cases separately. `Missing` is the unchanged deletion branch. `Failed` keeps the document in place as `TabReadFailed(message)` — never `TabDeleted` — fencing an in-flight tagged review read the way a deletion does; documents with a read in flight, withheld documents, and a review whose selected row is a deletion are left alone. `Present` keeps the existing change-detection rule, so a later good stat retries the failed read.
- **Docs / conventions**: `docs/remote-protocol.md` drops the "one reply-side sentinel exception" and documents the new reply shape; root `AGENTS.md` gains the rule that absence and failure are never sentinel values, on the wire included.

## Verification

- `moon check --target native` and `--target js` in `desktop/`
- `moon test --target native internal/host internal/protocol` (164 tests) and `moon test --target js frontend/fileeditor` (144 tests)
- `moon fmt`, `moon info`; `.mbti` diffs contain only the intended hunks

Not done here, discussed and deferred: re-reading a `TabDeleted` document when a fresh Changes snapshot lists its path — it only covers a lost watcher event and would race a stale snapshot; the new `stat_failed` log tells us whether that case ever happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
