### PR TITLE
test(web_search): add real-world tests against the live DeepSeek endpoint

### DIFF
--- a/agent_tool/web_search/moon.pkg
+++ b/agent_tool/web_search/moon.pkg
@@ -10,6 +10,7 @@ import {
   "moonbitlang/async",
   "moonbitlang/async/http",
   "moonbitlang/async/socket",
+  "moonbitlang/core/env",
   "moonbitlang/core/json",
 } for "test"
 

--- a/agent_tool/web_search/web_search_test.mbt
+++ b/agent_tool/web_search/web_search_test.mbt
@@ -164,11 +164,13 @@ async test "web_search rejects blank and oversized queries locally" {
 ///
 ///     Sources:
 ///     - [docs.moonbitlang.com](https://docs.moonbitlang.com/zh-cn/stable/_downloads/78d8998d78e60fd7b1b2f4c9bb2819fb/summary.md)
+///     - [docs.moonbitlang.com](https://docs.moonbitlang.com/en/stable/_downloads/78d8998d78e60fd7b1b2f4c9bb2819fb/summary.md)
 ///     - [MoonBit - 计算机编程语言](https://baike.baidu.com/item/MoonBit/64190586?fr=ge_ala#1)
 ///     - [MoonBit Language](https://docs.moonbitlang.com/en/stable/language/index.html)
 ///     - [MoonBit: Explore the Design of an AI-Friendly Programming Language](https://llm4code.github.io/assets/pdf/papers/7.pdf#1#1)
 ///     - [About us | MoonBit](https://www.moonbitlang.com/about-us)
-///     - ...
+///     - [MoonBit](https://baike.baidu.com/item/MoonBit)
+///     - [docs.moonbitlang.cn](https://docs.moonbitlang.cn/_sources/tutorial/for-go-programmers/index.md)
 ///
 ///     (Showing the first 8 sources. Refine the query for more.)
 ///
@@ -176,8 +178,8 @@ async test "web_search rejects blank and oversized queries locally" {
 ///
 /// Only the SHAPE is stable, not the contents: which URLs surface, whether
 /// titles are present (a title-less source falls back to its hostname label,
-/// as the first line above shows), whether citation snippets and dates are
-/// joined in, and whether the result cap actually truncates — all drift
+/// as the first two lines above show), whether citation snippets and dates
+/// are joined in, and whether the result cap actually truncates — all drift
 /// between runs.
 async test "realworld web_search performs a native search against DeepSeek" {
   guard @env.get_env_var("DEEPSEEK") is Some(api_key) && api_key != "" else {

--- a/agent_tool/web_search/web_search_test.mbt
+++ b/agent_tool/web_search/web_search_test.mbt
@@ -151,3 +151,52 @@ async test "web_search rejects blank and oversized queries locally" {
   assert_true(oversized.is_error)
   assert_true(oversized.content.contains("exceeds"))
 }
+
+///|
+/// Live check against the real DeepSeek Anthropic-compatible endpoint. Opt-in
+/// like `deepseek/client/client_realworld_test.mbt`: runs only when the
+/// `DEEPSEEK` key is exported, prints a skip notice otherwise. The real
+/// endpoint is exercised end to end — the tool must come back with at least
+/// one citeable source rendered as a markdown link, plus a success brief.
+async test "realworld web_search performs a native search against DeepSeek" {
+  guard @env.get_env_var("DEEPSEEK") is Some(api_key) && api_key != "" else {
+    println(
+      "DEEPSEEK environment variable is not set or is empty; skipping realworld web_search test",
+    )
+    return
+  }
+  let tool = @web_search.definition(api_key~)
+  guard tool.execute is Async(execute) else { fail("expected async executor") }
+  let action = execute({ "query": "MoonBit programming language" })
+  guard action is Respond(output) else { fail("expected Respond") }
+  assert_false(output.is_error)
+  assert_true(output.content.contains("Sources:"))
+  // A real search must return at least one citeable source with a markdown
+  // link; the URL itself is provider-chosen, only the shape is stable.
+  assert_true(output.content.contains("](https://"))
+  guard output.brief is Some(brief) else { fail("expected a brief") }
+  assert_true(brief.contains("web_search"))
+  assert_true(brief.contains("source(s)"))
+}
+
+///|
+/// Live auth-failure check: a bad key against the real endpoint must surface
+/// as a recoverable tool error carrying the provider's message — never a
+/// crash. Guarded on `DEEPSEEK` like the success test, so the offline suite
+/// stays network-free.
+async test "realworld web_search surfaces an auth failure from the live endpoint" {
+  guard @env.get_env_var("DEEPSEEK") is Some(api_key) && api_key != "" else {
+    println(
+      "DEEPSEEK environment variable is not set or is empty; skipping realworld web_search auth test",
+    )
+    return
+  }
+  let tool = @web_search.definition(api_key="sk-invalid-key-for-realworld-test")
+  guard tool.execute is Async(execute) else { fail("expected async executor") }
+  let action = execute({ "query": "MoonBit" })
+  guard action is Respond(output) else { fail("expected Respond") }
+  assert_true(output.is_error)
+  assert_true(output.content.contains("error: web_search failed"))
+  guard output.brief is Some(brief) else { fail("expected a brief") }
+  assert_true(brief.contains("(failed)"))
+}

--- a/agent_tool/web_search/web_search_test.mbt
+++ b/agent_tool/web_search/web_search_test.mbt
@@ -158,6 +158,27 @@ async test "web_search rejects blank and oversized queries locally" {
 /// `DEEPSEEK` key is exported, prints a skip notice otherwise. The real
 /// endpoint is exercised end to end — the tool must come back with at least
 /// one citeable source rendered as a markdown link, plus a success brief.
+///
+/// A typical live result looks like (this exact output came from a real run of
+/// this very test):
+///
+///     Sources:
+///     - [docs.moonbitlang.com](https://docs.moonbitlang.com/zh-cn/stable/_downloads/78d8998d78e60fd7b1b2f4c9bb2819fb/summary.md)
+///     - [MoonBit - 计算机编程语言](https://baike.baidu.com/item/MoonBit/64190586?fr=ge_ala#1)
+///     - [MoonBit Language](https://docs.moonbitlang.com/en/stable/language/index.html)
+///     - [MoonBit: Explore the Design of an AI-Friendly Programming Language](https://llm4code.github.io/assets/pdf/papers/7.pdf#1#1)
+///     - [About us | MoonBit](https://www.moonbitlang.com/about-us)
+///     - ...
+///
+///     (Showing the first 8 sources. Refine the query for more.)
+///
+///     Cite the relevant URLs above as markdown links in your answer.
+///
+/// Only the SHAPE is stable, not the contents: which URLs surface, whether
+/// titles are present (a title-less source falls back to its hostname label,
+/// as the first line above shows), whether citation snippets and dates are
+/// joined in, and whether the result cap actually truncates — all drift
+/// between runs.
 async test "realworld web_search performs a native search against DeepSeek" {
   guard @env.get_env_var("DEEPSEEK") is Some(api_key) && api_key != "" else {
     println(
@@ -169,6 +190,10 @@ async test "realworld web_search performs a native search against DeepSeek" {
   guard tool.execute is Async(execute) else { fail("expected async executor") }
   let action = execute({ "query": "MoonBit programming language" })
   guard action is Respond(output) else { fail("expected Respond") }
+  // debug_inspect(output.content, content="typical live web_search output")
+  // Uncomment while iterating to see the exact current output; it stays
+  // commented because real results drift between runs (see the doc comment
+  // above) and must not become a stable fixture.
   assert_false(output.is_error)
   assert_true(output.content.contains("Sources:"))
   // A real search must return at least one citeable source with a markdown


### PR DESCRIPTION
Adds two opt-in real-world tests to `agent_tool/web_search/web_search_test.mbt`, following the existing convention in `deepseek/client/client_realworld_test.mbt`:

- **realworld web_search performs a native search against DeepSeek** — a live round trip against `https://api.deepseek.com/anthropic/v1/messages` asserting the tool returns citeable markdown sources and a success brief.
- **realworld web_search surfaces an auth failure from the live endpoint** — a bad key must come back as a recoverable `is_error` tool result carrying the provider message, never a crash.

Both are guarded on `$DEEPSEEK`: without the key exported they print a skip notice and pass, keeping the offline suite network-free. With a key they run for real — both passed green against the live endpoint during development.

Verified locally: `moon check` clean, `moon fmt --check` clean, `moon test agent_tool/web_search` 18/18 green (16 local + 2 live).

Generated with SeekMoon