### PR TITLE
feat(desktop): expose GLM in the desktop UI

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -121,8 +121,10 @@ SeekMoon is bring-your-own-key: there is no hosted chat proxy, so requests
 go straight from the machine running the host to the configured provider,
 billed to that account. The default, **DeepSeek official**, sends requests
 to `api.deepseek.com` with your own key; the engine also falls back to the
-`DEEPSEEK` environment variable when no key is stored. **Custom URL**
-accepts any DeepSeek-compatible chat-completions endpoint, with the key
+`DEEPSEEK` environment variable when no key is stored. **Z.AI GLM** sends
+requests to `api.z.ai` with its own key (env fallback `GLM`) and offers the
+GLM 5.3 models on the composer's model chip. **Custom URL**
+accepts any OpenAI-compatible chat-completions endpoint, with the key
 optional — whether one is needed is the endpoint's business. The provider
 choice, the custom URL, and the keys live in the host's settings store
 (`engine-settings.json` in the runtime dir), shared by the desktop window

--- a/desktop/frontend/agent_model.mbt
+++ b/desktop/frontend/agent_model.mbt
@@ -120,23 +120,31 @@ test "agent choices round-trip their wire names" {
 }
 
 ///|
-/// The OpenSeek group always offers the two service tiers; a conversation
-/// running an unknown wire name keeps it visible, same as the old selector.
-fn openseek_model_group(selected : EngineModel) -> @composer.ModelGroup {
-  let options : Array[@composer.ModelOption] = [
-    {
-      value: ModelChoice::OpenSeekModel(High).wire(),
-      label: EngineModel::High.label(),
-    },
-    {
-      value: ModelChoice::OpenSeekModel(Low).wire(),
-      label: EngineModel::Low.label(),
-    },
-  ]
-  if selected is Other(name) {
+/// The OpenSeek group offers the configured provider's models: the DeepSeek
+/// service tiers, the GLM models, or — for a custom endpoint, where the key
+/// follows whichever model is named — every model this build knows. A
+/// conversation running a model outside that list keeps it visible, same as
+/// the old selector.
+fn openseek_model_group(
+  provider : ApiProvider,
+  selected : EngineModel,
+) -> @composer.ModelGroup {
+  let listed : Array[EngineModel] = match provider {
+    Deepseek => [High, Low]
+    Glm => [Glm53, Glm53Flash]
+    Custom => [High, Low, Glm53, Glm53Flash]
+  }
+  let options : Array[@composer.ModelOption] = []
+  for model in listed {
+    options.push({
+      value: ModelChoice::OpenSeekModel(model).wire(),
+      label: model.label(),
+    })
+  }
+  if !listed.contains(selected) {
     options.push({
       value: ModelChoice::OpenSeekModel(selected).wire(),
-      label: name,
+      label: selected.label(),
     })
   }
   { label: "OpenSeek", options, }
@@ -175,7 +183,7 @@ fn Model::openseek_model_chip(
   conv : Conversation,
 ) -> @composer.ModelSelect {
   let groups : Array[@composer.ModelGroup] = [
-    openseek_model_group(conv.engine_model),
+    openseek_model_group(self.api_provider, conv.engine_model),
   ]
   if self.composing_new_chat() {
     groups.push(self.codex_model_group())
@@ -192,26 +200,32 @@ fn Model::openseek_model_chip(
 
 ///|
 /// OpenSeek's reasoning chip shares the same control as Codex but offers only
-/// the values its DeepSeek request format defines. An unknown model may be a
+/// the values its request format defines. An unknown model may be a
 /// provider such as Kimi, so hiding the chip there is safer than sending a
-/// setting that provider deliberately ignores.
+/// setting that provider deliberately ignores. GLM 5.3 cannot disable
+/// thinking — the engine maps `no` to GLM's lowest supported effort — so its
+/// first option says "Low" rather than promising "Off".
 fn Model::openseek_reasoning_chip(
   self : Model,
   conv : Conversation,
 ) -> @composer.ReasoningSelect? {
   guard conv.engine_model.supports_reasoning() else { return None }
+  let reasoning = self.reasoning_for(conv.engine_model)
   let options : Array[@composer.ModelOption] = [
-    { value: ReasoningOff.wire(), label: "Off", },
+    {
+      value: ReasoningOff.wire(),
+      label: ReasoningOff.label_for_model(conv.engine_model),
+    },
     { value: ReasoningHigh.wire(), label: "High", },
     { value: ReasoningMax.wire(), label: "Max", },
   ]
   Some({
     id: "openseek-reasoning-picker",
     options,
-    selected: self.openseek_reasoning.wire(),
+    selected: reasoning.wire(),
     disabled: false,
     open: self.select_menu == Some(OpenSeekReasoningMenu),
-    title: "Reasoning effort: \{self.openseek_reasoning.label()}",
+    title: "Reasoning effort: \{reasoning.label_for_model(conv.engine_model)}",
   })
 }
 
@@ -222,7 +236,7 @@ fn Model::openseek_reasoning_chip(
 fn Model::codex_model_chip(self : Model) -> @composer.ModelSelect {
   let groups : Array[@composer.ModelGroup] = []
   if self.codex.composing_draft() {
-    groups.push(openseek_model_group(self.default_model))
+    groups.push(openseek_model_group(self.api_provider, self.default_model))
   }
   groups.push(self.codex_model_group())
   let selected = match self.codex.model_listing() {

--- a/desktop/frontend/agent_model.mbt
+++ b/desktop/frontend/agent_model.mbt
@@ -86,6 +86,9 @@ test "model choices round-trip and the agent namespaces stay disjoint" {
   assert_true(
     ModelChoice::parse("openseek:deepseek-v4-pro") is Some(OpenSeekModel(High)),
   )
+  assert_true(
+    ModelChoice::parse("openseek:glm-5.3") is Some(OpenSeekModel(Glm53)),
+  )
   // A tier's wire name inside the Codex namespace is a Codex id, never a
   // tier — and a bare wire name belongs to neither agent.
   assert_true(
@@ -148,6 +151,26 @@ fn openseek_model_group(
     })
   }
   { label: "OpenSeek", options, }
+}
+
+///|
+test "the model group follows the configured provider" {
+  let deepseek = openseek_model_group(Deepseek, High)
+  assert_eq(deepseek.options.map(option => option.label), ["High", "Low"])
+  let glm = openseek_model_group(Glm, Glm53)
+  assert_eq(glm.options.map(option => option.value), [
+    "openseek:glm-5.3", "openseek:glm-5.3-flash",
+  ])
+  // A conversation carried across a provider switch keeps its model visible,
+  // same as an unknown wire name always did.
+  let carried = openseek_model_group(Glm, High)
+  assert_eq(carried.options.map(option => option.label), [
+    "GLM 5.3", "GLM 5.3 Flash", "High",
+  ])
+  let custom = openseek_model_group(Custom, Other("proxy-model"))
+  assert_eq(custom.options.map(option => option.label), [
+    "High", "Low", "GLM 5.3", "GLM 5.3 Flash", "proxy-model",
+  ])
 }
 
 ///|

--- a/desktop/frontend/composer_input.mbt
+++ b/desktop/frontend/composer_input.mbt
@@ -75,6 +75,8 @@ fn Model::composer_input(self : Model) -> @composer.Input {
   if self.api_setup_banner_visible() {
     let text = if self.settings_status() is SetupRequired {
       "No endpoint URL configured — Send is disabled."
+    } else if self.api_provider is Glm {
+      "No GLM API key configured — Send is disabled."
     } else {
       "No DeepSeek API key configured — Send is disabled."
     }

--- a/desktop/frontend/console.mbt
+++ b/desktop/frontend/console.mbt
@@ -533,6 +533,7 @@ test "a revoked page device is retired without connecting a survivor" {
       provider: "deepseek",
       custom_api_url: "",
       has_deepseek_key: true,
+      has_glm_key: false,
       has_custom_key: false,
     }),
     legacy_cleanup_pending: true,

--- a/desktop/frontend/host_settings.mbt
+++ b/desktop/frontend/host_settings.mbt
@@ -14,6 +14,7 @@ fn HostSettings::from_status(
     provider: payload.provider,
     custom_api_url: payload.custom_api_url.unwrap_or(""),
     has_deepseek_key: payload.has_deepseek_key,
+    has_glm_key: payload.has_glm_key,
     has_custom_key: payload.has_custom_key,
   }
 }
@@ -101,6 +102,7 @@ fn provider_settings_patch(
     provider: Some(provider.wire()),
     custom_api_url: None,
     deepseek_api_key: None,
+    glm_api_key: None,
     custom_api_key: None,
     legacy_migration: None,
   }
@@ -114,6 +116,7 @@ fn custom_url_settings_patch(url : String) -> @protocol.SettingsSetPayload {
     provider: None,
     custom_api_url: Some(url),
     deepseek_api_key: None,
+    glm_api_key: None,
     custom_api_key: None,
     legacy_migration: None,
   }
@@ -128,6 +131,11 @@ fn api_key_settings_patch(
     provider: None,
     custom_api_url: None,
     deepseek_api_key: if provider is Deepseek {
+      Some(key)
+    } else {
+      None
+    },
+    glm_api_key: if provider is Glm {
       Some(key)
     } else {
       None
@@ -174,6 +182,8 @@ fn legacy_settings_patch(
     } else {
       Some(api_key)
     },
+    // No legacy page ever stored a GLM key; the import has nothing to carry.
+    glm_api_key: None,
     custom_api_key: if custom_api_key.is_empty() {
       None
     } else {

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -174,6 +174,13 @@ test "engine models round-trip their wire names" {
     EngineModel::parse("deepseek-v4-flash").unwrap().label(),
     content="Low",
   )
+  inspect(EngineModel::parse("glm-5.3").unwrap().label(), content="GLM 5.3")
+  inspect(
+    EngineModel::parse("glm-5.3-flash").unwrap().wire(),
+    content="glm-5.3-flash",
+  )
+  assert_true(EngineModel::parse("glm-5.3") is Some(Glm53))
+  assert_true(EngineModel::Glm53Flash.supports_reasoning())
   inspect(
     EngineModel::parse(" custom-model ").unwrap().wire(),
     content="custom-model",

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -1,12 +1,15 @@
 ///|
 /// Which model a conversation's turns run with. The composer's shared selector
-/// offers the two service tiers; `Other` retains a wire name this build does
-/// not know — a run started with `OPENSEEK_MODEL` set, or a newer engine's
-/// model echoed back by `agent.started` — so the chip reports what the engine
-/// actually ran instead of a tier it never used.
+/// offers the DeepSeek service tiers or the GLM models, following the
+/// configured provider; `Other` retains a wire name this build does not know —
+/// a run started with `OPENSEEK_MODEL` set, or a newer engine's model echoed
+/// back by `agent.started` — so the chip reports what the engine actually ran
+/// instead of a tier it never used.
 priv enum EngineModel {
   High
   Low
+  Glm53
+  Glm53Flash
   Other(String)
 } derive(Eq, Debug)
 
@@ -15,6 +18,8 @@ fn EngineModel::wire(self : EngineModel) -> String {
   match self {
     High => "deepseek-v4-pro"
     Low => "deepseek-v4-flash"
+    Glm53 => "glm-5.3"
+    Glm53Flash => "glm-5.3-flash"
     Other(name) => name
   }
 }
@@ -27,6 +32,8 @@ fn EngineModel::parse(value : String) -> EngineModel? {
   match value.trim().to_owned() {
     "deepseek-v4-pro" => Some(High)
     "deepseek-v4-flash" => Some(Low)
+    "glm-5.3" => Some(Glm53)
+    "glm-5.3-flash" => Some(Glm53Flash)
     "" => None
     name => Some(Other(name))
   }
@@ -39,18 +46,22 @@ fn EngineModel::label(self : EngineModel) -> String {
   match self {
     High => "High"
     Low => "Low"
+    Glm53 => "GLM 5.3"
+    Glm53Flash => "GLM 5.3 Flash"
     Other(name) => name
   }
 }
 
 ///|
-/// Whether this Desktop model is one of OpenSeek's DeepSeek models, whose
-/// request format accepts the `no`/`high`/`max` reasoning setting. Unknown
-/// models include providers such as Kimi, where sending this setting would
-/// claim a capability the model does not expose.
+/// Whether this Desktop model is one whose request format accepts the
+/// `no`/`high`/`max` reasoning setting: the DeepSeek models, and the GLM
+/// models (the engine maps `no` to GLM's lowest supported effort, because
+/// GLM 5.3 always reasons). Unknown models include providers such as Kimi,
+/// where sending this setting would claim a capability the model does not
+/// expose.
 fn EngineModel::supports_reasoning(self : EngineModel) -> Bool {
   match self {
-    High | Low => true
+    High | Low | Glm53 | Glm53Flash => true
     Other(_) => false
   }
 }
@@ -104,6 +115,20 @@ fn OpenSeekReasoning::label(self : OpenSeekReasoning) -> String {
     ReasoningOff => "Off"
     ReasoningHigh => "High"
     ReasoningMax => "Max"
+  }
+}
+
+///|
+/// GLM cannot turn thinking off: the shared lowest wire choice becomes its
+/// `low` effort, so the chip must not promise an unavailable Off state.
+fn OpenSeekReasoning::label_for_model(
+  self : OpenSeekReasoning,
+  model : EngineModel,
+) -> String {
+  if model is (Glm53 | Glm53Flash) && self is ReasoningOff {
+    "Low"
+  } else {
+    self.label()
   }
 }
 
@@ -237,6 +262,12 @@ const CodexReasoningEffortStorageKey : String = "openseek.codex_reasoning_effort
 /// request. It is page-local like the model choice and separate from Codex's
 /// catalog-backed setting because their supported wire values differ.
 const OpenSeekReasoningStorageKey : String = "openseek.reasoning_effort"
+
+///|
+/// GLM has forced thinking, so its lightweight default and later choices are
+/// kept apart from DeepSeek's reasoning preference. A user who wants Max for
+/// DeepSeek should not inherit it merely by switching the endpoint to GLM.
+const GlmReasoningStorageKey : String = "openseek.glm_reasoning_effort"
 
 ///|
 /// Every conversation whose tier the user has chosen, so reopening one
@@ -401,6 +432,7 @@ fn AppFontSize::pixels(self : AppFontSize) -> Double {
 /// reported.
 priv enum ApiProvider {
   Deepseek
+  Glm
   Custom
 } derive(Eq)
 
@@ -408,6 +440,7 @@ priv enum ApiProvider {
 fn ApiProvider::wire(self : ApiProvider) -> String {
   match self {
     Deepseek => "deepseek"
+    Glm => "glm"
     Custom => "custom"
   }
 }
@@ -419,8 +452,34 @@ fn ApiProvider::wire(self : ApiProvider) -> String {
 fn ApiProvider::parse(value : String) -> ApiProvider {
   match value.trim().to_owned() {
     "openseek" | "openseek-staging" | "deepseek" => Deepseek
+    "glm" => Glm
     "custom" => Custom
     _ => Deepseek
+  }
+}
+
+///|
+/// The model a fresh conversation starts from when the selected provider and
+/// the page's last model choice belong to different known model families.
+fn ApiProvider::default_model(self : ApiProvider) -> EngineModel {
+  match self {
+    Deepseek | Custom => High
+    Glm => Glm53
+  }
+}
+
+///|
+/// Whether a known model belongs to the official provider. Custom endpoints
+/// deliberately accept every model, and an unknown wire name stays pinned so
+/// a newer engine's model is never silently replaced by an older frontend.
+fn EngineModel::matches_provider(
+  self : EngineModel,
+  provider : ApiProvider,
+) -> Bool {
+  match (provider, self) {
+    (Custom, _) | (_, Other(_)) => true
+    (Deepseek, High | Low) | (Glm, Glm53 | Glm53Flash) => true
+    _ => false
   }
 }
 
@@ -1247,16 +1306,18 @@ priv struct Model {
   // default an unrelated chat has moved to since. Reopening recovers from
   // here; `default_model` is only for conversations this list has never held.
   conversation_models : Array[StoredConversationModel]
-  // The reasoning choice sent on the next OpenSeek operation. The host puts
-  // it in the engine-process environment and fingerprints it, so changing the
-  // chip cannot silently reuse an idle process configured for an older value.
+  // The DeepSeek (and non-GLM custom-model) reasoning choice sent on the next
+  // OpenSeek operation. GLM keeps a separate preference below because its
+  // forced-thinking low mode is the useful default for ordinary tasks.
   openseek_reasoning : OpenSeekReasoning
+  glm_reasoning : OpenSeekReasoning
   max_steps : String
   // Whether the host has a key stored for each keyed provider. The key text
   // itself never reaches a client — the Settings page only needs presence
   // (placeholder wording, the ready gate); a new key is staged in
   // `setup_api_key` until saved through `settings.set`.
   deepseek_key_saved : Bool
+  glm_key_saved : Bool
   custom_key_saved : Bool
   setup_api_key : String
   // Which endpoint the engine talks to; `custom_api_url` only matters when
@@ -1530,6 +1591,7 @@ priv struct HostSettings {
   provider : String
   custom_api_url : String
   has_deepseek_key : Bool
+  has_glm_key : Bool
   has_custom_key : Bool
 } derive(Eq)
 
@@ -1553,7 +1615,8 @@ priv enum Msg {
     agent~ : String,
     codex_model~ : String,
     codex_effort~ : String,
-    openseek_effort~ : String
+    openseek_effort~ : String,
+    glm_effort~ : String
   )
   // The legacy localStorage engine settings, read at bridge time. The
   // desktop window migrates them up to the host once; a browser page only
@@ -2382,8 +2445,10 @@ fn initial_model() -> Model {
     default_agent: OpenSeekAgent,
     conversation_models: [],
     openseek_reasoning: ReasoningMax,
+    glm_reasoning: ReasoningOff,
     max_steps: DefaultMaxSteps,
     deepseek_key_saved: false,
+    glm_key_saved: false,
     custom_key_saved: false,
     setup_api_key: "",
     api_provider: Deepseek,
@@ -2576,6 +2641,7 @@ fn Model::clear_host_settings(self : Model) -> Model {
     api_provider: Deepseek,
     custom_api_url: "",
     deepseek_key_saved: false,
+    glm_key_saved: false,
     custom_key_saved: false,
     setup_api_key: "",
     settings_saves: 0,
@@ -2592,14 +2658,50 @@ fn Model::clear_host_settings(self : Model) -> Model {
 /// mirrors the store, so a payload applied from a deferred flush can never
 /// yank the screen around on its own.
 fn Model::apply_host_settings(self : Model, settings : HostSettings) -> Model {
-  {
+  let next = {
     ..self,
     host_settings_revision: settings.revision,
     deferred_host_settings: None,
     api_provider: ApiProvider::parse(settings.provider),
     custom_api_url: settings.custom_api_url,
     deepseek_key_saved: settings.has_deepseek_key,
+    glm_key_saved: settings.has_glm_key,
     custom_key_saved: settings.has_custom_key,
+  }
+  next.align_fresh_conversation_with_provider()
+}
+
+///|
+/// Keep a never-started chat aligned with the host endpoint. Stored and
+/// already-running conversations remain pinned: changing their model behind
+/// the user's back would rewrite conversation semantics, while a fresh chat
+/// has no history to preserve and otherwise begins with a known-bad
+/// provider/model mismatch.
+fn Model::align_fresh_conversation_with_provider(self : Model) -> Model {
+  let default_model = if self.default_model.matches_provider(self.api_provider) {
+    self.default_model
+  } else {
+    self.api_provider.default_model()
+  }
+  let next = { ..self, default_model, }
+  guard next.composing_new_chat() &&
+    next.active_conversation() is Some(conv) &&
+    !conv.engine_model.matches_provider(next.api_provider) else {
+    return next
+  }
+  next.replace_conversation({ ..conv, engine_model: default_model, })
+}
+
+///|
+/// The reasoning preference for one model family. GLM's `ReasoningOff` wire
+/// value is translated by the engine to its lowest supported effort (`low`).
+fn Model::reasoning_for(
+  self : Model,
+  engine_model : EngineModel,
+) -> OpenSeekReasoning {
+  match engine_model {
+    Glm53 | Glm53Flash => self.glm_reasoning
+    High | Low | Other(_) => self.openseek_reasoning
   }
 }
 
@@ -2680,6 +2782,7 @@ fn Model::settle_api_setup(self : Model) -> Model {
 fn Model::api_ready(self : Model) -> Bool {
   match self.api_provider {
     Deepseek => self.deepseek_key_saved
+    Glm => self.glm_key_saved
     Custom => plausible_endpoint_url(self.custom_api_url)
   }
 }
@@ -2700,7 +2803,7 @@ fn plausible_endpoint_url(url : String) -> Bool {
 fn Model::settings_status(self : Model) -> Status {
   if self.api_ready() {
     Ready
-  } else if self.api_provider is Deepseek {
+  } else if self.api_provider is (Deepseek | Glm) {
     ApiKeyRequired
   } else {
     SetupRequired

--- a/desktop/frontend/storage.mbt
+++ b/desktop/frontend/storage.mbt
@@ -31,6 +31,7 @@ fn load_saved_settings(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
           codex_model=load_setting(CodexModelStorageKey),
           codex_effort=load_setting(CodexReasoningEffortStorageKey),
           openseek_effort=load_setting(OpenSeekReasoningStorageKey),
+          glm_effort=load_setting(GlmReasoningStorageKey),
         ),
       ),
     )
@@ -75,6 +76,14 @@ fn save_codex_reasoning_effort(effort : String) -> @cmd.Cmd {
 /// Persist OpenSeek's typed reasoning choice for its next engine operation.
 fn OpenSeekReasoning::save(self : OpenSeekReasoning) -> @cmd.Cmd {
   @cmd.custom_cmd(_ => save_setting(OpenSeekReasoningStorageKey, self.wire()))
+}
+
+///|
+/// Persist GLM's reasoning choice independently from DeepSeek's. In
+/// particular, a stored DeepSeek Max must not turn a fresh GLM chat into a
+/// long forced-thinking run.
+fn OpenSeekReasoning::save_for_glm(self : OpenSeekReasoning) -> @cmd.Cmd {
+  @cmd.custom_cmd(_ => save_setting(GlmReasoningStorageKey, self.wire()))
 }
 
 ///|

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -12011,6 +12011,16 @@ test "the official endpoint requires a key, a custom endpoint a URL" {
   assert_false(official.api_ready())
   assert_true(official.display_status() is ApiKeyRequired)
   assert_true({ ..official, deepseek_key_saved: true, }.api_ready())
+  // The GLM provider is gated on its own key, never DeepSeek's.
+  let glm = {
+    ..test_model(),
+    api_provider: Glm,
+    deepseek_key_saved: true,
+    glm_key_saved: false,
+  }
+  assert_false(glm.api_ready())
+  assert_true(glm.display_status() is ApiKeyRequired)
+  assert_true({ ..glm, glm_key_saved: true, }.api_ready())
   let custom = { ..test_model(), api_provider: Custom, custom_api_url: "", }
   assert_false(custom.api_ready())
   assert_true(custom.display_status() is SetupRequired)
@@ -12049,6 +12059,7 @@ test "loaded UI preferences parse their wire names" {
   assert_true(restored.default_model is Low)
   assert_true(restored.default_agent is CodexAgent)
   assert_true(restored.openseek_reasoning is ReasoningHigh)
+  assert_true(restored.glm_reasoning is ReasoningMax)
   // The stored conversation outranks the stored default for its own chat.
   assert_true(restored.active().engine_model is High)
   // Unknown stored values fall back to the defaults.
@@ -12076,6 +12087,7 @@ test "loaded UI preferences parse their wire names" {
   assert_true(unknown.app_font_size is Medium)
   assert_true(unknown.default_model is High)
   assert_true(unknown.openseek_reasoning is ReasoningMax)
+  assert_true(unknown.glm_reasoning is ReasoningOff)
   assert_true(unknown.default_agent is OpenSeekAgent)
   // A store that will not parse remembers nothing rather than wedging.
   assert_eq(unknown.conversation_models.length(), 0)
@@ -12679,6 +12691,63 @@ test "switching to a provider missing its key or URL opens the setup modal" {
 }
 
 ///|
+test "the GLM provider aligns only a fresh chat to its model family" {
+  let dispatch = test_dispatch()
+  let (_, glm) = update(dispatch, ProviderChanged("glm"), {
+    ..test_model(),
+    glm_key_saved: true,
+  })
+  assert_true(glm.api_provider is Glm)
+  assert_true(glm.default_model is Glm53)
+  assert_true(glm.active().engine_model is Glm53)
+  // GLM's forced-thinking default is the shared low wire value, independent
+  // from the Max preference DeepSeek keeps.
+  assert_true(glm.reasoning_for(glm.active().engine_model) is ReasoningOff)
+  assert_true(glm.openseek_reasoning is ReasoningMax)
+  // A host snapshot on a later launch performs the same alignment even
+  // though the page-local model preference loads before host settings do.
+  let (_, restored) = update_dev(
+    dispatch,
+    HostSettingsLoaded(
+      host_settings(provider="glm", has_glm_key=true),
+      connection_generation=None,
+    ),
+    test_model(),
+  )
+  assert_true(restored.default_model is Glm53)
+  assert_true(restored.active().engine_model is Glm53)
+  // Startup is order-independent: if the host's GLM snapshot arrives before
+  // localStorage, the later DeepSeek model preference cannot reintroduce a
+  // mismatched fresh chat.
+  let (_, preferences_after_host) = update(
+    dispatch,
+    SettingsLoaded(
+      notification_corner="",
+      tree_layout="",
+      theme="",
+      font="",
+      font_size="",
+      model="deepseek-v4-pro",
+      conversation_models="",
+      agent="",
+      codex_model="",
+      codex_effort="",
+      openseek_effort="",
+      glm_effort="",
+    ),
+    restored,
+  )
+  assert_true(preferences_after_host.default_model is Glm53)
+  assert_true(preferences_after_host.active().engine_model is Glm53)
+  // Once a conversation has begun, its pinned model remains explicit and
+  // visible for the user to change rather than being rewritten by Settings.
+  let (_, running) = update(dispatch, ProviderChanged("glm"), running_model())
+  assert_true(running.api_provider is Glm)
+  assert_true(running.default_model is Glm53)
+  assert_true(running.active().engine_model is High)
+}
+
+///|
 test "a dismissal survives the mirror reset a reconnect performs" {
   let dispatch = test_dispatch()
   let (_, keyless) = update_dev(
@@ -13200,6 +13269,20 @@ test "saving a key marks the active provider credential only" {
   assert_false(saved_custom.deepseek_key_saved)
   assert_true(saved_custom.custom_key_saved)
   assert_true(saved_custom.screen is Settings)
+  // A GLM key lands in the GLM slot alone.
+  let glm = {
+    ..test_model(),
+    api_provider: Glm,
+    deepseek_key_saved: false,
+    glm_key_saved: false,
+    setup_api_key: "  glm-new  ",
+    screen: Settings,
+  }
+  let (_, saved_glm) = update(dispatch, SaveApiKey, glm)
+  assert_true(saved_glm.glm_key_saved)
+  assert_false(saved_glm.deepseek_key_saved)
+  assert_false(saved_glm.custom_key_saved)
+  assert_true(saved_glm.screen is Settings)
 }
 
 ///|
@@ -13694,6 +13777,31 @@ test "custom select menus switch and dismiss deterministically" {
     open_before_switch,
   )
   assert_true(context_switched.select_menu is None)
+}
+
+///|
+test "GLM and DeepSeek remember independent reasoning choices" {
+  let dispatch = test_dispatch()
+  let glm = test_model().replace_conversation({
+    ..test_conversation(),
+    engine_model: Glm53,
+  })
+  guard glm.openseek_reasoning_chip(glm.active()) is Some(control) else {
+    fail("GLM reasoning control was hidden")
+  }
+  assert_eq(control.selected, "no")
+  assert_eq(control.options[0].label, "Low")
+  assert_eq(control.title, "Reasoning effort: Low")
+  let (_, glm_high) = update(dispatch, OpenSeekEffortPicked("high"), glm)
+  assert_true(glm_high.glm_reasoning is ReasoningHigh)
+  assert_true(glm_high.openseek_reasoning is ReasoningMax)
+  let deepseek = glm_high.replace_conversation({
+    ..glm_high.active(),
+    engine_model: High,
+  })
+  let (_, deepseek_off) = update(dispatch, OpenSeekEffortPicked("no"), deepseek)
+  assert_true(deepseek_off.openseek_reasoning is ReasoningOff)
+  assert_true(deepseek_off.glm_reasoning is ReasoningHigh)
 }
 
 ///|

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -962,7 +962,7 @@ fn run_slash_command(
             model.focused,
             session=conv.session_id,
             model=conv.engine_model,
-            reasoning=model.openseek_reasoning,
+            reasoning=model.reasoning_for(conv.engine_model),
             max_steps=model.max_steps,
             workspace=conv.project(),
           ),
@@ -1019,7 +1019,7 @@ fn send_goal(
       conv.session_id,
       workspace,
       conv.engine_model,
-      model.openseek_reasoning,
+      model.reasoning_for(conv.engine_model),
       model.max_steps,
       command,
       text,
@@ -1030,7 +1030,7 @@ fn send_goal(
     conv.device,
     session=conv.session_id,
     model=conv.engine_model,
-    reasoning=model.openseek_reasoning,
+    reasoning=model.reasoning_for(conv.engine_model),
     max_steps=model.max_steps,
     workspace=conv.project(),
     command,
@@ -1813,7 +1813,8 @@ fn update_msg(
       agent~,
       codex_model~,
       codex_effort~,
-      openseek_effort~
+      openseek_effort~,
+      glm_effort~
     ) => {
       let theme = Theme::parse(theme, model.theme)
       let app_font = AppFont::parse(font, model.app_font)
@@ -1829,6 +1830,9 @@ fn update_msg(
       )
       let openseek_reasoning = OpenSeekReasoning::parse(openseek_effort).unwrap_or(
         model.openseek_reasoning,
+      )
+      let glm_reasoning = OpenSeekReasoning::parse(glm_effort).unwrap_or(
+        model.glm_reasoning,
       )
       // The stored Codex pick seeds Codex's own selection state. When the
       // catalog arrives, `with_models` keeps this id if it is still listed
@@ -1856,6 +1860,28 @@ fn update_msg(
           url => open_external_link(dispatch, url),
         )
       }
+      let next = {
+        ..model,
+        notification_corner: NotificationCorner::parse(notification_corner),
+        tree_layout: @fileeditor.TreeLayout::parse(tree_layout),
+        theme,
+        app_font,
+        app_font_size,
+        default_model,
+        default_agent,
+        conversation_models: parse_conversation_models(remembered),
+        openseek_reasoning,
+        glm_reasoning,
+        codex,
+      }
+      // The localStorage read and the host settings request start together.
+      // If the host won that race, reconcile the just-loaded model preference
+      // now; otherwise `HostSettingsLoaded` performs the same fold later.
+      let next = if next.host_settings_loaded() {
+        next.align_fresh_conversation_with_provider()
+      } else {
+        next
+      }
       (
         @cmd.batch([
           theme.apply(model.system_dark),
@@ -1864,19 +1890,7 @@ fn update_msg(
           codex_cmd,
           codex_effort_cmd,
         ]),
-        {
-          ..model,
-          notification_corner: NotificationCorner::parse(notification_corner),
-          tree_layout: @fileeditor.TreeLayout::parse(tree_layout),
-          theme,
-          app_font,
-          app_font_size,
-          default_model,
-          default_agent,
-          conversation_models: parse_conversation_models(remembered),
-          openseek_reasoning,
-          codex,
-        },
+        next,
       )
     }
     // The host's settings, from the bridge-time `settings.get` or a peer's
@@ -2745,10 +2759,20 @@ fn update_msg(
       guard OpenSeekReasoning::parse(value) is Some(reasoning) else {
         return (@cmd.none, model)
       }
-      (
-        reasoning.save(),
-        { ..model, openseek_reasoning: reasoning, select_menu: None, },
-      )
+      guard model.active_conversation() is Some(conv) else {
+        return (@cmd.none, model)
+      }
+      if conv.engine_model is (Glm53 | Glm53Flash) {
+        (
+          reasoning.save_for_glm(),
+          { ..model, glm_reasoning: reasoning, select_menu: None, },
+        )
+      } else {
+        (
+          reasoning.save(),
+          { ..model, openseek_reasoning: reasoning, select_menu: None, },
+        )
+      }
     }
     MaxStepsChanged(value) => (@cmd.none, { ..model, max_steps: value, })
     SetupApiKeyChanged(value) => {
@@ -2774,7 +2798,7 @@ fn update_msg(
         setup_api_key: "",
         settings_saves: model.settings_saves + 1,
         select_menu: None,
-      }
+      }.align_fresh_conversation_with_provider()
       // The switch can move the endpoint between usable and not. Inside the
       // setup modal the form simply re-renders for the new provider; a
       // switch that breaks a usable endpoint away from the Settings page
@@ -3202,11 +3226,12 @@ fn update_msg(
           // modal optimistically; one that leaves it incomplete (Custom
           // with no URL yet) keeps the modal up mid-setup. A failed save
           // comes back as a toast.
-          Deepseek | Custom as provider => {
+          Deepseek | Glm | Custom as provider => {
             let next = {
               ..model,
               deepseek_key_saved: model.deepseek_key_saved ||
               provider is Deepseek,
+              glm_key_saved: model.glm_key_saved || provider is Glm,
               custom_key_saved: model.custom_key_saved || provider is Custom,
               setup_api_key: "",
               settings_saves: model.settings_saves + 1,
@@ -3362,7 +3387,7 @@ fn update_msg(
             task,
             submission_id,
             conv.engine_model,
-            model.openseek_reasoning,
+            model.reasoning_for(conv.engine_model),
             model.max_steps,
             conv.session_id,
             workspace,
@@ -3374,7 +3399,7 @@ fn update_msg(
             task,
             submission_id,
             conv.engine_model,
-            model.openseek_reasoning,
+            model.reasoning_for(conv.engine_model),
             model.max_steps,
             conv.session_id,
             workspace=conv.project(),
@@ -12013,6 +12038,7 @@ test "loaded UI preferences parse their wire names" {
       codex_model="gpt-5.4-codex",
       codex_effort="xhigh",
       openseek_effort="high",
+      glm_effort="max",
     ),
     test_model(),
   )
@@ -12040,6 +12066,7 @@ test "loaded UI preferences parse their wire names" {
       codex_model="",
       codex_effort="",
       openseek_effort="broken",
+      glm_effort="broken",
     ),
     test_model(),
   )
@@ -12457,6 +12484,7 @@ fn host_settings(
   provider~ : String,
   revision? : Int = 0,
   has_deepseek_key? : Bool = false,
+  has_glm_key? : Bool = false,
   custom_api_url? : String = "",
 ) -> HostSettings {
   {
@@ -12464,6 +12492,7 @@ fn host_settings(
     provider,
     custom_api_url,
     has_deepseek_key,
+    has_glm_key,
     has_custom_key: false,
   }
 }

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -938,6 +938,7 @@ fn update_check_controls(
 fn provider_hint(provider : ApiProvider) -> String {
   match provider {
     Deepseek => "Requests go straight to api.deepseek.com with your key."
+    Glm => "Requests go straight to api.z.ai with your key."
     Custom => "Any OpenAI-compatible chat-completions URL; key optional."
   }
 }
@@ -961,6 +962,12 @@ fn byok_setup_guide(provider : ApiProvider) -> @html.Html {
         step(1, "Open platform.deepseek.com and sign in."),
         step(2, "Create an API key under API Keys."),
         step(3, "Paste it into the DeepSeek API key field below and save."),
+      ]
+    Glm =>
+      [
+        step(1, "Open z.ai and sign in."),
+        step(2, "Create an API key under API Keys."),
+        step(3, "Paste it into the GLM API key field below and save."),
       ]
     Custom =>
       [
@@ -989,6 +996,17 @@ fn byok_setup_guide(provider : ApiProvider) -> @html.Html {
               icon(icon_link_external),
               @html.span("platform.deepseek.com → API Keys"),
             ],
+          ),
+        ]
+      },
+      ..if provider is Glm {
+        [
+          @html.a(
+            class="setting-link",
+            href="https://z.ai/manage-apikey/apikey-list",
+            target=Blank,
+            rel="noopener noreferrer",
+            [icon(icon_link_external), @html.span("z.ai → API Keys")],
           ),
         ]
       },
@@ -1021,6 +1039,7 @@ fn api_settings_rows(
           id="api-provider-select",
           options=[
             { value: "deepseek", label: "DeepSeek official (your API key)", },
+            { value: "glm", label: "Z.AI GLM (your API key)", },
             { value: "custom", label: "Custom URL", },
           ],
           selected=model.api_provider.wire(),
@@ -1055,17 +1074,17 @@ fn api_settings_rows(
   // The key lives on the host and is never echoed back — the page only
   // knows one is saved; saving a new one overwrites it.
   {
-    let key_saved = if model.api_provider is Custom {
-      model.custom_key_saved
-    } else {
-      model.deepseek_key_saved
+    let key_saved = match model.api_provider {
+      Deepseek => model.deepseek_key_saved
+      Glm => model.glm_key_saved
+      Custom => model.custom_key_saved
     }
     rows.push(
       setting_row(
-        if model.api_provider is Custom {
-          "Custom API key"
-        } else {
-          "DeepSeek API key"
+        match model.api_provider {
+          Deepseek => "DeepSeek API key"
+          Glm => "GLM API key"
+          Custom => "Custom API key"
         },
         [
           @html.input(
@@ -1267,10 +1286,12 @@ fn settings_page(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
             "Loading runtime settings…"
           } else if ready {
             "Runtime settings for the SeekMoon engine."
-          } else if model.api_provider is Custom {
-            "Enter a chat-completions endpoint URL to start."
           } else {
-            "Enter a DeepSeek API key to start."
+            match model.api_provider {
+              Deepseek => "Enter a DeepSeek API key to start."
+              Glm => "Enter a GLM API key to start."
+              Custom => "Enter a chat-completions endpoint URL to start."
+            }
           },
         ),
       ]),
@@ -2124,6 +2145,7 @@ fn update_confirm_modal(
 fn api_setup_modal(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
   let title = match model.api_provider {
     Deepseek => "Set up your DeepSeek API key"
+    Glm => "Set up your GLM API key"
     Custom => "Set your endpoint URL"
   }
   @html.div(class="modal-backdrop", on_click=dispatch(DismissApiSetup), [

--- a/desktop/internal/api/payload.mbt
+++ b/desktop/internal/api/payload.mbt
@@ -20,6 +20,7 @@ fn SettingsSetPayload::to_patch(
     provider: self.provider,
     custom_api_url: self.custom_api_url,
     deepseek_api_key: self.deepseek_api_key,
+    glm_api_key: self.glm_api_key,
     custom_api_key: self.custom_api_key,
   }
 }

--- a/desktop/internal/engine/config.mbt
+++ b/desktop/internal/engine/config.mbt
@@ -18,8 +18,11 @@ const PlaceholderApiKey = "unused"
 priv struct RunConfig {
   task : String
   api_key : String
+  // The environment variable that carries `api_key` to the engine; see
+  // `key_env_for`.
+  key_env : String
   // Custom chat-completions endpoint; None means the engine's built-in
-  // default (the official DeepSeek endpoint).
+  // default for the model's provider.
   api_url : String?
   model : String
   thinking : @protocol.OpenSeekThinking
@@ -53,7 +56,8 @@ fn RunConfig::configured_thinking(
 fn configured_api_key(
   stored_key? : String,
   api_url? : String,
-  deepseek_env? : String,
+  env_key? : String,
+  missing? : String = "an API key is required; add it in Settings",
 ) -> String raise EngineError {
   if stored_key is Some(value) {
     return value
@@ -61,12 +65,68 @@ fn configured_api_key(
   if api_url is Some(_) {
     return PlaceholderApiKey
   }
-  if deepseek_env is Some(value) {
+  if env_key is Some(value) {
     return value
   }
-  raise EngineError(
-    "DeepSeek API key is required; add it in Settings or set DEEPSEEK",
-  )
+  raise EngineError(missing)
+}
+
+///|
+/// The model runs fall back to when neither the request nor `OPENSEEK_MODEL`
+/// names one: each official provider's flagship, and DeepSeek's for a custom
+/// endpoint (any wire name works there, but the engine still needs one).
+fn ApiProvider::default_model(self : ApiProvider) -> String {
+  match self {
+    Glm => "glm-5.3"
+    Deepseek | Custom => DefaultModel
+  }
+}
+
+///|
+/// The environment variable the engine resolves for one model wire name.
+fn model_key_env(model : String) -> String {
+  if model.has_prefix("glm-") {
+    "GLM"
+  } else if model.has_prefix("kimi-") {
+    "KIMI"
+  } else {
+    "DEEPSEEK"
+  }
+}
+
+///|
+/// The environment variable that carries the run's API key to the engine.
+/// The engine resolves its chat key from a provider-specific variable chosen
+/// by the model (`Model::api_key`): `DEEPSEEK`, `KIMI`, or `GLM`. Official
+/// providers reject a model from another provider before a child process can
+/// inherit that model's ambient credential. A custom endpoint's key instead
+/// follows the model's variable, or the engine would never find it; the
+/// desktop stores the model as an opaque string, so that routing mirrors the
+/// engine's wire-name prefixes.
+fn key_env_for(
+  provider : ApiProvider,
+  model : String,
+) -> String raise EngineError {
+  let model_key = model_key_env(model)
+  match provider {
+    Deepseek => {
+      guard model_key == "DEEPSEEK" else {
+        raise EngineError(
+          "model \{model} does not belong to the configured DeepSeek provider",
+        )
+      }
+      "DEEPSEEK"
+    }
+    Glm => {
+      guard model_key == "GLM" else {
+        raise EngineError(
+          "model \{model} does not belong to the configured GLM provider",
+        )
+      }
+      "GLM"
+    }
+    Custom => model_key
+  }
 }
 
 ///|
@@ -208,17 +268,20 @@ async fn serve_config(
       "this conversation has no workspace; attach a project first",
     )
   }
+  let model = match model {
+    Some(model) => model
+    // The engine takes its model from OPENSEEK_MODEL (DEEPSEEK_MODEL is
+    // deliberately ignored — see `serve_engine_env`), so the host's
+    // fallback must read the same variable.
+    None =>
+      @env.get("OPENSEEK_MODEL").unwrap_or(settings.provider.default_model())
+  }
   {
     task,
     api_key: endpoint.api_key,
+    key_env: key_env_for(settings.provider, model),
     api_url: endpoint.api_url,
-    model: match model {
-      Some(model) => model
-      // The engine takes its model from OPENSEEK_MODEL (DEEPSEEK_MODEL is
-      // deliberately ignored — see `serve_engine_env`), so the host's
-      // fallback must read the same variable.
-      None => @env.get("OPENSEEK_MODEL").unwrap_or(DefaultModel)
-    },
+    model,
     thinking: RunConfig::configured_thinking(thinking),
     max_steps: configured_max_steps(max_steps),
     engine,
@@ -241,6 +304,9 @@ fn engine_fingerprint(config : RunConfig) -> String {
   [
     config.engine,
     config.api_key,
+    // The variable the key travels in is provider identity: the same key
+    // under a different variable is a different endpoint configuration.
+    config.key_env,
     config.api_url.unwrap_or(""),
     config.model,
     config.thinking.wire(),
@@ -256,6 +322,7 @@ test "a different endpoint cannot reuse a live engine process" {
   let base : RunConfig = {
     task: "t",
     api_key: "k",
+    key_env: "DEEPSEEK",
     api_url: None,
     model: "deepseek-v4-pro",
     thinking: ThinkingMax,
@@ -291,7 +358,7 @@ test "configured endpoint uses its stored key or the placeholder" {
   assert_eq(
     configured_api_key(
       api_url="https://proxy.example/chat/completions",
-      deepseek_env="official-key",
+      env_key="official-key",
     ),
     PlaceholderApiKey,
   )
@@ -299,16 +366,16 @@ test "configured endpoint uses its stored key or the placeholder" {
     configured_api_key(
       stored_key="custom-key",
       api_url="https://proxy.example/chat/completions",
-      deepseek_env="official-key",
+      env_key="official-key",
     ),
     "custom-key",
   )
 }
 
 ///|
-test "DeepSeek endpoint still uses DEEPSEEK env fallback" {
-  assert_eq(configured_api_key(deepseek_env="official-key"), "official-key")
-  let _ = configured_api_key() catch {
+test "official endpoints still use their env fallback" {
+  assert_eq(configured_api_key(env_key="official-key"), "official-key")
+  let _ = configured_api_key(missing="DeepSeek API key is required") catch {
     EngineError(message) => {
       assert_true(message.contains("DeepSeek API key is required"))
       return
@@ -344,6 +411,7 @@ async test "run config ignores OPENSEEK_API_URL in favor of the settings" {
     provider: Some("deepseek"),
     custom_api_url: None,
     deepseek_api_key: Some("sk-official"),
+    glm_api_key: None,
     custom_api_key: None,
   })
   let config = run_config(manager, {

--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -1430,11 +1430,14 @@ async fn engine_process_env(
   // Unix, so overriding PATH with inheritance enabled can leave two PATH
   // entries and let `/bin/sh` observe the original one.
   let env = @sys.get_env_vars()
-  // The engine reads the key from `DEEPSEEK` but the model from `OPENSEEK_MODEL`
-  // (the CLI's `--deepseek-api-key`/`--model` env bindings); the prefixes differ
+  // The engine reads the key from the provider-specific variable the config
+  // resolved (`DEEPSEEK`/`KIMI`/`GLM`; see `key_env_for`) but the model from
+  // `OPENSEEK_MODEL` (the CLI's `--model` env binding); the prefixes differ
   // on purpose, so the model must not go into `DEEPSEEK_MODEL` — the engine
-  // ignores that and falls back to its default model.
-  env["DEEPSEEK"] = config.api_key
+  // ignores that and falls back to its default model. Other providers' shell
+  // exports inherit untouched: the engine reads only its model's variable
+  // for chat, and `web_search` may legitimately use an ambient `DEEPSEEK`.
+  env[config.key_env] = config.api_key
   env["OPENSEEK_MODEL"] = config.model
   env["OPENSEEK_THINKING"] = config.thinking.wire()
   env["OPENSEEK_MAX_STEPS"] = config.max_steps.to_string()
@@ -2721,6 +2724,7 @@ async test "native engine env has one authoritative bundled moon path" {
   let config : RunConfig = {
     task: "t",
     api_key: "k",
+    key_env: "DEEPSEEK",
     api_url: None,
     model: "m",
     thinking: ThinkingHigh,
@@ -2830,6 +2834,7 @@ async test "engine startup rolls back follower on pre-spawn failure" {
   let config : RunConfig = {
     task: "test",
     api_key: "test",
+    key_env: "DEEPSEEK",
     api_url: None,
     model: "test",
     thinking: ThinkingMax,
@@ -2946,6 +2951,7 @@ fn pump_test_config(session : String) -> RunConfig {
   {
     task: "test",
     api_key: "test",
+    key_env: "DEEPSEEK",
     api_url: None,
     model: "test",
     thinking: ThinkingMax,

--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -2736,6 +2736,14 @@ async test "native engine env has one authoritative bundled moon path" {
   }
   let env = engine_process_env(config, Some(runtime))
   assert_eq(env["OPENSEEK_THINKING"], "high")
+  assert_eq(env["DEEPSEEK"], "k")
+  // A GLM run's key travels in GLM, and the resolved variable — not a
+  // hardcoded DEEPSEEK — is what the process env honors.
+  let glm_env = engine_process_env(
+    { ..config, key_env: "GLM", model: "glm-5.3", },
+    Some(runtime),
+  )
+  assert_eq(glm_env["GLM"], "k")
   @debug.assert_eq(engine_process_args(config), [
     "serve", "--session=s-env", "--dir", ".", "--approval", "ask",
   ])

--- a/desktop/internal/engine/follower.mbt
+++ b/desktop/internal/engine/follower.mbt
@@ -664,6 +664,7 @@ fn follower_test_config(
   {
     task: "test",
     api_key: "test",
+    key_env: "DEEPSEEK",
     api_url: None,
     model: "test",
     thinking: ThinkingMax,

--- a/desktop/internal/engine/glm_provider_wbtest.mbt
+++ b/desktop/internal/engine/glm_provider_wbtest.mbt
@@ -1,0 +1,17 @@
+///|
+test "official providers reject models from another provider" {
+  let mismatched = try key_env_for(Glm, "deepseek-v4-pro") catch {
+    EngineError(message) => message
+  } noraise {
+    _ => ""
+  }
+  assert_true(mismatched.contains("configured GLM provider"))
+  assert_eq(key_env_for(Glm, "glm-5.3"), "GLM")
+  assert_eq(key_env_for(Glm, "glm-5.3-flash"), "GLM")
+  assert_eq(key_env_for(Deepseek, "deepseek-v4-pro"), "DEEPSEEK")
+  // A custom endpoint deliberately follows the selected model family.
+  assert_eq(key_env_for(Custom, "glm-5.3"), "GLM")
+  assert_eq(key_env_for(Custom, "kimi-k2.7-code"), "KIMI")
+  assert_eq(key_env_for(Custom, "deepseek-v4-flash"), "DEEPSEEK")
+  assert_eq(key_env_for(Custom, "some-proxy-model"), "DEEPSEEK")
+}

--- a/desktop/internal/engine/ops.mbt
+++ b/desktop/internal/engine/ops.mbt
@@ -856,6 +856,7 @@ async test "start echoes the client submission id in Started" {
       provider: Some("custom"),
       custom_api_url: Some("https://example.invalid/chat/completions"),
       deepseek_api_key: None,
+      glm_api_key: None,
       custom_api_key: None,
     }),
   )
@@ -935,6 +936,7 @@ async test "a goal is delivered only once its command is on the wire" {
       provider: Some("custom"),
       custom_api_url: Some("https://example.invalid/chat/completions"),
       deepseek_api_key: None,
+      glm_api_key: None,
       custom_api_key: None,
     }),
   )
@@ -1060,6 +1062,7 @@ async test "setup failure retires the writer before an immediate next start" {
       provider: Some("custom"),
       custom_api_url: Some("https://example.invalid/chat/completions"),
       deepseek_api_key: None,
+      glm_api_key: None,
       custom_api_key: None,
     }),
   )
@@ -1172,6 +1175,7 @@ async test "a prompt bigger than the pipe still settles exactly once" {
       provider: Some("custom"),
       custom_api_url: Some("https://example.invalid/chat/completions"),
       deepseek_api_key: None,
+      glm_api_key: None,
       custom_api_key: None,
     }),
   )
@@ -1268,6 +1272,7 @@ async test "named session retries after its first prompt creates no record" {
       provider: Some("custom"),
       custom_api_url: Some("https://example.invalid/chat/completions"),
       deepseek_api_key: None,
+      glm_api_key: None,
       custom_api_key: None,
     }),
   )
@@ -1501,6 +1506,7 @@ async test "workspace detach refuses a running conversation without hiding it" {
       provider: Some("custom"),
       custom_api_url: Some("https://example.invalid/chat/completions"),
       deepseek_api_key: None,
+      glm_api_key: None,
       custom_api_key: None,
     }),
   )
@@ -1587,6 +1593,7 @@ async test "workspace detach drains an idle writer and its follower first" {
       provider: Some("custom"),
       custom_api_url: Some("https://example.invalid/chat/completions"),
       deepseek_api_key: None,
+      glm_api_key: None,
       custom_api_key: None,
     }),
   )

--- a/desktop/internal/engine/pkg.generated.mbti
+++ b/desktop/internal/engine/pkg.generated.mbti
@@ -85,6 +85,7 @@ pub(all) struct SettingsPatch {
   provider : String?
   custom_api_url : String?
   deepseek_api_key : String?
+  glm_api_key : String?
   custom_api_key : String?
 }
 

--- a/desktop/internal/engine/settings.mbt
+++ b/desktop/internal/engine/settings.mbt
@@ -786,6 +786,35 @@ async test "run config resolves the endpoint from the stored provider" {
     // The official endpoint is the engine default: no URL override.
     assert_true(config.api_url is None)
     assert_eq(config.api_key, "sk-stored")
+    assert_eq(config.key_env, "DEEPSEEK")
+    // The GLM provider resolves its own stored key into the GLM variable and
+    // defaults the run to a GLM model, still on the engine's built-in
+    // endpoint for it.
+    let previous_model = @sys.get_env_var("OPENSEEK_MODEL")
+    @sys.unset_env_var("OPENSEEK_MODEL")
+    defer (if previous_model is Some(value) {
+      @sys.set_env_var("OPENSEEK_MODEL", value)
+    })
+    let _ = update_settings(manager, {
+      provider: Some("glm"),
+      custom_api_url: None,
+      deepseek_api_key: None,
+      glm_api_key: Some("glm-stored"),
+      custom_api_key: None,
+    })
+    let glm = run_config(manager, {
+      task: "hello",
+      submission_id: None,
+      model: None,
+      thinking: None,
+      max_steps: None,
+      session: "s-settings-glm",
+      workspace: Some(workspace),
+    })
+    assert_true(glm.api_url is None)
+    assert_eq(glm.api_key, "glm-stored")
+    assert_eq(glm.key_env, "GLM")
+    assert_eq(glm.model, "glm-5.3")
     let _ = update_settings(manager, {
       provider: Some("custom"),
       custom_api_url: Some("https://proxy.example/chat/completions"),
@@ -808,6 +837,51 @@ async test "run config resolves the endpoint from the stored provider" {
     // A custom endpoint without a key gets the placeholder, never the
     // stored DeepSeek key.
     assert_eq(custom.api_key, PlaceholderApiKey)
+    assert_eq(custom.key_env, "DEEPSEEK")
+  })
+}
+
+///|
+async test "the GLM provider stores its own key and reports presence" {
+  with_settings_dir(async fn(_dir, manager) {
+    let status = update_settings(manager, {
+      provider: Some("glm"),
+      custom_api_url: None,
+      deepseek_api_key: None,
+      glm_api_key: Some("  glm-secret  "),
+      custom_api_key: None,
+    })
+    json_inspect(status, content={
+      "revision": 1,
+      "provider": "glm",
+      "has_deepseek_key": false,
+      "has_glm_key": true,
+      "has_custom_key": false,
+    })
+    // The status never carries the key; the store carries it trimmed, in its
+    // own slot rather than DeepSeek's.
+    assert_false(status.to_json().stringify().contains("glm-secret"))
+    let reloaded = load_engine_settings(manager.runtime_dir)
+    assert_true(reloaded.provider is Glm)
+    assert_true(reloaded.glm_api_key is Some("glm-secret"))
+    assert_true(reloaded.deepseek_api_key is None)
+  })
+}
+
+///|
+async test "the GLM env fallback reads as a usable key" {
+  with_settings_dir(async fn(_dir, manager) {
+    // The engine resolves GLM when no key is stored; the status must agree,
+    // or the frontend blocks Send on an endpoint that runs fine.
+    @sys.set_env_var("GLM", "glm-env")
+    defer @sys.unset_env_var("GLM")
+    json_inspect(settings_status(manager), content={
+      "revision": 0,
+      "provider": "deepseek",
+      "has_deepseek_key": false,
+      "has_glm_key": true,
+      "has_custom_key": false,
+    })
   })
 }
 

--- a/desktop/internal/engine/settings.mbt
+++ b/desktop/internal/engine/settings.mbt
@@ -40,13 +40,15 @@ const RelayServerOrigin : String = "https://openseek-api.moonbitlang.cn"
 ///|
 /// The chat endpoint selection: where runs send their requests. SeekMoon
 /// runs only on bring-your-own-key providers. `Deepseek` is the official
-/// DeepSeek endpoint with the user's own key; `Custom` is any other
-/// OpenAI-compatible endpoint, whose key is optional. The retired hosted
-/// proxy names (`openseek` / `openseek-staging`) still parse as `Deepseek`
-/// so old settings files and old clients degrade to the BYOK default
-/// instead of wedging.
+/// DeepSeek endpoint with the user's own key; `Glm` is the official Z.AI
+/// GLM endpoint with its own key; `Custom` is any other OpenAI-compatible
+/// endpoint, whose key is optional. The retired hosted proxy names
+/// (`openseek` / `openseek-staging`) still parse as `Deepseek` so old
+/// settings files and old clients degrade to the BYOK default instead of
+/// wedging.
 priv enum ApiProvider {
   Deepseek
+  Glm
   Custom
 }
 
@@ -54,6 +56,7 @@ priv enum ApiProvider {
 fn ApiProvider::wire(self : ApiProvider) -> String {
   match self {
     Deepseek => "deepseek"
+    Glm => "glm"
     Custom => "custom"
   }
 }
@@ -68,6 +71,7 @@ fn ApiProvider::wire(self : ApiProvider) -> String {
 fn ApiProvider::parse(value : String) -> ApiProvider? {
   match value {
     "openseek" | "openseek-staging" | "deepseek" => Some(Deepseek)
+    "glm" => Some(Glm)
     "custom" => Some(Custom)
     _ => None
   }
@@ -82,6 +86,7 @@ priv struct EngineSettings {
   provider : ApiProvider
   custom_api_url : String?
   deepseek_api_key : String?
+  glm_api_key : String?
   custom_api_key : String?
 }
 
@@ -133,6 +138,7 @@ fn decode_settings(raw : Map[String, Json]) -> EngineSettings {
     .unwrap_or(Deepseek),
     custom_api_url: settings_text(raw, "custom_api_url"),
     deepseek_api_key: settings_text(raw, "deepseek_api_key"),
+    glm_api_key: settings_text(raw, "glm_api_key"),
     custom_api_key: settings_text(raw, "custom_api_key"),
   }
 }
@@ -145,6 +151,7 @@ pub(all) struct SettingsPatch {
   provider : String?
   custom_api_url : String?
   deepseek_api_key : String?
+  glm_api_key : String?
   custom_api_key : String?
 }
 
@@ -159,11 +166,12 @@ fn settings_status_payload(
     revision,
     provider: settings.provider.wire(),
     custom_api_url: settings.custom_api_url,
-    // Presence ORs in the DEEPSEEK environment fallback exactly as the run
+    // Presence ORs in the provider's environment fallback exactly as the run
     // config resolves it (`configured_api_key`): an env-configured install
     // is runnable, and the frontend gates Send on this bit.
     has_deepseek_key: settings.deepseek_api_key is Some(_) ||
     @env.get("DEEPSEEK") is Some(_),
+    has_glm_key: settings.glm_api_key is Some(_) || @env.get("GLM") is Some(_),
     has_custom_key: settings.custom_api_key is Some(_),
   }
 }
@@ -219,6 +227,7 @@ pub async fn update_settings(
     raw.get("provider") is Some(_) ||
     raw.get("custom_api_url") is Some(_) ||
     raw.get("deepseek_api_key") is Some(_) ||
+    raw.get("glm_api_key") is Some(_) ||
     raw.get("custom_api_key") is Some(_)
   if legacy_migration && store_claimed {
     return settings_status_payload(current, manager.settings_revision)
@@ -231,6 +240,7 @@ pub async fn update_settings(
   }
   apply_text_patch(raw, "custom_api_url", patch.custom_api_url)
   apply_text_patch(raw, "deepseek_api_key", patch.deepseek_api_key)
+  apply_text_patch(raw, "glm_api_key", patch.glm_api_key)
   apply_text_patch(raw, "custom_api_key", patch.custom_api_key)
   // Version 2 retired the WSL engine mode. A settings write also removes the
   // old group so the durable file no longer advertises an ignored capability.
@@ -322,7 +332,16 @@ fn resolved_endpoint(
     Deepseek => {
       let key = configured_api_key(
         stored_key?=settings.deepseek_api_key,
-        deepseek_env?=@env.get("DEEPSEEK"),
+        env_key?=@env.get("DEEPSEEK"),
+        missing="DeepSeek API key is required; add it in Settings or set DEEPSEEK",
+      )
+      { api_key: key, api_url: None, }
+    }
+    Glm => {
+      let key = configured_api_key(
+        stored_key?=settings.glm_api_key,
+        env_key?=@env.get("GLM"),
+        missing="GLM API key is required; add it in Settings or set GLM",
       )
       { api_key: key, api_url: None, }
     }
@@ -367,18 +386,21 @@ pub async fn remote_server_base(manager : EngineManager) -> String? {
 async fn with_settings_dir(
   body : async (@pathx.Path, EngineManager) -> Unit,
 ) -> Unit {
-  // The status payload reads the DEEPSEEK fallback from the process
-  // environment; hold it steady so the expectations here cannot depend on
-  // the developer's shell. That variable is process-global while async tests
-  // run concurrently, so the package's ambient-environment lock has to cover
-  // the whole fixture: unsetting it here is worthless if a sibling test sets
-  // its own key while a body is mid-assertion. Callers must therefore not
-  // hold the lock themselves — it is not reentrant — and should do their own
-  // ambient-environment work inside `body` instead.
+  // The status payload reads the DEEPSEEK/GLM fallbacks from the process
+  // environment; hold them steady so the expectations here cannot depend on
+  // the developer's shell. Those variables are process-global while async
+  // tests run concurrently, so the package's ambient-environment lock has to
+  // cover the whole fixture: unsetting them here is worthless if a sibling
+  // test sets its own key while a body is mid-assertion. Callers must
+  // therefore not hold the lock themselves — it is not reentrant — and
+  // should do their own ambient-environment work inside `body` instead.
   ambient_env_test_lock.acquire()
   defer ambient_env_test_lock.release()
   let previous_key = @sys.get_env_var("DEEPSEEK")
   @sys.unset_env_var("DEEPSEEK")
+  let previous_glm_key = @sys.get_env_var("GLM")
+  @sys.unset_env_var("GLM")
+  defer (if previous_glm_key is Some(value) { @sys.set_env_var("GLM", value) })
   defer (if previous_key is Some(value) { @sys.set_env_var("DEEPSEEK", value) })
   let dir : @pathx.Path = Path(@fs.tmpdir(prefix="openseek-settings-"))
   defer (@fs.rmdir(dir.to_string(), recursive=true) catch { _ => () })
@@ -395,6 +417,7 @@ async test "missing settings read as the BYOK defaults" {
       "revision": 0,
       "provider": "deepseek",
       "has_deepseek_key": false,
+      "has_glm_key": false,
       "has_custom_key": false,
     })
   })
@@ -411,6 +434,7 @@ async test "the DEEPSEEK env fallback reads as a usable key" {
       "revision": 0,
       "provider": "deepseek",
       "has_deepseek_key": true,
+      "has_glm_key": false,
       "has_custom_key": false,
     })
   })
@@ -423,12 +447,14 @@ async test "a saved key round-trips as presence, never as text" {
       provider: Some("deepseek"),
       custom_api_url: None,
       deepseek_api_key: Some("  sk-secret  "),
+      glm_api_key: None,
       custom_api_key: None,
     })
     json_inspect(status, content={
       "revision": 1,
       "provider": "deepseek",
       "has_deepseek_key": true,
+      "has_glm_key": false,
       "has_custom_key": false,
     })
     // The status never carries the key; the file carries it trimmed.
@@ -455,12 +481,14 @@ async test "retired hosted providers converge on the DeepSeek default" {
       provider: Some("openseek-staging"),
       custom_api_url: None,
       deepseek_api_key: None,
+      glm_api_key: None,
       custom_api_key: None,
     })
     json_inspect(status, content={
       "revision": 1,
       "provider": "deepseek",
       "has_deepseek_key": false,
+      "has_glm_key": false,
       "has_custom_key": false,
     })
     let text = @fsx.read_text(settings_file(dir))
@@ -481,18 +509,21 @@ async test "a present-but-blank field clears the stored value" {
       provider: Some("custom"),
       custom_api_url: Some("https://proxy.example/chat/completions"),
       deepseek_api_key: None,
+      glm_api_key: None,
       custom_api_key: Some("sk-custom"),
     })
     let status = update_settings(manager, {
       provider: None,
       custom_api_url: Some("   "),
       deepseek_api_key: None,
+      glm_api_key: None,
       custom_api_key: Some(""),
     })
     json_inspect(status, content={
       "revision": 2,
       "provider": "custom",
       "has_deepseek_key": false,
+      "has_glm_key": false,
       "has_custom_key": false,
     })
   })
@@ -509,6 +540,7 @@ async test "a save removes the retired WSL settings group" {
       provider: None,
       custom_api_url: None,
       deepseek_api_key: Some("sk-kept"),
+      glm_api_key: None,
       custom_api_key: None,
     })
     guard @json.parse(@fsx.read_text(settings_file(dir))) is Object(fields) else {
@@ -531,6 +563,7 @@ async test "legacy migration cannot replay over a newer settings write" {
         provider: Some("deepseek"),
         custom_api_url: None,
         deepseek_api_key: Some("sk-old"),
+        glm_api_key: None,
         custom_api_key: None,
       },
       legacy_migration=true,
@@ -540,6 +573,7 @@ async test "legacy migration cannot replay over a newer settings write" {
       provider: Some("custom"),
       custom_api_url: Some("https://new.example/chat"),
       deepseek_api_key: Some(""),
+      glm_api_key: None,
       custom_api_key: Some("sk-new"),
     })
     assert_eq(modern.revision, 2)
@@ -552,6 +586,7 @@ async test "legacy migration cannot replay over a newer settings write" {
         provider: Some("deepseek"),
         custom_api_url: None,
         deepseek_api_key: Some("sk-old"),
+        glm_api_key: None,
         custom_api_key: None,
       },
       legacy_migration=true,
@@ -582,6 +617,7 @@ async test "concurrent disjoint settings patches merge and publish in revision o
             provider: Some("deepseek"),
             custom_api_url: None,
             deepseek_api_key: Some("sk-concurrent"),
+            glm_api_key: None,
             custom_api_key: None,
           },
           on_committed=fn(status) { committed.push(status.revision) },
@@ -595,6 +631,7 @@ async test "concurrent disjoint settings patches merge and publish in revision o
             provider: None,
             custom_api_url: Some("https://custom.example/chat"),
             deepseek_api_key: None,
+            glm_api_key: None,
             custom_api_key: Some("sk-custom"),
           },
           on_committed=fn(status) { committed.push(status.revision) },
@@ -638,6 +675,7 @@ async test "saves preserve fields a newer build added" {
       provider: None,
       custom_api_url: None,
       deepseek_api_key: Some("sk-new"),
+      glm_api_key: None,
       custom_api_key: None,
     })
     let text = @fsx.read_text(settings_file(dir))
@@ -667,6 +705,7 @@ async test "a newer-version file is read best-effort but never rewritten" {
         provider: Some("openseek"),
         custom_api_url: None,
         deepseek_api_key: None,
+        glm_api_key: None,
         custom_api_key: None,
       })
     catch {
@@ -689,6 +728,7 @@ async test "an unknown provider is refused on write, defaulted on read" {
         provider: Some("acme"),
         custom_api_url: None,
         deepseek_api_key: None,
+        glm_api_key: None,
         custom_api_key: None,
       })
     catch {
@@ -731,6 +771,7 @@ async test "run config resolves the endpoint from the stored provider" {
       provider: Some("deepseek"),
       custom_api_url: None,
       deepseek_api_key: Some("sk-stored"),
+      glm_api_key: None,
       custom_api_key: None,
     })
     let config = run_config(manager, {
@@ -749,6 +790,7 @@ async test "run config resolves the endpoint from the stored provider" {
       provider: Some("custom"),
       custom_api_url: Some("https://proxy.example/chat/completions"),
       deepseek_api_key: None,
+      glm_api_key: None,
       custom_api_key: None,
     })
     let custom = run_config(manager, {
@@ -776,6 +818,7 @@ async test "a custom provider without a URL refuses to start" {
       provider: Some("custom"),
       custom_api_url: None,
       deepseek_api_key: None,
+      glm_api_key: None,
       custom_api_key: None,
     })
     let refused = try

--- a/desktop/internal/engine/worktree_seam_wbtest.mbt
+++ b/desktop/internal/engine/worktree_seam_wbtest.mbt
@@ -286,6 +286,7 @@ async test "worktree remove refuses a running conversation without unmapping it"
       provider: Some("custom"),
       custom_api_url: Some("https://example.invalid/chat/completions"),
       deepseek_api_key: None,
+      glm_api_key: None,
       custom_api_key: None,
     }),
   )

--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -193,8 +193,46 @@ pub(all) struct SettingsSetPayload {
   provider : String?
   custom_api_url : String?
   deepseek_api_key : String?
+  glm_api_key : String?
   custom_api_key : String?
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(Debug, Eq)
+
+///|
+pub impl FromJson for SettingsSetPayload with fn from_json(json, path) {
+  let object = JsonObject::decode(json, path, "settings patch payload")
+  {
+    legacy_migration: object.optional_bool("legacy_migration"),
+    provider: object.optional_string("provider"),
+    custom_api_url: object.optional_string("custom_api_url"),
+    deepseek_api_key: object.optional_string("deepseek_api_key"),
+    glm_api_key: object.optional_string("glm_api_key"),
+    custom_api_key: object.optional_string("custom_api_key"),
+  }
+}
+
+///|
+pub impl ToJson for SettingsSetPayload with fn to_json(self) {
+  let fields : Map[String, Json] = Map([])
+  if self.legacy_migration is Some(value) {
+    fields["legacy_migration"] = value.to_json()
+  }
+  if self.provider is Some(value) {
+    fields["provider"] = value.to_json()
+  }
+  if self.custom_api_url is Some(value) {
+    fields["custom_api_url"] = value.to_json()
+  }
+  if self.deepseek_api_key is Some(value) {
+    fields["deepseek_api_key"] = value.to_json()
+  }
+  if self.glm_api_key is Some(value) {
+    fields["glm_api_key"] = value.to_json()
+  }
+  if self.custom_api_key is Some(value) {
+    fields["custom_api_key"] = value.to_json()
+  }
+  Json(fields)
+}
 
 ///|
 pub(all) struct WorkspacePayload {
@@ -991,8 +1029,37 @@ pub(all) struct SettingsStatusPayload {
   provider : String
   custom_api_url : String?
   has_deepseek_key : Bool
+  has_glm_key : Bool
   has_custom_key : Bool
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(Debug, Eq)
+
+///|
+pub impl FromJson for SettingsStatusPayload with fn from_json(json, path) {
+  let object = JsonObject::decode(json, path, "settings status payload")
+  {
+    revision: object.required_int("revision"),
+    provider: object.required_string("provider"),
+    custom_api_url: object.optional_string("custom_api_url"),
+    has_deepseek_key: object.required_bool("has_deepseek_key"),
+    has_glm_key: object.required_bool("has_glm_key"),
+    has_custom_key: object.required_bool("has_custom_key"),
+  }
+}
+
+///|
+pub impl ToJson for SettingsStatusPayload with fn to_json(self) {
+  let fields : Map[String, Json] = {
+    "revision": self.revision.to_json(),
+    "provider": self.provider.to_json(),
+    "has_deepseek_key": self.has_deepseek_key.to_json(),
+    "has_glm_key": self.has_glm_key.to_json(),
+    "has_custom_key": self.has_custom_key.to_json(),
+  }
+  if self.custom_api_url is Some(value) {
+    fields["custom_api_url"] = value.to_json()
+  }
+  Json(fields)
+}
 
 ///|
 /// Immutable identity of the installed desktop package. The native host reads

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -2008,26 +2008,32 @@ pub(all) struct SettingsSetPayload {
   provider : String?
   custom_api_url : String?
   deepseek_api_key : String?
+  glm_api_key : String?
   custom_api_key : String?
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+} derive(Eq, @debug.Debug)
 pub fn SettingsSetPayload::equal(Self, Self) -> Bool
 pub fn SettingsSetPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SettingsSetPayload::not_equal(Self, Self) -> Bool
 pub fn SettingsSetPayload::to_json(Self) -> Json
 pub fn SettingsSetPayload::to_repr(Self) -> @debug.Repr
+pub impl ToJson for SettingsSetPayload
+pub impl @json.FromJson for SettingsSetPayload
 
 pub(all) struct SettingsStatusPayload {
   revision : Int
   provider : String
   custom_api_url : String?
   has_deepseek_key : Bool
+  has_glm_key : Bool
   has_custom_key : Bool
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+} derive(Eq, @debug.Debug)
 pub fn SettingsStatusPayload::equal(Self, Self) -> Bool
 pub fn SettingsStatusPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SettingsStatusPayload::not_equal(Self, Self) -> Bool
 pub fn SettingsStatusPayload::to_json(Self) -> Json
 pub fn SettingsStatusPayload::to_repr(Self) -> @debug.Repr
+pub impl ToJson for SettingsStatusPayload
+pub impl @json.FromJson for SettingsStatusPayload
 
 pub(all) struct SkillsCatalogReply {
   skills : Array[MarketSkill]

--- a/desktop/internal/protocol/settings_codec_test.mbt
+++ b/desktop/internal/protocol/settings_codec_test.mbt
@@ -1,0 +1,60 @@
+///|
+test "settings patches preserve optional GLM fields and omit absence" {
+  let patch : @protocol.SettingsSetPayload = @json.from_json({
+    "provider": "glm",
+    "custom_api_url": null,
+    "deepseek_api_key": null,
+    "glm_api_key": "glm-secret",
+    "future_field": true,
+  })
+  assert_eq(patch.provider, Some("glm"))
+  assert_eq(patch.glm_api_key, Some("glm-secret"))
+  @debug.assert_eq(patch.to_json(), {
+    "provider": "glm",
+    "glm_api_key": "glm-secret",
+  })
+}
+
+///|
+test "settings status preserves and requires the GLM capability flag" {
+  let status : @protocol.SettingsStatusPayload = @json.from_json({
+    "revision": 8,
+    "provider": "glm",
+    "custom_api_url": null,
+    "has_deepseek_key": false,
+    "has_glm_key": true,
+    "has_custom_key": false,
+    "future_field": true,
+  })
+  assert_true(status.has_glm_key)
+  @debug.assert_eq(status.to_json(), {
+    "revision": 8,
+    "provider": "glm",
+    "has_deepseek_key": false,
+    "has_glm_key": true,
+    "has_custom_key": false,
+  })
+  let missing : @protocol.SettingsStatusPayload? = Some(
+    @json.from_json({
+      "revision": 8,
+      "provider": "glm",
+      "has_deepseek_key": false,
+      "has_custom_key": false,
+    }),
+  ) catch {
+    _ => None
+  }
+  assert_true(missing is None)
+  let malformed : @protocol.SettingsStatusPayload? = Some(
+    @json.from_json({
+      "revision": 8,
+      "provider": "glm",
+      "has_deepseek_key": false,
+      "has_glm_key": "yes",
+      "has_custom_key": false,
+    }),
+  ) catch {
+    _ => None
+  }
+  assert_true(malformed is None)
+}

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -384,7 +384,8 @@ at config time, so a change replaces the conversation's engine process on
 its next start.
 
 `provider` is the chat endpoint selection: `deepseek` (the official
-endpoint with the user's key) or `custom` (any OpenAI-compatible
+endpoint with the user's key), `glm` (the official Z.AI GLM endpoint
+with its own key), or `custom` (any OpenAI-compatible
 chat-completions URL; key optional). SeekMoon runs are
 bring-your-own-key only — the hosted proxy is retired, and the retired
 names `openseek` / `openseek-staging` are accepted aliases that resolve
@@ -396,16 +397,17 @@ still signs out a session whose issuer no longer matches the origin.
 | method | params | result |
 |---|---|---|
 | `settings.get` | `{}` | the status shape below |
-| `settings.set` | `{provider?, custom_api_url?, deepseek_api_key?, custom_api_key?, legacy_migration?}` — absent fields stay unchanged; a present string field is trimmed and, when empty, **clears** the stored value; an unknown `provider` is refused. `legacy_migration:true` is reserved for the bundled desktop's one-time import: once any settings write has claimed the durable store, a replay is acknowledged without changing it. | the status shape below, post-write |
+| `settings.set` | `{provider?, custom_api_url?, deepseek_api_key?, glm_api_key?, custom_api_key?, legacy_migration?}` — absent fields stay unchanged; a present string field is trimmed and, when empty, **clears** the stored value; an unknown `provider` is refused. `legacy_migration:true` is reserved for the bundled desktop's one-time import: once any settings write has claimed the durable store, a replay is acknowledged without changing it. | the status shape below, post-write |
 
 The status shape, also the params of every `settings.changed` notification:
 
 ```jsonc
 {
   "revision": 7,                    // host-process monotonic revision
-  "provider": "deepseek" | "custom",
+  "provider": "deepseek" | "glm" | "custom",
   "custom_api_url": "https://…",   // absent when unset
   "has_deepseek_key": false,       // presence only — the key text never leaves the host
+  "has_glm_key": false,
   "has_custom_key": false
 }
 ```


### PR DESCRIPTION
## Summary

Expose GLM in the desktop UI, completing the GLM rollout that #1119/#1120/#1121 landed in the engine, CLI, and TUI.

- **Settings / API endpoint**: a third BYOK provider, **Z.AI GLM (your API key)**, with its own stored `glm_api_key` (env fallback `GLM`), provider hint, setup guide with a z.ai API-keys link, API-setup modal title, and composer Send-gate notice. Key presence travels as `has_glm_key` in the `settings.*` status; `settings.set` accepts `glm_api_key` (protocol and store are purely additive — no settings-version bump, old files read unchanged).
- **Composer model chip**: the OpenSeek group now lists the configured provider's models — the DeepSeek tiers under DeepSeek, **GLM 5.3 / GLM 5.3 Flash** under GLM, and every known model under a custom endpoint (whose key follows the model). An off-list selection stays visible, same as unknown wire names always did.
- **Reasoning chip**: stays visible for GLM models; its lowest option is labeled **Low** rather than Off, since GLM 5.3 cannot disable thinking (the engine maps `no` to GLM's lowest supported effort).
- **Key routing (the safety-relevant change)**: the run's API key now travels in the provider's own environment variable (`DEEPSEEK`/`KIMI`/`GLM`) instead of unconditionally `DEEPSEEK`, chosen by the *provider* so a provider/model mismatch fails closed — the engine reports a missing key instead of the host shipping a Z.AI token to `api.deepseek.com` (where the engine's DeepSeek-only `web_search` would otherwise POST it). A custom endpoint's key follows the model's variable, which is the one the engine reads. The variable joins the engine fingerprint, and other providers' shell exports still inherit so an ambient `DEEPSEEK` keeps `web_search` available on GLM runs.
- **Host defaults**: a GLM-provider run with no model named defaults to `glm-5.3` instead of `deepseek-v4-pro`.
- Docs: `desktop/README.md` API-endpoint section and `docs/remote-protocol.md` `settings.*` section.

New tests cover the GLM settings round-trip and env fallback, per-provider key-env routing (including custom-endpoint model-following), the GLM run-config resolution and default model, the provider-aware model group, the GLM Send gate, and per-provider key saving.

## Validation

- `just check` (native + js check, `moon fmt --check`) and `just build`
- `moon test --target native`: 3333/3333 (provider keys blanked)
- `moon test --target js`: 3293/3293
- `moon cram test tests/cram`: 28/28
- Not exercised: a live end-to-end desktop run against the real Z.AI endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TpFW5LRBQs2DzXhxa8KD2
