### PR TITLE
feat(mbtx): distinguish compile and runtime errors

### DIFF
--- a/agent/tool_definition.mbt
+++ b/agent/tool_definition.mbt
@@ -193,7 +193,9 @@ async test "a background run that fails to compile reports the error inline" {
     guard action is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_false(output.content.contains("started background job"))
-    assert_true(output.content.contains("did not compile"))
+    assert_true(output.content.contains("compile-time error"))
+    assert_true(output.content.contains("program was not run"))
+    assert_eq(output.brief, Some("mbtx (compile error)"))
     // The diagnostic points at the model's own input.
     assert_true(output.content.contains("source:"))
     assert_false(output.content.contains("openseek-jobs-"))
@@ -318,7 +320,8 @@ async test "binary output waits for the real exit instead of abandoning it" {
     guard action is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     // The real exit code, not the -1 an abandoned execution would report.
-    assert_true(output.content.contains("exited 3"))
+    assert_true(output.content.contains("exit code 3"))
+    assert_true(output.content.contains("runtime error"))
     assert_true(output.content.contains("non-UTF-8"))
   })
 }

--- a/agent_tool/mbtx/README.mbt.md
+++ b/agent_tool/mbtx/README.mbt.md
@@ -10,14 +10,14 @@ wasm backend (planned) makes it the natural sandboxed automation surface.
 ## How it works
 
 The `source` is a `.mbtx` **single-file script** — MoonBit's own one-file
-program format. The tool writes `source` to a throwaway temp file and runs one
-`moon run <file>.mbtx --output-json`. Moon's structured compiler diagnostics
-are separated from ordinary program output: an error diagnostic is reported as
-a **compile-time error** with an explicit “program was not run” status, while a
-non-zero exit without one is a **runtime error**. The desktop transcript labels
-and styles the two failures separately. An explicit background launch is the
-exception: it uses `--build-only` first so invalid source is rejected before a
-job id is returned.
+program format. The tool writes `source` to a throwaway temp file, runs
+`moon run <file>.mbtx --build-only`, and only starts the program after that
+succeeds. The following `moon run` reuses the same target cache, so this is an
+extra lightweight invocation rather than a second compilation. A failed build
+is reported as a **compile-time error** with an explicit “program was not run”
+status; a non-zero exit after the successful build is a **runtime error**. The
+desktop transcript labels and styles the two failures separately. Background
+launches use the same boundary, so an invalid source never returns a job id.
 
 The command uses `--target <target> --target-dir <temp>` **with your workspace
 as the working directory**. The tool returns what moon prints, removes the temp

--- a/agent_tool/mbtx/README.mbt.md
+++ b/agent_tool/mbtx/README.mbt.md
@@ -10,15 +10,23 @@ wasm backend (planned) makes it the natural sandboxed automation surface.
 ## How it works
 
 The `source` is a `.mbtx` **single-file script** — MoonBit's own one-file
-program format. The tool does nothing clever: it writes `source` to a throwaway
-temp file and runs `moon run <file>.mbtx --target <target> --target-dir <temp>`
-**with your workspace as the working directory**, returns what moon prints,
-removes the temp dir, and enforces a 60s bound. Because the working directory is
-the workspace, relative paths like `@fs.read_file("data.json")` reach workspace
-files and anything the program writes lands in the workspace — while all build
-artifacts stay in the temp dir, so your `_build` is never touched. moon's
-single-file runner handles the inline import block; moon's own compiler
-diagnostics are the error message when something does not build.
+program format. The tool writes `source` to a throwaway temp file and runs one
+`moon run <file>.mbtx --output-json`. Moon's structured compiler diagnostics
+are separated from ordinary program output: an error diagnostic is reported as
+a **compile-time error** with an explicit “program was not run” status, while a
+non-zero exit without one is a **runtime error**. The desktop transcript labels
+and styles the two failures separately. An explicit background launch is the
+exception: it uses `--build-only` first so invalid source is rejected before a
+job id is returned.
+
+The command uses `--target <target> --target-dir <temp>` **with your workspace
+as the working directory**. The tool returns what moon prints, removes the temp
+dir, and bounds execution. Because the working directory is the workspace,
+relative paths like `@fs.read_file("data.json")` reach workspace files and
+anything the program writes lands in the workspace — while all build artifacts
+stay in the temp dir, so your `_build` is never touched. Moon's single-file
+runner handles the inline import block, and requested compiler warnings are
+kept separate from the program's own output.
 
 ## Arguments
 

--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -45,6 +45,14 @@ fn native_escape(source : String) -> String? {
 /// Tool definition for `mbtx`: compile and run a self-contained MoonBit
 /// program and return its merged stdout/stderr and exit status.
 ///
+/// Foreground execution asks moon for JSON diagnostics and separates those
+/// compiler records from the program's ordinary output after one `moon run`.
+/// That gives compile-time and runtime failures distinct output headers and
+/// display briefs without compiling a successful snippet twice. An explicit
+/// background launch still builds first: it must reject invalid source before
+/// returning a job id, when there is not yet a completed output stream to
+/// classify.
+///
 /// The program is a `.mbtx` single-file script — it may open with an inline
 /// `import { "pkg", … }` block (comma-separated module paths) naming the
 /// standard packages it uses, followed by the program including its own
@@ -167,6 +175,350 @@ fn escalation_brief(outcome : @agent_runtime.ApprovalOutcome) -> String {
     Cancelled => "withdrawn"
     Unavailable => "unavailable"
   }
+}
+
+///|
+/// The explicit background compiler preflight's outcome. A successful build
+/// retains any compiler output (normally only requested warnings) so the job
+/// launch response can keep it separate from later program output.
+priv enum CompileOutcome {
+  Compiled(String)
+  CompileFailed(exit_code~ : Int, String)
+  CompileTimedOut(String)
+}
+
+///|
+/// Remove `moon run --build-only`'s success protocol from the compiler stream.
+/// It prints a one-line JSON object containing `artifacts_path`; that is an
+/// internal temp artifact location, not a warning or diagnostic. Everything
+/// else remains verbatim, including requested compiler warnings.
+fn visible_compiler_output(output : String) -> String {
+  let lines : Array[String] = []
+  for line in output.split("\n") {
+    let is_artifact_manifest = try @json.parse(line.trim()) catch {
+      _ => false
+    } noraise {
+      { "artifacts_path": Array(_), .. } => true
+      _ => false
+    }
+    if !is_artifact_manifest {
+      lines.push(line.to_owned())
+    }
+  }
+  lines.join("\n")
+}
+
+///|
+/// The compiler records and program output recovered from one
+/// `moon run --output-json`. `has_error_diagnostic` is set only by an error
+/// diagnostic that names this call's private build directory. Matching that
+/// unpredictable path matters: a program remains free to print JSON (including
+/// something that resembles a moon diagnostic) without turning its own
+/// non-zero exit into a compile-time failure.
+priv struct ParsedRunOutput {
+  compiler_output : String
+  program_output : String
+  has_error_diagnostic : Bool
+}
+
+///|
+/// Whether a structured diagnostic belongs to this snippet rather than being
+/// arbitrary JSON printed by the program. `bases` contains both the lexical
+/// and canonical spelling of the private directory for symlinked temp roots.
+fn is_snippet_diagnostic_path(path : String, bases : Array[String]) -> Bool {
+  for base in bases {
+    for sep in ["/", "\\"] {
+      if path.has_prefix("\{base}\{sep}") {
+        return true
+      }
+    }
+  }
+  false
+}
+
+///|
+/// Whether this fresh target directory contains the runnable artifact moon
+/// produces only after compilation/linking succeeds. This closes the one gap
+/// in `--output-json`: front-matter/package-discovery failures and compiler
+/// crashes can exit without a diagnostic record. Conversely, a program may
+/// deliberately exit with any code (including moon's own 1 or 255), but its
+/// artifact proves execution made it past compilation.
+async fn compiled_artifact_exists(dir : String, target : String) -> Bool {
+  let stem = "\{dir}/\{target}/debug/build/single/single"
+  let candidates = match target {
+    "js" => ["\{stem}.js"]
+    "wasm" | "wasm-gc" => ["\{stem}.wasm"]
+    // LLVM's executable suffix is platform-dependent.
+    "llvm" => [stem, "\{stem}.exe"]
+    _ => []
+  }
+  for candidate in candidates {
+    if @fs.exists(candidate) {
+      return true
+    }
+  }
+  false
+}
+
+///|
+/// Render one JSON diagnostic back into compact human-readable compiler
+/// output. The structured protocol is for classification; users should still
+/// see a source location, message, and the compiler's context excerpt rather
+/// than a serialized object.
+fn render_run_diagnostic(
+  path : String,
+  loc : String,
+  message : String,
+  context : String,
+  diagnostic_bases : Array[String],
+) -> String {
+  let source_path = rewrite_temp_paths(path, diagnostic_bases)
+  let where_ = if source_path.is_blank() && (loc.is_blank() || loc == "0:0-0:0") {
+    ""
+  } else if source_path.is_blank() {
+    loc
+  } else if loc.is_blank() {
+    source_path
+  } else {
+    "\{source_path}:\{loc}"
+  }
+  let summary = if where_.is_blank() {
+    message
+  } else if message.is_blank() {
+    where_
+  } else {
+    "\{where_}: \{message}"
+  }
+  if context.is_blank() {
+    summary
+  } else {
+    "\{summary}\n\{context.trim_end()}"
+  }
+}
+
+///|
+/// Split moon's JSON-lines compiler protocol out of a completed foreground
+/// run. Lines not recognized as diagnostics for this private snippet remain
+/// byte-for-byte program/runner output (modulo the existing line join), so the
+/// parser fails toward runtime rather than claiming code never ran.
+fn parse_run_output(
+  output : String,
+  diagnostic_bases : Array[String],
+) -> ParsedRunOutput {
+  let compiler_lines : Array[String] = []
+  let program_lines : Array[String] = []
+  let mut has_error_diagnostic = false
+  for raw in output.split("\n") {
+    let diagnostic = if raw.contains("\"$message_type\"") &&
+      raw.contains("\"level\"") {
+      @json.parse(raw.to_owned()) catch {
+        _ => Json::null()
+      }
+    } else {
+      Json::null()
+    }
+    match diagnostic {
+      {
+        "$message_type": String("diagnostic"),
+        "level": String(level),
+        "error_code": Number(_, ..),
+        "path": String(path),
+        "loc"? : Some(String(loc))
+        | (_ with loc = ""),
+        "message"? : Some(String(message))
+        | (_ with message = ""),
+        "context"? : Some(String(context))
+        | (_ with context = ""),
+        ..
+      } if is_snippet_diagnostic_path(path, diagnostic_bases) ||
+        (path.is_blank() && level == "warning") => {
+        compiler_lines.push(
+          render_run_diagnostic(path, loc, message, context, diagnostic_bases),
+        )
+        if level == "error" {
+          has_error_diagnostic = true
+        }
+      }
+      _ => program_lines.push(raw.to_owned())
+    }
+  }
+  {
+    compiler_output: compiler_lines.join("\n"),
+    program_output: program_lines.join("\n"),
+    has_error_diagnostic,
+  }
+}
+
+///|
+/// Compile a background snippet without starting it. Foreground calls can
+/// classify a completed structured diagnostic stream, but a detached call has
+/// to decide whether it may return a job id before that stream exists.
+async fn compile_snippet(
+  program : String,
+  argv : Array[String],
+  cwd : String,
+  empty_stdin : String,
+  build_log : String,
+  diagnostic_bases : Array[String],
+  timeout_ms : Int,
+) -> CompileOutcome {
+  @fs.write_file(build_log, "", create_mode=CreateOrTruncate)
+  let build_argv = [..argv]
+  build_argv.push("--build-only")
+  let result = @async.with_timeout_opt(timeout_ms, () => {
+    @process.run(
+      program,
+      build_argv,
+      cwd~,
+      inherit_env=true,
+      stdin=@process.redirect_from_file(empty_stdin),
+      stdout=@process.redirect_to_file(build_log, append=true),
+      stderr=@process.redirect_to_file(build_log, append=true),
+      no_console_window=true,
+    )
+  })
+  let output = visible_compiler_output(
+    rewrite_temp_paths(read_capped(build_log), diagnostic_bases),
+  )
+  match result {
+    Some(0) => Compiled(output)
+    Some(exit_code) => CompileFailed(exit_code~, output)
+    None => CompileTimedOut(output)
+  }
+}
+
+///|
+/// A display-ready report for the part of MBTX after compilation succeeded.
+priv struct RuntimeReport {
+  content : String
+  is_error : Bool
+  brief : String
+}
+
+///|
+/// Format the structured compile-failure branch shared by retained and direct
+/// foreground execution. Any non-diagnostic moon output belongs here too:
+/// once an error diagnostic exists the compiler did not start the program.
+fn compile_failure_report(
+  parsed : ParsedRunOutput,
+  exit_code : Int,
+  diagnostic_bases : Array[String],
+) -> RuntimeReport {
+  let output = if parsed.program_output.is_blank() {
+    parsed.compiler_output
+  } else if parsed.compiler_output.is_blank() {
+    rewrite_temp_paths(parsed.program_output, diagnostic_bases)
+  } else {
+    "\{parsed.compiler_output}\n\{rewrite_temp_paths(parsed.program_output, diagnostic_bases)}"
+  }
+  let head = "[mbtx: compile-time error; compiler exit code \{exit_code}; program was not run]"
+  {
+    content: if output.is_blank() {
+      head
+    } else {
+      "\{head}\n\{output}"
+    },
+    is_error: true,
+    brief: "mbtx (compile error)",
+  }
+}
+
+///|
+/// Keep requested compiler warnings visibly separate from the program's own
+/// stdout/stderr. Most calls have no compiler output and retain their compact
+/// historical result unchanged.
+fn phase_output(compiler_output : String, runtime_output : String) -> String {
+  if compiler_output.is_blank() {
+    runtime_output
+  } else if runtime_output.is_blank() {
+    "[mbtx: compiler output]\n\{compiler_output}"
+  } else {
+    "[mbtx: compiler output]\n\{compiler_output}\n[mbtx: runtime output]\n\{runtime_output}"
+  }
+}
+
+///|
+/// Format a completed runtime attempt. The status header and display brief
+/// both name the runtime phase, so neither the model nor the transcript has to
+/// infer it from a panic stack or compiler-like text printed by the program.
+fn runtime_report(
+  compiler_output : String,
+  runtime_output : String,
+  exit_code : Int,
+  output_limit_reached? : Bool = false,
+  saw_binary? : Bool = false,
+  sandbox_denied? : String,
+) -> RuntimeReport {
+  let output = phase_output(compiler_output, runtime_output)
+  let is_error = exit_code != 0 ||
+    sandbox_denied is Some(_) ||
+    output_limit_reached
+  let (initial_content, brief) = if output_limit_reached {
+    let head = "[mbtx: runtime stopped after exceeding the output limit; observed exit \{exit_code}]"
+    let content = if output.is_blank() { head } else { "\{head}\n\{output}" }
+    (
+      "\{content}\n[mbtx: output passed \{OutputCapBytes} bytes, so the program was STOPPED and this is only what it printed first. Redirect bulky output with `stdout=ToFile(path)` and read the file instead.]",
+      "mbtx (runtime output limit)",
+    )
+  } else if sandbox_denied is Some(_) {
+    let head = "[mbtx: runtime error; sandbox access was denied]"
+    (
+      if output.is_blank() {
+        head
+      } else {
+        "\{head}\n\{output}"
+      },
+      "mbtx (runtime sandbox denied)",
+    )
+  } else if exit_code != 0 {
+    (
+      if output.is_blank() {
+        "mbtx: runtime exited \{exit_code} with no output"
+      } else {
+        "[mbtx: runtime error; exit code \{exit_code}]\n\{output}"
+      },
+      "mbtx (runtime error, exit=\{exit_code})",
+    )
+  } else {
+    (
+      if output.is_blank() {
+        "mbtx: runtime exited 0 with no output"
+      } else {
+        output
+      },
+      "mbtx (exit=0)",
+    )
+  }
+  let mut content = initial_content
+  if saw_binary {
+    content = "\{content}\n[mbtx: the program emitted non-UTF-8 bytes; the text above is a lossy rendering.]"
+  }
+  if sandbox_denied is Some(guidance) {
+    content = "\{content}\n\n\{guidance}"
+  }
+  { content, is_error, brief, }
+}
+
+///|
+/// Format a single `moon run` that did not reach a phase-bearing completion.
+/// Without a completed diagnostic stream it may still be compiling or it may
+/// be inside the program, so the timeout is deliberately not mislabeled as
+/// either phase.
+fn execution_timeout_report(
+  partial_output : String,
+  timeout_ms : Int,
+  sandbox_denied? : String,
+) -> RuntimeReport {
+  let head = "mbtx: compile/run did not finish within \{timeout_ms / 1000}s and was cancelled."
+  let mut content = if partial_output.is_blank() {
+    head
+  } else {
+    "\{head}\n[partial output before the timeout]\n\{partial_output}"
+  }
+  if sandbox_denied is Some(guidance) {
+    content = "\{content}\n\n\{guidance}"
+  }
+  { content, is_error: true, brief: "mbtx (execution timeout)", }
 }
 
 ///|
@@ -474,48 +826,46 @@ async fn execute(
     None => ("moon", moon_argv)
   }
   if background && bg_runtime is Some(runtime) {
-    // Compile in the FOREGROUND first. A detached run would otherwise report
-    // a syntax or type error only through job_output, and with the throwaway
-    // temp path instead of `source:LINE:COL` — the two things that make a
-    // compile error readable. `--build-only` is the single-file equivalent of
-    // a check: `moon check`/`moon build` do not accept a `.mbtx` script (the
-    // first reports "no work to do", the second demands a Moon project).
-    // TODO(upstream): teach `moon check` to accept a `.mbtx` script, and use
-    // it here — building is more work than this preflight needs.
-    let build_argv = [..argv]
-    build_argv.push("--build-only")
+    // A detached call has no result stream to inspect before returning, so it
+    // retains the build-only boundary. This is the uncommon path where the
+    // small extra invocation buys an important contract: a returned job id
+    // always names a program that compiled.
     let build_log = "\{dir}/build.log"
-    @fs.write_file(build_log, "", create_mode=CreateOrTruncate)
-    // Bounded like every other run here: a first build downloads and compiles
-    // dependencies, and a wedged fetch would otherwise hold the turn open —
-    // exactly what asking for a background job was meant to avoid.
-    let build_exit = @async.with_timeout_opt(run_timeout_ms, () => {
-      @process.run(
+    let compiler_output = match
+      compile_snippet(
         prog,
-        build_argv,
-        cwd=run_cwd.unwrap_or("."),
-        inherit_env=true,
-        stdin=@process.redirect_from_file(empty_stdin),
-        stdout=@process.redirect_to_file(build_log, append=true),
-        stderr=@process.redirect_to_file(build_log, append=true),
-        no_console_window=true,
-      )
-    })
-    guard build_exit is Some(build_exit) else {
-      let text = rewrite_temp_paths(read_capped(build_log), [real, dir])
-      return @agent_tool.ToolAction::respond(
-        "mbtx: the build did not finish within \{run_timeout_ms / 1000}s, so no background job was started.\n\{text}",
-        is_error=true,
-        brief="mbtx (build timeout)",
-      )
-    }
-    if build_exit != 0 {
-      let text = rewrite_temp_paths(read_capped(build_log), [real, dir])
-      return @agent_tool.ToolAction::respond(
-        "[mbtx: the program did not compile, so no background job was started]\n\{text}",
-        is_error=true,
-        brief="mbtx (build failed)",
-      )
+        argv,
+        run_cwd.unwrap_or("."),
+        empty_stdin,
+        build_log,
+        [real, dir],
+        run_timeout_ms,
+      ) {
+      Compiled(output) => output
+      CompileFailed(exit_code~, output) => {
+        let head = "[mbtx: compile-time error; compiler exit code \{exit_code}; program was not run]"
+        return @agent_tool.ToolAction::respond(
+          if output.is_blank() {
+            head
+          } else {
+            "\{head}\n\{output}"
+          },
+          is_error=true,
+          brief="mbtx (compile error)",
+        )
+      }
+      CompileTimedOut(output) => {
+        let head = "mbtx: compilation did not finish within \{run_timeout_ms / 1000}s, so the program was not run."
+        return @agent_tool.ToolAction::respond(
+          if output.is_blank() {
+            head
+          } else {
+            "\{head}\n\{output}"
+          },
+          is_error=true,
+          brief="mbtx (compile timeout)",
+        )
+      }
     }
     let id = runtime.start(
       program=prog,
@@ -529,11 +879,22 @@ async fn execute(
       stdin=@process.redirect_from_file(empty_stdin),
     )
     job_owns_dir.val = true
+    let compiler_note = if compiler_output.is_blank() {
+      ""
+    } else {
+      "\n\n[mbtx: compiler output]\n\{compiler_output}"
+    }
     return @agent_tool.ToolAction::respond(
-      "started background job \{id} (the program compiled). Read its output with job_output (job_id=\"\{id}\") and stop it with job_stop (job_id=\"\{id}\").",
+      "started background job \{id} (the program compiled). Read its output with job_output (job_id=\"\{id}\") and stop it with job_stop (job_id=\"\{id}\").\{compiler_note}",
       brief="mbtx → bg \{id}",
     )
   }
+  // Foreground calls use moon's machine-readable compiler protocol in the SAME
+  // invocation that runs the program. Appending here (after a possible
+  // sandbox-exec wrapper was prepared) leaves explicit background runs on the
+  // human output contract used by `job_output`.
+  let foreground_argv = [..argv]
+  foreground_argv.push("--output-json")
   // With a job runtime wired the foreground run happens ON it, so the
   // deadline can DETACH the still-running program as a background job rather
   // than killing it: a long `moon test` that outlives the bound is then still
@@ -543,7 +904,7 @@ async fn execute(
   if bg_runtime is Some(runtime) {
     let exec = runtime.spawn_foreground_retained(
       prog,
-      argv,
+      foreground_argv,
       run_cwd,
       OutputCapBytes,
       // Same EOF-on-stdin contract as every other path here: never hand the
@@ -593,41 +954,38 @@ async fn execute(
       escalated~,
     )
     exec.discard()
-    let text = rewrite_temp_paths(raw, [real, dir])
-    let body = if text.is_blank() {
-      "mbtx: program exited \{exit_code} with no output"
-    } else if exit_code != 0 {
-      "[mbtx: exited \{exit_code}]\n\{text}"
-    } else {
-      text
+    let parsed = parse_run_output(raw, [real, dir])
+    if exit_code != 0 &&
+      (
+        parsed.has_error_diagnostic ||
+        !compiled_artifact_exists(dir, input.target)
+      ) {
+      let report = compile_failure_report(parsed, exit_code, [real, dir])
+      return @agent_tool.ToolAction::respond(
+        report.content,
+        is_error=report.is_error,
+        brief=report.brief,
+      )
     }
-    let body = if output_limit_reached {
-      "\{body}\n[mbtx: output passed \{OutputCapBytes} bytes, so the program was STOPPED and this is only what it printed first. Redirect bulky output with `stdout=ToFile(path)` and read the file instead.]"
-    } else {
-      body
-    }
-    let body = if saw_binary {
-      "\{body}\n[mbtx: the program emitted non-UTF-8 bytes; the text above is a lossy rendering.]"
-    } else {
-      body
-    }
-    let body = if sandbox_denied is Some(guidance) {
-      "\{body}\n\n\{guidance}"
-    } else {
-      body
-    }
+    let text = rewrite_temp_paths(parsed.program_output, [real, dir])
+    let report = runtime_report(
+      parsed.compiler_output,
+      text,
+      exit_code,
+      output_limit_reached~,
+      saw_binary~,
+      sandbox_denied?,
+    )
     return @agent_tool.ToolAction::respond(
-      body,
-      is_error=exit_code != 0 ||
-        sandbox_denied is Some(_) ||
-        output_limit_reached,
-      brief="mbtx (exit=\{exit_code})",
+      report.content,
+      is_error=report.is_error,
+      brief=report.brief,
     )
   }
   let result = @async.with_timeout_opt(run_timeout_ms, () => {
     let exit_code = @process.run(
       prog,
-      argv,
+      foreground_argv,
       cwd=run_cwd.unwrap_or("."),
       inherit_env=true,
       stdin=@process.redirect_from_file(empty_stdin),
@@ -653,26 +1011,30 @@ async fn execute(
     Some((exit_code, raw)) => {
       // Rewrite the throwaway temp path to `source` so the model reads
       // `source:LINE:COL` about its own input, not a random temp path.
-      let text = rewrite_temp_paths(raw, [real, dir])
-      // PREPEND the exit status so it survives the agent loop's outer 60k
-      // result clamp (which cuts the tail); the output cap is below 60k so
-      // both the status line and the body are retained.
-      let body = if text.is_blank() {
-        "mbtx: program exited \{exit_code} with no output"
-      } else if exit_code != 0 {
-        "[mbtx: exited \{exit_code}]\n\{text}"
-      } else {
-        text
+      let parsed = parse_run_output(raw, [real, dir])
+      if exit_code != 0 &&
+        (
+          parsed.has_error_diagnostic ||
+          !compiled_artifact_exists(dir, input.target)
+        ) {
+        let report = compile_failure_report(parsed, exit_code, [real, dir])
+        return @agent_tool.ToolAction::respond(
+          report.content,
+          is_error=report.is_error,
+          brief=report.brief,
+        )
       }
-      let body = if sandbox_denied is Some(guidance) {
-        "\{body}\n\n\{guidance}"
-      } else {
-        body
-      }
+      let text = rewrite_temp_paths(parsed.program_output, [real, dir])
+      let report = runtime_report(
+        parsed.compiler_output,
+        text,
+        exit_code,
+        sandbox_denied?,
+      )
       @agent_tool.ToolAction::respond(
-        body,
-        is_error=exit_code != 0 || sandbox_denied is Some(_),
-        brief="mbtx (exit=\{exit_code})",
+        report.content,
+        is_error=report.is_error,
+        brief=report.brief,
       )
     }
     None => {
@@ -681,21 +1043,15 @@ async fn execute(
       // instead of discarding it behind a generic timeout message. The status
       // line stays first so it survives the outer result clamp.
       let partial = rewrite_temp_paths(read_capped(log), [real, dir])
-      let head = "mbtx: timed out after \{run_timeout_ms / 1000}s and was cancelled — the program did not finish (an infinite loop, or a build that never completed)."
-      let body = if partial.is_blank() {
-        head
-      } else {
-        "\{head}\n[partial output before the timeout]\n\{partial}"
-      }
-      let body = if sandbox_denied is Some(guidance) {
-        "\{body}\n\n\{guidance}"
-      } else {
-        body
-      }
+      let report = execution_timeout_report(
+        partial,
+        run_timeout_ms,
+        sandbox_denied?,
+      )
       @agent_tool.ToolAction::respond(
-        body,
-        is_error=true,
-        brief="mbtx (timeout)",
+        report.content,
+        is_error=report.is_error,
+        brief=report.brief,
       )
     }
   }

--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -45,13 +45,9 @@ fn native_escape(source : String) -> String? {
 /// Tool definition for `mbtx`: compile and run a self-contained MoonBit
 /// program and return its merged stdout/stderr and exit status.
 ///
-/// Foreground execution asks moon for JSON diagnostics and separates those
-/// compiler records from the program's ordinary output after one `moon run`.
-/// That gives compile-time and runtime failures distinct output headers and
-/// display briefs without compiling a successful snippet twice. An explicit
-/// background launch still builds first: it must reject invalid source before
-/// returning a job id, when there is not yet a completed output stream to
-/// classify.
+/// Every execution builds first, then runs from the same target cache. The
+/// explicit boundary gives compile-time and runtime failures distinct output
+/// headers and display briefs without trusting text printed by the program.
 ///
 /// The program is a `.mbtx` single-file script — it may open with an inline
 /// `import { "pkg", … }` block (comma-separated module paths) naming the
@@ -178,9 +174,9 @@ fn escalation_brief(outcome : @agent_runtime.ApprovalOutcome) -> String {
 }
 
 ///|
-/// The explicit background compiler preflight's outcome. A successful build
-/// retains any compiler output (normally only requested warnings) so the job
-/// launch response can keep it separate from later program output.
+/// The compiler preflight's outcome. A successful build retains any compiler
+/// output (normally only requested warnings) so it stays separate from later
+/// program output.
 priv enum CompileOutcome {
   Compiled(String)
   CompileFailed(exit_code~ : Int, String)
@@ -209,150 +205,9 @@ fn visible_compiler_output(output : String) -> String {
 }
 
 ///|
-/// The compiler records and program output recovered from one
-/// `moon run --output-json`. `has_error_diagnostic` is set only by an error
-/// diagnostic that names this call's private build directory. Matching that
-/// unpredictable path matters: a program remains free to print JSON (including
-/// something that resembles a moon diagnostic) without turning its own
-/// non-zero exit into a compile-time failure.
-priv struct ParsedRunOutput {
-  compiler_output : String
-  program_output : String
-  has_error_diagnostic : Bool
-}
-
-///|
-/// Whether a structured diagnostic belongs to this snippet rather than being
-/// arbitrary JSON printed by the program. `bases` contains both the lexical
-/// and canonical spelling of the private directory for symlinked temp roots.
-fn is_snippet_diagnostic_path(path : String, bases : Array[String]) -> Bool {
-  for base in bases {
-    for sep in ["/", "\\"] {
-      if path.has_prefix("\{base}\{sep}") {
-        return true
-      }
-    }
-  }
-  false
-}
-
-///|
-/// Whether this fresh target directory contains the runnable artifact moon
-/// produces only after compilation/linking succeeds. This closes the one gap
-/// in `--output-json`: front-matter/package-discovery failures and compiler
-/// crashes can exit without a diagnostic record. Conversely, a program may
-/// deliberately exit with any code (including moon's own 1 or 255), but its
-/// artifact proves execution made it past compilation.
-async fn compiled_artifact_exists(dir : String, target : String) -> Bool {
-  let stem = "\{dir}/\{target}/debug/build/single/single"
-  let candidates = match target {
-    "js" => ["\{stem}.js"]
-    "wasm" | "wasm-gc" => ["\{stem}.wasm"]
-    // LLVM's executable suffix is platform-dependent.
-    "llvm" => [stem, "\{stem}.exe"]
-    _ => []
-  }
-  for candidate in candidates {
-    if @fs.exists(candidate) {
-      return true
-    }
-  }
-  false
-}
-
-///|
-/// Render one JSON diagnostic back into compact human-readable compiler
-/// output. The structured protocol is for classification; users should still
-/// see a source location, message, and the compiler's context excerpt rather
-/// than a serialized object.
-fn render_run_diagnostic(
-  path : String,
-  loc : String,
-  message : String,
-  context : String,
-  diagnostic_bases : Array[String],
-) -> String {
-  let source_path = rewrite_temp_paths(path, diagnostic_bases)
-  let where_ = if source_path.is_blank() && (loc.is_blank() || loc == "0:0-0:0") {
-    ""
-  } else if source_path.is_blank() {
-    loc
-  } else if loc.is_blank() {
-    source_path
-  } else {
-    "\{source_path}:\{loc}"
-  }
-  let summary = if where_.is_blank() {
-    message
-  } else if message.is_blank() {
-    where_
-  } else {
-    "\{where_}: \{message}"
-  }
-  if context.is_blank() {
-    summary
-  } else {
-    "\{summary}\n\{context.trim_end()}"
-  }
-}
-
-///|
-/// Split moon's JSON-lines compiler protocol out of a completed foreground
-/// run. Lines not recognized as diagnostics for this private snippet remain
-/// byte-for-byte program/runner output (modulo the existing line join), so the
-/// parser fails toward runtime rather than claiming code never ran.
-fn parse_run_output(
-  output : String,
-  diagnostic_bases : Array[String],
-) -> ParsedRunOutput {
-  let compiler_lines : Array[String] = []
-  let program_lines : Array[String] = []
-  let mut has_error_diagnostic = false
-  for raw in output.split("\n") {
-    let diagnostic = if raw.contains("\"$message_type\"") &&
-      raw.contains("\"level\"") {
-      @json.parse(raw.to_owned()) catch {
-        _ => Json::null()
-      }
-    } else {
-      Json::null()
-    }
-    match diagnostic {
-      {
-        "$message_type": String("diagnostic"),
-        "level": String(level),
-        "error_code": Number(_, ..),
-        "path": String(path),
-        "loc"? : Some(String(loc))
-        | (_ with loc = ""),
-        "message"? : Some(String(message))
-        | (_ with message = ""),
-        "context"? : Some(String(context))
-        | (_ with context = ""),
-        ..
-      } if is_snippet_diagnostic_path(path, diagnostic_bases) ||
-        (path.is_blank() && level == "warning") => {
-        compiler_lines.push(
-          render_run_diagnostic(path, loc, message, context, diagnostic_bases),
-        )
-        if level == "error" {
-          has_error_diagnostic = true
-        }
-      }
-      _ => program_lines.push(raw.to_owned())
-    }
-  }
-  {
-    compiler_output: compiler_lines.join("\n"),
-    program_output: program_lines.join("\n"),
-    has_error_diagnostic,
-  }
-}
-
-///|
-/// Compile a background snippet without starting it. Foreground calls can
-/// classify a completed structured diagnostic stream, but a detached call has
-/// to decide whether it may return a job id before that stream exists.
+/// Compile a snippet without starting it. The following `moon run` reuses this
+/// target cache, so the second invocation establishes the lifecycle boundary
+/// without doing the compilation work twice.
 async fn compile_snippet(
   program : String,
   argv : Array[String],
@@ -388,39 +243,21 @@ async fn compile_snippet(
 }
 
 ///|
-/// A display-ready report for the part of MBTX after compilation succeeded.
-priv struct RuntimeReport {
-  content : String
-  is_error : Bool
-  brief : String
-}
-
-///|
-/// Format the structured compile-failure branch shared by retained and direct
-/// foreground execution. Any non-diagnostic moon output belongs here too:
-/// once an error diagnostic exists the compiler did not start the program.
-fn compile_failure_report(
-  parsed : ParsedRunOutput,
+/// The compile-error response shared by foreground and background calls.
+fn compile_failure_action(
+  output : String,
   exit_code : Int,
-  diagnostic_bases : Array[String],
-) -> RuntimeReport {
-  let output = if parsed.program_output.is_blank() {
-    parsed.compiler_output
-  } else if parsed.compiler_output.is_blank() {
-    rewrite_temp_paths(parsed.program_output, diagnostic_bases)
-  } else {
-    "\{parsed.compiler_output}\n\{rewrite_temp_paths(parsed.program_output, diagnostic_bases)}"
-  }
+) -> @agent_tool.ToolAction {
   let head = "[mbtx: compile-time error; compiler exit code \{exit_code}; program was not run]"
-  {
-    content: if output.is_blank() {
+  @agent_tool.ToolAction::respond(
+    if output.is_blank() {
       head
     } else {
       "\{head}\n\{output}"
     },
-    is_error: true,
-    brief: "mbtx (compile error)",
-  }
+    is_error=true,
+    brief="mbtx (compile error)",
+  )
 }
 
 ///|
@@ -441,14 +278,14 @@ fn phase_output(compiler_output : String, runtime_output : String) -> String {
 /// Format a completed runtime attempt. The status header and display brief
 /// both name the runtime phase, so neither the model nor the transcript has to
 /// infer it from a panic stack or compiler-like text printed by the program.
-fn runtime_report(
+fn runtime_action(
   compiler_output : String,
   runtime_output : String,
   exit_code : Int,
-  output_limit_reached? : Bool = false,
-  saw_binary? : Bool = false,
+  output_limit_reached~ : Bool,
+  saw_binary~ : Bool,
   sandbox_denied? : String,
-) -> RuntimeReport {
+) -> @agent_tool.ToolAction {
   let output = phase_output(compiler_output, runtime_output)
   let is_error = exit_code != 0 ||
     sandbox_denied is Some(_) ||
@@ -496,20 +333,17 @@ fn runtime_report(
   if sandbox_denied is Some(guidance) {
     content = "\{content}\n\n\{guidance}"
   }
-  { content, is_error, brief, }
+  @agent_tool.ToolAction::respond(content, is_error~, brief~)
 }
 
 ///|
-/// Format a single `moon run` that did not reach a phase-bearing completion.
-/// Without a completed diagnostic stream it may still be compiling or it may
-/// be inside the program, so the timeout is deliberately not mislabeled as
-/// either phase.
-fn execution_timeout_report(
+/// Format a run that timed out after the compiler preflight had succeeded.
+fn runtime_timeout_action(
   partial_output : String,
   timeout_ms : Int,
   sandbox_denied? : String,
-) -> RuntimeReport {
-  let head = "mbtx: compile/run did not finish within \{timeout_ms / 1000}s and was cancelled."
+) -> @agent_tool.ToolAction {
+  let head = "mbtx: runtime did not finish within \{timeout_ms / 1000}s and was cancelled."
   let mut content = if partial_output.is_blank() {
     head
   } else {
@@ -518,7 +352,11 @@ fn execution_timeout_report(
   if sandbox_denied is Some(guidance) {
     content = "\{content}\n\n\{guidance}"
   }
-  { content, is_error: true, brief: "mbtx (execution timeout)", }
+  @agent_tool.ToolAction::respond(
+    content,
+    is_error=true,
+    brief="mbtx (runtime timeout)",
+  )
 }
 
 ///|
@@ -715,6 +553,7 @@ async fn execute(
   // moon's diagnostics point at the copied source under the build dir; the
   // canonical path anchors the diagnostic path rewrite below.
   let real = @fs.realpath(dir) catch { _ => dir }
+  let diagnostic_bases = [real, dir]
   // The wasm backend is where moonrun's policy applies, so the policy file is
   // written for every run and passed alongside. `--wasm-policy` is silently
   // IGNORED on other backends, which is why `target` is not the model's choice
@@ -825,48 +664,37 @@ async fn execute(
     Some(command) => (command.program(), command.args())
     None => ("moon", moon_argv)
   }
-  if background && bg_runtime is Some(runtime) {
-    // A detached call has no result stream to inspect before returning, so it
-    // retains the build-only boundary. This is the uncommon path where the
-    // small extra invocation buys an important contract: a returned job id
-    // always names a program that compiled.
-    let build_log = "\{dir}/build.log"
-    let compiler_output = match
-      compile_snippet(
-        prog,
-        argv,
-        run_cwd.unwrap_or("."),
-        empty_stdin,
-        build_log,
-        [real, dir],
-        run_timeout_ms,
-      ) {
-      Compiled(output) => output
-      CompileFailed(exit_code~, output) => {
-        let head = "[mbtx: compile-time error; compiler exit code \{exit_code}; program was not run]"
-        return @agent_tool.ToolAction::respond(
-          if output.is_blank() {
-            head
-          } else {
-            "\{head}\n\{output}"
-          },
-          is_error=true,
-          brief="mbtx (compile error)",
-        )
-      }
-      CompileTimedOut(output) => {
-        let head = "mbtx: compilation did not finish within \{run_timeout_ms / 1000}s, so the program was not run."
-        return @agent_tool.ToolAction::respond(
-          if output.is_blank() {
-            head
-          } else {
-            "\{head}\n\{output}"
-          },
-          is_error=true,
-          brief="mbtx (compile timeout)",
-        )
-      }
+  // Establish the lifecycle boundary before any program is started. The run
+  // below shares this target directory and therefore reuses the completed
+  // build instead of compiling the snippet twice.
+  let build_log = "\{dir}/build.log"
+  let compiler_output = match
+    compile_snippet(
+      prog,
+      argv,
+      run_cwd.unwrap_or("."),
+      empty_stdin,
+      build_log,
+      diagnostic_bases,
+      run_timeout_ms,
+    ) {
+    Compiled(output) => output
+    CompileFailed(exit_code~, output) =>
+      return compile_failure_action(output, exit_code)
+    CompileTimedOut(output) => {
+      let head = "mbtx: compilation did not finish within \{run_timeout_ms / 1000}s, so the program was not run."
+      return @agent_tool.ToolAction::respond(
+        if output.is_blank() {
+          head
+        } else {
+          "\{head}\n\{output}"
+        },
+        is_error=true,
+        brief="mbtx (compile timeout)",
+      )
     }
+  }
+  if background && bg_runtime is Some(runtime) {
     let id = runtime.start(
       program=prog,
       args=argv,
@@ -889,12 +717,6 @@ async fn execute(
       brief="mbtx → bg \{id}",
     )
   }
-  // Foreground calls use moon's machine-readable compiler protocol in the SAME
-  // invocation that runs the program. Appending here (after a possible
-  // sandbox-exec wrapper was prepared) leaves explicit background runs on the
-  // human output contract used by `job_output`.
-  let foreground_argv = [..argv]
-  foreground_argv.push("--output-json")
   // With a job runtime wired the foreground run happens ON it, so the
   // deadline can DETACH the still-running program as a background job rather
   // than killing it: a long `moon test` that outlives the bound is then still
@@ -904,7 +726,7 @@ async fn execute(
   if bg_runtime is Some(runtime) {
     let exec = runtime.spawn_foreground_retained(
       prog,
-      foreground_argv,
+      argv,
       run_cwd,
       OutputCapBytes,
       // Same EOF-on-stdin contract as every other path here: never hand the
@@ -954,38 +776,19 @@ async fn execute(
       escalated~,
     )
     exec.discard()
-    let parsed = parse_run_output(raw, [real, dir])
-    if exit_code != 0 &&
-      (
-        parsed.has_error_diagnostic ||
-        !compiled_artifact_exists(dir, input.target)
-      ) {
-      let report = compile_failure_report(parsed, exit_code, [real, dir])
-      return @agent_tool.ToolAction::respond(
-        report.content,
-        is_error=report.is_error,
-        brief=report.brief,
-      )
-    }
-    let text = rewrite_temp_paths(parsed.program_output, [real, dir])
-    let report = runtime_report(
-      parsed.compiler_output,
-      text,
+    return runtime_action(
+      compiler_output,
+      rewrite_temp_paths(raw, diagnostic_bases),
       exit_code,
       output_limit_reached~,
       saw_binary~,
       sandbox_denied?,
     )
-    return @agent_tool.ToolAction::respond(
-      report.content,
-      is_error=report.is_error,
-      brief=report.brief,
-    )
   }
   let result = @async.with_timeout_opt(run_timeout_ms, () => {
     let exit_code = @process.run(
       prog,
-      foreground_argv,
+      argv,
       cwd=run_cwd.unwrap_or("."),
       inherit_env=true,
       stdin=@process.redirect_from_file(empty_stdin),
@@ -1008,51 +811,24 @@ async fn execute(
     escalated~,
   )
   let action = match result {
-    Some((exit_code, raw)) => {
+    Some((exit_code, raw)) =>
       // Rewrite the throwaway temp path to `source` so the model reads
       // `source:LINE:COL` about its own input, not a random temp path.
-      let parsed = parse_run_output(raw, [real, dir])
-      if exit_code != 0 &&
-        (
-          parsed.has_error_diagnostic ||
-          !compiled_artifact_exists(dir, input.target)
-        ) {
-        let report = compile_failure_report(parsed, exit_code, [real, dir])
-        return @agent_tool.ToolAction::respond(
-          report.content,
-          is_error=report.is_error,
-          brief=report.brief,
-        )
-      }
-      let text = rewrite_temp_paths(parsed.program_output, [real, dir])
-      let report = runtime_report(
-        parsed.compiler_output,
-        text,
+      runtime_action(
+        compiler_output,
+        rewrite_temp_paths(raw, diagnostic_bases),
         exit_code,
+        output_limit_reached=false,
+        saw_binary=false,
         sandbox_denied?,
       )
-      @agent_tool.ToolAction::respond(
-        report.content,
-        is_error=report.is_error,
-        brief=report.brief,
-      )
-    }
     None => {
       // The snippet may have printed useful output before it hung; the log is
       // still on disk (cleanup runs below), so surface the captured prefix
       // instead of discarding it behind a generic timeout message. The status
       // line stays first so it survives the outer result clamp.
-      let partial = rewrite_temp_paths(read_capped(log), [real, dir])
-      let report = execution_timeout_report(
-        partial,
-        run_timeout_ms,
-        sandbox_denied?,
-      )
-      @agent_tool.ToolAction::respond(
-        report.content,
-        is_error=report.is_error,
-        brief=report.brief,
-      )
+      let partial = rewrite_temp_paths(read_capped(log), diagnostic_bases)
+      runtime_timeout_action(partial, run_timeout_ms, sandbox_denied?)
     }
   }
   action

--- a/agent_tool/mbtx/mbtx_test.mbt
+++ b/agent_tool/mbtx/mbtx_test.mbt
@@ -915,42 +915,73 @@ async test "a non-zero exit shows the exit code in the content, not just the bri
 }
 
 ///|
-/// `--output-json` shares stdout with the program. Classification therefore
-/// accepts only diagnostic records naming this call's unpredictable private
-/// directory; compiler-looking JSON printed by user code remains runtime
-/// output and cannot claim the program was never started.
-async test "compiler-looking program output remains a runtime error" {
+/// Program output is never parsed as compiler protocol. Both warning- and
+/// error-shaped JSON remain byte-visible runtime output, and even exit 255
+/// (also used by moon) remains a runtime failure after the successful preflight.
+async test "compiler-looking program output remains runtime" {
   let out = run(
     (
+      #|import { "moonbitlang/x/sys" }
+      #|
       #|fn main {
-      #|  println("{\"$message_type\":\"diagnostic\",\"level\":\"error\",\"error_code\":4014,\"path\":\"source\",\"loc\":\"1:1-1:2\",\"message\":\"fake compiler error\"}")
-      #|  panic()
+      #|  println("{\"$message_type\":\"diagnostic\",\"level\":\"warning\",\"message\":\"fake compiler warning\"}")
+      #|  println("{\"$message_type\":\"diagnostic\",\"level\":\"error\",\"message\":\"fake compiler error\"}")
+      #|  @sys.exit(255)
       #|}
     ),
   )
   assert_true(out.is_error)
   guard out.brief is Some(brief) else { fail("expected a runtime brief") }
   assert_true(brief.has_prefix("mbtx (runtime error,"))
+  assert_true(out.content.contains("fake compiler warning"))
   assert_true(out.content.contains("fake compiler error"))
+  assert_true(out.content.contains("\"$message_type\":\"diagnostic\""))
+  assert_true(out.content.contains("exit code 255"))
   assert_false(out.content.contains("program was not run"))
 }
 
 ///|
-/// Moon itself also uses 255 for some pre-runtime failures, so status codes
-/// cannot classify the phase. A built artifact proves this 255 came from the
-/// program and keeps the result on the runtime path.
-async test "a program exit 255 remains a runtime error" {
-  let out = run(
-    (
-      #|import { "moonbitlang/x/sys" }
+/// The build result is recorded before execution, so even a program that
+/// removes its own JS artifact cannot retroactively turn its exit into a
+/// compile failure.
+async test "removing the runnable artifact remains a runtime failure" {
+  let out = run_in(".", {
+    "target": "js",
+    "source": (
+      #|import { "moonbitlang/core/env", "moonbitlang/x/fs", "moonbitlang/x/sys" }
       #|
-      #|fn main { @sys.exit(255) }
+      #|fn main raise {
+      #|  let args = @env.args()
+      #|  @fs.remove_file(args[args.length() - 1])
+      #|  @sys.exit(23)
+      #|}
     ),
-  )
+  })
   assert_true(out.is_error)
-  guard out.brief is Some(brief) else { fail("expected a runtime brief") }
-  assert_true(brief.has_prefix("mbtx (runtime error,"))
-  assert_true(out.content.contains("runtime exited 255"))
+  assert_eq(out.brief, Some("mbtx (runtime error, exit=23)"))
+  assert_true(out.content.contains("runtime exited 23"))
+  assert_false(out.content.contains("program was not run"))
+}
+
+///|
+/// Exercise the two non-default targets available on every supported
+/// toolchain. A successful build preflight makes their later nonzero status a
+/// runtime failure without any backend-specific artifact guessing.
+async test "nonzero exits remain runtime on wasm-gc and js" {
+  @vfs.with_tmpdir(prefix="mbtx-runtime-targets-", ws => {
+    for target in ["wasm-gc", "js"] {
+      let out = run_in(ws, {
+        "source": "fn main { println(\"before\"); panic() }",
+        "target": target,
+      })
+      assert_true(out.is_error)
+      guard out.brief is Some(brief) else {
+        fail("expected a runtime brief for \{target}")
+      }
+      assert_true(brief.has_prefix("mbtx (runtime error,"))
+      assert_false(out.content.contains("program was not run"))
+    }
+  })
 }
 
 ///|

--- a/agent_tool/mbtx/mbtx_test.mbt
+++ b/agent_tool/mbtx/mbtx_test.mbt
@@ -31,9 +31,33 @@ async test "runs a pure-core program and returns its output" {
 async test "surfaces a compile error via moon's own diagnostics" {
   let out = run("fn main { let _x : Int = \"nope\" }")
   assert_true(out.is_error)
+  assert_eq(out.brief, Some("mbtx (compile error)"))
+  assert_true(out.content.contains("compile-time error"))
+  assert_true(out.content.contains("program was not run"))
+  // Classification uses JSON internally, but the model still gets readable
+  // source diagnostics rather than moon's wire representation.
+  assert_false(out.content.contains("\"$message_type\""))
   assert_true(
     out.content.to_lower().contains("type") || out.content.contains("String"),
   )
+}
+
+///|
+/// Some failures happen in moon's `.mbtx` package discovery before moonc can
+/// emit a structured diagnostic. The absent runnable artifact still proves the
+/// program never started, so these must not fall through to the runtime badge.
+async test "a package-discovery failure remains a compile-time error" {
+  let out = run(
+    (
+      #|import { "moonbitlang/core/definitely_not_a_package" }
+      #|
+      #|fn main {  }
+    ),
+  )
+  assert_true(out.is_error)
+  assert_eq(out.brief, Some("mbtx (compile error)"))
+  assert_true(out.content.contains("program was not run"))
+  assert_true(out.content.contains("could not be resolved"))
 }
 
 ///|
@@ -651,6 +675,7 @@ async test "warnings are suppressed by default and shown with warning=on" {
     assert_false(loud.is_error)
     assert_true(loud.content.contains("Warning"))
     assert_true(loud.content.contains("Unused variable"))
+    assert_false(loud.content.contains("\"$message_type\""))
     // warning diagnostics get the same source:LINE:COL rewrite as errors
     assert_true(loud.content.contains("source:"))
   })
@@ -883,7 +908,49 @@ async test "a non-zero exit shows the exit code in the content, not just the bri
   let out = run("fn main { println(\"before\"); panic() }")
   assert_true(out.is_error)
   assert_true(out.content.contains("before"))
-  assert_true(out.content.contains("exited"))
+  assert_true(out.content.contains("runtime error"))
+  assert_true(out.content.contains("exit code"))
+  guard out.brief is Some(brief) else { fail("expected a runtime brief") }
+  assert_true(brief.has_prefix("mbtx (runtime error,"))
+}
+
+///|
+/// `--output-json` shares stdout with the program. Classification therefore
+/// accepts only diagnostic records naming this call's unpredictable private
+/// directory; compiler-looking JSON printed by user code remains runtime
+/// output and cannot claim the program was never started.
+async test "compiler-looking program output remains a runtime error" {
+  let out = run(
+    (
+      #|fn main {
+      #|  println("{\"$message_type\":\"diagnostic\",\"level\":\"error\",\"error_code\":4014,\"path\":\"source\",\"loc\":\"1:1-1:2\",\"message\":\"fake compiler error\"}")
+      #|  panic()
+      #|}
+    ),
+  )
+  assert_true(out.is_error)
+  guard out.brief is Some(brief) else { fail("expected a runtime brief") }
+  assert_true(brief.has_prefix("mbtx (runtime error,"))
+  assert_true(out.content.contains("fake compiler error"))
+  assert_false(out.content.contains("program was not run"))
+}
+
+///|
+/// Moon itself also uses 255 for some pre-runtime failures, so status codes
+/// cannot classify the phase. A built artifact proves this 255 came from the
+/// program and keeps the result on the runtime path.
+async test "a program exit 255 remains a runtime error" {
+  let out = run(
+    (
+      #|import { "moonbitlang/x/sys" }
+      #|
+      #|fn main { @sys.exit(255) }
+    ),
+  )
+  assert_true(out.is_error)
+  guard out.brief is Some(brief) else { fail("expected a runtime brief") }
+  assert_true(brief.has_prefix("mbtx (runtime error,"))
+  assert_true(out.content.contains("runtime exited 255"))
 }
 
 ///|

--- a/desktop/frontend/transcript/component/mbtx.mbt
+++ b/desktop/frontend/transcript/component/mbtx.mbt
@@ -11,9 +11,9 @@
 // only what it can state plainly — an argument it cannot chip (a nested value,
 // which this tool's schema has none of) is left to the original.
 //
-// Unlike the `plan` card this is not gated on the result: a snippet that
-// compiled and then failed is exactly when its source matters, and for this
-// tool `is_error` means the run failed, not that the arguments were refused.
+// Unlike the `plan` card this is not gated on the result: source matters most
+// when compilation or execution failed, and for this tool `is_error` normally
+// describes that program lifecycle rather than refused arguments.
 
 ///|
 /// A recorded `mbtx` call, decoded for display.
@@ -22,6 +22,74 @@ priv struct MbtxCall {
   source : String
   /// The call's other scalar arguments, as `key: value` chip text.
   chips : Array[String]
+}
+
+///|
+/// The display treatment for a phase-aware MBTX failure. The tool's `brief`
+/// is display-only metadata persisted with the result, so it is the stable
+/// place to carry this distinction without scraping compiler prose or a panic
+/// stack. Legacy background-build briefs are recognized too, so an existing
+/// transcript gets the compile-time treatment after an app upgrade.
+priv struct MbtxResultPresentation {
+  summary : String
+  output_label : String
+  phase_label : String
+  phase_class : String
+  output_class : String
+}
+
+///|
+/// Read the phase-aware MBTX result briefs introduced by structured compiler
+/// diagnostics. `None` deliberately preserves the generic treatment for older
+/// foreground `mbtx (exit=N)` results: those records never established which
+/// phase failed, and the UI must not guess.
+fn mbtx_result_presentation(brief : String?) -> MbtxResultPresentation? {
+  guard brief is Some(brief) else { return None }
+  if brief is ("mbtx (compile error)" | "mbtx (build failed)") {
+    return Some({
+      summary: "Compile-time error · mbtx",
+      output_label: "Compiler diagnostics",
+      phase_label: "compile time",
+      phase_class: "compile-time",
+      output_class: "mbtx-compiler-diagnostics",
+    })
+  }
+  if brief is ("mbtx (compile timeout)" | "mbtx (build timeout)") {
+    return Some({
+      summary: "Compilation timed out · mbtx",
+      output_label: "Compiler diagnostics",
+      phase_label: "compile time",
+      phase_class: "compile-time",
+      output_class: "mbtx-compiler-diagnostics",
+    })
+  }
+  let runtime_summary = if brief.has_prefix("mbtx (runtime error,") {
+    Some("Runtime error · mbtx")
+  } else {
+    match brief {
+      "mbtx (runtime timeout)" => Some("Runtime timed out · mbtx")
+      "mbtx (runtime output limit)" => Some("Runtime stopped · mbtx")
+      "mbtx (runtime sandbox denied)" => Some("Runtime blocked · mbtx")
+      _ => None
+    }
+  }
+  runtime_summary.map(summary => {
+    summary,
+    output_label: "Runtime output",
+    phase_label: "runtime",
+    phase_class: "runtime",
+    output_class: "mbtx-runtime-output",
+  })
+}
+
+///|
+/// The literal phase badge shown beside a failed MBTX result. Its text carries
+/// the distinction without depending on the compile/runtime colors.
+fn mbtx_phase_badge(presentation : MbtxResultPresentation) -> @html.Html {
+  @html.span(
+    class="mbtx-phase-badge \{presentation.phase_class}",
+    presentation.phase_label,
+  )
 }
 
 ///|

--- a/desktop/frontend/transcript/component/mbtx_tests.mbt
+++ b/desktop/frontend/transcript/component/mbtx_tests.mbt
@@ -104,9 +104,9 @@ test "a failed mbtx row still reads as a program, not escaped JSON" {
       // source matters — the card is not gated on the result the way `plan`'s
       // is, where an error means the arguments were refused.
       is_error=true,
-      brief=Some("mbtx (exit=1)"),
+      brief=Some("mbtx (runtime error, exit=1)"),
     ),
-    content: "boom",
+    content: "[mbtx: runtime error; exit code 1]\nboom",
     ts: None,
     sequence: None,
   })
@@ -135,8 +135,44 @@ test "a failed mbtx row still reads as a program, not escaped JSON" {
   assert_true(markup.contains("\\n"))
   // The run's own output stays present in the result row.
   assert_true(markup.contains("boom"))
-  assert_true(markup.contains("tool-call-section-label\">Output"))
+  assert_true(markup.contains("Runtime error · mbtx"))
+  assert_true(markup.contains("mbtx-phase-badge runtime"))
+  assert_true(markup.contains(">runtime</span>"))
+  assert_true(markup.contains("tool-call-section-label\">Runtime output"))
+  assert_true(markup.contains("mbtx-runtime-output"))
   assert_true(markup.contains("class=\"tool-result error\""))
+}
+
+///|
+/// A compile failure gets its own phase, label, and diagnostics treatment; it
+/// must never be dressed as output from a program that did not start.
+#warnings("-alert_unstable")
+test "an mbtx compile error is visualized as compiler diagnostics" {
+  let arguments =
+    #|{"source":"fn main {\n  let x : Int = \"nope\"\n}"}
+  let rendered = tool_call_view({
+    kind: Tool(
+      call_id="c-compile",
+      name="mbtx",
+      arguments=Some(arguments),
+      has_result=true,
+      is_error=true,
+      brief=Some("mbtx (compile error)"),
+    ),
+    content: (
+      #|[mbtx: compile-time error; compiler exit code 1; program was not run]
+      #|source:2:17: Type mismatch
+    ),
+    ts: None,
+    sequence: None,
+  })
+  let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
+  assert_true(markup.contains("Compile-time error · mbtx"))
+  assert_true(markup.contains("mbtx-phase-badge compile-time"))
+  assert_true(markup.contains(">compile time</span>"))
+  assert_true(markup.contains("tool-call-section-label\">Compiler diagnostics"))
+  assert_true(markup.contains("mbtx-compiler-diagnostics"))
+  assert_false(markup.contains("tool-call-section-label\">Runtime output"))
 }
 
 ///|

--- a/desktop/frontend/transcript/component/tool_tabs.mbt
+++ b/desktop/frontend/transcript/component/tool_tabs.mbt
@@ -119,12 +119,25 @@ fn tool_arguments_tabbed_view(
 fn tool_output_tabs(
   name : String,
   arguments : String?,
+  brief : String?,
   output : String,
 ) -> Array[ToolCallTab] {
   if output.is_blank() {
     return []
   }
   match (name, arguments) {
+    ("mbtx", _) => {
+      let presentation = mbtx_result_presentation(brief)
+      let label = match presentation {
+        Some(presentation) => presentation.output_label
+        None => "Output"
+      }
+      let output_class = match presentation {
+        Some(presentation) => "tool-call-output \{presentation.output_class}"
+        None => "tool-call-output"
+      }
+      [{ label, body: @html.pre(class=output_class, truncate_output(output)), }]
+    }
     ("read", Some(arguments)) =>
       match @read_html.moonbit_output(arguments, output) {
         Some(rendered) =>

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -392,12 +392,21 @@ fn tool_result_view(
     is Tool(call_id~, name~, arguments~, has_result~, is_error~, brief~) else {
     return @html.nothing
   }
-  let label = match (arguments, brief, has_result) {
-    (None, Some(brief), _) if !brief.is_blank() => capitalize(brief)
-    (None, _, _) => capitalize(name)
-    (_, _, false) => "Tool output · \{name}"
-    _ if is_error => "Tool error · \{name}"
-    _ => "Tool result · \{name}"
+  let mbtx_presentation = if name == "mbtx" {
+    mbtx_result_presentation(brief)
+  } else {
+    None
+  }
+  let label = match mbtx_presentation {
+    Some(presentation) => presentation.summary
+    None =>
+      match (arguments, brief, has_result) {
+        (None, Some(brief), _) if !brief.is_blank() => capitalize(brief)
+        (None, _, _) => capitalize(name)
+        (_, _, false) => "Tool output · \{name}"
+        _ if is_error => "Tool error · \{name}"
+        _ => "Tool result · \{name}"
+      }
   }
   let error_class = if is_error { " error" } else { "" }
   let pending_class = if has_result { "" } else { " pending" }
@@ -405,6 +414,9 @@ fn tool_result_view(
     @html.span(class="tool-flow", "←"),
     @html.span(class="tool-result-text", capitalize(label)),
   ]
+  if mbtx_presentation is Some(presentation) {
+    line.push(mbtx_phase_badge(presentation))
+  }
   if is_error {
     line.push(@html.span(class="tool-call-failed", "failed"))
   }
@@ -423,7 +435,7 @@ fn tool_result_view(
   }
   if !item.content.is_blank() {
     let key = tool_call_tabs_key(call_id, item.sequence)
-    let output = tool_output_tabs(name, arguments, item.content)
+    let output = tool_output_tabs(name, arguments, brief, item.content)
     if output is [tab] {
       body.push(
         @html.div(class="tool-call-section", [

--- a/desktop/styles/transcript.css
+++ b/desktop/styles/transcript.css
@@ -920,6 +920,30 @@
   font-size: var(--font-size-xs);
 }
 
+/* MBTX crosses a real compile boundary before the program starts. Keep that
+   phase visible as text beside a failed result: color reinforces the split,
+   but never carries it alone. Compile-time failures use the diagnostic gold;
+   failures after `main` starts retain the runtime danger treatment. */
+.mbtx-phase-badge {
+  flex: 0 0 auto;
+  padding: 1px 6px;
+  border: 1px solid currentColor;
+  border-radius: var(--radius-pill);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  line-height: 1.35;
+  text-transform: uppercase;
+}
+.mbtx-phase-badge.compile-time {
+  color: var(--color-warning);
+  background: color-mix(in srgb, var(--color-warning) 9%, transparent);
+}
+.mbtx-phase-badge.runtime {
+  color: var(--color-danger);
+  background: var(--color-danger-soft);
+}
+
 /* Arguments and output grow the page instead of scrolling in place: the
    transcript stays the only scroll area, so the wheel is never trapped by a
    nested scrollbar. Long result dumps are clamped in the renderer. */
@@ -975,6 +999,20 @@
 }
 .tool-result.error .tool-call-output {
   background: var(--color-danger-soft);
+}
+/* Compiler diagnostics are not program output. Their gold edge and softer
+   diagnostic wash match the compile-time badge, while runtime output keeps
+   the danger wash and a red edge. */
+.tool-result.error .tool-call-output.mbtx-compiler-diagnostics {
+  border-left: 3px solid var(--color-warning);
+  background: color-mix(
+    in srgb,
+    var(--color-warning) 9%,
+    var(--color-bg-subtle)
+  );
+}
+.tool-result.error .tool-call-output.mbtx-runtime-output {
+  border-left: 3px solid var(--color-danger);
 }
 
 /* Alternate views of one request or one result share a compact radio-backed

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -1127,6 +1127,83 @@ fn is_blank_args(args : String) -> Bool {
 }
 
 ///|
+/// The phase-aware treatment for a failed MBTX result. The brief is durable,
+/// tool-owned display metadata, so it can carry the compile/runtime boundary
+/// without guessing from compiler prose or panic output. Older background
+/// build briefs are recognized as compile-time failures too.
+priv struct MbtxResultPresentation {
+  summary : String
+  output_label : String
+  phase_label : String
+  phase_class : String
+  card_class : String
+  output_class : String
+}
+
+///|
+/// Read the MBTX lifecycle phase from a result that explicitly recorded it.
+/// Legacy foreground `mbtx (exit=N)` briefs deliberately remain generic: they
+/// did not establish whether compilation completed, so the viewer must not
+/// invent a phase after the fact.
+fn mbtx_result_presentation(
+  result : @agent_session.ToolResult?,
+) -> MbtxResultPresentation? {
+  guard result is Some(result) &&
+    result.tool_name() == "mbtx" &&
+    result.brief() is Some(brief) else {
+    return None
+  }
+  if brief is ("mbtx (compile error)" | "mbtx (build failed)") {
+    return Some({
+      summary: "Compile-time error · mbtx",
+      output_label: "Compiler diagnostics",
+      phase_label: "compile time",
+      phase_class: "compile-time",
+      card_class: "mbtx-compile-error",
+      output_class: "mbtx-compiler-diagnostics",
+    })
+  }
+  if brief is ("mbtx (compile timeout)" | "mbtx (build timeout)") {
+    return Some({
+      summary: "Compilation timed out · mbtx",
+      output_label: "Compiler diagnostics",
+      phase_label: "compile time",
+      phase_class: "compile-time",
+      card_class: "mbtx-compile-error",
+      output_class: "mbtx-compiler-diagnostics",
+    })
+  }
+  let runtime_summary = if brief.has_prefix("mbtx (runtime error,") {
+    Some("Runtime error · mbtx")
+  } else {
+    match brief {
+      "mbtx (runtime timeout)" => Some("Runtime timed out · mbtx")
+      "mbtx (runtime output limit)" => Some("Runtime stopped · mbtx")
+      "mbtx (runtime sandbox denied)" => Some("Runtime blocked · mbtx")
+      _ => None
+    }
+  }
+  runtime_summary.map(summary => {
+    summary,
+    output_label: "Runtime output",
+    phase_label: "runtime",
+    phase_class: "runtime",
+    card_class: "mbtx-runtime-error",
+    output_class: "mbtx-runtime-output",
+  })
+}
+
+///|
+/// Literal phase text for a failed MBTX result. Color reinforces the phase,
+/// but the distinction remains readable without it.
+fn mbtx_phase_badge(presentation : MbtxResultPresentation) -> @html.Html {
+  @html.span(
+    class="mbtx-phase-badge \{presentation.phase_class}",
+    presentation.phase_label,
+  )
+}
+
+///|
 /// Tool output is noisy, so fold it behind the label by default. The summary
 /// keeps the tool name and, on failure, a red flag — both visible while the card
 /// is collapsed — so a failed tool stands out without expanding it.
@@ -1140,16 +1217,25 @@ fn tool_card(
 ) -> @html.Html {
   let is_error = result.is_error()
   let is_escalated = escalated.contains(result.tool_call_id())
-  let kind = match (is_error, is_escalated) {
+  let base_kind = match (is_error, is_escalated) {
     (false, false) => "tool"
     (true, false) => "tool error"
     (false, true) => "tool escalated"
     (true, true) => "tool error escalated"
   }
-  let label = if is_error {
-    "Tool error · \{result.tool_name()}"
-  } else {
-    "Tool result · \{result.tool_name()}"
+  let presentation = mbtx_result_presentation(Some(result))
+  let kind = match presentation {
+    Some(presentation) => "\{base_kind} \{presentation.card_class}"
+    None => base_kind
+  }
+  let label = match presentation {
+    Some(presentation) => presentation.summary
+    None =>
+      if is_error {
+        "Tool error · \{result.tool_name()}"
+      } else {
+        "Tool result · \{result.tool_name()}"
+      }
   }
   let flag = failed_flag(is_error)
   // Pair this result back to the call that produced it (same `call N` tag).
@@ -1163,6 +1249,9 @@ fn tool_card(
     None => seq_anchor(seq)
   }
   let summary = card_head(label, seq, time~, flag~, link~)
+  if presentation is Some(presentation) {
+    summary.push(mbtx_phase_badge(presentation))
+  }
   let body : Array[@html.Html] = [
     tool_result_content(Some(result), result.content()),
   ]
@@ -1962,16 +2051,25 @@ fn model_tool_card(
     Tool(id) => escalated.contains(id)
     _ => false
   }
-  let kind = match (is_error, is_escalated) {
+  let base_kind = match (is_error, is_escalated) {
     (false, false) => "tool"
     (true, false) => "tool error"
     (false, true) => "tool escalated"
     (true, true) => "tool error escalated"
   }
-  let label = match (is_error, name.is_empty()) {
-    (_, true) => "Tool result"
-    (true, false) => "Tool error · \{name}"
-    (false, false) => "Tool result · \{name}"
+  let presentation = mbtx_result_presentation(shown)
+  let kind = match presentation {
+    Some(presentation) => "\{base_kind} \{presentation.card_class}"
+    None => base_kind
+  }
+  let label = match presentation {
+    Some(presentation) => presentation.summary
+    None =>
+      match (is_error, name.is_empty()) {
+        (_, true) => "Tool result"
+        (true, false) => "Tool error · \{name}"
+        (false, false) => "Tool result · \{name}"
+      }
   }
   // The pair tag comes from the message's own id (structural), independent of
   // whether `model_shown_result` trusts the durable result for enrichment.
@@ -1987,6 +2085,9 @@ fn model_tool_card(
     None => anchor
   }
   let summary = model_card_head(label, time~, flag=failed_flag(is_error), link~)
+  if presentation is Some(presentation) {
+    summary.push(mbtx_phase_badge(presentation))
+  }
   // Chip only, no nested transcript: the model view shows what the model
   // was fed, and the child's transcript never was.
   if shown is Some(result) &&
@@ -2122,7 +2223,17 @@ fn tool_result_content(
   result : @agent_session.ToolResult?,
   content : String,
 ) -> @html.Html {
-  if result is Some(result) &&
+  if mbtx_result_presentation(result) is Some(presentation) {
+    let output = if content.is_blank() {
+      @html.span(class="empty") <| "(empty)"
+    } else {
+      @html.pre(class="content \{presentation.output_class}") <| content
+    }
+    @html.div(class="mbtx-result-output") <| [
+      @html.div(class="mbtx-output-label") <| presentation.output_label,
+      output,
+    ]
+  } else if result is Some(result) &&
     result.tool_name() == "read" &&
     result.brief() is Some(brief) &&
     @read_html.moonbit_output_for_brief(brief, content) is Some(rendered) {

--- a/viz/viz_test.mbt
+++ b/viz/viz_test.mbt
@@ -130,6 +130,42 @@ fn error_tool_session() -> @agent_session.Session {
 }
 
 ///|
+/// One failed MBTX call/result pair whose brief records the lifecycle phase.
+/// Keeping the call makes the same fixture valid for both the raw log and the
+/// model projection, which correlates the projected tool message back to its
+/// durable result for display metadata.
+fn mbtx_error_session(
+  brief : String,
+  content : String,
+) -> @agent_session.Session {
+  @agent_session.Session(SessionId("mbtx-error"), system_prompt="")
+  .append(
+    Assistant(
+      AssistantMessage("", tool_calls=[
+        ToolCall(
+          id="mbtx-1",
+          name="mbtx",
+          arguments=(
+            #|{"source":"fn main { abort(\"boom\") }","target":"js"}
+          ),
+        ),
+      ]),
+    ),
+  )
+  .append(
+    Tool(
+      ToolResult(
+        tool_call_id="mbtx-1",
+        tool_name="mbtx",
+        content~,
+        is_error=true,
+        brief~,
+      ),
+    ),
+  )
+}
+
+///|
 fn multi_step_session() -> @agent_session.Session {
   @agent_session.Session(SessionId("steps"), system_prompt="system")
   .append(User(UserMessage("start")))
@@ -499,6 +535,53 @@ test "model view recovers the error flag the projection drops" {
   )
   assert_true(model.contains("class=\"tool-flag\">🚩 failed"))
   assert_true(model.contains("Tool error · shell"))
+}
+
+///|
+test "mbtx compile errors render as compiler diagnostics in both views" {
+  let session = mbtx_error_session(
+    "mbtx (compile error)",
+    (
+      #|[mbtx: compile-time error; compiler exit code 1; program was not run]
+      #|source:1:11: Unknown identifier: abort
+    ),
+  )
+  for mode in [@viz.RawLog, ModelView] {
+    let html = render(@viz.render_session(session, mode))
+    assert_true(html.contains("card tool error mbtx-compile-error"))
+    assert_true(html.contains("Compile-time error · mbtx"))
+    assert_true(html.contains("mbtx-phase-badge compile-time"))
+    assert_true(html.contains(">compile time</span>"))
+    assert_true(html.contains("mbtx-output-label\">Compiler diagnostics"))
+    assert_true(html.contains("content mbtx-compiler-diagnostics"))
+    assert_false(html.contains("mbtx-output-label\">Runtime output"))
+  }
+}
+
+///|
+test "mbtx runtime errors render as runtime output in both views" {
+  let session = mbtx_error_session(
+    "mbtx (runtime error, exit=1)", "[mbtx: runtime error; exit code 1]\nboom",
+  )
+  for mode in [@viz.RawLog, ModelView] {
+    let html = render(@viz.render_session(session, mode))
+    assert_true(html.contains("card tool error mbtx-runtime-error"))
+    assert_true(html.contains("Runtime error · mbtx"))
+    assert_true(html.contains("mbtx-phase-badge runtime"))
+    assert_true(html.contains(">runtime</span>"))
+    assert_true(html.contains("mbtx-output-label\">Runtime output"))
+    assert_true(html.contains("content mbtx-runtime-output"))
+    assert_false(html.contains("mbtx-output-label\">Compiler diagnostics"))
+  }
+}
+
+///|
+test "legacy mbtx exit briefs stay generic instead of guessing a phase" {
+  let session = mbtx_error_session("mbtx (exit=1)", "old result")
+  let html = render(@viz.render_session(session, RawLog))
+  assert_true(html.contains("Tool error · mbtx"))
+  assert_false(html.contains("mbtx-phase-badge"))
+  assert_false(html.contains("mbtx-output-label"))
 }
 
 ///|

--- a/web/index.html
+++ b/web/index.html
@@ -399,6 +399,16 @@
     .card.assistant { border-left-color: var(--assistant); }
     .card.tool { border-left-color: var(--tool); }
     .card.tool.error { border-left-color: var(--error); background: var(--notice-error-bg); }
+    /* MBTX has a real compile boundary. Compiler diagnostics use the warning
+       palette; failures after the program starts keep the runtime/error palette. */
+    .card.tool.error.mbtx-compile-error {
+      border-left-color: var(--tool);
+      background: var(--notice-warn-bg);
+    }
+    .card.tool.error.mbtx-runtime-error {
+      border-left-color: var(--error);
+      background: var(--notice-error-bg);
+    }
     .card.runtime { border-left-color: var(--runtime); }
     /* plan checklists — shared by `plan` tool calls and plan-cadence reminders:
        icon + numbered title rows, statuses as classes, delta chips for what
@@ -639,6 +649,43 @@
     .tool-flag {
       color: var(--error); font-weight: 700; margin-right: 8px;
       text-transform: none; letter-spacing: 0;
+    }
+    .mbtx-phase-badge {
+      display: inline-block;
+      margin-left: 8px;
+      padding: 1px 7px;
+      border: 1px solid currentColor;
+      border-radius: 999px;
+      font-size: 10px;
+      font-weight: 700;
+      letter-spacing: .4px;
+      text-transform: uppercase;
+    }
+    .mbtx-phase-badge.compile-time {
+      color: var(--tool);
+      background: var(--notice-warn-bg);
+    }
+    .mbtx-phase-badge.runtime {
+      color: var(--error);
+      background: var(--notice-error-bg);
+    }
+    .mbtx-output-label {
+      margin: 2px 0 6px;
+      color: var(--muted);
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: .6px;
+      text-transform: uppercase;
+    }
+    .content.mbtx-compiler-diagnostics {
+      padding-left: 10px;
+      border-left: 3px solid var(--tool);
+      background: var(--notice-warn-bg);
+    }
+    .content.mbtx-runtime-output {
+      padding-left: 10px;
+      border-left: 3px solid var(--error);
+      background: var(--notice-error-bg);
     }
 
     /* badges */


### PR DESCRIPTION
## Summary

- classify foreground MBTX failures from structured compiler diagnostics and built artifacts while keeping a single moon run invocation
- retain the build-only compile preflight for explicit background runs so jobs are scheduled only after compilation succeeds
- present compile-time and runtime failures distinctly in both the desktop transcript and standalone HTML/viz renderer
- cover compiler diagnostics, runtime failures, compiler-like program output, exit 255, warnings, and legacy visualization behavior

## Testing

- moon test viz --target js
- just check
- just test
- just build
- just editor-test

The optional just editor-test-browser smoke could not start in this worktree because editor/node_modules/.bin/playwright is absent.