### PR TITLE
feat(editor): add immediate feedback apply action

### DIFF
--- a/desktop/frontend/codex/model.mbt
+++ b/desktop/frontend/codex/model.mbt
@@ -1214,12 +1214,15 @@ pub fn State::draft_text(self : State) -> String {
 /// Add an editor comment as the same annotation chip OpenSeek renders. The
 /// textarea remains the user's typed draft; selected source and comment travel
 /// as structured context and are deduplicated like ordinary file mentions.
+/// Original-revision comments retain their source line but deliberately have no
+/// working-document navigation range.
 pub fn State::with_editor_comment(
   self : State,
   file : String,
   range : @common.Range,
   comment : String,
   quote : String,
+  side? : @mention_context.AnnotationSide = @mention_context.WorkingRevision,
 ) -> State {
   let mentions = self.mentions.copy()
   let annotation : @composer.Mention = {
@@ -1229,9 +1232,13 @@ pub fn State::with_editor_comment(
       end_line=range.end_line_number,
       quote~,
       comment~,
-      side=@mention_context.WorkingRevision,
+      side~,
     ),
-    range: Some(range),
+    range: if side is @mention_context.OriginalRevision {
+      None
+    } else {
+      Some(range)
+    },
   }
   if !mentions.contains(annotation) {
     mentions.push(annotation)
@@ -3239,6 +3246,26 @@ test "Codex editor annotations stay in chips and preserve model context" {
       side=@mention_context.WorkingRevision,
     ),
   ])
+  let original = twice.with_editor_comment(
+    "src/main.mbt",
+    @common.Range::Range(3, 1, 3, 11),
+    "keep this removal",
+    "obsolete()",
+    side=@mention_context.OriginalRevision,
+  )
+  assert_eq(original.mentions.length(), 2)
+  assert_true(
+    original.mentions[1].ref_
+    is @mention_context.Annotation(
+      file="src/main.mbt",
+      start_line=3,
+      end_line=3,
+      quote="obsolete()",
+      comment="keep this removal",
+      side=@mention_context.OriginalRevision
+    ),
+  )
+  assert_eq(original.mentions[1].range, None)
 }
 
 ///|

--- a/desktop/frontend/codex/pkg.generated.mbti
+++ b/desktop/frontend/codex/pkg.generated.mbti
@@ -7,6 +7,7 @@ import {
   "moonbitlang/editor/base/common",
   "openseek_desktop/frontend/composer",
   "openseek_desktop/frontend/interop",
+  "openseek_desktop/frontend/mention_context",
   "openseek_desktop/frontend/pathx",
   "openseek_desktop/frontend/sidebar/conversation",
   "openseek_desktop/frontend/sidebar/section",
@@ -56,6 +57,7 @@ pub fn Msg::server_request(Json, String, Json, Int) -> Self
 pub fn Msg::start_draft(String, String) -> Self
 pub fn Msg::status_changed(Json) -> Self
 pub fn Msg::unarchive_thread(String) -> Self
+pub fn Msg::worktree_changed(String, String, String, String, Bool) -> Self
 
 pub(all) struct PageActions {
   toggle_sidebar : @cmd.Cmd
@@ -98,12 +100,12 @@ pub fn State::pending_auth_url(Self) -> String?
 pub fn State::project_activation(Self, SidebarContext, String) -> String?
 pub fn State::project_conversations(Self, SidebarContext, String) -> Array[CodexProjectRow]
 pub fn State::project_draft(Self, SidebarContext, String) -> @conversation.Input?
-pub fn State::reasoning_effort_chip(Self) -> @composer.ReasoningSelect?
+pub fn State::reasoning_effort_chip(Self, Bool) -> @composer.ReasoningSelect?
 pub fn State::refresh(Self, @cmd.Emit[Msg], @interop.ChannelId) -> (@cmd.Cmd, Self)
 pub fn State::sign_in_required(Self) -> Bool
 pub fn State::signed_in(Self) -> Bool
 pub fn State::transcript_items(Self) -> Array[@transcript.TranscriptItem]
-pub fn State::with_editor_comment(Self, String, @common.Range, String, String) -> Self
+pub fn State::with_editor_comment(Self, String, @common.Range, String, String, side? : @mention_context.AnnotationSide) -> Self
 pub fn State::with_git_details_closed(Self) -> Self
 pub fn State::worktree_launch_workspace(Self, @interop.ChannelId) -> @common.Uri?
 

--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -466,6 +466,15 @@ fn request_viewer_mount(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
           )
         })
         |> ignore
+        services.feedback.on_did_submit_feedback(event => {
+          // `add_feedback` fires first, so the scheduler receives the comment
+          // chip before this apply action. Ignore batches without user review
+          // items; only the inline user's explicit action should send a prompt.
+          if event.user_count > 0 {
+            scheduler.add(dispatch(ApplyAllFeedback))
+          }
+        })
+        |> ignore
       }
       if viewer_state.markdown_viewer is None &&
         viewer_state.services is Some(services) &&
@@ -661,18 +670,23 @@ fn diff_comment_message(
 /// Clear one comment bubble from the editor once its text has become a
 /// composer chip — the chip is the comment's carrier from then on. Routed by
 /// the same model URI the feedback was filed under. Public for the main
-/// package's `EditorCommentAdded` handler, which owns the chip flow.
+/// package's `EditorCommentAdded` handler, which owns the chip flow. Removal
+/// waits until after render so Add-and-Apply can synchronously mark the still
+/// accepted item submitted and publish its host event first.
 pub fn remove_editor_feedback(
   resource : ModelUri,
   feedback_id : String,
 ) -> @cmd.Cmd {
-  @cmd.custom_cmd(_scheduler => {
-    guard viewer_state.services is Some(services) else { return }
-    // The string is the `to_string()` of a URI this package minted, so the
-    // re-parse cannot fail; a stray unparsable string has no bubble anyway.
-    let uri = @common.Uri::parse(resource.0) catch { _ => return }
-    services.feedback.remove_feedback(uri, feedback_id)
-  })
+  @cmd.custom_cmd(
+    _scheduler => {
+      guard viewer_state.services is Some(services) else { return }
+      // The string is the `to_string()` of a URI this package minted, so the
+      // re-parse cannot fail; a stray unparsable string has no bubble anyway.
+      let uri = @common.Uri::parse(resource.0) catch { _ => return }
+      services.feedback.remove_feedback(uri, feedback_id)
+    },
+    kind=@cmd.after_render,
+  )
 }
 
 ///|

--- a/desktop/frontend/fileeditor/feedback/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/feedback/pkg.generated.mbti
@@ -22,6 +22,7 @@ pub fn DesktopFeedbackService::add_feedback(Self, @common.Uri, @common.Range, St
 pub fn DesktopFeedbackService::agent_feedback_handle(Self) -> @agent_feedback_api.AgentFeedbackHandle
 pub fn DesktopFeedbackService::clear_feedback(Self, @common.Uri) -> Unit
 pub fn DesktopFeedbackService::on_did_add_feedback(Self, (AgentFeedbackAddedEvent) -> Unit) -> @common.Disposable
+pub fn DesktopFeedbackService::on_did_submit_feedback(Self, (@agent_feedback_api.AgentFeedbackSubmittedEvent) -> Unit) -> @common.Disposable
 pub fn DesktopFeedbackService::remove_feedback(Self, @common.Uri, String) -> Unit
 pub fn DesktopFeedbackService::set_feedback_enabled(Self, @common.Uri, Bool) -> Unit
 

--- a/desktop/frontend/fileeditor/feedback/service.mbt
+++ b/desktop/frontend/fileeditor/feedback/service.mbt
@@ -24,6 +24,9 @@ struct DesktopFeedbackService {
   ]
   did_change_navigation : @common.Emitter[@common.Uri]
   did_add_feedback : @common.Emitter[AgentFeedbackAddedEvent]
+  did_submit_feedback : @common.Emitter[
+    @agent_feedback_api.AgentFeedbackSubmittedEvent,
+  ]
   items_by_resource : Map[String, Array[@agent_feedback_api.AgentFeedback]]
   navigation_anchor_by_resource : Map[String, String]
   enabled_resources : Map[String, Bool]
@@ -36,6 +39,7 @@ pub fn DesktopFeedbackService::DesktopFeedbackService() -> DesktopFeedbackServic
     did_change_feedback: @common.Emitter(),
     did_change_navigation: @common.Emitter(),
     did_add_feedback: @common.Emitter(),
+    did_submit_feedback: Emitter(),
     items_by_resource: Map([]),
     navigation_anchor_by_resource: Map([]),
     enabled_resources: Map([]),
@@ -89,6 +93,17 @@ pub fn DesktopFeedbackService::on_did_add_feedback(
   listener : (AgentFeedbackAddedEvent) -> Unit,
 ) -> @common.Disposable {
   self.did_add_feedback.event(listener)
+}
+
+///|
+/// Subscribes to the Viewer's explicit apply action. Desktop keeps this
+/// host-only so the shared Viewer handle remains a mutation capability, while
+/// the application decides how submitted feedback enters its message queue.
+pub fn DesktopFeedbackService::on_did_submit_feedback(
+  self : DesktopFeedbackService,
+  listener : (@agent_feedback_api.AgentFeedbackSubmittedEvent) -> Unit,
+) -> @common.Disposable {
+  self.did_submit_feedback.event(listener)
 }
 
 ///|
@@ -287,22 +302,40 @@ fn DesktopFeedbackService::add_reply(
 
 ///|
 /// Moves every accepted item to submitted after the Viewer completes its local
-/// submission flow.
+/// submission flow, then reports the exact batch to the Desktop host.
 fn DesktopFeedbackService::mark_feedback_submitted(
   self : DesktopFeedbackService,
   resource : @common.Uri,
 ) -> Unit {
   let items = self.items_for(resource)
-  let mut changed = false
-  for index, item in items {
-    if item.state == @agent_feedback_api.Accepted {
-      items[index] = { ..item, state: @agent_feedback_api.Submitted, }
-      changed = true
+  let submitted : Array[@agent_feedback_api.AgentFeedback] = []
+  let mut user_count = 0
+  let mut agent_review_count = 0
+  let mut reply_count = 0
+  for index in 0..<items.length() {
+    let item = items[index]
+    guard item.state == Accepted else { continue }
+    match item.kind {
+      UserReview => user_count += 1
+      AgentReview => agent_review_count += 1
     }
+    reply_count += item.replies.length()
+    let updated : @agent_feedback_api.AgentFeedback = {
+      ..item,
+      state: Submitted,
+    }
+    items[index] = updated
+    submitted.push(updated)
   }
-  if changed {
-    self.handle_items_changed(resource)
-  }
+  guard !submitted.is_empty() else { return }
+  self.handle_items_changed(resource)
+  self.did_submit_feedback.fire({
+    resource,
+    items: submitted,
+    user_count,
+    agent_review_count,
+    reply_count,
+  })
 }
 
 ///|

--- a/desktop/frontend/fileeditor/feedback/service_test.mbt
+++ b/desktop/frontend/fileeditor/feedback/service_test.mbt
@@ -26,6 +26,11 @@ test "Desktop feedback backing connects host controls to the Viewer handle" {
 test "Desktop feedback backing implements every stateful handle mutation" {
   let service = @feedback.DesktopFeedbackService()
   let resource = @common.Uri::parse("file:///workspace/lib.mbt")
+  let submitted_ids : Ref[Array[String]] = Ref([])
+  service.on_did_submit_feedback(event => {
+    submitted_ids.val = event.items.map(item => item.id)
+  })
+  |> ignore
   let handle = service.agent_feedback_handle()
   let item = handle.add_feedback(
     resource,
@@ -41,6 +46,7 @@ test "Desktop feedback backing implements every stateful handle mutation" {
   assert_eq(stored.map(item => item.text), Some("reworded"))
   assert_eq(stored.map(item => item.replies), Some(["done"]))
   assert_eq(stored.map(item => item.state), Some(@agent_feedback_api.Submitted))
+  assert_eq(submitted_ids.val, [item.id])
   let navigation_id = "agentFeedback:" + item.id
   handle.set_navigation_anchor(resource, Some(navigation_id))
   let bearing = handle.get_navigation_bearing(resource, [navigation_id])

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -992,6 +992,11 @@ pub(all) enum Msg {
     comment~ : String,
     feedback_id~ : String
   )
+  // The inline input's Apply all feedback action follows its synchronous
+  // comment-added event. The application root intercepts this after attaching
+  // the new annotation chip and submits the main-window composer through its
+  // ordinary prompt/steer queue.
+  ApplyAllFeedback
   // The user submitted a comment from a full-diff surface. Both line domains
   // cross the package boundary: additions/context use the modified number,
   // while an original-pane selection remains identifiable to the composer

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -3664,7 +3664,8 @@ pub fn update(
     // chip there, which then clears the editor bubble through
     // `remove_editor_feedback`. Reaching this arm means the main update
     // didn't intercept it; changing nothing is the safe answer.
-    EditorCommentAdded(..) | DiffCommentAdded(..) => (@cmd.none, state)
+    EditorCommentAdded(..) | DiffCommentAdded(..) | ApplyAllFeedback =>
+      (@cmd.none, state)
   }
 }
 

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -2382,6 +2382,28 @@ fn update_msg(
         model.replace_conversation({ ..conv, mentions, }),
       )
     }
+    // The feedback service queues this after the comment-added message above,
+    // so the new annotation is already in the visible composer batch. Reuse
+    // each agent's normal submit path: an idle task starts, while a running
+    // task receives the batch through its existing steer/message queue.
+    FileEditor(@fileeditor.ApplyAllFeedback) =>
+      match model.screen {
+        Chat => update_msg(dispatch, Send, model)
+        Codex => {
+          let input = model.codex_composer_input()
+          update_msg(
+            dispatch,
+            CodexComposerAction(
+              @composer.DraftSubmitted(
+                identity=input.identity,
+                draft=input.draft,
+              ),
+            ),
+            model,
+          )
+        }
+        Skills | Settings | WorkspaceSettings(..) => (@cmd.none, model)
+      }
     // Full-diff comments carry both line domains because a deletion has no
     // working-document position. Prefer the modified line for additions and
     // context; retain the original line for an original-only deletion. Only a
@@ -2418,6 +2440,25 @@ fn update_msg(
               (line_number, None, @mention_context.OriginalRevision)
             _ => return (clear_feedback, model)
           }
+      }
+      if model.screen is Codex {
+        let end_column = if quote.is_empty() { 1 } else { quote.length() + 1 }
+        let comment_range = range.unwrap_or(
+          @common.Range::Range(line_number, 1, line_number, end_column),
+        )
+        return (
+          clear_feedback,
+          {
+            ..model,
+            codex: model.codex.with_editor_comment(
+              file.0,
+              comment_range,
+              comment,
+              quote,
+              side~,
+            ),
+          },
+        )
       }
       guard model.active_conversation() is Some(conv) else {
         return (clear_feedback, model)
@@ -16062,6 +16103,40 @@ test "EditorCommentAdded attaches a deduplicated annotation chip" {
 }
 
 ///|
+test "ApplyAllFeedback queues the attached annotation on a running task" {
+  let dispatch = test_dispatch()
+  let model = running_model()
+  let (_, batched) = update(
+    dispatch,
+    FileEditor(
+      EditorCommentAdded(
+        resource=@fileeditor.ModelUri::of(
+          @interop.ChannelId::Local.test_resource("/work/project/src/main.mbt"),
+        ),
+        file=Relative("src/main.mbt"),
+        range=@common.Range::Range(5, 1, 6, 3),
+        quote="fn parse_hover() {",
+        comment="rename this",
+        feedback_id="viewer-feedback-immediate",
+      ),
+    ),
+    model,
+  )
+  assert_eq(batched.active().mentions.length(), 1)
+  let (_, applied) = update(
+    dispatch,
+    FileEditor(@fileeditor.ApplyAllFeedback),
+    batched,
+  )
+  assert_true(applied.active().mentions.is_empty())
+  assert_eq(applied.active().pending_steers.length(), 1)
+  let steer = applied.active().pending_steers[0]
+  assert_eq(steer.mentions.length(), 1)
+  assert_true(steer.content.contains("<user_mentions>"))
+  assert_true(steer.content.contains("rename this"))
+}
+
+///|
 test "DiffCommentAdded preserves modified and original-only line identity" {
   let dispatch = test_dispatch()
   let file = @pathx.Relative("src/main.mbt")
@@ -16120,6 +16195,61 @@ test "DiffCommentAdded preserves modified and original-only line identity" {
 }
 
 ///|
+test "Codex original-side diff feedback queues in the Codex draft" {
+  let dispatch = test_dispatch()
+  let codex = @codex.State::from_thread_snapshot({
+    "thread": {
+      "id": "codex-thread-original-feedback",
+      "cwd": "/work/project",
+      "preview": "Review",
+      "turns": [
+        { "id": "codex-turn-original", "status": "inProgress", "items": [] },
+      ],
+    },
+  })
+  let model = { ..test_model(), codex, screen: Codex, }
+  let (_, batched) = update(
+    dispatch,
+    FileEditor(
+      DiffCommentAdded(
+        file=Relative("src/main.mbt"),
+        original_line_number=Some(3),
+        modified_line_number=None,
+        quote="obsolete()",
+        comment="keep this removal",
+        resource=None,
+        feedback_id=None,
+      ),
+    ),
+    model,
+  )
+  assert_true(batched.active().mentions.is_empty())
+  let draft = batched.codex_composer_input().draft
+  assert_eq(draft.mentions.length(), 1)
+  assert_true(
+    draft.mentions[0].ref_
+    is Annotation(
+      file="src/main.mbt",
+      start_line=3,
+      end_line=3,
+      quote="obsolete()",
+      comment="keep this removal",
+      side=@mention_context.OriginalRevision
+    ),
+  )
+  assert_eq(draft.mentions[0].range, None)
+  let (_, applied) = update(
+    dispatch,
+    FileEditor(@fileeditor.ApplyAllFeedback),
+    batched,
+  )
+  let queued = applied.codex.transcript_items()
+  assert_eq(queued.length(), 1)
+  assert_true(queued[0].content.contains("side=\"original\""))
+  assert_true(queued[0].content.contains("keep this removal"))
+}
+
+///|
 test "original-revision diff comment chip does not navigate into the working file" {
   let dispatch = test_dispatch()
   let original_comment : Mention = {
@@ -16174,6 +16304,50 @@ test "Codex editor comments use annotation context, not textarea text or OpenSee
   // The textarea stays untouched. Codex owns the annotation chip and sends
   // its file/range/comment/quote through the shared mention envelope.
   assert_eq(once.codex.draft_text(), "")
+}
+
+///|
+test "Codex ApplyAllFeedback steers the running task through its composer" {
+  let dispatch = test_dispatch()
+  let codex = @codex.State::from_thread_snapshot({
+    "thread": {
+      "id": "codex-thread-feedback",
+      "cwd": "/work/project",
+      "preview": "Review",
+      "turns": [
+        { "id": "codex-turn-feedback", "status": "inProgress", "items": [] },
+      ],
+    },
+  })
+  let model = { ..test_model(), codex, screen: Codex, }
+  let (_, batched) = update(
+    dispatch,
+    FileEditor(
+      EditorCommentAdded(
+        resource=@fileeditor.ModelUri::of(
+          @interop.ChannelId::Local.test_resource("/work/project/src/main.mbt"),
+        ),
+        file=Relative("src/main.mbt"),
+        range=@common.Range::Range(5, 1, 6, 3),
+        quote="fn parse_hover() {",
+        comment="rename this",
+        feedback_id="viewer-feedback-codex-immediate",
+      ),
+    ),
+    model,
+  )
+  let before = batched.codex_composer_input()
+  assert_eq(before.draft.mentions.length(), 1)
+  let (_, applied) = update(
+    dispatch,
+    FileEditor(@fileeditor.ApplyAllFeedback),
+    batched,
+  )
+  let queued = applied.codex.transcript_items()
+  assert_eq(queued.length(), 1)
+  assert_true(queued[0].kind is @transcript.User)
+  assert_true(queued[0].content.contains("<user_mentions>"))
+  assert_true(queued[0].content.contains("rename this"))
 }
 
 ///|

--- a/editor/internal/viewer/contrib/agent_feedback/browser/agent_feedback_input_widget.mbt
+++ b/editor/internal/viewer/contrib/agent_feedback/browser/agent_feedback_input_widget.mbt
@@ -1,11 +1,10 @@
 // The inline "Add Feedback" input, porting `AgentFeedbackInputWidget`
 // (`vscode/src/vs/sessions/contrib/agentFeedback/browser/
 // agentFeedbackEditorInputContribution.ts:44-242`): a floating overlay node
-// with an auto-growing textarea and review-style Cancel/Add actions. The
-// primary action swaps Add ↔ Add-and-Submit while Alt is held
-// (upstream's `ModifierKeyEmitter` swap, driven here from the textarea's own
-// keydown/keyup since the widget owns the focus while typing). The widget is
-// a null-position overlay widget: the glue positions it by writing
+// with an auto-growing textarea and explicit Cancel/Add/Apply actions. Add
+// keeps the feedback in the host's main-window batch; Apply submits that
+// batch through the host's ordinary message queue. The widget is a
+// null-position overlay widget: the glue positions it by writing
 // `top`/`left` (`setPosition` → `layoutOverlayWidget` upstream). Keyboard is
 // handled on the textarea directly (Shift+Enter inserts a newline, Enter adds,
 // Alt+Enter adds and submits, Escape cancels). The editor-keydown steal and
@@ -39,7 +38,7 @@ let input_max_height_px : Double = 180.0
 pub(all) struct AgentFeedbackInputWidgetHost {
   /// Enter — `onDidTriggerAdd`.
   on_add : () -> Unit
-  /// Alt+Enter — `onDidTriggerAddAndSubmit`.
+  /// Alt+Enter or Apply all feedback — `onDidTriggerAddAndSubmit`.
   on_add_and_submit : () -> Unit
   /// Escape inside the textarea — the contribution hides and refocuses.
   on_cancel : () -> Unit
@@ -58,8 +57,8 @@ struct AgentFeedbackInputWidget {
   root : @rdom.Element
   textarea : @rdom.Element
   cancel : @rdom.Element
-  action : @rdom.Element
-  mut showing_alt : Bool
+  add : @rdom.Element
+  apply : @rdom.Element
 }
 
 ///|
@@ -85,21 +84,37 @@ pub fn AgentFeedbackInputWidget::AgentFeedbackInputWidget(
   )
   cancel.set_attribute("title", "Cancel feedback (Escape)")
   cancel.set_inner_html("Cancel")
-  let action = document.create_element("button")
-  action.set_attribute("type", "button")
-  action.set_attribute("data-agent-feedback-action", "add")
+  let add = document.create_element("button")
+  add.set_attribute("type", "button")
+  add.set_attribute(
+    "class", "agent-feedback-input-action agent-feedback-input-action-secondary agent-feedback-input-action-add",
+  )
+  add.set_attribute("data-agent-feedback-action", "add")
+  add.set_attribute("title", "Add feedback to the batch (Enter)")
+  add.set_attribute("aria-label", "Add feedback")
+  add.set_inner_html("Add feedback")
+  let apply = document.create_element("button")
+  apply.set_attribute("type", "button")
+  apply.set_attribute(
+    "class", "agent-feedback-input-action agent-feedback-input-action-primary agent-feedback-input-action-apply",
+  )
+  apply.set_attribute("data-agent-feedback-action", "apply")
+  apply.set_attribute("title", "Apply all feedback (Alt+Enter)")
+  apply.set_attribute("aria-label", "Apply all feedback")
+  apply.set_inner_html("Apply all feedback")
   actions.append_child(cancel.as_node())
-  actions.append_child(action.as_node())
+  actions.append_child(add.as_node())
+  actions.append_child(apply.as_node())
   root.append_child(actions.as_node())
   let widget : AgentFeedbackInputWidget = {
     host,
     root,
     textarea,
     cancel,
-    action,
-    showing_alt: false,
+    add,
+    apply,
   }
-  widget.render_action()
+  widget.update_actions_enabled()
   widget.hook_events()
   widget
 }
@@ -109,30 +124,6 @@ pub fn AgentFeedbackInputWidget::get_dom_node(
   self : AgentFeedbackInputWidget,
 ) -> @rdom.Element {
   self.root
-}
-
-///|
-/// `_updateActionForAlt`: the primary button's label/title swap between Add
-/// and Add-and-Submit with the Alt key.
-fn AgentFeedbackInputWidget::render_action(
-  self : AgentFeedbackInputWidget,
-) -> Unit {
-  if self.showing_alt {
-    self.action.set_attribute(
-      "class", "agent-feedback-input-action agent-feedback-input-action-primary agent-feedback-input-action-send",
-    )
-    self.action.set_attribute("title", "Add Feedback and Submit (Alt+Enter)")
-    self.action.set_attribute("aria-label", "Add feedback and submit")
-    self.action.set_inner_html("Add &amp; submit")
-  } else {
-    self.action.set_attribute(
-      "class", "agent-feedback-input-action agent-feedback-input-action-primary agent-feedback-input-action-add",
-    )
-    self.action.set_attribute("title", "Add Feedback (Enter)")
-    self.action.set_attribute("aria-label", "Add feedback")
-    self.action.set_inner_html("Add feedback")
-  }
-  self.update_action_enabled()
 }
 
 ///|
@@ -149,7 +140,8 @@ fn AgentFeedbackInputWidget::hook_events(
   self.root.add_event_listener("mousedown", event => {
     event.stop_propagation()
     if !input_event_targets(event, self.textarea) &&
-      !input_event_targets(event, self.action) &&
+      !input_event_targets(event, self.add) &&
+      !input_event_targets(event, self.apply) &&
       !input_event_targets(event, self.cancel) {
       event.prevent_default()
       @base_browser.focus_prevent_scroll(self.textarea)
@@ -160,15 +152,18 @@ fn AgentFeedbackInputWidget::hook_events(
     event.stop_propagation()
     (self.host.on_cancel)()
   })
-  self.action.add_event_listener("click", event => {
+  self.add.add_event_listener("click", event => {
     event.prevent_default()
     event.stop_propagation()
     if self.has_text() {
-      if self.showing_alt {
-        (self.host.on_add_and_submit)()
-      } else {
-        (self.host.on_add)()
-      }
+      (self.host.on_add)()
+    }
+  })
+  self.apply.add_event_listener("click", event => {
+    event.prevent_default()
+    event.stop_propagation()
+    if self.has_text() {
+      (self.host.on_add_and_submit)()
     }
   })
   self.textarea.add_event_listener("keydown", event => {
@@ -178,20 +173,9 @@ fn AgentFeedbackInputWidget::hook_events(
     }
     event.stop_propagation()
   })
-  self.textarea.add_event_listener("keyup", event => {
-    match event.to_keyboard_event() {
-      Some(keyboard) =>
-        if self.showing_alt && !keyboard.alt_key() {
-          self.showing_alt = false
-          self.render_action()
-        }
-      None => ()
-    }
-    event.stop_propagation()
-  })
   self.textarea.add_event_listener("input", _ => {
     self.auto_size()
-    self.update_action_enabled()
+    self.update_actions_enabled()
     (self.host.on_layout)()
   })
   self.textarea.add_event_listener("blur", _ => {
@@ -207,10 +191,6 @@ fn AgentFeedbackInputWidget::handle_keydown(
   event : @rdom.Event,
   keyboard : @rdom.KeyboardEvent,
 ) -> Unit {
-  if keyboard.alt_key() != self.showing_alt {
-    self.showing_alt = keyboard.alt_key()
-    self.render_action()
-  }
   match keyboard.key() {
     "Escape" => {
       event.prevent_default()
@@ -263,7 +243,7 @@ pub fn AgentFeedbackInputWidget::clear_input(
   self : AgentFeedbackInputWidget,
 ) -> Unit {
   input_set_textarea_value(self.textarea, "")
-  self.update_action_enabled()
+  self.update_actions_enabled()
   self.auto_size()
 }
 
@@ -326,13 +306,15 @@ pub fn AgentFeedbackInputWidget::measured_width(
 }
 
 ///|
-fn AgentFeedbackInputWidget::update_action_enabled(
+fn AgentFeedbackInputWidget::update_actions_enabled(
   self : AgentFeedbackInputWidget,
 ) -> Unit {
   if self.has_text() {
-    self.action.remove_attribute("disabled")
+    self.add.remove_attribute("disabled")
+    self.apply.remove_attribute("disabled")
   } else {
-    self.action.set_attribute("disabled", "true")
+    self.add.set_attribute("disabled", "true")
+    self.apply.set_attribute("disabled", "true")
   }
 }
 

--- a/editor/tests/browser/component/agent_feedback.spec.js
+++ b/editor/tests/browser/component/agent_feedback.spec.js
@@ -6,7 +6,7 @@ import {
 
 // End-to-end coverage for the agent-feedback contrib: collapsed bubbles from
 // seeded service items, expand/collapse with the one-expanded rule, the
-// hover "+" glyph → inline input → Enter add flow, reply and remove
+// hover "+" glyph → inline input → add/apply flows, reply and remove
 // mutations (observed through the service events mirrored on
 // #feedback-events), and the bubbles tracking editor scrolls.
 
@@ -124,13 +124,19 @@ test('agent feedback: bubbles, glyph add flow, reply, remove, scroll', async ({ 
     '.agent-feedback-input-action-cancel',
   );
   const addFeedback = page.locator(
-    '.agent-feedback-input-action-primary',
+    '.agent-feedback-input-action-add',
+  );
+  const applyAllFeedback = page.locator(
+    '.agent-feedback-input-action-apply',
   );
   await expect(cancelFeedback).toHaveText('Cancel');
   await expect(addFeedback).toHaveText('Add feedback');
+  await expect(applyAllFeedback).toHaveText('Apply all feedback');
   await expect(addFeedback).toBeDisabled();
+  await expect(applyAllFeedback).toBeDisabled();
   await input.fill('Needs a guard clause');
   await expect(addFeedback).toBeEnabled();
+  await expect(applyAllFeedback).toBeEnabled();
   const singleLineHeight = (await boxOf(input)).height;
   await input.press('Shift+Enter');
   await expect(input).toHaveValue('Needs a guard clause\n');
@@ -153,6 +159,24 @@ test('agent feedback: bubbles, glyph add flow, reply, remove, scroll', async ({ 
     );
   await expect(page.locator('.agent-feedback-input-widget')).not.toBeVisible();
   await expect(widgets).toHaveCount(3);
+
+  // A second item can apply the complete accepted batch immediately. The
+  // explicit button is always visible; Alt+Enter remains its keyboard path.
+  const nextQuietLine = page
+    .locator('.view-line', { hasText: 'filler line 4' })
+    .first();
+  await nextQuietLine.hover();
+  const nextGlyphBox = await boxOf(glyph);
+  await page.mouse.click(
+    nextGlyphBox.x + nextGlyphBox.width / 2,
+    nextGlyphBox.y + nextGlyphBox.height / 2,
+  );
+  await expect(input).toBeFocused();
+  await input.fill('Apply this batch now');
+  await applyAllFeedback.click();
+  await expect.poll(async () => (await eventCounts(page)).added).toBe(2);
+  await expect.poll(async () => (await eventCounts(page)).submitted).toBe(5);
+  await expect(page.locator('.agent-feedback-input-widget')).not.toBeVisible();
 
   // Remove: the hover action bar's remove button drops the item; the far
   // bubble (one comment) disappears with it.

--- a/editor/viewer/contrib/agent_feedback/browser/agent_feedback.css
+++ b/editor/viewer/contrib/agent_feedback/browser/agent_feedback.css
@@ -130,7 +130,8 @@
   cursor: pointer;
 }
 
-.agent-feedback-input-widget .agent-feedback-input-action-cancel {
+.agent-feedback-input-widget .agent-feedback-input-action-cancel,
+.agent-feedback-input-widget .agent-feedback-input-action-secondary {
   color: var(--vscode-button-secondaryForeground);
   background: var(--vscode-button-secondaryBackground);
 }
@@ -141,7 +142,9 @@
 }
 
 .agent-feedback-input-widget
-  .agent-feedback-input-action-cancel:hover:not([disabled]) {
+  .agent-feedback-input-action-cancel:hover:not([disabled]),
+.agent-feedback-input-widget
+  .agent-feedback-input-action-secondary:hover:not([disabled]) {
   background: var(--vscode-button-secondaryHoverBackground);
 }
 


### PR DESCRIPTION
## Summary

- add explicit Add feedback and Apply all feedback actions to the inline editor feedback widget
- keep Add feedback batched in the main composer, while Apply all feedback submits the accepted batch through the existing Chat or Codex prompt/steer queue
- preserve original-revision diff annotations in Codex and defer bubble removal so add-and-apply event ordering stays deterministic

## Verification

- just check
- just test (3334 native, 3300 JS, and 28 cram tests)
- just build
- just editor-test (1080 wasm, 1864 JS, and 1215 native tests)
- just editor-test-browser (107 browser tests)
- focused agent feedback Playwright component test

## Review

A fresh Codex CLI review completed with no remaining findings. Earlier independent review passes caught event-ordering, original-side routing, and generated-interface issues; those were fixed and re-reviewed.