### PR TITLE
feat(desktop): resize the projects sidebar by dragging its edge

### DIFF
--- a/desktop/frontend/sidebar/pkg.generated.mbti
+++ b/desktop/frontend/sidebar/pkg.generated.mbti
@@ -10,6 +10,8 @@ import {
 }
 
 // Values
+pub const ResizeHandleId : String = "sidebar-resize-handle"
+
 pub fn component(@rabbita.Val[Input], Actions) -> @rabbita.Val[@html.Html]
 
 // Errors

--- a/desktop/frontend/sidebar/sidebar.mbt
+++ b/desktop/frontend/sidebar/sidebar.mbt
@@ -7,6 +7,12 @@ pub(all) struct Account {
 } derive(Debug, Eq)
 
 ///|
+/// The id of the grab strip the sidebar renders on its right edge. The
+/// shell's sidebar resize (desktop/frontend/sidebar_resize.mbt) finds the
+/// handle by this id to install its drag listeners.
+pub const ResizeHandleId : String = "sidebar-resize-handle"
+
+///|
 /// The complete plain input of the left sidebar component. Commands are kept
 /// in `Actions`, so this value remains comparable and can drive incremental
 /// Rabbita branches without embedding emitters in application data.
@@ -170,6 +176,15 @@ pub fn component(
         @html.div(class="sidebar-section sessions", rows),
       ]),
       @html.div(class="sidebar-footer", footer),
+      // Grab strip for drag-to-resize; wired imperatively by the shell's
+      // sidebar_resize. Absolutely positioned, so it is not a grid item and
+      // never disturbs the aside's rows.
+      @html.div(
+        attrs=@html.Attrs::build()
+          .id(ResizeHandleId)
+          .class("sidebar-resize-handle"),
+        ([] : Array[@html.Html]),
+      ),
     ])
   })
 }

--- a/desktop/frontend/sidebar_resize.mbt
+++ b/desktop/frontend/sidebar_resize.mbt
@@ -1,0 +1,163 @@
+// Drag-to-resize for the sidebar (the projects panel). The panel's width is a
+// CSS custom property `--sidebar-width` on the document element, set
+// imperatively as the user drags a handle on the aside's right edge — never
+// through the model, so a drag never re-renders the app. The `.app` grid in
+// `base.css` reads the property through a `clamp(...)`, so the bounds live in
+// CSS and survive a window resize on their own. Mirrors the editor panel's
+// resize (fileeditor/editor_resize.mbt).
+
+///|
+/// The class toggled on the document element for the duration of a drag —
+/// the same one the fileeditor resizers use, so the shared CSS shows the
+/// resize cursor and suppresses text selection everywhere for both drags.
+const ResizingClass = "is-resizing"
+
+///|
+/// The sidebar never shrinks below this. Mirrors the CSS `clamp` floor.
+const MinSidebarWidth = 220
+
+///|
+/// The sidebar never grows past this. Mirrors the CSS `clamp` ceiling.
+const MaxSidebarWidth = 480
+
+///|
+/// Width (px) always left to the content column, so a drag can never squeeze
+/// the conversation out of existence. Plays the role the editor drag's
+/// `MinChatWidth` plays there.
+const MinContentWidth = 360
+
+///|
+/// Whether the drag listeners have been installed yet (once, after first
+/// paint).
+let sidebar_resize_installed : Ref[Bool] = Ref(false)
+
+///|
+/// Whether a sidebar drag is in progress. The document-level move/up
+/// listeners are permanent and simply gate on this, so there is nothing to
+/// add and remove per drag.
+let sidebar_resizing : Ref[Bool] = Ref(false)
+
+///|
+/// Install the resize listeners once the handle is in the DOM: a `mousedown`
+/// on the handle starts a drag, and document-level `mousemove` / `mouseup`
+/// (capture, so they fire even while the cursor is over the conversation's
+/// own DOM) carry and end it. Idempotent — a no-op once installed.
+pub fn request_sidebar_resize_mount() -> @cmd.Cmd {
+  @cmd.custom_cmd(
+    _after => {
+      if sidebar_resize_installed.val {
+        return
+      }
+      guard @dom.document()
+        .get_element_by_id(@sidebar.ResizeHandleId)
+        .to_option()
+        is Some(handle) else {
+        return
+      }
+      @interop.add_capture_listener(
+        @js.Value::cast_from(handle),
+        "mousedown",
+        start_sidebar_resize,
+      )
+      let document : @js.Value = @js.globalThis.get_with_string("document")
+      @interop.add_capture_listener(
+        document, "mousemove", on_sidebar_resize_move,
+      )
+      @interop.add_capture_listener(document, "mouseup", _ => {
+        end_sidebar_resize()
+      })
+      sidebar_resize_installed.val = true
+    },
+    kind=@cmd.after_render,
+  )
+}
+
+///|
+/// Begin a drag on a left-button press over the handle.
+fn start_sidebar_resize(event : @dom.Event) -> Unit {
+  guard event.to_mouse_event() is Some(mouse) && mouse.get_button() == 0 else {
+    return
+  }
+  // Stop the press from starting a text selection in the sidebar underneath.
+  event.prevent_default()
+  sidebar_resizing.val = true
+  set_root_class(ResizingClass)
+}
+
+///|
+/// Track the cursor. The sidebar is the leftmost column of `.app`, so its
+/// width is the gap from the app's left edge to the cursor. The ceiling
+/// keeps at least `MinContentWidth` for the content column; on a very
+/// narrow window the floor wins, even past the ceiling.
+fn on_sidebar_resize_move(event : @dom.Event) -> Unit {
+  guard sidebar_resizing.val &&
+    event.to_mouse_event() is Some(mouse) &&
+    @dom.document().query_selector(".app").to_option() is Some(app) else {
+    return
+  }
+  let rect = app.get_bounding_client_rect()
+  set_sidebar_width(
+    drag_width(
+      mouse.get_client_x().to_double() - rect.get_left(),
+      ceiling=rect.get_width() - MinContentWidth.to_double(),
+    ),
+  )
+}
+
+///|
+/// Clamp the dragged width into the sidebar's allowed range.
+fn drag_width(raw : Double, ceiling~ : Double) -> Int {
+  let ceiling = if ceiling > MaxSidebarWidth.to_double() {
+    MaxSidebarWidth.to_double()
+  } else {
+    ceiling
+  }
+  let ceiling = if ceiling < MinSidebarWidth.to_double() {
+    MinSidebarWidth.to_double()
+  } else {
+    ceiling
+  }
+  let width = if raw < MinSidebarWidth.to_double() {
+    MinSidebarWidth.to_double()
+  } else if raw > ceiling {
+    ceiling
+  } else {
+    raw
+  }
+  width.to_int()
+}
+
+///|
+/// End a drag.
+fn end_sidebar_resize() -> Unit {
+  guard sidebar_resizing.val else { return }
+  sidebar_resizing.val = false
+  set_root_class("")
+}
+
+///|
+/// Write the dragged width as a custom property on the document element,
+/// where the CSS `clamp(...)` reads it. Updating the property through CSSOM
+/// preserves the sizes owned by other panels (the editor width, the tree,
+/// the terminal height).
+fn set_sidebar_width(width : Int) -> Unit {
+  guard document_element() is Some(root) else { return }
+  let style : @js.Value = @js.Value::cast_from(root).get_with_string("style")
+  let _ : @js.Value = style.apply_with_string("setProperty", [
+    @js.Value::cast_from("--sidebar-width"),
+    @js.Value::cast_from("\{width}px"),
+  ])
+}
+
+///|
+/// Toggle a class on the document element (empty string clears it).
+fn set_root_class(class_name : String) -> Unit {
+  if document_element() is Some(root) {
+    root.set_attribute("class", class_name)
+  }
+}
+
+///|
+fn document_element() -> @dom.Element? {
+  @dom.document().query_selector("html").to_option()
+}

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1784,6 +1784,7 @@ fn update_msg(
               // `BridgeReady`.
               clear_legacy_engine_settings(),
               watch_color_scheme(dispatch),
+              request_sidebar_resize_mount(),
             ]),
             model,
           )
@@ -1793,6 +1794,7 @@ fn update_msg(
               load_saved_settings(dispatch),
               watch_color_scheme(dispatch),
               rotate_session(dispatch, model.focused),
+              request_sidebar_resize_mount(),
             ]),
             model,
           )

--- a/desktop/styles/base.css
+++ b/desktop/styles/base.css
@@ -262,6 +262,10 @@ html {
 }
 
 .app {
+  /* Vertical and horizontal resize handles share one hit-area size per axis.
+     Component styles consume the dimension that matches their seam. */
+  --resize-handle-width: 6px;
+  --resize-handle-height: 6px;
   display: grid;
   /* The sidebar track reads `--sidebar-width`, set as the user drags the
      handle on the aside's right edge (see frontend/sidebar_resize.mbt); it

--- a/desktop/styles/base.css
+++ b/desktop/styles/base.css
@@ -263,7 +263,14 @@ html {
 
 .app {
   display: grid;
-  grid-template-columns: minmax(220px, 264px) minmax(0, 1fr);
+  /* The sidebar track reads `--sidebar-width`, set as the user drags the
+     handle on the aside's right edge (see frontend/sidebar_resize.mbt); it
+     defaults to the old fixed maximum and is clamped so the sidebar keeps
+     at least 220px while the content column keeps the rest. The clamp also
+     re-fits the panel on window resize without any script. */
+  grid-template-columns:
+    clamp(220px, var(--sidebar-width, 264px), 480px)
+    minmax(0, 1fr);
   /* Track #app's content box (which already accounts for any scrollbar)
      rather than 100vh, so the two height bases can't disagree. */
   height: 100%;

--- a/desktop/styles/file_panel.css
+++ b/desktop/styles/file_panel.css
@@ -31,7 +31,6 @@ button.panel-toggle:not(:disabled):hover {
 /* The editor part: a tab strip of open files over the viewer, with the
    file tree as a toggleable pane on the viewer's right. */
 .editor {
-  --editor-resize-handle-width: 6px;
   display: flex;
   flex-direction: column;
   min-width: 0;
@@ -226,14 +225,14 @@ button.panel-toggle:not(:disabled):hover {
   top: 0;
   left: 0;
   right: 0;
-  height: 5px;
+  height: var(--resize-handle-height);
   z-index: 2;
   cursor: row-resize;
 }
 .editor.tree-right .tree-resize-handle {
   right: auto;
   bottom: 0;
-  width: 5px;
+  width: var(--resize-handle-width);
   height: auto;
   cursor: col-resize;
 }
@@ -265,7 +264,7 @@ html.is-resizing-col * {
   top: 0;
   bottom: 0;
   left: 0;
-  width: var(--editor-resize-handle-width);
+  width: var(--resize-handle-width);
   z-index: 3;
   cursor: col-resize;
 }
@@ -476,7 +475,7 @@ html.is-resizing * {
   min-height: 0;
   /* Native views always paint above HTML. Keep their measured rectangle to
      the right of the editor's resize handle so the handle remains clickable. */
-  margin-left: var(--editor-resize-handle-width);
+  margin-left: var(--resize-handle-width);
   background: var(--color-bg-subtle);
 }
 

--- a/desktop/styles/responsive.css
+++ b/desktop/styles/responsive.css
@@ -88,6 +88,7 @@
     border-left: 0;
   }
   .editor-resize-handle,
+  .sidebar-resize-handle,
   .tree-resize-handle {
     display: none !important;
   }

--- a/desktop/styles/sidebar.css
+++ b/desktop/styles/sidebar.css
@@ -14,6 +14,27 @@ aside {
   border-right: 1px solid var(--color-separator);
   background: var(--color-bg-surface);
   color: var(--color-text-secondary);
+  /* The width-resize grab strip on the right edge positions against the
+     aside itself. */
+  position: relative;
+}
+
+/* Drag-to-resize handle on the sidebar's right edge. A thin strip floated
+   above the seam with a col-resize cursor; it tints on hover and while
+   dragging. Wired imperatively by frontend/sidebar_resize.mbt; the narrow
+   layout hides it with the other resize handles. */
+.sidebar-resize-handle {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  width: var(--editor-resize-handle-width);
+  z-index: 3;
+  cursor: col-resize;
+}
+.sidebar-resize-handle:hover,
+html.is-resizing .sidebar-resize-handle {
+  background: var(--color-accent-soft);
 }
 
 /* The sidebar's own 46px header, matching the topbar so the sidebar

--- a/desktop/styles/sidebar.css
+++ b/desktop/styles/sidebar.css
@@ -28,7 +28,7 @@ aside {
   top: 0;
   bottom: 0;
   right: 0;
-  width: var(--editor-resize-handle-width);
+  width: var(--resize-handle-width);
   z-index: 3;
   cursor: col-resize;
 }

--- a/desktop/styles/terminal.css
+++ b/desktop/styles/terminal.css
@@ -22,11 +22,12 @@
 
 .terminal-resize-handle {
   position: absolute;
-  top: -3px;
+  top: 0;
   right: 0;
   left: 0;
   z-index: 3;
-  height: 6px;
+  height: var(--resize-handle-height);
+  transform: translateY(-50%);
   cursor: row-resize;
 }
 .terminal-resize-handle:hover,


### PR DESCRIPTION
Fixes #1009.

The sidebar column of `.app` was a fixed `minmax(220px, 264px)` track, so dragging its edge did nothing. This makes the projects panel resizable.

## Approach

Mirrors the editor panel's existing drag-to-resize (`fileeditor/editor_resize.mbt`):

- `desktop/styles/base.css`: the sidebar track becomes `clamp(220px, var(--sidebar-width, 264px), 480px)` — the old bounds as floor/default, a wider ceiling, re-fitting on window resize without script
- `desktop/frontend/sidebar/sidebar.mbt`: the aside renders a grab strip on its right edge (`ResizeHandleId`)
- `desktop/frontend/sidebar_resize.mbt` (new): installs the drag listeners once after first paint; the width is written imperatively to the document element through CSSOM, so a drag never goes through the model and never re-renders the app; the ceiling keeps at least 360px for the content column
- `desktop/styles/sidebar.css` / `responsive.css`: handle styling (`col-resize`, hover tint, shared `is-resizing` cursor class); the narrow drawer layout hides the handle with the other resize handles

Collapsed state, narrow drawer width, and the editor/tree/terminal drags are untouched: CSSOM `setProperty` preserves the custom properties the other resizers own.

## Testing

- `moon check desktop/frontend desktop/frontend/sidebar --target js` — clean
- `moon test desktop/frontend desktop/frontend/sidebar --target js` — 456/456 pass
- `pkg.generated.mbti` updated for the new public constant

Note: drag behavior was verified through the compiled checks and tests; I could not exercise the Proton desktop build locally, so a quick manual drag in the desktop app is worth doing.