### PR TITLE
Refactor: rewrite 229 simplifiable assignments as augmented assignments

### DIFF
--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -162,7 +162,7 @@ async test "run_turn_with_append closes failed persisted turns" {
     session=initial,
     task="hello",
     append_item=(session, item) => {
-      calls = calls + 1
+      calls += 1
       if calls == 2 {
         fail("persist terminal failed")
       }

--- a/agent_tool/edit/edit.mbt
+++ b/agent_tool/edit/edit.mbt
@@ -868,7 +868,7 @@ fn line_end_offset(content : String, line : Int) -> Int {
       if current_line == line {
         break cursor + 1
       }
-      current_line = current_line + 1
+      current_line += 1
     }
   } nobreak {
     len
@@ -899,7 +899,7 @@ fn line_number_at_offset(content : String, offset : Int) -> Int {
   let mut line = 1
   for cursor in 0..<bounded_offset {
     if content[cursor] == '\n' {
-      line = line + 1
+      line += 1
     }
   }
   line

--- a/agent_tool/internal/auto_check/auto_check.mbt
+++ b/agent_tool/internal/auto_check/auto_check.mbt
@@ -119,12 +119,12 @@ fn tally_diagnostics(text : String, truncated~ : Bool) -> CheckErrors {
         | (_ with message = ""),
         ..
       } => {
-        error_count = error_count + 1
+        error_count += 1
         if first_errors.length() < RevertErrorDisplayLimit {
           first_errors.push(format_diagnostic_line(path, loc, message))
         }
       }
-      { "level": String("warning"), .. } => warning_count = warning_count + 1
+      { "level": String("warning"), .. } => warning_count += 1
       _ => ()
     }
   }

--- a/agent_tool/multi_edit/multi_edit.mbt
+++ b/agent_tool/multi_edit/multi_edit.mbt
@@ -1016,7 +1016,7 @@ fn line_end_offset(content : String, line : Int) -> Int {
       if current_line == line {
         break cursor + 1
       }
-      current_line = current_line + 1
+      current_line += 1
     }
   } nobreak {
     len

--- a/cmd/tui/state.mbt
+++ b/cmd/tui/state.mbt
@@ -166,7 +166,7 @@ fn State::new(config : AppConfig) -> State {
 /// agent running. Returns the new run id so the caller can tag the spawned task's
 /// messages with it.
 fn State::start_run(self : State, started_ms : Int64) -> Int {
-  self.run_id = self.run_id + 1
+  self.run_id += 1
   self.run = Running(started_ms)
   self.step_response = None
   self.streaming_preview = None

--- a/deepseek/client/client_retry_test.mbt
+++ b/deepseek/client/client_retry_test.mbt
@@ -17,7 +17,7 @@ async fn flaky_server(
     server.run_forever(
       (_request, body, conn) => {
         let _ = body.read_all()
-        hits.val = hits.val + 1
+        hits.val += 1
         if hits.val <= failures {
           conn.send_response(status, "Error", extra_headers={
             "Content-Type": "text/plain",
@@ -174,7 +174,7 @@ async test "streaming chat retries a pre-delta stream drop" {
       server.run_forever(
         (_request, body, conn) => {
           let _ = body.read_all()
-          hits.val = hits.val + 1
+          hits.val += 1
           conn.send_response(200, "OK", extra_headers={
             "Content-Type": "text/event-stream",
           })
@@ -221,7 +221,7 @@ async test "streaming chat never retries after the first delta" {
       server.run_forever(
         (_request, body, conn) => {
           let _ = body.read_all()
-          hits.val = hits.val + 1
+          hits.val += 1
           conn.send_response(200, "OK", extra_headers={
             "Content-Type": "text/event-stream",
           })
@@ -272,7 +272,7 @@ async test "streaming chat never retries after a tool-call-only delta" {
       server.run_forever(
         (_request, body, conn) => {
           let _ = body.read_all()
-          hits.val = hits.val + 1
+          hits.val += 1
           conn.send_response(200, "OK", extra_headers={
             "Content-Type": "text/event-stream",
           })

--- a/deepseek/client/client_stream_test.mbt
+++ b/deepseek/client/client_stream_test.mbt
@@ -134,7 +134,7 @@ async test "streaming chat retries an idle stall before any event" {
       server.run_forever(
         (_request, body, conn) => {
           let _ = body.read_all()
-          hits.val = hits.val + 1
+          hits.val += 1
           conn.send_response(200, "OK", extra_headers={
             "Content-Type": "text/event-stream",
           })
@@ -189,7 +189,7 @@ async test "streaming chat fails an idle stall after a delta without retrying" {
       server.run_forever(
         (_request, body, conn) => {
           let _ = body.read_all()
-          hits.val = hits.val + 1
+          hits.val += 1
           conn.send_response(200, "OK", extra_headers={
             "Content-Type": "text/event-stream",
           })
@@ -246,7 +246,7 @@ async test "streaming chat does not retry an idle stall after an unterminated da
       server.run_forever(
         (_request, body, conn) => {
           let _ = body.read_all()
-          hits.val = hits.val + 1
+          hits.val += 1
           conn.send_response(200, "OK", extra_headers={
             "Content-Type": "text/event-stream",
           })

--- a/desktop/frontend/dock/view.mbt
+++ b/desktop/frontend/dock/view.mbt
@@ -213,10 +213,10 @@ pub fn tabs_bar(
   for chip in chips {
     let mut classes = "editor-tab"
     if state.active == Some(chip.tab) {
-      classes = classes + " active"
+      classes += " active"
     }
     if chip.missing {
-      classes = classes + " deleted"
+      classes += " deleted"
     }
     let tab = chip.tab
     tabs.push(

--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -877,7 +877,7 @@ fn show_history_diff_in_viewer(
       services.feedback.clear_feedback(previous.original.uri)
       services.feedback.clear_feedback(previous.modified.uri)
     }
-    viewer_state.version = viewer_state.version + 1
+    viewer_state.version += 1
     let version = viewer_state.version
     let name = basename(diff.path)
     let language = language_id(name)
@@ -1149,7 +1149,7 @@ fn show_file_in_viewer(
           viewer_state.markdown_view_states[prev.0] = view_state
         }
       }
-      viewer_state.version = viewer_state.version + 1
+      viewer_state.version += 1
       let version = viewer_state.version
       let text_model = @model.TextModel(
         uri,

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -887,7 +887,7 @@ fn reconcile_reviews_after_changes(
           }
           continue
         }
-        review_generation = review_generation + 1
+        review_generation += 1
         let generation = review_generation
         let has_working_file = change.has_working_tree_file()
         let missing_rename_source = change.kind
@@ -1649,7 +1649,7 @@ fn refresh_unknown_head_reviews(
     } else {
       path
     }
-    review_generation = review_generation + 1
+    review_generation += 1
     let generation = review_generation
     docs[path] = { ..doc, review: Some({ ..review, generation, }), }
     background_review_requests[path] = generation
@@ -1965,7 +1965,7 @@ pub fn sync(
         }
         // Git baseline replies do not carry the filesystem epoch. Advance
         // every review token so a background legacy refresh is fenced too.
-        review_generation = review_generation + 1
+        review_generation += 1
         docs[path] = {
           ..doc,
           review: Some({ ..review, generation: review_generation, }),
@@ -3373,7 +3373,7 @@ pub fn update(
                     // that was already in flight. Advance its token so an
                     // older successful read cannot resurrect deleted working
                     // text.
-                    review_generation = review_generation + 1
+                    review_generation += 1
                     Some({ ..review, working_generation: review_generation, })
                   }
                   _ => doc.review
@@ -3425,7 +3425,7 @@ pub fn update(
                     // Like a deletion, the failure is newer than any tagged
                     // read still in flight: an older success must not settle
                     // text the host can no longer vouch for.
-                    review_generation = review_generation + 1
+                    review_generation += 1
                     Some({ ..review, working_generation: review_generation, })
                   }
                   _ => doc.review
@@ -3482,7 +3482,7 @@ pub fn update(
               active_reloading = true
               let working_generation = match doc.review {
                 Some(review) => {
-                  review_generation = review_generation + 1
+                  review_generation += 1
                   // A tagged review read can be fenced out if its Git row
                   // disappears first. Preserve a stale marker so leaving review
                   // mode hands the active tab to a replacement ordinary read.

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -270,10 +270,10 @@ pub fn editor_classes(state : State, ctx : Ctx) -> String {
     (ctx.active_file is None && ctx.active_history_diff is None)
   let mut classes = "editor"
   if tree_visible {
-    classes = classes + " tree-open"
+    classes += " tree-open"
   }
   if ctx.tree_layout is RightSidebar {
-    classes = classes + " tree-right"
+    classes += " tree-right"
   }
   classes
 }
@@ -900,7 +900,7 @@ fn graph_row_width(row : GraphRow) -> Int {
 fn find_last_graph_lane(lanes : Array[GraphLane], id : String) -> Int? {
   let mut index = lanes.length()
   while index > 0 {
-    index = index - 1
+    index -= 1
     if lanes[index].id == id {
       return Some(index)
     }
@@ -983,7 +983,7 @@ fn git_graph_cell(
           ),
         )
       } else {
-        output_swimlane_index = output_swimlane_index + 1
+        output_swimlane_index += 1
       }
     } else if output_swimlane_index < row.output_swimlanes.length() &&
       node.id == row.output_swimlanes[output_swimlane_index].id {
@@ -1001,7 +1001,7 @@ fn git_graph_cell(
           attrs=@svg.Attrs::build().stroke_linecap("round"),
         ),
       )
-      output_swimlane_index = output_swimlane_index + 1
+      output_swimlane_index += 1
     }
   }
 
@@ -1162,10 +1162,10 @@ fn git_commit_row(
   }
   let mut row_class = "git-commit-row"
   if head {
-    row_class = row_class + " current"
+    row_class += " current"
   }
   if expanded {
-    row_class = row_class + " selected"
+    row_class += " selected"
   }
   let children : Array[@html.Html] = [
     @html.button(
@@ -1440,10 +1440,10 @@ fn changed_file_row(
   let reviewed = state.reviewed_changes.contains(change)
   let mut class = if selected { "change-row selected" } else { "change-row" }
   if reviewed {
-    class = class + " reviewed"
+    class += " reviewed"
   }
   if !change.selectable() {
-    class = class + " disabled"
+    class += " disabled"
   }
   let children = [
     @html.span(class="change-path", change.path.0),

--- a/desktop/frontend/sidebar/conversation/conversation.mbt
+++ b/desktop/frontend/sidebar/conversation/conversation.mbt
@@ -160,16 +160,16 @@ pub fn component(
   state.map3(input, child_rows, (state, input, child_rows) => {
     let mut class = "conversation-row"
     if input.nested {
-      class = class + " nested"
+      class += " nested"
     }
     if input.subrun {
-      class = class + " subrun"
+      class += " subrun"
     }
     if input.active {
-      class = class + " active"
+      class += " active"
     }
     if input.running {
-      class = class + " running"
+      class += " running"
     }
     let children : Array[@html.Html] = []
     if input.children.is_empty() {

--- a/desktop/frontend/sidebar/project/project.mbt
+++ b/desktop/frontend/sidebar/project/project.mbt
@@ -150,9 +150,9 @@ fn State::next_preview_limit(self : State, input : Input) -> Int {
   let mut revealed = 0
   while limit < input.conversations.length() && revealed < PreviewStep {
     if !input.conversations[limit].active {
-      revealed = revealed + 1
+      revealed += 1
     }
-    limit = limit + 1
+    limit += 1
   }
   limit
 }
@@ -278,10 +278,10 @@ pub fn component(
       "workspace-row collapsible"
     }
     if input.activation is Some(_) {
-      class = class + " active"
+      class += " active"
     }
     if state.menu_open {
-      class = class + " menu-open"
+      class += " menu-open"
     }
     let row_children : Array[@html.Html] = [
       @html.button(

--- a/desktop/frontend/sidebar/section/section.mbt
+++ b/desktop/frontend/sidebar/section/section.mbt
@@ -136,7 +136,7 @@ fn Actions::placeholder_component(
   input.map(row => {
     let mut class = "conversation-row placeholder"
     if row.nested {
-      class = class + " nested"
+      class += " nested"
     }
     if !row.class_name.is_empty() {
       class = class + " " + row.class_name
@@ -261,7 +261,7 @@ pub fn component(
       "sidebar-heading section-heading collapsible"
     }
     if input.activation is Some(_) {
-      class = class + " active"
+      class += " active"
     }
     let heading : Array[@html.Html] = [
       @html.span(class="sidebar-label", input.label),

--- a/desktop/frontend/transcript/component/edit_diff.mbt
+++ b/desktop/frontend/transcript/component/edit_diff.mbt
@@ -59,7 +59,7 @@ fn multi_edit_card(arguments : String) -> @html.Html? {
       decode_edit(entry_fields, path_key="file") is Some(edit) else {
       continue
     }
-    shown = shown + 1
+    shown += 1
     rendered.push(
       @html.div(class="edit-entry", [
         chip_row(edit.chips),

--- a/desktop/frontend/transcript/component/rendering.mbt
+++ b/desktop/frontend/transcript/component/rendering.mbt
@@ -60,7 +60,7 @@ fn durable_step_ordinals(rows : Array[VisibleRow]) -> Map[Int, Int] {
     }
     if evidence && ordinals.get(sequence) is None {
       ordinals.set(sequence, next)
-      next = next + 1
+      next += 1
     }
   }
   ordinals
@@ -218,7 +218,7 @@ fn TranscriptRenderer::stream_children(
           if visible[index].item.kind is (Tool(..) | Reasoning) {
             activity.push(visible[index].item)
           }
-          index = index + 1
+          index += 1
         }
         if !activity.is_empty() {
           items.set(
@@ -256,7 +256,7 @@ fn TranscriptRenderer::stream_children(
         let row = visible[index]
         self.insert_row(items, row, index)
         left_boundary = Some(row.identity)
-        index = index + 1
+        index += 1
         continue
       }
       let run : Array[@transcript.TranscriptItem] = []
@@ -270,7 +270,7 @@ fn TranscriptRenderer::stream_children(
           break
         }
         run.push(visible[index].item)
-        index = index + 1
+        index += 1
       }
       items.set(
         TranscriptRenderKey::activity_after(left_boundary).wire(),

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -100,7 +100,7 @@ fn activity_view(
       let tools : Array[@transcript.TranscriptItem] = []
       while index < items.length() && items[index].kind is Tool(..) {
         tools.push(items[index])
-        index = index + 1
+        index += 1
       }
       rows.push(
         @html.div(class="activity-work", tool_run_views(tools, subrun?)),
@@ -118,7 +118,7 @@ fn activity_view(
           false,
         ),
       )
-      index = index + 1
+      index += 1
     }
   }
   if live_reasoning is Some(content) {

--- a/desktop/frontend/transcript_rendering.mbt
+++ b/desktop/frontend/transcript_rendering.mbt
@@ -72,7 +72,7 @@ fn Conversation::reasoning_for_render(self : Conversation) -> (String?, Bool) {
   if live.complete && !candidate.is_empty() {
     let mut index = self.messages.length()
     while index > 0 {
-      index = index - 1
+      index -= 1
       if self.messages[index].kind is Reasoning {
         if self.messages[index].sequence is Some(sequence) &&
           sequence > self.turn.reasoning_frontier &&

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -2013,10 +2013,10 @@ fn view(
     "content"
   }
   if file_panel_visible && model.right_panel_expanded {
-    content_class = content_class + " panel-expanded"
+    content_class += " panel-expanded"
   }
   if terminal_panel_visible {
-    content_class = content_class + " terminal-open"
+    content_class += " terminal-open"
   }
   let children : Array[@html.Html] = [
     sidebar_html,

--- a/desktop/internal/codex/actor.mbt
+++ b/desktop/internal/codex/actor.mbt
@@ -141,7 +141,7 @@ fn ReverseRequestRegistry::ReverseRequestRegistry() -> ReverseRequestRegistry {
 ///|
 fn ReverseRequestRegistry::reset(self : ReverseRequestRegistry) -> Unit {
   self.requests = Map([])
-  self.generation = self.generation + 1
+  self.generation += 1
 }
 
 ///|
@@ -159,7 +159,7 @@ fn ReverseRequestRegistry::insert(
   request : @jsonrpc.PeerRequest,
 ) -> Unit {
   self.requests[key] = request
-  self.generation = self.generation + 1
+  self.generation += 1
 }
 
 ///|
@@ -169,7 +169,7 @@ fn ReverseRequestRegistry::take(
 ) -> @jsonrpc.PeerRequest? {
   guard self.requests.get(key) is Some(request) else { return None }
   self.requests.remove(key)
-  self.generation = self.generation + 1
+  self.generation += 1
   Some(request)
 }
 

--- a/desktop/internal/engine/api.mbt
+++ b/desktop/internal/engine/api.mbt
@@ -36,7 +36,7 @@ fn normalize_submission_id(submission_id : String?) -> String? {
     } else {
       4
     }
-    byte_length = byte_length + width
+    byte_length += width
     if byte_length > SubmissionIdMaxBytes {
       return None
     }

--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -786,7 +786,7 @@ fn EngineManager::begin_record_read(
       "this conversation is moving between live and archived stores",
     )
   }
-  state.readers = state.readers + 1
+  state.readers += 1
   state
 }
 
@@ -796,7 +796,7 @@ fn EngineManager::end_record_read(
   session : String,
   state : SessionRecordGuard,
 ) -> Unit {
-  state.readers = state.readers - 1
+  state.readers -= 1
   self.prune_record_guard(session, state)
 }
 
@@ -816,7 +816,7 @@ fn EngineManager::begin_record_op(
       },
     )
   }
-  state.active_ops = state.active_ops + 1
+  state.active_ops += 1
   state
 }
 
@@ -826,7 +826,7 @@ fn EngineManager::end_record_op(
   session : String,
   state : SessionRecordGuard,
 ) -> Unit {
-  state.active_ops = state.active_ops - 1
+  state.active_ops -= 1
   self.prune_record_guard(session, state)
 }
 

--- a/desktop/internal/engine/follower.mbt
+++ b/desktop/internal/engine/follower.mbt
@@ -471,7 +471,7 @@ async fn stop_follower_instance(
     // slip behind the drain request, and ensure_follower can never mistake
     // this generation for an active reusable actor.
     follower.stopping = true
-    follower.stop_generation = follower.stop_generation + 1
+    follower.stop_generation += 1
     let generation = follower.stop_generation
     let queued = follower.inbox.try_put(
       Stop(final_scan~, writer_exited~, generation~),
@@ -486,9 +486,9 @@ async fn stop_follower_instance(
     }
     generation
   }
-  follower.stop_observers = follower.stop_observers + 1
+  follower.stop_observers += 1
   defer {
-    follower.stop_observers = follower.stop_observers - 1
+    follower.stop_observers -= 1
     // Keep a failed generation closed while any of its callers still need
     // to observe the result. The last observer reactivates the actor, after
     // which a later lifecycle operation may start a fresh retry generation.
@@ -1027,7 +1027,7 @@ async test "abrupt EOF leaves a failed drain for a later caller to retry" {
     let mut finishes = 0
     for event in emitted {
       if event is Finished(payload) && payload.run_id == "r-abrupt-eof" {
-        finishes = finishes + 1
+        finishes += 1
       }
     }
     assert_eq(finishes, 1)

--- a/desktop/internal/engine/ops.mbt
+++ b/desktop/internal/engine/ops.mbt
@@ -1124,7 +1124,7 @@ async test "setup failure retires the writer before an immediate next start" {
     let mut first_finishes = 0
     for event in emitted {
       if event is Finished(payload) && payload.run_id == first {
-        first_finishes = first_finishes + 1
+        first_finishes += 1
       }
     }
     assert_eq(first_finishes, 1)
@@ -1221,7 +1221,7 @@ async test "a prompt bigger than the pipe still settles exactly once" {
     let mut finishes = 0
     for event in emitted {
       if event is Finished(payload) && payload.run_id == run_id {
-        finishes = finishes + 1
+        finishes += 1
       }
     }
     assert_eq(finishes, 1)

--- a/desktop/internal/engine/settings.mbt
+++ b/desktop/internal/engine/settings.mbt
@@ -252,7 +252,7 @@ pub async fn update_settings(
   // still holding the same lock, so two clients can never observe revision 2
   // before revision 1. The API shields this finite commit+broadcast section
   // from requester cancellation.
-  manager.settings_revision = manager.settings_revision + 1
+  manager.settings_revision += 1
   let status = settings_status_payload(
     decode_settings(raw),
     manager.settings_revision,

--- a/desktop/internal/host/semantic_search.mbt
+++ b/desktop/internal/host/semantic_search.mbt
@@ -529,7 +529,7 @@ fn first_semantic_diagnostic(detail : String) -> String {
     if !line.is_empty() && !line.has_prefix("  ") && !line.has_prefix("\t") {
       return line
     }
-    i = i - 1
+    i -= 1
   }
   // Fallback: last non-empty line.
   i = lines.length() - 1
@@ -538,7 +538,7 @@ fn first_semantic_diagnostic(detail : String) -> String {
     if !line.is_empty() {
       return line
     }
-    i = i - 1
+    i -= 1
   }
   "moongrep could not complete the search."
 }

--- a/desktop/internal/session_record/record.mbt
+++ b/desktop/internal/session_record/record.mbt
@@ -272,7 +272,7 @@ async fn Tail::read_forward(self : Tail) -> Array[@protocol.SessionEvent] {
       error if @async.is_being_cancelled() => raise error
       error => raise Unreadable("cannot read the session record: \{error}")
     }
-    self.offset = self.offset + take
+    self.offset += take
     self.anchor = anchor_of(chunk)
     let mut line_start = 0
     for index in 0..<chunk.length() {

--- a/desktop/internal/subrun/probe.mbt
+++ b/desktop/internal/subrun/probe.mbt
@@ -112,7 +112,7 @@ async fn SubrunProbeState::poll(self : SubrunProbeState) -> Bool {
   let chunk = file.read_exactly_at(take.to_int(), position=self.offset) catch {
     _ => return false
   }
-  self.offset = self.offset + take
+  self.offset += take
   self.anchor = anchor_of(chunk)
   let pending = self.carry + chunk
   let mut changed = false
@@ -160,7 +160,7 @@ fn SubrunProbeState::consume(self : SubrunProbeState, line : BytesView) -> Bool 
   guard item.get("kind") is Some(String(kind)) else { return false }
   match kind {
     "assistant" => {
-      self.steps = self.steps + 1
+      self.steps += 1
       // The child records its assistant item BEFORE running the calls in it,
       // so this is the only account of what a slow tool is doing while it
       // runs — waiting for the `tool_result` would leave the lane showing

--- a/desktop/internal/terminal/terminal_test.mbt
+++ b/desktop/internal/terminal/terminal_test.mbt
@@ -17,7 +17,7 @@ async fn wait_for_output(
   let mut seen = ""
   for ;; {
     if pushes.get() is Output(data~, ..) {
-      seen = seen + @utf8.decode_lossy(data)
+      seen += @utf8.decode_lossy(data)
       if seen.contains(needle) {
         break
       }

--- a/editor/base/common/extpath.mbt
+++ b/editor/base/common/extpath.mbt
@@ -169,7 +169,7 @@ fn is_equal_or_parent(
     return js_slice(base, sep_offset, end=sep_offset + 1) == separator
   }
   if js_slice(parent_candidate, parent_candidate.length() - 1) != separator {
-    parent_candidate = parent_candidate + separator
+    parent_candidate += separator
   }
   base.has_prefix(parent_candidate)
 }

--- a/editor/base/common/lifecycle_wbtest.mbt
+++ b/editor/base/common/lifecycle_wbtest.mbt
@@ -1,7 +1,7 @@
 ///|
 test "disposable is idempotent" {
   let count = Ref(0)
-  let disposable = Disposable::from(() => count.val = count.val + 1)
+  let disposable = Disposable::from(() => count.val += 1)
   disposable.dispose()
   disposable.dispose()
   assert_eq(count.val, 1)
@@ -12,10 +12,8 @@ test "emitter listener disposable removes only that listener" {
   let emitter : Emitter[String] = Emitter()
   let first = Ref("")
   let second = Ref("")
-  let first_subscription = emitter.event(value => first.val = first.val + value)
-  let second_subscription = emitter.event(value => {
-    second.val = second.val + value
-  })
+  let first_subscription = emitter.event(value => first.val += value)
+  let second_subscription = emitter.event(value => second.val += value)
   emitter.fire("a")
   first_subscription.dispose()
   emitter.fire("b")
@@ -72,11 +70,11 @@ test "microtask emitter default schedule flushes inline" {
 test "emitter dispose stops active and later listeners" {
   let emitter : Emitter[String] = Emitter()
   let seen = Ref("")
-  emitter.event(value => seen.val = seen.val + value).dispose()
-  emitter.event(value => seen.val = seen.val + value) |> ignore
+  emitter.event(value => seen.val += value).dispose()
+  emitter.event(value => seen.val += value) |> ignore
   emitter.fire("a")
   emitter.dispose()
-  emitter.event(value => seen.val = seen.val + value) |> ignore
+  emitter.event(value => seen.val += value) |> ignore
   emitter.fire("b")
   assert_eq(seen.val, "a")
 }

--- a/editor/base/common/path.mbt
+++ b/editor/base/common/path.mbt
@@ -52,13 +52,13 @@ fn js_slice(s : String, start : Int, end? : Int) -> String {
   let mut start = start
   let mut end = end.unwrap_or(len)
   if start < 0 {
-    start = len + start
+    start += len
     if start < 0 {
       start = 0
     }
   }
   if end < 0 {
-    end = len + end
+    end += len
     if end < 0 {
       end = 0
     }
@@ -694,7 +694,7 @@ fn Win32::relative_impl(from : String, to : String) -> String {
   let mut i2 = from_start + last_common_sep + 1
   while i2 <= from_end {
     if i2 == from_end || char_code_at(from, i2) == char_backward_slash {
-      out = out + (if out is "" { ".." } else { "\\.." })
+      out += if out is "" { ".." } else { "\\.." }
     }
     i2 += 1
   }
@@ -1151,7 +1151,7 @@ fn Posix::relative_impl(from : String, to : String) -> String {
   let mut i2 = from_start + last_common_sep + 1
   while i2 <= from_end {
     if i2 == from_end || char_code_at(from, i2) == char_forward_slash {
-      out = out + (if out is "" { ".." } else { "/.." })
+      out += if out is "" { ".." } else { "/.." }
     }
     i2 += 1
   }

--- a/editor/base/common/uri.mbt
+++ b/editor/base/common/uri.mbt
@@ -764,23 +764,23 @@ fn as_formatted(uri : Uri, skip_encoding : Bool) -> String {
       authority = js_slice(authority, idx + 1)
       idx = last_index_of_char(userinfo, char_colon)
       if idx == -1 {
-        res = res + encoder(userinfo, false, false)
+        res += encoder(userinfo, false, false)
       } else {
         // <user>:<pass>@<auth>
-        res = res + encoder(js_slice(userinfo, 0, end=idx), false, false)
+        res += encoder(js_slice(userinfo, 0, end=idx), false, false)
         res = "\{res}:"
-        res = res + encoder(js_slice(userinfo, idx + 1), false, true)
+        res += encoder(js_slice(userinfo, idx + 1), false, true)
       }
       res = "\{res}@"
     }
     authority = to_lower_js(authority)
     idx = last_index_of_char(authority, char_colon)
     if idx == -1 {
-      res = res + encoder(authority, false, true)
+      res += encoder(authority, false, true)
     } else {
       // <auth>:<port>
-      res = res + encoder(js_slice(authority, 0, end=idx), false, true)
-      res = res + js_slice(authority, idx)
+      res += encoder(js_slice(authority, 0, end=idx), false, true)
+      res += js_slice(authority, idx)
     }
   }
   if path != "" {
@@ -799,7 +799,7 @@ fn as_formatted(uri : Uri, skip_encoding : Bool) -> String {
       }
     }
     // encode the rest of the path
-    res = res + encoder(path, true, false)
+    res += encoder(path, true, false)
   }
   if query != "" {
     res = "\{res}?\{encoder(query, false, false)}"

--- a/editor/internal/shell/examples/embedded_viewer/main.mbt
+++ b/editor/internal/shell/examples/embedded_viewer/main.mbt
@@ -426,7 +426,7 @@ let embed_model_version : Ref[Int] = Ref(0)
 
 ///|
 fn next_embed_model_version() -> Int {
-  embed_model_version.val = embed_model_version.val + 1
+  embed_model_version.val += 1
   embed_model_version.val
 }
 

--- a/editor/internal/shell/workbench/app.mbt
+++ b/editor/internal/shell/workbench/app.mbt
@@ -1114,7 +1114,7 @@ fn protocol_error_update(
 fn document_to_text_model(
   document : @workspace.DocumentSnapshot,
 ) -> @model.TextModel {
-  workbench_model_version.val = workbench_model_version.val + 1
+  workbench_model_version.val += 1
   TextModel(
     document.uri,
     document.display_name,

--- a/editor/internal/shell/workbench/definition_navigation.mbt
+++ b/editor/internal/shell/workbench/definition_navigation.mbt
@@ -77,11 +77,11 @@ async fn resolve_preview_model(
           return Some(acquire_preview_reference(state, model))
         Some(_) => {
           state.model = None
-          state.in_flight = state.in_flight + 1
+          state.in_flight += 1
           state
         }
         None => {
-          state.in_flight = state.in_flight + 1
+          state.in_flight += 1
           state
         }
       }
@@ -109,7 +109,7 @@ async fn resolve_preview_model(
       )
   }
   if state.in_flight > 0 {
-    state.in_flight = state.in_flight - 1
+    state.in_flight -= 1
   }
   if preview_resources_shutdown.val {
     begin_preview_resource_shutdown(state)
@@ -147,10 +147,10 @@ fn acquire_preview_reference(
   state : PreviewResourceState,
   model : @model.TextModel,
 ) -> @navigation_api.TextModelReference {
-  state.leases = state.leases + 1
+  state.leases += 1
   TextModelReference(model, release=() => {
     if state.leases > 0 {
-      state.leases = state.leases - 1
+      state.leases -= 1
     }
     retire_preview_resource_if_unused(state)
   })

--- a/editor/internal/shell/workbench/definition_navigation_wbtest.mbt
+++ b/editor/internal/shell/workbench/definition_navigation_wbtest.mbt
@@ -90,7 +90,7 @@ test "preview shutdown waits for real leases and in-flight reads" {
   assert_true(preview_resources.contains(pending_uri.to_string()))
 
   // Simulates the late resolver continuation decrementing its own request.
-  pending_state.in_flight = pending_state.in_flight - 1
+  pending_state.in_flight -= 1
   retire_preview_resource_if_unused(pending_state)
   assert_true(pending_state.lifecycle == PreviewResourceDisposed)
   assert_false(preview_resources.contains(pending_uri.to_string()))
@@ -195,7 +195,7 @@ async test "remote definition provider preserves ordered locations and cancellat
   protocol_send.val = Some(packet => {
     match packet {
       OpenDocument(request) => {
-        preview_open_count.val = preview_open_count.val + 1
+        preview_open_count.val += 1
         resolve_pending_response(
           DocumentLoaded({
             id: request.id,
@@ -210,7 +210,7 @@ async test "remote definition provider preserves ordered locations and cancellat
         )
         |> ignore
       }
-      CloseDocument(_) => preview_close_count.val = preview_close_count.val + 1
+      CloseDocument(_) => preview_close_count.val += 1
       _ => unexpected_packet.val = true
     }
   })
@@ -259,7 +259,7 @@ async test "remote definition provider preserves ordered locations and cancellat
   protocol_send.val = Some(packet => {
     match packet {
       OpenDocument(request) => {
-        shutdown_open_count.val = shutdown_open_count.val + 1
+        shutdown_open_count.val += 1
         match preview_resources.get(request.uri.to_string()) {
           Some(state) =>
             shutdown_saw_real_in_flight.val = state.in_flight == 1 &&
@@ -283,8 +283,7 @@ async test "remote definition provider preserves ordered locations and cancellat
         )
         |> ignore
       }
-      CloseDocument(_) =>
-        shutdown_close_count.val = shutdown_close_count.val + 1
+      CloseDocument(_) => shutdown_close_count.val += 1
       _ => unexpected_packet.val = true
     }
   })

--- a/editor/internal/shell/workbench/document_source.mbt
+++ b/editor/internal/shell/workbench/document_source.mbt
@@ -105,7 +105,7 @@ fn open_active_document_cmd(
   view_state : DocumentViewState,
 ) -> @rabbita.Cmd {
   @cmd.custom_cmd(_ => {
-    active_document_generation.val = active_document_generation.val + 1
+    active_document_generation.val += 1
     let generation = active_document_generation.val
     close_active_document_source()
     active_document_uri.val = Some(uri)

--- a/editor/internal/shell/workbench/harness.mbt
+++ b/editor/internal/shell/workbench/harness.mbt
@@ -56,7 +56,7 @@ fn emit_render_event(
   payload = "\{payload}\"lineCount\":\{line_count.to_string()}"
   payload = "\{payload},\"tokenCount\":\{token_count.to_string()}"
   payload = "\{payload},\"diagnosticCount\":"
-  payload = payload + diagnostic_count.to_string()
+  payload += diagnostic_count.to_string()
   payload = "\{payload},\"revision\":\{json_string(revision)}"
   payload = "\{payload},\"tokenizeMs\":\{tokenize_ms.to_string()}"
   payload = "\{payload},\"buildMs\":\{build_ms.to_string()}"

--- a/editor/internal/shell/workbench/protocol_client.mbt
+++ b/editor/internal/shell/workbench/protocol_client.mbt
@@ -36,7 +36,7 @@ fn send_protocol_packet(packet : @remote_protocol.ClientPacket) -> Unit {
 
 ///|
 fn next_request_id(prefix : String) -> String {
-  request_counter.val = request_counter.val + 1
+  request_counter.val += 1
   "\{prefix}-\{request_counter.val.to_string()}"
 }
 

--- a/editor/internal/shell/workbench/protocol_client_wbtest.mbt
+++ b/editor/internal/shell/workbench/protocol_client_wbtest.mbt
@@ -100,9 +100,7 @@ test "cancelling an in-flight request resumes once and consumes its late respons
       }
     },
     cancellation_subscription: Some(
-      @base_common.Disposable::from(() => {
-        subscription_disposals.val = subscription_disposals.val + 1
-      }),
+      @base_common.Disposable::from(() => subscription_disposals.val += 1),
     ),
     sent: true,
   }
@@ -154,9 +152,7 @@ test "send failure resumes every pending request without waiting for Closed" {
       }
     },
     cancellation_subscription: Some(
-      @base_common.Disposable::from(() => {
-        subscription_disposals.val = subscription_disposals.val + 1
-      }),
+      @base_common.Disposable::from(() => subscription_disposals.val += 1),
     ),
     sent: true,
   }

--- a/editor/internal/shell/workbench/repo_picker.mbt
+++ b/editor/internal/shell/workbench/repo_picker.mbt
@@ -26,7 +26,7 @@ let repo_picker_generation : Ref[Int] = Ref(0)
 
 ///|
 fn next_repo_picker_generation() -> Int {
-  repo_picker_generation.val = repo_picker_generation.val + 1
+  repo_picker_generation.val += 1
   repo_picker_generation.val
 }
 

--- a/editor/internal/shell/workbench/tree_provider.mbt
+++ b/editor/internal/shell/workbench/tree_provider.mbt
@@ -105,7 +105,7 @@ async fn first_moonbit_file(
   if budget.val <= 0 || depth > auto_open_max_depth {
     return None
   }
-  budget.val = budget.val - 1
+  budget.val -= 1
   match workspace_tree_provider.resolve(uri) {
     WorkspaceResolved(stat) =>
       match stat.children {

--- a/editor/internal/viewer/browser/testing/registry.mbt
+++ b/editor/internal/viewer/browser/testing/registry.mbt
@@ -46,7 +46,7 @@ pub fn register_viewer(
   set_hidden_areas~ : (Array[@base_common.Range], String?, Bool) -> Unit,
 ) -> @base_common.Disposable {
   unregister_viewer(viewer_id)
-  next_registration_id.val = next_registration_id.val + 1
+  next_registration_id.val += 1
   let registration_id = next_registration_id.val
   viewer_entries[viewer_id] = {
     registration_id,

--- a/editor/internal/viewer/browser/view/selections.mbt
+++ b/editor/internal/viewer/browser/view/selections.mbt
@@ -101,9 +101,8 @@ fn render_selection_lines(
       continue
     }
     let (corner_html, selection_html) = render_styled_line_html(line, styled)
-    inner_corners[line_index] = inner_corners[line_index] + corner_html
-    rest_of_selection[line_index] = rest_of_selection[line_index] +
-      selection_html
+    inner_corners[line_index] += corner_html
+    rest_of_selection[line_index] += selection_html
   }
   // `output.map(([innerCorners, rest]) => innerCorners + rest)`.
   let result : Array[String] = []

--- a/editor/internal/viewer/browser/view/view_event_dispatcher.mbt
+++ b/editor/internal/viewer/browser/view/view_event_dispatcher.mbt
@@ -48,7 +48,7 @@ fn ViewEventDispatcher::ViewEventDispatcher(
 
 ///|
 fn ViewEventDispatcher::begin(self : ViewEventDispatcher) -> ViewEventCollector {
-  self.collector_depth = self.collector_depth + 1
+  self.collector_depth += 1
   match self.collector {
     Some(collector) => collector
     None => {
@@ -64,7 +64,7 @@ fn ViewEventDispatcher::end(self : ViewEventDispatcher) -> Unit {
   if self.collector_depth <= 0 {
     abort("ViewEventDispatcher.end without matching begin")
   }
-  self.collector_depth = self.collector_depth - 1
+  self.collector_depth -= 1
   if self.collector_depth > 0 {
     return
   }

--- a/editor/internal/viewer/browser/view/view_events_wbtest.mbt
+++ b/editor/internal/viewer/browser/view/view_events_wbtest.mbt
@@ -291,7 +291,7 @@ fn CountingViewEventHandler::force_should_render(
   self : CountingViewEventHandler,
 ) -> Unit {
   self.dirty = true
-  self.force_count = self.force_count + 1
+  self.force_count += 1
 }
 
 ///|

--- a/editor/internal/viewer/code_editor_widget/exports.mbt
+++ b/editor/internal/viewer/code_editor_widget/exports.mbt
@@ -53,7 +53,7 @@ pub fn EditorDecorationsCollection::append(
   new_decorations : Array[@model.ModelDeltaDecoration],
 ) -> Array[String] {
   let appended = self.viewer.delta_decorations([], new_decorations)
-  self.decoration_ids = self.decoration_ids + appended
+  self.decoration_ids += appended
   appended
 }
 

--- a/editor/internal/viewer/contrib/hover/browser/content_hover_widget_wbtest.mbt
+++ b/editor/internal/viewer/contrib/hover/browser/content_hover_widget_wbtest.mbt
@@ -77,21 +77,15 @@ test "hover render lifetimes dispose on replacement hide and teardown" {
   let second_count = Ref(0)
   let third_count = Ref(0)
   let lifetimes : Array[@base_common.Disposable] = []
-  lifetimes.push(
-    @base_common.Disposable::from(() => first_count.val = first_count.val + 1),
-  )
-  lifetimes.push(
-    @base_common.Disposable::from(() => second_count.val = second_count.val + 1),
-  )
+  lifetimes.push(@base_common.Disposable::from(() => first_count.val += 1))
+  lifetimes.push(@base_common.Disposable::from(() => second_count.val += 1))
 
   // `_setRenderedHover` begins a replacement with the same clear operation.
   dispose_hover_render_disposables(lifetimes)
   assert_eq(first_count.val, 1)
   assert_eq(second_count.val, 1)
 
-  lifetimes.push(
-    @base_common.Disposable::from(() => third_count.val = third_count.val + 1),
-  )
+  lifetimes.push(@base_common.Disposable::from(() => third_count.val += 1))
   // `hide` and retained-widget `dispose` both converge on this operation.
   dispose_hover_render_disposables(lifetimes)
   dispose_hover_render_disposables(lifetimes)
@@ -104,9 +98,7 @@ test "opaque hover rows lifetime drains retained resources exactly once" {
   let count = Ref(0)
   let rows : HoverRowsRender = {
     fragment: @rdom.document().create_document_fragment(),
-    disposables: [
-      @base_common.Disposable::from(() => count.val = count.val + 1),
-    ],
+    disposables: [@base_common.Disposable::from(() => count.val += 1)],
     transferred: false,
     disposed: false,
   }

--- a/editor/internal/viewer/contrib/references/browser/references_peek_widget_reference_wbtest.mbt
+++ b/editor/internal/viewer/contrib/references/browser/references_peek_widget_reference_wbtest.mbt
@@ -499,12 +499,12 @@ fn ReferencesPeekTestLog::callbacks(
   self : ReferencesPeekTestLog,
 ) -> ReferencesPeekWidgetCallbacks {
   {
-    on_close: () => self.close_count.val = self.close_count.val + 1,
+    on_close: () => self.close_count.val += 1,
     on_select: item => self.selected.push(item.flat_index),
     on_confirm: item => self.confirmed.push(item.flat_index),
     on_open_side: item => self.opened_side.push(item.flat_index),
-    on_next: () => self.next_count.val = self.next_count.val + 1,
-    on_previous: () => self.previous_count.val = self.previous_count.val + 1,
+    on_next: () => self.next_count.val += 1,
+    on_previous: () => self.previous_count.val += 1,
     on_expand_group: group => self.expanded.push(group.group_index),
   }
 }

--- a/editor/internal/viewer/markdown/markdown.mbt
+++ b/editor/internal/viewer/markdown/markdown.mbt
@@ -111,7 +111,7 @@ fn markdown_cmark_input(markdown : String) -> String {
     if @common.is_high_surrogate(unit) {
       if i + 1 < markdown.length() &&
         @common.is_low_surrogate(markdown[i + 1].to_int()) {
-        i = i + 2
+        i += 2
       } else {
         needs_cleaning = true
         break
@@ -120,7 +120,7 @@ fn markdown_cmark_input(markdown : String) -> String {
       needs_cleaning = true
       break
     } else {
-      i = i + 1
+      i += 1
     }
   }
   guard needs_cleaning else { return markdown }
@@ -133,13 +133,13 @@ fn markdown_cmark_input(markdown : String) -> String {
       @common.is_low_surrogate(markdown[i + 1].to_int()) {
       cleaned.write_char(Int::unsafe_to_char(unit))
       cleaned.write_char(Int::unsafe_to_char(markdown[i + 1].to_int()))
-      i = i + 2
+      i += 2
     } else if @common.is_high_surrogate(unit) || @common.is_low_surrogate(unit) {
       cleaned.write_char(Int::unsafe_to_char(0xFFFD))
-      i = i + 1
+      i += 1
     } else {
       cleaned.write_char(Int::unsafe_to_char(unit))
-      i = i + 1
+      i += 1
     }
   }
   cleaned.to_string()

--- a/editor/internal/viewer/markdown/source_projection.mbt
+++ b/editor/internal/viewer/markdown/source_projection.mbt
@@ -184,7 +184,7 @@ fn markdown_rendered_element_indices(doc : @cmark.Doc) -> Array[(Int, Int)] {
   let add = fn(block : @cmark.Block) {
     if markdown_block_renders_one_root_element(block) {
       result.push((block.meta().id, rendered_element_index))
-      rendered_element_index = rendered_element_index + 1
+      rendered_element_index += 1
     }
   }
   match doc.block {

--- a/editor/internal/viewer/markdown/source_projection_wbtest.mbt
+++ b/editor/internal/viewer/markdown/source_projection_wbtest.mbt
@@ -78,7 +78,7 @@ test "root-element ordinals ignore omitted blocks and nested anchors" {
   for anchor in rendered.projection.block_anchors {
     match anchor.rendered_element_index {
       Some(index) => ordinals.push(index)
-      None => nested_anchor_count = nested_anchor_count + 1
+      None => nested_anchor_count += 1
     }
   }
   assert_eq(ordinals, [0, 1, 2, 3])

--- a/editor/internal/viewer/ui/scrollbar/scrollable_element.mbt
+++ b/editor/internal/viewer/ui/scrollbar/scrollable_element.mbt
@@ -574,8 +574,8 @@ pub fn mouse_wheel_scroll_deltas(
   }
   if alt_key {
     // fastScrolling
-    delta_x = delta_x * fast_scroll_sensitivity
-    delta_y = delta_y * fast_scroll_sensitivity
+    delta_x *= fast_scroll_sensitivity
+    delta_y *= fast_scroll_sensitivity
   }
   (
     -away_from_zero(scroll_wheel_sensitivity * delta_x),

--- a/editor/platform/log/exports.mbt
+++ b/editor/platform/log/exports.mbt
@@ -46,7 +46,7 @@ pub impl Logger for MemoryLogger with fn log(self, entry) {
 ///|
 /// Records a flush boundary in memory.
 pub impl Logger for MemoryLogger with fn flush(self) {
-  self.flush_count.val = self.flush_count.val + 1
+  self.flush_count.val += 1
 }
 
 ///|

--- a/editor/server/host/main/main.mbt
+++ b/editor/server/host/main/main.mbt
@@ -40,36 +40,36 @@ fn parse_args(args : ArrayView[String]) -> DevServerConfig {
       "--root" =>
         if i + 1 < args.length() {
           root = args[i + 1]
-          i = i + 1
+          i += 1
         }
       "--port" =>
         if i + 1 < args.length() {
           port = parse_port(args[i + 1], port)
-          i = i + 1
+          i += 1
         }
       "--host" =>
         if i + 1 < args.length() {
           host = args[i + 1]
-          i = i + 1
+          i += 1
         }
       "--asset-dir" =>
         if i + 1 < args.length() {
           asset_dir = args[i + 1]
-          i = i + 1
+          i += 1
         }
       "--moon-command" =>
         if i + 1 < args.length() {
           moon_command = args[i + 1]
-          i = i + 1
+          i += 1
         }
       "--browse-root" =>
         if i + 1 < args.length() {
           browse_root = args[i + 1]
-          i = i + 1
+          i += 1
         }
       _ => ()
     }
-    i = i + 1
+    i += 1
   }
   { root, host, port, asset_dir, moon_command, browse_root, }
 }

--- a/editor/server/host/native_host.mbt
+++ b/editor/server/host/native_host.mbt
@@ -264,7 +264,7 @@ fn ProtocolSessions::attach(
   self : ProtocolSessions,
   outbox : @aqueue.Queue[String],
 ) -> Int {
-  self.next_session_id.val = self.next_session_id.val + 1
+  self.next_session_id.val += 1
   self.outboxes.set(self.next_session_id.val, outbox)
   self.next_session_id.val
 }

--- a/editor/server/host/native_host_test.mbt
+++ b/editor/server/host/native_host_test.mbt
@@ -164,7 +164,7 @@ async fn wait_for_events(
   let mut remaining = 50
   while events.length() < count && remaining > 0 {
     @async.sleep(20)
-    remaining = remaining - 1
+    remaining -= 1
   }
   if events.length() < count {
     fail("timed out waiting for native watch event")

--- a/editor/tests/browser/moonbit/component/viewer_api_scenario.mbt
+++ b/editor/tests/browser/moonbit/component/viewer_api_scenario.mbt
@@ -105,7 +105,7 @@ fn run_viewer_api_test() -> Unit {
       )
       let scroll_event_count = Ref(0)
       viewer.on_did_scroll_change(event => {
-        scroll_event_count.val = scroll_event_count.val + 1
+        scroll_event_count.val += 1
         host.set_attribute(
           "data-scroll-events",
           scroll_event_count.val.to_string(),
@@ -115,7 +115,7 @@ fn run_viewer_api_test() -> Unit {
       |> ignore
       @viewer_testing.on_did_render_model(viewer.get_id(), event => {
         if event.fresh {
-          rendered_count.val = rendered_count.val + 1
+          rendered_count.val += 1
           view_line_count.val = event.line_count
           rendered_line_count.val = event.rendered_lines
         }

--- a/editor/tests/browser/moonbit/perf/render_perf_scenario.mbt
+++ b/editor/tests/browser/moonbit/perf/render_perf_scenario.mbt
@@ -119,7 +119,7 @@ fn record_sample(
   if sample_index.val >= 0 {
     samples.push(elapsed)
   }
-  sample_index.val = sample_index.val + 1
+  sample_index.val += 1
   if sample_index.val >= 3 {
     finish_perf_report(ctx, done, samples)
   } else {

--- a/editor/viewer/common/config/font_info.mbt
+++ b/editor/viewer/common/config/font_info.mbt
@@ -127,7 +127,7 @@ pub fn BareFontInfo::create(
     line_height = golden_line_height_ratio * font_size
   } else if line_height < minimum_line_height.to_double() {
     // Values too small to be line heights in pixels are in ems.
-    line_height = line_height * font_size
+    line_height *= font_size
   }
   // Enforce integer, minimum constraints (`Math.round` of a non-negative
   // ratio is `floor(x + 0.5)`).

--- a/editor/viewer/common/model/abstract_syntax_token_backend.mbt
+++ b/editor/viewer/common/model/abstract_syntax_token_backend.mbt
@@ -245,7 +245,7 @@ fn AttachedViewHandler::handle_state_change(
 ///|
 /// Cancels the current one-shot and invalidates stale callbacks.
 fn AttachedViewHandler::cancel_pending(self : AttachedViewHandler) -> Unit {
-  self.generation.val = self.generation.val + 1
+  self.generation.val += 1
   match self.pending {
     Some(handle) => handle.dispose()
     None => ()

--- a/editor/viewer/common/model/interval_tree.mbt
+++ b/editor/viewer/common/model/interval_tree.mbt
@@ -538,8 +538,8 @@ fn normalize_delta(t : IntervalTree) -> Unit {
     }
 
     // handle current node
-    node.start = delta + node.start
-    node.end = delta + node.end
+    node.start += delta
+    node.end += delta
     node.delta = 0
     recompute_max_end(node)
     set_node_is_visited(node, true)

--- a/editor/viewer/common/model/set_value_wbtest.mbt
+++ b/editor/viewer/common/model/set_value_wbtest.mbt
@@ -107,9 +107,7 @@ test "set_value re-seeds visible token state without a full reset event" {
 test "no content event is emitted while disposing" {
   let model = wb_model("alpha")
   let mut content_events = 0
-  let _sub = model.on_did_change_content(_ => {
-    content_events = content_events + 1
-  })
+  let _sub = model.on_did_change_content(_ => content_events += 1)
   let _will = model.on_will_dispose(() => model.set_value("ghost"))
   model.dispose()
   // the swap and version bump still happened; only the events are

--- a/editor/viewer/common/model/text_model.mbt
+++ b/editor/viewer/common/model/text_model.mbt
@@ -623,7 +623,7 @@ pub fn TextModel::get_version_id(self : TextModel) -> Int {
 /// `_increaseVersionId` (`textModel.ts:782-785`). The
 /// `_alternativeVersionId` mirror is N-A (undo/redo not ported).
 fn TextModel::increase_version_id(self : TextModel) -> Unit {
-  self.version_id = self.version_id + 1
+  self.version_id += 1
 }
 
 ///|

--- a/editor/viewer/common/render_line_ir_test.mbt
+++ b/editor/viewer/common/render_line_ir_test.mbt
@@ -187,7 +187,7 @@ fn count_occurrences(haystack : String, needle : String) -> Int {
   }
   for index in 0..<=(haystack.length() - needle_len) {
     if haystack[index:index + needle_len].to_owned() == needle {
-      count = count + 1
+      count += 1
     }
   }
   count

--- a/editor/viewer/common/tokens/contiguous_tokens_store.mbt
+++ b/editor/viewer/common/tokens/contiguous_tokens_store.mbt
@@ -165,7 +165,7 @@ fn ContiguousTokensStore::ensure_line(
 ) -> Unit {
   while line_index >= self.len {
     self.line_tokens.push(Missing)
-    self.len = self.len + 1
+    self.len += 1
   }
 }
 

--- a/editor/viewer/common/tokens/line_tokens.mbt
+++ b/editor/viewer/common/tokens/line_tokens.mbt
@@ -187,19 +187,21 @@ pub fn LineTokens::with_inserted(
         insert_tokens[next_insert_token_idx].offset
       ) {
       // original token ends before the next insert token
-      text = text +
-        substr(self.text, original_end_offset, next_original_token_end_offset)
+      text += substr(
+        self.text,
+        original_end_offset,
+        next_original_token_end_offset,
+      )
       let metadata = self.tokens[(next_original_token_idx << 1) + 1]
       new_tokens.push(text.length().reinterpret_as_uint())
       new_tokens.push(metadata)
-      next_original_token_idx = next_original_token_idx + 1
+      next_original_token_idx += 1
       original_end_offset = next_original_token_end_offset
     } else if has_insert {
       let next_insert_token = insert_tokens[next_insert_token_idx]
       if next_insert_token.offset > original_end_offset {
         // insert token is in the middle of the next token
-        text = text +
-          substr(self.text, original_end_offset, next_insert_token.offset)
+        text += substr(self.text, original_end_offset, next_insert_token.offset)
         let metadata = if next_original_token_idx < self.tokens_count {
           self.tokens[(next_original_token_idx << 1) + 1]
         } else {
@@ -209,10 +211,10 @@ pub fn LineTokens::with_inserted(
         new_tokens.push(metadata)
         original_end_offset = next_insert_token.offset
       }
-      text = text + next_insert_token.text
+      text += next_insert_token.text
       new_tokens.push(text.length().reinterpret_as_uint())
       new_tokens.push(next_insert_token.token_metadata.to_uint())
-      next_insert_token_idx = next_insert_token_idx + 1
+      next_insert_token_idx += 1
     } else {
       break
     }

--- a/editor/viewer/common/view_layout/line_decorations.mbt
+++ b/editor/viewer/common/view_layout/line_decorations.mbt
@@ -86,12 +86,12 @@ pub fn LineDecorationsNormalizer::normalize(
     if start_column > 1 &&
       start_column - 2 < line_length &&
       @base_common.is_high_surrogate(line_content[start_column - 2].to_int()) {
-      start_column = start_column - 1
+      start_column -= 1
     }
     if end_column > 1 &&
       end_column - 2 < line_length &&
       @base_common.is_high_surrogate(line_content[end_column - 2].to_int()) {
-      end_column = end_column - 1
+      end_column -= 1
     }
     let start_offset = (start_column - 1).clamp(min=0, max=line_length)
     let max_end_offset = if line_length == 0 {
@@ -149,7 +149,7 @@ fn DecorationSegmentStack::consume_lower_than(
     let mut stop_index = 0
     while stop_index + 1 < self.count &&
           self.stop_offsets[stop_index] == self.stop_offsets[stop_index + 1] {
-      stop_index = stop_index + 1
+      stop_index += 1
     }
     result.push({
       start_offset: offset,
@@ -198,10 +198,10 @@ fn DecorationSegmentStack::insert(
         self.metadata.insert(index, metadata)
         inserted = true
       }
-      index = index + 1
+      index += 1
     }
   }
-  self.count = self.count + 1
+  self.count += 1
 }
 
 ///|

--- a/editor/viewer/common/view_layout/lines_layout.mbt
+++ b/editor/viewer/common/view_layout/lines_layout.mbt
@@ -140,7 +140,7 @@ fn javascript_to_int32(value : Double) -> Int {
     return 0
   }
   if wrapped < 0.0 {
-    wrapped = wrapped + modulus
+    wrapped += modulus
   }
   if wrapped >= signed_boundary {
     (wrapped - modulus).to_int()
@@ -172,7 +172,7 @@ pub fn WhitespaceChangeAccessor::insert_whitespace(
   // Keep public number carriers raw until this exact LinesLayout boundary.
   let height_in_px = javascript_to_int32(height_in_px)
   let min_width = javascript_to_int32(min_width)
-  self.layout.last_whitespace_id = self.layout.last_whitespace_id + 1
+  self.layout.last_whitespace_id += 1
   let id = "\{self.layout.instance_id}\{self.layout.last_whitespace_id}"
   self.layout.pending_changes.insert(
     EditorWhitespace(id, after_line_number, ordinal, height_in_px, min_width),
@@ -237,7 +237,7 @@ pub fn LinesLayout::LinesLayout(
   padding_top : Int,
   padding_bottom : Int,
 ) -> LinesLayout {
-  lines_layout_instance_count.val = lines_layout_instance_count.val + 1
+  lines_layout_instance_count.val += 1
   {
     instance_id: @base_common.single_letter_hash(
       lines_layout_instance_count.val,
@@ -515,7 +515,7 @@ pub fn LinesLayout::on_lines_deleted(
   from_line_number : Int,
   to_line_number : Int,
 ) -> Unit {
-  self.line_count = self.line_count - (to_line_number - from_line_number + 1)
+  self.line_count -= to_line_number - from_line_number + 1
   for i in 0..<self.arr.length() {
     let after_line_number = self.arr[i].after_line_number
     if from_line_number <= after_line_number &&
@@ -526,8 +526,7 @@ pub fn LinesLayout::on_lines_deleted(
     } else if after_line_number > to_line_number {
       // The line this whitespace was after has been moved up
       //  => move whitespace up
-      self.arr[i].after_line_number = self.arr[i].after_line_number -
-        (to_line_number - from_line_number + 1)
+      self.arr[i].after_line_number -= to_line_number - from_line_number + 1
     }
   }
 }
@@ -539,12 +538,11 @@ pub fn LinesLayout::on_lines_inserted(
   from_line_number : Int,
   to_line_number : Int,
 ) -> Unit {
-  self.line_count = self.line_count + (to_line_number - from_line_number + 1)
+  self.line_count += to_line_number - from_line_number + 1
   for i in 0..<self.arr.length() {
     let after_line_number = self.arr[i].after_line_number
     if from_line_number <= after_line_number {
-      self.arr[i].after_line_number = self.arr[i].after_line_number +
-        (to_line_number - from_line_number + 1)
+      self.arr[i].after_line_number += to_line_number - from_line_number + 1
     }
   }
 }
@@ -567,7 +565,7 @@ pub fn LinesLayout::get_whitespaces_accumulated_height(
   let mut start_index = (0).max(self.prefix_sum_valid_index + 1)
   if start_index == 0 {
     self.arr[0].prefix_sum = self.arr[0].height.to_double()
-    start_index = start_index + 1
+    start_index += 1
   }
   for i in start_index..<=index {
     self.arr[i].prefix_sum = self.arr[i - 1].prefix_sum +
@@ -845,8 +843,7 @@ pub fn LinesLayout::get_lines_viewport_data(
     big_numbers_delta = big_numbers_delta /
       self.default_line_height *
       self.default_line_height
-    current_line_relative_offset = current_line_relative_offset -
-      big_numbers_delta.to_double()
+    current_line_relative_offset -= big_numbers_delta.to_double()
   }
   let lines_offsets : Array[Double] = []
   let vertical_center = vertical_offset1.to_double() +
@@ -871,21 +868,18 @@ pub fn LinesLayout::get_lines_viewport_data(
     }
 
     // Count current line height in the vertical offsets.
-    current_vertical_offset = current_vertical_offset + line_height.to_double()
+    current_vertical_offset += line_height.to_double()
     lines_offsets.push(current_line_relative_offset)
 
     // Next line starts immediately after this one.
-    current_line_relative_offset = current_line_relative_offset +
-      line_height.to_double()
+    current_line_relative_offset += line_height.to_double()
     while current_whitespace_after_line_number == Some(line_number) {
       // Push down next line with the height of the current whitespace.
-      current_line_relative_offset = current_line_relative_offset +
-        current_whitespace_height.to_double()
+      current_line_relative_offset += current_whitespace_height.to_double()
 
       // Count current whitespace in the vertical offsets.
-      current_vertical_offset = current_vertical_offset +
-        current_whitespace_height.to_double()
-      whitespace_index = whitespace_index + 1
+      current_vertical_offset += current_whitespace_height.to_double()
+      whitespace_index += 1
       if whitespace_index >= whitespace_count {
         current_whitespace_after_line_number = None
       } else {
@@ -905,7 +899,7 @@ pub fn LinesLayout::get_lines_viewport_data(
     if line_number == end_line_number {
       break
     }
-    line_number = line_number + 1
+    line_number += 1
   }
   if centered_line_number == -1 {
     centered_line_number = end_line_number
@@ -917,16 +911,14 @@ pub fn LinesLayout::get_lines_viewport_data(
   let mut completely_visible_end_line_number = end_line_number
   if completely_visible_start_line_number < completely_visible_end_line_number {
     if start_line_number_vertical_offset < vertical_offset1 {
-      completely_visible_start_line_number = completely_visible_start_line_number +
-        1
+      completely_visible_start_line_number += 1
     }
   }
   if completely_visible_start_line_number < completely_visible_end_line_number {
     let end_line_height = self.get_line_height_for_line_number(end_line_number)
     if end_line_number_vertical_offset.to_double() + end_line_height.to_double() >
       vertical_offset2.to_double() {
-      completely_visible_end_line_number = completely_visible_end_line_number -
-        1
+      completely_visible_end_line_number -= 1
     }
   }
   {

--- a/editor/viewer/common/view_layout/lines_layout_gate_c_wbtest.mbt
+++ b/editor/viewer/common/view_layout/lines_layout_gate_c_wbtest.mbt
@@ -283,7 +283,7 @@ test "LinesLayout mixed bulk commit resolves conflicts, stably sorts, and resets
 
   let mut running_height = 0.0
   for i, height in expected_heights {
-    running_height = running_height + height.to_double()
+    running_height += height.to_double()
     assert_eq(layout.get_whitespaces_accumulated_height(i), running_height)
     assert_eq(layout.arr[i].prefix_sum, running_height)
   }

--- a/editor/viewer/common/view_layout/render_line_renderer.mbt
+++ b/editor/viewer/common/view_layout/render_line_renderer.mbt
@@ -81,7 +81,6 @@ pub fn render_view_line(
       // Empty line carrying inline (before/after) decorations.
       html.write_string("<span class=\"view-line-content\">")
       let mut before_count = 0
-      let mut after_count = 0
       let mut contains_foreign : ForeignElementType = None
       for decoration in input.line_decorations {
         if decoration.decoration_type == Before ||
@@ -90,11 +89,10 @@ pub fn render_view_line(
             $|<span class="\{decoration.class_name}"></span>
           if decoration.decoration_type == Before {
             contains_foreign = add_foreign_element(contains_foreign, Before)
-            before_count = before_count + 1
+            before_count += 1
           }
           if decoration.decoration_type == After {
             contains_foreign = add_foreign_element(contains_foreign, After)
-            after_count = after_count + 1
           }
         }
       }
@@ -438,7 +436,7 @@ fn extract_control_characters(
           contains_rtl: false,
         })
       }
-      char_offset = char_offset + 1
+      char_offset += 1
     }
     if char_offset > last_end_index {
       last_end_index = token_end_index
@@ -502,7 +500,7 @@ fn apply_render_whitespace(
     while has_selections &&
           current_selection_index < selections.length() &&
           selections[current_selection_index].end_exclusive <= char_index {
-      current_selection_index = current_selection_index + 1
+      current_selection_index += 1
     }
     let mut is_in_whitespace = if char_index < first_non_whitespace_index ||
       char_index > last_non_whitespace_index {
@@ -578,13 +576,13 @@ fn apply_render_whitespace(
     if ch_code == cc_tab {
       tmp_indent = tab_size
     } else if @base_common.is_full_width_character(ch_code) {
-      tmp_indent = tmp_indent + 2
+      tmp_indent += 2
     } else {
-      tmp_indent = tmp_indent + 1
+      tmp_indent += 1
     }
     was_in_whitespace = is_in_whitespace
     while char_index == token_end_index {
-      token_index = token_index + 1
+      token_index += 1
       if token_index < tokens_length {
         token_type = tokens[token_index].class_name
         token_contains_rtl = tokens[token_index].contains_rtl
@@ -680,7 +678,7 @@ fn apply_inline_decorations(
           metadata: token_metadata | decoration.metadata,
           contains_rtl: token_contains_rtl,
         })
-        decoration_index = decoration_index + 1
+        decoration_index += 1
       } else {
         last_result_end_index = token_end_index
         result.push({
@@ -714,7 +712,7 @@ fn apply_inline_decorations(
         metadata: decoration.metadata,
         contains_rtl: false,
       })
-      decoration_index = decoration_index + 1
+      decoration_index += 1
     }
   }
   result
@@ -781,11 +779,11 @@ fn render_line(
         } else {
           1
         }
-        part_width = part_width + char_width
+        part_width += char_width
         if probe_index >= faux_indent_length {
-          probe_visible = probe_visible + char_width
+          probe_visible += char_width
         }
-        probe_index = probe_index + 1
+        probe_index += 1
       }
       if part_renders_whitespace_with_width {
         html.write_string(" style=\"width:")
@@ -821,12 +819,12 @@ fn render_line(
           append_code(html, render_space_char_code)
           append_code(html, ch_zwnj)
         }
-        char_offset_in_part = char_offset_in_part + produced_characters
-        char_horizontal_offset = char_horizontal_offset + char_width
+        char_offset_in_part += produced_characters
+        char_horizontal_offset += char_width
         if char_index >= faux_indent_length {
-          visible_column = visible_column + char_width
+          visible_column += char_width
         }
-        char_index = char_index + 1
+        char_index += 1
       }
     } else {
       html.write_char('>')
@@ -883,7 +881,7 @@ fn render_line(
           run_start = char_index + 1
         } else {
           if @base_common.is_full_width_character(charcode) {
-            char_width = char_width + 1
+            char_width += 1
           }
           if render_control_characters && charcode < 32 {
             flush_run(html, line_content, run_start, char_index)
@@ -902,17 +900,17 @@ fn render_line(
           }
           // else: normal char, kept in the pending run
         }
-        char_offset_in_part = char_offset_in_part + produced_characters
-        char_horizontal_offset = char_horizontal_offset + char_width
+        char_offset_in_part += produced_characters
+        char_horizontal_offset += char_width
         if char_index >= faux_indent_length {
-          visible_column = visible_column + char_width
+          visible_column += char_width
         }
-        char_index = char_index + 1
+        char_index += 1
       }
       flush_run(html, line_content, run_start, part_end_index)
     }
     if part_is_empty_and_has_pseudo_after {
-      part_displacement = part_displacement + 1
+      part_displacement += 1
     } else {
       part_displacement = 0
     }

--- a/editor/viewer/common/view_layout/scrollable.mbt
+++ b/editor/viewer/common/view_layout/scrollable.mbt
@@ -941,7 +941,7 @@ fn truncate_double(value : Double) -> Double {
     return 0.0
   }
   if wrapped < 0.0 {
-    wrapped = wrapped + modulus
+    wrapped += modulus
   }
   if wrapped >= signed_boundary {
     wrapped - modulus

--- a/editor/viewer/common/view_model/cursor_move_operations.mbt
+++ b/editor/viewer/common/view_model/cursor_move_operations.mbt
@@ -296,10 +296,12 @@ fn cursor_right_position(
   let mut line_number = line_number
   let mut column = column
   if column < model.get_line_max_column(line_number) {
-    column = column +
-      cursor_next_char_length(model.get_line_content(line_number), column - 1)
+    column += cursor_next_char_length(
+      model.get_line_content(line_number),
+      column - 1,
+    )
   } else if line_number < model.get_line_count() {
-    line_number = line_number + 1
+    line_number += 1
     column = model.get_line_min_column(line_number)
   }
   Position(line_number, column)
@@ -411,8 +413,7 @@ fn cursor_vertical(
         Position(line_number, column),
         affinity,
       )
-      leftover_visible_columns = leftover_visible_columns +
-        (column - new_position.column)
+      leftover_visible_columns += column - new_position.column
       line_number = new_position.line_number
       column = new_position.column
     }

--- a/editor/viewer/common/view_model/model_line_projection_reference_wbtest.mbt
+++ b/editor/viewer/common/view_model/model_line_projection_reference_wbtest.mbt
@@ -59,7 +59,7 @@ fn projection_assert_token_ends(
   assert_true(data.tokens.get_count() > 0)
   let mut token_text = ""
   for i in 0..<data.tokens.get_count() {
-    token_text = token_text + data.tokens.get_token_text(i)
+    token_text += data.tokens.get_token_text(i)
   }
   assert_eq(spaces(data.min_column - 1) + token_text, data.content)
   assert_eq(

--- a/editor/viewer/common/view_model/monospace_line_breaks_computer.mbt
+++ b/editor/viewer/common/view_model/monospace_line_breaks_computer.mbt
@@ -263,10 +263,10 @@ fn create_line_breaks(
   if @base_common.is_high_surrogate(prev_char_code) {
     // A surrogate pair must always be considered as a single unit, so it is
     // never to be broken.
-    visible_column = visible_column + 1.0
+    visible_column += 1.0
     prev_char_code = line_text[1].to_int()
     prev_char_code_class = classifier.get(prev_char_code)
-    start_offset = start_offset + 1
+    start_offset += 1
   }
   let mut i = start_offset
   while i < len {
@@ -277,7 +277,7 @@ fn create_line_breaks(
     if @base_common.is_high_surrogate(char_code) {
       // A surrogate pair must always be considered as a single unit, so it
       // is never to be broken.
-      i = i + 1
+      i += 1
       char_code_class = CHARACTER_CLASS_NONE
       char_width = 2.0
     } else {
@@ -292,7 +292,7 @@ fn create_line_breaks(
       break_offset = char_start_offset
       break_offset_visible_column = visible_column
     }
-    visible_column = visible_column + char_width
+    visible_column += char_width
     // Check if adding character at `i` will go over the breaking column.
     if visible_column > breaking_column {
       // We need to break at least before character at `i`:
@@ -309,7 +309,7 @@ fn create_line_breaks(
     }
     prev_char_code = char_code
     prev_char_code_class = char_code_class
-    i = i + 1
+    i += 1
   }
   if breaking_offsets.length() == 0 && !has_injections {
     return None
@@ -463,7 +463,7 @@ fn compute_wrapped_text_indent_length(
         } else {
           1
         }
-        wrapped_text_indent_length = wrapped_text_indent_length + char_width
+        wrapped_text_indent_length += char_width
       }
       // Increase indent of continuation lines, if desired.
       let number_of_additional_tabs = match wrapping_indent {
@@ -472,8 +472,9 @@ fn compute_wrapped_text_indent_length(
         _ => 0
       }
       for _ in 0..<number_of_additional_tabs {
-        wrapped_text_indent_length = wrapped_text_indent_length +
-          tab_character_width(wrapped_text_indent_length, tab_size)
+        wrapped_text_indent_length += tab_character_width(
+          wrapped_text_indent_length, tab_size,
+        )
       }
       // Force sticking to beginning of line if no character would fit except
       // for the indentation.

--- a/editor/viewer/common/view_model/view_model_test.mbt
+++ b/editor/viewer/common/view_model/view_model_test.mbt
@@ -277,7 +277,7 @@ test "projected long moonbit lines retain source text across segments" {
   assert_true(view_model.line_count() > 1)
   let mut joined = ""
   for line_number in 1..<=view_model.line_count() {
-    joined = joined + view_model.lines().get_view_line_content(line_number)
+    joined += view_model.lines().get_view_line_content(line_number)
   }
   assert_eq(joined, text)
 }

--- a/editor/viewer/common/view_model/view_model_tokens_test.mbt
+++ b/editor/viewer/common/view_model/view_model_tokens_test.mbt
@@ -182,7 +182,7 @@ test "windowed view-line reads stay passive while covering stored defaults" {
     let mut joined = ""
     let tokens = line.tokens
     for i in 0..<tokens.get_count() {
-      joined = joined + tokens.get_token_text(i)
+      joined += tokens.get_token_text(i)
     }
     assert_eq(joined, line.content)
   }

--- a/editor/viewer/common/view_model/viewport_data_test.mbt
+++ b/editor/viewer/common/view_model/viewport_data_test.mbt
@@ -3,7 +3,7 @@ fn join_token_text(line : @view_model.ViewLineData) -> String {
   let mut out = ""
   let tokens = line.tokens
   for i in 0..<tokens.get_count() {
-    out = out + tokens.get_token_text(i)
+    out += tokens.get_token_text(i)
   }
   out
 }

--- a/jsonrpc/client.mbt
+++ b/jsonrpc/client.mbt
@@ -125,7 +125,7 @@ pub async fn Client::request(
 ) -> Json {
   guard !self.closed else { raise Closed }
   let id = self.next_id
-  self.next_id = self.next_id + 1
+  self.next_id += 1
   let inbox : @async.Queue[Result[Json, ResponseError]] = Queue(kind=Unbounded)
   self.pending.set(id, inbox)
   defer self.pending.remove(id)

--- a/mcp/client_test.mbt
+++ b/mcp/client_test.mbt
@@ -241,7 +241,7 @@ async test "list_tools follows nextCursor pagination" {
     let reply = fn(request : Json) -> Json? {
       match method_of(request) {
         "tools/list" => {
-          calls.val = calls.val + 1
+          calls.val += 1
           if calls.val == 1 {
             Some(
               success(request, {

--- a/mcp/streamhttp/transport.mbt
+++ b/mcp/streamhttp/transport.mbt
@@ -498,7 +498,7 @@ async fn SseLineReader::next_line(self : SseLineReader) -> String? {
       self.buf[j] = self.buf[self.start + j]
     }
     self.buf.truncate(remaining)
-    self.scan = self.scan - self.start
+    self.scan -= self.start
     self.start = 0
   }
   for ;; {
@@ -521,7 +521,7 @@ async fn SseLineReader::next_line(self : SseLineReader) -> String? {
         // deciding, then resume from this position.
         break
       }
-      i = i + 1
+      i += 1
     }
     self.scan = i
     if self.eof {

--- a/mcp/tools/tools.mbt
+++ b/mcp/tools/tools.mbt
@@ -159,7 +159,7 @@ pub async fn[X] build_grouped(
         @emit.emit(McpToolRenamed(from=tool.name, to=name))
       }
       seen[name] = ()
-      total = total + 1
+      total += 1
       mine.push(
         @agent_tool.AgentToolDefinition(
           name~,

--- a/tui/doc/doc_test.mbt
+++ b/tui/doc/doc_test.mbt
@@ -71,7 +71,7 @@ test "split_lines splits CRLF and CR so no stray carriage return remains" {
   inspect(blocks.length(), content="2")
   let mut total_rows = 0
   for block in blocks {
-    total_rows = total_rows + @doc.Doc::Doc([block]).layout(width=40).length()
+    total_rows += @doc.Doc::Doc([block]).layout(width=40).length()
   }
   inspect(total_rows, content="2")
 }

--- a/tui/internal/render/render_test.mbt
+++ b/tui/internal/render/render_test.mbt
@@ -12,7 +12,7 @@ fn display_prefix(text : String, units : Int) -> String {
     match line.next(end) {
       Some(next) => {
         end = next
-        remaining = remaining - 1
+        remaining -= 1
       }
       None => remaining = 0
     }

--- a/tui/internal/text/text.mbt
+++ b/tui/internal/text/text.mbt
@@ -81,10 +81,10 @@ fn sanitize_line(line : @displaytext.DisplayText) -> String {
     if unit == "\t" {
       let spaces = TabWidth - col % TabWidth
       builder <+ "\{String::make(spaces, ' ')}"
-      col = col + spaces
+      col += spaces
     } else if !is_control_unit(unit) {
       builder <+ "\{unit}"
-      col = col + unit_width(line, start~, end~)
+      col += unit_width(line, start~, end~)
     }
     start = end
   }


### PR DESCRIPTION
## What

Moongrep-driven refactor: the `moonbitlang/simplifiable_assignment` builtin rule (`moonx moonbit-community/moongrep lint --output-json`) reported 229 `target = target op rhs` assignments across 86 files. This PR rewrites them as augmented assignments (`target op= rhs`), e.g.:

- `self.run_id = self.run_id + 1` → `self.run_id += 1`
- `node.start = delta + node.start` → `node.start += delta` (right-operand `+` form)
- multi-line wraps such as `text = text +\n        substr(...)` → `text +=\n        substr(...)`

Operators involved: `+`, `-`, `*`. Every rewrite was applied only when the assignment target is side-effect free (plain identifier / field-access / index chain with no calls), per the rule's own guidance.

Also removes one dead counter the rewrite exposed: `after_count` in `editor/viewer/common/view_layout/render_line_renderer.mbt` was incremented but never read (previously masked by the self-assignment).

## How it was done

1. Collected all 229 findings as JSON Lines and generated a `multi_edit` batch — each edit is the exact `matched_source` slice replaced by the transformed text, anchored by line.
2. Applied the batch, then `moon fmt` and `moon check`.
3. Re-ran the lint: `simplifiable_assignment` findings dropped 229 → 0.

## Verification

- `moon check`: 0 errors, 0 warnings; `moon fmt --check`: clean.
- Full `moon test`: 2072/2076 passed. The 4 failures are `agent_tool/shell` output-limit tests that fail only in this local checkout: its extra trees (`.claude/`, `.worktrees/`, `.repos/`, `.moonagent/`) make the sandbox-profile workspace scan exceed the tests' 1000ms timeout. They pass 11/11 in a clean worktree of `origin/main`, and this diff does not touch `agent_tool/shell` — expected to be green on CI's fresh clone.

Generated with SeekMoon