### PR TITLE
feat(llm): map thinking modes to GLM reasoning effort and preserved thinking

### DIFF
--- a/deepseek/README.mbt.md
+++ b/deepseek/README.mbt.md
@@ -22,8 +22,8 @@ The HTTP client lives in `bobzhang/openseek/deepseek/client`.
   and what to say about it, is left to each command main. This is the one place
   in the package that reads parsed CLI options, and it lives here because the
   model tag is what decides which provider a key belongs to.
-- `ThinkingMode`: typed control for DeepSeek V4 thinking (`No`, `High`, or
-  `Max`).
+- `ThinkingMode`: typed thinking control (`No`, `High`, or `Max`), translated
+  to each provider's supported request policy.
 - `Role`: `System`, `User`, `Assistant`, and `Tool(tool_call_id)`, with `Show`
   for wire strings and `Debug` for inspection.
 - `ChatMessage(role, content=..., tool_calls?, reasoning_content?)`: one typed
@@ -36,7 +36,8 @@ The HTTP client lives in `bobzhang/openseek/deepseek/client`.
   model?=Deepseek(V4Pro)) <| messages`: builds the full DeepSeek chat completions request
   body. Streaming requests include usage-bearing stream options. Kimi K2.7 Code
   requests omit DeepSeek-specific thinking fields and preserve assistant
-  `reasoning_content`. The per-value
+  `reasoning_content`. GLM requests keep reasoning across tool turns and map
+  `No` to GLM's supported `low` effort. The per-value
   encoders for messages, tool definitions, and tool calls are package-private
   implementation details.
 - `ToolDefinition(name, description, parameters, strict?)`: a native DeepSeek

--- a/deepseek/client/README.mbt.md
+++ b/deepseek/client/README.mbt.md
@@ -32,7 +32,8 @@ model is `deepseek-v4-pro`, and `thinking=No` is sent unless a different mode is
 provided. Kimi K2.7 Code models default to
 `https://api.moonshot.cn/v1/chat/completions` and omit DeepSeek-specific
 thinking fields when the request body is encoded.
-Z.AI GLM models default to `https://api.z.ai/api/paas/v4/chat/completions`.
+Z.AI GLM models default to `https://api.z.ai/api/paas/v4/chat/completions`;
+GLM 5.3 always reasons, so `thinking=No` maps to `reasoning_effort=low`.
 
 Retries cover transient failures: transport errors, HTTP 429, and HTTP 5xx.
 Other HTTP 4xx responses fail immediately. `retry_attempts` counts total tries;

--- a/deepseek/encode_chat_request_test.mbt
+++ b/deepseek/encode_chat_request_test.mbt
@@ -202,6 +202,69 @@ test "kimi highspeed uses the same code-model request policy" {
 }
 
 ///|
+test "glm maps no to low effort and preserves tool-turn reasoning" {
+  let call = @deepseek.ToolCall(
+    id="call_53",
+    name="shell",
+    arguments="{\"cmd\":\"moon test\"}",
+  )
+  let body = @deepseek.encode_chat_request(
+    model=Glm(G53),
+    thinking=No,
+    stream=true,
+  ) <| [
+    ChatMessage(User, content="run tests"),
+    ChatMessage(
+      Assistant,
+      content="",
+      tool_calls=[call],
+      reasoning_content="validate before finishing",
+    ),
+    ChatMessage(Tool("call_53"), content="exit=0\nok"),
+  ]
+  json_inspect(body, content={
+    "model": "glm-5.3",
+    "messages": [
+      { "role": "user", "content": "run tests" },
+      {
+        "role": "assistant",
+        "content": null,
+        "tool_calls": [
+          {
+            "id": "call_53",
+            "type": "function",
+            "function": {
+              "name": "shell",
+              "arguments": "{\"cmd\":\"moon test\"}",
+            },
+          },
+        ],
+        "reasoning_content": "validate before finishing",
+      },
+      { "role": "tool", "content": "exit=0\nok", "tool_call_id": "call_53" },
+    ],
+    "stream": true,
+    "stream_options": { "include_usage": true },
+    "thinking": { "type": "enabled", "clear_thinking": false },
+    "reasoning_effort": "low",
+  })
+}
+
+///|
+test "glm flash enables preserved thinking at max effort" {
+  let body = @deepseek.encode_chat_request(model=Glm(G53Flash), thinking=Max) <| [
+    ChatMessage(User, content="solve"),
+  ]
+  json_inspect(body, content={
+    "model": "glm-5.3-flash",
+    "messages": [{ "role": "user", "content": "solve" }],
+    "stream": false,
+    "thinking": { "type": "enabled", "clear_thinking": false },
+    "reasoning_effort": "max",
+  })
+}
+
+///|
 test "deepseek tool-enabled reasoning and tool result round-trip" {
   let tool = @deepseek.ToolDefinition("shell", "Run a shell command.", {
     "type": "object",

--- a/deepseek/json_encode.mbt
+++ b/deepseek/json_encode.mbt
@@ -1,4 +1,29 @@
 ///|
+/// Provider-specific thinking fields for a chat-completions request.
+///
+/// Kimi K2.7 Code documentation says not to pass `thinking`.
+/// https://platform.kimi.ai/docs/guide/use-kimi-k2-thinking-model#using-the-kimi-k2-7-code-model
+fn thinking_json_fields(
+  model : Model,
+  thinking : ThinkingMode?,
+) -> Array[(String, Json)] {
+  match (model, thinking) {
+    (Kimi(_), _) | (_, None) => []
+    (_, Some(No)) => [("thinking", ({ "type": "disabled" } : Json))]
+    (_, Some(High)) =>
+      [
+        ("thinking", ({ "type": "enabled" } : Json)),
+        ("reasoning_effort", Json("high")),
+      ]
+    (_, Some(Max)) =>
+      [
+        ("thinking", ({ "type": "enabled" } : Json)),
+        ("reasoning_effort", Json("max")),
+      ]
+  }
+}
+
+///|
 /// Encodes a `ChatMessage` as a chat-completions `messages[]` entry.
 ///
 /// Assistant messages whose `content` is empty but carry tool calls are
@@ -93,23 +118,7 @@ pub fn encode_chat_request(
         ..if tools.length() > 0 {
           [("tools", ([ for tool in tools => tool ] : Json))]
         },
-        // Kimi K2.7 Code documentation says not to pass `thinking`.
-        // https://platform.kimi.ai/docs/guide/use-kimi-k2-thinking-model#using-the-kimi-k2-7-code-model
-        ..if !(model is Kimi(_)) && thinking is Some(mode) {
-          match mode {
-            No => [("thinking", ({ "type": "disabled" } : Json))]
-            High =>
-              [
-                ("thinking", ({ "type": "enabled" } : Json)),
-                ("reasoning_effort", Json("high")),
-              ]
-            Max =>
-              [
-                ("thinking", ({ "type": "enabled" } : Json)),
-                ("reasoning_effort", Json("max")),
-              ]
-          }
-        },
+        ..thinking_json_fields(model, thinking),
       ],
     ),
   )

--- a/deepseek/json_encode.mbt
+++ b/deepseek/json_encode.mbt
@@ -1,14 +1,25 @@
 ///|
 /// Provider-specific thinking fields for a chat-completions request.
 ///
-/// Kimi K2.7 Code documentation says not to pass `thinking`.
-/// https://platform.kimi.ai/docs/guide/use-kimi-k2-thinking-model#using-the-kimi-k2-7-code-model
+/// GLM-5.3 models cannot disable thinking. Map OpenSeek's lowest setting to
+/// GLM's `low` effort and preserve complete reasoning across agent tool turns.
 fn thinking_json_fields(
   model : Model,
   thinking : ThinkingMode?,
 ) -> Array[(String, Json)] {
   match (model, thinking) {
     (Kimi(_), _) | (_, None) => []
+    (Glm(_), Some(mode)) => {
+      let effort = match mode {
+        No => "low"
+        High => "high"
+        Max => "max"
+      }
+      [
+        ("thinking", ({ "type": "enabled", "clear_thinking": false } : Json)),
+        ("reasoning_effort", Json(effort)),
+      ]
+    }
     (_, Some(No)) => [("thinking", ({ "type": "disabled" } : Json))]
     (_, Some(High)) =>
       [
@@ -30,8 +41,8 @@ fn thinking_json_fields(
 /// encoded with JSON `content: null`, as the API requires.
 ///
 /// Assistant `reasoning_content` is always replayed: DeepSeek requires it
-/// when tools are enabled and ignores it otherwise, and Kimi K2.7 Code
-/// always requires it.
+/// when tools are enabled and ignores it otherwise, Kimi K2.7 Code always
+/// requires it, and GLM coding-agent requests use preserved thinking.
 ///
 /// See: https://api-docs.deepseek.com/guides/thinking_mode#thinking-mode-with-tool-calls
 /// See: https://platform.kimi.ai/docs/guide/use-kimi-k2-thinking-model#using-the-kimi-k2-7-code-model


### PR DESCRIPTION
## Summary

Part 2 of a 3-PR split of #1084, stacked on #1119. Two commits, meant to be read separately:

1. **Pure refactor**: extract `thinking_json_fields(model, thinking)` from `encode_chat_request`, no behavior change (existing request snapshots unchanged).
2. **GLM policy**: GLM 5.3 cannot disable thinking, so `ThinkingMode::No` maps to `reasoning_effort: "low"` instead of `thinking: {"type": "disabled"}`, and every GLM request enables preserved thinking (`"clear_thinking": false`) so complete reasoning is retained across agent tool turns.

Request snapshot tests cover the `No`→`low` shape across a tool turn (with `reasoning_content` replayed) and the flash max-effort shape.

Stack: #1119 ← **this PR** ← part 3 (CLI/TUI/eval surface + docs).

## Validation

- `just check` (native + js check, `moon fmt --check`)
- `moon test --target native`: 3329/3329 (with provider keys blanked)
- `moon test --target js`: 3292/3292
- `moon cram test tests/cram`: 28/28

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TpFW5LRBQs2DzXhxa8KD2