### PR TITLE
refactor(bgjobs): construct BgJobRuntime via the type-named constructor

### DIFF
--- a/agent/tool_definition.mbt
+++ b/agent/tool_definition.mbt
@@ -87,7 +87,7 @@ pub async fn[X] build_tools(
   // loop's lossless steer queue (surfaced to the model at the next step, or
   // persisted while idle) and poke the controller so an idle engine wakes to
   // drain it instead of leaving it until the next prompt.
-  let bg_runtime = @bgjobs.BgJobRuntime::new(scope, spill_dir?, on_job_exit=snapshot => {
+  let bg_runtime = @bgjobs.BgJobRuntime::BgJobRuntime(scope, spill_dir?, on_job_exit=snapshot => {
     runtime.queue_steer(Notice(background_notice_text(snapshot)))
     if on_background_wake is Some(wake) {
       wake()
@@ -260,7 +260,7 @@ async test "a foreground run past its deadline becomes a job instead of dying" {
   @async.with_task_group(group => {
     let scope = @agent_runtime.AgentTaskScope(group)
     let spill_dir = @fs.tmpdir(prefix="openseek-jobs-test-")
-    let bg_runtime = @bgjobs.BgJobRuntime::new(scope, spill_dir~)
+    let bg_runtime = @bgjobs.BgJobRuntime::BgJobRuntime(scope, spill_dir~)
     let mbtx = @mbtx.definition(
       workspace_root=".",
       bg_runtime~,
@@ -333,7 +333,7 @@ async test "binary output does not escape the deadline" {
   @async.with_task_group(group => {
     let scope = @agent_runtime.AgentTaskScope(group)
     let spill_dir = @fs.tmpdir(prefix="openseek-jobs-binary-")
-    let bg_runtime = @bgjobs.BgJobRuntime::new(scope, spill_dir~)
+    let bg_runtime = @bgjobs.BgJobRuntime::BgJobRuntime(scope, spill_dir~)
     let mbtx = @mbtx.definition(
       workspace_root=".",
       bg_runtime~,

--- a/agent_tool/bgjobs/bgjobs.mbt
+++ b/agent_tool/bgjobs/bgjobs.mbt
@@ -35,7 +35,7 @@ let default_hard_timeout_ms : Int = 1_800_000
 /// can leave descendants running after the job is reported terminal.
 ///
 /// One `BgJobRuntime` is created per session and shared by the `shell`
-/// (`run_in_background`), `shell_output`, and `shell_stop` tools. `new` captures
+/// (`run_in_background`), `shell_output`, and `shell_stop` tools. the constructor captures
 /// the session group in a spawn closure, so the runtime is not generic and can be
 /// an optional tool argument.
 pub struct BgJobRuntime {
@@ -136,7 +136,7 @@ pub struct BgJobSnapshot {
 /// `hard_output_cap` bounds any single job's *full* retained output (characters);
 /// the watchdog kills a job that floods past it — production uses the default,
 /// tests shrink it to exercise the watchdog cheaply.
-pub fn[X] BgJobRuntime::new(
+pub fn[X] BgJobRuntime::BgJobRuntime(
   scope : @agent_runtime.AgentTaskScope[X],
   spill_dir? : String,
   hard_output_cap? : Int = @shell_exec.default_hard_cap,
@@ -455,7 +455,7 @@ async fn wait_for_first(notices : Array[BgJobSnapshot]) -> Unit {
 #cfg(not(platform="windows"))
 async test "bg job runs to completion and captures output" {
   @async.with_task_group(group => {
-    let rt = BgJobRuntime::new(AgentTaskScope(group))
+    let rt = BgJobRuntime::BgJobRuntime(AgentTaskScope(group))
     let id = rt.start(
       program="sh",
       args=["-c", "printf hello"],
@@ -474,7 +474,7 @@ async test "bg job runs to completion and captures output" {
 #cfg(not(platform="windows"))
 async test "bg job records a non-zero exit code" {
   @async.with_task_group(group => {
-    let rt = BgJobRuntime::new(AgentTaskScope(group))
+    let rt = BgJobRuntime::BgJobRuntime(AgentTaskScope(group))
     let id = rt.start(program="sh", args=["-c", "exit 3"], command="exit 3")
     let snap = poll_until_terminal(rt, id)
     assert_true(snap.status is Exited(3))
@@ -486,7 +486,7 @@ async test "bg job records a non-zero exit code" {
 #cfg(not(platform="windows"))
 async test "stop terminates a running job" {
   @async.with_task_group(group => {
-    let rt = BgJobRuntime::new(AgentTaskScope(group))
+    let rt = BgJobRuntime::BgJobRuntime(AgentTaskScope(group))
     let id = rt.start(program="sleep", args=["30"], command="sleep 30")
     @async.sleep(50)
     assert_true(rt.snapshot(id).unwrap().status is Running)
@@ -499,7 +499,7 @@ async test "stop terminates a running job" {
 #cfg(not(platform="windows"))
 async test "a large-output job spills; snapshot previews, read_output is full" {
   @async.with_task_group(group => {
-    let rt = BgJobRuntime::new(AgentTaskScope(group), spill_dir="/tmp")
+    let rt = BgJobRuntime::BgJobRuntime(AgentTaskScope(group), spill_dir="/tmp")
     let id = rt.start(
       program="sh",
       args=["-c", "seq 1 5000"],
@@ -523,7 +523,7 @@ async test "a large-output job spills; snapshot previews, read_output is full" {
 async test "adopt registers an already-running execution as a job" {
   @async.with_task_group(group => {
     let scope : @agent_runtime.AgentTaskScope[Unit] = AgentTaskScope(group)
-    let rt = BgJobRuntime::new(scope)
+    let rt = BgJobRuntime::BgJobRuntime(scope)
     let exec = @shell_exec.ShellExecution::start(scope, program="sleep", args=[
       "30",
     ])
@@ -541,7 +541,7 @@ async test "adopt registers an already-running execution as a job" {
 async test "on_job_exit fires once on a natural exit, never on stop" {
   @async.with_task_group(group => {
     let seen : Array[BgJobSnapshot] = []
-    let rt = BgJobRuntime::new(AgentTaskScope(group), on_job_exit=snapshot => {
+    let rt = BgJobRuntime::BgJobRuntime(AgentTaskScope(group), on_job_exit=snapshot => {
       seen.push(snapshot)
     })
     let done = rt.start(
@@ -565,7 +565,7 @@ async test "on_job_exit fires once on a natural exit, never on stop" {
 #cfg(not(platform="windows"))
 async test "snapshot, read_output, and stop handle unknown ids" {
   @async.with_task_group(group => {
-    let rt = BgJobRuntime::new(AgentTaskScope(group))
+    let rt = BgJobRuntime::BgJobRuntime(AgentTaskScope(group))
     assert_true(rt.snapshot("nope") is None)
     assert_true(rt.read_output("nope") is None)
     assert_false(rt.stop("nope"))
@@ -576,7 +576,7 @@ async test "snapshot, read_output, and stop handle unknown ids" {
 #cfg(not(platform="windows"))
 async test "start allocates one id per job (id matches its spill file)" {
   @async.with_task_group(group => {
-    let rt = BgJobRuntime::new(AgentTaskScope(group), spill_dir="/tmp")
+    let rt = BgJobRuntime::BgJobRuntime(AgentTaskScope(group), spill_dir="/tmp")
     // The first started job is bg-1 (not bg-2): start must not reserve an id for
     // the spill path and then allocate a second one for the registry entry.
     let a = rt.start(program="sh", args=["-c", "printf a"], command="a")
@@ -590,7 +590,7 @@ async test "start allocates one id per job (id matches its spill file)" {
 #cfg(not(platform="windows"))
 async test "two jobs run independently with distinct ids" {
   @async.with_task_group(group => {
-    let rt = BgJobRuntime::new(AgentTaskScope(group))
+    let rt = BgJobRuntime::BgJobRuntime(AgentTaskScope(group))
     let a = rt.start(program="sh", args=["-c", "printf aaa"], command="a")
     let b = rt.start(program="sh", args=["-c", "printf bbb"], command="b")
     assert_true(a != b)
@@ -609,9 +609,11 @@ async test "the watchdog kills a background job that floods past the hard cap" {
     let notices : Array[BgJobSnapshot] = []
     // Tiny hard cap so `yes` trips the watchdog immediately instead of running
     // to the 20M default.
-    let rt = BgJobRuntime::new(AgentTaskScope(group), hard_output_cap=200, on_job_exit=snapshot => {
-      notices.push(snapshot)
-    })
+    let rt = BgJobRuntime::BgJobRuntime(
+      AgentTaskScope(group),
+      hard_output_cap=200,
+      on_job_exit=snapshot => notices.push(snapshot),
+    )
     let id = rt.start(program="yes", args=[], command="yes")
     let snapshot = poll_until_terminal(rt, id)
     // Killed by the watchdog — not left running with its output dropped — and
@@ -632,9 +634,11 @@ async test "the watchdog kills a background job that floods past the hard cap" {
 async test "the reaper kills a background job that outlives the time cap" {
   @async.with_task_group(group => {
     let notices : Array[BgJobSnapshot] = []
-    let rt = BgJobRuntime::new(AgentTaskScope(group), hard_timeout_ms=80, on_job_exit=snapshot => {
-      notices.push(snapshot)
-    })
+    let rt = BgJobRuntime::BgJobRuntime(
+      AgentTaskScope(group),
+      hard_timeout_ms=80,
+      on_job_exit=snapshot => notices.push(snapshot),
+    )
     let id = rt.start(program="sh", args=["-c", "sleep 5"], command="sleep 5")
     let snapshot = poll_until_terminal(rt, id)
     assert_true(snapshot.status is Stopped)
@@ -651,7 +655,10 @@ async test "the reaper kills a background job that outlives the time cap" {
 #cfg(not(platform="windows"))
 async test "an adopted job keeps its original wall-clock deadline" {
   @async.with_task_group(group => {
-    let rt = BgJobRuntime::new(AgentTaskScope(group), hard_timeout_ms=150)
+    let rt = BgJobRuntime::BgJobRuntime(
+      AgentTaskScope(group),
+      hard_timeout_ms=150,
+    )
     // The execution starts OUTSIDE the registry (a foreground command) and
     // burns most of its lifetime before being adopted on detach.
     let exec = rt.spawn_foreground_retained("sh", ["-c", "sleep 5"], None, 200)
@@ -669,7 +676,10 @@ async test "an adopted job keeps its original wall-clock deadline" {
 #cfg(not(platform="windows"))
 async test "a requested stop is not blamed on the reaper" {
   @async.with_task_group(group => {
-    let rt = BgJobRuntime::new(AgentTaskScope(group), hard_timeout_ms=60_000)
+    let rt = BgJobRuntime::BgJobRuntime(
+      AgentTaskScope(group),
+      hard_timeout_ms=60_000,
+    )
     let id = rt.start(program="sh", args=["-c", "sleep 5"], command="sleep 5")
     let _ = rt.stop(id)
     guard rt.snapshot(id) is Some(snapshot) else { fail("expected snapshot") }

--- a/agent_tool/bgjobs/pkg.generated.mbti
+++ b/agent_tool/bgjobs/pkg.generated.mbti
@@ -16,9 +16,9 @@ import {
 pub struct BgJobRuntime {
   // private fields
 }
+pub fn[X] BgJobRuntime::BgJobRuntime(@agent_runtime.AgentTaskScope[X], spill_dir? : String, hard_output_cap? : Int, hard_timeout_ms? : Int, on_job_exit? : (BgJobSnapshot) -> Unit) -> Self
 pub fn BgJobRuntime::adopt(Self, @shell_exec.ShellExecution, command~ : String, cwd? : String, sandboxed_command? : @sandbox.SandboxedCommand, read_only_review? : Bool) -> String
 pub fn BgJobRuntime::list(Self) -> Array[BgJobSnapshot]
-pub fn[X] BgJobRuntime::new(@agent_runtime.AgentTaskScope[X], spill_dir? : String, hard_output_cap? : Int, hard_timeout_ms? : Int, on_job_exit? : (BgJobSnapshot) -> Unit) -> Self
 pub async fn BgJobRuntime::read_output(Self, String) -> String?
 pub async fn BgJobRuntime::read_output_tail(Self, String, Int) -> String?
 pub fn BgJobRuntime::snapshot(Self, String) -> BgJobSnapshot?

--- a/agent_tool/job_output/job_output_test.mbt
+++ b/agent_tool/job_output/job_output_test.mbt
@@ -30,7 +30,7 @@ async fn poll_bg_terminal(bg : @bgjobs.BgJobRuntime, id : String) -> Unit {
 #cfg(not(platform="windows"))
 async test "job_output returns a running job's output and status" {
   @async.with_task_group(group => {
-    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let bg = @bgjobs.BgJobRuntime::BgJobRuntime(AgentTaskScope(group))
     let id = bg.start(
       program="sh",
       args=["-c", "printf hi; sleep 30"],
@@ -49,7 +49,7 @@ async test "job_output returns a running job's output and status" {
 #cfg(not(platform="windows"))
 async test "job_output reports a finished job's exit code" {
   @async.with_task_group(group => {
-    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let bg = @bgjobs.BgJobRuntime::BgJobRuntime(AgentTaskScope(group))
     let id = bg.start(program="sh", args=["-c", "exit 2"], command="job")
     poll_bg_terminal(bg, id)
     let output = run_job_output(bg, { "job_id": id })
@@ -63,7 +63,10 @@ async test "job_output reports a finished job's exit code" {
 async test "job_output windows a large job's output and notes truncation" {
   @async.with_task_group(group => {
     let dir = @fs.tmpdir(prefix="openseek-test-")
-    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group), spill_dir=dir)
+    let bg = @bgjobs.BgJobRuntime::BgJobRuntime(
+      AgentTaskScope(group),
+      spill_dir=dir,
+    )
     let id = bg.start(
       program="sh",
       args=["-c", "seq 1 20000"],
@@ -88,7 +91,7 @@ async test "job_output windows a large job's output and notes truncation" {
 async test "job_output flags dropped output for a memory-only job" {
   @async.with_task_group(group => {
     // Memory-only runtime (no spill dir): output past the budget is dropped.
-    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let bg = @bgjobs.BgJobRuntime::BgJobRuntime(AgentTaskScope(group))
     let id = bg.start(
       program="sh",
       args=["-c", "seq 1 2000"],
@@ -107,7 +110,7 @@ async test "job_output flags dropped output for a memory-only job" {
 #cfg(not(platform="windows"))
 async test "job_output marks binary background output as a tool error" {
   @async.with_task_group(group => {
-    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let bg = @bgjobs.BgJobRuntime::BgJobRuntime(AgentTaskScope(group))
     // A background command with non-UTF-8 output that exits 0 must still be a
     // tool error when read, matching the foreground path.
     let id = bg.start(
@@ -126,7 +129,7 @@ async test "job_output marks binary background output as a tool error" {
 #cfg(not(platform="windows"))
 async test "job_output errors on an unknown job id" {
   @async.with_task_group(group => {
-    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let bg = @bgjobs.BgJobRuntime::BgJobRuntime(AgentTaskScope(group))
     let output = run_job_output(bg, { "job_id": "nope" })
     assert_true(output.is_error)
     assert_true(output.content.contains("no background job"))
@@ -137,7 +140,7 @@ async test "job_output errors on an unknown job id" {
 #cfg(not(platform="windows"))
 async test "wait_ms blocks until the job finishes and returns its output" {
   @async.with_task_group(group => {
-    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let bg = @bgjobs.BgJobRuntime::BgJobRuntime(AgentTaskScope(group))
     let id = bg.start(
       program="sh",
       args=["-c", "sleep 1; echo WAITED-OK"],
@@ -155,7 +158,7 @@ async test "wait_ms blocks until the job finishes and returns its output" {
 #cfg(not(platform="windows"))
 async test "a wait_ms deadline on a still-running job is not an error" {
   @async.with_task_group(group => {
-    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let bg = @bgjobs.BgJobRuntime::BgJobRuntime(AgentTaskScope(group))
     let id = bg.start(program="sh", args=["-c", "sleep 30"], command="slow")
     let output = run_job_output(bg, { "job_id": id, "wait_ms": 200 })
     // Deadline expiry just reports the live status; the model can call again.
@@ -169,7 +172,7 @@ async test "a wait_ms deadline on a still-running job is not an error" {
 #cfg(not(platform="windows"))
 async test "a non-positive wait_ms is a tool error" {
   @async.with_task_group(group => {
-    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let bg = @bgjobs.BgJobRuntime::BgJobRuntime(AgentTaskScope(group))
     let id = bg.start(program="sh", args=["-c", "true"], command="noop")
     let output = run_job_output(bg, { "job_id": id, "wait_ms": -5 })
     assert_true(output.is_error)
@@ -181,7 +184,7 @@ async test "a non-positive wait_ms is a tool error" {
 #cfg(not(platform="windows"))
 async test "a non-numeric wait_ms is a tool error, not silently ignored" {
   @async.with_task_group(group => {
-    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let bg = @bgjobs.BgJobRuntime::BgJobRuntime(AgentTaskScope(group))
     let id = bg.start(program="sh", args=["-c", "true"], command="noop")
     let output = run_job_output(bg, { "job_id": id, "wait_ms": "30000" })
     assert_true(output.is_error)

--- a/agent_tool/job_stop/job_stop_test.mbt
+++ b/agent_tool/job_stop/job_stop_test.mbt
@@ -2,7 +2,7 @@
 #cfg(not(platform="windows"))
 async test "job_stop cancels a running job" {
   @async.with_task_group(group => {
-    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let bg = @bgjobs.BgJobRuntime::BgJobRuntime(AgentTaskScope(group))
     let id = bg.start(program="sleep", args=["30"], command="sleep 30")
     @async.sleep(50)
     assert_true(bg.snapshot(id).unwrap().status is Running)
@@ -21,7 +21,7 @@ async test "job_stop cancels a running job" {
 #cfg(not(platform="windows"))
 async test "job_stop errors on an unknown job id" {
   @async.with_task_group(group => {
-    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let bg = @bgjobs.BgJobRuntime::BgJobRuntime(AgentTaskScope(group))
     let action = match @job_stop.definition(bg).execute {
       Async(execute) => execute({ "job_id": "nope" })
       Sync(_) => fail("job_stop should be async")

--- a/agent_tool/shell/sandbox_wbtest.mbt
+++ b/agent_tool/shell/sandbox_wbtest.mbt
@@ -1662,7 +1662,7 @@ async test "the lab kernel backstop holds through the background job path" {
   let lab = @fs.realpath(@fs.tmpdir(prefix="openseek-lab-bg-lab-"))
   @fs.symlink(target=ws, "\{lab}/link")
   @async.with_task_group(group => {
-    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let bg = @bgjobs.BgJobRuntime::BgJobRuntime(AgentTaskScope(group))
     let action = execute_with_workspace(
       ws,
       { "cmd": "moon new \{lab}/link/probe", "run_in_background": true },

--- a/agent_tool/shell/shell_test.mbt
+++ b/agent_tool/shell/shell_test.mbt
@@ -33,7 +33,7 @@ async fn run_shell_wired(
 #cfg(not(platform="windows"))
 async test "run_in_background starts a job and returns its id" {
   @async.with_task_group(group => {
-    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let bg = @bgjobs.BgJobRuntime::BgJobRuntime(AgentTaskScope(group))
     let output = run_shell_wired(bg, {
       "cmd": "printf hi",
       "run_in_background": true,
@@ -48,7 +48,7 @@ async test "run_in_background starts a job and returns its id" {
 #cfg(not(platform="windows"))
 async test "run_in_background rejects timeout_ms" {
   @async.with_task_group(group => {
-    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let bg = @bgjobs.BgJobRuntime::BgJobRuntime(AgentTaskScope(group))
     let output = run_shell_wired(bg, {
       "cmd": "printf hi",
       "run_in_background": true,
@@ -63,7 +63,7 @@ async test "run_in_background rejects timeout_ms" {
 #cfg(not(platform="windows"))
 async test "foreground runs through the execution model" {
   @async.with_task_group(group => {
-    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let bg = @bgjobs.BgJobRuntime::BgJobRuntime(AgentTaskScope(group))
     let output = run_shell_wired(bg, { "cmd": "printf hi" })
     assert_false(output.is_error)
     assert_true(output.content.contains("hi"))
@@ -75,7 +75,7 @@ async test "foreground runs through the execution model" {
 #cfg(not(platform="windows"))
 async test "wired foreground reports binary output as lossy text with encoding warning" {
   @async.with_task_group(group => {
-    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let bg = @bgjobs.BgJobRuntime::BgJobRuntime(AgentTaskScope(group))
     // Non-UTF-8 output is no longer a hard tool error: the platform shell
     // sets UTF-8 encoding (Windows: chcp 65001), so remaining binary output
     // is returned as lossy-decoded text with an encoding warning.
@@ -88,7 +88,7 @@ async test "wired foreground reports binary output as lossy text with encoding w
 #cfg(not(platform="windows"))
 async test "foreground enforces max_output_chars with an output-limit error" {
   @async.with_task_group(group => {
-    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let bg = @bgjobs.BgJobRuntime::BgJobRuntime(AgentTaskScope(group))
     // `yes` exceeds the tiny budget; the shared foreground path must report the
     // output-limit error, not silently drop output as a success.
     let output = run_shell_wired(bg, { "cmd": "yes", "max_output_chars": 100 })
@@ -102,7 +102,10 @@ async test "foreground enforces max_output_chars with an output-limit error" {
 async test "a timed command that floods output is an output-limit error, not detached" {
   @async.with_task_group(group => {
     let dir = @fs.tmpdir(prefix="openseek-test-")
-    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group), spill_dir=dir)
+    let bg = @bgjobs.BgJobRuntime::BgJobRuntime(
+      AgentTaskScope(group),
+      spill_dir=dir,
+    )
     // A long timeout, but the runaway must be killed at the output limit promptly
     // (not run to the timeout and then backgrounded).
     let output = run_shell_wired(bg, {
@@ -123,7 +126,10 @@ async test "a timed command that floods output is an output-limit error, not det
 async test "a detached foreground job retains full output past the inline cap" {
   @async.with_task_group(group => {
     let dir = @fs.tmpdir(prefix="openseek-test-")
-    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group), spill_dir=dir)
+    let bg = @bgjobs.BgJobRuntime::BgJobRuntime(
+      AgentTaskScope(group),
+      spill_dir=dir,
+    )
     // Under the output limit at the timeout (still sleeping) → cleanly detached;
     // then it floods output, which a detached job retains (the output-limit kill
     // is cleared on detach).
@@ -156,7 +162,7 @@ async test "a detached foreground job retains full output past the inline cap" {
 #cfg(not(platform="windows"))
 async test "a foreground command that times out is detached to the background" {
   @async.with_task_group(group => {
-    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let bg = @bgjobs.BgJobRuntime::BgJobRuntime(AgentTaskScope(group))
     let output = run_shell_wired(bg, { "cmd": "sleep 2", "timeout_ms": 100 })
     assert_false(output.is_error)
     assert_true(output.content.contains("moved to the background"))
@@ -312,7 +318,7 @@ async test "shell description teaches background jobs only when a runtime is wir
   // Wired: guide the model to background long-running work and to rely on the
   // pushed completion notice instead of blocking on sleeps or polling.
   @async.with_task_group(group => {
-    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let bg = @bgjobs.BgJobRuntime::BgJobRuntime(AgentTaskScope(group))
     let wired = @shell.definition(bg_runtime=bg).description
     assert_true(wired.contains("run_in_background"))
     assert_true(wired.contains("notice"))
@@ -2140,7 +2146,7 @@ async test "an omitted timeout gets a default that kills on the unwired path" {
 #cfg(not(platform="windows"))
 async test "an omitted timeout detaches at the default on the wired path" {
   @async.with_task_group() <| group => {
-    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let bg = @bgjobs.BgJobRuntime::BgJobRuntime(AgentTaskScope(group))
     let output = exec_shell(
       @shell.definition(bg_runtime=bg, default_timeout_ms=50),
       { "cmd": "sleep 2" },
@@ -2168,7 +2174,7 @@ async test "an explicit timeout above the ceiling is an error, not a clamp" {
 #cfg(not(platform="windows"))
 async test "run_in_background without timeout_ms is unaffected by defaults" {
   @async.with_task_group() <| group => {
-    let bg = @bgjobs.BgJobRuntime::new(AgentTaskScope(group))
+    let bg = @bgjobs.BgJobRuntime::BgJobRuntime(AgentTaskScope(group))
     let output = exec_shell(
       @shell.definition(bg_runtime=bg, default_timeout_ms=50),
       { "cmd": "sleep 1", "run_in_background": true },


### PR DESCRIPTION
Replace the `BgJobRuntime::new` factory with the custom constructor
`BgJobRuntime::BgJobRuntime` (a function named after the type — the MoonBit
constructor idiom), and update every call site: the `shell` / `shell_output` /
`shell_stop` tool definitions in `agent` and the bgjobs, shell, job_output, and
job_stop tests. `pkg.generated.mbti` is regenerated via `moon info`.

Verified:

- `moon check` clean across the workspace
- `moon fmt --check` clean on the touched packages
- `moon test agent_tool/bgjobs agent_tool/shell agent_tool/job_output agent_tool/job_stop` — 162 tests pass
- no remaining `BgJobRuntime::new` references

Generated with SeekMoon
