### PR TITLE
agent_tool tidy-ups: top-level respond, mbtx FFI rationale, doc-hidden to_repr

### DIFF
--- a/agent/auto_compact_test.mbt
+++ b/agent/auto_compact_test.mbt
@@ -187,7 +187,7 @@ fn probe_tools(results : Array[String]) -> @agent_tool.Tools raise {
       schema=JsonSchema({ "type": "object" }),
       execute=Sync(_args => {
         calls += 1
-        @agent_tool.ToolAction::respond(results[calls - 1])
+        @agent_tool.respond(results[calls - 1])
       }),
     ),
   ])
@@ -212,7 +212,7 @@ fn finish_and_probe_tools() -> @agent_tool.Tools raise {
       name="probe",
       description="Probe tool.",
       schema=JsonSchema({ "type": "object" }),
-      execute=Sync(_args => @agent_tool.ToolAction::respond("result-1")),
+      execute=Sync(_args => @agent_tool.respond("result-1")),
     ),
   ])
 }
@@ -483,9 +483,7 @@ async test "a non-control finish shadow is skip-closed at the ceiling" {
         name="finish",
         description="Not a completion.",
         schema=JsonSchema({ "type": "object" }),
-        execute=Sync(_args => {
-          @agent_tool.ToolAction::respond("shadow ran anyway")
-        }),
+        execute=Sync(_args => @agent_tool.respond("shadow ran anyway")),
       ),
     ])
     let session = @agent_session.Session(
@@ -627,7 +625,7 @@ async test "a pressured custom control completion is salvaged at the ceiling" {
         name="probe",
         description="Probe tool.",
         schema=JsonSchema({ "type": "object" }),
-        execute=Sync(_args => @agent_tool.ToolAction::respond("result-1")),
+        execute=Sync(_args => @agent_tool.respond("result-1")),
       ),
     ])
     let session = @agent_session.Session(
@@ -689,16 +687,14 @@ async test "a lone control verdict without a finish executes then yields" {
         name="record",
         description="Record a verdict.",
         schema=JsonSchema({ "type": "object" }),
-        execute=Sync(_args => {
-          @agent_tool.ToolAction::respond("verdict recorded")
-        }),
+        execute=Sync(_args => @agent_tool.respond("verdict recorded")),
         control=true,
       ),
       AgentToolDefinition(
         name="probe",
         description="Probe tool.",
         schema=JsonSchema({ "type": "object" }),
-        execute=Sync(_args => @agent_tool.ToolAction::respond("result-1")),
+        execute=Sync(_args => @agent_tool.respond("result-1")),
       ),
     ])
     let session = @agent_session.Session(
@@ -1123,7 +1119,7 @@ fn flood_definition(chars : Int) -> @agent_tool.AgentToolDefinition {
     name="flood",
     description="Flood tool.",
     schema=JsonSchema({ "type": "object" }),
-    execute=Sync(_args => @agent_tool.ToolAction::respond(content)),
+    execute=Sync(_args => @agent_tool.respond(content)),
   )
 }
 

--- a/agent/concurrent_tools_test.mbt
+++ b/agent/concurrent_tools_test.mbt
@@ -33,7 +33,7 @@ fn probe_tool(
       journal.push("start-\{tag}")
       @async.sleep(60)
       journal.push("end-\{tag}")
-      @agent_tool.ToolAction::respond("ok-\{tag}")
+      @agent_tool.respond("ok-\{tag}")
     }),
   )
 }

--- a/agent/goal_check_test.mbt
+++ b/agent/goal_check_test.mbt
@@ -177,7 +177,7 @@ async test "a finish tool call mid-batch closes the batch before the check" {
         schema=JsonSchema({ "type": "object" }),
         execute=Sync(_args => {
           probe_ran = true
-          @agent_tool.ToolAction::respond("probe-result")
+          @agent_tool.respond("probe-result")
         }),
       ),
     ])

--- a/agent/goal_gate_test.mbt
+++ b/agent/goal_gate_test.mbt
@@ -241,7 +241,7 @@ async test "a replacement goal cancels the pending review before launch" {
             runtime.queue_steer(
               Notice("\{@agent_session.GoalPrefix}\na brand new objective"),
             )
-            @agent_tool.ToolAction::respond("queued")
+            @agent_tool.respond("queued")
           }),
         ),
       ]),

--- a/agent/goal_reminder_test.mbt
+++ b/agent/goal_reminder_test.mbt
@@ -47,7 +47,7 @@ fn goal_probe_tools() -> @agent_tool.Tools raise {
       name="probe",
       description="Probe tool.",
       schema=JsonSchema({ "type": "object" }),
-      execute=Sync(_args => @agent_tool.ToolAction::respond("probe-result")),
+      execute=Sync(_args => @agent_tool.respond("probe-result")),
     ),
   ])
 }

--- a/agent/goal_tool_test.mbt
+++ b/agent/goal_tool_test.mbt
@@ -27,7 +27,7 @@ fn goal_tools_with_probe() -> @agent_tool.Tools raise {
       name="probe",
       description="Probe tool.",
       schema=JsonSchema({ "type": "object" }),
-      execute=Sync(_args => @agent_tool.ToolAction::respond("probe-result")),
+      execute=Sync(_args => @agent_tool.respond("probe-result")),
     ),
   ])
 }

--- a/agent/tool_batch_test.mbt
+++ b/agent/tool_batch_test.mbt
@@ -62,7 +62,7 @@ async test "agent executes each normal tool call in a response batch" {
         schema=JsonSchema({ "type": "object" }),
         execute=Sync(_args => {
           first_called = true
-          @agent_tool.ToolAction::respond("first-result")
+          @agent_tool.respond("first-result")
         }),
       ),
       AgentToolDefinition(
@@ -71,7 +71,7 @@ async test "agent executes each normal tool call in a response batch" {
         schema=JsonSchema({ "type": "object" }),
         execute=Sync(_args => {
           second_called = true
-          @agent_tool.ToolAction::respond("second-result")
+          @agent_tool.respond("second-result")
         }),
       ),
     ])
@@ -165,7 +165,7 @@ async test "max-step exhaustion preserves continued session state" {
         name="continue_test",
         description="Force the agent loop to continue.",
         schema=JsonSchema({ "type": "object" }),
-        execute=Sync(_args => @agent_tool.ToolAction::respond("continue-result")),
+        execute=Sync(_args => @agent_tool.respond("continue-result")),
       ),
     ])
     let result = @agent.run_turn_in_scope(
@@ -247,7 +247,7 @@ async test "agent failure terminal uses the latest persisted session" {
         name="ok_test",
         description="Produce a normal response after the assistant tool call.",
         schema=JsonSchema({ "type": "object" }),
-        execute=Sync(_args => @agent_tool.ToolAction::respond("ok-result")),
+        execute=Sync(_args => @agent_tool.respond("ok-result")),
       ),
     ])
     let _ = @agent.run_turn_in_scope(

--- a/agent_explore/tool.mbt
+++ b/agent_explore/tool.mbt
@@ -97,13 +97,13 @@ async fn execute(
   arguments : Json,
 ) -> @agent_tool.ToolAction {
   guard arguments is { "query": String(query), .. } && !query.is_blank() else {
-    return @agent_tool.ToolAction::respond(
+    return @agent_tool.respond(
       "error: explore requires a non-empty string `query`",
       is_error=true,
     )
   }
   guard query.length() <= max_query_chars else {
-    return @agent_tool.ToolAction::respond(
+    return @agent_tool.respond(
       "error: explore query exceeds \{max_query_chars} chars — ask one self-contained question",
       is_error=true,
     )
@@ -113,7 +113,7 @@ async fn execute(
     _ => None
   }
   guard !(hints is Some(h) && h.length() > max_hints_chars) else {
-    return @agent_tool.ToolAction::respond(
+    return @agent_tool.respond(
       "error: explore hints exceed \{max_hints_chars} chars",
       is_error=true,
     )
@@ -121,7 +121,7 @@ async fn execute(
   // Reserve BEFORE launch: the allowance gates the launch slot; a granted
   // child always runs at the full explore ceiling.
   guard budget.reserve(default_explore_max_steps) is Some(granted_steps) else {
-    return @agent_tool.ToolAction::respond(
+    return @agent_tool.respond(
       "explore budget exhausted for this turn — answer from what you already know, or read the files directly.",
       is_error=true,
       brief="explore (budget exhausted)",
@@ -164,12 +164,12 @@ async fn execute(
   // sees briefs.
   match result.value() {
     Some(report) =>
-      @agent_tool.ToolAction::respond(
+      @agent_tool.respond(
         render_report(report),
         brief="explore \{result.subrun_id()} (\{report.citations.length()} citation(s), \{result.steps_used()} step(s))",
       )
     None =>
-      @agent_tool.ToolAction::respond(
+      @agent_tool.respond(
         "explore produced no report (\{Repr(result.terminal())}) — fall back to reading directly.",
         is_error=true,
         brief="explore \{result.subrun_id()} (no report)",

--- a/agent_subrun/capture.mbt
+++ b/agent_subrun/capture.mbt
@@ -46,7 +46,7 @@ pub fn[T] capture_tool(
     execute=Sync(args => {
       match parse(args) {
         Err(problems) =>
-          @agent_tool.ToolAction::respond(
+          @agent_tool.respond(
             "\{name} rejected: \{problems.join("; ")}",
             is_error=true,
             brief=name,

--- a/agent_subrun/child_test.mbt
+++ b/agent_subrun/child_test.mbt
@@ -137,7 +137,7 @@ async fn run_answer_kind(
           name="probe",
           description="Probe tool.",
           schema=JsonSchema({ "type": "object" }),
-          execute=Sync(_args => @agent_tool.ToolAction::respond("result-1")),
+          execute=Sync(_args => @agent_tool.respond("result-1")),
         ),
       ])
     },

--- a/agent_tool/README.mbt.md
+++ b/agent_tool/README.mbt.md
@@ -95,12 +95,12 @@ step to decide what to do.
 ```moonbit check
 ///|
 test "tool action helpers" {
-  let response = @agent_tool.ToolAction::respond("ok")
+  let response = @agent_tool.respond("ok")
   guard response is Respond(output) else { fail("expected Respond") }
   assert_eq(output.content, "ok")
   assert_false(output.is_error)
 
-  let failed = @agent_tool.ToolAction::respond("bad", is_error=true)
+  let failed = @agent_tool.respond("bad", is_error=true)
   guard failed is Respond(error_output) else { fail("expected Respond") }
   assert_eq(error_output.content, "bad")
   assert_true(error_output.is_error)

--- a/agent_tool/agent_tool.mbt
+++ b/agent_tool/agent_tool.mbt
@@ -164,12 +164,23 @@ pub enum ToolAction {
 /// Builds a normal tool response action. `brief` is an optional one-line summary
 /// surfaced in the visualizer (see `ToolOutput::brief`); it never reaches the
 /// model.
-pub fn ToolAction::respond(
+pub fn respond(
   content : String,
   is_error? : Bool = false,
   brief? : String,
 ) -> ToolAction {
   Respond(ToolOutput(content, is_error~, brief?))
+}
+
+///|
+/// Deprecated method form of `respond`; call the top-level function instead.
+#deprecated("use respond instead")
+pub fn ToolAction::respond(
+  content : String,
+  is_error? : Bool = false,
+  brief? : String,
+) -> ToolAction {
+  respond(content, is_error~, brief?)
 }
 
 ///|
@@ -307,15 +318,14 @@ pub async fn execute_tool_call(
                 Some("\{call.name} \{brief_basename(path)}")
               _ => None
             }
-            ToolAction::respond(
+            respond(
               "error: \{call.name} failed: \{error}",
               is_error=true,
               brief?,
             )
           }
       }
-    None =>
-      ToolAction::respond("error: unknown tool \{call.name}", is_error=true)
+    None => respond("error: unknown tool \{call.name}", is_error=true)
   }
 }
 
@@ -344,11 +354,11 @@ test "reject invalid native tool call arguments" {
 
 ///|
 test "ToolAction helpers build structured actions" {
-  let response = ToolAction::respond("ok")
+  let response = respond("ok")
   guard response is Respond(output) else { fail("expected Respond") }
   assert_eq(output.content, "ok")
   assert_false(output.is_error)
-  let error_response = ToolAction::respond("bad", is_error=true)
+  let error_response = respond("bad", is_error=true)
   guard error_response is Respond(error_output) else {
     fail("expected error Respond")
   }
@@ -369,7 +379,7 @@ test "Tools::function_tools converts the registry to deepseek tool definitions" 
       name: "echo",
       description: "Echo the input.",
       schema: JsonSchema({ "type": "object" }),
-      execute: Sync(_args => ToolAction::respond("ok")),
+      execute: Sync(_args => respond("ok")),
       control: false,
       concurrent_safe: false,
     },
@@ -386,7 +396,7 @@ test "Tools::find returns the registered definition by name" {
       name: "echo",
       description: "Echo.",
       schema: JsonSchema({ "type": "object" }),
-      execute: Sync(_args => ToolAction::respond("ok")),
+      execute: Sync(_args => respond("ok")),
       control: false,
       concurrent_safe: false,
     },
@@ -403,7 +413,7 @@ test "Tools::Tools raises on duplicate tool names" {
       name: "echo",
       description: "First.",
       schema: JsonSchema({ "type": "object" }),
-      execute: Sync(_args => ToolAction::respond("first")),
+      execute: Sync(_args => respond("first")),
       control: false,
       concurrent_safe: false,
     },
@@ -411,7 +421,7 @@ test "Tools::Tools raises on duplicate tool names" {
       name: "echo",
       description: "Second.",
       schema: JsonSchema({ "type": "object" }),
-      execute: Sync(_args => ToolAction::respond("second")),
+      execute: Sync(_args => respond("second")),
       control: false,
       concurrent_safe: false,
     },
@@ -444,8 +454,8 @@ async test "execute_tool_call dispatches to registered executor" {
       schema: JsonSchema({ "type": "object" }),
       execute: Sync(args => {
         match args {
-          { "value": String(v), .. } => ToolAction::respond(v)
-          _ => ToolAction::respond("no value", is_error=true)
+          { "value": String(v), .. } => respond(v)
+          _ => respond("no value", is_error=true)
         }
       }),
       control: false,
@@ -465,8 +475,8 @@ async test "execute_tool_call dispatches to registered executor" {
 async fn async_echo(args : Json) -> ToolAction {
   @async.pause()
   match args {
-    { "value": String(v), .. } => ToolAction::respond(v)
-    _ => ToolAction::respond("no value", is_error=true)
+    { "value": String(v), .. } => respond(v)
+    _ => respond("no value", is_error=true)
   }
 }
 
@@ -529,7 +539,7 @@ test "Tools::function_tools preserves description and schema" {
         "type": "object",
         "properties": Json::empty_object(),
       }),
-      execute: Sync(_args => ToolAction::respond("ok")),
+      execute: Sync(_args => respond("ok")),
       control: false,
       concurrent_safe: false,
     },
@@ -556,7 +566,7 @@ test "Tools::function_tools yields one entry per definition" {
       name: "first",
       description: "First.",
       schema: JsonSchema({ "type": "object" }),
-      execute: Sync(_args => ToolAction::respond("1")),
+      execute: Sync(_args => respond("1")),
       control: false,
       concurrent_safe: false,
     },
@@ -564,7 +574,7 @@ test "Tools::function_tools yields one entry per definition" {
       name: "second",
       description: "Second.",
       schema: JsonSchema({ "type": "object" }),
-      execute: Sync(_args => ToolAction::respond("2")),
+      execute: Sync(_args => respond("2")),
       control: false,
       concurrent_safe: false,
     },
@@ -572,7 +582,7 @@ test "Tools::function_tools yields one entry per definition" {
       name: "third",
       description: "Third.",
       schema: JsonSchema({ "type": "object" }),
-      execute: Sync(_args => ToolAction::respond("3")),
+      execute: Sync(_args => respond("3")),
       control: false,
       concurrent_safe: false,
     },

--- a/agent_tool/agent_tool.mbt
+++ b/agent_tool/agent_tool.mbt
@@ -173,17 +173,6 @@ pub fn respond(
 }
 
 ///|
-/// Deprecated method form of `respond`; call the top-level function instead.
-#deprecated("use respond instead")
-pub fn ToolAction::respond(
-  content : String,
-  is_error? : Bool = false,
-  brief? : String,
-) -> ToolAction {
-  respond(content, is_error~, brief?)
-}
-
-///|
 /// Build a one-line tool brief: collapse `text` to a single line, trim it, and
 /// cap it to `limit` characters (appending `…` when cut). Iterates by character
 /// so a cap never splits a surrogate pair. Line breaks and tabs become spaces;

--- a/agent_tool/edit/edit.mbt
+++ b/agent_tool/edit/edit.mbt
@@ -134,7 +134,7 @@ async fn execute_with_workspace(
   let input = @decode.decode(arguments) catch {
     error => {
       let message = @tool_error.failure_message("\{error}")
-      return @agent_tool.ToolAction::respond(
+      return @agent_tool.respond(
         "error: edit requires \{message}",
         is_error=true,
       )
@@ -147,7 +147,7 @@ async fn execute_with_workspace(
   if !input.replace_all_preview &&
     write_scope is Some(scope) &&
     scope.deny_reason(path) is Some(reason) {
-    return @agent_tool.ToolAction::respond(
+    return @agent_tool.respond(
       "error editing \{path}: write blocked: \{reason}",
       is_error=true,
       brief="edit \{@agent_tool.brief_basename(path)}",
@@ -167,7 +167,7 @@ async fn edit_file(
   // `→ edit · edit <file> 🚩` on the folded call line.
   let fail_brief = "edit \{@agent_tool.brief_basename(path)}"
   fn err(message : String) -> @agent_tool.ToolAction {
-    @agent_tool.ToolAction::respond(
+    @agent_tool.respond(
       "error editing \{path}: \{message}",
       is_error=true,
       brief=fail_brief,
@@ -510,7 +510,7 @@ async fn preview_replace_all(
   report.write_string(
     "\nreview guidance: text matches cannot see types — for typed-code renames prefer the compiler loop (add the new name, deprecate the old, fix what moon check flags), and if this list is code-heavy or type-ambiguous, switch to it instead of applying. Preview-select-apply is for what the compiler cannot check (comments, docs, .mbt.md prose, string literals); multi_edit re-verifies the applied batch (parse gate + moon check auto-revert).\n",
   )
-  @agent_tool.ToolAction::respond(
+  @agent_tool.respond(
     report.to_string(),
     brief="edit preview \{@agent_tool.brief_basename(path)} (\{sites.length()} site(s))",
   )
@@ -654,7 +654,7 @@ async fn commit_edit(
   write_scope? : @write_scope.WriteScope,
 ) -> @agent_tool.ToolAction {
   if @manifest_error.write_error(path, new_content) is Some(message) {
-    return @agent_tool.ToolAction::respond(
+    return @agent_tool.respond(
       "error editing \{path}: \{message}",
       is_error=true,
       brief=fail_brief,
@@ -673,7 +673,7 @@ async fn commit_edit(
   // filesystem state that awaits ago may have changed (a path component
   // re-linked underneath the tool).
   if write_scope is Some(scope) && scope.deny_reason(path) is Some(reason) {
-    return @agent_tool.ToolAction::respond(
+    return @agent_tool.respond(
       "error editing \{path}: write blocked: \{reason}",
       is_error=true,
       brief=fail_brief,
@@ -690,7 +690,7 @@ async fn commit_edit(
     @agent_tool.content_digest(new_content),
   )
   let response = @auto_check.append_summary(path, summary)
-  @agent_tool.ToolAction::respond(response, brief=ok_brief)
+  @agent_tool.respond(response, brief=ok_brief)
 }
 
 ///|
@@ -765,7 +765,7 @@ async fn parse_gate_rejection(
     }
     let bound = if gate.truncated { "≥" } else { "" }
     return Some(
-      @agent_tool.ToolAction::respond(
+      @agent_tool.respond(
         edit_reject_report(path, new_content, gate, introduced~, before_count~),
         is_error=true,
         brief="edit rejected (\{bound}\{introduced} parse error(s))",

--- a/agent_tool/goal/goal.mbt
+++ b/agent_tool/goal/goal.mbt
@@ -71,10 +71,10 @@ fn execute(arguments : Json) -> @agent_tool.ToolAction {
   try @decode.decode(arguments) catch {
     error => {
       let message = @tool_error.failure_message("\{error}")
-      @agent_tool.ToolAction::respond("error: \{message}", is_error=true)
+      @agent_tool.respond("error: \{message}", is_error=true)
     }
   } noraise {
-    _ => @agent_tool.ToolAction::respond("goal status recorded")
+    _ => @agent_tool.respond("goal status recorded")
   }
 }
 

--- a/agent_tool/job_output/job_output.mbt
+++ b/agent_tool/job_output/job_output.mbt
@@ -41,13 +41,13 @@ async fn execute(
   arguments : Json,
 ) -> @agent_tool.ToolAction {
   guard arguments is { "job_id": String(job_id), .. } else {
-    return @agent_tool.ToolAction::respond(
+    return @agent_tool.respond(
       "error: job_output requires a string job_id",
       is_error=true,
     )
   }
   guard bg_runtime.snapshot(job_id) is Some(_) else {
-    return @agent_tool.ToolAction::respond(
+    return @agent_tool.respond(
       "error: no background job with id \{job_id}",
       is_error=true,
     )
@@ -62,8 +62,7 @@ async fn execute(
       let _ = bg_runtime.wait_exit(job_id, wait)
     }
     Ok(None) => ()
-    Err(message) =>
-      return @agent_tool.ToolAction::respond(message, is_error=true)
+    Err(message) => return @agent_tool.respond(message, is_error=true)
   }
   // Recent output, bounded to a window so a poll cannot flood the conversation
   // with a large job's full log. For output over the window, show the *tail*
@@ -75,7 +74,7 @@ async fn execute(
   // footer must reflect that post-read state, not a stale pre-read one — else a
   // tail could be presented as complete or with an out-of-date status.
   guard bg_runtime.snapshot(job_id) is Some(snapshot) else {
-    return @agent_tool.ToolAction::respond(
+    return @agent_tool.respond(
       "error: no background job with id \{job_id}",
       is_error=true,
     )
@@ -154,7 +153,7 @@ async fn execute(
   }
   content.write_string(footer)
   let content = content.to_string()
-  @agent_tool.ToolAction::respond(content, is_error~)
+  @agent_tool.respond(content, is_error~)
 }
 
 ///|

--- a/agent_tool/job_stop/job_stop.mbt
+++ b/agent_tool/job_stop/job_stop.mbt
@@ -24,15 +24,15 @@ async fn execute(
   arguments : Json,
 ) -> @agent_tool.ToolAction {
   guard arguments is { "job_id": String(job_id), .. } else {
-    return @agent_tool.ToolAction::respond(
+    return @agent_tool.respond(
       "error: job_stop requires a string job_id",
       is_error=true,
     )
   }
   if bg_runtime.stop(job_id) {
-    @agent_tool.ToolAction::respond("stopped background job \{job_id}")
+    @agent_tool.respond("stopped background job \{job_id}")
   } else {
-    @agent_tool.ToolAction::respond(
+    @agent_tool.respond(
       "error: no background job with id \{job_id}",
       is_error=true,
     )

--- a/agent_tool/mbtx/internal/decode/decode.mbt
+++ b/agent_tool/mbtx/internal/decode/decode.mbt
@@ -186,4 +186,9 @@ test "decode rejects non-object arguments" {
 }
 
 ///|
+/// Re-export the derived `Debug` representation as a trait extension so the
+/// method stays callable. Deliberately not promoted into a method on
+/// `MbtxInput` — the derived `Debug` impl is the real API.
+#deprecated("the derived Debug impl is the API; use @debug.repr or the trait directly")
+#doc(hidden)
 pub extend MbtxInput with Debug::{to_repr}

--- a/agent_tool/mbtx/internal/decode/pkg.generated.mbti
+++ b/agent_tool/mbtx/internal/decode/pkg.generated.mbti
@@ -19,7 +19,6 @@ pub struct MbtxInput {
   run_in_background : Bool
   escalated : Bool
 } derive(@debug.Debug)
-pub fn MbtxInput::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -24,24 +24,6 @@ const OutputCapBytes : Int = 48_000
 const WarnOffList : String = "-a+partial_match@partial_match+multiline_string_escape@multiline_string_escape+invalid_inline_wasm@invalid_inline_wasm+unannotated_ffi@unannotated_ffi"
 
 ///|
-/// Best-effort refusal of native FFI (`extern`, which can bind libc `system`
-/// and sidesteps every guard above it). Spawning processes is no longer an
-/// escape — it is what this tool is for — but FFI still is. A substring scan is
-/// NOT a real boundary; HARD containment is deferred to the planned wasm
-/// backend (safe by construction). Returns the reason to report, or None.
-fn native_escape(source : String) -> String? {
-  // Match the FFI syntax (`extern "c" fn …`), not the bare word. Scanning for
-  // `extern` alone refused a snippet whose only offence was a commit message
-  // mentioning it — the word appears in prose and string literals, the quote
-  // that follows it does not.
-  if source.contains("extern \"") {
-    Some("uses native FFI (extern), which the wasm sandbox will contain later")
-  } else {
-    None
-  }
-}
-
-///|
 /// Tool definition for `mbtx`: compile and run a self-contained MoonBit
 /// program and return its merged stdout/stderr and exit status.
 ///
@@ -191,9 +173,18 @@ async fn execute(
         is_error=true,
       )
   }
-  if native_escape(input.source) is Some(reason) {
+  // Refuse FFI (`extern`), the one construct no mbtx target runs sandboxed.
+  // The wasm family needs no scan — the compiler refuses `extern "c"` and
+  // `extern "js"` on those backends outright — but the js target's host is
+  // bare node, where `extern "js"` reaches host globals, and llvm is
+  // unsandboxed native codegen. Match the FFI syntax (`extern "c"`/`extern
+  // "js"`), not the bare word: `extern` alone appears in prose and string
+  // literals (a snippet quoting a commit message was refused once), the quote
+  // that follows it does not. A substring scan is NOT a real boundary; it is
+  // what keeps the non-wasm targets' "compute-only" promise true.
+  if input.source.contains("extern \"") {
     return @agent_tool.ToolAction::respond(
-      "mbtx refuses this program: it \{reason}. mbtx is the compute/IO surface; deeper containment arrives with the wasm backend.",
+      "mbtx refuses this program: it uses native FFI (extern), which no mbtx target can run sandboxed — the wasm family refuses to compile it, and the js/llvm targets have no policy to contain it.",
       is_error=true,
     )
   }

--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -168,7 +168,7 @@ async fn execute(
 ) -> @agent_tool.ToolAction {
   let input = @decode.decode(arguments) catch {
     error =>
-      return @agent_tool.ToolAction::respond(
+      return @agent_tool.respond(
         "error: mbtx requires \{@tool_error.failure_message("\{error}")}",
         is_error=true,
       )
@@ -183,7 +183,7 @@ async fn execute(
   // that follows it does not. A substring scan is NOT a real boundary; it is
   // what keeps the non-wasm targets' "compute-only" promise true.
   if input.source.contains("extern \"") {
-    return @agent_tool.ToolAction::respond(
+    return @agent_tool.respond(
       "mbtx refuses this program: it uses native FFI (extern), which no mbtx target can run sandboxed — the wasm family refuses to compile it, and the js/llvm targets have no policy to contain it.",
       is_error=true,
     )
@@ -194,13 +194,13 @@ async fn execute(
   let run_cwd = @workspace_path.resolve_cwd(workspace_root, input.cwd)
   if run_cwd is Some(c) {
     guard @fs.exists(c) else {
-      return @agent_tool.ToolAction::respond(
+      return @agent_tool.respond(
         "error: mbtx cwd does not exist: \{c}",
         is_error=true,
       )
     }
     guard @fs.kind(c) is Directory else {
-      return @agent_tool.ToolAction::respond(
+      return @agent_tool.respond(
         "error: mbtx cwd is not a directory: \{c}",
         is_error=true,
       )
@@ -216,7 +216,7 @@ async fn execute(
   // wraps only the process body; output is redirected to a file (not buffered in
   // memory) and read back capped, so a flood cannot exhaust memory.
   if input.run_in_background && bg_runtime is None {
-    return @agent_tool.ToolAction::respond(
+    return @agent_tool.respond(
       "error: run_in_background is not available in this context",
       is_error=true,
     )
@@ -226,7 +226,7 @@ async fn execute(
   // cannot spawn or touch files at all — so asking here would spend a person's
   // attention on a grant that changes nothing about the run.
   if input.escalated && input.target != "wasm" {
-    return @agent_tool.ToolAction::respond(
+    return @agent_tool.respond(
       "mbtx: `escalated` applies to the wasm target, which is the one the sandbox policy binds; `\{input.target}` runs no policy to lift and cannot spawn or touch files anyway. Drop `escalated`, or drop `target` to use wasm.",
       is_error=true,
     )
@@ -256,7 +256,7 @@ async fn execute(
       None => Unavailable
     }
     guard outcome is AllowedOnce else {
-      return @agent_tool.ToolAction::respond(
+      return @agent_tool.respond(
         escalation_refused(outcome),
         is_error=true,
         brief="mbtx (escalation \{escalation_brief(outcome)})",
@@ -279,7 +279,7 @@ async fn execute(
     @fs.mkdir(dir, recursive=true) catch {
       error if @async.is_being_cancelled() => raise error
       _ =>
-        return @agent_tool.ToolAction::respond(
+        return @agent_tool.respond(
           "mbtx: could not create a working directory for the background job.",
           is_error=true,
         )
@@ -294,7 +294,7 @@ async fn execute(
     @fs.mkdir(dir, recursive=true) catch {
       error if @async.is_being_cancelled() => raise error
       _ =>
-        return @agent_tool.ToolAction::respond(
+        return @agent_tool.respond(
           "mbtx: could not create a working directory in the scratch lab.",
           is_error=true,
         )
@@ -306,7 +306,7 @@ async fn execute(
       // swallowing it into an ordinary tool error.
       error if @async.is_being_cancelled() => raise error
       _ =>
-        return @agent_tool.ToolAction::respond(
+        return @agent_tool.respond(
           "mbtx: could not create a temporary working directory.",
           is_error=true,
         )
@@ -494,7 +494,7 @@ async fn execute(
     })
     guard build_exit is Some(build_exit) else {
       let text = rewrite_temp_paths(read_capped(build_log), [real, dir])
-      return @agent_tool.ToolAction::respond(
+      return @agent_tool.respond(
         "mbtx: the build did not finish within \{run_timeout_ms / 1000}s, so no background job was started.\n\{text}",
         is_error=true,
         brief="mbtx (build timeout)",
@@ -502,7 +502,7 @@ async fn execute(
     }
     if build_exit != 0 {
       let text = rewrite_temp_paths(read_capped(build_log), [real, dir])
-      return @agent_tool.ToolAction::respond(
+      return @agent_tool.respond(
         "[mbtx: the program did not compile, so no background job was started]\n\{text}",
         is_error=true,
         brief="mbtx (build failed)",
@@ -520,7 +520,7 @@ async fn execute(
       stdin=@process.redirect_from_file(empty_stdin),
     )
     job_owns_dir.val = true
-    return @agent_tool.ToolAction::respond(
+    return @agent_tool.respond(
       "started background job \{id} (the program compiled). Read its output with job_output (job_id=\"\{id}\") and stop it with job_stop (job_id=\"\{id}\").",
       brief="mbtx → bg \{id}",
     )
@@ -561,7 +561,7 @@ async fn execute(
         sandboxed_command?,
       )
       job_owns_dir.val = true
-      return @agent_tool.ToolAction::respond(
+      return @agent_tool.respond(
         "mbtx: still running after \{run_timeout_ms / 1000}s, so it moved to the background as job \{id} (nothing was lost). Read its output with job_output (job_id=\"\{id}\") and stop it with job_stop (job_id=\"\{id}\").",
         brief="mbtx → bg \{id}",
       )
@@ -607,7 +607,7 @@ async fn execute(
     } else {
       body
     }
-    return @agent_tool.ToolAction::respond(
+    return @agent_tool.respond(
       body,
       is_error=exit_code != 0 ||
         sandbox_denied is Some(_) ||
@@ -660,7 +660,7 @@ async fn execute(
       } else {
         body
       }
-      @agent_tool.ToolAction::respond(
+      @agent_tool.respond(
         body,
         is_error=exit_code != 0 || sandbox_denied is Some(_),
         brief="mbtx (exit=\{exit_code})",
@@ -683,11 +683,7 @@ async fn execute(
       } else {
         body
       }
-      @agent_tool.ToolAction::respond(
-        body,
-        is_error=true,
-        brief="mbtx (timeout)",
-      )
+      @agent_tool.respond(body, is_error=true, brief="mbtx (timeout)")
     }
   }
   action

--- a/agent_tool/multi_edit/multi_edit.mbt
+++ b/agent_tool/multi_edit/multi_edit.mbt
@@ -130,7 +130,7 @@ async fn execute_with_workspace(
 ) -> @agent_tool.ToolAction {
   let args = @decode.decode_args(arguments) catch {
     error =>
-      return @agent_tool.ToolAction::respond(
+      return @agent_tool.respond(
         "error: multi_edit requires \{@tool_error.failure_message("\{error}")}",
         is_error=true,
       )
@@ -144,7 +144,7 @@ async fn execute_with_workspace(
     }
   }
   if edits.is_empty() {
-    return @agent_tool.ToolAction::respond(
+    return @agent_tool.respond(
       "error: multi_edit requires edits and/or edits_file (no edits were provided)",
       is_error=true,
     )
@@ -173,7 +173,7 @@ async fn load_edits_file(
     error if @async.is_being_cancelled() => raise error
     error =>
       return Err(
-        @agent_tool.ToolAction::respond(
+        @agent_tool.respond(
           "error: multi_edit could not read edits file \{path}: \{error}",
           is_error=true,
           brief~,
@@ -183,7 +183,7 @@ async fn load_edits_file(
   let json = @json.parse(text) catch {
     error =>
       return Err(
-        @agent_tool.ToolAction::respond(
+        @agent_tool.respond(
           "error: multi_edit edits file \{path} is not valid JSON: \{error}",
           is_error=true,
           brief~,
@@ -193,7 +193,7 @@ async fn load_edits_file(
   let edits = @decode.decode_edits_json(json) catch {
     error =>
       return Err(
-        @agent_tool.ToolAction::respond(
+        @agent_tool.respond(
           "error: multi_edit requires \{@tool_error.failure_message("\{error}")} in edits file \{path}",
           is_error=true,
           brief~,
@@ -268,7 +268,7 @@ async fn multi_edit_files(
   // A file's edits must form one contiguous block so each file is read,
   // validated, and written exactly once.
   if check_contiguity(resolved) is Some(message) {
-    return @agent_tool.ToolAction::respond(message, is_error=true, brief~)
+    return @agent_tool.respond(message, is_error=true, brief~)
   }
   let groups = group_contiguous(resolved)
   let failures : Array[EditFailure] = []
@@ -297,11 +297,7 @@ async fn multi_edit_files(
     prepared.push({ file: group.file, path: group.path, content, plans, })
   }
   if failures.length() > 0 {
-    return @agent_tool.ToolAction::respond(
-      failure_report(failures),
-      is_error=true,
-      brief~,
-    )
+    return @agent_tool.respond(failure_report(failures), is_error=true, brief~)
   }
   // Render each file and run the write guard before touching disk, so a guarded
   // path aborts the whole batch instead of leaving earlier files written. The
@@ -340,11 +336,7 @@ async fn multi_edit_files(
     }
   }
   if failures.length() > 0 {
-    return @agent_tool.ToolAction::respond(
-      failure_report(failures),
-      is_error=true,
-      brief~,
-    )
+    return @agent_tool.respond(failure_report(failures), is_error=true, brief~)
   }
   // Pre-write syntax gate over the rendered batch (see parse_gate.mbt): if
   // any edited `.mbt` file would gain new lex/parse errors, reject the whole
@@ -360,7 +352,7 @@ async fn multi_edit_files(
     // decided on filesystem state that awaits ago may have changed.
     if write_scope is Some(scope) &&
       scope.deny_reason(write.path) is Some(reason) {
-      return @agent_tool.ToolAction::respond(
+      return @agent_tool.respond(
         "error multi_editing \{write.path}: write blocked: \{reason}; earlier files in the batch may already be written",
         is_error=true,
         brief~,
@@ -369,7 +361,7 @@ async fn multi_edit_files(
     @fs.write_file(write.path, write.new_content, create_mode=CreateOrTruncate) catch {
       error if @async.is_being_cancelled() => raise error
       error =>
-        return @agent_tool.ToolAction::respond(
+        return @agent_tool.respond(
           "error multi_editing \{write.path}: error writing file: \{error}; earlier files in the batch may already be written",
           is_error=true,
           brief~,
@@ -392,10 +384,7 @@ async fn multi_edit_files(
         write_scope?,
       )
     [] =>
-      @agent_tool.ToolAction::respond(
-        success_summary(writes),
-        brief=success_brief(writes),
-      )
+      @agent_tool.respond(success_summary(writes), brief=success_brief(writes))
   }
   // Record each file's provenance and content digest AFTER the auto-revert guard
   // above, which may have rewritten some files back to their pre-batch content —
@@ -513,7 +502,7 @@ async fn parse_gate_batch_rejection(
   let any_truncated = rejections.any(rejection => rejection.truncated)
   let bound = if any_truncated { "≥" } else { "" }
   Some(
-    @agent_tool.ToolAction::respond(
+    @agent_tool.respond(
       batch_reject_report(rejections, total~, any_truncated~),
       is_error=true,
       brief="multi_edit rejected (\{bound}\{total} parse error(s))",
@@ -580,16 +569,13 @@ async fn revert_guarded_response(
   write_scope? : @write_scope.WriteScope,
 ) -> @agent_tool.ToolAction {
   let summary = success_summary(writes)
-  let kept = @agent_tool.ToolAction::respond(
-    summary,
-    brief=success_brief(writes),
-  )
+  let kept = @agent_tool.respond(summary, brief=success_brief(writes))
   let after = count_errors_or_none(check_path)
   // Not a MoonBit project, or the check could not run: keep the batch exactly
   // as applied, just as before this guardrail existed.
   guard after is Some(after) else { return kept }
   if after.error_count <= threshold {
-    return @agent_tool.ToolAction::respond(
+    return @agent_tool.respond(
       keep_response(summary, after, threshold),
       brief=success_brief(writes),
     )
@@ -607,7 +593,7 @@ async fn revert_guarded_response(
   let introduced = after.error_count - before_count
   if introduced > threshold {
     // Real breakage. Stay reverted (the originals are already back on disk).
-    @agent_tool.ToolAction::respond(
+    @agent_tool.respond(
       revert_report(writes, after, introduced~, threshold~, restore_failures~),
       is_error=true,
       brief="multi_edit reverted (\{introduced} new error(s))",
@@ -627,7 +613,7 @@ async fn revert_guarded_response(
     if reapply_failures.length() > 0 {
       // Final contents are uncertain: these files may still hold their
       // pre-batch text.
-      @agent_tool.ToolAction::respond(
+      @agent_tool.respond(
         "error multi_editing: the batch was kept, but re-applying it did not fully succeed — these files may not hold the batch content: \{reapply_failures.join(", ")}; re-read them before further edits",
         is_error=true,
         brief="multi_edit partially re-applied",
@@ -636,13 +622,13 @@ async fn revert_guarded_response(
       // Every final write landed, so the tree holds the batch — but the
       // baseline this keep decision compared against was measured with these
       // files unrestored, so the decision itself deserves the caveat.
-      @agent_tool.ToolAction::respond(
+      @agent_tool.respond(
         keep_response(summary, after, threshold, introduced~) +
         "\nnote: the pre-batch baseline was measured with \{restore_failures.length()} file(s) unrestored (\{restore_failures.join(", ")}), so the introduced-error count may be understated",
         brief=success_brief(writes),
       )
     } else {
-      @agent_tool.ToolAction::respond(
+      @agent_tool.respond(
         keep_response(summary, after, threshold, introduced~),
         brief=success_brief(writes),
       )

--- a/agent_tool/pkg.generated.mbti
+++ b/agent_tool/pkg.generated.mbti
@@ -72,8 +72,6 @@ pub enum ToolAction {
   Control(AgentControl)
 } derive(@debug.Debug)
 pub fn ToolAction::finish(String) -> Self
-#deprecated
-pub fn ToolAction::respond(String, is_error? : Bool, brief? : String) -> Self
 pub fn ToolAction::to_repr(Self) -> @debug.Repr
 
 pub(all) enum ToolExecutor {

--- a/agent_tool/pkg.generated.mbti
+++ b/agent_tool/pkg.generated.mbti
@@ -15,6 +15,8 @@ pub fn content_digest(String) -> String
 
 pub async fn execute_tool_call(AgentToolCall, Tools) -> ToolAction
 
+pub fn respond(String, is_error? : Bool, brief? : String) -> ToolAction
+
 // Errors
 
 // Types and methods
@@ -70,6 +72,7 @@ pub enum ToolAction {
   Control(AgentControl)
 } derive(@debug.Debug)
 pub fn ToolAction::finish(String) -> Self
+#deprecated
 pub fn ToolAction::respond(String, is_error? : Bool, brief? : String) -> Self
 pub fn ToolAction::to_repr(Self) -> @debug.Repr
 

--- a/agent_tool/plan/plan.mbt
+++ b/agent_tool/plan/plan.mbt
@@ -116,7 +116,7 @@ fn execute(arguments : Json) -> @agent_tool.ToolAction {
   let input = @steps.decode(arguments) catch {
     error => {
       let message = @tool_error.failure_message("\{error}")
-      return @agent_tool.ToolAction::respond(
+      return @agent_tool.respond(
         "error: plan requires \{message}",
         is_error=true,
       )
@@ -147,10 +147,7 @@ fn is_verification_title(title : String) -> Bool {
 fn render(input : @steps.PlanInput) -> @agent_tool.ToolAction {
   let total = input.steps.length()
   if total == 0 {
-    return @agent_tool.ToolAction::respond(
-      "Plan cleared.",
-      brief="plan cleared",
-    )
+    return @agent_tool.respond("Plan cleared.", brief="plan cleared")
   }
   let completed = input.steps.count_if(step => step.status is Completed)
   // The decoder rejects plans with more than one in_progress step, so the
@@ -185,7 +182,7 @@ fn render(input : @steps.PlanInput) -> @agent_tool.ToolAction {
         "plan \{completed}/\{total}"
       }
   }
-  @agent_tool.ToolAction::respond(content, brief~)
+  @agent_tool.respond(content, brief~)
 }
 
 ///|

--- a/agent_tool/read/read.mbt
+++ b/agent_tool/read/read.mbt
@@ -71,7 +71,7 @@ async fn execute(
   let input = @decode.decode(arguments) catch {
     error => {
       let message = @tool_error.failure_message("\{error}")
-      return @agent_tool.ToolAction::respond(
+      return @agent_tool.respond(
         "error: read requires \{message}",
         is_error=true,
       )
@@ -90,7 +90,7 @@ async fn read_file(
     _ => false
   }
   if is_directory {
-    return @agent_tool.ToolAction::respond(
+    return @agent_tool.respond(
       "error reading \{path}: path is a directory; use the shell tool with `ls` or `tree` to inspect directories, then read specific files.",
       is_error=true,
       brief~,
@@ -102,7 +102,7 @@ async fn read_file(
   // containing only a newline is not empty (it has blank lines) and renders
   // normally.
   if content == "" {
-    return @agent_tool.ToolAction::respond(
+    return @agent_tool.respond(
       "<system>start_line=\{input.start_line} shown_lines=0 total_lines=0 truncated=false note=empty file</system>",
       is_error=false,
       brief~,
@@ -177,7 +177,7 @@ async fn read_file(
   // model sees `truncated=true` in the footer, so treating it as a tool error
   // would only teach the loop to retry a read that worked. The brief carries
   // the marker so a human scanning the transcript sees the cut too.
-  @agent_tool.ToolAction::respond(
+  @agent_tool.respond(
     output.to_string(),
     is_error=false,
     brief=if truncated { "\{brief} (truncated)" } else { brief },

--- a/agent_tool/remove/remove.mbt
+++ b/agent_tool/remove/remove.mbt
@@ -92,7 +92,7 @@ async fn execute_with_workspace(
   let input = @decode.decode(arguments) catch {
     error => {
       let message = @tool_error.failure_message("\{error}")
-      return @agent_tool.ToolAction::respond(
+      return @agent_tool.respond(
         "error: remove requires \{message}",
         is_error=true,
       )
@@ -102,7 +102,7 @@ async fn execute_with_workspace(
   // Containment gate for confined (worker) registries: deletion is a
   // write-class operation. Re-checked immediately before the delete.
   if write_scope is Some(scope) && scope.deny_reason(path) is Some(reason) {
-    return @agent_tool.ToolAction::respond(
+    return @agent_tool.respond(
       "error removing \{path}: write blocked: \{reason}",
       is_error=true,
       brief="remove \{@agent_tool.brief_basename(path)}",
@@ -120,7 +120,7 @@ async fn remove_file(
 ) -> @agent_tool.ToolAction {
   let fail_brief = "remove \{@agent_tool.brief_basename(path)}"
   fn err(message : String) -> @agent_tool.ToolAction {
-    @agent_tool.ToolAction::respond(
+    @agent_tool.respond(
       "error removing \{path}: \{message}",
       is_error=true,
       brief=fail_brief,
@@ -180,7 +180,7 @@ async fn remove_file(
   // the build just as an edit can.
   let summary = "ok: removed \{path} (reason: \{input.reason})"
   let content = @auto_check.append_summary(path, summary)
-  @agent_tool.ToolAction::respond(
+  @agent_tool.respond(
     content,
     brief=@agent_tool.brief_line("removed \{input.path}"),
   )

--- a/agent_tool/shell/shell.mbt
+++ b/agent_tool/shell/shell.mbt
@@ -181,7 +181,7 @@ async fn execute_with_workspace(
   let input = @decode.decode(arguments) catch {
     error => {
       let message = @tool_error.failure_message("\{error}")
-      return @agent_tool.ToolAction::respond(
+      return @agent_tool.respond(
         "error: shell requires \{message}",
         is_error=true,
       )
@@ -200,7 +200,7 @@ async fn execute_with_workspace(
       worker_root=scope.worker_root,
     )
     is Some(reason) {
-    return @agent_tool.ToolAction::respond(
+    return @agent_tool.respond(
       "blocked in worker mode: \{reason}; your writes are confined to \{scope.worker_root}",
       is_error=true,
     )
@@ -219,7 +219,7 @@ async fn execute_with_workspace(
       ),
       scratch_dir~,
     ) {
-    return @agent_tool.ToolAction::respond(
+    return @agent_tool.respond(
       "blocked in read-only review mode: `\{input.cmd}` runs a source-mutating moon command (fmt/info/test --update) outside your scratch lab; a review reports rather than rewrites the tree. Use plain `moon check`/`moon test` (no --update), `git`, `read` — or run the experiment inside your scratch lab.",
       is_error=true,
     )
@@ -229,7 +229,7 @@ async fn execute_with_workspace(
       parsed_command,
     )
     is Some(message) {
-    return @agent_tool.ToolAction::respond(message, is_error=true)
+    return @agent_tool.respond(message, is_error=true)
   }
   let cwd = @workspace_path.resolve_cwd(workspace_root, input.cwd)
   shell(
@@ -243,11 +243,7 @@ async fn execute_with_workspace(
     scratch_dir?,
     worker_sandbox?,
   ) catch {
-    error =>
-      @agent_tool.ToolAction::respond(
-        "error running shell: \{error}",
-        is_error=true,
-      )
+    error => @agent_tool.respond("error running shell: \{error}", is_error=true)
   }
 }
 
@@ -295,20 +291,20 @@ async fn shell(
   // An explicit wait request above the ceiling is an error, not a silent
   // clamp — the caller asked for wait semantics this tool will not provide.
   if input.timeout_ms is Some(explicit) && explicit > HardMaxForegroundTimeoutMs {
-    return @agent_tool.ToolAction::respond(
+    return @agent_tool.respond(
       "error: timeout_ms \{explicit} exceeds the maximum \{HardMaxForegroundTimeoutMs}ms; run longer work with run_in_background and poll it with shell_output",
       is_error=true,
     )
   }
   if cwd is Some(cwd) {
     guard @fs.exists(cwd) else {
-      return @agent_tool.ToolAction::respond(
+      return @agent_tool.respond(
         "error: cwd does not exist: \{cwd}",
         is_error=true,
       )
     }
     guard @fs.kind(cwd) is Directory else {
-      return @agent_tool.ToolAction::respond(
+      return @agent_tool.respond(
         "error: cwd is not a directory: \{cwd}",
         is_error=true,
       )
@@ -319,7 +315,7 @@ async fn shell(
       scratch_dir,
     )
     is Some(target) {
-    return @agent_tool.ToolAction::respond(
+    return @agent_tool.respond(
       direct_source_blocked_content("source file write redirect", target),
       is_error=true,
       brief=shell_brief(input.cmd, None),
@@ -409,7 +405,7 @@ async fn shell(
   let agent_output = match result {
     ShellExecuted(output) => output
     ShellPreblockedSourceTree(target) =>
-      return @agent_tool.ToolAction::respond(
+      return @agent_tool.respond(
         direct_source_blocked_content("source tree operation", target),
         is_error=true,
         brief=shell_brief(input.cmd, None),
@@ -420,7 +416,7 @@ async fn shell(
       } else {
         " (default foreground budget; pass timeout_ms up to \{HardMaxForegroundTimeoutMs}ms for longer waits)"
       }
-      return @agent_tool.ToolAction::respond(
+      return @agent_tool.respond(
         "error: shell command timed out after \{effective_timeout_ms}ms\{budget}",
         is_error=true,
       )
@@ -431,7 +427,7 @@ async fn shell(
       } else {
         " (default foreground budget)"
       }
-      return @agent_tool.ToolAction::respond(
+      return @agent_tool.respond(
         "command still running after \{effective_timeout_ms}ms\{budget}; moved to the background as job \{id}. Read its output with shell_output (job_id=\"\{id}\") and stop it with shell_stop (job_id=\"\{id}\").",
         brief="\{@agent_tool.brief_line(input.cmd, limit=48)} → bg \{id}",
       )
@@ -453,7 +449,7 @@ async fn shell(
     input.timeout_ms,
     input.max_output_chars,
   )
-  @agent_tool.ToolAction::respond(
+  @agent_tool.respond(
     content,
     is_error=response.is_error || sandbox_denied,
     brief=shell_brief(input.cmd, output.exit_code),
@@ -626,13 +622,13 @@ async fn start_background(
   bg_runtime? : @bgjobs.BgJobRuntime,
 ) -> @agent_tool.ToolAction {
   guard bg_runtime is Some(runtime) else {
-    return @agent_tool.ToolAction::respond(
+    return @agent_tool.respond(
       "error: run_in_background is not available in this context",
       is_error=true,
     )
   }
   if input.timeout_ms is Some(_) {
-    return @agent_tool.ToolAction::respond(
+    return @agent_tool.respond(
       "error: timeout_ms is not supported with run_in_background; a background job runs until it finishes or is stopped with shell_stop",
       is_error=true,
     )
@@ -647,7 +643,7 @@ async fn start_background(
       scratch_dir,
     )
     is Some(target) {
-    return @agent_tool.ToolAction::respond(
+    return @agent_tool.respond(
       direct_source_blocked_content("source tree operation", target),
       is_error=true,
       brief=shell_brief(input.cmd, None),
@@ -670,7 +666,7 @@ async fn start_background(
     sandboxed_command?=launch.sandboxed_command,
     read_only_review~,
   )
-  @agent_tool.ToolAction::respond(
+  @agent_tool.respond(
     "started background job \{id}: `\{input.cmd}`. Read its output with shell_output (job_id=\"\{id}\") and stop it with shell_stop (job_id=\"\{id}\").",
     brief="\{@agent_tool.brief_line(input.cmd, limit=48)} → bg \{id}",
   )

--- a/agent_tool/web_search/web_search.mbt
+++ b/agent_tool/web_search/web_search.mbt
@@ -142,13 +142,13 @@ async fn execute(
   arguments : Json,
 ) -> @agent_tool.ToolAction {
   guard arguments is { "query": String(query), .. } && !query.is_blank() else {
-    return @agent_tool.ToolAction::respond(
+    return @agent_tool.respond(
       "error: web_search requires a non-empty string `query`",
       is_error=true,
     )
   }
   guard query.length() <= MaxQueryChars else {
-    return @agent_tool.ToolAction::respond(
+    return @agent_tool.respond(
       "error: web_search query exceeds \{MaxQueryChars} chars — ask one focused question",
       is_error=true,
     )
@@ -166,13 +166,13 @@ async fn execute(
     error if @async.is_being_cancelled() || @async.is_cancellation_error(error) =>
       raise error
     error =>
-      return @agent_tool.ToolAction::respond(
+      return @agent_tool.respond(
         "error: web_search failed: \{error}",
         is_error=true,
         brief=failure_brief(query),
       )
   }
-  @agent_tool.ToolAction::respond(
+  @agent_tool.respond(
     format_output(outcome),
     brief=success_brief(query, outcome.sources.length()),
   )

--- a/agent_tool/write/write.mbt
+++ b/agent_tool/write/write.mbt
@@ -97,7 +97,7 @@ async fn execute_with_workspace(
   let input = @decode.decode(arguments) catch {
     error => {
       let message = @tool_error.failure_message("\{error}")
-      return @agent_tool.ToolAction::respond(
+      return @agent_tool.respond(
         "error: write requires \{message}",
         is_error=true,
       )
@@ -107,7 +107,7 @@ async fn execute_with_workspace(
   // Containment gate for confined (worker) registries; re-checked below
   // immediately before the file is written.
   if write_scope is Some(scope) && scope.deny_reason(path) is Some(reason) {
-    return @agent_tool.ToolAction::respond(
+    return @agent_tool.respond(
       "error writing \{path}: write blocked: \{reason}",
       is_error=true,
       brief="write \{@agent_tool.brief_basename(path)}",
@@ -124,7 +124,7 @@ async fn write_file(
   write_scope? : @write_scope.WriteScope,
 ) -> @agent_tool.ToolAction {
   if @manifest_error.write_error(path, input.content) is Some(message) {
-    return @agent_tool.ToolAction::respond(
+    return @agent_tool.respond(
       "error writing \{path}: \{message}",
       is_error=true,
       brief="write \{@agent_tool.brief_basename(path)}",
@@ -147,7 +147,7 @@ async fn write_file(
   // stops a link named `x.txt` pointing at `lib.mbt` from slipping past the
   // suffix check and truncating the source through CreateOrTruncate below.
   if @fs.exists(path) && (is_mbt_source(path) || is_mbt_source(target)) {
-    return @agent_tool.ToolAction::respond(
+    return @agent_tool.respond(
       "error writing \{path}: existing source file — use edit or multi_edit to change it (an empty old_string inserts new code); write is for creating new files",
       is_error=true,
       brief="write \{@agent_tool.brief_basename(path)}",
@@ -171,7 +171,7 @@ async fn write_file(
       }
       if gate is Some(gate) && gate.errors.length() > 0 {
         let bound = if gate.truncated { "≥" } else { "" }
-        return @agent_tool.ToolAction::respond(
+        return @agent_tool.respond(
           write_reject_report(path, input.content, gate),
           is_error=true,
           brief="write rejected (\{bound}\{gate.errors.length()} parse error(s))",
@@ -183,7 +183,7 @@ async fn write_file(
   // are created for the target): the early gate decided on filesystem state
   // that awaits ago may have changed underneath the tool.
   if write_scope is Some(scope) && scope.deny_reason(path) is Some(reason) {
-    return @agent_tool.ToolAction::respond(
+    return @agent_tool.respond(
       "error writing \{path}: write blocked: \{reason}",
       is_error=true,
       brief="write \{@agent_tool.brief_basename(path)}",
@@ -254,7 +254,7 @@ async fn write_file(
     },
   )
   let content = @auto_check.append_summary(path, summary)
-  @agent_tool.ToolAction::respond(content, brief=ok_brief)
+  @agent_tool.respond(content, brief=ok_brief)
 }
 
 ///|

--- a/cmd/openseek/review_tool.mbt
+++ b/cmd/openseek/review_tool.mbt
@@ -68,14 +68,14 @@ async fn execute_review(
     (Some(focus), None) => focus
     (None, Some(goal)) => goal
     (None, None) =>
-      return @agent_tool.ToolAction::respond(
+      return @agent_tool.respond(
         "error: no standing goal exists — pass `focus` with the criteria to audit against",
         is_error=true,
       )
   }
   guard budget.reserve(@agent_review.default_audit_max_steps)
     is Some(granted_steps) else {
-    return @agent_tool.ToolAction::respond(
+    return @agent_tool.respond(
       "review budget exhausted for this turn — validate directly (run the checks yourself).",
       is_error=true,
       brief="review (budget exhausted)",
@@ -114,13 +114,13 @@ async fn execute_review(
   // Display-only: the model never sees briefs.
   match result.value() {
     Some(report) =>
-      @agent_tool.ToolAction::respond(
+      @agent_tool.respond(
         report.digest(),
         is_error=report.findings.any(f => f.severity == "blocker"),
         brief="review \{result.subrun_id()} (\{report.findings.length()} finding(s), \{result.steps_used()} step(s))",
       )
     None =>
-      @agent_tool.ToolAction::respond(
+      @agent_tool.respond(
         "review produced no report (\{@agent_tool.brief_line("\{Repr(result.terminal())}", limit=200)}) — validate directly instead.",
         is_error=true,
         brief="review \{result.subrun_id()} (no report)",

--- a/cmd/openseek/subtask_tool.mbt
+++ b/cmd/openseek/subtask_tool.mbt
@@ -157,7 +157,7 @@ async fn subtask_execute(
   match arguments {
     { "slices": Array(entries), .. } => {
       guard !entries.is_empty() else {
-        return @agent_tool.ToolAction::respond(
+        return @agent_tool.respond(
           "error: subtask `slices` must not be empty",
           is_error=true,
         )
@@ -166,7 +166,7 @@ async fn subtask_execute(
       // try_acquire, so entries past the cap would fail as "slots full"
       // while the call still looked accepted.
       guard entries.length() <= max_active_workers else {
-        return @agent_tool.ToolAction::respond(
+        return @agent_tool.respond(
           "error: subtask `slices` accepts at most \{max_active_workers} slices per call (got \{entries.length()}) — send the rest in a follow-up call once these integrate",
           is_error=true,
         )
@@ -175,10 +175,7 @@ async fn subtask_execute(
         match decode_launch(entry) {
           Ok(spec) => specs.push(spec)
           Err(reason) =>
-            return @agent_tool.ToolAction::respond(
-              "error: \{reason}",
-              is_error=true,
-            )
+            return @agent_tool.respond("error: \{reason}", is_error=true)
         }
       }
     }
@@ -186,10 +183,7 @@ async fn subtask_execute(
       match decode_launch(arguments) {
         Ok(spec) => specs.push(spec)
         Err(reason) =>
-          return @agent_tool.ToolAction::respond(
-            "error: \{reason}",
-            is_error=true,
-          )
+          return @agent_tool.respond("error: \{reason}", is_error=true)
       }
   }
   subtask_launch_many(env, specs)
@@ -204,7 +198,7 @@ async fn subtask_lifecycle(
   let geometry = match @subtask.resolve_geometry(workspace_root) {
     Ok(geometry) => geometry
     Err(reason) =>
-      return @agent_tool.ToolAction::respond(
+      return @agent_tool.respond(
         "error: subtask \{action}: \{reason}",
         is_error=true,
       )
@@ -212,7 +206,7 @@ async fn subtask_lifecycle(
   let (entries, _) = @subtask.load_entries(geometry.common_git_dir)
   guard entries.filter(e => e.name == name && !e.state.is_terminal()).last()
     is Some(entry) else {
-    return @agent_tool.ToolAction::respond(
+    return @agent_tool.respond(
       "error: no active subtask named \{name}",
       is_error=true,
       brief="subtask \{action} \{name}",
@@ -222,12 +216,12 @@ async fn subtask_lifecycle(
     "discard" =>
       match @subtask.discard(geometry, entry) {
         Ok(_) =>
-          @agent_tool.ToolAction::respond(
+          @agent_tool.respond(
             "subtask \{name} discarded: worktree and branch removed, paths freed.",
             brief="subtask discarded \{name}",
           )
         Err(reason) =>
-          @agent_tool.ToolAction::respond(
+          @agent_tool.respond(
             "error: subtask discard: \{reason}",
             is_error=true,
             brief="subtask discard \{name}",
@@ -240,7 +234,7 @@ async fn subtask_lifecycle(
         _ => @subtask.integrate_abort(geometry, entry)
       }
       let content = "subtask \{name} \{action}: \{outcome.result}\n\{outcome.detail.join("\n")}"
-      @agent_tool.ToolAction::respond(
+      @agent_tool.respond(
         content,
         is_error=outcome.result == "refused",
         brief="subtask \{action} \{name} (\{outcome.result})",
@@ -340,7 +334,7 @@ async fn subtask_launch_many(
   out <+
     "\{specs.length()} slice(s) launched concurrently:\n\{summary.to_string()}\n"
   out <+ "\{detail.to_string()}"
-  @agent_tool.ToolAction::respond(
+  @agent_tool.respond(
     out.to_string(),
     is_error=any_error,
     brief="subtask \{specs.length()} slices (\{briefs.join(", ")})",
@@ -369,7 +363,7 @@ async fn subtask_launch_one(
   // later failure path has exactly one transaction to roll back.
   guard worker_slots.try_acquire() else {
     return {
-      action: @agent_tool.ToolAction::respond(
+      action: @agent_tool.respond(
         "subtask worker slots are full (max \{max_active_workers} active) — integrate or await the running slices first.",
         is_error=true,
         brief="subtask (slots full)",
@@ -385,7 +379,7 @@ async fn subtask_launch_one(
   guard env.budget.reserve(@agent_worker.default_worker_max_steps)
     is Some(granted_steps) else {
     return {
-      action: @agent_tool.ToolAction::respond(
+      action: @agent_tool.respond(
         "subtask budget exhausted for this turn — do the remaining slices yourself or continue next turn.",
         is_error=true,
         brief="subtask (budget exhausted)",
@@ -405,7 +399,7 @@ async fn subtask_launch_one(
     Ok(provisioned) => provisioned
     Err(reason) =>
       return {
-        action: @agent_tool.ToolAction::respond(
+        action: @agent_tool.respond(
           "error: subtask provision: \{reason}",
           is_error=true,
           brief="subtask \{name} (provision refused)",
@@ -519,7 +513,7 @@ async fn run_worker_slice(
   let mergeable = captured.entry.state is Committed
   let is_error = !mergeable && !(captured.entry.state is NoChanges)
   {
-    action: @agent_tool.ToolAction::respond(
+    action: @agent_tool.respond(
       out.to_string(),
       is_error~,
       brief="subtask \{result.subrun_id()} \{name} (\{Repr(captured.entry.state)}, \{result.steps_used()} step(s))",
@@ -541,14 +535,14 @@ async fn subtask_continue(
   name : String,
 ) -> @agent_tool.ToolAction {
   guard arguments is { "task": String(task), .. } && !task.is_blank() else {
-    return @agent_tool.ToolAction::respond(
+    return @agent_tool.respond(
       "error: subtask continue=\{name} requires a `task` — the remainder work order for the fresh worker",
       is_error=true,
       brief="subtask continue \{name}",
     )
   }
   guard task.length() <= max_task_chars else {
-    return @agent_tool.ToolAction::respond(
+    return @agent_tool.respond(
       "error: subtask task for \{name} exceeds \{max_task_chars} chars",
       is_error=true,
       brief="subtask continue \{name}",
@@ -559,7 +553,7 @@ async fn subtask_continue(
     _ => None
   }
   guard !(parent_context is Some(c) && c.length() > max_context_chars) else {
-    return @agent_tool.ToolAction::respond(
+    return @agent_tool.respond(
       "error: subtask context for \{name} exceeds \{max_context_chars} chars",
       is_error=true,
       brief="subtask continue \{name}",
@@ -568,14 +562,14 @@ async fn subtask_continue(
   let geometry = match @subtask.resolve_geometry(env.workspace_root) {
     Ok(geometry) => geometry
     Err(reason) =>
-      return @agent_tool.ToolAction::respond(
+      return @agent_tool.respond(
         "error: subtask continue: \{reason}",
         is_error=true,
         brief="subtask continue \{name}",
       )
   }
   guard worker_slots.try_acquire() else {
-    return @agent_tool.ToolAction::respond(
+    return @agent_tool.respond(
       "subtask worker slots are full (max \{max_active_workers} active) — integrate or await the running slices first.",
       is_error=true,
       brief="subtask continue (slots full)",
@@ -584,7 +578,7 @@ async fn subtask_continue(
   defer worker_slots.release()
   guard env.budget.reserve(@agent_worker.default_worker_max_steps)
     is Some(granted_steps) else {
-    return @agent_tool.ToolAction::respond(
+    return @agent_tool.respond(
       "subtask budget exhausted for this turn — do the remaining work yourself or continue next turn.",
       is_error=true,
       brief="subtask continue (budget exhausted)",
@@ -593,7 +587,7 @@ async fn subtask_continue(
   let entry = match @subtask.resume_running(geometry, name) {
     Ok(entry) => entry
     Err(reason) =>
-      return @agent_tool.ToolAction::respond(
+      return @agent_tool.respond(
         "error: subtask continue: \{reason}",
         is_error=true,
         brief="subtask continue \{name}",

--- a/eval/tool_harness/harness.mbt
+++ b/eval/tool_harness/harness.mbt
@@ -278,7 +278,7 @@ async fn dispatch(
   )
   let call = @agent_tool.AgentToolCall(native_call) catch {
     error =>
-      return @agent_tool.ToolAction::respond(
+      return @agent_tool.respond(
         "error: invalid harness call: \{error}",
         is_error=true,
       )

--- a/mcp/tools/tools.mbt
+++ b/mcp/tools/tools.mbt
@@ -304,7 +304,7 @@ async fn call_tool(
         "MCP tool `\{tool}` call failed: \{error}",
         MaxToolOutputChars,
       )
-      return @agent_tool.ToolAction::respond(message, is_error=true)
+      return @agent_tool.respond(message, is_error=true)
     }
   }
   guard outcome is Some(result) else {
@@ -312,7 +312,7 @@ async fn call_tool(
       "MCP tool `\{tool}` timed out after \{CallTimeoutMs / 1000}s",
       MaxToolOutputChars,
     )
-    return @agent_tool.ToolAction::respond(message, is_error=true)
+    return @agent_tool.respond(message, is_error=true)
   }
   let (content, truncated) = cap_chars(result.render_text(), MaxToolOutputChars)
   let text = if truncated {
@@ -320,7 +320,7 @@ async fn call_tool(
   } else {
     content
   }
-  @agent_tool.ToolAction::respond(
+  @agent_tool.respond(
     text,
     is_error=result.is_error,
     brief=@agent_tool.brief_line(text),


### PR DESCRIPTION
Four agent_tool/mbtx tidy-ups from review comments:

1. **agent_tool: promote `ToolAction::respond` to top-level `respond`** — add `pub fn respond` as the canonical builder and migrate all 163 call sites across 28 files (agent_tool tools, agent tests, agent_explore, agent_subrun, mcp/tools, cmd/openseek, eval/tool_harness, README.mbt.md) to `respond` / `@agent_tool.respond`. The old method was kept briefly as a `#deprecated` alias to drive the migration with compiler warnings, then removed once zero callers remained — future use is a compile error, not a warning. Regenerated the agent_tool interface with `moon info`.

2. **mbtx: inline `native_escape` and update its rationale** — the wasm family refuses FFI at compile time, so the substring scan is redundant on the sandboxed target; it is kept as the only FFI guard for the js target (verified: the js backend compiles and runs host bindings against bare node) and llvm (unsandboxed native codegen). Inlined the one-use helper and fixed the stale refusal message that claimed containment "arrives" with the wasm backend.

3. **mbtx: keep `MbtxInput::to_repr` a deprecated, doc-hidden extend** — annotated the `pub extend` with `#deprecated` + `#doc(hidden)` so `moon info` no longer promotes it into a method on `MbtxInput`; the derived `Debug` impl remains the real API.

## Verification

- `moon check` (workspace, rebased onto origin/main): 0 errors, 0 warnings
- `moon fmt`: clean
- Tests: agent_tool + agent + mcp/tools + agent_explore + agent_subrun + eval/tool_harness: 166/166; cmd/openseek: 80/80; agent_tool after alias removal: 23/23

Generated with SeekMoon