### PR TITLE
refactor(agent_tool): share the line-offset scan between edit tools

### DIFF
--- a/agent_tool/edit/edit.mbt
+++ b/agent_tool/edit/edit.mbt
@@ -204,7 +204,7 @@ async fn edit_file(
     // summary reports the actual inclusive line range the new content
     // occupies — real coordinates the model can anchor follow-up edits on,
     // not the (possibly clamped) requested line.
-    let at = line_start_offset(content, input.start_line).clamp(
+    let at = @line_offset.line_start_offset(content, input.start_line).clamp(
       min=0,
       max=content.length(),
     )
@@ -832,9 +832,9 @@ fn select_edit_region(
   input : @decode.EditInput,
 ) -> EditRegion {
   let start_line = input.start_line
-  let start = line_start_offset(content, start_line)
+  let start = @line_offset.line_start_offset(content, start_line)
   let end = match input.end_line {
-    Some(line) => line_end_offset(content, line)
+    Some(line) => @line_offset.line_end_offset(content, line)
     None => content.length()
   }
   // `decode` guarantees end_line >= start_line when both are present. These
@@ -845,34 +845,6 @@ fn select_edit_region(
     prefix: content.unsafe_substring(start=0, end=start),
     body: content.unsafe_substring(start~, end~),
     suffix: content.unsafe_substring(start=end, end=content.length()),
-  }
-}
-
-///|
-fn line_start_offset(content : String, line : Int) -> Int {
-  // Line `line` starts right after line `line - 1` ends (nobreak: both scans
-  // land on content.length() for a line past EOF).
-  if line <= 1 {
-    0
-  } else {
-    line_end_offset(content, line - 1)
-  }
-}
-
-///|
-fn line_end_offset(content : String, line : Int) -> Int {
-  let len = content.length()
-  for cursor in 0..<len; current_line = 1 {
-    if content[cursor] == '\n' {
-      if current_line == line {
-        break cursor + 1
-      }
-      continue current_line + 1
-    } else {
-      continue current_line
-    }
-  } nobreak {
-    len
   }
 }
 
@@ -933,8 +905,8 @@ fn old_string_context(
   )
   let lines : Array[String] = ["\n\nfile context:"]
   for line_no in first_line..<=last_line {
-    let ls = line_start_offset(content, line_no)
-    let le = line_end_offset(content, line_no)
+    let ls = @line_offset.line_start_offset(content, line_no)
+    let le = @line_offset.line_end_offset(content, line_no)
     let line_text = if le > ls && content[le - 1] == '\n' {
       content.unsafe_substring(start=ls, end=le - 1)
     } else {
@@ -949,7 +921,7 @@ fn old_string_context(
     lines.push("\{gutter} \{line_no} | \{line_text}")
   }
   // Compare old_string with the actual content at the anchor offset
-  let anchor_offset = line_start_offset(content, start_line)
+  let anchor_offset = @line_offset.line_start_offset(content, start_line)
   let compare_len = old_string.length().min(content.length() - anchor_offset)
   if compare_len > 0 {
     let actual = content.unsafe_substring(

--- a/agent_tool/edit/moon.pkg
+++ b/agent_tool/edit/moon.pkg
@@ -4,6 +4,7 @@ import {
   "bobzhang/openseek/agent_tool/internal/manifest_error",
   "bobzhang/openseek/agent_tool/internal/auto_check",
   "bobzhang/openseek/agent_tool/internal/error" @tool_error,
+  "bobzhang/openseek/agent_tool/internal/line_offset",
   "bobzhang/openseek/agent_tool/write_scope",
   "bobzhang/openseek/internal/workspace_path",
   "moonbitlang/async",

--- a/agent_tool/internal/line_offset/README.mbt.md
+++ b/agent_tool/internal/line_offset/README.mbt.md
@@ -1,0 +1,78 @@
+# agent_tool/internal/line_offset
+
+Two functions that turn a 1-based line number into a code-unit offset in a
+string. `edit` and `multi_edit` both anchor their searches to a line range, and
+both need the same answer to "where does line N start, and where does it end?",
+so the scan lives here rather than once per tool.
+
+Nothing here reads a file. The input is content already in memory, and the
+result is an offset into that same string — safe to hand straight to
+`unsafe_substring`, because both functions clamp to the content's length.
+
+## The contract
+
+- **Lines are 1-based.** Line 1 starts at offset 0.
+- **An end offset is *past* the newline.** `line_end_offset(c, n)` and
+  `line_start_offset(c, n + 1)` name the same position, so an inclusive line
+  range `[start, end]` is the half-open offset range
+  `[line_start_offset(c, start), line_end_offset(c, end))`.
+- **Out of range clamps, never fails.** A line past the end of the content —
+  and a line number below 1 — yields an in-bounds offset.
+
+```mbt check
+///|
+test "offsets bracket each line, end offsets landing past the newline" {
+  let content = "alpha\nbeta\ngamma\n"
+  inspect(@line_offset.line_start_offset(content, 1), content="0")
+  inspect(@line_offset.line_end_offset(content, 1), content="6")
+  // Line 2's start is line 1's end: an inclusive line range is a half-open
+  // offset range.
+  inspect(@line_offset.line_start_offset(content, 2), content="6")
+  inspect(@line_offset.line_end_offset(content, 2), content="11")
+  inspect(content.unsafe_substring(start=6, end=11), content="beta\n")
+}
+
+///|
+test "a line with no trailing newline ends at the content's end" {
+  let content = "alpha\nbeta"
+  inspect(@line_offset.line_end_offset(content, 2), content="10")
+  inspect(content.length(), content="10")
+}
+```
+
+## Edges worth knowing
+
+Every out-of-range question answers with an in-bounds offset, which is what
+lets a caller clamp a decoded line range instead of rejecting it.
+
+```mbt check
+///|
+test "out-of-range lines clamp to the ends of the content" {
+  let content = "alpha\nbeta\n"
+  // Past EOF: both ends land on the content's length, so the selected slice is
+  // empty rather than invalid.
+  inspect(@line_offset.line_start_offset(content, 99), content="11")
+  inspect(@line_offset.line_end_offset(content, 99), content="11")
+  // Below 1: line 0 and line -5 both start where line 1 does.
+  inspect(@line_offset.line_start_offset(content, 0), content="0")
+  inspect(@line_offset.line_start_offset(content, -5), content="0")
+}
+
+///|
+test "empty content has one empty line" {
+  inspect(@line_offset.line_start_offset("", 1), content="0")
+  inspect(@line_offset.line_end_offset("", 1), content="0")
+}
+```
+
+A `\r\n` line ending is *not* special-cased: the scan splits on `\n`, so the
+`\r` belongs to the line it terminates and shows up inside the selected slice.
+
+```mbt check
+///|
+test "CRLF keeps its carriage return inside the line" {
+  let content = "alpha\r\nbeta\r\n"
+  inspect(@line_offset.line_end_offset(content, 1), content="7")
+  inspect(content.unsafe_substring(start=0, end=7), content="alpha\r\n")
+}
+```

--- a/agent_tool/internal/line_offset/README.md
+++ b/agent_tool/internal/line_offset/README.md
@@ -1,0 +1,1 @@
+README.mbt.md

--- a/agent_tool/internal/line_offset/line_offset.mbt
+++ b/agent_tool/internal/line_offset/line_offset.mbt
@@ -1,0 +1,39 @@
+///|
+/// Where a 1-based line begins in `content`, as a code-unit offset.
+///
+/// Line 1 — and any lower number — begins at 0; every other line begins right
+/// after the previous one ends. A line past the end of `content` yields
+/// `content.length()`, so a range anchored beyond EOF selects an empty slice
+/// instead of failing.
+pub fn line_start_offset(content : String, line : Int) -> Int {
+  // Line `line` starts right after line `line - 1` ends (nobreak: both scans
+  // land on content.length() for a line past EOF).
+  if line <= 1 {
+    0
+  } else {
+    line_end_offset(content, line - 1)
+  }
+}
+
+///|
+/// Where a 1-based line ends in `content`, as a code-unit offset.
+///
+/// The offset is *past* the line's terminating newline, so
+/// `line_end_offset(content, n)` and `line_start_offset(content, n + 1)` name
+/// the same position. A line that is not newline-terminated — the last one, or
+/// any line past the end — ends at `content.length()`.
+pub fn line_end_offset(content : String, line : Int) -> Int {
+  let len = content.length()
+  for cursor in 0..<len; current_line = 1 {
+    if content[cursor] == '\n' {
+      if current_line == line {
+        break cursor + 1
+      }
+      continue current_line + 1
+    } else {
+      continue current_line
+    }
+  } nobreak {
+    len
+  }
+}

--- a/agent_tool/internal/line_offset/moon.pkg
+++ b/agent_tool/internal/line_offset/moon.pkg
@@ -1,0 +1,1 @@
+warnings = "+unnecessary_annotation"

--- a/agent_tool/internal/line_offset/pkg.generated.mbti
+++ b/agent_tool/internal/line_offset/pkg.generated.mbti
@@ -1,0 +1,15 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_tool/internal/line_offset"
+
+// Values
+pub fn line_end_offset(String, Int) -> Int
+
+pub fn line_start_offset(String, Int) -> Int
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits

--- a/agent_tool/multi_edit/moon.pkg
+++ b/agent_tool/multi_edit/moon.pkg
@@ -2,6 +2,7 @@ import {
   "bobzhang/openseek/agent_tool",
   "bobzhang/openseek/agent_tool/internal/auto_check",
   "bobzhang/openseek/agent_tool/internal/error" @tool_error,
+  "bobzhang/openseek/agent_tool/internal/line_offset",
   "bobzhang/openseek/agent_tool/write_scope",
   "bobzhang/openseek/agent_tool/internal/manifest_error",
   "bobzhang/openseek/agent_tool/multi_edit/internal/decode",

--- a/agent_tool/multi_edit/multi_edit.mbt
+++ b/agent_tool/multi_edit/multi_edit.mbt
@@ -873,7 +873,7 @@ fn validate_edit(
         message: "old_string and new_string are both empty",
       })
     }
-    let at = line_start_offset(content, item.start_line).clamp(
+    let at = @line_offset.line_start_offset(content, item.start_line).clamp(
       min=0,
       max=content.length(),
     )
@@ -986,42 +986,14 @@ fn select_edit_region(
   start_line : Int,
   end_line : Int?,
 ) -> EditRegion {
-  let start = line_start_offset(content, start_line)
+  let start = @line_offset.line_start_offset(content, start_line)
   let end = match end_line {
-    Some(line) => line_end_offset(content, line)
+    Some(line) => @line_offset.line_end_offset(content, line)
     None => content.length()
   }
   let start = start.clamp(min=0, max=content.length())
   let end = end.clamp(min=start, max=content.length())
   { body: content.unsafe_substring(start~, end~), start_offset: start, }
-}
-
-///|
-fn line_start_offset(content : String, line : Int) -> Int {
-  // Line `line` starts right after line `line - 1` ends (nobreak: both scans
-  // land on content.length() for a line past EOF).
-  if line <= 1 {
-    0
-  } else {
-    line_end_offset(content, line - 1)
-  }
-}
-
-///|
-fn line_end_offset(content : String, line : Int) -> Int {
-  let len = content.length()
-  for cursor in 0..<len; current_line = 1 {
-    if content[cursor] == '\n' {
-      if current_line == line {
-        break cursor + 1
-      }
-      continue current_line + 1
-    } else {
-      continue current_line
-    }
-  } nobreak {
-    len
-  }
 }
 
 ///|


### PR DESCRIPTION
`edit` and `multi_edit` each carried a byte-identical `line_start_offset`/`line_end_offset` pair — the scan that turns a decoded 1-based line range into offsets both tools slice content with.

Move it to `agent_tool/internal/line_offset`, next to the other shared internal vocabulary, and import it from both. The new package's README pins the contract the copies only implied: end offsets land past the newline, out-of-range lines clamp instead of failing, and `\r\n` is not special-cased — 5 doc tests cover those edges.

Verified with `just check`, `just build`, and `just test` (native 3331 passed, JS 3295 passed, cram 28/28).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R1VPFniuQNZ2QbD9suuhwg