### PR TITLE
feat(mbtx): admit `codex review` on the spawn allowlist

### DIFF
--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -1051,6 +1051,8 @@ fn description(background~ : Bool, escalation~ : Bool) -> String {
     #|  `stash list|show`. Not `config`. A global option BEFORE the subcommand
     #|  (`-c`, `-C`, `--git-dir`, `--work-tree`) is refused.
     #|- `gh` — pr, issue, run, `repo view`, api, `auth status`.
+    #|- `codex` — review (read-only review of the current branch/diff; not
+    #|  `exec`, `install`, or a bare `codex`).
     #|- `rg` and `diff`.
   let base_tail =
     #|## Isolation and limits

--- a/agent_tool/mbtx/mbtx_test.mbt
+++ b/agent_tool/mbtx/mbtx_test.mbt
@@ -327,6 +327,7 @@ async test "the spawn allowlist discriminates between subcommands" {
       #|  println("moon-publish: \{probe("moon", ["publish"])}")
       #|  println("just: \{probe("just", ["--version"])}")
       #|  println("curl: \{probe("curl", ["--version"])}")
+      #|  println("codex-exec: \{probe("codex", ["exec", "run ls"])}")
       #|}
     ),
   )
@@ -355,6 +356,12 @@ async test "the spawn allowlist discriminates between subcommands" {
   assert_true(out.content.contains("moon-publish: refused"))
   assert_true(out.content.contains("just: refused"))
   assert_true(out.content.contains("curl: refused"))
+  // The same prefix gating admits exactly one verb of the Codex CLI: the
+  // read-only `review`. The policy refusal fires before the binary resolves,
+  // so `exec` is refused whether or not codex is installed; asserting that
+  // `review` runs would depend on the machine having it, so only the negative
+  // side is portable.
+  assert_true(out.content.contains("codex-exec: refused"))
 }
 
 ///|

--- a/agent_tool/mbtx/mbtx_wbtest.mbt
+++ b/agent_tool/mbtx/mbtx_wbtest.mbt
@@ -75,3 +75,22 @@ test "the spawn policy admits Proton subcommands but not global cwd options" {
 // prose is NOT pinned by a test: asserting a prompt contains particular words
 // only breaks on rewrites. Keeping the list and the prompts in step is a
 // review-time job, not a test-time one.
+
+///|
+/// Codex CLI is admitted one verb only: the read-only `review`. There is no
+/// bare rule and no verb that runs or installs an agent (`exec`, `install`),
+/// so the prefix gating keeps the agentic binary's surface to review.
+test "the spawn policy admits only the codex review verb" {
+  let codex_prefixes : Array[Array[String]] = []
+  for entry in spawnable_commands {
+    let (program, args_prefix) = entry
+    if program == "codex" {
+      codex_prefixes.push(args_prefix)
+    }
+  }
+  assert_eq(codex_prefixes.length(), 1)
+  assert_eq(codex_prefixes[0], ["review"])
+  assert_false(codex_prefixes.contains([]))
+  assert_false(codex_prefixes.contains(["exec"]))
+  assert_false(codex_prefixes.contains(["install"]))
+}

--- a/agent_tool/mbtx/wasm_policy.mbt
+++ b/agent_tool/mbtx/wasm_policy.mbt
@@ -183,6 +183,14 @@ let spawnable_commands : Array[(String, Array[String])] = [
   ("gh", ["repo", "view"]),
   ("gh", ["api"]),
   ("gh", ["auth", "status"]),
+  // The Codex CLI, one verb only: `review` reads the current branch/diff and
+  // reports findings — the review shape a shipping turn wants — while the
+  // other verbs stay out: a bare `codex` opens an interactive agent, and
+  // `exec`/`install` run or set one up. An admitted verb can still spawn
+  // children of its own (the reviewer is an LLM agent, not a plain reader),
+  // which is the already-accepted `moon run` shape; what the prefix buys is
+  // that only the review FORM of this program exists in a turn's vocabulary.
+  ("codex", ["review"]),
   // The only two read-only utilities without a MoonBit equivalent worth using:
   // `rg` searches a whole tree faster than a snippet can walk it, and `diff`
   // produces a structured comparison. Their mutating counterparts (`rm`, `mv`,

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -99,6 +99,8 @@ these programs can be started:
   `stash list|show`. Not `config`. A global option BEFORE the subcommand
   (`-c`, `-C`, `--git-dir`, `--work-tree`) is refused.
 - `gh` — pr, issue, run, `repo view`, api, `auth status`.
+- `codex` — review (read-only review of the current branch/diff; not
+  `exec`, `install`, or a bare `codex`).
 - `rg` and `diff`.
 - `moonx` — runs other MoonBit binaries in wasm/sandbox mode; see
   [Structural search with `moongrep`](#structural-search-with-moongrep) below

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -104,6 +104,8 @@ fn default_prompt() -> String {
     #|  `stash list|show`. Not `config`. A global option BEFORE the subcommand
     #|  (`-c`, `-C`, `--git-dir`, `--work-tree`) is refused.
     #|- `gh` — pr, issue, run, `repo view`, api, `auth status`.
+    #|- `codex` — review (read-only review of the current branch/diff; not
+    #|  `exec`, `install`, or a bare `codex`).
     #|- `rg` and `diff`.
     #|- `moonx` — runs other MoonBit binaries in wasm/sandbox mode; see
     #|  [Structural search with `moongrep`](#structural-search-with-moongrep) below


### PR DESCRIPTION
Admit the Codex CLI's `review` verb on the mbtx spawn allowlist, one
subcommand only: `codex review` reads the current branch/diff and reports
findings, while `exec`, `install`, and a bare `codex` (interactive agent)
still match no prefix rule and are refused. This fits the allowlist's
per-subcommand design — the policy is the agent's command vocabulary, not
a security perimeter, and `moon run` already admits an arbitrary-program
runner. The reviewer can spawn children of its own, the already-accepted
`moon run` shape; what the prefix buys is that only the review FORM of
this program exists in a turn's vocabulary.

Updated in step:
- `agent_tool/mbtx/wasm_policy.mbt` — the `("codex", ["review"])` entry
- `agent_tool/mbtx/mbtx.mbt` — mbtx tool description prose
- `agent_tool/mbtx/mbtx_test.mbt` — `codex exec` refused in the
  subcommand-discrimination test
- `agent_tool/mbtx/mbtx_wbtest.mbt` — white-box test pinning exactly one
  codex rule with prefix `["review"]`
- `prompt/default_prompt.mbt.md` + generated copy — system prompt prose

Verified locally:
- `moon check --target native agent_tool/mbtx`: clean
- `moon test --target native agent_tool/mbtx`: 50/50 pass
- `moon fmt --check agent_tool/mbtx prompt`: clean

Not verified here: a live `codex review` run (the binary is not on the
running tool's allowlist and the positive path depends on it being
installed).

Generated with SeekMoon