### PR TITLE
docs(prompt): use moonx for moongrep commands

### DIFF
--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -322,9 +322,10 @@ and comments do not matter, but syntax shape does (`Some(1)` does not match
 pattern). A metavariable used twice must capture equal structure. `--guard
 '{$name: "regex"}'` filters `id` and `const` captures (substring match
 unless anchored with `^...$`). When a pattern surprises you,
-`moongrep dump --expr '...'` or `dump --impl 'fn f { ... }'` prints the CST
-of a snippet, and `moongrep docs RuleSpec` / `docs CLISpec` print the full
-specs.
+`moonx moonbit-community/moongrep dump --expr '...'` or
+`moonx moonbit-community/moongrep dump --impl 'fn f { ... }'` prints the CST
+of a snippet. `moonx moonbit-community/moongrep docs RuleSpec` and
+`moonx moonbit-community/moongrep docs CLISpec` print the full specs.
 
 The builtin `lint` rules are advisory style checks — `catch_all`, for
 instance, flags deliberate `catch { _ => () }` swallows. Treat rule counts

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -327,9 +327,10 @@ fn default_prompt() -> String {
     #|pattern). A metavariable used twice must capture equal structure. `--guard
     #|'{$name: "regex"}'` filters `id` and `const` captures (substring match
     #|unless anchored with `^...$`). When a pattern surprises you,
-    #|`moongrep dump --expr '...'` or `dump --impl 'fn f { ... }'` prints the CST
-    #|of a snippet, and `moongrep docs RuleSpec` / `docs CLISpec` print the full
-    #|specs.
+    #|`moonx moonbit-community/moongrep dump --expr '...'` or
+    #|`moonx moonbit-community/moongrep dump --impl 'fn f { ... }'` prints the CST
+    #|of a snippet. `moonx moonbit-community/moongrep docs RuleSpec` and
+    #|`moonx moonbit-community/moongrep docs CLISpec` print the full specs.
     #|
     #|The builtin `lint` rules are advisory style checks — `catch_all`, for
     #|instance, flags deliberate `catch { _ => () }` swallows. Treat rule counts


### PR DESCRIPTION
## Summary

- replace bare `moongrep dump` examples with complete `moonx moonbit-community/moongrep dump` commands
- replace shorthand docs examples with complete `moonx moonbit-community/moongrep docs` commands
- regenerate the embedded default prompt

This follows up on #1135 and keeps the prose consistent with its executable `@shell.Cmd("moonx", ...)` example. The published coordinate was verified with `moonx moonbit-community/moongrep --help`.

## Testing

- `moon test prompt` — 20 passed
- `just check`
- `just test` — native 3339 passed; JavaScript 3300 passed; Cram 28 passed
- `just build`
- `moon info && moon fmt`