### PR TITLE
Redesign desktop review toolbar

### DIFF
--- a/desktop/frontend/fileeditor/diff_provider_policy_wbtest.mbt
+++ b/desktop/frontend/fileeditor/diff_provider_policy_wbtest.mbt
@@ -13,7 +13,7 @@ test "diff provider forces Core outside .mbt without overwriting preference" {
 }
 
 ///|
-test "desktop diff provider preferences and fallback status are host state" {
+test "selecting a Moon diff algorithm enters Diff view and retains policy" {
   let initial = State::empty()
   assert_true(initial.review_diff_mode is ReviewDiffCore)
   assert_true(initial.review_diff_ignore_comments)
@@ -28,11 +28,11 @@ test "desktop diff provider preferences and fallback status are host state" {
       generation: 1,
       working_generation: 1,
       baseline: ReviewContent("old source"),
-      view_mode: ReviewDiff,
+      view_mode: ReviewSource,
       selected,
     }),
   }
-  let state = { ..owned_state(), docs, }
+  let state = { ..owned_state(), docs, review_view_mode: ReviewSource, }
   let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path), }
   let (_, tree) = update(
     test_emit(),
@@ -41,6 +41,11 @@ test "desktop diff provider preferences and fallback status are host state" {
     ctx,
   )
   assert_true(tree.review_diff_mode is ReviewDiffTree)
+  assert_true(tree.review_view_mode is ReviewDiff)
+  assert_true(
+    tree.docs.get(path)
+    is Some({ review: Some({ view_mode: ReviewDiff, .. }), .. }),
+  )
   assert_eq(tree.review_diff_status, None)
   let (_, include_comments) = update(
     test_emit(),

--- a/desktop/frontend/fileeditor/git_history_wbtest.mbt
+++ b/desktop/frontend/fileeditor/git_history_wbtest.mbt
@@ -161,7 +161,7 @@ test "historical model URIs encode revision side and path immutably" {
 }
 
 ///|
-test "historical tabs use only the inert diff surface and history breadcrumb" {
+test "historical tabs use only the inert diff surface and history controls" {
   let diff : @dock.GitHistoryDiff = {
     commit: "1111111111111111111111111111111111111111",
     parent: Some("0000000000000000000000000000000000000000"),
@@ -193,61 +193,33 @@ test "historical tabs use only the inert diff surface and history breadcrumb" {
   assert_true(
     body.contains("id=\"diff-editor-host\" class=\"viewer-host editor-shell\""),
   )
-  let breadcrumb = render_review_snapshot(
-    breadcrumb_view(test_emit(), state, ctx),
-  )
   inspect(
-    breadcrumb,
+    render_review_control(review_diff_mode_toolbar(test_emit(), state, ctx)),
     content=(
-      #|<div class="viewer-breadcrumb review-toolbar history-breadcrumb">
-      #|<div class="viewer-breadcrumb-row">
-      #|<div class="crumb-path">
-      #|<span class="crumb history-commit-crumb">11111111</span>
-      #|<span class="crumb-sep">›</span>
-      #|<span class="crumb crumb-file">src/main.mbt</span>
-      #|</div>
-      #|<button title="Hide file tree" class="panel-toggle">
-      #|<span aria-hidden="true" class="icon">
-      #|<svg>…</svg>
-      #|</span>
-      #|</button>
-      #|</div>
-      #|<div class="review-command-row">
       #|<div role="toolbar" aria-label="Comparison algorithm" class="review-mode-toolbar review-history-mode-toolbar">
       #|<button data-diff-mode="core" aria-label="Line diff" aria-pressed="true" title="Use Line diff" type="button" class="review-mode-button active">Line</button>
       #|<button data-diff-mode="token" aria-label="Token diff" aria-pressed="false" title="Use Token diff" type="button" class="review-mode-button">Token</button>
       #|<button data-diff-mode="tree" aria-label="Tree diff" aria-pressed="false" title="Use Tree diff" type="button" class="review-mode-button">Tree</button>
       #|</div>
-      #|<span aria-hidden="true" class="review-control-divider">
-      #|</span>
+    ),
+  )
+  inspect(
+    render_review_control(review_diff_layout_toggle(test_emit(), state, ctx)),
+    content=(
       #|<div role="group" aria-label="Diff layout" class="review-layout-control">
       #|<button data-layout="side-by-side" aria-label="Split diff layout" aria-pressed="true" title="Use side-by-side diff layout" type="button" class="review-layout-button active">Split</button>
       #|<button data-layout="inline" aria-label="Unified diff layout" aria-pressed="false" title="Use unified diff layout" type="button" class="review-layout-button">Unified</button>
       #|</div>
-      #|<button aria-label="Ignore comments" aria-pressed="false" title="Available in Token and Tree diff" type="button" class="review-comments-control" disabled>Comments: ignored</button>
-      #|<span role="status" aria-live="polite" class="review-diff-mode-status hidden">
-      #|</span>
-      #|<div role="group" aria-label="Diff change navigation" class="review-diff-navigation">
-      #|<button data-action="previous-diff-change" aria-label="Previous change" aria-keyshortcuts="Shift+F7" title="Previous change (Shift+F7)" type="button" class="review-nav-button" disabled>
-      #|<span aria-hidden="true" class="icon">
-      #|<svg>…</svg>
-      #|</span>
-      #|</button>
-      #|<button data-action="next-diff-change" aria-label="Next change" aria-keyshortcuts="F7" title="Next change (F7)" type="button" class="review-nav-button" disabled>
-      #|<span aria-hidden="true" class="icon">
-      #|<svg>…</svg>
-      #|</span>
-      #|</button>
-      #|</div>
-      #|</div>
-      #|</div>
     ),
   )
-  let disabled_navigation = render_review_snapshot(
-    review_diff_navigation(test_emit(), state, ctx),
+  inspect(
+    render_review_control(review_comments_control(test_emit(), state, ctx)),
+    content=(
+      #|<button aria-label="Ignore comments" aria-pressed="false" title="Available in Token and Tree diff" type="button" class="review-comments-control" disabled>Comments: ignored</button>
+    ),
   )
   inspect(
-    disabled_navigation,
+    render_review_control(review_diff_navigation(test_emit(), state, ctx)),
     content=(
       #|<div role="group" aria-label="Diff change navigation" class="review-diff-navigation">
       #|<button data-action="previous-diff-change" aria-label="Previous change" aria-keyshortcuts="Shift+F7" title="Previous change (Shift+F7)" type="button" class="review-nav-button" disabled>
@@ -263,15 +235,14 @@ test "historical tabs use only the inert diff surface and history breadcrumb" {
       #|</div>
     ),
   )
-  let enabled_navigation = render_review_snapshot(
-    review_diff_navigation(
-      test_emit(),
-      { ..state, review_diff_navigation_available: true, },
-      ctx,
-    ),
-  )
   inspect(
-    enabled_navigation,
+    render_review_control(
+      review_diff_navigation(
+        test_emit(),
+        { ..state, review_diff_navigation_available: true, },
+        ctx,
+      ),
+    ),
     content=(
       #|<div role="group" aria-label="Diff change navigation" class="review-diff-navigation">
       #|<button data-action="previous-diff-change" aria-label="Previous change" aria-keyshortcuts="Shift+F7" title="Previous change (Shift+F7)" type="button" class="review-nav-button">
@@ -285,6 +256,37 @@ test "historical tabs use only the inert diff surface and history breadcrumb" {
       #|</span>
       #|</button>
       #|</div>
+    ),
+  )
+
+  let text_diff = { ..diff, path: @pathx.Relative("README.md"), }
+  let text_history_docs : Map[String, HistoryDiffDoc] = Map([])
+  text_history_docs[history_diff_key(text_diff)] = {
+    diff: text_diff,
+    generation: 1,
+    original: HistoryBlobContent("old"),
+    modified: HistoryBlobContent("new"),
+  }
+  let text_state = {
+    ..state,
+    history_docs: text_history_docs,
+    review_diff_mode: ReviewDiffTree,
+    review_diff_status: Some({
+      requested: ReviewDiffTree,
+      effective: ReviewDiffToken,
+      fell_back: true,
+    }),
+  }
+  let text_ctx = {
+    ..ctx,
+    open_history_diffs: [text_diff],
+    active_history_diff: Some(text_diff),
+  }
+  inspect(
+    render_review_control(review_diff_status(text_state, text_ctx)),
+    content=(
+      #|<span role="status" aria-live="polite" class="review-diff-mode-status hidden">
+      #|</span>
     ),
   )
 }

--- a/desktop/frontend/fileeditor/git_history_wbtest.mbt
+++ b/desktop/frontend/fileeditor/git_history_wbtest.mbt
@@ -193,31 +193,100 @@ test "historical tabs use only the inert diff surface and history breadcrumb" {
   assert_true(
     body.contains("id=\"diff-editor-host\" class=\"viewer-host editor-shell\""),
   )
-  let breadcrumb = render_review_html(breadcrumb_view(test_emit(), state, ctx))
-  assert_true(breadcrumb.contains("11111111"))
-  assert_true(breadcrumb.contains("src/main.mbt"))
-  assert_true(breadcrumb.contains("aria-label=\"Inline diff layout\""))
-  assert_true(breadcrumb.contains("aria-label=\"Diff change navigation\""))
-  assert_true(breadcrumb.contains("title=\"Previous change (Shift+F7)\""))
-  assert_true(breadcrumb.contains("data-action=\"previous-diff-change\""))
-  assert_true(breadcrumb.contains("aria-keyshortcuts=\"Shift+F7\""))
-  assert_true(breadcrumb.contains("title=\"Next change (F7)\""))
-  assert_true(breadcrumb.contains("data-action=\"next-diff-change\""))
-  assert_true(breadcrumb.contains("aria-keyshortcuts=\"F7\""))
-  let disabled_navigation = render_review_html(
+  let breadcrumb = render_review_snapshot(
+    breadcrumb_view(test_emit(), state, ctx),
+  )
+  inspect(
+    breadcrumb,
+    content=(
+      #|<div class="viewer-breadcrumb review-toolbar history-breadcrumb">
+      #|<div class="viewer-breadcrumb-row">
+      #|<div class="crumb-path">
+      #|<span class="crumb history-commit-crumb">11111111</span>
+      #|<span class="crumb-sep">›</span>
+      #|<span class="crumb crumb-file">src/main.mbt</span>
+      #|</div>
+      #|<button title="Hide file tree" class="panel-toggle">
+      #|<span aria-hidden="true" class="icon">
+      #|<svg>…</svg>
+      #|</span>
+      #|</button>
+      #|</div>
+      #|<div class="review-command-row">
+      #|<div role="toolbar" aria-label="Comparison algorithm" class="review-mode-toolbar review-history-mode-toolbar">
+      #|<button data-diff-mode="core" aria-label="Line diff" aria-pressed="true" title="Use Line diff" type="button" class="review-mode-button active">Line</button>
+      #|<button data-diff-mode="token" aria-label="Token diff" aria-pressed="false" title="Use Token diff" type="button" class="review-mode-button">Token</button>
+      #|<button data-diff-mode="tree" aria-label="Tree diff" aria-pressed="false" title="Use Tree diff" type="button" class="review-mode-button">Tree</button>
+      #|</div>
+      #|<span aria-hidden="true" class="review-control-divider">
+      #|</span>
+      #|<div role="group" aria-label="Diff layout" class="review-layout-control">
+      #|<button data-layout="side-by-side" aria-label="Split diff layout" aria-pressed="true" title="Use side-by-side diff layout" type="button" class="review-layout-button active">Split</button>
+      #|<button data-layout="inline" aria-label="Unified diff layout" aria-pressed="false" title="Use unified diff layout" type="button" class="review-layout-button">Unified</button>
+      #|</div>
+      #|<button aria-label="Ignore comments" aria-pressed="false" title="Available in Token and Tree diff" type="button" class="review-comments-control" disabled>Comments: ignored</button>
+      #|<span role="status" aria-live="polite" class="review-diff-mode-status hidden">
+      #|</span>
+      #|<div role="group" aria-label="Diff change navigation" class="review-diff-navigation">
+      #|<button data-action="previous-diff-change" aria-label="Previous change" aria-keyshortcuts="Shift+F7" title="Previous change (Shift+F7)" type="button" class="review-nav-button" disabled>
+      #|<span aria-hidden="true" class="icon">
+      #|<svg>…</svg>
+      #|</span>
+      #|</button>
+      #|<button data-action="next-diff-change" aria-label="Next change" aria-keyshortcuts="F7" title="Next change (F7)" type="button" class="review-nav-button" disabled>
+      #|<span aria-hidden="true" class="icon">
+      #|<svg>…</svg>
+      #|</span>
+      #|</button>
+      #|</div>
+      #|</div>
+      #|</div>
+    ),
+  )
+  let disabled_navigation = render_review_snapshot(
     review_diff_navigation(test_emit(), state, ctx),
   )
-  assert_true(disabled_navigation.contains("disabled"))
-  let enabled_navigation = render_review_html(
+  inspect(
+    disabled_navigation,
+    content=(
+      #|<div role="group" aria-label="Diff change navigation" class="review-diff-navigation">
+      #|<button data-action="previous-diff-change" aria-label="Previous change" aria-keyshortcuts="Shift+F7" title="Previous change (Shift+F7)" type="button" class="review-nav-button" disabled>
+      #|<span aria-hidden="true" class="icon">
+      #|<svg>…</svg>
+      #|</span>
+      #|</button>
+      #|<button data-action="next-diff-change" aria-label="Next change" aria-keyshortcuts="F7" title="Next change (F7)" type="button" class="review-nav-button" disabled>
+      #|<span aria-hidden="true" class="icon">
+      #|<svg>…</svg>
+      #|</span>
+      #|</button>
+      #|</div>
+    ),
+  )
+  let enabled_navigation = render_review_snapshot(
     review_diff_navigation(
       test_emit(),
       { ..state, review_diff_navigation_available: true, },
       ctx,
     ),
   )
-  assert_false(enabled_navigation.contains("disabled"))
-  assert_false(breadcrumb.contains("Mark reviewed"))
-  assert_false(breadcrumb.contains("View file"))
+  inspect(
+    enabled_navigation,
+    content=(
+      #|<div role="group" aria-label="Diff change navigation" class="review-diff-navigation">
+      #|<button data-action="previous-diff-change" aria-label="Previous change" aria-keyshortcuts="Shift+F7" title="Previous change (Shift+F7)" type="button" class="review-nav-button">
+      #|<span aria-hidden="true" class="icon">
+      #|<svg>…</svg>
+      #|</span>
+      #|</button>
+      #|<button data-action="next-diff-change" aria-label="Next change" aria-keyshortcuts="F7" title="Next change (F7)" type="button" class="review-nav-button">
+      #|<span aria-hidden="true" class="icon">
+      #|<svg>…</svg>
+      #|</span>
+      #|</button>
+      #|</div>
+    ),
+  )
 }
 
 ///|

--- a/desktop/frontend/fileeditor/git_history_wbtest.mbt
+++ b/desktop/frontend/fileeditor/git_history_wbtest.mbt
@@ -161,7 +161,7 @@ test "historical model URIs encode revision side and path immutably" {
 }
 
 ///|
-test "historical tabs use only the inert diff surface and history controls" {
+test "historical tabs use only the inert diff surface and history breadcrumb" {
   let diff : @dock.GitHistoryDiff = {
     commit: "1111111111111111111111111111111111111111",
     parent: Some("0000000000000000000000000000000000000000"),
@@ -193,33 +193,61 @@ test "historical tabs use only the inert diff surface and history controls" {
   assert_true(
     body.contains("id=\"diff-editor-host\" class=\"viewer-host editor-shell\""),
   )
+  let breadcrumb = render_review_snapshot(
+    breadcrumb_view(test_emit(), state, ctx),
+  )
   inspect(
-    render_review_control(review_diff_mode_toolbar(test_emit(), state, ctx)),
+    breadcrumb,
     content=(
+      #|<div class="viewer-breadcrumb review-toolbar history-breadcrumb">
+      #|<div class="viewer-breadcrumb-row">
+      #|<div class="crumb-path">
+      #|<span class="crumb history-commit-crumb">11111111</span>
+      #|<span class="crumb-sep">›</span>
+      #|<span class="crumb crumb-file">src/main.mbt</span>
+      #|</div>
+      #|<button title="Hide file tree" class="panel-toggle">
+      #|<span aria-hidden="true" class="icon">
+      #|<svg>…</svg>
+      #|</span>
+      #|</button>
+      #|</div>
+      #|<div class="review-command-row">
       #|<div role="toolbar" aria-label="Comparison algorithm" class="review-mode-toolbar review-history-mode-toolbar">
       #|<button data-diff-mode="core" aria-label="Line diff" aria-pressed="true" title="Use Line diff" type="button" class="review-mode-button active">Line</button>
       #|<button data-diff-mode="token" aria-label="Token diff" aria-pressed="false" title="Use Token diff" type="button" class="review-mode-button">Token</button>
       #|<button data-diff-mode="tree" aria-label="Tree diff" aria-pressed="false" title="Use Tree diff" type="button" class="review-mode-button">Tree</button>
       #|</div>
-    ),
-  )
-  inspect(
-    render_review_control(review_diff_layout_toggle(test_emit(), state, ctx)),
-    content=(
+      #|<span aria-hidden="true" class="review-control-divider">
+      #|</span>
       #|<div role="group" aria-label="Diff layout" class="review-layout-control">
       #|<button data-layout="side-by-side" aria-label="Split diff layout" aria-pressed="true" title="Use side-by-side diff layout" type="button" class="review-layout-button active">Split</button>
       #|<button data-layout="inline" aria-label="Unified diff layout" aria-pressed="false" title="Use unified diff layout" type="button" class="review-layout-button">Unified</button>
       #|</div>
-    ),
-  )
-  inspect(
-    render_review_control(review_comments_control(test_emit(), state, ctx)),
-    content=(
       #|<button aria-label="Ignore comments" aria-pressed="false" title="Available in Token and Tree diff" type="button" class="review-comments-control" disabled>Comments: ignored</button>
+      #|<span role="status" aria-live="polite" class="review-diff-mode-status hidden">
+      #|</span>
+      #|<div role="group" aria-label="Diff change navigation" class="review-diff-navigation">
+      #|<button data-action="previous-diff-change" aria-label="Previous change" aria-keyshortcuts="Shift+F7" title="Previous change (Shift+F7)" type="button" class="review-nav-button" disabled>
+      #|<span aria-hidden="true" class="icon">
+      #|<svg>…</svg>
+      #|</span>
+      #|</button>
+      #|<button data-action="next-diff-change" aria-label="Next change" aria-keyshortcuts="F7" title="Next change (F7)" type="button" class="review-nav-button" disabled>
+      #|<span aria-hidden="true" class="icon">
+      #|<svg>…</svg>
+      #|</span>
+      #|</button>
+      #|</div>
+      #|</div>
+      #|</div>
     ),
   )
+  let disabled_navigation = render_review_snapshot(
+    review_diff_navigation(test_emit(), state, ctx),
+  )
   inspect(
-    render_review_control(review_diff_navigation(test_emit(), state, ctx)),
+    disabled_navigation,
     content=(
       #|<div role="group" aria-label="Diff change navigation" class="review-diff-navigation">
       #|<button data-action="previous-diff-change" aria-label="Previous change" aria-keyshortcuts="Shift+F7" title="Previous change (Shift+F7)" type="button" class="review-nav-button" disabled>
@@ -235,14 +263,15 @@ test "historical tabs use only the inert diff surface and history controls" {
       #|</div>
     ),
   )
-  inspect(
-    render_review_control(
-      review_diff_navigation(
-        test_emit(),
-        { ..state, review_diff_navigation_available: true, },
-        ctx,
-      ),
+  let enabled_navigation = render_review_snapshot(
+    review_diff_navigation(
+      test_emit(),
+      { ..state, review_diff_navigation_available: true, },
+      ctx,
     ),
+  )
+  inspect(
+    enabled_navigation,
     content=(
       #|<div role="group" aria-label="Diff change navigation" class="review-diff-navigation">
       #|<button data-action="previous-diff-change" aria-label="Previous change" aria-keyshortcuts="Shift+F7" title="Previous change (Shift+F7)" type="button" class="review-nav-button">
@@ -258,18 +287,28 @@ test "historical tabs use only the inert diff surface and history controls" {
       #|</div>
     ),
   )
+}
 
-  let text_diff = { ..diff, path: @pathx.Relative("README.md"), }
-  let text_history_docs : Map[String, HistoryDiffDoc] = Map([])
-  text_history_docs[history_diff_key(text_diff)] = {
-    diff: text_diff,
+///|
+test "non-Moon history hides retained Moon fallback status" {
+  let diff : @dock.GitHistoryDiff = {
+    commit: "1111111111111111111111111111111111111111",
+    parent: Some("0000000000000000000000000000000000000000"),
+    path: @pathx.Relative("README.md"),
+    original_path: None,
+    status: "modified",
+    kind: "file",
+  }
+  let history_docs : Map[String, HistoryDiffDoc] = Map([])
+  history_docs[history_diff_key(diff)] = {
+    diff,
     generation: 1,
     original: HistoryBlobContent("old"),
     modified: HistoryBlobContent("new"),
   }
-  let text_state = {
-    ..state,
-    history_docs: text_history_docs,
+  let state = {
+    ..graph_fixture_state(),
+    history_docs,
     review_diff_mode: ReviewDiffTree,
     review_diff_status: Some({
       requested: ReviewDiffTree,
@@ -277,17 +316,14 @@ test "historical tabs use only the inert diff surface and history controls" {
       fell_back: true,
     }),
   }
-  let text_ctx = {
-    ..ctx,
-    open_history_diffs: [text_diff],
-    active_history_diff: Some(text_diff),
+  let ctx = {
+    ..test_ctx(),
+    open_history_diffs: [diff],
+    active_history_diff: Some(diff),
   }
   inspect(
-    render_review_control(review_diff_status(text_state, text_ctx)),
-    content=(
-      #|<span role="status" aria-live="polite" class="review-diff-mode-status hidden">
-      #|</span>
-    ),
+    render_review_html(review_diff_status(state, ctx)),
+    content="<span role=\"status\" aria-live=\"polite\" class=\"review-diff-mode-status hidden\"></span>",
   )
 }
 

--- a/desktop/frontend/fileeditor/git_history_wbtest.mbt
+++ b/desktop/frontend/fileeditor/git_history_wbtest.mbt
@@ -161,7 +161,7 @@ test "historical model URIs encode revision side and path immutably" {
 }
 
 ///|
-test "historical tabs use only the inert diff surface and history breadcrumb" {
+test "historical tabs use only the inert diff surface and history controls" {
   let diff : @dock.GitHistoryDiff = {
     commit: "1111111111111111111111111111111111111111",
     parent: Some("0000000000000000000000000000000000000000"),
@@ -193,61 +193,33 @@ test "historical tabs use only the inert diff surface and history breadcrumb" {
   assert_true(
     body.contains("id=\"diff-editor-host\" class=\"viewer-host editor-shell\""),
   )
-  let breadcrumb = render_review_snapshot(
-    breadcrumb_view(test_emit(), state, ctx),
-  )
   inspect(
-    breadcrumb,
+    render_review_control(review_diff_mode_toolbar(test_emit(), state, ctx)),
     content=(
-      #|<div class="viewer-breadcrumb review-toolbar history-breadcrumb">
-      #|<div class="viewer-breadcrumb-row">
-      #|<div class="crumb-path">
-      #|<span class="crumb history-commit-crumb">11111111</span>
-      #|<span class="crumb-sep">›</span>
-      #|<span class="crumb crumb-file">src/main.mbt</span>
-      #|</div>
-      #|<button title="Hide file tree" class="panel-toggle">
-      #|<span aria-hidden="true" class="icon">
-      #|<svg>…</svg>
-      #|</span>
-      #|</button>
-      #|</div>
-      #|<div class="review-command-row">
       #|<div role="toolbar" aria-label="Comparison algorithm" class="review-mode-toolbar review-history-mode-toolbar">
       #|<button data-diff-mode="core" aria-label="Line diff" aria-pressed="true" title="Use Line diff" type="button" class="review-mode-button active">Line</button>
       #|<button data-diff-mode="token" aria-label="Token diff" aria-pressed="false" title="Use Token diff" type="button" class="review-mode-button">Token</button>
       #|<button data-diff-mode="tree" aria-label="Tree diff" aria-pressed="false" title="Use Tree diff" type="button" class="review-mode-button">Tree</button>
       #|</div>
-      #|<span aria-hidden="true" class="review-control-divider">
-      #|</span>
+    ),
+  )
+  inspect(
+    render_review_control(review_diff_layout_toggle(test_emit(), state, ctx)),
+    content=(
       #|<div role="group" aria-label="Diff layout" class="review-layout-control">
       #|<button data-layout="side-by-side" aria-label="Split diff layout" aria-pressed="true" title="Use side-by-side diff layout" type="button" class="review-layout-button active">Split</button>
       #|<button data-layout="inline" aria-label="Unified diff layout" aria-pressed="false" title="Use unified diff layout" type="button" class="review-layout-button">Unified</button>
       #|</div>
-      #|<button aria-label="Ignore comments" aria-pressed="false" title="Available in Token and Tree diff" type="button" class="review-comments-control" disabled>Comments: ignored</button>
-      #|<span role="status" aria-live="polite" class="review-diff-mode-status hidden">
-      #|</span>
-      #|<div role="group" aria-label="Diff change navigation" class="review-diff-navigation">
-      #|<button data-action="previous-diff-change" aria-label="Previous change" aria-keyshortcuts="Shift+F7" title="Previous change (Shift+F7)" type="button" class="review-nav-button" disabled>
-      #|<span aria-hidden="true" class="icon">
-      #|<svg>…</svg>
-      #|</span>
-      #|</button>
-      #|<button data-action="next-diff-change" aria-label="Next change" aria-keyshortcuts="F7" title="Next change (F7)" type="button" class="review-nav-button" disabled>
-      #|<span aria-hidden="true" class="icon">
-      #|<svg>…</svg>
-      #|</span>
-      #|</button>
-      #|</div>
-      #|</div>
-      #|</div>
     ),
   )
-  let disabled_navigation = render_review_snapshot(
-    review_diff_navigation(test_emit(), state, ctx),
+  inspect(
+    render_review_control(review_comments_control(test_emit(), state, ctx)),
+    content=(
+      #|<button aria-label="Ignore comments" aria-pressed="false" title="Available in Token and Tree diff" type="button" class="review-comments-control" disabled>Comments: ignored</button>
+    ),
   )
   inspect(
-    disabled_navigation,
+    render_review_control(review_diff_navigation(test_emit(), state, ctx)),
     content=(
       #|<div role="group" aria-label="Diff change navigation" class="review-diff-navigation">
       #|<button data-action="previous-diff-change" aria-label="Previous change" aria-keyshortcuts="Shift+F7" title="Previous change (Shift+F7)" type="button" class="review-nav-button" disabled>
@@ -263,15 +235,14 @@ test "historical tabs use only the inert diff surface and history breadcrumb" {
       #|</div>
     ),
   )
-  let enabled_navigation = render_review_snapshot(
-    review_diff_navigation(
-      test_emit(),
-      { ..state, review_diff_navigation_available: true, },
-      ctx,
-    ),
-  )
   inspect(
-    enabled_navigation,
+    render_review_control(
+      review_diff_navigation(
+        test_emit(),
+        { ..state, review_diff_navigation_available: true, },
+        ctx,
+      ),
+    ),
     content=(
       #|<div role="group" aria-label="Diff change navigation" class="review-diff-navigation">
       #|<button data-action="previous-diff-change" aria-label="Previous change" aria-keyshortcuts="Shift+F7" title="Previous change (Shift+F7)" type="button" class="review-nav-button">
@@ -287,28 +258,18 @@ test "historical tabs use only the inert diff surface and history breadcrumb" {
       #|</div>
     ),
   )
-}
 
-///|
-test "non-Moon history hides retained Moon fallback status" {
-  let diff : @dock.GitHistoryDiff = {
-    commit: "1111111111111111111111111111111111111111",
-    parent: Some("0000000000000000000000000000000000000000"),
-    path: @pathx.Relative("README.md"),
-    original_path: None,
-    status: "modified",
-    kind: "file",
-  }
-  let history_docs : Map[String, HistoryDiffDoc] = Map([])
-  history_docs[history_diff_key(diff)] = {
-    diff,
+  let text_diff = { ..diff, path: @pathx.Relative("README.md"), }
+  let text_history_docs : Map[String, HistoryDiffDoc] = Map([])
+  text_history_docs[history_diff_key(text_diff)] = {
+    diff: text_diff,
     generation: 1,
     original: HistoryBlobContent("old"),
     modified: HistoryBlobContent("new"),
   }
-  let state = {
-    ..graph_fixture_state(),
-    history_docs,
+  let text_state = {
+    ..state,
+    history_docs: text_history_docs,
     review_diff_mode: ReviewDiffTree,
     review_diff_status: Some({
       requested: ReviewDiffTree,
@@ -316,14 +277,17 @@ test "non-Moon history hides retained Moon fallback status" {
       fell_back: true,
     }),
   }
-  let ctx = {
-    ..test_ctx(),
-    open_history_diffs: [diff],
-    active_history_diff: Some(diff),
+  let text_ctx = {
+    ..ctx,
+    open_history_diffs: [text_diff],
+    active_history_diff: Some(text_diff),
   }
   inspect(
-    render_review_html(review_diff_status(state, ctx)),
-    content="<span role=\"status\" aria-live=\"polite\" class=\"review-diff-mode-status hidden\"></span>",
+    render_review_control(review_diff_status(text_state, text_ctx)),
+    content=(
+      #|<span role="status" aria-live="polite" class="review-diff-mode-status hidden">
+      #|</span>
+    ),
   )
 }
 

--- a/desktop/frontend/fileeditor/review_surfaces_wbtest.mbt
+++ b/desktop/frontend/fileeditor/review_surfaces_wbtest.mbt
@@ -5,6 +5,27 @@ fn render_review_html(node : @html.Html) -> String {
 }
 
 ///|
+/// Keep toolbar snapshots structural: one tag per line, with icon presence
+/// visible but path geometry owned by the icon tests.
+fn render_review_snapshot(node : @html.Html) -> String {
+  let rendered = render_review_html(node).replace_all(old="><", new=">\n<")
+  let lines : Array[String] = []
+  let mut inside_svg = false
+  for view in rendered.split("\n") {
+    let line = "\{view}"
+    if line.has_prefix("<svg ") {
+      lines.push("<svg>…</svg>")
+      inside_svg = true
+    } else if line == "</svg>" {
+      inside_svg = false
+    } else if !inside_svg {
+      lines.push(line)
+    }
+  }
+  lines.join("\n")
+}
+
+///|
 test "desktop review keeps sibling hosts stable across source and diff modes" {
   let path = @pathx.Relative("src/main.mbt")
   let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path), }
@@ -46,21 +67,67 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
       "id=\"diff-editor-host\" class=\"viewer-host editor-shell moonbit-viewer-surface-hidden\"",
     ),
   )
-  let source_breadcrumb = render_review_html(
+  let source_breadcrumb = render_review_snapshot(
     breadcrumb_view(test_emit(), source_state, ctx),
   )
-  assert_true(source_breadcrumb.contains("aria-label=\"Full diff\""))
-  assert_true(source_breadcrumb.contains("aria-pressed=\"false\""))
-  assert_true(source_breadcrumb.contains(">View full diff</button>"))
-  assert_false(source_breadcrumb.contains("aria-label=\"Inline diff layout\""))
-  assert_false(
-    source_breadcrumb.contains("aria-label=\"Diff change navigation\""),
+  inspect(
+    source_breadcrumb,
+    content=(
+      #|<div class="viewer-breadcrumb review-toolbar">
+      #|<div class="viewer-breadcrumb-row">
+      #|<div class="crumb-path">
+      #|<button aria-controls="breadcrumb-directory-picker" aria-expanded="false" title="Show files in Workspace" type="button" class="crumb crumb-directory">Workspace</button>
+      #|<span class="crumb-sep">›</span>
+      #|<button aria-controls="breadcrumb-directory-picker" aria-expanded="false" title="Show files in src" type="button" class="crumb crumb-directory">src</button>
+      #|<span class="crumb-sep">›</span>
+      #|<span class="crumb crumb-file">main.mbt</span>
+      #|</div>
+      #|<div role="group" aria-label="Changed file navigation" class="review-navigation">
+      #|<button aria-label="Previous changed file" title="Previous changed file" type="button" class="review-nav-button" disabled>‹</button>
+      #|<span aria-live="polite" class="review-nav-position">1 of 1</span>
+      #|<button aria-label="Next changed file" title="Next changed file" type="button" class="review-nav-button" disabled>›</button>
+      #|</div>
+      #|<button aria-label="Mark file reviewed" aria-pressed="false" title="Mark this changed file as reviewed" type="button" class="review-badge review-progress">Mark reviewed</button>
+      #|<button title="Hide file tree" class="panel-toggle">
+      #|<span aria-hidden="true" class="icon">
+      #|<svg>…</svg>
+      #|</span>
+      #|</button>
+      #|</div>
+      #|<div class="review-command-row">
+      #|<div role="toolbar" aria-label="Review mode" class="review-mode-toolbar">
+      #|<button data-review-mode="file" aria-label="File view" aria-pressed="true" title="Show file" type="button" class="review-mode-button active">File</button>
+      #|<span aria-hidden="true" class="review-mode-divider">
+      #|</span>
+      #|<button data-diff-mode="core" aria-label="Line diff" aria-pressed="false" title="Use Line diff" type="button" class="review-mode-button">Line</button>
+      #|<button data-diff-mode="token" aria-label="Token diff" aria-pressed="false" title="Use Token diff" type="button" class="review-mode-button">Token</button>
+      #|<button data-diff-mode="tree" aria-label="Tree diff" aria-pressed="false" title="Use Tree diff" type="button" class="review-mode-button">Tree</button>
+      #|</div>
+      #|<span aria-hidden="true" class="review-control-divider">
+      #|</span>
+      #|<div role="group" aria-label="Diff layout" class="review-layout-control disabled">
+      #|<button data-layout="side-by-side" aria-label="Split diff layout" aria-pressed="false" title="Use side-by-side diff layout" type="button" class="review-layout-button" disabled>Split</button>
+      #|<button data-layout="inline" aria-label="Unified diff layout" aria-pressed="false" title="Use unified diff layout" type="button" class="review-layout-button" disabled>Unified</button>
+      #|</div>
+      #|<button aria-label="Ignore comments" aria-pressed="false" title="Available in diff view" type="button" class="review-comments-control" disabled>Comments: ignored</button>
+      #|<span role="status" aria-live="polite" class="review-diff-mode-status hidden">
+      #|</span>
+      #|<div role="group" aria-label="Diff change navigation" class="review-diff-navigation">
+      #|<button data-action="previous-diff-change" aria-label="Previous change" aria-keyshortcuts="Shift+F7" title="Previous change (Shift+F7)" type="button" class="review-nav-button" disabled>
+      #|<span aria-hidden="true" class="icon">
+      #|<svg>…</svg>
+      #|</span>
+      #|</button>
+      #|<button data-action="next-diff-change" aria-label="Next change" aria-keyshortcuts="F7" title="Next change (F7)" type="button" class="review-nav-button" disabled>
+      #|<span aria-hidden="true" class="icon">
+      #|<svg>…</svg>
+      #|</span>
+      #|</button>
+      #|</div>
+      #|</div>
+      #|</div>
+    ),
   )
-  assert_true(source_breadcrumb.contains(">Mark reviewed</button>"))
-  assert_true(
-    source_breadcrumb.contains("aria-label=\"Changed file navigation\""),
-  )
-  assert_true(source_breadcrumb.contains(">1 of 1</span>"))
 
   let diff_doc = {
     ..source_doc,
@@ -83,100 +150,157 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
   assert_true(
     diff.contains("id=\"diff-editor-host\" class=\"viewer-host editor-shell\""),
   )
-  let diff_breadcrumb = render_review_html(
+  let diff_breadcrumb = render_review_snapshot(
     breadcrumb_view(test_emit(), diff_state, ctx),
   )
-  assert_true(diff_breadcrumb.contains("aria-label=\"Full diff\""))
-  assert_true(diff_breadcrumb.contains("aria-pressed=\"true\""))
-  assert_true(diff_breadcrumb.contains(">View file</button>"))
-  assert_true(diff_breadcrumb.contains("aria-label=\"Inline diff layout\""))
-  assert_true(diff_breadcrumb.contains("aria-pressed=\"false\""))
-  assert_true(diff_breadcrumb.contains("data-layout=\"side-by-side\""))
-  assert_true(diff_breadcrumb.contains("review-layout-icon split"))
-  assert_true(diff_breadcrumb.contains("aria-label=\"Diff change navigation\""))
-  assert_true(diff_breadcrumb.contains("title=\"Previous change (Shift+F7)\""))
-  assert_true(diff_breadcrumb.contains("aria-label=\"Previous change\""))
-  assert_true(diff_breadcrumb.contains("aria-keyshortcuts=\"Shift+F7\""))
-  assert_true(diff_breadcrumb.contains("data-action=\"previous-diff-change\""))
-  assert_true(diff_breadcrumb.contains("title=\"Next change (F7)\""))
-  assert_true(diff_breadcrumb.contains("aria-label=\"Next change\""))
-  assert_true(diff_breadcrumb.contains("aria-keyshortcuts=\"F7\""))
-  assert_true(diff_breadcrumb.contains("data-action=\"next-diff-change\""))
-  assert_true(diff_breadcrumb.contains("class=\"icon\""))
-  assert_true(diff_breadcrumb.contains("disabled"))
-  let enabled_navigation = render_review_html(
+  inspect(
+    diff_breadcrumb,
+    content=(
+      #|<div class="viewer-breadcrumb review-toolbar">
+      #|<div class="viewer-breadcrumb-row">
+      #|<div class="crumb-path">
+      #|<button aria-controls="breadcrumb-directory-picker" aria-expanded="false" title="Show files in Workspace" type="button" class="crumb crumb-directory">Workspace</button>
+      #|<span class="crumb-sep">›</span>
+      #|<button aria-controls="breadcrumb-directory-picker" aria-expanded="false" title="Show files in src" type="button" class="crumb crumb-directory">src</button>
+      #|<span class="crumb-sep">›</span>
+      #|<span class="crumb crumb-file">main.mbt</span>
+      #|</div>
+      #|<div role="group" aria-label="Changed file navigation" class="review-navigation">
+      #|<button aria-label="Previous changed file" title="Previous changed file" type="button" class="review-nav-button" disabled>‹</button>
+      #|<span aria-live="polite" class="review-nav-position">1 of 1</span>
+      #|<button aria-label="Next changed file" title="Next changed file" type="button" class="review-nav-button" disabled>›</button>
+      #|</div>
+      #|<button aria-label="Mark file reviewed" aria-pressed="false" title="Mark this changed file as reviewed" type="button" class="review-badge review-progress">Mark reviewed</button>
+      #|<button title="Hide file tree" class="panel-toggle">
+      #|<span aria-hidden="true" class="icon">
+      #|<svg>…</svg>
+      #|</span>
+      #|</button>
+      #|</div>
+      #|<div class="review-command-row">
+      #|<div role="toolbar" aria-label="Review mode" class="review-mode-toolbar">
+      #|<button data-review-mode="file" aria-label="File view" aria-pressed="false" title="Show file" type="button" class="review-mode-button">File</button>
+      #|<span aria-hidden="true" class="review-mode-divider">
+      #|</span>
+      #|<button data-diff-mode="core" aria-label="Line diff" aria-pressed="true" title="Use Line diff" type="button" class="review-mode-button active">Line</button>
+      #|<button data-diff-mode="token" aria-label="Token diff" aria-pressed="false" title="Use Token diff" type="button" class="review-mode-button">Token</button>
+      #|<button data-diff-mode="tree" aria-label="Tree diff" aria-pressed="false" title="Use Tree diff" type="button" class="review-mode-button">Tree</button>
+      #|</div>
+      #|<span aria-hidden="true" class="review-control-divider">
+      #|</span>
+      #|<div role="group" aria-label="Diff layout" class="review-layout-control">
+      #|<button data-layout="side-by-side" aria-label="Split diff layout" aria-pressed="true" title="Use side-by-side diff layout" type="button" class="review-layout-button active">Split</button>
+      #|<button data-layout="inline" aria-label="Unified diff layout" aria-pressed="false" title="Use unified diff layout" type="button" class="review-layout-button">Unified</button>
+      #|</div>
+      #|<button aria-label="Ignore comments" aria-pressed="false" title="Available in Token and Tree diff" type="button" class="review-comments-control" disabled>Comments: ignored</button>
+      #|<span role="status" aria-live="polite" class="review-diff-mode-status hidden">
+      #|</span>
+      #|<div role="group" aria-label="Diff change navigation" class="review-diff-navigation">
+      #|<button data-action="previous-diff-change" aria-label="Previous change" aria-keyshortcuts="Shift+F7" title="Previous change (Shift+F7)" type="button" class="review-nav-button" disabled>
+      #|<span aria-hidden="true" class="icon">
+      #|<svg>…</svg>
+      #|</span>
+      #|</button>
+      #|<button data-action="next-diff-change" aria-label="Next change" aria-keyshortcuts="F7" title="Next change (F7)" type="button" class="review-nav-button" disabled>
+      #|<span aria-hidden="true" class="icon">
+      #|<svg>…</svg>
+      #|</span>
+      #|</button>
+      #|</div>
+      #|</div>
+      #|</div>
+    ),
+  )
+  let enabled_navigation = render_review_snapshot(
     review_diff_navigation(
       test_emit(),
       { ..diff_state, review_diff_navigation_available: true, },
       ctx,
     ),
   )
-  assert_true(
-    enabled_navigation.contains("aria-label=\"Diff change navigation\""),
-  )
-  assert_false(enabled_navigation.contains("disabled"))
-  assert_true(diff_breadcrumb.contains("aria-label=\"Comparison algorithm\""))
-  assert_true(diff_breadcrumb.contains("data-diff-mode=\"core\""))
-  assert_true(diff_breadcrumb.contains("data-diff-mode=\"token\""))
-  assert_true(diff_breadcrumb.contains("data-diff-mode=\"tree\""))
-  assert_true(diff_breadcrumb.contains("aria-label=\"Ignore comments\""))
-
-  let fallback_breadcrumb = render_review_html(
-    breadcrumb_view(
-      test_emit(),
-      {
-        ..diff_state,
-        review_diff_mode: ReviewDiffTree,
-        review_diff_status: Some({
-          requested: ReviewDiffTree,
-          effective: ReviewDiffToken,
-          fell_back: true,
-        }),
-      },
-      ctx,
+  inspect(
+    enabled_navigation,
+    content=(
+      #|<div role="group" aria-label="Diff change navigation" class="review-diff-navigation">
+      #|<button data-action="previous-diff-change" aria-label="Previous change" aria-keyshortcuts="Shift+F7" title="Previous change (Shift+F7)" type="button" class="review-nav-button">
+      #|<span aria-hidden="true" class="icon">
+      #|<svg>…</svg>
+      #|</span>
+      #|</button>
+      #|<button data-action="next-diff-change" aria-label="Next change" aria-keyshortcuts="F7" title="Next change (F7)" type="button" class="review-nav-button">
+      #|<span aria-hidden="true" class="icon">
+      #|<svg>…</svg>
+      #|</span>
+      #|</button>
+      #|</div>
     ),
   )
-  assert_true(
-    fallback_breadcrumb.contains("Tree unavailable — showing Token diff"),
-  )
-  assert_true(fallback_breadcrumb.contains("aria-live=\"polite\""))
 
-  let core_fallback_breadcrumb = render_review_html(
-    breadcrumb_view(
-      test_emit(),
-      {
-        ..diff_state,
-        review_diff_mode: ReviewDiffToken,
-        review_diff_status: Some({
-          requested: ReviewDiffToken,
-          effective: ReviewDiffCore,
-          fell_back: true,
-        }),
-      },
-      ctx,
+  let fallback_state = {
+    ..diff_state,
+    review_diff_mode: ReviewDiffTree,
+    review_diff_status: Some({
+      requested: ReviewDiffTree,
+      effective: ReviewDiffToken,
+      fell_back: true,
+    }),
+  }
+  let fallback_status = render_review_snapshot(
+    review_diff_status(fallback_state, ctx),
+  )
+  inspect(
+    fallback_status,
+    content=(
+      #|<span role="status" aria-live="polite" class="review-diff-mode-status">Tree unavailable — showing Token diff</span>
     ),
   )
-  assert_true(
-    core_fallback_breadcrumb.contains("Token unavailable — showing Core diff"),
+
+  let core_fallback_state = {
+    ..diff_state,
+    review_diff_mode: ReviewDiffToken,
+    review_diff_status: Some({
+      requested: ReviewDiffToken,
+      effective: ReviewDiffCore,
+      fell_back: true,
+    }),
+  }
+  let core_fallback_status = render_review_snapshot(
+    review_diff_status(core_fallback_state, ctx),
+  )
+  inspect(
+    core_fallback_status,
+    content=(
+      #|<span role="status" aria-live="polite" class="review-diff-mode-status">Token unavailable — showing Line diff</span>
+    ),
   )
 
-  let inline_breadcrumb = render_review_html(
-    breadcrumb_view(
+  let inline_layout = render_review_snapshot(
+    review_diff_layout_toggle(
       test_emit(),
       { ..diff_state, review_diff_layout: ReviewInline, },
       ctx,
     ),
   )
-  assert_true(inline_breadcrumb.contains("aria-label=\"Inline diff layout\""))
-  assert_true(inline_breadcrumb.contains("aria-pressed=\"true\""))
-  assert_true(inline_breadcrumb.contains("data-layout=\"inline\""))
-  assert_true(inline_breadcrumb.contains("review-layout-icon inline"))
+  inspect(
+    inline_layout,
+    content=(
+      #|<div role="group" aria-label="Diff layout" class="review-layout-control">
+      #|<button data-layout="side-by-side" aria-label="Split diff layout" aria-pressed="false" title="Use side-by-side diff layout" type="button" class="review-layout-button">Split</button>
+      #|<button data-layout="inline" aria-label="Unified diff layout" aria-pressed="true" title="Use unified diff layout" type="button" class="review-layout-button active">Unified</button>
+      #|</div>
+    ),
+  )
 
   let reviewed_state = { ..diff_state, reviewed_changes: [selected], }
-  let reviewed_breadcrumb = render_review_html(
-    breadcrumb_view(test_emit(), reviewed_state, ctx),
+  let reviewed_progress = render_review_snapshot(
+    review_progress(test_emit(), reviewed_state, ctx),
   )
-  assert_true(reviewed_breadcrumb.contains(">✓ Reviewed</button>"))
+  inspect(
+    reviewed_progress,
+    content=(
+      #|<button aria-label="Mark file reviewed" aria-pressed="true" title="Return this changed file to the review queue" type="button" class="review-badge review-progress reviewed">✓ Reviewed</button>
+    ),
+  )
   let reviewed_tree = render_review_html(
     tree_pane(test_emit(), reviewed_state, ctx),
   )
@@ -240,7 +364,7 @@ test "desktop explicitly routes Markdown source while DiffEditor stays code-only
 }
 
 ///|
-test "non-MoonBit full diff omits specialized provider controls" {
+test "non-MoonBit review keeps File and Line without specialized controls" {
   let path = @pathx.Relative("README.md")
   let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path), }
   let selected = test_modified_change(path)
@@ -255,17 +379,66 @@ test "non-MoonBit full diff omits specialized provider controls" {
       selected,
     }),
   }
-  let breadcrumb = render_review_html(
+  let breadcrumb = render_review_snapshot(
     breadcrumb_view(
       test_emit(),
       { ..owned_state(), docs, review_diff_mode: ReviewDiffTree, },
       ctx,
     ),
   )
-  assert_false(breadcrumb.contains("aria-label=\"Comparison algorithm\""))
-  assert_true(breadcrumb.contains("aria-label=\"Diff change navigation\""))
-  assert_true(breadcrumb.contains("data-action=\"previous-diff-change\""))
-  assert_true(breadcrumb.contains("data-action=\"next-diff-change\""))
+  inspect(
+    breadcrumb,
+    content=(
+      #|<div class="viewer-breadcrumb review-toolbar">
+      #|<div class="viewer-breadcrumb-row">
+      #|<div class="crumb-path">
+      #|<button aria-controls="breadcrumb-directory-picker" aria-expanded="false" title="Show files in Workspace" type="button" class="crumb crumb-directory">Workspace</button>
+      #|<span class="crumb-sep">›</span>
+      #|<span class="crumb crumb-file">README.md</span>
+      #|</div>
+      #|<span class="review-navigation hidden">
+      #|</span>
+      #|<span class="review-badge hidden">
+      #|</span>
+      #|<button title="Hide file tree" class="panel-toggle">
+      #|<span aria-hidden="true" class="icon">
+      #|<svg>…</svg>
+      #|</span>
+      #|</button>
+      #|</div>
+      #|<div class="review-command-row">
+      #|<div role="toolbar" aria-label="Review mode" class="review-mode-toolbar">
+      #|<button data-review-mode="file" aria-label="File view" aria-pressed="false" title="Show file" type="button" class="review-mode-button">File</button>
+      #|<span aria-hidden="true" class="review-mode-divider">
+      #|</span>
+      #|<button data-diff-mode="core" aria-label="Line diff" aria-pressed="true" title="Use Line diff" type="button" class="review-mode-button active">Line</button>
+      #|</div>
+      #|<span aria-hidden="true" class="review-control-divider">
+      #|</span>
+      #|<div role="group" aria-label="Diff layout" class="review-layout-control">
+      #|<button data-layout="side-by-side" aria-label="Split diff layout" aria-pressed="true" title="Use side-by-side diff layout" type="button" class="review-layout-button active">Split</button>
+      #|<button data-layout="inline" aria-label="Unified diff layout" aria-pressed="false" title="Use unified diff layout" type="button" class="review-layout-button">Unified</button>
+      #|</div>
+      #|<span class="review-comments-control hidden">
+      #|</span>
+      #|<span role="status" aria-live="polite" class="review-diff-mode-status hidden">
+      #|</span>
+      #|<div role="group" aria-label="Diff change navigation" class="review-diff-navigation">
+      #|<button data-action="previous-diff-change" aria-label="Previous change" aria-keyshortcuts="Shift+F7" title="Previous change (Shift+F7)" type="button" class="review-nav-button" disabled>
+      #|<span aria-hidden="true" class="icon">
+      #|<svg>…</svg>
+      #|</span>
+      #|</button>
+      #|<button data-action="next-diff-change" aria-label="Next change" aria-keyshortcuts="F7" title="Next change (F7)" type="button" class="review-nav-button" disabled>
+      #|<span aria-hidden="true" class="icon">
+      #|<svg>…</svg>
+      #|</span>
+      #|</button>
+      #|</div>
+      #|</div>
+      #|</div>
+    ),
+  )
 }
 
 ///|

--- a/desktop/frontend/fileeditor/review_surfaces_wbtest.mbt
+++ b/desktop/frontend/fileeditor/review_surfaces_wbtest.mbt
@@ -5,9 +5,9 @@ fn render_review_html(node : @html.Html) -> String {
 }
 
 ///|
-/// Snapshot one toolbar control at a time. Icon presence stays visible while
-/// SVG geometry remains outside these interaction tests.
-fn render_review_control(node : @html.Html) -> String {
+/// Keep toolbar snapshots structural: one tag per line, with icon presence
+/// visible but path geometry owned by the icon tests.
+fn render_review_snapshot(node : @html.Html) -> String {
   let rendered = render_review_html(node).replace_all(old="><", new=">\n<")
   let lines : Array[String] = []
   let mut inside_svg = false
@@ -67,9 +67,34 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
       "id=\"diff-editor-host\" class=\"viewer-host editor-shell moonbit-viewer-surface-hidden\"",
     ),
   )
+  let source_breadcrumb = render_review_snapshot(
+    breadcrumb_view(test_emit(), source_state, ctx),
+  )
   inspect(
-    render_review_control(review_mode_toolbar(test_emit(), source_state, ctx)),
+    source_breadcrumb,
     content=(
+      #|<div class="viewer-breadcrumb review-toolbar">
+      #|<div class="viewer-breadcrumb-row">
+      #|<div class="crumb-path">
+      #|<button aria-controls="breadcrumb-directory-picker" aria-expanded="false" title="Show files in Workspace" type="button" class="crumb crumb-directory">Workspace</button>
+      #|<span class="crumb-sep">›</span>
+      #|<button aria-controls="breadcrumb-directory-picker" aria-expanded="false" title="Show files in src" type="button" class="crumb crumb-directory">src</button>
+      #|<span class="crumb-sep">›</span>
+      #|<span class="crumb crumb-file">main.mbt</span>
+      #|</div>
+      #|<div role="group" aria-label="Changed file navigation" class="review-navigation">
+      #|<button aria-label="Previous changed file" title="Previous changed file" type="button" class="review-nav-button" disabled>‹</button>
+      #|<span aria-live="polite" class="review-nav-position">1 of 1</span>
+      #|<button aria-label="Next changed file" title="Next changed file" type="button" class="review-nav-button" disabled>›</button>
+      #|</div>
+      #|<button aria-label="Mark file reviewed" aria-pressed="false" title="Mark this changed file as reviewed" type="button" class="review-badge review-progress">Mark reviewed</button>
+      #|<button title="Hide file tree" class="panel-toggle">
+      #|<span aria-hidden="true" class="icon">
+      #|<svg>…</svg>
+      #|</span>
+      #|</button>
+      #|</div>
+      #|<div class="review-command-row">
       #|<div role="toolbar" aria-label="Review mode" class="review-mode-toolbar">
       #|<button data-review-mode="file" aria-label="File view" aria-pressed="true" title="Show file" type="button" class="review-mode-button active">File</button>
       #|<span aria-hidden="true" class="review-mode-divider">
@@ -78,32 +103,15 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
       #|<button data-diff-mode="token" aria-label="Token diff" aria-pressed="false" title="Use Token diff" type="button" class="review-mode-button">Token</button>
       #|<button data-diff-mode="tree" aria-label="Tree diff" aria-pressed="false" title="Use Tree diff" type="button" class="review-mode-button">Tree</button>
       #|</div>
-    ),
-  )
-  inspect(
-    render_review_control(
-      review_diff_layout_toggle(test_emit(), source_state, ctx),
-    ),
-    content=(
+      #|<span aria-hidden="true" class="review-control-divider">
+      #|</span>
       #|<div role="group" aria-label="Diff layout" class="review-layout-control disabled">
       #|<button data-layout="side-by-side" aria-label="Split diff layout" aria-pressed="false" title="Use side-by-side diff layout" type="button" class="review-layout-button" disabled>Split</button>
       #|<button data-layout="inline" aria-label="Unified diff layout" aria-pressed="false" title="Use unified diff layout" type="button" class="review-layout-button" disabled>Unified</button>
       #|</div>
-    ),
-  )
-  inspect(
-    render_review_control(
-      review_comments_control(test_emit(), source_state, ctx),
-    ),
-    content=(
       #|<button aria-label="Ignore comments" aria-pressed="false" title="Available in diff view" type="button" class="review-comments-control" disabled>Comments: ignored</button>
-    ),
-  )
-  inspect(
-    render_review_control(
-      review_diff_navigation(test_emit(), source_state, ctx),
-    ),
-    content=(
+      #|<span role="status" aria-live="polite" class="review-diff-mode-status hidden">
+      #|</span>
       #|<div role="group" aria-label="Diff change navigation" class="review-diff-navigation">
       #|<button data-action="previous-diff-change" aria-label="Previous change" aria-keyshortcuts="Shift+F7" title="Previous change (Shift+F7)" type="button" class="review-nav-button" disabled>
       #|<span aria-hidden="true" class="icon">
@@ -115,6 +123,8 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
       #|<svg>…</svg>
       #|</span>
       #|</button>
+      #|</div>
+      #|</div>
       #|</div>
     ),
   )
@@ -140,9 +150,34 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
   assert_true(
     diff.contains("id=\"diff-editor-host\" class=\"viewer-host editor-shell\""),
   )
+  let diff_breadcrumb = render_review_snapshot(
+    breadcrumb_view(test_emit(), diff_state, ctx),
+  )
   inspect(
-    render_review_control(review_mode_toolbar(test_emit(), diff_state, ctx)),
+    diff_breadcrumb,
     content=(
+      #|<div class="viewer-breadcrumb review-toolbar">
+      #|<div class="viewer-breadcrumb-row">
+      #|<div class="crumb-path">
+      #|<button aria-controls="breadcrumb-directory-picker" aria-expanded="false" title="Show files in Workspace" type="button" class="crumb crumb-directory">Workspace</button>
+      #|<span class="crumb-sep">›</span>
+      #|<button aria-controls="breadcrumb-directory-picker" aria-expanded="false" title="Show files in src" type="button" class="crumb crumb-directory">src</button>
+      #|<span class="crumb-sep">›</span>
+      #|<span class="crumb crumb-file">main.mbt</span>
+      #|</div>
+      #|<div role="group" aria-label="Changed file navigation" class="review-navigation">
+      #|<button aria-label="Previous changed file" title="Previous changed file" type="button" class="review-nav-button" disabled>‹</button>
+      #|<span aria-live="polite" class="review-nav-position">1 of 1</span>
+      #|<button aria-label="Next changed file" title="Next changed file" type="button" class="review-nav-button" disabled>›</button>
+      #|</div>
+      #|<button aria-label="Mark file reviewed" aria-pressed="false" title="Mark this changed file as reviewed" type="button" class="review-badge review-progress">Mark reviewed</button>
+      #|<button title="Hide file tree" class="panel-toggle">
+      #|<span aria-hidden="true" class="icon">
+      #|<svg>…</svg>
+      #|</span>
+      #|</button>
+      #|</div>
+      #|<div class="review-command-row">
       #|<div role="toolbar" aria-label="Review mode" class="review-mode-toolbar">
       #|<button data-review-mode="file" aria-label="File view" aria-pressed="false" title="Show file" type="button" class="review-mode-button">File</button>
       #|<span aria-hidden="true" class="review-mode-divider">
@@ -151,33 +186,40 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
       #|<button data-diff-mode="token" aria-label="Token diff" aria-pressed="false" title="Use Token diff" type="button" class="review-mode-button">Token</button>
       #|<button data-diff-mode="tree" aria-label="Tree diff" aria-pressed="false" title="Use Tree diff" type="button" class="review-mode-button">Tree</button>
       #|</div>
-    ),
-  )
-  inspect(
-    render_review_control(
-      review_diff_layout_toggle(test_emit(), diff_state, ctx),
-    ),
-    content=(
+      #|<span aria-hidden="true" class="review-control-divider">
+      #|</span>
       #|<div role="group" aria-label="Diff layout" class="review-layout-control">
       #|<button data-layout="side-by-side" aria-label="Split diff layout" aria-pressed="true" title="Use side-by-side diff layout" type="button" class="review-layout-button active">Split</button>
       #|<button data-layout="inline" aria-label="Unified diff layout" aria-pressed="false" title="Use unified diff layout" type="button" class="review-layout-button">Unified</button>
       #|</div>
-    ),
-  )
-  inspect(
-    render_review_control(review_comments_control(test_emit(), diff_state, ctx)),
-    content=(
       #|<button aria-label="Ignore comments" aria-pressed="false" title="Available in Token and Tree diff" type="button" class="review-comments-control" disabled>Comments: ignored</button>
+      #|<span role="status" aria-live="polite" class="review-diff-mode-status hidden">
+      #|</span>
+      #|<div role="group" aria-label="Diff change navigation" class="review-diff-navigation">
+      #|<button data-action="previous-diff-change" aria-label="Previous change" aria-keyshortcuts="Shift+F7" title="Previous change (Shift+F7)" type="button" class="review-nav-button" disabled>
+      #|<span aria-hidden="true" class="icon">
+      #|<svg>…</svg>
+      #|</span>
+      #|</button>
+      #|<button data-action="next-diff-change" aria-label="Next change" aria-keyshortcuts="F7" title="Next change (F7)" type="button" class="review-nav-button" disabled>
+      #|<span aria-hidden="true" class="icon">
+      #|<svg>…</svg>
+      #|</span>
+      #|</button>
+      #|</div>
+      #|</div>
+      #|</div>
+    ),
+  )
+  let enabled_navigation = render_review_snapshot(
+    review_diff_navigation(
+      test_emit(),
+      { ..diff_state, review_diff_navigation_available: true, },
+      ctx,
     ),
   )
   inspect(
-    render_review_control(
-      review_diff_navigation(
-        test_emit(),
-        { ..diff_state, review_diff_navigation_available: true, },
-        ctx,
-      ),
-    ),
+    enabled_navigation,
     content=(
       #|<div role="group" aria-label="Diff change navigation" class="review-diff-navigation">
       #|<button data-action="previous-diff-change" aria-label="Previous change" aria-keyshortcuts="Shift+F7" title="Previous change (Shift+F7)" type="button" class="review-nav-button">
@@ -203,8 +245,11 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
       fell_back: true,
     }),
   }
+  let fallback_status = render_review_snapshot(
+    review_diff_status(fallback_state, ctx),
+  )
   inspect(
-    render_review_control(review_diff_status(fallback_state, ctx)),
+    fallback_status,
     content=(
       #|<span role="status" aria-live="polite" class="review-diff-mode-status">Tree unavailable — showing Token diff</span>
     ),
@@ -219,21 +264,25 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
       fell_back: true,
     }),
   }
+  let core_fallback_status = render_review_snapshot(
+    review_diff_status(core_fallback_state, ctx),
+  )
   inspect(
-    render_review_control(review_diff_status(core_fallback_state, ctx)),
+    core_fallback_status,
     content=(
       #|<span role="status" aria-live="polite" class="review-diff-mode-status">Token unavailable — showing Line diff</span>
     ),
   )
 
-  inspect(
-    render_review_control(
-      review_diff_layout_toggle(
-        test_emit(),
-        { ..diff_state, review_diff_layout: ReviewInline, },
-        ctx,
-      ),
+  let inline_layout = render_review_snapshot(
+    review_diff_layout_toggle(
+      test_emit(),
+      { ..diff_state, review_diff_layout: ReviewInline, },
+      ctx,
     ),
+  )
+  inspect(
+    inline_layout,
     content=(
       #|<div role="group" aria-label="Diff layout" class="review-layout-control">
       #|<button data-layout="side-by-side" aria-label="Split diff layout" aria-pressed="false" title="Use side-by-side diff layout" type="button" class="review-layout-button">Split</button>
@@ -243,8 +292,11 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
   )
 
   let reviewed_state = { ..diff_state, reviewed_changes: [selected], }
+  let reviewed_progress = render_review_snapshot(
+    review_progress(test_emit(), reviewed_state, ctx),
+  )
   inspect(
-    render_review_control(review_progress(test_emit(), reviewed_state, ctx)),
+    reviewed_progress,
     content=(
       #|<button aria-label="Mark file reviewed" aria-pressed="true" title="Return this changed file to the review queue" type="button" class="review-badge review-progress reviewed">✓ Reviewed</button>
     ),
@@ -327,54 +379,59 @@ test "non-MoonBit review keeps File and Line without specialized controls" {
       selected,
     }),
   }
-  let state = {
-    ..owned_state(),
-    docs,
-    review_diff_mode: ReviewDiffTree,
-    // Reproduce switching away after a Moon provider reported a fallback.
-    review_diff_status: Some({
-      requested: ReviewDiffTree,
-      effective: ReviewDiffToken,
-      fell_back: true,
-    }),
-  }
+  let breadcrumb = render_review_snapshot(
+    breadcrumb_view(
+      test_emit(),
+      {
+        ..owned_state(),
+        docs,
+        review_diff_mode: ReviewDiffTree,
+        review_diff_status: Some({
+          requested: ReviewDiffTree,
+          effective: ReviewDiffToken,
+          fell_back: true,
+        }),
+      },
+      ctx,
+    ),
+  )
   inspect(
-    render_review_control(review_mode_toolbar(test_emit(), state, ctx)),
+    breadcrumb,
     content=(
+      #|<div class="viewer-breadcrumb review-toolbar">
+      #|<div class="viewer-breadcrumb-row">
+      #|<div class="crumb-path">
+      #|<button aria-controls="breadcrumb-directory-picker" aria-expanded="false" title="Show files in Workspace" type="button" class="crumb crumb-directory">Workspace</button>
+      #|<span class="crumb-sep">›</span>
+      #|<span class="crumb crumb-file">README.md</span>
+      #|</div>
+      #|<span class="review-navigation hidden">
+      #|</span>
+      #|<span class="review-badge hidden">
+      #|</span>
+      #|<button title="Hide file tree" class="panel-toggle">
+      #|<span aria-hidden="true" class="icon">
+      #|<svg>…</svg>
+      #|</span>
+      #|</button>
+      #|</div>
+      #|<div class="review-command-row">
       #|<div role="toolbar" aria-label="Review mode" class="review-mode-toolbar">
       #|<button data-review-mode="file" aria-label="File view" aria-pressed="false" title="Show file" type="button" class="review-mode-button">File</button>
       #|<span aria-hidden="true" class="review-mode-divider">
       #|</span>
       #|<button data-diff-mode="core" aria-label="Line diff" aria-pressed="true" title="Use Line diff" type="button" class="review-mode-button active">Line</button>
       #|</div>
-    ),
-  )
-  inspect(
-    render_review_control(review_diff_layout_toggle(test_emit(), state, ctx)),
-    content=(
+      #|<span aria-hidden="true" class="review-control-divider">
+      #|</span>
       #|<div role="group" aria-label="Diff layout" class="review-layout-control">
       #|<button data-layout="side-by-side" aria-label="Split diff layout" aria-pressed="true" title="Use side-by-side diff layout" type="button" class="review-layout-button active">Split</button>
       #|<button data-layout="inline" aria-label="Unified diff layout" aria-pressed="false" title="Use unified diff layout" type="button" class="review-layout-button">Unified</button>
       #|</div>
-    ),
-  )
-  inspect(
-    render_review_control(review_comments_control(test_emit(), state, ctx)),
-    content=(
       #|<span class="review-comments-control hidden">
       #|</span>
-    ),
-  )
-  inspect(
-    render_review_control(review_diff_status(state, ctx)),
-    content=(
       #|<span role="status" aria-live="polite" class="review-diff-mode-status hidden">
       #|</span>
-    ),
-  )
-  inspect(
-    render_review_control(review_diff_navigation(test_emit(), state, ctx)),
-    content=(
       #|<div role="group" aria-label="Diff change navigation" class="review-diff-navigation">
       #|<button data-action="previous-diff-change" aria-label="Previous change" aria-keyshortcuts="Shift+F7" title="Previous change (Shift+F7)" type="button" class="review-nav-button" disabled>
       #|<span aria-hidden="true" class="icon">
@@ -386,6 +443,8 @@ test "non-MoonBit review keeps File and Line without specialized controls" {
       #|<svg>…</svg>
       #|</span>
       #|</button>
+      #|</div>
+      #|</div>
       #|</div>
     ),
   )

--- a/desktop/frontend/fileeditor/review_surfaces_wbtest.mbt
+++ b/desktop/frontend/fileeditor/review_surfaces_wbtest.mbt
@@ -5,9 +5,9 @@ fn render_review_html(node : @html.Html) -> String {
 }
 
 ///|
-/// Keep toolbar snapshots structural: one tag per line, with icon presence
-/// visible but path geometry owned by the icon tests.
-fn render_review_snapshot(node : @html.Html) -> String {
+/// Snapshot one toolbar control at a time. Icon presence stays visible while
+/// SVG geometry remains outside these interaction tests.
+fn render_review_control(node : @html.Html) -> String {
   let rendered = render_review_html(node).replace_all(old="><", new=">\n<")
   let lines : Array[String] = []
   let mut inside_svg = false
@@ -67,34 +67,9 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
       "id=\"diff-editor-host\" class=\"viewer-host editor-shell moonbit-viewer-surface-hidden\"",
     ),
   )
-  let source_breadcrumb = render_review_snapshot(
-    breadcrumb_view(test_emit(), source_state, ctx),
-  )
   inspect(
-    source_breadcrumb,
+    render_review_control(review_mode_toolbar(test_emit(), source_state, ctx)),
     content=(
-      #|<div class="viewer-breadcrumb review-toolbar">
-      #|<div class="viewer-breadcrumb-row">
-      #|<div class="crumb-path">
-      #|<button aria-controls="breadcrumb-directory-picker" aria-expanded="false" title="Show files in Workspace" type="button" class="crumb crumb-directory">Workspace</button>
-      #|<span class="crumb-sep">›</span>
-      #|<button aria-controls="breadcrumb-directory-picker" aria-expanded="false" title="Show files in src" type="button" class="crumb crumb-directory">src</button>
-      #|<span class="crumb-sep">›</span>
-      #|<span class="crumb crumb-file">main.mbt</span>
-      #|</div>
-      #|<div role="group" aria-label="Changed file navigation" class="review-navigation">
-      #|<button aria-label="Previous changed file" title="Previous changed file" type="button" class="review-nav-button" disabled>‹</button>
-      #|<span aria-live="polite" class="review-nav-position">1 of 1</span>
-      #|<button aria-label="Next changed file" title="Next changed file" type="button" class="review-nav-button" disabled>›</button>
-      #|</div>
-      #|<button aria-label="Mark file reviewed" aria-pressed="false" title="Mark this changed file as reviewed" type="button" class="review-badge review-progress">Mark reviewed</button>
-      #|<button title="Hide file tree" class="panel-toggle">
-      #|<span aria-hidden="true" class="icon">
-      #|<svg>…</svg>
-      #|</span>
-      #|</button>
-      #|</div>
-      #|<div class="review-command-row">
       #|<div role="toolbar" aria-label="Review mode" class="review-mode-toolbar">
       #|<button data-review-mode="file" aria-label="File view" aria-pressed="true" title="Show file" type="button" class="review-mode-button active">File</button>
       #|<span aria-hidden="true" class="review-mode-divider">
@@ -103,15 +78,32 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
       #|<button data-diff-mode="token" aria-label="Token diff" aria-pressed="false" title="Use Token diff" type="button" class="review-mode-button">Token</button>
       #|<button data-diff-mode="tree" aria-label="Tree diff" aria-pressed="false" title="Use Tree diff" type="button" class="review-mode-button">Tree</button>
       #|</div>
-      #|<span aria-hidden="true" class="review-control-divider">
-      #|</span>
+    ),
+  )
+  inspect(
+    render_review_control(
+      review_diff_layout_toggle(test_emit(), source_state, ctx),
+    ),
+    content=(
       #|<div role="group" aria-label="Diff layout" class="review-layout-control disabled">
       #|<button data-layout="side-by-side" aria-label="Split diff layout" aria-pressed="false" title="Use side-by-side diff layout" type="button" class="review-layout-button" disabled>Split</button>
       #|<button data-layout="inline" aria-label="Unified diff layout" aria-pressed="false" title="Use unified diff layout" type="button" class="review-layout-button" disabled>Unified</button>
       #|</div>
+    ),
+  )
+  inspect(
+    render_review_control(
+      review_comments_control(test_emit(), source_state, ctx),
+    ),
+    content=(
       #|<button aria-label="Ignore comments" aria-pressed="false" title="Available in diff view" type="button" class="review-comments-control" disabled>Comments: ignored</button>
-      #|<span role="status" aria-live="polite" class="review-diff-mode-status hidden">
-      #|</span>
+    ),
+  )
+  inspect(
+    render_review_control(
+      review_diff_navigation(test_emit(), source_state, ctx),
+    ),
+    content=(
       #|<div role="group" aria-label="Diff change navigation" class="review-diff-navigation">
       #|<button data-action="previous-diff-change" aria-label="Previous change" aria-keyshortcuts="Shift+F7" title="Previous change (Shift+F7)" type="button" class="review-nav-button" disabled>
       #|<span aria-hidden="true" class="icon">
@@ -123,8 +115,6 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
       #|<svg>…</svg>
       #|</span>
       #|</button>
-      #|</div>
-      #|</div>
       #|</div>
     ),
   )
@@ -150,34 +140,9 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
   assert_true(
     diff.contains("id=\"diff-editor-host\" class=\"viewer-host editor-shell\""),
   )
-  let diff_breadcrumb = render_review_snapshot(
-    breadcrumb_view(test_emit(), diff_state, ctx),
-  )
   inspect(
-    diff_breadcrumb,
+    render_review_control(review_mode_toolbar(test_emit(), diff_state, ctx)),
     content=(
-      #|<div class="viewer-breadcrumb review-toolbar">
-      #|<div class="viewer-breadcrumb-row">
-      #|<div class="crumb-path">
-      #|<button aria-controls="breadcrumb-directory-picker" aria-expanded="false" title="Show files in Workspace" type="button" class="crumb crumb-directory">Workspace</button>
-      #|<span class="crumb-sep">›</span>
-      #|<button aria-controls="breadcrumb-directory-picker" aria-expanded="false" title="Show files in src" type="button" class="crumb crumb-directory">src</button>
-      #|<span class="crumb-sep">›</span>
-      #|<span class="crumb crumb-file">main.mbt</span>
-      #|</div>
-      #|<div role="group" aria-label="Changed file navigation" class="review-navigation">
-      #|<button aria-label="Previous changed file" title="Previous changed file" type="button" class="review-nav-button" disabled>‹</button>
-      #|<span aria-live="polite" class="review-nav-position">1 of 1</span>
-      #|<button aria-label="Next changed file" title="Next changed file" type="button" class="review-nav-button" disabled>›</button>
-      #|</div>
-      #|<button aria-label="Mark file reviewed" aria-pressed="false" title="Mark this changed file as reviewed" type="button" class="review-badge review-progress">Mark reviewed</button>
-      #|<button title="Hide file tree" class="panel-toggle">
-      #|<span aria-hidden="true" class="icon">
-      #|<svg>…</svg>
-      #|</span>
-      #|</button>
-      #|</div>
-      #|<div class="review-command-row">
       #|<div role="toolbar" aria-label="Review mode" class="review-mode-toolbar">
       #|<button data-review-mode="file" aria-label="File view" aria-pressed="false" title="Show file" type="button" class="review-mode-button">File</button>
       #|<span aria-hidden="true" class="review-mode-divider">
@@ -186,40 +151,33 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
       #|<button data-diff-mode="token" aria-label="Token diff" aria-pressed="false" title="Use Token diff" type="button" class="review-mode-button">Token</button>
       #|<button data-diff-mode="tree" aria-label="Tree diff" aria-pressed="false" title="Use Tree diff" type="button" class="review-mode-button">Tree</button>
       #|</div>
-      #|<span aria-hidden="true" class="review-control-divider">
-      #|</span>
+    ),
+  )
+  inspect(
+    render_review_control(
+      review_diff_layout_toggle(test_emit(), diff_state, ctx),
+    ),
+    content=(
       #|<div role="group" aria-label="Diff layout" class="review-layout-control">
       #|<button data-layout="side-by-side" aria-label="Split diff layout" aria-pressed="true" title="Use side-by-side diff layout" type="button" class="review-layout-button active">Split</button>
       #|<button data-layout="inline" aria-label="Unified diff layout" aria-pressed="false" title="Use unified diff layout" type="button" class="review-layout-button">Unified</button>
       #|</div>
-      #|<button aria-label="Ignore comments" aria-pressed="false" title="Available in Token and Tree diff" type="button" class="review-comments-control" disabled>Comments: ignored</button>
-      #|<span role="status" aria-live="polite" class="review-diff-mode-status hidden">
-      #|</span>
-      #|<div role="group" aria-label="Diff change navigation" class="review-diff-navigation">
-      #|<button data-action="previous-diff-change" aria-label="Previous change" aria-keyshortcuts="Shift+F7" title="Previous change (Shift+F7)" type="button" class="review-nav-button" disabled>
-      #|<span aria-hidden="true" class="icon">
-      #|<svg>…</svg>
-      #|</span>
-      #|</button>
-      #|<button data-action="next-diff-change" aria-label="Next change" aria-keyshortcuts="F7" title="Next change (F7)" type="button" class="review-nav-button" disabled>
-      #|<span aria-hidden="true" class="icon">
-      #|<svg>…</svg>
-      #|</span>
-      #|</button>
-      #|</div>
-      #|</div>
-      #|</div>
-    ),
-  )
-  let enabled_navigation = render_review_snapshot(
-    review_diff_navigation(
-      test_emit(),
-      { ..diff_state, review_diff_navigation_available: true, },
-      ctx,
     ),
   )
   inspect(
-    enabled_navigation,
+    render_review_control(review_comments_control(test_emit(), diff_state, ctx)),
+    content=(
+      #|<button aria-label="Ignore comments" aria-pressed="false" title="Available in Token and Tree diff" type="button" class="review-comments-control" disabled>Comments: ignored</button>
+    ),
+  )
+  inspect(
+    render_review_control(
+      review_diff_navigation(
+        test_emit(),
+        { ..diff_state, review_diff_navigation_available: true, },
+        ctx,
+      ),
+    ),
     content=(
       #|<div role="group" aria-label="Diff change navigation" class="review-diff-navigation">
       #|<button data-action="previous-diff-change" aria-label="Previous change" aria-keyshortcuts="Shift+F7" title="Previous change (Shift+F7)" type="button" class="review-nav-button">
@@ -245,11 +203,8 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
       fell_back: true,
     }),
   }
-  let fallback_status = render_review_snapshot(
-    review_diff_status(fallback_state, ctx),
-  )
   inspect(
-    fallback_status,
+    render_review_control(review_diff_status(fallback_state, ctx)),
     content=(
       #|<span role="status" aria-live="polite" class="review-diff-mode-status">Tree unavailable — showing Token diff</span>
     ),
@@ -264,25 +219,21 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
       fell_back: true,
     }),
   }
-  let core_fallback_status = render_review_snapshot(
-    review_diff_status(core_fallback_state, ctx),
-  )
   inspect(
-    core_fallback_status,
+    render_review_control(review_diff_status(core_fallback_state, ctx)),
     content=(
       #|<span role="status" aria-live="polite" class="review-diff-mode-status">Token unavailable — showing Line diff</span>
     ),
   )
 
-  let inline_layout = render_review_snapshot(
-    review_diff_layout_toggle(
-      test_emit(),
-      { ..diff_state, review_diff_layout: ReviewInline, },
-      ctx,
-    ),
-  )
   inspect(
-    inline_layout,
+    render_review_control(
+      review_diff_layout_toggle(
+        test_emit(),
+        { ..diff_state, review_diff_layout: ReviewInline, },
+        ctx,
+      ),
+    ),
     content=(
       #|<div role="group" aria-label="Diff layout" class="review-layout-control">
       #|<button data-layout="side-by-side" aria-label="Split diff layout" aria-pressed="false" title="Use side-by-side diff layout" type="button" class="review-layout-button">Split</button>
@@ -292,11 +243,8 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
   )
 
   let reviewed_state = { ..diff_state, reviewed_changes: [selected], }
-  let reviewed_progress = render_review_snapshot(
-    review_progress(test_emit(), reviewed_state, ctx),
-  )
   inspect(
-    reviewed_progress,
+    render_review_control(review_progress(test_emit(), reviewed_state, ctx)),
     content=(
       #|<button aria-label="Mark file reviewed" aria-pressed="true" title="Return this changed file to the review queue" type="button" class="review-badge review-progress reviewed">✓ Reviewed</button>
     ),
@@ -379,59 +327,54 @@ test "non-MoonBit review keeps File and Line without specialized controls" {
       selected,
     }),
   }
-  let breadcrumb = render_review_snapshot(
-    breadcrumb_view(
-      test_emit(),
-      {
-        ..owned_state(),
-        docs,
-        review_diff_mode: ReviewDiffTree,
-        review_diff_status: Some({
-          requested: ReviewDiffTree,
-          effective: ReviewDiffToken,
-          fell_back: true,
-        }),
-      },
-      ctx,
-    ),
-  )
+  let state = {
+    ..owned_state(),
+    docs,
+    review_diff_mode: ReviewDiffTree,
+    // Reproduce switching away after a Moon provider reported a fallback.
+    review_diff_status: Some({
+      requested: ReviewDiffTree,
+      effective: ReviewDiffToken,
+      fell_back: true,
+    }),
+  }
   inspect(
-    breadcrumb,
+    render_review_control(review_mode_toolbar(test_emit(), state, ctx)),
     content=(
-      #|<div class="viewer-breadcrumb review-toolbar">
-      #|<div class="viewer-breadcrumb-row">
-      #|<div class="crumb-path">
-      #|<button aria-controls="breadcrumb-directory-picker" aria-expanded="false" title="Show files in Workspace" type="button" class="crumb crumb-directory">Workspace</button>
-      #|<span class="crumb-sep">›</span>
-      #|<span class="crumb crumb-file">README.md</span>
-      #|</div>
-      #|<span class="review-navigation hidden">
-      #|</span>
-      #|<span class="review-badge hidden">
-      #|</span>
-      #|<button title="Hide file tree" class="panel-toggle">
-      #|<span aria-hidden="true" class="icon">
-      #|<svg>…</svg>
-      #|</span>
-      #|</button>
-      #|</div>
-      #|<div class="review-command-row">
       #|<div role="toolbar" aria-label="Review mode" class="review-mode-toolbar">
       #|<button data-review-mode="file" aria-label="File view" aria-pressed="false" title="Show file" type="button" class="review-mode-button">File</button>
       #|<span aria-hidden="true" class="review-mode-divider">
       #|</span>
       #|<button data-diff-mode="core" aria-label="Line diff" aria-pressed="true" title="Use Line diff" type="button" class="review-mode-button active">Line</button>
       #|</div>
-      #|<span aria-hidden="true" class="review-control-divider">
-      #|</span>
+    ),
+  )
+  inspect(
+    render_review_control(review_diff_layout_toggle(test_emit(), state, ctx)),
+    content=(
       #|<div role="group" aria-label="Diff layout" class="review-layout-control">
       #|<button data-layout="side-by-side" aria-label="Split diff layout" aria-pressed="true" title="Use side-by-side diff layout" type="button" class="review-layout-button active">Split</button>
       #|<button data-layout="inline" aria-label="Unified diff layout" aria-pressed="false" title="Use unified diff layout" type="button" class="review-layout-button">Unified</button>
       #|</div>
+    ),
+  )
+  inspect(
+    render_review_control(review_comments_control(test_emit(), state, ctx)),
+    content=(
       #|<span class="review-comments-control hidden">
       #|</span>
+    ),
+  )
+  inspect(
+    render_review_control(review_diff_status(state, ctx)),
+    content=(
       #|<span role="status" aria-live="polite" class="review-diff-mode-status hidden">
       #|</span>
+    ),
+  )
+  inspect(
+    render_review_control(review_diff_navigation(test_emit(), state, ctx)),
+    content=(
       #|<div role="group" aria-label="Diff change navigation" class="review-diff-navigation">
       #|<button data-action="previous-diff-change" aria-label="Previous change" aria-keyshortcuts="Shift+F7" title="Previous change (Shift+F7)" type="button" class="review-nav-button" disabled>
       #|<span aria-hidden="true" class="icon">
@@ -443,8 +386,6 @@ test "non-MoonBit review keeps File and Line without specialized controls" {
       #|<svg>…</svg>
       #|</span>
       #|</button>
-      #|</div>
-      #|</div>
       #|</div>
     ),
   )

--- a/desktop/frontend/fileeditor/review_surfaces_wbtest.mbt
+++ b/desktop/frontend/fileeditor/review_surfaces_wbtest.mbt
@@ -5,9 +5,9 @@ fn render_review_html(node : @html.Html) -> String {
 }
 
 ///|
-/// Keep toolbar snapshots structural: one tag per line, with icon presence
-/// visible but path geometry owned by the icon tests.
-fn render_review_snapshot(node : @html.Html) -> String {
+/// Snapshot one toolbar control at a time. Icon presence stays visible while
+/// SVG geometry remains outside these interaction tests.
+fn render_review_control(node : @html.Html) -> String {
   let rendered = render_review_html(node).replace_all(old="><", new=">\n<")
   let lines : Array[String] = []
   let mut inside_svg = false
@@ -67,34 +67,9 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
       "id=\"diff-editor-host\" class=\"viewer-host editor-shell moonbit-viewer-surface-hidden\"",
     ),
   )
-  let source_breadcrumb = render_review_snapshot(
-    breadcrumb_view(test_emit(), source_state, ctx),
-  )
   inspect(
-    source_breadcrumb,
+    render_review_control(review_mode_toolbar(test_emit(), source_state, ctx)),
     content=(
-      #|<div class="viewer-breadcrumb review-toolbar">
-      #|<div class="viewer-breadcrumb-row">
-      #|<div class="crumb-path">
-      #|<button aria-controls="breadcrumb-directory-picker" aria-expanded="false" title="Show files in Workspace" type="button" class="crumb crumb-directory">Workspace</button>
-      #|<span class="crumb-sep">›</span>
-      #|<button aria-controls="breadcrumb-directory-picker" aria-expanded="false" title="Show files in src" type="button" class="crumb crumb-directory">src</button>
-      #|<span class="crumb-sep">›</span>
-      #|<span class="crumb crumb-file">main.mbt</span>
-      #|</div>
-      #|<div role="group" aria-label="Changed file navigation" class="review-navigation">
-      #|<button aria-label="Previous changed file" title="Previous changed file" type="button" class="review-nav-button" disabled>‹</button>
-      #|<span aria-live="polite" class="review-nav-position">1 of 1</span>
-      #|<button aria-label="Next changed file" title="Next changed file" type="button" class="review-nav-button" disabled>›</button>
-      #|</div>
-      #|<button aria-label="Mark file reviewed" aria-pressed="false" title="Mark this changed file as reviewed" type="button" class="review-badge review-progress">Mark reviewed</button>
-      #|<button title="Hide file tree" class="panel-toggle">
-      #|<span aria-hidden="true" class="icon">
-      #|<svg>…</svg>
-      #|</span>
-      #|</button>
-      #|</div>
-      #|<div class="review-command-row">
       #|<div role="toolbar" aria-label="Review mode" class="review-mode-toolbar">
       #|<button data-review-mode="file" aria-label="File view" aria-pressed="true" title="Show file" type="button" class="review-mode-button active">File</button>
       #|<span aria-hidden="true" class="review-mode-divider">
@@ -103,15 +78,32 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
       #|<button data-diff-mode="token" aria-label="Token diff" aria-pressed="false" title="Use Token diff" type="button" class="review-mode-button">Token</button>
       #|<button data-diff-mode="tree" aria-label="Tree diff" aria-pressed="false" title="Use Tree diff" type="button" class="review-mode-button">Tree</button>
       #|</div>
-      #|<span aria-hidden="true" class="review-control-divider">
-      #|</span>
+    ),
+  )
+  inspect(
+    render_review_control(
+      review_diff_layout_toggle(test_emit(), source_state, ctx),
+    ),
+    content=(
       #|<div role="group" aria-label="Diff layout" class="review-layout-control disabled">
       #|<button data-layout="side-by-side" aria-label="Split diff layout" aria-pressed="false" title="Use side-by-side diff layout" type="button" class="review-layout-button" disabled>Split</button>
       #|<button data-layout="inline" aria-label="Unified diff layout" aria-pressed="false" title="Use unified diff layout" type="button" class="review-layout-button" disabled>Unified</button>
       #|</div>
+    ),
+  )
+  inspect(
+    render_review_control(
+      review_comments_control(test_emit(), source_state, ctx),
+    ),
+    content=(
       #|<button aria-label="Ignore comments" aria-pressed="false" title="Available in diff view" type="button" class="review-comments-control" disabled>Comments: ignored</button>
-      #|<span role="status" aria-live="polite" class="review-diff-mode-status hidden">
-      #|</span>
+    ),
+  )
+  inspect(
+    render_review_control(
+      review_diff_navigation(test_emit(), source_state, ctx),
+    ),
+    content=(
       #|<div role="group" aria-label="Diff change navigation" class="review-diff-navigation">
       #|<button data-action="previous-diff-change" aria-label="Previous change" aria-keyshortcuts="Shift+F7" title="Previous change (Shift+F7)" type="button" class="review-nav-button" disabled>
       #|<span aria-hidden="true" class="icon">
@@ -123,8 +115,6 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
       #|<svg>…</svg>
       #|</span>
       #|</button>
-      #|</div>
-      #|</div>
       #|</div>
     ),
   )
@@ -150,34 +140,9 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
   assert_true(
     diff.contains("id=\"diff-editor-host\" class=\"viewer-host editor-shell\""),
   )
-  let diff_breadcrumb = render_review_snapshot(
-    breadcrumb_view(test_emit(), diff_state, ctx),
-  )
   inspect(
-    diff_breadcrumb,
+    render_review_control(review_mode_toolbar(test_emit(), diff_state, ctx)),
     content=(
-      #|<div class="viewer-breadcrumb review-toolbar">
-      #|<div class="viewer-breadcrumb-row">
-      #|<div class="crumb-path">
-      #|<button aria-controls="breadcrumb-directory-picker" aria-expanded="false" title="Show files in Workspace" type="button" class="crumb crumb-directory">Workspace</button>
-      #|<span class="crumb-sep">›</span>
-      #|<button aria-controls="breadcrumb-directory-picker" aria-expanded="false" title="Show files in src" type="button" class="crumb crumb-directory">src</button>
-      #|<span class="crumb-sep">›</span>
-      #|<span class="crumb crumb-file">main.mbt</span>
-      #|</div>
-      #|<div role="group" aria-label="Changed file navigation" class="review-navigation">
-      #|<button aria-label="Previous changed file" title="Previous changed file" type="button" class="review-nav-button" disabled>‹</button>
-      #|<span aria-live="polite" class="review-nav-position">1 of 1</span>
-      #|<button aria-label="Next changed file" title="Next changed file" type="button" class="review-nav-button" disabled>›</button>
-      #|</div>
-      #|<button aria-label="Mark file reviewed" aria-pressed="false" title="Mark this changed file as reviewed" type="button" class="review-badge review-progress">Mark reviewed</button>
-      #|<button title="Hide file tree" class="panel-toggle">
-      #|<span aria-hidden="true" class="icon">
-      #|<svg>…</svg>
-      #|</span>
-      #|</button>
-      #|</div>
-      #|<div class="review-command-row">
       #|<div role="toolbar" aria-label="Review mode" class="review-mode-toolbar">
       #|<button data-review-mode="file" aria-label="File view" aria-pressed="false" title="Show file" type="button" class="review-mode-button">File</button>
       #|<span aria-hidden="true" class="review-mode-divider">
@@ -186,40 +151,33 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
       #|<button data-diff-mode="token" aria-label="Token diff" aria-pressed="false" title="Use Token diff" type="button" class="review-mode-button">Token</button>
       #|<button data-diff-mode="tree" aria-label="Tree diff" aria-pressed="false" title="Use Tree diff" type="button" class="review-mode-button">Tree</button>
       #|</div>
-      #|<span aria-hidden="true" class="review-control-divider">
-      #|</span>
+    ),
+  )
+  inspect(
+    render_review_control(
+      review_diff_layout_toggle(test_emit(), diff_state, ctx),
+    ),
+    content=(
       #|<div role="group" aria-label="Diff layout" class="review-layout-control">
       #|<button data-layout="side-by-side" aria-label="Split diff layout" aria-pressed="true" title="Use side-by-side diff layout" type="button" class="review-layout-button active">Split</button>
       #|<button data-layout="inline" aria-label="Unified diff layout" aria-pressed="false" title="Use unified diff layout" type="button" class="review-layout-button">Unified</button>
       #|</div>
-      #|<button aria-label="Ignore comments" aria-pressed="false" title="Available in Token and Tree diff" type="button" class="review-comments-control" disabled>Comments: ignored</button>
-      #|<span role="status" aria-live="polite" class="review-diff-mode-status hidden">
-      #|</span>
-      #|<div role="group" aria-label="Diff change navigation" class="review-diff-navigation">
-      #|<button data-action="previous-diff-change" aria-label="Previous change" aria-keyshortcuts="Shift+F7" title="Previous change (Shift+F7)" type="button" class="review-nav-button" disabled>
-      #|<span aria-hidden="true" class="icon">
-      #|<svg>…</svg>
-      #|</span>
-      #|</button>
-      #|<button data-action="next-diff-change" aria-label="Next change" aria-keyshortcuts="F7" title="Next change (F7)" type="button" class="review-nav-button" disabled>
-      #|<span aria-hidden="true" class="icon">
-      #|<svg>…</svg>
-      #|</span>
-      #|</button>
-      #|</div>
-      #|</div>
-      #|</div>
-    ),
-  )
-  let enabled_navigation = render_review_snapshot(
-    review_diff_navigation(
-      test_emit(),
-      { ..diff_state, review_diff_navigation_available: true, },
-      ctx,
     ),
   )
   inspect(
-    enabled_navigation,
+    render_review_control(review_comments_control(test_emit(), diff_state, ctx)),
+    content=(
+      #|<button aria-label="Ignore comments" aria-pressed="false" title="Available in Token and Tree diff" type="button" class="review-comments-control" disabled>Comments: ignored</button>
+    ),
+  )
+  inspect(
+    render_review_control(
+      review_diff_navigation(
+        test_emit(),
+        { ..diff_state, review_diff_navigation_available: true, },
+        ctx,
+      ),
+    ),
     content=(
       #|<div role="group" aria-label="Diff change navigation" class="review-diff-navigation">
       #|<button data-action="previous-diff-change" aria-label="Previous change" aria-keyshortcuts="Shift+F7" title="Previous change (Shift+F7)" type="button" class="review-nav-button">
@@ -245,11 +203,8 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
       fell_back: true,
     }),
   }
-  let fallback_status = render_review_snapshot(
-    review_diff_status(fallback_state, ctx),
-  )
   inspect(
-    fallback_status,
+    render_review_control(review_diff_status(fallback_state, ctx)),
     content=(
       #|<span role="status" aria-live="polite" class="review-diff-mode-status">Tree unavailable — showing Token diff</span>
     ),
@@ -264,25 +219,21 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
       fell_back: true,
     }),
   }
-  let core_fallback_status = render_review_snapshot(
-    review_diff_status(core_fallback_state, ctx),
-  )
   inspect(
-    core_fallback_status,
+    render_review_control(review_diff_status(core_fallback_state, ctx)),
     content=(
       #|<span role="status" aria-live="polite" class="review-diff-mode-status">Token unavailable — showing Line diff</span>
     ),
   )
 
-  let inline_layout = render_review_snapshot(
-    review_diff_layout_toggle(
-      test_emit(),
-      { ..diff_state, review_diff_layout: ReviewInline, },
-      ctx,
-    ),
-  )
   inspect(
-    inline_layout,
+    render_review_control(
+      review_diff_layout_toggle(
+        test_emit(),
+        { ..diff_state, review_diff_layout: ReviewInline, },
+        ctx,
+      ),
+    ),
     content=(
       #|<div role="group" aria-label="Diff layout" class="review-layout-control">
       #|<button data-layout="side-by-side" aria-label="Split diff layout" aria-pressed="false" title="Use side-by-side diff layout" type="button" class="review-layout-button">Split</button>
@@ -292,11 +243,8 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
   )
 
   let reviewed_state = { ..diff_state, reviewed_changes: [selected], }
-  let reviewed_progress = render_review_snapshot(
-    review_progress(test_emit(), reviewed_state, ctx),
-  )
   inspect(
-    reviewed_progress,
+    render_review_control(review_progress(test_emit(), reviewed_state, ctx)),
     content=(
       #|<button aria-label="Mark file reviewed" aria-pressed="true" title="Return this changed file to the review queue" type="button" class="review-badge review-progress reviewed">✓ Reviewed</button>
     ),
@@ -379,50 +327,54 @@ test "non-MoonBit review keeps File and Line without specialized controls" {
       selected,
     }),
   }
-  let breadcrumb = render_review_snapshot(
-    breadcrumb_view(
-      test_emit(),
-      { ..owned_state(), docs, review_diff_mode: ReviewDiffTree, },
-      ctx,
-    ),
-  )
+  let state = {
+    ..owned_state(),
+    docs,
+    review_diff_mode: ReviewDiffTree,
+    // Reproduce switching away after a Moon provider reported a fallback.
+    review_diff_status: Some({
+      requested: ReviewDiffTree,
+      effective: ReviewDiffToken,
+      fell_back: true,
+    }),
+  }
   inspect(
-    breadcrumb,
+    render_review_control(review_mode_toolbar(test_emit(), state, ctx)),
     content=(
-      #|<div class="viewer-breadcrumb review-toolbar">
-      #|<div class="viewer-breadcrumb-row">
-      #|<div class="crumb-path">
-      #|<button aria-controls="breadcrumb-directory-picker" aria-expanded="false" title="Show files in Workspace" type="button" class="crumb crumb-directory">Workspace</button>
-      #|<span class="crumb-sep">›</span>
-      #|<span class="crumb crumb-file">README.md</span>
-      #|</div>
-      #|<span class="review-navigation hidden">
-      #|</span>
-      #|<span class="review-badge hidden">
-      #|</span>
-      #|<button title="Hide file tree" class="panel-toggle">
-      #|<span aria-hidden="true" class="icon">
-      #|<svg>…</svg>
-      #|</span>
-      #|</button>
-      #|</div>
-      #|<div class="review-command-row">
       #|<div role="toolbar" aria-label="Review mode" class="review-mode-toolbar">
       #|<button data-review-mode="file" aria-label="File view" aria-pressed="false" title="Show file" type="button" class="review-mode-button">File</button>
       #|<span aria-hidden="true" class="review-mode-divider">
       #|</span>
       #|<button data-diff-mode="core" aria-label="Line diff" aria-pressed="true" title="Use Line diff" type="button" class="review-mode-button active">Line</button>
       #|</div>
-      #|<span aria-hidden="true" class="review-control-divider">
-      #|</span>
+    ),
+  )
+  inspect(
+    render_review_control(review_diff_layout_toggle(test_emit(), state, ctx)),
+    content=(
       #|<div role="group" aria-label="Diff layout" class="review-layout-control">
       #|<button data-layout="side-by-side" aria-label="Split diff layout" aria-pressed="true" title="Use side-by-side diff layout" type="button" class="review-layout-button active">Split</button>
       #|<button data-layout="inline" aria-label="Unified diff layout" aria-pressed="false" title="Use unified diff layout" type="button" class="review-layout-button">Unified</button>
       #|</div>
+    ),
+  )
+  inspect(
+    render_review_control(review_comments_control(test_emit(), state, ctx)),
+    content=(
       #|<span class="review-comments-control hidden">
       #|</span>
+    ),
+  )
+  inspect(
+    render_review_control(review_diff_status(state, ctx)),
+    content=(
       #|<span role="status" aria-live="polite" class="review-diff-mode-status hidden">
       #|</span>
+    ),
+  )
+  inspect(
+    render_review_control(review_diff_navigation(test_emit(), state, ctx)),
+    content=(
       #|<div role="group" aria-label="Diff change navigation" class="review-diff-navigation">
       #|<button data-action="previous-diff-change" aria-label="Previous change" aria-keyshortcuts="Shift+F7" title="Previous change (Shift+F7)" type="button" class="review-nav-button" disabled>
       #|<span aria-hidden="true" class="icon">
@@ -434,8 +386,6 @@ test "non-MoonBit review keeps File and Line without specialized controls" {
       #|<svg>…</svg>
       #|</span>
       #|</button>
-      #|</div>
-      #|</div>
       #|</div>
     ),
   )

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -2162,6 +2162,52 @@ pub fn sync(
 }
 
 ///|
+/// Select one review surface while keeping every parked changed-file tab
+/// aligned with the panel preference. Algorithm buttons use this same
+/// transition when they open a diff directly from File view.
+fn select_review_view_mode(
+  dispatch : @cmd.Emit[Msg],
+  state : State,
+  ctx : Ctx,
+  view_mode : ReviewViewMode,
+) -> (@cmd.Cmd, State) {
+  guard ctx.active_file is Some(path) &&
+    state.docs.get(path) is Some(doc) &&
+    doc.review is Some(_) &&
+    doc.diff_content() is Some(_) else {
+    return (@cmd.none, state)
+  }
+  let docs = state.docs.copy()
+  // Reopening an older tab must not resurrect a stale per-document surface.
+  for review_path, review_doc in state.docs {
+    match review_doc.review {
+      Some(parked) =>
+        docs[review_path] = {
+          ..review_doc,
+          review: Some({ ..parked, view_mode, }),
+        }
+      None => ()
+    }
+  }
+  let next_doc = docs.get(path).unwrap()
+  let show = show_pending_review(
+    dispatch,
+    ctx,
+    state.editor_search_highlights(path),
+    path,
+    next_doc,
+  )
+  let command = match view_mode {
+    // A window/tree resize can measure the display:none source host at the
+    // Viewer's 5px minimum while the diff is visible. Measure again only after
+    // File mode has restored the source host's real box.
+    ReviewSource => @cmd.batch([show, request_viewer_remeasure()])
+    ReviewDiff => show
+  }
+  (command, { ..state, docs, review_view_mode: view_mode, })
+}
+
+///|
 pub fn update(
   dispatch : @cmd.Emit[Msg],
   msg : Msg,
@@ -2204,46 +2250,11 @@ pub fn update(
         (@cmd.none, state)
       }
     ToggleReviewDiff => {
-      guard ctx.active_file is Some(path) &&
-        state.docs.get(path) is Some(doc) &&
-        doc.review is Some(_) &&
-        doc.diff_content() is Some(_) else {
-        return (@cmd.none, state)
-      }
       let view_mode = match state.review_view_mode {
         ReviewSource => ReviewDiff
         ReviewDiff => ReviewSource
       }
-      let docs = state.docs.copy()
-      // Keep every parked review aligned with the panel preference. Otherwise
-      // revisiting an older tab could resurrect its stale per-document mode
-      // and make the next file forget what the reviewer currently sees.
-      for review_path, review_doc in state.docs {
-        match review_doc.review {
-          Some(parked) =>
-            docs[review_path] = {
-              ..review_doc,
-              review: Some({ ..parked, view_mode, }),
-            }
-          None => ()
-        }
-      }
-      let next_doc = docs.get(path).unwrap()
-      let show = show_pending_review(
-        dispatch,
-        ctx,
-        state.editor_search_highlights(path),
-        path,
-        next_doc,
-      )
-      let command = match view_mode {
-        // A window/tree resize can measure the display:none source host at the
-        // Viewer's 5px minimum while the diff is visible. Measure again only
-        // after source mode has restored the host's real box.
-        ReviewSource => @cmd.batch([show, request_viewer_remeasure()])
-        ReviewDiff => show
-      }
-      (command, { ..state, docs, review_view_mode: view_mode, })
+      select_review_view_mode(dispatch, state, ctx, view_mode)
     }
     ToggleReviewDiffLayout => {
       let review_ready = ctx.active_file is Some(path) &&
@@ -2265,11 +2276,29 @@ pub fn update(
       )
     }
     ReviewDiffModeSelected(mode) => {
-      guard moon_diff_ready(state, ctx) else { return (@cmd.none, state) }
-      (
-        apply_review_diff_provider(mode, state.review_diff_ignore_comments),
-        { ..state, review_diff_mode: mode, review_diff_status: None, },
+      guard moon_diff_available(state, ctx) else { return (@cmd.none, state) }
+      let provider = apply_review_diff_provider(
+        mode,
+        state.review_diff_ignore_comments,
       )
+      let selected = {
+        ..state,
+        review_diff_mode: mode,
+        review_diff_status: None,
+      }
+      if ctx.active_file is Some(path) &&
+        state.docs.get(path)
+        is Some({ review: Some({ view_mode: ReviewSource, .. }), .. }) {
+        let (show, diff) = select_review_view_mode(
+          dispatch,
+          selected,
+          ctx,
+          ReviewDiff,
+        )
+        (@cmd.batch([provider, show]), diff)
+      } else {
+        (provider, selected)
+      }
     }
     ToggleReviewDiffIgnoreComments => {
       guard moon_diff_ready(state, ctx) &&

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -1670,40 +1670,62 @@ fn crumb_link(
 }
 
 ///|
-/// The breadcrumb row under the tab bar: the active file's path as
+/// The breadcrumb under the tab bar: the active file's path as
 /// `dir › dir › file` (the file segment emphasized) behind a leading
 /// "Workspace" crumb. Every crumb but the last opens a VS Code-style picker
 /// of that directory's immediate children, without moving or hiding the
 /// source viewer behind it.
-/// The tree-pane toggle rides this row's right edge, directly under the tab
-/// bar's panel toggle. With no file open the whole row hides (via CSS — it
-/// stays in the DOM so the editor's child order, and thus the viewer host,
-/// is never re-keyed) and the tree shows unconditionally in its place.
+/// Reviews add a second, wrapping command row so the path, file navigation,
+/// and completion action never compete with comparison settings. With no file
+/// open the whole breadcrumb hides; it stays in the DOM so the editor's child
+/// order, and thus the viewer host, is never re-keyed.
 pub fn breadcrumb_view(
   dispatch : @cmd.Emit[Msg],
   state : State,
   ctx : Ctx,
 ) -> @html.Html {
   if ctx.active_history_diff is Some(diff) {
-    return @html.div(class="viewer-breadcrumb history-breadcrumb", [
-      @html.div(class="crumb-path", [
-        @html.span(
-          class="crumb history-commit-crumb",
-          short_commit(diff.commit),
-        ),
-        @html.span(class="crumb-sep", "›"),
-        @html.span(class="crumb crumb-file", diff.path.0),
-      ]),
-      review_diff_mode_toolbar(dispatch, state, ctx),
-      review_diff_navigation(dispatch, state, ctx),
-      review_diff_layout_toggle(dispatch, state, ctx),
-      @html.button(
-        class="panel-toggle",
-        title=if state.tree_open { "Hide file tree" } else { "Show file tree" },
-        on_click=dispatch(ToggleTree),
-        icon(icon_folder),
-      ),
-    ])
+    return @html.div(
+      class="viewer-breadcrumb review-toolbar history-breadcrumb",
+      [
+        @html.div(class="viewer-breadcrumb-row", [
+          @html.div(class="crumb-path", [
+            @html.span(
+              class="crumb history-commit-crumb",
+              short_commit(diff.commit),
+            ),
+            @html.span(class="crumb-sep", "›"),
+            @html.span(class="crumb crumb-file", diff.path.0),
+          ]),
+          @html.button(
+            class="panel-toggle",
+            title=if state.tree_open {
+              "Hide file tree"
+            } else {
+              "Show file tree"
+            },
+            on_click=dispatch(ToggleTree),
+            icon(icon_folder),
+          ),
+        ]),
+        @html.div(class="review-command-row", [
+          review_diff_mode_toolbar(dispatch, state, ctx),
+          @html.span(
+            class=if moon_diff_available(state, ctx) {
+              "review-control-divider"
+            } else {
+              "review-control-divider hidden"
+            },
+            attrs=@html.Attrs::build().aria_hidden("true"),
+            "",
+          ),
+          review_diff_layout_toggle(dispatch, state, ctx),
+          review_comments_control(dispatch, state, ctx),
+          review_diff_status(state, ctx),
+          review_diff_navigation(dispatch, state, ctx),
+        ]),
+      ],
+    )
   }
   let crumbs : Array[@html.Html] = []
   match ctx.active_file {
@@ -1735,32 +1757,71 @@ pub fn breadcrumb_view(
     }
     None => crumbs.push(@html.span(class="crumb crumb-file", "Workspace"))
   }
-  let children : Array[@html.Html] = [
+  let review = full_diff_available(state, ctx)
+  let path_row : Array[@html.Html] = [
     @html.div(class="crumb-path", crumbs),
     review_navigation(dispatch, state, ctx),
-    review_badge(dispatch, state, ctx),
-    review_diff_mode_toolbar(dispatch, state, ctx),
-    review_diff_navigation(dispatch, state, ctx),
-    review_diff_layout_toggle(dispatch, state, ctx),
-    review_progress(dispatch, state, ctx),
+  ]
+  if review {
+    path_row.push(review_progress(dispatch, state, ctx))
+  } else {
+    path_row.push(review_badge(dispatch, state, ctx))
+    path_row.push(review_progress(dispatch, state, ctx))
+  }
+  path_row.push(
     @html.button(
       class="panel-toggle",
       title=if state.tree_open { "Hide file tree" } else { "Show file tree" },
       on_click=dispatch(ToggleTree),
       icon(icon_folder),
     ),
-  ]
-  if state.highlighted is Some(directory) {
-    children.push(breadcrumb_picker(dispatch, state, ctx, directory))
-  }
-  @html.div(
-    class=if ctx.active_file is None {
-      "viewer-breadcrumb hidden"
-    } else {
-      "viewer-breadcrumb"
-    },
-    children,
   )
+  if review {
+    let children : Array[@html.Html] = [
+      @html.div(class="viewer-breadcrumb-row", path_row),
+      @html.div(class="review-command-row", [
+        review_mode_toolbar(dispatch, state, ctx),
+        @html.span(
+          class="review-control-divider",
+          attrs=@html.Attrs::build().aria_hidden("true"),
+          "",
+        ),
+        review_diff_layout_toggle(dispatch, state, ctx),
+        review_comments_control(dispatch, state, ctx),
+        review_diff_status(state, ctx),
+        review_diff_navigation(dispatch, state, ctx),
+      ]),
+    ]
+    if state.highlighted is Some(directory) {
+      children.push(breadcrumb_picker(dispatch, state, ctx, directory))
+    }
+    @html.div(class="viewer-breadcrumb review-toolbar", children)
+  } else {
+    if state.highlighted is Some(directory) {
+      path_row.push(breadcrumb_picker(dispatch, state, ctx, directory))
+    }
+    @html.div(
+      class=if ctx.active_file is None {
+        "viewer-breadcrumb hidden"
+      } else {
+        "viewer-breadcrumb"
+      },
+      path_row,
+    )
+  }
+}
+
+///|
+fn full_diff_available(state : State, ctx : Ctx) -> Bool {
+  let review_available = ctx.active_file is Some(path) &&
+    state.docs.get(path) is Some(doc) &&
+    doc.review is Some(_) &&
+    doc.diff_content() is Some(_)
+  let history_available = ctx.active_history_diff is Some(diff) &&
+    state.history_docs.get(history_diff_key(diff)) is Some(history) &&
+    history.original.text() is Some(_) &&
+    history.modified.text() is Some(_)
+  review_available || history_available
 }
 
 ///|
@@ -1777,24 +1838,29 @@ fn full_diff_ready(state : State, ctx : Ctx) -> Bool {
 }
 
 ///|
-fn moon_diff_ready(state : State, ctx : Ctx) -> Bool {
-  let review_ready = ctx.active_file is Some(path) &&
-    path.0.to_lower().has_suffix(".mbt") &&
+fn moon_diff_available(state : State, ctx : Ctx) -> Bool {
+  let review_available = ctx.active_file is Some(path) &&
+    supports_moon_diff(path.0) &&
     state.docs.get(path) is Some(doc) &&
-    doc.review is Some({ view_mode: ReviewDiff, .. }) &&
+    doc.review is Some(_) &&
     doc.diff_content() is Some(_)
-  let history_ready = ctx.active_history_diff is Some(diff) &&
-    diff.path.0.to_lower().has_suffix(".mbt") &&
+  let history_available = ctx.active_history_diff is Some(diff) &&
+    supports_moon_diff(diff.path.0) &&
     state.history_docs.get(history_diff_key(diff)) is Some(history) &&
     history.original.text() is Some(_) &&
     history.modified.text() is Some(_)
-  review_ready || history_ready
+  review_available || history_available
+}
+
+///|
+fn moon_diff_ready(state : State, ctx : Ctx) -> Bool {
+  moon_diff_available(state, ctx) && full_diff_ready(state, ctx)
 }
 
 ///|
 fn ReviewDiffMode::label(self : ReviewDiffMode) -> String {
   match self {
-    ReviewDiffCore => "Core"
+    ReviewDiffCore => "Line"
     ReviewDiffToken => "Token"
     ReviewDiffTree => "Tree"
   }
@@ -1811,25 +1877,130 @@ fn ReviewDiffMode::attribute(self : ReviewDiffMode) -> String {
 
 ///|
 fn review_diff_mode_button(
-  dispatch : @cmd.Emit[Msg],
-  selected : ReviewDiffMode,
   mode : ReviewDiffMode,
+  active : Bool,
+  on_click : @cmd.Cmd,
 ) -> @html.Html {
-  let active = selected == mode
   @html.button(
     type_="button",
     class=if active {
-      "review-badge review-badge-action active"
+      "review-mode-button active"
     } else {
-      "review-badge review-badge-action"
+      "review-mode-button"
     },
     title="Use " + mode.label() + " diff",
-    on_click=dispatch(ReviewDiffModeSelected(mode)),
+    on_click~,
     attrs=@html.Attrs::build()
       .data_set("diff-mode", mode.attribute())
       .aria_label(mode.label() + " diff")
       .aria_pressed(active.to_string()),
     mode.label(),
+  )
+}
+
+///|
+fn review_mode_toolbar(
+  dispatch : @cmd.Emit[Msg],
+  state : State,
+  ctx : Ctx,
+) -> @html.Html {
+  guard ctx.active_file is Some(path) &&
+    state.docs.get(path) is Some(doc) &&
+    doc.review is Some(review) &&
+    doc.diff_content() is Some(_) else {
+    return @html.span(class="review-mode-toolbar hidden", "")
+  }
+  let diff = review.view_mode == ReviewDiff
+  let moon = supports_moon_diff(path.0)
+  let children : Array[@html.Html] = [
+    @html.button(
+      type_="button",
+      class=if diff {
+        "review-mode-button"
+      } else {
+        "review-mode-button active"
+      },
+      title="Show file",
+      on_click=if diff { dispatch(ToggleReviewDiff) } else { @cmd.none },
+      attrs=@html.Attrs::build()
+        .data_set("review-mode", "file")
+        .aria_label("File view")
+        .aria_pressed((!diff).to_string()),
+      "File",
+    ),
+    @html.span(
+      class="review-mode-divider",
+      attrs=@html.Attrs::build().aria_hidden("true"),
+      "",
+    ),
+    review_diff_mode_button(
+      ReviewDiffCore,
+      diff && (!moon || state.review_diff_mode == ReviewDiffCore),
+      if moon {
+        dispatch(ReviewDiffModeSelected(ReviewDiffCore))
+      } else if diff {
+        @cmd.none
+      } else {
+        dispatch(ToggleReviewDiff)
+      },
+    ),
+  ]
+  if moon {
+    children.push(
+      review_diff_mode_button(
+        ReviewDiffToken,
+        diff && state.review_diff_mode == ReviewDiffToken,
+        dispatch(ReviewDiffModeSelected(ReviewDiffToken)),
+      ),
+    )
+    children.push(
+      review_diff_mode_button(
+        ReviewDiffTree,
+        diff && state.review_diff_mode == ReviewDiffTree,
+        dispatch(ReviewDiffModeSelected(ReviewDiffTree)),
+      ),
+    )
+  }
+  @html.div(
+    class="review-mode-toolbar",
+    attrs=@html.Attrs::build().role("toolbar").aria_label("Review mode"),
+    children,
+  )
+}
+
+///|
+/// Historical comparisons have no File surface, but retain the same explicit
+/// MoonBit comparison algorithms as changed-file reviews.
+fn review_diff_mode_toolbar(
+  dispatch : @cmd.Emit[Msg],
+  state : State,
+  ctx : Ctx,
+) -> @html.Html {
+  guard moon_diff_ready(state, ctx) else {
+    return @html.span(class="review-mode-toolbar hidden", "")
+  }
+  @html.div(
+    class="review-mode-toolbar review-history-mode-toolbar",
+    attrs=@html.Attrs::build()
+      .role("toolbar")
+      .aria_label("Comparison algorithm"),
+    [
+      review_diff_mode_button(
+        ReviewDiffCore,
+        state.review_diff_mode == ReviewDiffCore,
+        dispatch(ReviewDiffModeSelected(ReviewDiffCore)),
+      ),
+      review_diff_mode_button(
+        ReviewDiffToken,
+        state.review_diff_mode == ReviewDiffToken,
+        dispatch(ReviewDiffModeSelected(ReviewDiffToken)),
+      ),
+      review_diff_mode_button(
+        ReviewDiffTree,
+        state.review_diff_mode == ReviewDiffTree,
+        dispatch(ReviewDiffModeSelected(ReviewDiffTree)),
+      ),
+    ],
   )
 }
 
@@ -1847,58 +2018,60 @@ fn review_diff_fallback_text(state : State) -> String {
 }
 
 ///|
-/// MoonBit-aware comparison policy belongs to the desktop review chrome.
-/// Other file types omit these controls and the imperative provider forces
-/// Core without overwriting the retained Token/Tree preference.
-fn review_diff_mode_toolbar(
+fn review_diff_status(state : State, ctx : Ctx) -> @html.Html {
+  let fallback = if full_diff_ready(state, ctx) {
+    review_diff_fallback_text(state)
+  } else {
+    ""
+  }
+  @html.span(
+    class=if fallback.is_empty() {
+      "review-diff-mode-status hidden"
+    } else {
+      "review-diff-mode-status"
+    },
+    attrs=@html.Attrs::build().role("status").aria_live("polite"),
+    fallback,
+  )
+}
+
+///|
+fn review_comments_control(
   dispatch : @cmd.Emit[Msg],
   state : State,
   ctx : Ctx,
 ) -> @html.Html {
-  guard moon_diff_ready(state, ctx) else {
-    return @html.span(class="review-diff-mode-toolbar hidden", "")
+  guard moon_diff_available(state, ctx) else {
+    return @html.span(class="review-comments-control hidden", "")
   }
-  let fallback = review_diff_fallback_text(state)
-  @html.div(
-    class="review-diff-mode-toolbar",
+  let enabled = full_diff_ready(state, ctx) &&
+    state.review_diff_mode != ReviewDiffCore
+  @html.button(
+    type_="button",
+    class=if enabled && state.review_diff_ignore_comments {
+      "review-comments-control active"
+    } else {
+      "review-comments-control"
+    },
+    title=if !full_diff_ready(state, ctx) {
+      "Available in diff view"
+    } else if state.review_diff_mode == ReviewDiffCore {
+      "Available in Token and Tree diff"
+    } else if state.review_diff_ignore_comments {
+      "Include comments in the comparison"
+    } else {
+      "Ignore comment-only changes"
+    },
+    disabled=!enabled,
+    on_click=dispatch(ToggleReviewDiffIgnoreComments),
     attrs=@html.Attrs::build()
-      .role("toolbar")
-      .aria_label("Comparison algorithm"),
-    [
-      review_diff_mode_button(dispatch, state.review_diff_mode, ReviewDiffCore),
-      review_diff_mode_button(dispatch, state.review_diff_mode, ReviewDiffToken),
-      review_diff_mode_button(dispatch, state.review_diff_mode, ReviewDiffTree),
-      @html.button(
-        type_="button",
-        class=if state.review_diff_ignore_comments {
-          "review-badge review-badge-action active"
-        } else {
-          "review-badge review-badge-action"
-        },
-        title=if state.review_diff_mode == ReviewDiffCore {
-          "Available in Token and Tree diff"
-        } else if state.review_diff_ignore_comments {
-          "Include comments in the comparison"
-        } else {
-          "Ignore comment-only changes"
-        },
-        disabled=state.review_diff_mode == ReviewDiffCore,
-        on_click=dispatch(ToggleReviewDiffIgnoreComments),
-        attrs=@html.Attrs::build()
-          .aria_label("Ignore comments")
-          .aria_pressed(state.review_diff_ignore_comments.to_string()),
-        "Ignore comments",
-      ),
-      @html.span(
-        class=if fallback.is_empty() {
-          "review-diff-mode-status hidden"
-        } else {
-          "review-diff-mode-status"
-        },
-        attrs=@html.Attrs::build().role("status").aria_live("polite"),
-        fallback,
-      ),
-    ],
+      .aria_label("Ignore comments")
+      .aria_pressed((enabled && state.review_diff_ignore_comments).to_string()),
+    if state.review_diff_ignore_comments {
+      "Comments: ignored"
+    } else {
+      "Comments: included"
+    },
   )
 }
 
@@ -1911,9 +2084,11 @@ fn review_diff_navigation(
   state : State,
   ctx : Ctx,
 ) -> @html.Html {
-  guard full_diff_ready(state, ctx) else {
+  guard full_diff_available(state, ctx) else {
     return @html.span(class="review-diff-navigation hidden", "")
   }
+  let enabled = full_diff_ready(state, ctx) &&
+    state.review_diff_navigation_available
   @html.div(
     class="review-diff-navigation",
     attrs=@html.Attrs::build()
@@ -1924,7 +2099,7 @@ fn review_diff_navigation(
         type_="button",
         class="review-nav-button",
         title="Previous change (Shift+F7)",
-        disabled=!state.review_diff_navigation_available,
+        disabled=!enabled,
         on_click=dispatch(RevealPreviousReviewDiffChange),
         attrs=@html.Attrs::build()
           .data_set("action", "previous-diff-change")
@@ -1936,7 +2111,7 @@ fn review_diff_navigation(
         type_="button",
         class="review-nav-button",
         title="Next change (F7)",
-        disabled=!state.review_diff_navigation_available,
+        disabled=!enabled,
         on_click=dispatch(RevealNextReviewDiffChange),
         attrs=@html.Attrs::build()
           .data_set("action", "next-diff-change")
@@ -1949,39 +2124,68 @@ fn review_diff_navigation(
 }
 
 ///|
-/// The full comparison keeps its two models mounted while this compact control
-/// changes only their layout. Source mode hides the control but preserves the
-/// panel preference for the next full-diff reveal.
+/// The full comparison keeps its two models mounted while this explicit pair
+/// changes only their layout. File mode preserves the preference but disables
+/// both choices so it cannot imply that a source file is split or unified.
 fn review_diff_layout_toggle(
   dispatch : @cmd.Emit[Msg],
   state : State,
   ctx : Ctx,
 ) -> @html.Html {
-  guard full_diff_ready(state, ctx) else {
-    return @html.span(class="review-badge hidden", "")
+  guard full_diff_available(state, ctx) else {
+    return @html.span(class="review-layout-control hidden", "")
   }
+  let ready = full_diff_ready(state, ctx)
   let inline = state.review_diff_layout == ReviewInline
-  @html.button(
-    type_="button",
-    class="review-badge review-badge-action review-layout-toggle",
-    title=if inline {
-      "Use side-by-side diff layout"
+  @html.div(
+    class=if ready {
+      "review-layout-control"
     } else {
-      "Use inline diff layout"
+      "review-layout-control disabled"
     },
-    on_click=dispatch(ToggleReviewDiffLayout),
-    attrs=@html.Attrs::build()
-      .data_set("layout", if inline { "inline" } else { "side-by-side" })
-      .aria_label("Inline diff layout")
-      .aria_pressed(inline.to_string()),
-    @html.span(
-      class=if inline {
-        "review-layout-icon inline"
-      } else {
-        "review-layout-icon split"
-      },
-      "",
-    ),
+    attrs=@html.Attrs::build().role("group").aria_label("Diff layout"),
+    [
+      @html.button(
+        type_="button",
+        class=if ready && !inline {
+          "review-layout-button active"
+        } else {
+          "review-layout-button"
+        },
+        title="Use side-by-side diff layout",
+        disabled=!ready,
+        on_click=if ready && inline {
+          dispatch(ToggleReviewDiffLayout)
+        } else {
+          @cmd.none
+        },
+        attrs=@html.Attrs::build()
+          .data_set("layout", "side-by-side")
+          .aria_label("Split diff layout")
+          .aria_pressed((ready && !inline).to_string()),
+        "Split",
+      ),
+      @html.button(
+        type_="button",
+        class=if ready && inline {
+          "review-layout-button active"
+        } else {
+          "review-layout-button"
+        },
+        title="Use unified diff layout",
+        disabled=!ready,
+        on_click=if ready && !inline {
+          dispatch(ToggleReviewDiffLayout)
+        } else {
+          @cmd.none
+        },
+        attrs=@html.Attrs::build()
+          .data_set("layout", "inline")
+          .aria_label("Unified diff layout")
+          .aria_pressed((ready && inline).to_string()),
+        "Unified",
+      ),
+    ],
   )
 }
 

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -2019,7 +2019,9 @@ fn review_diff_fallback_text(state : State) -> String {
 
 ///|
 fn review_diff_status(state : State, ctx : Ctx) -> @html.Html {
-  let fallback = if full_diff_ready(state, ctx) {
+  // Provider status may outlive the comparison that produced it. Only a
+  // Moon-aware active diff can interpret that retained status.
+  let fallback = if moon_diff_ready(state, ctx) {
     review_diff_fallback_text(state)
   } else {
     ""

--- a/desktop/styles/file_panel.css
+++ b/desktop/styles/file_panel.css
@@ -1782,6 +1782,36 @@ button.git-history-file:focus-visible {
   background: var(--color-bg-surface);
 }
 
+/* A review keeps path/navigation and comparison settings on separate rows.
+   Control groups wrap as units, so a narrow editor may grow vertically but
+   never clips an unlabeled option or the change-navigation arrows. */
+.viewer-breadcrumb.review-toolbar {
+  display: block;
+  height: auto;
+  padding: 0;
+  white-space: nowrap;
+}
+
+.viewer-breadcrumb-row,
+.review-command-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  min-height: 34px;
+  padding: 0 18px 0 12px;
+}
+
+.viewer-breadcrumb-row {
+  border-bottom: 1px solid var(--color-separator);
+}
+
+.review-command-row {
+  flex-wrap: wrap;
+  padding-block: 4px;
+  background: var(--color-bg-subtle);
+}
+
 /* The path crumbs grow and ellipsize. */
 .crumb-path {
   display: flex;
@@ -2044,78 +2074,122 @@ button.git-history-file:focus-visible {
   background: var(--color-bg-subtle);
 }
 
-.review-diff-mode-toolbar {
+.review-mode-toolbar,
+.review-layout-control {
   display: inline-flex;
   flex: 0 0 auto;
   align-items: center;
-  gap: 2px;
+  padding: 2px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-control-surface);
 }
 
-.review-diff-mode-toolbar.hidden,
+.review-mode-toolbar.hidden,
+.review-layout-control.hidden,
+.review-comments-control.hidden,
+.review-control-divider.hidden,
 .review-diff-mode-status.hidden {
   display: none;
 }
 
-.review-diff-mode-toolbar .review-badge {
-  max-width: none;
-  padding-inline: 5px;
+.review-mode-button,
+.review-layout-button {
+  appearance: none;
+  min-height: 22px;
+  padding: 2px 7px;
+  border: 0;
+  border-radius: var(--radius-xs);
+  color: var(--color-text-secondary);
+  background: transparent;
+  font: inherit;
+  font-size: var(--font-size-xs);
+  line-height: 16px;
+  cursor: pointer;
 }
 
-.review-diff-mode-toolbar .review-badge.active {
-  border-color: transparent;
+.review-mode-button:hover,
+.review-layout-button:hover:not(:disabled) {
+  color: var(--color-text-primary);
+  background: var(--color-bg-subtle);
+}
+
+.review-mode-button.active,
+.review-layout-button.active {
+  color: var(--color-accent-strong);
+  background: color-mix(in srgb, var(--color-accent) 20%, transparent);
+  font-weight: 600;
+}
+
+.review-mode-divider,
+.review-control-divider {
+  flex: 0 0 auto;
+  width: 1px;
+  height: 18px;
+  background: var(--color-border);
+}
+
+.review-mode-divider {
+  margin: 0 3px;
+}
+
+.review-control-divider {
+  margin: 0 2px;
+}
+
+.review-layout-control.disabled {
+  color: var(--color-text-muted);
+  opacity: 0.5;
+}
+
+.review-layout-button:disabled {
+  color: inherit;
+  cursor: default;
+}
+
+.review-comments-control {
+  appearance: none;
+  flex: 0 0 auto;
+  min-height: 28px;
+  padding: 3px 8px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-secondary);
+  background: var(--color-control-surface);
+  font: inherit;
+  font-size: var(--font-size-xs);
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.review-comments-control:hover:not(:disabled) {
+  color: var(--color-text-primary);
+  background: var(--color-bg-surface);
+}
+
+.review-comments-control.active {
   color: var(--color-accent-strong);
   background: color-mix(in srgb, var(--color-accent) 20%, transparent);
 }
 
-.review-diff-mode-toolbar .review-badge:disabled {
+.review-comments-control:disabled {
+  color: var(--color-text-muted);
   cursor: default;
   opacity: 0.5;
 }
 
+.review-command-row .review-diff-navigation {
+  margin-left: auto;
+}
+
 .review-diff-mode-status {
+  flex: 1 1 120px;
+  min-width: 0;
   max-width: 220px;
   overflow: hidden;
   color: var(--color-text-muted);
   font-size: var(--font-size-xs);
   text-overflow: ellipsis;
-}
-
-.review-layout-toggle {
-  display: grid;
-  place-items: center;
-  width: 24px;
-  min-width: 24px;
-  max-width: none;
-  height: 22px;
-  padding: 0;
-}
-
-.review-layout-icon {
-  position: relative;
-  display: block;
-  box-sizing: border-box;
-  width: 12px;
-  height: 10px;
-  border: 1px solid currentColor;
-  border-radius: 1px;
-}
-
-.review-layout-icon.split::after {
-  content: "";
-  position: absolute;
-  inset: 0 auto 0 50%;
-  border-left: 1px solid currentColor;
-}
-
-.review-layout-icon.inline::after {
-  content: "";
-  position: absolute;
-  top: 2px;
-  right: 2px;
-  left: 2px;
-  height: 1px;
-  background: currentColor;
-  box-shadow: 0 2px 0 currentColor, 0 4px 0 currentColor;
 }
 
 .review-progress {


### PR DESCRIPTION
## Why

The review toolbar mixed the file-view choice with comparison algorithms and hid layout semantics behind an icon. At narrower widths, those controls competed with the breadcrumb and could push change navigation out of view.

## What changed

- Split path, file navigation, and review completion from comparison settings into two responsive rows.
- Present File, Line, Token, and Tree as one explicit mode selector, with a divider separating File from comparison algorithms.
- Replace the layout icon with explicit Split and Unified choices, expose comment policy directly, and disable diff-only controls while File is selected.
- Apply the same comparison language to historical diffs and retain the simpler File/Line choice for non-MoonBit files.
- Lock the complete rendered toolbar structure with readable multiline snapshots.

## Why this is correct and minimal

The change reuses the existing review state, commands, diff provider, and file-navigation behavior. Selecting an algorithm enters the existing diff surface, while returning to File preserves the current diff preferences. No comparison algorithm implementation changes are included; the production changes stay within the desktop file-editor view, transition, and styles, with focused test coverage.