### PR TITLE
test(shell): give output-limit probes a generous deadline

### DIFF
--- a/agent_tool/shell/shell_test.mbt
+++ b/agent_tool/shell/shell_test.mbt
@@ -490,7 +490,11 @@ async test "shell stops oversized output while the command is still running on U
   let output = run_shell({
     "cmd": "printf %s 'abcdef'; sleep 2",
     "max_output_chars": 3,
-    "timeout_ms": 1000,
+    // The deadline must only be generous enough to outlive the sandbox-profile
+    // workspace scan that every command launch pays; the assertion is about the
+    // output limit triggering, never about this timeout (a tight 1s budget
+    // raced the scan and flaked under parallel load).
+    "timeout_ms": 10000,
   })
   assert_true(output.is_error)
   assert_true(
@@ -522,7 +526,10 @@ async test "shell does not cut multi-byte utf8 output mid-character on Unix" {
   let output = run_shell({
     "cmd": "printf %s '中中中'; sleep 2",
     "max_output_chars": 2,
-    "timeout_ms": 1000,
+    // Generous deadline: the assertion is the output limit, not the timeout
+    // (a tight 1s budget raced the sandbox-profile workspace scan and flaked
+    // under parallel load).
+    "timeout_ms": 10000,
   })
   assert_true(output.is_error)
   assert_true(
@@ -554,7 +561,10 @@ async test "shell does not split four-byte utf8 characters on Unix" {
   let output = run_shell({
     "cmd": "printf %s '😀😀'; sleep 2",
     "max_output_chars": 1,
-    "timeout_ms": 1000,
+    // Generous deadline: the assertion is the output limit, not the timeout
+    // (a tight 1s budget raced the sandbox-profile workspace scan and flaked
+    // under parallel load).
+    "timeout_ms": 10000,
   })
   assert_true(output.is_error)
   assert_true(
@@ -603,7 +613,10 @@ async test "shell output limit wins over an unbounded producer on Unix" {
   let output = run_shell({
     "cmd": "while :; do printf %s 'yyyyyyyyyy'; done",
     "max_output_chars": 5,
-    "timeout_ms": 1000,
+    // Generous deadline: the assertion is the output limit, not the timeout
+    // (a tight 1s budget raced the sandbox-profile workspace scan and flaked
+    // under parallel load).
+    "timeout_ms": 10000,
   })
   assert_true(output.is_error)
   assert_true(


### PR DESCRIPTION
## What

Fixes the flaky `agent_tool/shell` output-limit tests: the four Unix probes ("stops oversized output", "does not cut multi-byte utf8", "does not split four-byte utf8", "output limit wins over an unbounded producer") raced a 1s deadline against the sandbox-profile workspace scan that every untrusted command launch pays.

Under parallel load the scan can exceed 1s — reproduced deterministically in the local checkout (whose extra tool/worktree dirs make the scan slow): the command then reports "timed out after 1000ms" instead of hitting the output limit, and the assertion fails. The same race hit CI's full-suite run three times (three different tests of this family).

The tests' assertions only ever check that the output limit triggers (`output_limit_reached=true`, no "timed out" text) — never the deadline itself — so a 10s budget removes the race without weakening what they assert.

## Verification

- The previously-deterministic failure environment (main checkout with the large extra trees) now passes the family 11/11.
- Full `agent_tool/shell` suite: 137/137 pass; `moon fmt --check` clean.

Generated with SeekMoon