### PR TITLE
docs(prompt): encourage parallel explore scouts

### DIFF
--- a/agent_explore/README.mbt.md
+++ b/agent_explore/README.mbt.md
@@ -25,3 +25,32 @@ Contract highlights:
   spending anything, and a granted child always runs at its full ceiling.
 - Failure is graceful: no report / timeout / budget exhaustion all return an
   is_error result telling the parent to fall back to reading directly.
+
+## Evaluating Parent Tool Selection
+
+Prompt wording is effective only if the parent model chooses `explore` at the
+right time. A unit test that checks whether the prompt contains a phrase cannot
+measure that behavior. Compare the baseline and candidate prompts with the same
+model, thinking mode, repository revision, user tasks, and step budget. Run each
+case at least ten times because tool selection is nondeterministic.
+
+Use a balanced case set:
+
+- **Parallel-positive:** one read-only architecture question with two or three
+  independent tracks, such as tracing subrun budgeting, explore child launch,
+  and desktop result presentation. The desired first action is one batched
+  assistant step containing two or three non-overlapping `explore` calls.
+- **Single-positive:** one broad cross-package flow question. The desired
+  behavior is one early `explore` call followed by targeted spot-checks.
+- **Negative control:** an exact symbol or known-file question answerable with
+  one `moon ide doc` query or one focused read. The desired behavior is no
+  `explore` call.
+
+Record positive selection rate, first-step parallel batch rate, negative-control
+over-delegation, duplicate/overlapping scout questions, citations that survive
+spot-checking, tool errors, total model steps, tokens, and wall time. Promote a
+prompt change only when selection and useful batching improve without materially
+raising negative-control delegation, errors, or end-to-end cost. Run the normal
+`eval/prompt_task` suite as a regression check after this focused selection A/B;
+its implementation tasks measure overall task quality but are not, by
+themselves, a sensitive test of `explore` selection.

--- a/agent_explore/tool.mbt
+++ b/agent_explore/tool.mbt
@@ -54,15 +54,14 @@ pub fn definition(
     concurrent_safe=true,
     description=(
       #|Delegate ONE self-contained question to a read-only scout subagent and get a
-      #|bounded, cited answer. Use it when answering would mean reading MANY files or
-      #|discovering MoonBit APIs you are not sure about — (a) workspace questions ("where
-      #|is X handled, how does Y flow") where you want the conclusion, not the file dumps;
-      #|(b) MoonBit stdlib/dependency API discovery (what a package offers, exact
-      #|signatures) — prefer this over guessing APIs from memory. For a single direct
-      #|lookup you can do in one step (one `moon ide doc` query, one file read), do it
-      #|yourself instead. The scout cannot edit anything and returns file:line citations
-      #|you can verify. Independent questions? Issue SEVERAL explore calls in the same
-      #|step — they run concurrently.
+      #|bounded, cited answer. Use it EARLY for unfamiliar cross-package work, fan-out
+      #|searches, end-to-end traces, or MoonBit APIs you are not sure about. When a task
+      #|has 2-3 independent discovery tracks, issue one non-overlapping explore call per
+      #|track in the SAME step BEFORE tracing them yourself; the calls run concurrently.
+      #|Good questions include where X is handled, how Y flows, who calls Z, which tests
+      #|cover it, or what API a package offers. Include known paths or symbols as hints.
+      #|For one direct lookup (one `moon ide doc` query or one focused file read), do it
+      #|yourself. The scout cannot edit and returns file:line citations you can verify.
     ),
     schema=JsonSchema({
       "type": "object",

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -349,16 +349,18 @@ tools that rewrite source as their job (`moon fmt`, `moon info`,
   returns severity-tagged findings with file:line citations. A blocker
   finding means the claim does not hold yet. Costs a bounded subagent run;
   for small changes, validate directly instead.
-- `explore` tool: delegate ONE self-contained question to a read-only scout
-  subagent when answering it yourself would mean reading MANY files or a
-  fan-out search — "where is X handled", "how does Y flow end to end", "what
-  does this package offer for Z" — and you want the cited conclusion, not the
-  file contents in your context. For a single direct lookup (one
-  `moon ide doc` query, one file read), do it yourself instead. The scout
-  cannot edit anything, returns file:line citations you can spot-check, and
-  shares a small per-turn budget (a few delegations per turn), so spend it on
-  questions that genuinely fan out. Independent questions batch: issue the
-  explore calls in the SAME step and they run concurrently.
+- `explore` tool: use read-only scouts EARLY when unfamiliar work crosses
+  packages, needs a fan-out search, or needs an end-to-end trace. Each call
+  delegates ONE self-contained question and returns a bounded conclusion with
+  file:line citations, keeping the scout's file reads out of your context.
+  Default to one scout for one broad trace. When a task has TWO OR MORE
+  independent discovery tracks (for example entry points, runtime flow,
+  callers/tests, or API surface), issue 2-3 non-overlapping `explore` calls in
+  the SAME step BEFORE tracing those tracks yourself; they run concurrently.
+  Include known paths or symbols as hints. Do a direct lookup yourself when
+  one `moon ide doc` query or one focused file read can settle it. The scouts
+  cannot edit, and their shared per-turn budget is bounded, so spot-check the
+  returned citations and do not delegate overlapping questions.
 - `subtask` tool: parallelize LARGE partitionable work — three or more
   independent slices that each need real edit+verify cycles (fixing warnings
   by category, per-package sweeps, migration chunks). Each launch names a

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -354,16 +354,18 @@ fn default_prompt() -> String {
     #|  returns severity-tagged findings with file:line citations. A blocker
     #|  finding means the claim does not hold yet. Costs a bounded subagent run;
     #|  for small changes, validate directly instead.
-    #|- `explore` tool: delegate ONE self-contained question to a read-only scout
-    #|  subagent when answering it yourself would mean reading MANY files or a
-    #|  fan-out search — "where is X handled", "how does Y flow end to end", "what
-    #|  does this package offer for Z" — and you want the cited conclusion, not the
-    #|  file contents in your context. For a single direct lookup (one
-    #|  `moon ide doc` query, one file read), do it yourself instead. The scout
-    #|  cannot edit anything, returns file:line citations you can spot-check, and
-    #|  shares a small per-turn budget (a few delegations per turn), so spend it on
-    #|  questions that genuinely fan out. Independent questions batch: issue the
-    #|  explore calls in the SAME step and they run concurrently.
+    #|- `explore` tool: use read-only scouts EARLY when unfamiliar work crosses
+    #|  packages, needs a fan-out search, or needs an end-to-end trace. Each call
+    #|  delegates ONE self-contained question and returns a bounded conclusion with
+    #|  file:line citations, keeping the scout's file reads out of your context.
+    #|  Default to one scout for one broad trace. When a task has TWO OR MORE
+    #|  independent discovery tracks (for example entry points, runtime flow,
+    #|  callers/tests, or API surface), issue 2-3 non-overlapping `explore` calls in
+    #|  the SAME step BEFORE tracing those tracks yourself; they run concurrently.
+    #|  Include known paths or symbols as hints. Do a direct lookup yourself when
+    #|  one `moon ide doc` query or one focused file read can settle it. The scouts
+    #|  cannot edit, and their shared per-turn budget is bounded, so spot-check the
+    #|  returned citations and do not delegate overlapping questions.
     #|- `subtask` tool: parallelize LARGE partitionable work — three or more
     #|  independent slices that each need real edit+verify cycles (fixing warnings
     #|  by category, per-package sweeps, migration chunks). Each launch names a


### PR DESCRIPTION
## Summary

- make `explore` an early default for unfamiliar cross-package and fan-out investigation
- direct the parent to batch 2-3 non-overlapping discovery tracks in the same concurrent step
- preserve direct lookup as the negative case and align the tool description with the system prompt
- document a behavioral A/B protocol for measuring selection, useful batching, over-delegation, citation quality, and cost

## Validation

- `moon test prompt --target native` (20 passed)
- `moon test agent_explore --target native` (12 passed)
- `moon info`
- `moon fmt`
- `just check`
- `just test`
- `moon cram test tests/cram` (28 passed)
- `just build`

A live baseline/candidate model A/B was intentionally not run because it is nondeterministic and consumes provider API credits; the repeatable evaluation protocol is included in `agent_explore/README.mbt.md`.