### PR TITLE
feat(llm): expose GLM models in the CLI, TUI, and eval harnesses

### DIFF
--- a/README.mbt.md
+++ b/README.mbt.md
@@ -1,8 +1,9 @@
 # bobzhang/openseek
 
-OpenSeek is a small MoonBit foundation for a DeepSeek-backed coding agent. The
-module is split into pure data, HTTP transport, agent orchestration, and a CLI
-entry point so request encoding can be tested without network access.
+OpenSeek is a small MoonBit foundation for an OpenAI-compatible coding agent
+supporting DeepSeek, Kimi, and Z.AI GLM models. The module is split into pure
+data, HTTP transport, agent orchestration, and a CLI entry point so request
+encoding can be tested without network access.
 
 For a picture of how the pieces fit together — module architecture, the core
 data model, and the life of one agent turn — see
@@ -54,8 +55,8 @@ git submodule update --init editor/vscode     # opt-in performance suite
 | Package | Purpose | Docs |
 | --- | --- | --- |
 | `bobzhang/openseek` | Root package and module overview. | `README.mbt.md` |
-| `bobzhang/openseek/deepseek` | Pure DeepSeek chat data, JSON encoding, and response decoding. | `deepseek/README.mbt.md` |
-| `bobzhang/openseek/deepseek/client` | Native-only HTTP transport for DeepSeek chat completions. | `deepseek/client/README.mbt.md` |
+| `bobzhang/openseek/deepseek` | Pure chat data, provider-aware JSON encoding, and response decoding. | `deepseek/README.mbt.md` |
+| `bobzhang/openseek/deepseek/client` | Native-only HTTP transport for supported chat-completions providers. | `deepseek/client/README.mbt.md` |
 | `bobzhang/openseek/agent_runtime` | Native-only agent task-group and extensible runtime event queue. | `agent_runtime/README.mbt.md` |
 | `bobzhang/openseek/agent_session` | Typed durable conversation state and DeepSeek message projection. | `agent_session/README.mbt.md` |
 | `bobzhang/openseek/agent_session/store` | Native filesystem-backed append-only session store. | `agent_session/store/README.mbt.md` |
@@ -149,11 +150,19 @@ export KIMI=sk-...
 moon run cmd/openseek -- --model kimi-k2.7-code-highspeed run "inspect this project"
 ```
 
+For Z.AI GLM models, set `GLM`:
+
+```bash
+export GLM=...
+moon run cmd/openseek -- --model glm-5.3 run "inspect this project"
+```
+
 `OPENSEEK_MODEL` is optional and defaults to `deepseek-v4-pro`.
 `OPENSEEK_MAX_STEPS` is optional; when omitted, turns are bounded by the
 model's context window (a checkpoint summary carries each turn into the
-next) rather than a step count. Pass `--max-steps` to cap steps for one run. `--thinking no|high|max` controls DeepSeek
-thinking mode and effort (default: max).
+next) rather than a step count. Pass `--max-steps` to cap steps for one run.
+`--thinking no|high|max` controls thinking mode and effort (default: max); GLM
+maps `no` to its lowest supported effort because GLM 5.3 always reasons.
 Pass `--dir <workspace>` to run one-shot commands against another workspace
 while still launching from the current shell. The default is `.`; if the final
 directory component is missing and its parent exists, OpenSeek creates it and

--- a/cmd/openseek/README.md
+++ b/cmd/openseek/README.md
@@ -36,14 +36,15 @@ moon run cmd/openseek -- run [--api-key sk-...] [--model deepseek-v4-pro] [--api
 ```
 
 Runs require `--api-key` or the provider-specific environment variable:
-`DEEPSEEK` for DeepSeek models and `KIMI` for Kimi models. `--model` can also
-be supplied with `OPENSEEK_MODEL`; it accepts `deepseek-v4-flash`,
-`deepseek-v4-pro`, `kimi-k2.7-code`, and `kimi-k2.7-code-highspeed`, and
-defaults to `deepseek-v4-pro`. `--max-steps` can also be supplied with
+`DEEPSEEK` for DeepSeek models, `KIMI` for Kimi models, and `GLM` for Z.AI GLM
+models. `--model` can also be supplied with `OPENSEEK_MODEL`; it accepts
+`deepseek-v4-flash`, `deepseek-v4-pro`, `kimi-k2.7-code`,
+`kimi-k2.7-code-highspeed`, `glm-5.3`, and `glm-5.3-flash`, and defaults to
+`deepseek-v4-pro`. `--max-steps` can also be supplied with
 `OPENSEEK_MAX_STEPS`; when omitted, turns are bounded by the model's context
 window instead of a step count. `--api-url` can also be supplied
-with `OPENSEEK_API_URL`; when omitted, OpenSeek uses the default DeepSeek chat
-completions endpoint, or the Kimi endpoint for Kimi models.
+with `OPENSEEK_API_URL`; when omitted, OpenSeek uses the official endpoint for
+the model's provider.
 `--dir` defaults to `.` and becomes the workspace root for relative prompt
 files, sessions, workspace skills, and agent tools. If the directory itself is
 missing but its parent exists, OpenSeek creates that final component and logs a
@@ -63,7 +64,7 @@ list` / `openseek sessions show <id>` (or the viz server) and resumable with
 `--session` is rejected.
 
 Without an explicit prompt file, the CLI uses the default built-in prompt
-(`prompt/default_prompt.mbt.md`) for the supported DeepSeek and Kimi model
+(`prompt/default_prompt.mbt.md`) for the supported DeepSeek, Kimi, and GLM model
 names. The older base prompt remains in `prompt/base_prompt.mbt.md` for
 comparison and experiments, but it is not selected by default.
 

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -1376,18 +1376,25 @@ test "cli defaults model and max steps" {
 }
 
 ///|
-test "cli uses KIMI only for Kimi models" {
+test "cli uses provider API keys only for their models" {
   let kimi = run_matches(argv=["write", "MoonBit"], env={
     "KIMI": "kimi-key",
     "OPENSEEK_MODEL": "kimi-k2.7-code-highspeed",
   })
   let kimi_model : @deepseek.Model = Kimi(K27CodeHighSpeed)
   assert_eq(kimi_model.api_key(kimi.values), Some("kimi-key"))
+  let glm = run_matches(argv=["write", "MoonBit"], env={
+    "GLM": "glm-key",
+    "OPENSEEK_MODEL": "glm-5.3-flash",
+  })
+  let glm_model : @deepseek.Model = Glm(G53Flash)
+  assert_eq(glm_model.api_key(glm.values), Some("glm-key"))
   let deepseek = run_matches(argv=["write", "MoonBit"], env={
     "KIMI": "kimi-key",
+    "GLM": "glm-key",
   })
-  // KIMI is not a fallback for a DeepSeek model: no arm matches, so the
-  // caller sees `None` and reports it.
+  // Provider keys are not fallbacks for a DeepSeek model: no arm matches, so
+  // the caller sees `None` and reports it.
   let deepseek_model : @deepseek.Model = Deepseek(V4Pro)
   assert_true(deepseek_model.api_key(deepseek.values) is None)
 }

--- a/cmd/tui/README.md
+++ b/cmd/tui/README.md
@@ -43,7 +43,7 @@ startup banner) stores the conversation under `--session-root` (default
 ## Configuration
 
 `--api-key` or a provider-specific key env is required: `DEEPSEEK` for DeepSeek
-models and `KIMI` for Kimi models. `--model`, `--api-url`,
+models, `KIMI` for Kimi models, and `GLM` for Z.AI GLM models. `--model`, `--api-url`,
 `--max-steps`, and `--thinking` mirror the engine's flags and are forwarded to
 it through the environment, alongside the session settings.
 

--- a/cmd/tui/main.mbt
+++ b/cmd/tui/main.mbt
@@ -34,12 +34,20 @@ pub fn tui_shared_options(global? : Bool = false) -> Array[@argparse.OptionArg] 
       hidden=true,
     ),
     OptionArg(
+      "glm-api-key",
+      long="glm-api-key",
+      env="GLM",
+      default_values=[""],
+      global~,
+      hidden=true,
+    ),
+    OptionArg(
       "model",
       long="model",
       env="OPENSEEK_MODEL",
       default_values=[@deepseek.Deepseek(V4Pro).to_string()],
       global~,
-      about="Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, or kimi-k2.7-code-highspeed.",
+      about="Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, kimi-k2.7-code-highspeed, glm-5.3, or glm-5.3-flash.",
     ),
     OptionArg(
       "api-url",
@@ -47,7 +55,7 @@ pub fn tui_shared_options(global? : Bool = false) -> Array[@argparse.OptionArg] 
       env="OPENSEEK_API_URL",
       default_values=[""],
       global~,
-      about="DeepSeek-compatible chat completions endpoint.",
+      about="OpenAI-compatible chat completions endpoint.",
     ),
     OptionArg(
       "max-steps",
@@ -62,7 +70,7 @@ pub fn tui_shared_options(global? : Bool = false) -> Array[@argparse.OptionArg] 
       env="OPENSEEK_THINKING",
       default_values=["max"],
       global~,
-      about="DeepSeek thinking mode: no, high, or max.",
+      about="Model thinking mode: no, high, or max; GLM maps no to low effort.",
     ),
     OptionArg(
       "session",
@@ -497,7 +505,7 @@ test "cli parses api url" {
 }
 
 ///|
-test "cli uses KIMI only for Kimi models" {
+test "cli uses provider API keys only for their models" {
   let kimi = cli_command().parse(argv=[], env={
     "KIMI": "kimi-key",
     "OPENSEEK_MODEL": "kimi-k2.7-code-highspeed",
@@ -505,16 +513,26 @@ test "cli uses KIMI only for Kimi models" {
   let kimi_config = parse_config(kimi)
   assert_eq(kimi_config.api_key, "kimi-key")
   assert_true(kimi_config.model is Kimi(K27CodeHighSpeed))
-  // KIMI is not a fallback for a DeepSeek model: `Model::api_key` returns
+  let glm = cli_command().parse(argv=[], env={
+    "GLM": "glm-key",
+    "OPENSEEK_MODEL": "glm-5.3",
+  })
+  let glm_config = parse_config(glm)
+  assert_eq(glm_config.api_key, "glm-key")
+  assert_true(glm_config.model is Glm(G53))
+  // Provider keys do not fall back across models: `Model::api_key` returns
   // `None` and this main is the one that turns that into a failure.
-  let deepseek = cli_command().parse(argv=[], env={ "KIMI": "kimi-key" })
+  let deepseek = cli_command().parse(argv=[], env={
+    "KIMI": "kimi-key",
+    "GLM": "glm-key",
+  })
   let _ = parse_config(deepseek) catch {
     error => {
       assert_true("\{error}".contains("an API key is required"))
       return
     }
   }
-  fail("KIMI was accepted for a DeepSeek model")
+  fail("a non-DeepSeek key was accepted for a DeepSeek model")
 }
 
 ///|

--- a/deepseek/client/README.mbt.md
+++ b/deepseek/client/README.mbt.md
@@ -218,5 +218,6 @@ The blackbox test suite includes a real DeepSeek API smoke test when `DEEPSEEK`
 is set. Kimi smoke tests are opt-in: set `KIMI` to a Kimi API key. The normal
 Kimi smoke also uses `OPENSEEK_MODEL` to choose the Kimi model; streaming,
 tool-call, and multi-turn reasoning-content smokes use `kimi-k2.7-code`.
+The GLM streaming tool-call smoke test runs when `GLM` is set.
 Without those environment variables, the smoke tests print skip messages and
 return successfully.

--- a/deepseek/client/client_realworld_test.mbt
+++ b/deepseek/client/client_realworld_test.mbt
@@ -189,3 +189,43 @@ async test "realworld Kimi API multi-turn reasoning-content smoke test" {
   assert_true(second.content.contains("done"))
   assert_true(second.usage.total_tokens > 0)
 }
+
+///|
+async test "realworld GLM streaming tool-call smoke test" {
+  guard @env.get_env_var("GLM") is Some(api_key) && api_key != "" else {
+    println(
+      "GLM environment variable is not set or is empty; skipping realworld GLM streaming tool-call smoke test",
+    )
+    return
+  }
+
+  let client = @client.Client(api_key~, model=Glm(G53), thinking=High)
+  let tool = @deepseek.ToolDefinition(
+    "return_token",
+    "Return the exact token requested by the user.",
+    {
+      "type": "object",
+      "properties": { "token": { "type": "string" } },
+      "required": ["token"],
+    },
+    strict=true,
+  )
+  let response = client.chat(
+    [
+      ChatMessage(
+        System,
+        content=(
+          #|You must call the return_token tool exactly once. Do not answer in text.
+        ),
+      ),
+      ChatMessage(User, content="Call return_token with token pong."),
+    ],
+    tools=[tool],
+    stream=StreamHandler(on_content_delta=_ => ()),
+  )
+  assert_eq(response.tool_calls.length(), 1)
+  assert_eq(response.tool_calls[0].name, "return_token")
+  assert_true(response.tool_calls[0].id != "")
+  assert_true(response.tool_calls[0].arguments.contains("pong"))
+  assert_true(response.usage.total_tokens > 0)
+}

--- a/eval/file_edit/cmd/main/main.mbt
+++ b/eval/file_edit/cmd/main/main.mbt
@@ -24,7 +24,7 @@ fn cli_command() -> @argparse.Command {
         "model",
         long="model",
         default_values=[@deepseek.Deepseek(V4Flash).to_string()],
-        about="Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, or kimi-k2.7-code-highspeed.",
+        about="Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, kimi-k2.7-code-highspeed, glm-5.3, or glm-5.3-flash.",
       ),
       OptionArg(
         "runs",

--- a/eval/prompt_task/cmd/main/config.mbt
+++ b/eval/prompt_task/cmd/main/config.mbt
@@ -7,8 +7,8 @@ fn config_from_matches(matches : @argparse.Matches) -> @harness.Config raise {
   )
   guard min_successes <= runs else { fail("--min-successes must be <= --runs") }
   // An empty --api-key is allowed: the harness falls back to the provider's
-  // environment variable (DEEPSEEK/KIMI), which is the only way a cross-provider
-  // run authenticates each model with its own key.
+  // environment variable (DEEPSEEK/KIMI/GLM), which is the only way a
+  // cross-provider run authenticates each model with its own key.
   let api_key = @cli.value(matches, "api-key")
   Config(
     api_key~,

--- a/eval/prompt_task/cmd/main/main.mbt
+++ b/eval/prompt_task/cmd/main/main.mbt
@@ -49,7 +49,7 @@ fn cli_command() -> @argparse.Command {
         "model",
         long="model",
         default_values=[@deepseek.Deepseek(V4Flash).to_string()],
-        about="Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, or kimi-k2.7-code-highspeed.",
+        about="Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, kimi-k2.7-code-highspeed, glm-5.3, or glm-5.3-flash.",
       ),
       OptionArg(
         "runs",

--- a/prompt/README.mbt.md
+++ b/prompt/README.mbt.md
@@ -7,15 +7,14 @@ functions through the module-level `md_to_mbt_string` dev-build rule.
 ## Prompt Sources
 
 - `default_prompt.mbt.md`: the default built-in prompt used by the supported
-  DeepSeek and Kimi model names.
+  DeepSeek, Kimi, and GLM model names.
 - `base_prompt.mbt.md`: the older built-in prompt, retained for comparison and
   prompt experiments but not selected by default.
 
 ## API Shape
 
 - `system_prompt_for_model(model)`: return the default built-in prompt for a
-  supported chat model. The supported DeepSeek and Kimi model names all use
-  `default_prompt.mbt.md`.
+  supported chat model. All supported model names use `default_prompt.mbt.md`.
 
 The agent package depends on this package for its default prompt, while the CLI
 can still override or append prompt files for A/B experiments.

--- a/prompt/prompt.mbt
+++ b/prompt/prompt.mbt
@@ -1,7 +1,7 @@
 ///|
 /// Selects the built-in system prompt for a supported chat model.
 ///
-/// Supported DeepSeek and Kimi model names currently share the default
+/// Supported DeepSeek, Kimi, and GLM model names currently share the default
 /// prompt. The older base prompt remains in the package for comparison and
 /// prompt experiments, but it is not selected by default.
 pub fn system_prompt_for_model(_model : @deepseek.Model) -> String {

--- a/tests/cram/cli.md
+++ b/tests/cram/cli.md
@@ -35,10 +35,10 @@ Commands:
 Options:
   -h, --help                     Show help information.
   --api-key <api-key>            API key for the selected chat provider. [default: ]
-  --model <model>                Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, or kimi-k2.7-code-highspeed. [env: OPENSEEK_MODEL] [default: deepseek-v4-pro]
-  --api-url <api-url>            DeepSeek-compatible chat completions endpoint. [env: OPENSEEK_API_URL] [default: ]
+  --model <model>                Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, kimi-k2.7-code-highspeed, glm-5.3, or glm-5.3-flash. [env: OPENSEEK_MODEL] [default: deepseek-v4-pro]
+  --api-url <api-url>            OpenAI-compatible chat completions endpoint. [env: OPENSEEK_API_URL] [default: ]
   --max-steps <max-steps>        Maximum agent steps per turn; omit to bound turns by the model's context window instead (a checkpoint summary carries each turn into the next). [env: OPENSEEK_MAX_STEPS]
-  --thinking <thinking>          DeepSeek thinking mode: no, high, or max. [env: OPENSEEK_THINKING] [default: max]
+  --thinking <thinking>          Model thinking mode: no, high, or max; GLM maps no to low effort. [env: OPENSEEK_THINKING] [default: max]
   --session <session>            Create or resume this durable session id.
   --session-root <session-root>  Directory containing durable OpenSeek sessions. [default: .openseek]
 ```
@@ -131,10 +131,10 @@ Arguments:
 Options:
   -h, --help                                                   Show help information.
   --api-key <api-key>                                          API key for the selected chat provider. [default: ]
-  --model <model>                                              Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, or kimi-k2.7-code-highspeed. [env: OPENSEEK_MODEL] [default: deepseek-v4-pro]
-  --api-url <api-url>                                          DeepSeek-compatible chat completions endpoint. [env: OPENSEEK_API_URL] [default: ]
+  --model <model>                                              Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, kimi-k2.7-code-highspeed, glm-5.3, or glm-5.3-flash. [env: OPENSEEK_MODEL] [default: deepseek-v4-pro]
+  --api-url <api-url>                                          OpenAI-compatible chat completions endpoint. [env: OPENSEEK_API_URL] [default: ]
   --max-steps <max-steps>                                      Maximum agent steps per turn; omit to bound turns by the model's context window instead (a checkpoint summary carries each turn into the next). [env: OPENSEEK_MAX_STEPS]
-  --thinking <thinking>                                        DeepSeek thinking mode: no, high, or max. [env: OPENSEEK_THINKING] [default: max]
+  --thinking <thinking>                                        Model thinking mode: no, high, or max; GLM maps no to low effort. [env: OPENSEEK_THINKING] [default: max]
   --session <session>                                          Create or resume this durable session id.
   --session-root <session-root>                                Directory containing durable OpenSeek sessions. [default: .openseek]
   --no-session                                                 Run ephemerally: do not record this run to a durable session.

--- a/tests/cram/tui.md
+++ b/tests/cram/tui.md
@@ -24,10 +24,10 @@ OpenSeek terminal UI.
 Options:
   -h, --help                     Show help information.
   --api-key <api-key>            API key for the selected chat provider. [default: ]
-  --model <model>                Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, or kimi-k2.7-code-highspeed. [env: OPENSEEK_MODEL] [default: deepseek-v4-pro]
-  --api-url <api-url>            DeepSeek-compatible chat completions endpoint. [env: OPENSEEK_API_URL] [default: ]
+  --model <model>                Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, kimi-k2.7-code-highspeed, glm-5.3, or glm-5.3-flash. [env: OPENSEEK_MODEL] [default: deepseek-v4-pro]
+  --api-url <api-url>            OpenAI-compatible chat completions endpoint. [env: OPENSEEK_API_URL] [default: ]
   --max-steps <max-steps>        Maximum agent steps per turn; omit to bound turns by the model's context window instead (a checkpoint summary carries each turn into the next). [env: OPENSEEK_MAX_STEPS]
-  --thinking <thinking>          DeepSeek thinking mode: no, high, or max. [env: OPENSEEK_THINKING] [default: max]
+  --thinking <thinking>          Model thinking mode: no, high, or max; GLM maps no to low effort. [env: OPENSEEK_THINKING] [default: max]
   --session <session>            Create or resume this durable session id.
   --session-root <session-root>  Directory containing durable OpenSeek sessions. [default: .openseek]
   --continue                     Resume the most recently active session in --session-root.


### PR DESCRIPTION
## Summary

Part 3 of a 3-PR split of #1084, stacked on #1119 and #1120. With this PR the stack's tree matches #1084 rebased onto main.

- register the hidden `--glm-api-key` option (backed by the `GLM` env var) in the shared TUI/CLI option table
- list `glm-5.3` and `glm-5.3-flash` in every `--model` help string, genericize the DeepSeek-specific `--api-url`/`--thinking` wording, and refresh the cram help snapshots
- add the guarded live GLM streaming tool-call smoke test (runs only when `GLM` is set; prints a skip message otherwise)
- document GLM usage in the root, CLI, TUI, client, and prompt READMEs, including that GLM maps `--thinking no` to low effort because GLM 5.3 always reasons

## Validation

Carried over from #1084 (same final tree, rebased):

- live glm-5.3 strict streaming tool-call smoke: passed 1/1 in 6.7 seconds
- effectiveness trial: a real OpenSeek prompt-task run with glm-5.3-flash (low thinking) built a MoonBit TOML-subset parser and CLI; the independent evaluator passed all five probes and the project passed 10/10 model-authored tests (22m15s, 116 steps, 40 tool errors — capable but inefficient). A glm-5.3 max-thinking trial streamed reasoning but made no first tool call in 7m43s and was stopped; high thinking has request-level coverage but no end-to-end run.

Re-run on this stack:

- `just check` (native + js check, `moon fmt --check`)
- `moon test --target native`: 3330/3330 (with provider keys blanked)
- `moon test --target js`: 3292/3292
- `moon cram test tests/cram`: 28/28

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TpFW5LRBQs2DzXhxa8KD2