### PR TITLE
refactor(edit): use functional for-loop state in line_end_offset

### DIFF
--- a/agent_tool/edit/edit.mbt
+++ b/agent_tool/edit/edit.mbt
@@ -862,13 +862,14 @@ fn line_start_offset(content : String, line : Int) -> Int {
 ///|
 fn line_end_offset(content : String, line : Int) -> Int {
   let len = content.length()
-  let mut current_line = 1
-  for cursor in 0..<len {
+  for cursor in 0..<len; current_line = 1 {
     if content[cursor] == '\n' {
       if current_line == line {
         break cursor + 1
       }
-      current_line += 1
+      continue current_line + 1
+    } else {
+      continue current_line
     }
   } nobreak {
     len


### PR DESCRIPTION
## What

Refactor `line_end_offset` in `agent_tool/edit/edit.mbt` to use a MoonBit
for-loop state variable instead of a mutable accumulator.

Before:

```moonbit
let mut current_line = 1
for cursor in 0..<len {
  if content[cursor] == '\n' {
    if current_line == line {
      break cursor + 1
    }
    current_line += 1
  }
} nobreak {
  len
}
```

After:

```moonbit
for cursor in 0..<len; current_line = 1 {
  if content[cursor] == '\n' {
    if current_line == line {
      break cursor + 1
    }
    continue current_line + 1
  } else {
    continue current_line
  }
} nobreak {
  len
}
```

Semantics are unchanged: the scan still breaks on the newline that ends
line `line` and still returns `len` for lines past EOF.

## Verification

- `moon check` clean
- `moon test agent_tool/edit` — 66/66 pass
- `moon fmt --check agent_tool/edit` clean

Generated with SeekMoon