### PR TITLE
docs(mbtx): align collateral with automatic handoff

### DIFF
--- a/agent/README.mbt.md
+++ b/agent/README.mbt.md
@@ -106,7 +106,9 @@ calls `@agent.run`, but that decision lives outside the `agent` package.
 - `mbtx`: compile and run a self-contained MoonBit program — both the
   scripting surface (transform files, parse JSON, compute, probe the language)
   and the command runner, since processes are spawned from the program through
-  the shell-free `moonbitlang/async/shell` API. Supports `run_in_background`;
+  the shell-free `moonbitlang/async/shell` API. Calls return inline for up to
+  five seconds, then automatically hand the same execution to the background
+  runtime;
 - `job_output` / `job_stop`: read or stop a background job;
 - `read`: read a text file;
 - `edit`: replace exact text in a file;

--- a/agent_tool/job_output/README.mbt.md
+++ b/agent_tool/job_output/README.mbt.md
@@ -1,8 +1,8 @@
 # Job Output Tool
 
 `job_output` reads a background job's recent output and status by its
-`job_id` — the id `mbtx` returns when called with
-`run_in_background=true`.
+`job_id` — the id `mbtx` returns when a run is still active after its
+five-second foreground grace period and moves to the background automatically.
 
 The primary consumption path for job results is the **pushed completion
 notice** (a job announces itself when it finishes); `job_output` is for
@@ -42,7 +42,8 @@ Two invariants drove the implementation:
    that appends or exits while the read yields cannot produce a stale footer.
 2. **Foreground error-semantics parity.** A background job read later behaves
    exactly like the same snippet run in the foreground: binary (non-UTF-8)
-   output is a tool error even at exit 0 (`binary_output=true`), and a
-   sandboxed source-write denial is detected by scanning the *full* retained
-   output (the denial line can be earlier than the displayed tail) with the
-   same guidance appended, footer still last.
+   output is a tool error even at exit 0 (`binary_output=true`). While the job
+   is running, denial detection checks only the bounded recent tail; once the
+   job is terminal, the *full* retained output is scanned once and that
+   classification is cached. This catches a denial line earlier than the final
+   displayed tail, with the same guidance appended and the footer still last.

--- a/agent_tool/job_stop/README.mbt.md
+++ b/agent_tool/job_stop/README.mbt.md
@@ -1,7 +1,8 @@
 # Job Stop Tool
 
 `job_stop` cancels a running background job by its `job_id` — the id
-`mbtx` returns when called with `run_in_background=true`.
+`mbtx` returns when a run moves to the background automatically after its
+foreground grace period.
 
 Stopping is a request against the job's shared execution: the child process is
 cancelled and the job lands on the `Stopped` status, which `job_output`

--- a/agent_tool/mbtx/README.mbt.md
+++ b/agent_tool/mbtx/README.mbt.md
@@ -4,21 +4,26 @@ Compile and run a **self-contained MoonBit program** and return its merged
 stdout/stderr and exit status. It is the agent's way to *script in MoonBit* —
 for automation (read and transform files, parse JSON, compute) and for probing
 how a language feature behaves — instead of reaching for shell `python`/`node`.
-The more the agent scripts in MoonBit, the more fluent it gets, and the safe
-wasm backend (planned) makes it the natural sandboxed automation surface.
+The default wasm backend runs under moonrun's policy, making it the natural
+sandboxed automation surface.
 
 ## How it works
 
 The `source` is a `.mbtx` **single-file script** — MoonBit's own one-file
-program format. The tool does nothing clever: it writes `source` to a throwaway
-temp file and runs `moon run <file>.mbtx --target <target> --target-dir <temp>`
-**with your workspace as the working directory**, returns what moon prints,
-removes the temp dir, and enforces a 60s bound. Because the working directory is
-the workspace, relative paths like `@fs.read_file("data.json")` reach workspace
-files and anything the program writes lands in the workspace — while all build
-artifacts stay in the temp dir, so your `_build` is never touched. moon's
-single-file runner handles the inline import block; moon's own compiler
-diagnostics are the error message when something does not build.
+program format. The tool writes it into a throwaway directory and runs
+`moon run <file>.mbtx --target <target> --target-dir <temp>` with the workspace
+(or explicit `cwd`) as the program's working directory. Relative reads therefore
+reach workspace files, while snippet build artifacts stay out of your `_build`.
+Moon's single-file runner handles the inline import block, and compiler
+diagnostics are rewritten to stable `source:LINE:COL` locations.
+
+With the agent's background runtime, every call waits inline for up to five
+seconds. A still-running compile or program is then adopted as the same
+background execution: the call returns its job id, completion is pushed later,
+and the snippet directory is reclaimed when the job becomes terminal. There is
+no foreground/background argument to choose. A standalone definition without a
+job runtime stays in the foreground for up to 300 seconds and is cancelled at
+that deadline.
 
 ## Arguments
 
@@ -26,9 +31,11 @@ diagnostics are the error message when something does not build.
   inline `import { "pkg", "pkg", … }` block (comma-separated module paths),
   then the program including its own `main`. Use `async fn main` for
   filesystem/stdio work.
-- `target` (string, optional, default `native`): the backend — one of
-  `native`, `wasm`, `wasm-gc`, `js`, `llvm`. The async IO packages
-  (`@fs`, `@stdio`, `@process`) require `native`.
+- `target` (string, optional, default `wasm`): one of `wasm`, `wasm-gc`, `js`,
+  or `llvm`. The default wasm backend is the policy-bound command/IO surface;
+  the other targets are intended for pure compute, reject explicit native FFI,
+  and run without that policy. `native` is deliberately unavailable because
+  moonrun cannot apply the policy to it.
 - `cwd` (string, optional, default workspace root): the working directory the
   program runs in. A relative `cwd` resolves against the workspace root, like
   the `shell` tool.
@@ -52,14 +59,21 @@ the workspace, not mbtx. Use it for self-contained scripts; to exercise
 your working-tree code, add a `*_test.mbt` to that package and run `moon test`
 via shell.
 
-## Source-file protection
+## Sandbox policy and source-file protection
 
-Because the program runs in your workspace, on **macOS** the run is wrapped in
-`sandbox-exec` with a profile that **denies direct writes to protected source
-files** (`*.mbt`, `*.mbti`, `*.mbt.md`, `moon.mod`/`moon.pkg`/`moon.work`)
-anywhere except the throwaway build dir — the same profile the `shell` tool
-uses. A snippet can still read anything and write non-source outputs (e.g.
-`people.json`).
+The default wasm run carries a moonrun policy on every platform. The snippet
+may read anywhere but may write only inside its own `@fs.tmpdir()` and any
+caller-provided scratch lab; changing other workspace files belongs to the file
+tools. Process spawning is checked against the implementation's allowlist; the
+live tool description summarizes the command surface the model should use.
+Allowed commands such as `moon fmt` or `git checkout` run as child processes
+and are not subject to the guest filesystem rule.
+
+Read-only review/explore roles add a best-effort macOS `sandbox-exec` profile
+around the runner to deny writes to protected MoonBit source and manifest
+files, including writes attempted by allowed child commands. Worker roles use a
+separate profile that permits their own worktree and denies sibling/shared
+roots. The moonrun policy remains the cross-platform boundary.
 
 A denied write surfaces inside the program as a bare OS error (e.g.
 `OSError("@fs.open(): \"keep.mbt\": Operation not permitted")`), which on its
@@ -69,13 +83,10 @@ sandbox denied the write by design, the snippet should not try to work around
 it, and source changes belong to the `edit` tool. The run is reported as an
 error even if the snippet caught the failure and exited 0, matching `shell`.
 
-This is **best-effort, not a hard boundary**: `shell` also statically preflights
-its command text to catch directory-rename tricks, which is impossible for an
-arbitrary snippet — so a determined program can still smuggle sources in or out
-via directory renames. Treat it as a guard against accidental source clobbering,
-not a security boundary; full containment is the planned wasm backend's job. On
-non-macOS hosts (or inside a nested sandbox that cannot enforce) the run is
-unsandboxed.
+The extra kernel profile is **best-effort** and may be unavailable inside a
+nested sandbox; it is defense in depth, not the cross-platform policy. A denied
+write is surfaced as a tool error with guidance instead of being mistaken for a
+filesystem fault.
 
 ## Escalation
 

--- a/agent_tool/mbtx/internal/decode/README.mbt.md
+++ b/agent_tool/mbtx/internal/decode/README.mbt.md
@@ -2,6 +2,8 @@
 
 Argument decoding for the `mbtx` tool. `decode(Json) -> MbtxInput`
 reads the required `source` string (a `.mbtx` program) and the optional
-`target` backend (default `native`, validated against
-`native`/`wasm`/`wasm-gc`/`js`/`llvm`), naming the offending field on failure so
-the error fed back to the model says exactly what to fix.
+`target` backend (default `wasm`, validated against
+`wasm`/`wasm-gc`/`js`/`llvm`), `cwd`, `warning`, and `escalated` fields. It names
+the offending field on failure so the error fed back to the model says exactly
+what to fix. The removed `run_in_background` field is rejected explicitly with
+migration guidance: handoff is automatic when the caller wires a job runtime.

--- a/desktop/frontend/transcript/component/mbtx.mbt
+++ b/desktop/frontend/transcript/component/mbtx.mbt
@@ -43,7 +43,9 @@ fn decode_mbtx_call(arguments : String) -> MbtxCall? {
   }
   let chips = scalar_chips(
     fields,
-    // The order the tool's README introduces them in.
+    // The order the tool's README introduces current arguments in. Keep the
+    // removed `run_in_background` last so transcripts recorded by older
+    // versions remain readable; new calls never emit it.
     known=["target", "cwd", "escalated", "warning", "run_in_background"],
     dramatized=["source"],
   )

--- a/desktop/frontend/transcript/component/mbtx_tests.mbt
+++ b/desktop/frontend/transcript/component/mbtx_tests.mbt
@@ -20,7 +20,7 @@ test "an mbtx call decodes to its program and its arguments" {
 /// The chip row is built from a fixed key order rather than the recorded
 /// JSON's, which is whatever the model emitted and is not preserved by the
 /// parsed map — otherwise two identical calls could chip in different orders.
-test "mbtx chips read in a fixed order, whatever the payload's is" {
+test "mbtx chips keep fixed order and render the historical background flag" {
   let arguments =
     #|{"zzz":1,"run_in_background":true,"cwd":null,"source":"fn main {  }","warning":"on","target":"wasm","aaa":"x","extra":{"k":1}}
   guard decode_mbtx_call(arguments) is Some(call) else {
@@ -28,7 +28,8 @@ test "mbtx chips read in a fixed order, whatever the payload's is" {
   }
   // A null is the tool's own spelling of "unset", and a nested value cannot be
   // stated in one line: neither gets a chip, and the Original JSON view is
-  // what carries them.
+  // what carries them. `run_in_background` is no longer accepted by the live
+  // tool, but must remain visible in already-recorded transcripts.
   assert_eq(call.chips, [
     "target: wasm", "warning: on", "run_in_background: true", "aaa: x", "zzz: 1",
   ])

--- a/eval/bgjobs_capability/main.mbt
+++ b/eval/bgjobs_capability/main.mbt
@@ -1,15 +1,15 @@
 ///|
-/// Capability eval: does the agent *choose* background jobs when they are
-/// merely the smart strategy? Unlike `eval/bgjobs_e2e` (which instructs the
-/// model to use `run_in_background` and validates the plumbing), these prompts
-/// never mention background jobs, `job_output`, or notices — the scorecard
-/// measures the model's own judgment:
+/// Capability eval for automatic background handoff. These prompts never
+/// mention background jobs, `job_output`, or notices: the engine must move a
+/// slow `mbtx` call after its foreground grace, while the model must use the
+/// resulting time and job lifecycle sensibly:
 ///
 /// - S1 "overlap": a ~20s command plus quick questions, with an efficiency
-///   hint. Smart play: background the slow command, answer the quick questions
-///   while it runs, fold the result in when it lands.
+///   hint. Expected play: the slow command hands off automatically; answer the
+///   quick questions while it runs, then fold in its result.
 /// - S2 "fire and forget": a ~45s command the user explicitly does not want to
-///   wait for. Smart play: background it and end the turn well under 45s.
+///   wait for. Expected play: let automatic handoff return the job id and end
+///   the turn well under 45s.
 ///
 /// The scorecard is informational (behavior varies run to run); the eval exits
 /// non-zero only when the engine itself misbehaves. Run manually:
@@ -31,7 +31,8 @@ async fn main {
 
 ///|
 /// S1: the model is never told how — only that time matters. Judgment under
-/// measurement: does it background the slow command and overlap the quick work?
+/// measurement: does automatic handoff occur, and does the model overlap the
+/// quick work instead of waiting on the job immediately?
 async fn scenario_overlap(engine : Engine) -> Unit {
   println("== S1 overlap: slow command + quick questions, efficiency hint ==")
   let started_ms = @env.now().reinterpret_as_int64()
@@ -52,7 +53,7 @@ async fn scenario_overlap(engine : Engine) -> Unit {
   let wall_s = (@env.now().reinterpret_as_int64() - started_ms) / 1000
   let backgrounded = seen.search_by(event => {
     event is { "event": String("tool_result"), "content": String(content), .. } &&
-    content.contains("started background job")
+    content.contains("moved to the background")
   })
   // The marker inside a plain `mbtx` result means the slow program ran
   // (and blocked) in the foreground.
@@ -67,7 +68,7 @@ async fn scenario_overlap(engine : Engine) -> Unit {
         ..
       } &&
       content.contains("INTEG-OK-31337") &&
-      !content.contains("started background job")
+      !content.contains("moved to the background")
     })
   // Any tool activity strictly between the job start and the marker retrieval
   // shows the wait was actually used for work.
@@ -97,7 +98,7 @@ async fn scenario_overlap(engine : Engine) -> Unit {
       answer
     _ => ""
   }
-  report("S1 used background job (the core judgment)", backgrounded is Some(_))
+  report("S1 automatically handed off the slow run", backgrounded is Some(_))
   report("S1 did not block the turn on the slow command", !blocked_foreground)
   report("S1 overlapped quick work with the running job", overlapped)
   report(
@@ -135,9 +136,9 @@ async fn scenario_fire_and_forget(engine : Engine) -> Unit {
     .any(event => {
       event
       is { "event": String("tool_result"), "content": String(content), .. } &&
-      content.contains("started background job")
+      content.contains("moved to the background")
     })
-  report("S2 used background job", backgrounded)
+  report("S2 automatically handed off the slow run", backgrounded)
   report(
     "S2 finished well before the 45s job (did not block)",
     finished is Some(_) && wall_s < 35,


### PR DESCRIPTION
Stack 3/3; depends on #1143, which depends on #1142.

## Summary

- align README and tool docs with the 5-second automatic handoff and runtime-less 300-second foreground contract
- update the background-jobs capability eval to measure automatic routing and useful overlap
- preserve the removed run_in_background field only when rendering historical saved transcripts

## Codex review

Reviewed independently with a fresh Codex CLI run at ultra reasoning. All four documentation-precision findings were addressed: non-wasm confinement is qualified, scratch write roots are documented, allowlist wording matches the implementation, and full denial scanning is described as terminal-only and cached.

## Validation

- moon test --target js desktop/frontend/transcript/component (56 passed)
- moon test -p bobzhang/openseek/agent_tool/mbtx (51 passed)
- moon test -p bobzhang/openseek/agent (95 passed)
- moon check --target native eval/bgjobs_capability
- just check
- just test (native 3349/3349, JS 3301/3301, cram 28/28)
- just build
- moon info && moon fmt
- git diff --check