### PR TITLE
chore: migrate deprecated lexscan to lexmatch

### DIFF
--- a/agent/goal.mbt
+++ b/agent/goal.mbt
@@ -340,7 +340,7 @@ fn decode_goal_status(arguments : Json) -> Result[@goal.GoalStatus, String] {
 /// Tool packages normally share `agent_tool/internal/error`, but the agent is
 /// outside that internal visibility boundary.
 fn goal_decode_failure_message(error_text : String) -> String {
-  lexscan error_text {
+  lexmatch error_text {
     // Greedy across lines to the LAST ` FAILED: ` marker — the same piece
     // rev_find chose.
     (re"^(.|\n)* FAILED: ", after=message) =>

--- a/agent_tool/internal/auto_check/parse_gate.mbt
+++ b/agent_tool/internal/auto_check/parse_gate.mbt
@@ -317,7 +317,7 @@ fn loc_line_span(loc : String) -> (Int, Int)? {
   // An end that does not open with digits (or is missing) falls back to the
   // start line, matching the compiler's lenient loc forms; parse failures on
   // validated digit runs can only be overflow, which is malformed too.
-  lexscan loc {
+  lexmatch loc {
     (re"^[0-9]+" as start) +
     re"(:[^\-]*)?-" +
     (re"[0-9]+" as end_) +

--- a/agent_tool/internal/error/error.mbt
+++ b/agent_tool/internal/error/error.mbt
@@ -3,7 +3,7 @@
 /// rendering. This keeps tool argument errors stable when validation lives in
 /// an internal package and the raw error string includes source locations.
 pub fn failure_message(error_text : String) -> String {
-  lexscan error_text {
+  lexmatch error_text {
     // Greedy across lines to the LAST ` FAILED: ` marker — the same piece
     // rev_find chose.
     (re"^(.|\n)* FAILED: ", after=message) =>

--- a/agent_tool/shell/internal/command_policy/command_policy.mbt
+++ b/agent_tool/shell/internal/command_policy/command_policy.mbt
@@ -83,7 +83,7 @@ fn scan_sed_args_for_in_place(args : Array[String], start : Int) -> Bool {
 /// scanner must skip that operand): a `-e`/`-f` cluster whose `e`/`f` is the last
 /// character, or `--expression`/`--file` without an attached `=value`.
 fn sed_option_consumes_next(arg : String) -> Bool {
-  lexscan arg {
+  lexmatch arg {
     re"^--(expression|file)$" => true
     // A short cluster whose first `e`/`f`/`i` is an `e` or `f` in final
     // position: that flag consumes the NEXT word as its value. An `i` first,
@@ -98,7 +98,7 @@ fn sed_option_consumes_next(arg : String) -> Bool {
 /// (`/usr/bin/sed`, `./sed`) compares equal to `sed`. Handles both separators.
 fn command_basename(name : String) -> String {
   let normalized = name.replace_all(old="\\", new="/")
-  lexscan normalized {
+  lexmatch normalized {
     // Greedy `.*` runs to the LAST slash; the remainder is the basename.
     (re"^.*/", after=base) => base.to_owned()
     _ => name
@@ -111,7 +111,7 @@ fn command_basename(name : String) -> String {
 /// `-Ei`). `-e`/`-f` consume the rest of the token as their value, so an `i`
 /// inside a script like `-e's/i/x/'` is not mistaken for `-i`.
 fn is_sed_in_place_flag(arg : String) -> Bool {
-  lexscan arg {
+  lexmatch arg {
     re"^--in-place(=.*)?$" => true
     // A short cluster whose first `e`/`f`/`i` is an `i` (any position — the
     // rest of the token is its in-place suffix, e.g. `-i.bak`). Start-anchored

--- a/agent_tool/shell/internal/shell_parse/parser.mbt
+++ b/agent_tool/shell/internal/shell_parse/parser.mbt
@@ -196,7 +196,7 @@ fn is_fd_redirect_op(op : String) -> Bool {
 
 ///|
 fn is_fd_word(word : String) -> Bool {
-  lexscan word {
+  lexmatch word {
     re"^[0-9]+$" => true
     _ => false
   }
@@ -221,7 +221,7 @@ fn is_env_assignment_word(word : String) -> Bool {
 
 ///|
 fn is_valid_env_name(name : String) -> Bool {
-  lexscan name {
+  lexmatch name {
     re"^[A-Za-z_][A-Za-z0-9_]*$" => true
     _ => false
   }

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -533,7 +533,7 @@ fn is_source_readonly_moon_subcommand(
 /// original strip-then-literal-match, not a looser prefix; the end anchor also
 /// makes the arms mutually exclusive (`>` backtracks to `>>` on `">>"`).
 fn redirect_writes_file(redirect : @shell_parse.Redirect) -> Bool {
-  lexscan redirect.op {
+  lexmatch redirect.op {
     re"^[0-9]*" + re">&$" => !is_fd_redirect_target(redirect.target)
     re"^[0-9]*" + re"(>|>\||>>|<>|&>|&>>)$" => true
     _ => false
@@ -542,7 +542,7 @@ fn redirect_writes_file(redirect : @shell_parse.Redirect) -> Bool {
 
 ///|
 fn is_fd_redirect_target(target : String) -> Bool {
-  lexscan target {
+  lexmatch target {
     re"^(-|[0-9]*)$" => true
     _ => false
   }
@@ -1498,7 +1498,7 @@ fn command_text_env_assignment_word(word : String) -> Bool {
 
 ///|
 fn command_text_valid_env_name(name : StringView) -> Bool {
-  lexscan name {
+  lexmatch name {
     re"^[A-Za-z_][A-Za-z0-9_]*$" => true
     _ => false
   }

--- a/agent_tool/write/write.mbt
+++ b/agent_tool/write/write.mbt
@@ -331,7 +331,7 @@ fn parent_dir(path : String) -> String {
   // Everything before the last `/` or `\` — greedy prefix, then a separator,
   // then a separator-free tail. No separator (or one at index 0) means no
   // directory component.
-  lexscan path {
+  lexmatch path {
     (re"^(.|\n)*" as dir) + re"[/\\][^/\\]*$" => dir.to_owned()
     _ => ""
   }

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -509,7 +509,7 @@ async fn random_salt() -> String {
 
 ///|
 fn failure_message(error_text : String) -> String {
-  lexscan error_text {
+  lexmatch error_text {
     (re"^error: ", after=message) => message.to_owned()
     // `(.|\n)*` is greedy across lines, so the remainder follows the LAST
     // marker occurrence — the same piece the split-and-take-last form chose.

--- a/cmd/openseek/mcp.mbt
+++ b/cmd/openseek/mcp.mbt
@@ -200,7 +200,7 @@ fn redact_url(url : String) -> String {
   // `://` anywhere — matching the decoder's leniency and staying fail-closed
   // for malformed values like `/https://user:secret@host` — and drop a
   // `userinfo@` that precedes any `/` in what follows. The userinfo arm is
-  // start-anchored on purpose: an unanchored lexscan arm SEARCHES, and would
+  // start-anchored on purpose: an unanchored lexmatch arm SEARCHES, and would
   // redact an `@` sitting in the path.
   let kept = if url =~ (re"[?#]", before~, after=_) { before } else { url }
   let (prefix, rest) = if kept =~ (re"://", before~, after~) {
@@ -208,7 +208,7 @@ fn redact_url(url : String) -> String {
   } else {
     ("", kept)
   }
-  lexscan rest {
+  lexmatch rest {
     re"^[^/@]*@" + (re"(.|\n)*$" as tail) => "\{prefix}\{tail}"
     _ => "\{prefix}\{rest}"
   }

--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -1110,7 +1110,7 @@ fn sidebar_nested_rows(
 /// The parent session id a subrun child session id derives from
 /// (`<parent>-sr-N`), or `None` for every other id.
 fn subrun_parent_id(id : String) -> String? {
-  lexscan id {
+  lexmatch id {
     (re"^(.|\n)*" as parent) + re"-sr-[0-9]+$" => Some(parent.to_owned())
     _ => None
   }
@@ -1133,7 +1133,7 @@ fn sidebar_groups(rows : Array[SessionRow]) -> Array[String] {
 /// The directory portion of `p` (before the last `/` or `\`), or `""` when
 /// `p` has no directory component.
 fn parent_dir(p : String) -> String {
-  lexscan p {
+  lexmatch p {
     (re"^(.|\n)*" as dir) + re"[/\\][^/\\]*$" => dir.to_owned()
     _ => ""
   }

--- a/editor/syntax/lang_javascript/lexer.mbt
+++ b/editor/syntax/lang_javascript/lexer.mbt
@@ -87,7 +87,7 @@ priv enum StepOp {
 
 ///|
 fn normal_step(view : StringView, top : Byte) -> (StepOp, StringView) {
-  lexscan view with longest {
+  lexmatch view with longest {
     (re"^[ \t]+", after=rest) => (Blank, rest)
     (re"^//.*", after=rest) => (Emit(Comment), rest)
     // The empty block comment first: longest-match would otherwise read
@@ -136,7 +136,7 @@ fn comment_step(
   view : StringView,
   tag : @syntax.HighlightTag,
 ) -> (StepOp, StringView) {
-  lexscan view with longest {
+  lexmatch view with longest {
     (re"^\*/", after=rest) => (Pop(tag), rest)
     (re"^[^*]+", after=rest) => (Emit(tag), rest)
     (re"^\*", after=rest) => (Emit(tag), rest)
@@ -146,7 +146,7 @@ fn comment_step(
 
 ///|
 fn template_step(view : StringView) -> (StepOp, StringView) {
-  lexscan view with longest {
+  lexmatch view with longest {
     (re"^\$[{]", after=rest) => (Push(StringEscape, b'i'), rest)
     (re"^\\.", after=rest) => (Emit(StringEscape), rest)
     (re"^`", after=rest) => (Pop(String), rest)

--- a/editor/syntax/lang_json/lexer.mbt
+++ b/editor/syntax/lang_json/lexer.mbt
@@ -72,7 +72,7 @@ priv enum StepOp {
 
 ///|
 fn normal_step(view : StringView) -> (StepOp, StringView) {
-  lexscan view with longest {
+  lexmatch view with longest {
     (re"^[ \t]+", after=rest) => (Blank, rest)
     (re"^//.*", after=rest) => (Emit(Comment), rest)
     (re"^/\*", after=rest) => (EnterComment, rest)
@@ -105,7 +105,7 @@ fn normal_step(view : StringView) -> (StepOp, StringView) {
 
 ///|
 fn comment_step(view : StringView) -> (StepOp, StringView) {
-  lexscan view with longest {
+  lexmatch view with longest {
     (re"^\*/", after=rest) => (LeaveComment, rest)
     (re"^[^*]+", after=rest) => (Emit(Comment), rest)
     (re"^\*", after=rest) => (Emit(Comment), rest)

--- a/editor/syntax/lang_moonbit/lexer.mbt
+++ b/editor/syntax/lang_moonbit/lexer.mbt
@@ -85,7 +85,7 @@ priv enum StepOp {
 /// arms need the current mode because `}` closes an interpolation in b'i'
 /// but is a plain delimiter elsewhere.
 fn normal_step(view : StringView, top : Byte) -> (StepOp, StringView) {
-  lexscan view with longest {
+  lexmatch view with longest {
     (re"^[ \t]+", after=rest) => (Blank, rest)
     (re"^///.*", after=rest) => (Emit(CommentDoc), rest)
     (re"^//.*", after=rest) => (Emit(Comment), rest)
@@ -129,7 +129,7 @@ fn normal_step(view : StringView, top : Byte) -> (StepOp, StringView) {
 /// and the closing quote. An unterminated string falls to the `.` arm
 /// one character at a time and the line-end reset recovers the mode.
 fn string_step(view : StringView) -> (StepOp, StringView) {
-  lexscan view with longest {
+  lexmatch view with longest {
     (re"^\\u[{][0-9a-fA-F]+[}]", after=rest) => (Emit(StringEscape), rest)
     (re"^\\[{]", after=rest) => (Push(StringEscape, b'i'), rest)
     (re"^\\.", after=rest) => (Emit(StringEscape), rest)
@@ -145,7 +145,7 @@ fn string_step(view : StringView) -> (StepOp, StringView) {
 /// escape and interpolation forms as `"` strings, terminated only by the
 /// line end.
 fn dollar_step(view : StringView) -> (StepOp, StringView) {
-  lexscan view with longest {
+  lexmatch view with longest {
     (re"^\\[{]", after=rest) => (Push(StringEscape, b'i'), rest)
     (re"^\\.", after=rest) => (Emit(StringEscape), rest)
     (re"^[^\\]+", after=rest) => (Emit(String), rest)

--- a/editor/syntax/tokenizer_test.mbt
+++ b/editor/syntax/tokenizer_test.mbt
@@ -24,7 +24,7 @@ impl @syntax.LineTokenizer for BlockCommentToy with fn tokenize_line(
   let tokens : Array[@syntax.LineToken] = []
   let in_comment = for at = 0, view = line_text[:], in_comment = state ==
                          toy_comment; view.length() > 0; {
-    lexscan view with longest {
+    lexmatch view with longest {
       (re"^(?:/\*|\*/|[^*/]+|.)" as lexeme, after~) => {
         let next = line_text.length() - after.length()
         if in_comment || lexeme is "/*" {


### PR DESCRIPTION
## What

Every `lexscan` in the repo targets a `String` or `StringView` — the non-streaming form the compiler now deprecates:

> Warning (deprecated_syntax): The syntax `lexscan` with a String target for non-streaming lexical matching is deprecated. Use `lexmatch` instead.

25 sites across both workspaces (9 in `editor/`, 16 in the root). These warnings are currently the **only** thing keeping `just check` and the editor's `moon check --target all --warn-list +73 --deny-warn` from passing clean, so they are on track to break the stable CI gate as soon as the toolchain there catches up.

## Change

Pure keyword rename at 25 sites. Every changed line is the keyword and nothing else — verified by filtering the diff for any line that isn't `-lexscan` / `+lexmatch` (empty).

**On safety of the sweep:** the sites were taken from the *compiler's own warning locations*, not a textual `grep`. Streaming `lexscan` over a `@lexbuf.Lexbuf` / `AsyncLexbuf` / `StringScanner` is **not** deprecated and must keep the old keyword. I diffed the warned set against every `lexscan` in the tree: the two sets are identical, so there are no streaming uses here — but that is a fact I checked rather than assumed.

Two doc touch-ups fall out of this:
- `editor/syntax/lang_moonbit/lexer.mbt` already described its rule sets as "`lexmatch` compiled to a tagged DFA", so the code now agrees with its own module doc.
- One comment in `cmd/openseek/mcp.mbt` naming the old keyword is updated.

## Testing

Fully verified:
- `just check` — `moon check --target native --deny-warn`, `--target js --deny-warn`, `moon fmt --check` all **clean**. Previously 25 warnings.
- `moon check --target all --warn-list +73 --deny-warn` in `editor/` (the exact stable-CI command) — **clean**. Previously 9 warnings.
- `moon test --target all` in `editor/` — native 1161, js 1738, wasm 1033, all passing, counts identical to pre-change.
- Root packages I could build: `shell_parse` 24, `command_policy` 9, `internal/error` 5 — all passing.

**Could not run locally, flagging honestly:** the root `moon test` does not build on my machine, on this branch *and on clean main alike* (20 identical `Error: [4222]`). The cause is the vendored `moonbitlang/x` 0.4.49 dep — `.mooncakes/moonbitlang/x/path/win32/path.mbt:278` uses `lexscan` over a `String`, which my local toolchain (moonc v0.10.7, 2026-08-07) has escalated from deprecation to a hard error. Any package depending on `@path` therefore can't build locally, which covers `agent_tool/shell`, `agent_tool/write`, `agent`, `cmd/openseek`, and `cmd/viz_app`. This is pre-existing and unrelated to this PR, so **CI is the gate for those packages.**

That dependency is worth noting on its own: it is the same deprecation, one level down, and it will break the build outright the moment CI's toolchain advances to where mine already is.

## Risk

`agent_tool/shell/sandbox.mbt` and `command_policy.mbt` parse shell commands for the sandbox, so they are security-relevant. A rename the compiler accepts and whose tests pass is low risk, but reviewers should look there first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)