### PR TITLE
docs(prompt): teach moongrep JSON parsing, streaming, and local-dir exclusions

### DIFF
--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -300,11 +300,16 @@ default root `.` means the whole repository, which is the typical use.
 agent-friendly output: one JSON object per finding with `file` (relative to
 the scan root, often `./`-prefixed), `rule_id`, `description`, `range`
 (1-based `line`/`column`), `matched_source`, and `source_context`; a scan
-with zero findings writes nothing and still exits 0. A whole-repo scan can
-match many nodes, so bound what you print (as above) or redirect stdout
-with `stdout=ToFile(...)` under `@fs.tmpdir(prefix="run-")`. `--rules <dir>`
-and `--rule <file>` load YAML rule files, `--disable <rule-id>` drops a
-loaded rule, and `--verbose` traces traversal on stderr.
+with zero findings writes nothing and still exits 0. When parsing records
+with `@json.parse`, integer fields such as `range.start.line` pattern-match
+as the `Number` variant (a `Double`; call `.to_int()` on it), not `Int`. A
+whole-repo scan can match many nodes — `@shell.Cmd(...).output()` raises
+`OutputLimitExceeded` on large captures — so stream with `.each_line()`
+(one record per callback line, as in the `moon check` example above) to
+count or aggregate findings, and redirect stderr with `stderr=ToFile(...)`
+so skip warnings do not flood the merged output. `--rules <dir>` and
+`--rule <file>` load YAML rule files, `--disable <rule-id>` drops a loaded
+rule, and `--verbose` traces traversal on stderr.
 
 A `--pattern` is a MoonBit *expression* containing `$(name:kind)`
 metavariables — `exp`, `id`, `const`, `arg`, `pat`, `type` — plus `$_` to
@@ -318,16 +323,26 @@ unless anchored with `^...$`). When a pattern surprises you,
 of a snippet, and `moongrep docs RuleSpec` / `docs CLISpec` print the full
 specs.
 
+The builtin `lint` rules are advisory style checks — `catch_all`, for
+instance, flags deliberate `catch { _ => () }` swallows. Treat rule counts
+as signal, not a bug list, and read `matched_source` before acting on a
+finding.
+
 Exit codes: 0 for help, dump, findings, no-findings, and parse warnings
 (no-match is NOT grep's 1); 2 usage; 3 invalid dump input; 4 rule-source
 failure; 5 invalid rule content (including a `--pattern` that is not a valid
 MoonBit expression); 6 missing/unreadable scan input; 7 output failure. The
 scanner follows symlinks, so a broken symlink anywhere under the scan root
-aborts the whole scan with 6 — some workspaces contain dangling symlinks
-(this one does, under `editor/codemirror/demo/`, `.worktrees/`, and
-`.moonagent/`), so scope scans to the subdirectory you care about (pass it
-as the scan root) or `--exclude` those paths instead of scanning `.` from
-the root.
+aborts the whole scan with 6 — this repo's `editor/codemirror/demo/` holds
+dangling symlinks, and tool/eval directories are NOT in the default
+exclusions, so a whole-repo scan from this root also descends into
+`.claude/`, `.worktrees/`, `.moonagent/`, and `.repos/` and doubles every
+finding across the nested checkouts. Exclude them:
+`--exclude .claude --exclude .worktrees --exclude .moonagent --exclude
+.repos --exclude editor/codemirror/demo`. Source blocks whose syntax the
+bundled parser does not know yet (e.g. nested record-spread `is` patterns)
+are skipped with a stderr warning while exit stays 0 — treat skipped blocks
+as a blind spot.
 
 ## Tool Protocol
 

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -302,12 +302,13 @@ the scan root, often `./`-prefixed), `rule_id`, `description`, `range`
 (1-based `line`/`column`), `matched_source`, and `source_context`; a scan
 with zero findings writes nothing and still exits 0. When parsing records
 with `@json.parse`, integer fields such as `range.start.line` pattern-match
-as the `Number` variant (a `Double`; call `.to_int()` on it), not `Int`. A
-whole-repo scan can match many nodes — `@shell.Cmd(...).output()` raises
-`OutputLimitExceeded` on large captures — so stream with `.each_line()`
-(one record per callback line, as in the `moon check` example above) to
-count or aggregate findings, and redirect stderr with `stderr=ToFile(...)`
-so skip warnings do not flood the merged output. `--rules <dir>` and
+as `Number(value)` (a `Double`; call `.to_int()` on it), not `Int`. A
+whole-repo scan can match many nodes — `@shell.Cmd(...).output()` cannot
+capture unbounded output, so a large scan hits the shell's output-limit
+error — stream with `.each_line()` (one record per callback line, as in the
+`moon check` example above) to count or aggregate findings, and redirect
+stderr with `stderr=ToFile(...)` so skip warnings do not flood the merged
+output. `--rules <dir>` and
 `--rule <file>` load YAML rule files, `--disable <rule-id>` drops a loaded
 rule, and `--verbose` traces traversal on stderr.
 
@@ -333,16 +334,15 @@ Exit codes: 0 for help, dump, findings, no-findings, and parse warnings
 failure; 5 invalid rule content (including a `--pattern` that is not a valid
 MoonBit expression); 6 missing/unreadable scan input; 7 output failure. The
 scanner follows symlinks, so a broken symlink anywhere under the scan root
-aborts the whole scan with 6 — this repo's `editor/codemirror/demo/` holds
-dangling symlinks, and tool/eval directories are NOT in the default
-exclusions, so a whole-repo scan from this root also descends into
-`.claude/`, `.worktrees/`, `.moonagent/`, and `.repos/` and doubles every
-finding across the nested checkouts. Exclude them:
-`--exclude .claude --exclude .worktrees --exclude .moonagent --exclude
-.repos --exclude editor/codemirror/demo`. Source blocks whose syntax the
-bundled parser does not know yet (e.g. nested record-spread `is` patterns)
-are skipped with a stderr warning while exit stays 0 — treat skipped blocks
-as a blind spot.
+aborts the whole scan with 6. Tool/eval/worktree directories are also NOT
+in the default exclusions: a whole-repo scan descends into them and
+duplicates findings across nested checkouts, or aborts on a dangling
+symlink inside one. When such directories exist under the scan root,
+exclude them up front — in this checkout: `--exclude .claude --exclude
+.worktrees --exclude .moonagent --exclude .repos --exclude
+editor/codemirror/demo`. Source blocks whose syntax the bundled parser does
+not know yet (e.g. nested record-spread `is` patterns) are skipped with a
+stderr warning while exit stays 0 — treat skipped blocks as a blind spot.
 
 ## Tool Protocol
 

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -307,12 +307,13 @@ fn default_prompt() -> String {
     #|(1-based `line`/`column`), `matched_source`, and `source_context`; a scan
     #|with zero findings writes nothing and still exits 0. When parsing records
     #|with `@json.parse`, integer fields such as `range.start.line` pattern-match
-    #|as the `Number` variant (a `Double`; call `.to_int()` on it), not `Int`. A
-    #|whole-repo scan can match many nodes — `@shell.Cmd(...).output()` raises
-    #|`OutputLimitExceeded` on large captures — so stream with `.each_line()`
-    #|(one record per callback line, as in the `moon check` example above) to
-    #|count or aggregate findings, and redirect stderr with `stderr=ToFile(...)`
-    #|so skip warnings do not flood the merged output. `--rules <dir>` and
+    #|as `Number(value)` (a `Double`; call `.to_int()` on it), not `Int`. A
+    #|whole-repo scan can match many nodes — `@shell.Cmd(...).output()` cannot
+    #|capture unbounded output, so a large scan hits the shell's output-limit
+    #|error — stream with `.each_line()` (one record per callback line, as in the
+    #|`moon check` example above) to count or aggregate findings, and redirect
+    #|stderr with `stderr=ToFile(...)` so skip warnings do not flood the merged
+    #|output. `--rules <dir>` and
     #|`--rule <file>` load YAML rule files, `--disable <rule-id>` drops a loaded
     #|rule, and `--verbose` traces traversal on stderr.
     #|
@@ -338,16 +339,15 @@ fn default_prompt() -> String {
     #|failure; 5 invalid rule content (including a `--pattern` that is not a valid
     #|MoonBit expression); 6 missing/unreadable scan input; 7 output failure. The
     #|scanner follows symlinks, so a broken symlink anywhere under the scan root
-    #|aborts the whole scan with 6 — this repo's `editor/codemirror/demo/` holds
-    #|dangling symlinks, and tool/eval directories are NOT in the default
-    #|exclusions, so a whole-repo scan from this root also descends into
-    #|`.claude/`, `.worktrees/`, `.moonagent/`, and `.repos/` and doubles every
-    #|finding across the nested checkouts. Exclude them:
-    #|`--exclude .claude --exclude .worktrees --exclude .moonagent --exclude
-    #|.repos --exclude editor/codemirror/demo`. Source blocks whose syntax the
-    #|bundled parser does not know yet (e.g. nested record-spread `is` patterns)
-    #|are skipped with a stderr warning while exit stays 0 — treat skipped blocks
-    #|as a blind spot.
+    #|aborts the whole scan with 6. Tool/eval/worktree directories are also NOT
+    #|in the default exclusions: a whole-repo scan descends into them and
+    #|duplicates findings across nested checkouts, or aborts on a dangling
+    #|symlink inside one. When such directories exist under the scan root,
+    #|exclude them up front — in this checkout: `--exclude .claude --exclude
+    #|.worktrees --exclude .moonagent --exclude .repos --exclude
+    #|editor/codemirror/demo`. Source blocks whose syntax the bundled parser does
+    #|not know yet (e.g. nested record-spread `is` patterns) are skipped with a
+    #|stderr warning while exit stays 0 — treat skipped blocks as a blind spot.
     #|
     #|## Tool Protocol
     #|

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -305,11 +305,16 @@ fn default_prompt() -> String {
     #|agent-friendly output: one JSON object per finding with `file` (relative to
     #|the scan root, often `./`-prefixed), `rule_id`, `description`, `range`
     #|(1-based `line`/`column`), `matched_source`, and `source_context`; a scan
-    #|with zero findings writes nothing and still exits 0. A whole-repo scan can
-    #|match many nodes, so bound what you print (as above) or redirect stdout
-    #|with `stdout=ToFile(...)` under `@fs.tmpdir(prefix="run-")`. `--rules <dir>`
-    #|and `--rule <file>` load YAML rule files, `--disable <rule-id>` drops a
-    #|loaded rule, and `--verbose` traces traversal on stderr.
+    #|with zero findings writes nothing and still exits 0. When parsing records
+    #|with `@json.parse`, integer fields such as `range.start.line` pattern-match
+    #|as the `Number` variant (a `Double`; call `.to_int()` on it), not `Int`. A
+    #|whole-repo scan can match many nodes — `@shell.Cmd(...).output()` raises
+    #|`OutputLimitExceeded` on large captures — so stream with `.each_line()`
+    #|(one record per callback line, as in the `moon check` example above) to
+    #|count or aggregate findings, and redirect stderr with `stderr=ToFile(...)`
+    #|so skip warnings do not flood the merged output. `--rules <dir>` and
+    #|`--rule <file>` load YAML rule files, `--disable <rule-id>` drops a loaded
+    #|rule, and `--verbose` traces traversal on stderr.
     #|
     #|A `--pattern` is a MoonBit *expression* containing `$(name:kind)`
     #|metavariables — `exp`, `id`, `const`, `arg`, `pat`, `type` — plus `$_` to
@@ -323,16 +328,26 @@ fn default_prompt() -> String {
     #|of a snippet, and `moongrep docs RuleSpec` / `docs CLISpec` print the full
     #|specs.
     #|
+    #|The builtin `lint` rules are advisory style checks — `catch_all`, for
+    #|instance, flags deliberate `catch { _ => () }` swallows. Treat rule counts
+    #|as signal, not a bug list, and read `matched_source` before acting on a
+    #|finding.
+    #|
     #|Exit codes: 0 for help, dump, findings, no-findings, and parse warnings
     #|(no-match is NOT grep's 1); 2 usage; 3 invalid dump input; 4 rule-source
     #|failure; 5 invalid rule content (including a `--pattern` that is not a valid
     #|MoonBit expression); 6 missing/unreadable scan input; 7 output failure. The
     #|scanner follows symlinks, so a broken symlink anywhere under the scan root
-    #|aborts the whole scan with 6 — some workspaces contain dangling symlinks
-    #|(this one does, under `editor/codemirror/demo/`, `.worktrees/`, and
-    #|`.moonagent/`), so scope scans to the subdirectory you care about (pass it
-    #|as the scan root) or `--exclude` those paths instead of scanning `.` from
-    #|the root.
+    #|aborts the whole scan with 6 — this repo's `editor/codemirror/demo/` holds
+    #|dangling symlinks, and tool/eval directories are NOT in the default
+    #|exclusions, so a whole-repo scan from this root also descends into
+    #|`.claude/`, `.worktrees/`, `.moonagent/`, and `.repos/` and doubles every
+    #|finding across the nested checkouts. Exclude them:
+    #|`--exclude .claude --exclude .worktrees --exclude .moonagent --exclude
+    #|.repos --exclude editor/codemirror/demo`. Source blocks whose syntax the
+    #|bundled parser does not know yet (e.g. nested record-spread `is` patterns)
+    #|are skipped with a stderr warning while exit stays 0 — treat skipped blocks
+    #|as a blind spot.
     #|
     #|## Tool Protocol
     #|


### PR DESCRIPTION
## What

Hardens the "Structural search with `moongrep`" section of the default system prompt based on actual usage (whole-repo dogfooding and a 229-site refactor driven by `moonx moonbit-community/moongrep lint`), then reviewed to avoid ad-hoc guidelines:

- **JSON parsing**: integer fields such as `range.start.line` pattern-match as `Number(value)` (a `Double`; call `.to_int()`), not `Int` — the pattern that actually works with current `moonbitlang/core` JSON.
- **Streaming**: `@shell.Cmd(...).output()` cannot capture unbounded output — a whole-repo scan with thousands of matches hits the shell's output-limit error. Stream with `.each_line()` (one record per callback line, as in the `moon check` example) and redirect stderr with `stderr=ToFile(...)` so skip warnings don't flood the merged output.
- **Local-dir exclusions, principle-first**: tool/eval/worktree directories are not in moongrep's default exclusions, so whole-repo scans descend into them and duplicate findings across nested checkouts (or abort on a dangling symlink inside one). The general rule leads; this checkout's exact `--exclude` set (`.claude`, `.worktrees`, `.moonagent`, `.repos`, `editor/codemirror/demo`) is given as a scoped example, not a mandate.
- **Advisory rules**: builtin `lint` rules are style checks — `catch_all` flags deliberate `catch { _ => () }` swallows — treat counts as signal, read `matched_source`.
- **Parser-lag blind spot**: source blocks whose syntax the bundled parser doesn't know yet are skipped with a stderr warning (exit stays 0).

`prompt/generated_default_prompt.mbt` regenerated via the `md_to_mbt_string` dev_build rule. (Second commit is a review pass that de-ad-hocs the first draft: principle-first exclusion guidance, version-tolerant phrasing for the output-limit error.)

## Verification

Every claim comes from commands actually run in this repo during the moongrep dogfood + refactor work: `Number`-variant parsing, the output-limit capture failure, the duplicated findings across the local tool dirs, and the parse-skip warnings (e.g. nested record-spread `is` patterns). `moon check prompt`, `moon test prompt` (20/20), and `moon fmt --check` on both files are green.

Generated with SeekMoon