### PR TITLE
feat(llm): add typed GLM 5.3 models with endpoint and key routing

### DIFF
--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -157,6 +157,7 @@ fn engine_extra_env(config : AppConfig) -> Map[String, String] {
   }
   let api_key_env = match config.model {
     Kimi(_) => "KIMI"
+    Glm(_) => "GLM"
     Deepseek(_) => "DEEPSEEK"
   }
   env[api_key_env] = config.api_key
@@ -1027,6 +1028,9 @@ test "engine configuration puts supported placement in argv" {
   let kimi_env = engine_extra_env({ ..config, model: Kimi(K27CodeHighSpeed), })
   assert_true(kimi_env.get("KIMI") == Some(config.api_key))
   assert_true(kimi_env.get("DEEPSEEK") is None)
+  let glm_env = engine_extra_env({ ..config, model: Glm(G53), })
+  assert_true(glm_env.get("GLM") == Some(config.api_key))
+  assert_true(glm_env.get("DEEPSEEK") is None)
   @debug.assert_eq(config.engine_command_args("run", ["--", "task"]), [
     "run", "--session=test", "--session-root=.openseek", "--dir=.", "--", "task",
   ])

--- a/deepseek/README.mbt.md
+++ b/deepseek/README.mbt.md
@@ -2,20 +2,22 @@
 
 This pure package provides strongly typed DeepSeek chat data and JSON
 encoding/decoding. Use it when constructing requests, parsing responses, or
-testing DeepSeek chat behavior without network access. The typed model list
-also covers Kimi K2.7 Code models where their request policy differs from
-DeepSeek's.
+testing compatible chat behavior without network access. The typed model list
+also covers Kimi K2.7 Code and Z.AI GLM 5.3 models where their request policies
+differ from DeepSeek's.
 
 The HTTP client lives in `bobzhang/openseek/deepseek/client`.
 
 ## API Shape
 
-- `Model`: provider-tagged chat models, e.g. `Deepseek(V4Pro)` and
-  `Kimi(K27Code)`, with `Show` for wire strings and `Debug` for inspection.
+- `Model`: provider-tagged chat models, e.g. `Deepseek(V4Pro)`,
+  `Kimi(K27Code)`, and `Glm(G53)`, with `Show` for wire strings and `Debug` for
+  inspection.
 - `Model::api_key(matches)`: resolves the key a command main should send for
   this model — an explicit `--api-key` first, then the provider-specific
-  option (`--deepseek-api-key` / `--kimi-api-key`, which the command tables
-  back with `DEEPSEEK` / `KIMI`), and `None` when neither is set. It is the
+  option (`--deepseek-api-key` / `--kimi-api-key` / `--glm-api-key`, which the
+  command tables back with `DEEPSEEK` / `KIMI` / `GLM`), and `None` when
+  neither is set. It is the
   shared answer to *where a key may come from*; whether a missing one is fatal,
   and what to say about it, is left to each command main. This is the one place
   in the package that reads parsed CLI options, and it lives here because the
@@ -55,7 +57,7 @@ flowchart LR
   app["agent / tests"] --> root["deepseek\nmodels, messages, tools, JSON"]
   session["agent_session\nchat projection"] --> root
   client["deepseek/client\nHTTP, retries, SSE"] --> root
-  client --> api["DeepSeek / Kimi chat API"]
+  client --> api["DeepSeek / Kimi / Z.AI GLM chat API"]
 ```
 
 The core API is a set of public data types around chat request and response
@@ -70,6 +72,7 @@ classDiagram
     <<tagged union>>
     Deepseek(DsVariant)
     Kimi(KimiVariant)
+    Glm(GlmVariant)
     +parse(String) Model
   }
 
@@ -84,6 +87,16 @@ classDiagram
     K27Code
     K27CodeHighSpeed
   }
+
+  class GlmVariant {
+    <<enumeration>>
+    G53
+    G53Flash
+  }
+
+  Model --> DsVariant
+  Model --> KimiVariant
+  Model --> GlmVariant
 
   class ThinkingMode {
     <<enumeration>>
@@ -204,7 +217,7 @@ The usual sequence is:
 sequenceDiagram
   participant Caller
   participant Encoder as encode_chat_request
-  participant API as DeepSeek / Kimi API
+  participant API as chat-completions provider
   participant Tool as local tool
 
   Caller->>Encoder: messages + ToolDefinition[]

--- a/deepseek/api_key.mbt
+++ b/deepseek/api_key.mbt
@@ -36,6 +36,8 @@ pub fn Model::api_key(
       Some(k.trim().to_owned())
     (Kimi(_), { "kimi-api-key": [k, ..], .. }) if !k.is_blank() =>
       Some(k.trim().to_owned())
+    (Glm(_), { "glm-api-key": [k, ..], .. }) if !k.is_blank() =>
+      Some(k.trim().to_owned())
     _ => None
   }
 }

--- a/deepseek/client/README.mbt.md
+++ b/deepseek/client/README.mbt.md
@@ -1,10 +1,11 @@
 # DeepSeek Client
 
-This package is the effectful HTTP transport for DeepSeek chat completions. It
-uses `bobzhang/openseek/deepseek` for typed models, messages, tool definitions,
-request JSON encoding, and response JSON decoding.
+This package is the effectful HTTP transport for DeepSeek-, Kimi-, and
+Z.AI-compatible chat completions. It uses `bobzhang/openseek/deepseek` for typed
+models, messages, tool definitions, request JSON encoding, and response JSON
+decoding.
 
-Use this package when code needs to call the real DeepSeek API. Keep pure
+Use this package when code needs to call a supported provider API. Keep pure
 request/response tests in `bobzhang/openseek/deepseek`; use this package for
 transport behavior such as retries, HTTP errors, and streaming.
 
@@ -31,6 +32,7 @@ model is `deepseek-v4-pro`, and `thinking=No` is sent unless a different mode is
 provided. Kimi K2.7 Code models default to
 `https://api.moonshot.cn/v1/chat/completions` and omit DeepSeek-specific
 thinking fields when the request body is encoded.
+Z.AI GLM models default to `https://api.z.ai/api/paas/v4/chat/completions`.
 
 Retries cover transient failures: transport errors, HTTP 429, and HTTP 5xx.
 Other HTTP 4xx responses fail immediately. `retry_attempts` counts total tries;
@@ -71,7 +73,7 @@ Without `stream`, `Client::chat` builds the same JSON body as
 configuration, then posts it to `api_url` with `Content-Type:
 application/json` and bearer authorization.
 
-Use `tools=[...]` when the model may request native DeepSeek function calls.
+Use `tools=[...]` when the model may request native function calls.
 Use `response_format=JsonObject` only when the assistant content itself must be
 a JSON object.
 

--- a/deepseek/client/client.mbt
+++ b/deepseek/client/client.mbt
@@ -5,12 +5,16 @@ const DeepSeekDefaultApiUrl : String = "https://api.deepseek.com/chat/completion
 const KimiDefaultApiUrl : String = "https://api.moonshot.cn/v1/chat/completions"
 
 ///|
+const GlmDefaultApiUrl : String = "https://api.z.ai/api/paas/v4/chat/completions"
+
+///|
 let default_model : @deepseek.Model = Deepseek(V4Pro)
 
 ///|
 fn default_api_url_for_model(model : @deepseek.Model) -> String {
   match model {
     Kimi(_) => KimiDefaultApiUrl
+    Glm(_) => GlmDefaultApiUrl
     Deepseek(_) => DeepSeekDefaultApiUrl
   }
 }

--- a/deepseek/client/client_test.mbt
+++ b/deepseek/client/client_test.mbt
@@ -10,6 +10,8 @@ test "client defaults" {
 test "client endpoint defaults follow selected model" {
   let kimi = @client.Client(api_key="test-key", model=Kimi(K27Code))
   assert_eq(kimi.api_url, "https://api.moonshot.cn/v1/chat/completions")
+  let glm = @client.Client(api_key="test-key", model=Glm(G53))
+  assert_eq(glm.api_url, "https://api.z.ai/api/paas/v4/chat/completions")
   let proxied = @client.Client(
     api_key="test-key",
     model=Kimi(K27CodeHighSpeed),

--- a/deepseek/deepseek.mbt
+++ b/deepseek/deepseek.mbt
@@ -13,10 +13,18 @@ pub(all) enum KimiVariant {
 } derive(Eq, Debug)
 
 ///|
+/// Z.AI GLM chat model variants.
+pub(all) enum GlmVariant {
+  G53
+  G53Flash
+} derive(Eq, Debug)
+
+///|
 /// Supported chat models grouped by provider.
 pub(all) enum Model {
   Deepseek(DsVariant)
   Kimi(KimiVariant)
+  Glm(GlmVariant)
 } derive(Eq, Debug)
 
 ///|
@@ -38,11 +46,21 @@ impl Show for KimiVariant with fn to_string(self : KimiVariant) -> String {
 }
 
 ///|
+/// Returns the wire name for a Z.AI GLM chat model variant.
+impl Show for GlmVariant with fn to_string(self : GlmVariant) -> String {
+  match self {
+    G53 => "glm-5.3"
+    G53Flash => "glm-5.3-flash"
+  }
+}
+
+///|
 /// Returns the wire name for a chat model.
 pub impl Show for Model with fn to_string(self : Model) -> String {
   match self {
     Deepseek(variant) => "\{variant}"
     Kimi(variant) => "\{variant}"
+    Glm(variant) => "\{variant}"
   }
 }
 
@@ -54,6 +72,8 @@ pub fn Model::parse(input : String) -> Model raise {
     "deepseek-v4-pro" => Deepseek(V4Pro)
     "kimi-k2.7-code" => Kimi(K27Code)
     "kimi-k2.7-code-highspeed" => Kimi(K27CodeHighSpeed)
+    "glm-5.3" => Glm(G53)
+    "glm-5.3-flash" => Glm(G53Flash)
     other => fail("unknown model: \{other}")
   }
 }
@@ -71,6 +91,7 @@ pub fn Model::context_window(self : Model) -> Int {
   match self {
     Deepseek(V4Flash | V4Pro) => 1_000_000
     Kimi(K27Code | K27CodeHighSpeed) => 262_144
+    Glm(G53 | G53Flash) => 1_000_000
   }
 }
 
@@ -234,6 +255,12 @@ pub extend KimiVariant with Debug::{to_repr}
 
 ///|
 pub extend KimiVariant with Eq::{equal, not_equal}
+
+///|
+pub extend GlmVariant with Debug::{to_repr}
+
+///|
+pub extend GlmVariant with Eq::{equal, not_equal}
 
 ///|
 pub extend Model with Debug::{to_repr}

--- a/deepseek/deepseek_test.mbt
+++ b/deepseek/deepseek_test.mbt
@@ -21,6 +21,8 @@ test "model parsing" {
   assert_true(
     @deepseek.Model::parse("kimi-k2.7-code-highspeed") is Kimi(K27CodeHighSpeed),
   )
+  assert_true(@deepseek.Model::parse("glm-5.3") is Glm(G53))
+  assert_true(@deepseek.Model::parse("glm-5.3-flash") is Glm(G53Flash))
   assert_eq(
     @deepseek.Model::parse("deepseek-v4-flash").to_string(),
     "deepseek-v4-flash",
@@ -37,6 +39,11 @@ test "model parsing" {
     @deepseek.Model::parse("kimi-k2.7-code-highspeed").to_string(),
     "kimi-k2.7-code-highspeed",
   )
+  assert_eq(@deepseek.Model::parse("glm-5.3").to_string(), "glm-5.3")
+  assert_eq(
+    @deepseek.Model::parse("glm-5.3-flash").to_string(),
+    "glm-5.3-flash",
+  )
 }
 
 ///|
@@ -48,6 +55,8 @@ test "context windows per model" {
     (Kimi(K27CodeHighSpeed) : @deepseek.Model).context_window(),
     262_144,
   )
+  assert_eq((Glm(G53) : @deepseek.Model).context_window(), 1_000_000)
+  assert_eq((Glm(G53Flash) : @deepseek.Model).context_window(), 1_000_000)
 }
 
 ///|

--- a/deepseek/pkg.generated.mbti
+++ b/deepseek/pkg.generated.mbti
@@ -39,6 +39,14 @@ pub fn DsVariant::equal(Self, Self) -> Bool
 pub fn DsVariant::not_equal(Self, Self) -> Bool
 pub fn DsVariant::to_repr(Self) -> @debug.Repr
 
+pub(all) enum GlmVariant {
+  G53
+  G53Flash
+} derive(Eq, @debug.Debug)
+pub fn GlmVariant::equal(Self, Self) -> Bool
+pub fn GlmVariant::not_equal(Self, Self) -> Bool
+pub fn GlmVariant::to_repr(Self) -> @debug.Repr
+
 pub(all) enum KimiVariant {
   K27Code
   K27CodeHighSpeed
@@ -50,6 +58,7 @@ pub fn KimiVariant::to_repr(Self) -> @debug.Repr
 pub(all) enum Model {
   Deepseek(DsVariant)
   Kimi(KimiVariant)
+  Glm(GlmVariant)
 } derive(Eq, @debug.Debug)
 pub fn Model::api_key(Self, Map[String, Array[String]]) -> String?
 pub fn Model::context_window(Self) -> Int

--- a/eval/file_edit/harness/harness.mbt
+++ b/eval/file_edit/harness/harness.mbt
@@ -158,6 +158,7 @@ fn trial_extra_env(
 fn api_key_env_for_model(model : @deepseek.Model) -> String {
   match model {
     Kimi(_) => "KIMI"
+    Glm(_) => "GLM"
     Deepseek(_) => "DEEPSEEK"
   }
 }

--- a/eval/prompt_task/harness/harness.mbt
+++ b/eval/prompt_task/harness/harness.mbt
@@ -116,9 +116,9 @@ fn trial_extra_env(
   // An explicit `api_key` overrides this model's provider key for every trial.
   // An empty one means "let the engine inherit its provider key from the
   // parent environment" — the only way one suite can span providers, since
-  // DeepSeek reads DEEPSEEK and Kimi reads KIMI and a single shared key cannot
-  // authenticate both. Overriding unconditionally would clobber the inherited
-  // KIMI (or DEEPSEEK) of the other provider's trials with the wrong key.
+  // DeepSeek reads DEEPSEEK, Kimi reads KIMI, and GLM reads GLM; a single
+  // shared key cannot authenticate all providers. Overriding unconditionally
+  // would clobber another provider's inherited key with the wrong key.
   if config.api_key != "" {
     env[api_key_env_for_model(config.model)] = config.api_key
   }
@@ -129,6 +129,7 @@ fn trial_extra_env(
 fn api_key_env_for_model(model : @deepseek.Model) -> String {
   match model {
     Kimi(_) => "KIMI"
+    Glm(_) => "GLM"
     Deepseek(_) => "DEEPSEEK"
   }
 }

--- a/eval/prompt_task/harness/harness_wbtest.mbt
+++ b/eval/prompt_task/harness/harness_wbtest.mbt
@@ -19,12 +19,19 @@ test "trial environment configures model and isolated skills" {
   let env = trial_extra_env(config, "/tmp/workspace")
   assert_true(env.get("DEEPSEEK") == Some("key"))
   assert_true(env.get("KIMI") is None)
+  assert_true(env.get("GLM") is None)
   let kimi_env = trial_extra_env(
     { ..config, model: Kimi(K27CodeHighSpeed), },
     "/tmp/workspace",
   )
   assert_true(kimi_env.get("KIMI") == Some("key"))
   assert_true(kimi_env.get("DEEPSEEK") is None)
+  let glm_env = trial_extra_env(
+    { ..config, model: Glm(G53), },
+    "/tmp/workspace",
+  )
+  assert_true(glm_env.get("GLM") == Some("key"))
+  assert_true(glm_env.get("DEEPSEEK") is None)
   guard env.get("OPENSEEK_GLOBAL_SKILLS_DIR") is Some(skills_dir) else {
     fail("expected OPENSEEK_GLOBAL_SKILLS_DIR")
   }
@@ -34,7 +41,7 @@ test "trial environment configures model and isolated skills" {
 ///|
 test "empty api key leaves provider keys to the inherited environment" {
   // A cross-provider suite runs with an empty key so each trial inherits its
-  // own DEEPSEEK/KIMI from the parent env; the harness must not pin either
+  // own DEEPSEEK/KIMI/GLM from the parent env; the harness must not pin a
   // variable to an empty string, which would shadow the inherited key.
   let config = Config(
     api_key="",


### PR DESCRIPTION
## Summary

Part 1 of a 3-PR split of #1084 (splitting for easier review; content is #1084 rebased onto current main).

- add typed `glm-5.3` and `glm-5.3-flash` models (`GlmVariant`, `Model::Glm`) with parse/Show round-trips and a 1M context window
- default GLM requests to the Z.AI chat-completions endpoint `https://api.z.ai/api/paas/v4/chat/completions`
- route GLM credentials through the `GLM` environment variable: the `glm-api-key` arm in `Model::api_key`, the TUI engine env, and both eval harness envs

Adding the `Glm` constructor forces an arm in every exhaustive `match` on `Model`, which is why the routing fan-out travels with the type. Not yet included: the GLM thinking/encoding policy (part 2) and the CLI/TUI `--glm-api-key` registration, help text, smoke test, and user docs (part 3).

Stack: **this PR** ← part 2 (encoding policy) ← part 3 (CLI/TUI/eval surface + docs).

## Validation

- `just check` (native + js check, `moon fmt --check`)
- `moon test --target native`: 3327/3327 (with provider keys blanked)
- `moon test --target js`: 3290/3290
- `moon cram test tests/cram`: 28/28

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TpFW5LRBQs2DzXhxa8KD2