### PR TITLE
fix(desktop): re-navigate a reused browser tab to the clicked URL

### DIFF
--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -4764,11 +4764,25 @@ fn update_msg(
         match reuse {
           Some(id) => {
             let dock = @dock.open_browser(model.dock, id)
+            // The reuse matched this page's optimistic URL mirror, which can
+            // drift from what the native view actually shows — a host op that
+            // failed, or a reload's `close_all` that swept the view. Focusing
+            // alone would present the stale page under the clicked URL, so a
+            // reuse re-navigates: `browser.navigate` rebuilds the view when
+            // it is gone, and dropping the pane placement makes the next sync
+            // measure and show whatever the host has now.
             (
-              @cmd.none,
+              browser_navigate(
+                dispatch,
+                id,
+                url,
+                model.theme.is_dark(model.system_dark),
+              ),
               {
                 ..model,
+                preview: @preview.navigate(model.preview, id, url),
                 dock,
+                browser_pane: { shown: None, rect: None, geo: None, },
                 right_panel_open: true,
                 right_panel_menu_open: false,
               },
@@ -18243,7 +18257,8 @@ test "web links open (and reuse) a dock browser tab; other schemes do not" {
     @preview.page(model.preview, 2).unwrap().url ==
     Some("https://terminal.example/docs"),
   )
-  // The same URL re-activates the existing tab instead of duplicating.
+  // The same URL re-activates the existing tab instead of duplicating, and
+  // the reuse re-navigates so the view cannot keep showing a stale page.
   let (_, model) = update(
     dispatch,
     ExternalLinkClicked("http://127.0.0.1:5173/"),
@@ -18251,6 +18266,12 @@ test "web links open (and reuse) a dock browser tab; other schemes do not" {
   )
   assert_eq(model.dock.tabs.length(), 2)
   assert_eq(model.preview.pages.length(), 2)
+  assert_true(@dock.active_browser(model.dock) == Some(1))
+  assert_true(
+    @preview.page(model.preview, 1).unwrap().url ==
+    Some("http://127.0.0.1:5173/"),
+  )
+  assert_true(@preview.page(model.preview, 1).unwrap().loading)
   assert_eq(model.file_panel.file_link_generation, generation + 3)
   // External sites are web pages too: they get their own tab.
   let (_, model) = update(
@@ -18345,6 +18366,51 @@ test "a remote console routes loopback links to the system browser too" {
   )
   assert_true(model.dock.tabs.is_empty())
   assert_true(model.preview.pages.is_empty())
+}
+
+///|
+test "re-clicking a chat link re-navigates the reused tab to the clicked URL" {
+  // The reuse matched the page's optimistic URL mirror, which can have
+  // drifted from what the native view shows — the clicked link must win over
+  // whatever the tab currently displays, and the stale pane placement must
+  // not survive a possibly rebuilt view (#1021).
+  let dispatch = test_dispatch()
+  let model = desktop_model()
+  let (_, model) = update(
+    dispatch,
+    ExternalLinkClicked("http://127.0.0.1:5173/"),
+    model,
+  )
+  let rect : @preview.Rect = { x: 480, y: 46, width: 640, height: 700, }
+  let (_, model) = update(dispatch, BrowserPaneMeasured(rect~), model)
+  assert_true(model.browser_pane.shown == Some(1))
+  let (_, model) = update(
+    dispatch,
+    ExternalLinkClicked("https://github.com/moonbit"),
+    model,
+  )
+  assert_true(@dock.active_browser(model.dock) == Some(2))
+  // Back to the first link: its tab re-activates AND re-navigates.
+  let (_, model) = update(
+    dispatch,
+    ExternalLinkClicked("http://127.0.0.1:5173/"),
+    model,
+  )
+  assert_eq(model.dock.tabs.length(), 2)
+  assert_true(@dock.active_browser(model.dock) == Some(1))
+  let page = @preview.page(model.preview, 1).unwrap()
+  assert_true(page.url == Some("http://127.0.0.1:5173/"))
+  assert_eq(page.input, "http://127.0.0.1:5173/")
+  assert_true(page.loading)
+  assert_true(page.failure is None)
+  // A rebuilt view arrives hidden at a placeholder size, so the placement
+  // the old view had is dropped for the next sync to re-measure.
+  assert_true(model.browser_pane.shown is None)
+  assert_true(model.browser_pane.rect is None)
+  // …and the re-measure places the view again.
+  let (_, model) = update(dispatch, BrowserPaneMeasured(rect~), model)
+  assert_true(model.browser_pane.shown == Some(1))
+  assert_true(model.browser_pane.rect == Some(rect))
 }
 
 ///|


### PR DESCRIPTION
Fixes #1021

## Problem

Clicking a link in the chat history reuses an existing Browser tab when the page's optimistic URL mirror (`page.url`) matches the clicked URL — but the reuse branch only re-activated the tab (`@cmd.none`), never navigated. The mirror can drift from what the native view actually shows: a `browser.open`/`browser.navigate` op the host refused (failure is only a toast), a load failure that keeps `page.url` at the target while the view never got there, or a reload's `close_all` that swept the view away. The reused tab then keeps displaying the previously loaded page while the address bar shows the clicked URL, and nothing reconverges.

## Fix

A same-URL reuse now re-navigates to the clicked URL instead of trusting the mirror:

- send `browser.navigate` for the reused page (the host op is create-if-missing, so it also rebuilds a view a `close_all` swept),
- commit the clicked URL via `@preview.navigate` so the address bar and the mirror match the page being loaded,
- drop the cached `browser_pane` placement — a rebuilt view arrives hidden at a placeholder size, so the next sync re-measures and places whatever the host has now (same discipline as `BrowserNavigateSubmitted`).

Behavior note: a repeat click on the very URL a tab is already showing now reloads it. The mirror alone cannot prove what the view displays, so re-navigating is what guarantees "the address bar URL always matches the page currently displayed".

## Tests

- updated "web links open (and reuse) a dock browser tab; other schemes do not": a reuse now re-activates, commits the clicked URL and sets `loading`
- new "re-clicking a chat link re-navigates the reused tab to the clicked URL": covers the issue repro (A → B → A) — the reused tab is re-activated and re-navigated, `page.url`/`input`/`loading` reflect the clicked URL, the stale pane placement is dropped, and a follow-up `BrowserPaneMeasured` places the view again

`moon check --target js frontend` and `moon test --target js frontend` (461 tests) pass.
