### PR TITLE
Add moongrep structural-search guidance to the system prompt

### DIFF
--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -100,7 +100,9 @@ these programs can be started:
   (`-c`, `-C`, `--git-dir`, `--work-tree`) is refused.
 - `gh` — pr, issue, run, `repo view`, api, `auth status`.
 - `rg` and `diff`.
-- `moonx` — runs other MoonBit binaries in wasm/sandbox mode.
+- `moonx` — runs other MoonBit binaries in wasm/sandbox mode; see
+  [Structural search with `moongrep`](#structural-search-with-moongrep) below
+  for AST-based code search.
 
 Anything else is refused, including the obvious ones such as `ls`, `cat`, and
 `sh`. Each of those is a line of MoonBit here, which also works on Windows,
@@ -258,6 +260,74 @@ tools that rewrite source as their job (`moon fmt`, `moon info`,
 - `moon bench`: run benchmarks, e.g. `moon bench lib/parser`.
 - `moon coverage analyze`: inspect test coverage when coverage matters.
   Example: `moon coverage analyze --package user/project/parser`.
+
+### Structural search with `moongrep`
+
+`moonx` also runs `moongrep`, a structural (AST-based) search and lint tool
+for MoonBit — use it when a text grep cannot express the shape you need
+("all `inspect` calls whose `content` is a literal", "every `match` over
+`Some`/`None`", "every call of one function nested inside another"). No `--`
+separator is needed: the arguments after the coordinate are moongrep's own.
+
+```mbtx
+///|
+import {
+  "moonbitlang/async",
+  "moonbitlang/async/shell",
+}
+
+///|
+async fn main {
+  let out = @shell.Cmd("moonx", [
+    "moonbit-community/moongrep", "scan",
+    "--pattern",
+    "match $(value:exp) { Some($(some:id)) => $(some_body:exp); None => $(none_body:exp) }",
+    "--output-json",
+  ]).output()
+  println("exit=\{out.exit_code()}")
+  // Whole-repo scans can match many nodes; keep the printed excerpt bounded.
+  let stdout = out.stdout()
+  let n = if stdout.length() > 2000 { 2000 } else { stdout.length() }
+  println(stdout[:n])
+}
+```
+
+`scan` (and `lint`, which prepends the embedded builtin rules) scans
+recursively from the scan root — a directory or a single `.mbt` file; the
+default root `.` means the whole repository, which is the typical use.
+`.git`, `_build`, `.mooncakes`, and `target` are skipped by default;
+`--exclude <name-or-path>` skips more entries. Use `--output-json` for
+agent-friendly output: one JSON object per finding with `file` (relative to
+the scan root, often `./`-prefixed), `rule_id`, `description`, `range`
+(1-based `line`/`column`), `matched_source`, and `source_context`; a scan
+with zero findings writes nothing and still exits 0. A whole-repo scan can
+match many nodes, so bound what you print (as above) or redirect stdout
+with `stdout=ToFile(...)` under `@fs.tmpdir(prefix="run-")`. `--rules <dir>`
+and `--rule <file>` load YAML rule files, `--disable <rule-id>` drops a
+loaded rule, and `--verbose` traces traversal on stderr.
+
+A `--pattern` is a MoonBit *expression* containing `$(name:kind)`
+metavariables — `exp`, `id`, `const`, `arg`, `pat`, `type` — plus `$_` to
+match anything without capturing. Matching is on the untyped CST: whitespace
+and comments do not matter, but syntax shape does (`Some(1)` does not match
+`Some($(some:id))`; `Ok`/`Err` branches do not match a `Some`/`None`
+pattern). A metavariable used twice must capture equal structure. `--guard
+'{$name: "regex"}'` filters `id` and `const` captures (substring match
+unless anchored with `^...$`). When a pattern surprises you,
+`moongrep dump --expr '...'` or `dump --impl 'fn f { ... }'` prints the CST
+of a snippet, and `moongrep docs RuleSpec` / `docs CLISpec` print the full
+specs.
+
+Exit codes: 0 for help, dump, findings, no-findings, and parse warnings
+(no-match is NOT grep's 1); 2 usage; 3 invalid dump input; 4 rule-source
+failure; 5 invalid rule content (including a `--pattern` that is not a valid
+MoonBit expression); 6 missing/unreadable scan input; 7 output failure. The
+scanner follows symlinks, so a broken symlink anywhere under the scan root
+aborts the whole scan with 6 — some workspaces contain dangling symlinks
+(this one does, under `editor/codemirror/demo/`, `.worktrees/`, and
+`.moonagent/`), so scope scans to the subdirectory you care about (pass it
+as the scan root) or `--exclude` those paths instead of scanning `.` from
+the root.
 
 ## Tool Protocol
 

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -105,7 +105,9 @@ fn default_prompt() -> String {
     #|  (`-c`, `-C`, `--git-dir`, `--work-tree`) is refused.
     #|- `gh` — pr, issue, run, `repo view`, api, `auth status`.
     #|- `rg` and `diff`.
-    #|- `moonx` — runs other MoonBit binaries in wasm/sandbox mode.
+    #|- `moonx` — runs other MoonBit binaries in wasm/sandbox mode; see
+    #|  [Structural search with `moongrep`](#structural-search-with-moongrep) below
+    #|  for AST-based code search.
     #|
     #|Anything else is refused, including the obvious ones such as `ls`, `cat`, and
     #|`sh`. Each of those is a line of MoonBit here, which also works on Windows,
@@ -263,6 +265,74 @@ fn default_prompt() -> String {
     #|- `moon bench`: run benchmarks, e.g. `moon bench lib/parser`.
     #|- `moon coverage analyze`: inspect test coverage when coverage matters.
     #|  Example: `moon coverage analyze --package user/project/parser`.
+    #|
+    #|### Structural search with `moongrep`
+    #|
+    #|`moonx` also runs `moongrep`, a structural (AST-based) search and lint tool
+    #|for MoonBit — use it when a text grep cannot express the shape you need
+    #|("all `inspect` calls whose `content` is a literal", "every `match` over
+    #|`Some`/`None`", "every call of one function nested inside another"). No `--`
+    #|separator is needed: the arguments after the coordinate are moongrep's own.
+    #|
+    #|```mbtx
+    #|///|
+    #|import {
+    #|  "moonbitlang/async",
+    #|  "moonbitlang/async/shell",
+    #|}
+    #|
+    #|///|
+    #|async fn main {
+    #|  let out = @shell.Cmd("moonx", [
+    #|    "moonbit-community/moongrep", "scan",
+    #|    "--pattern",
+    #|    "match $(value:exp) { Some($(some:id)) => $(some_body:exp); None => $(none_body:exp) }",
+    #|    "--output-json",
+    #|  ]).output()
+    #|  println("exit=\{out.exit_code()}")
+    #|  // Whole-repo scans can match many nodes; keep the printed excerpt bounded.
+    #|  let stdout = out.stdout()
+    #|  let n = if stdout.length() > 2000 { 2000 } else { stdout.length() }
+    #|  println(stdout[:n])
+    #|}
+    #|```
+    #|
+    #|`scan` (and `lint`, which prepends the embedded builtin rules) scans
+    #|recursively from the scan root — a directory or a single `.mbt` file; the
+    #|default root `.` means the whole repository, which is the typical use.
+    #|`.git`, `_build`, `.mooncakes`, and `target` are skipped by default;
+    #|`--exclude <name-or-path>` skips more entries. Use `--output-json` for
+    #|agent-friendly output: one JSON object per finding with `file` (relative to
+    #|the scan root, often `./`-prefixed), `rule_id`, `description`, `range`
+    #|(1-based `line`/`column`), `matched_source`, and `source_context`; a scan
+    #|with zero findings writes nothing and still exits 0. A whole-repo scan can
+    #|match many nodes, so bound what you print (as above) or redirect stdout
+    #|with `stdout=ToFile(...)` under `@fs.tmpdir(prefix="run-")`. `--rules <dir>`
+    #|and `--rule <file>` load YAML rule files, `--disable <rule-id>` drops a
+    #|loaded rule, and `--verbose` traces traversal on stderr.
+    #|
+    #|A `--pattern` is a MoonBit *expression* containing `$(name:kind)`
+    #|metavariables — `exp`, `id`, `const`, `arg`, `pat`, `type` — plus `$_` to
+    #|match anything without capturing. Matching is on the untyped CST: whitespace
+    #|and comments do not matter, but syntax shape does (`Some(1)` does not match
+    #|`Some($(some:id))`; `Ok`/`Err` branches do not match a `Some`/`None`
+    #|pattern). A metavariable used twice must capture equal structure. `--guard
+    #|'{$name: "regex"}'` filters `id` and `const` captures (substring match
+    #|unless anchored with `^...$`). When a pattern surprises you,
+    #|`moongrep dump --expr '...'` or `dump --impl 'fn f { ... }'` prints the CST
+    #|of a snippet, and `moongrep docs RuleSpec` / `docs CLISpec` print the full
+    #|specs.
+    #|
+    #|Exit codes: 0 for help, dump, findings, no-findings, and parse warnings
+    #|(no-match is NOT grep's 1); 2 usage; 3 invalid dump input; 4 rule-source
+    #|failure; 5 invalid rule content (including a `--pattern` that is not a valid
+    #|MoonBit expression); 6 missing/unreadable scan input; 7 output failure. The
+    #|scanner follows symlinks, so a broken symlink anywhere under the scan root
+    #|aborts the whole scan with 6 — some workspaces contain dangling symlinks
+    #|(this one does, under `editor/codemirror/demo/`, `.worktrees/`, and
+    #|`.moonagent/`), so scope scans to the subdirectory you care about (pass it
+    #|as the scan root) or `--exclude` those paths instead of scanning `.` from
+    #|the root.
     #|
     #|## Tool Protocol
     #|


### PR DESCRIPTION
## What

Add structural-search guidance for `moongrep` to the built-in system prompt so the agent can use `moonx moonbit-community/moongrep` for AST-based MoonBit code search.

- `prompt/default_prompt.mbt.md`: new "Structural search with `moongrep`" subsection, plus a pointer on the `moonx` allowlist entry.
- `prompt/generated_default_prompt.mbt`: regenerated via the `md_to_mbt_string` dev_build rule (`moon run --target native scripts/md_to_mbt_string -- ...`).

The default example is the typical whole-repository scan (scan root `.`, no `--` separator), with a bounded-print excerpt because a whole-repo scan can match thousands of nodes. The guidance also covers: the `--output-json` record schema, `$(name:kind)` metavariables (`exp`/`id`/`const`/`arg`/`pat`/`type`) and `$_`, `--guard` regex filters, `dump`/`docs` for debugging patterns, exit codes, and the broken-symlink caveat that aborts scans with status 6.

## Verification

- Every `moonx moonbit-community/moongrep` claim was exercised against this repo: whole-repo `scan . --pattern --output-json`, single-file and directory scan roots, `lint` (builtin rules), `--guard` on `const` captures, `dump --expr` / `dump --impl`, `docs --list`, and the no-`--` invocation form.
- The exact `mbtx` example embedded in the prompt was run verbatim through the mbtx tool in a clean worktree checkout (whole-repo scan, exit 0, bounded excerpt printed).
- `moon check prompt`, `moon test prompt` (20/20), and `moon fmt --check` on the two changed files are all green.

Generated with SeekMoon