### PR TITLE
refactor(mbtx): hand off long runs automatically

### DIFF
--- a/agent/README.mbt.md
+++ b/agent/README.mbt.md
@@ -106,7 +106,9 @@ calls `@agent.run`, but that decision lives outside the `agent` package.
 - `mbtx`: compile and run a self-contained MoonBit program — both the
   scripting surface (transform files, parse JSON, compute, probe the language)
   and the command runner, since processes are spawned from the program through
-  the shell-free `moonbitlang/async/shell` API. Supports `run_in_background`;
+  the shell-free `moonbitlang/async/shell` API. Calls return inline for up to
+  five seconds, then automatically hand the same execution to the background
+  runtime;
 - `job_output` / `job_stop`: read or stop a background job;
 - `read`: read a text file;
 - `edit`: replace exact text in a file;

--- a/agent/tool_definition.mbt
+++ b/agent/tool_definition.mbt
@@ -190,7 +190,7 @@ async test "a compile error reached inside the grace reports inline" {
       workspace_root=".",
       bg_runtime~,
       job_dir=spill_dir,
-      auto_background_after_ms=10_000,
+      auto_background_after_ms=60_000,
     )
     let action = match mbtx.execute {
       Async(execute) =>
@@ -243,15 +243,52 @@ async test "a compile error after handoff keeps source diagnostics" {
     assert_true(result.is_error)
     assert_true(result.content.contains("source:"))
     assert_false(result.content.contains("openseek-compile-job-"))
-    // The retained output file remains in the runtime root, but the snippet and
-    // target directory are reclaimed as soon as the adopted process is terminal.
-    for _ in 0..<200 {
-      if !@fs.exists("\{spill_dir}/snippet-0") {
-        break
-      }
-      @async.sleep(5)
+    // The session owns this directory after handoff. It remains available until
+    // teardown so any result files named by terminal output remain readable.
+    assert_true(@fs.exists("\{spill_dir}/snippet-0"))
+    @fs.rmdir(spill_dir, recursive=true) catch {
+      _ => ()
     }
-    assert_false(@fs.exists("\{spill_dir}/snippet-0"))
+  })
+}
+
+///|
+/// A handed-off snippet may put a bulky result in its policy-owned temp area
+/// and print the path. Terminal status must not delete that result before the
+/// completion notice can be acted on; the session teardown owns reclamation.
+async test "a handed-off job keeps result files until session teardown" {
+  @async.with_task_group(group => {
+    let spill_dir = @fs.tmpdir(prefix="openseek-job-result-")
+    let bg_runtime = @bgjobs.BgJobRuntime(AgentTaskScope(group), spill_dir~)
+    let mbtx = @mbtx.definition(
+      workspace_root=".",
+      bg_runtime~,
+      job_dir=spill_dir,
+      auto_background_after_ms=1,
+    )
+    let result_path = "\{spill_dir}/snippet-0/tmp/report.txt"
+    let source = (
+      #|import { "moonbitlang/async", "moonbitlang/async/fs" }
+      #|
+      #|async fn main {
+      #|  @fs.write_file("RESULT_PATH", "kept", create_mode=CreateOrTruncate)
+      #|  println("RESULT_PATH")
+      #|}
+    ).replace_all(old="RESULT_PATH", new=result_path)
+    let action = match mbtx.execute {
+      Async(execute) => execute({ "source": source })
+      Sync(_) => fail("mbtx should be async")
+    }
+    guard action is Respond(output) else { fail("expected Respond") }
+    assert_true(output.content.contains("moved to the background"))
+    guard bg_runtime.list() is [job, ..] else { fail("no job registered") }
+    let read = match @job_output.definition(bg_runtime).execute {
+      Async(execute) => execute({ "job_id": job.id, "wait_ms": 120_000 })
+      Sync(_) => fail("job_output should be async")
+    }
+    guard read is Respond(result) else { fail("expected Respond") }
+    assert_false(result.is_error)
+    assert_eq(@fs.read_file(result_path).text(), "kept")
     @fs.rmdir(spill_dir, recursive=true) catch {
       _ => ()
     }
@@ -347,6 +384,40 @@ async test "a non-wasm handed-off job does not invent a policy refusal" {
 }
 
 ///|
+/// The same policy-active gate applies before handoff. Whether an ordinary
+/// non-wasm run crosses the grace period must not change how its output is
+/// classified.
+async test "a non-wasm inline run does not invent a policy refusal" {
+  @async.with_task_group(group => {
+    let spill_dir = @fs.tmpdir(prefix="openseek-js-inline-")
+    let bg_runtime = @bgjobs.BgJobRuntime(AgentTaskScope(group), spill_dir~)
+    let mbtx = @mbtx.definition(
+      workspace_root=".",
+      bg_runtime~,
+      job_dir=spill_dir,
+      auto_background_after_ms=60_000,
+    )
+    assert_true(mbtx.description.contains("up to 60s"))
+    let action = match mbtx.execute {
+      Async(execute) =>
+        execute({
+          "source": "fn main { println(\"Sandbox policy blocked file write: example\") }",
+          "target": "js",
+        })
+      Sync(_) => fail("mbtx should be async")
+    }
+    guard action is Respond(output) else { fail("expected Respond") }
+    assert_false(output.is_error)
+    assert_false(output.content.contains("moved to the background"))
+    assert_true(output.content.contains("Sandbox policy blocked"))
+    assert_false(output.content.contains("mbtx sandbox:"))
+    @fs.rmdir(spill_dir, recursive=true) catch {
+      _ => ()
+    }
+  })
+}
+
+///|
 /// An automatically handed-off snippet must not inherit the engine's fd 0:
 /// under `serve` that descriptor carries JSONL commands. It gets immediate EOF
 /// before continuing as a job.
@@ -380,6 +451,18 @@ async test "an automatically handed-off snippet reads EOF on stdin" {
     assert_true(output.content.contains("moved to the background"))
     // The job read EOF rather than blocking on (or stealing from) fd 0.
     guard bg_runtime.list() is [job, ..] else { fail("no job registered") }
+    let mut saw_eof = false
+    // Handoff can happen while a cold dependency build is still running. Wait
+    // for the first program output instead of racing the compiler.
+    for _ in 0..<2400 {
+      let recent = bg_runtime.read_output_tail(job.id, 12000).unwrap_or("")
+      if recent.contains("got=false") {
+        saw_eof = true
+        break
+      }
+      @async.sleep(25)
+    }
+    assert_true(saw_eof)
     let read = match @job_output.definition(bg_runtime).execute {
       Async(execute) => execute({ "job_id": job.id })
       Sync(_) => fail("job_output should be async")
@@ -441,8 +524,16 @@ async test "a foreground run past its deadline becomes a job instead of dying" {
 /// tool waits out the real exit and says the rendering was lossy.
 async test "binary output waits for the real exit instead of abandoning it" {
   @async.with_task_group(group => {
-    let tools = build_tools(AgentRuntime(), AgentTaskScope(group))
-    guard tools.find("mbtx") is Some(mbtx) else { fail("mbtx tool missing") }
+    let spill_dir = @fs.tmpdir(prefix="openseek-binary-inline-")
+    let bg_runtime = @bgjobs.BgJobRuntime(AgentTaskScope(group), spill_dir~)
+    // This test is about waiting for the real exit, not the production 5s
+    // handoff threshold. Keep cold dependency builds safely inside its premise.
+    let mbtx = @mbtx.definition(
+      workspace_root=".",
+      bg_runtime~,
+      job_dir=spill_dir,
+      auto_background_after_ms=60_000,
+    )
     // Emit an invalid UTF-8 byte, then keep working briefly before exiting 3.
     let source =
       #|import { "moonbitlang/async", "moonbitlang/async/stdio", "moonbitlang/x/sys" }
@@ -462,6 +553,43 @@ async test "binary output waits for the real exit instead of abandoning it" {
     // The real exit code, not the -1 an abandoned execution would report.
     assert_true(output.content.contains("exited 3"))
     assert_true(output.content.contains("non-UTF-8"))
+    @fs.rmdir(spill_dir, recursive=true) catch {
+      _ => ()
+    }
+  })
+}
+
+///|
+/// The foreground output cap is fixed, so the failure must prevent a useless
+/// identical retry and point directly at the file-redirection escape hatch.
+/// Inline cleanup removes the snippet temp dir before the next tool call, so
+/// the recovery must also say to read the reduced result inside that snippet.
+async test "the inline output cap gives actionable retry guidance" {
+  @async.with_task_group(group => {
+    let spill_dir = @fs.tmpdir(prefix="openseek-inline-cap-")
+    let bg_runtime = @bgjobs.BgJobRuntime(AgentTaskScope(group), spill_dir~)
+    let mbtx = @mbtx.definition(
+      workspace_root=".",
+      bg_runtime~,
+      job_dir=spill_dir,
+      auto_background_after_ms=60_000,
+    )
+    let action = match mbtx.execute {
+      Async(execute) =>
+        execute({
+          "source": "fn main { for _ in 0..<50_000 { println(\"x\") } }",
+        })
+      Sync(_) => fail("mbtx should be async")
+    }
+    guard action is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("fixed 48000-byte inline limit"))
+    assert_true(output.content.contains("Retrying the same call"))
+    assert_true(output.content.contains("stdout=ToFile(path)"))
+    assert_true(output.content.contains("same snippet read the file"))
+    @fs.rmdir(spill_dir, recursive=true) catch {
+      _ => ()
+    }
   })
 }
 
@@ -510,26 +638,18 @@ async test "a finished background job queues a notice and wakes the controller" 
   @async.with_task_group(group => {
     let runtime = @agent_runtime.AgentRuntime()
     let mut woke = false
-    let spill_dir = @fs.tmpdir(prefix="openseek-jobs-notice-")
-    let bg_runtime = @bgjobs.BgJobRuntime::BgJobRuntime(
-      AgentTaskScope(group),
-      spill_dir~,
-      on_job_exit=snapshot => {
-        runtime.queue_steer(Notice(background_notice_text(snapshot)))
-        woke = true
-      },
-    )
-    let mbtx = @mbtx.definition(
-      workspace_root=".",
-      bg_runtime~,
-      job_dir=spill_dir,
-      auto_background_after_ms=500,
-    )
+    // Exercise the production registry wiring itself. Reproducing its
+    // queue-steer + wake callback here would let that wiring regress while the
+    // test continued to pass against its copy.
+    let tools = build_tools(runtime, AgentTaskScope(group), on_background_wake=() => {
+      woke = true
+    })
+    guard tools.find("mbtx") is Some(mbtx) else { fail("mbtx tool missing") }
     let source =
       #|import { "moonbitlang/async" }
       #|
       #|async fn main {
-      #|  @async.sleep(800)
+      #|  @async.sleep(5_500)
       #|  println(1)
       #|}
     let action = match mbtx.execute {
@@ -554,9 +674,6 @@ async test "a finished background job queues a notice and wakes the controller" 
     assert_true(woke)
     let steers = runtime.drain_steers()
     assert_true(steers.any(s => s is Notice(_)))
-    @fs.rmdir(spill_dir, recursive=true) catch {
-      _ => ()
-    }
   })
 }
 

--- a/agent/tool_definition.mbt
+++ b/agent/tool_definition.mbt
@@ -265,7 +265,7 @@ async test "a foreground run past its deadline becomes a job instead of dying" {
       workspace_root=".",
       bg_runtime~,
       job_dir=spill_dir,
-      run_timeout_ms=1500,
+      auto_background_after_ms=1500,
     )
     let source =
       #|import { "moonbitlang/async" }
@@ -338,7 +338,7 @@ async test "binary output does not escape the deadline" {
       workspace_root=".",
       bg_runtime~,
       job_dir=spill_dir,
-      run_timeout_ms=1500,
+      auto_background_after_ms=1500,
     )
     let source =
       #|import { "moonbitlang/async", "moonbitlang/async/stdio" }

--- a/agent/tool_definition.mbt
+++ b/agent/tool_definition.mbt
@@ -160,94 +160,236 @@ async test "the registry has no shell tool family" {
     assert_false(names.contains("shell_output"))
     assert_false(names.contains("shell_stop"))
     guard tools.find("mbtx") is Some(mbtx) else { fail("mbtx tool missing") }
-    // A job runtime is wired here, so the background argument must be OFFERED:
-    // the schema is what decides whether the model can make the call at all.
+    // Background handoff is automatic, so the schema carries no duration-mode
+    // choice for the model to make.
     let JsonSchema(schema) = mbtx.schema
     guard schema is { "properties": Object(properties), .. } else {
       fail("expected an object schema")
     }
     let names = properties.keys().collect()
-    assert_eq(names.length(), 5)
-    for name in ["source", "target", "cwd", "warning", "run_in_background"] {
+    assert_eq(names.length(), 4)
+    for name in ["source", "target", "cwd", "warning"] {
       assert_true(names.contains(name))
     }
+    assert_false(mbtx.description.contains("run_in_background"))
+    assert_true(mbtx.description.contains("AUTOMATICALLY"))
   }
 }
 
 ///|
-/// A snippet that does not compile must report that HERE, not as a job the
-/// model has to go read with `job_output` — and not with the throwaway temp
-/// path in place of `source:LINE:COL`. The tool builds before it detaches.
-async test "a background run that fails to compile reports the error inline" {
+/// A compile error reached inside the foreground grace reports inline, with
+/// the throwaway path rewritten to `source:LINE:COL`.
+async test "a compile error reached inside the grace reports inline" {
   @async.with_task_group(group => {
-    let tools = build_tools(AgentRuntime(), AgentTaskScope(group))
-    guard tools.find("mbtx") is Some(mbtx) else { fail("mbtx tool missing") }
+    let spill_dir = @fs.tmpdir(prefix="openseek-compile-inline-")
+    let bg_runtime = @bgjobs.BgJobRuntime::BgJobRuntime(
+      AgentTaskScope(group),
+      spill_dir~,
+    )
+    let mbtx = @mbtx.definition(
+      workspace_root=".",
+      bg_runtime~,
+      job_dir=spill_dir,
+      auto_background_after_ms=10_000,
+    )
     let action = match mbtx.execute {
       Async(execute) =>
-        execute({
-          "source": "fn main { let _x : Int = \"nope\" }",
-          "run_in_background": true,
-        })
+        execute({ "source": "fn main { let _x : Int = \"nope\" }" })
       Sync(_) => fail("mbtx should be async")
     }
     guard action is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
-    assert_false(output.content.contains("started background job"))
-    assert_true(output.content.contains("did not compile"))
+    assert_false(output.content.contains("moved to the background"))
     // The diagnostic points at the model's own input.
     assert_true(output.content.contains("source:"))
-    assert_false(output.content.contains("openseek-jobs-"))
+    assert_false(output.content.contains("openseek-compile-inline-"))
+    @fs.rmdir(spill_dir, recursive=true) catch {
+      _ => ()
+    }
   })
 }
 
 ///|
-/// A detached snippet must not inherit the engine's fd 0: under `serve` that
-/// descriptor carries the JSONL commands, so a snippet reading stdin would
-/// consume them. It gets an empty file (immediate EOF) like a foreground run.
-async test "a background snippet reads EOF on stdin, not the engine's channel" {
+/// If compilation itself crosses the grace, the same process becomes a job.
+/// Its later diagnostic must still name the submitted `source`, not the
+/// session-owned throwaway directory.
+async test "a compile error after handoff keeps source diagnostics" {
   @async.with_task_group(group => {
-    let runtime = @agent_runtime.AgentRuntime()
-    let mut woke = false
-    let tools = build_tools(runtime, AgentTaskScope(group), on_background_wake=() => {
-      woke = true
-    })
-    guard tools.find("mbtx") is Some(mbtx) else { fail("mbtx tool missing") }
+    let spill_dir = @fs.tmpdir(prefix="openseek-compile-job-")
+    let bg_runtime = @bgjobs.BgJobRuntime::BgJobRuntime(
+      AgentTaskScope(group),
+      spill_dir~,
+    )
+    let mbtx = @mbtx.definition(
+      workspace_root=".",
+      bg_runtime~,
+      job_dir=spill_dir,
+      auto_background_after_ms=1,
+    )
+    let action = match mbtx.execute {
+      Async(execute) =>
+        execute({ "source": "fn main { let _x : Int = \"nope\" }" })
+      Sync(_) => fail("mbtx should be async")
+    }
+    guard action is Respond(output) else { fail("expected Respond") }
+    assert_false(output.is_error)
+    assert_true(output.content.contains("moved to the background"))
+    guard bg_runtime.list() is [job, ..] else { fail("no job registered") }
+    let read = match @job_output.definition(bg_runtime).execute {
+      Async(execute) => execute({ "job_id": job.id, "wait_ms": 30_000 })
+      Sync(_) => fail("job_output should be async")
+    }
+    guard read is Respond(result) else { fail("expected Respond") }
+    assert_true(result.is_error)
+    assert_true(result.content.contains("source:"))
+    assert_false(result.content.contains("openseek-compile-job-"))
+    // The retained output file remains in the runtime root, but the snippet and
+    // target directory are reclaimed as soon as the adopted process is terminal.
+    for _ in 0..<200 {
+      if !@fs.exists("\{spill_dir}/snippet-0") {
+        break
+      }
+      @async.sleep(5)
+    }
+    assert_false(@fs.exists("\{spill_dir}/snippet-0"))
+    @fs.rmdir(spill_dir, recursive=true) catch {
+      _ => ()
+    }
+  })
+}
+
+///|
+/// Escalation removes the moonrun policy before launch. If that run hands off,
+/// job_output must remember the absence rather than treating similar guest text
+/// as a refusal from a policy that was not present.
+async test "an escalated handed-off job does not invent a policy refusal" {
+  @async.with_task_group(group => {
+    let spill_dir = @fs.tmpdir(prefix="openseek-escalated-job-")
+    let bg_runtime = @bgjobs.BgJobRuntime::BgJobRuntime(
+      AgentTaskScope(group),
+      spill_dir~,
+    )
+    let mbtx = @mbtx.definition(
+      workspace_root=".",
+      bg_runtime~,
+      job_dir=spill_dir,
+      auto_background_after_ms=1,
+      approval=ApprovalChannel(_ => AllowedOnce),
+    )
+    let source =
+      #|import { "moonbitlang/async" }
+      #|
+      #|async fn main {
+      #|  @async.sleep(100)
+      #|  println("Sandbox policy blocked file write: example")
+      #|}
+    let action = match mbtx.execute {
+      Async(execute) => execute({ "source": source, "escalated": true })
+      Sync(_) => fail("mbtx should be async")
+    }
+    guard action is Respond(output) else { fail("expected Respond") }
+    assert_true(output.content.contains("moved to the background"))
+    guard bg_runtime.list() is [job, ..] else { fail("no job registered") }
+    let read = match @job_output.definition(bg_runtime).execute {
+      Async(execute) => execute({ "job_id": job.id, "wait_ms": 30_000 })
+      Sync(_) => fail("job_output should be async")
+    }
+    guard read is Respond(result) else { fail("expected Respond") }
+    assert_false(result.is_error)
+    assert_true(result.content.contains("Sandbox policy blocked"))
+    assert_false(result.content.contains("mbtx sandbox:"))
+    @fs.rmdir(spill_dir, recursive=true) catch {
+      _ => ()
+    }
+  })
+}
+
+///|
+/// The moonrun policy is wired only for the wasm backend. A compute-only
+/// backend printing the runtime's marker is ordinary guest output, not evidence
+/// of a policy that was never active.
+async test "a non-wasm handed-off job does not invent a policy refusal" {
+  @async.with_task_group(group => {
+    let spill_dir = @fs.tmpdir(prefix="openseek-js-job-")
+    let bg_runtime = @bgjobs.BgJobRuntime::BgJobRuntime(
+      AgentTaskScope(group),
+      spill_dir~,
+    )
+    let mbtx = @mbtx.definition(
+      workspace_root=".",
+      bg_runtime~,
+      job_dir=spill_dir,
+      auto_background_after_ms=1,
+    )
+    let source =
+      #|fn main {
+      #|  println("Sandbox policy blocked file write: example")
+      #|}
+    let action = match mbtx.execute {
+      Async(execute) => execute({ "source": source, "target": "js" })
+      Sync(_) => fail("mbtx should be async")
+    }
+    guard action is Respond(output) else { fail("expected Respond") }
+    assert_true(output.content.contains("moved to the background"))
+    guard bg_runtime.list() is [job, ..] else { fail("no job registered") }
+    let read = match @job_output.definition(bg_runtime).execute {
+      Async(execute) => execute({ "job_id": job.id, "wait_ms": 30_000 })
+      Sync(_) => fail("job_output should be async")
+    }
+    guard read is Respond(result) else { fail("expected Respond") }
+    assert_false(result.is_error)
+    assert_true(result.content.contains("Sandbox policy blocked"))
+    assert_false(result.content.contains("mbtx sandbox:"))
+    @fs.rmdir(spill_dir, recursive=true) catch {
+      _ => ()
+    }
+  })
+}
+
+///|
+/// An automatically handed-off snippet must not inherit the engine's fd 0:
+/// under `serve` that descriptor carries JSONL commands. It gets immediate EOF
+/// before continuing as a job.
+async test "an automatically handed-off snippet reads EOF on stdin" {
+  @async.with_task_group(group => {
+    let spill_dir = @fs.tmpdir(prefix="openseek-jobs-stdin-")
+    let bg_runtime = @bgjobs.BgJobRuntime::BgJobRuntime(
+      AgentTaskScope(group),
+      spill_dir~,
+    )
+    let mbtx = @mbtx.definition(
+      workspace_root=".",
+      bg_runtime~,
+      job_dir=spill_dir,
+      auto_background_after_ms=1500,
+    )
     let source =
       #|import { "moonbitlang/async", "moonbitlang/async/stdio" }
       #|
       #|async fn main {
       #|  let line = @stdio.stdin.read_until("\n")
       #|  @stdio.stdout.write("got=\{line is Some(_)}\n")
+      #|  @async.sleep(60_000)
       #|}
     let action = match mbtx.execute {
-      Async(execute) => execute({ "source": source, "run_in_background": true })
+      Async(execute) => execute({ "source": source })
       Sync(_) => fail("mbtx should be async")
     }
     guard action is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
-    for _ in 0..<2400 {
-      if woke {
-        break
-      }
-      @async.sleep(25)
-    }
-    assert_true(woke)
+    assert_true(output.content.contains("moved to the background"))
     // The job read EOF rather than blocking on (or stealing from) fd 0.
-    guard tools.find("job_output") is Some(job_output) else {
-      fail("job_output tool missing")
-    }
-    guard output.content.split_once("background job ") is Some((_, rest)) else {
-      fail("no job id in: \{output.content}")
-    }
-    guard rest.split_once(" ") is Some((job_id, _)) else {
-      fail("no job id in: \{output.content}")
-    }
-    let read = match job_output.execute {
-      Async(execute) => execute({ "job_id": job_id.to_owned() })
+    guard bg_runtime.list() is [job, ..] else { fail("no job registered") }
+    let read = match @job_output.definition(bg_runtime).execute {
+      Async(execute) => execute({ "job_id": job.id })
       Sync(_) => fail("job_output should be async")
     }
     guard read is Respond(job) else { fail("expected Respond") }
     assert_true(job.content.contains("got=false"))
+    let _ = bg_runtime.stop(bg_runtime.list()[0].id)
+    @fs.rmdir(spill_dir, recursive=true) catch {
+      _ => ()
+    }
   })
 }
 
@@ -362,32 +504,47 @@ async test "binary output does not escape the deadline" {
 }
 
 ///|
-/// Background jobs survived the move off the shell tool: a detached
-/// `mbtx` snippet still queues a completion notice and wakes an idle
-/// controller when it exits.
+/// An automatic handoff still queues a completion notice and wakes an idle
+/// controller when the adopted process exits.
 async test "a finished background job queues a notice and wakes the controller" {
   @async.with_task_group(group => {
     let runtime = @agent_runtime.AgentRuntime()
     let mut woke = false
-    let tools = build_tools(runtime, AgentTaskScope(group), on_background_wake=() => {
-      woke = true
-    })
-    guard tools.find("mbtx") is Some(mbtx) else { fail("mbtx tool missing") }
+    let spill_dir = @fs.tmpdir(prefix="openseek-jobs-notice-")
+    let bg_runtime = @bgjobs.BgJobRuntime::BgJobRuntime(
+      AgentTaskScope(group),
+      spill_dir~,
+      on_job_exit=snapshot => {
+        runtime.queue_steer(Notice(background_notice_text(snapshot)))
+        woke = true
+      },
+    )
+    let mbtx = @mbtx.definition(
+      workspace_root=".",
+      bg_runtime~,
+      job_dir=spill_dir,
+      auto_background_after_ms=500,
+    )
+    let source =
+      #|import { "moonbitlang/async" }
+      #|
+      #|async fn main {
+      #|  @async.sleep(800)
+      #|  println(1)
+      #|}
     let action = match mbtx.execute {
-      Async(execute) =>
-        execute({
-          "source": "fn main { println(1) }",
-          "run_in_background": true,
-        })
+      Async(execute) => execute({ "source": source })
       Sync(_) => fail("mbtx should be async")
     }
-    guard action is Respond(output) else { fail("expected the job to start") }
+    guard action is Respond(output) else {
+      fail("expected the run to hand off")
+    }
     assert_false(output.is_error)
+    assert_true(output.content.contains("moved to the background"))
     // The job exits on its own → on_job_exit wakes the controller and queues a
     // completion notice. The budget is generous because the job compiles the
     // snippet before running it, on a machine that may be running the rest of
-    // the suite in parallel; the loop leaves as soon as the wake lands, so a
-    // fast machine pays none of it.
+    // the suite in parallel; the loop leaves as soon as the wake lands.
     for _ in 0..<2400 {
       if woke {
         break
@@ -397,6 +554,9 @@ async test "a finished background job queues a notice and wakes the controller" 
     assert_true(woke)
     let steers = runtime.drain_steers()
     assert_true(steers.any(s => s is Notice(_)))
+    @fs.rmdir(spill_dir, recursive=true) catch {
+      _ => ()
+    }
   })
 }
 

--- a/agent_tool/bgjobs/bgjobs.mbt
+++ b/agent_tool/bgjobs/bgjobs.mbt
@@ -100,6 +100,20 @@ priv struct BgJob {
   // Preserve the shell policy context that decides whether a standalone
   // trusted writer is a valid recovery from a sandbox denial.
   read_only_review : Bool
+  // Display-only rewrites carried by the launching tool (for example, mapping
+  // a throwaway compiler path back to the submitted source name).
+  output_rewrites : Array[(String, String)]
+  // True only when the launching tool enabled moonrun's policy, so ordinary
+  // job output resembling a refusal cannot be misclassified as one.
+  moonrun_policy_active : Bool
+  // Optional launcher-owned resources to reclaim once the process is terminal.
+  // Cleared before invocation so cleanup is exactly once even if more terminal
+  // observers are added later.
+  mut on_terminal : (async () -> Unit)?
+  // A terminal denial scan may read a large retained log. Cache its
+  // classification so repeated job_output calls do not repeat that allocation.
+  mut denial_scanned : Bool
+  mut denial_feedback : String?
 }
 
 ///|
@@ -122,6 +136,8 @@ pub struct BgJobSnapshot {
   had_invalid_utf8 : Bool
   sandboxed_command : @sandbox.SandboxedCommand?
   read_only_review : Bool
+  output_rewrites : Array[(String, String)]
+  moonrun_policy_active : Bool
   // The job was killed by the output-limit watchdog (flooded past the hard cap),
   // not stopped on request — surfaced so the kill is never silent.
   killed_by_output_limit : Bool
@@ -242,6 +258,8 @@ pub async fn BgJobRuntime::start(
   max_output_chars? : Int = default_max_output_chars,
   sandboxed_command? : @sandbox.SandboxedCommand,
   read_only_review? : Bool = false,
+  output_rewrites? : Array[(String, String)] = [],
+  moonrun_policy_active? : Bool = false,
   stdin? : &@process.ProcessInput,
 ) -> String {
   // Reserve one id and use it for both the spill file and the registry entry, so
@@ -251,7 +269,17 @@ pub async fn BgJobRuntime::start(
   let exec = (self.spawn_exec)(
     program, args, cwd, max_output_chars, spill_path, stdin,
   )
-  self.register(id, exec, command~, cwd?, sandboxed_command?, read_only_review~)
+  self.register(
+    id,
+    exec,
+    command~,
+    cwd?,
+    sandboxed_command?,
+    read_only_review~,
+    output_rewrites~,
+    moonrun_policy_active~,
+    on_terminal=None,
+  )
   id
 }
 
@@ -267,9 +295,22 @@ pub fn BgJobRuntime::adopt(
   cwd? : String,
   sandboxed_command? : @sandbox.SandboxedCommand,
   read_only_review? : Bool = false,
+  output_rewrites? : Array[(String, String)] = [],
+  moonrun_policy_active? : Bool = false,
+  on_terminal? : async () -> Unit,
 ) -> String {
   let id = self.next_id()
-  self.register(id, exec, command~, cwd?, sandboxed_command?, read_only_review~)
+  self.register(
+    id,
+    exec,
+    command~,
+    cwd?,
+    sandboxed_command?,
+    read_only_review~,
+    output_rewrites~,
+    moonrun_policy_active~,
+    on_terminal~,
+  )
   id
 }
 
@@ -283,6 +324,9 @@ fn BgJobRuntime::register(
   cwd? : String,
   sandboxed_command? : @sandbox.SandboxedCommand,
   read_only_review~ : Bool,
+  output_rewrites~ : Array[(String, String)],
+  moonrun_policy_active~ : Bool,
+  on_terminal~ : (async () -> Unit)?,
 ) -> Unit {
   self.jobs[id] = {
     id,
@@ -291,6 +335,11 @@ fn BgJobRuntime::register(
     exec,
     sandboxed_command,
     read_only_review,
+    output_rewrites: output_rewrites.copy(),
+    moonrun_policy_active,
+    on_terminal,
+    denial_scanned: false,
+    denial_feedback: None,
   }
   // Watch for the job ending on its own and fire `on_job_exit` once: a natural
   // exit, or the output-limit watchdog killing a flooding job — both must be
@@ -301,6 +350,13 @@ fn BgJobRuntime::register(
   // `snapshot(id)` always resolves.
   (self.spawn_watcher)(() => {
     exec.wait()
+    // The output spill belongs to the runtime, but a launcher may also have
+    // handed the job a separate build directory. Reclaim that directory for
+    // natural exit, watchdog kills, and requested stops alike.
+    if self.jobs.get(id) is Some(job) && job.on_terminal is Some(cleanup) {
+      job.on_terminal = None
+      cleanup()
+    }
     guard self.on_job_exit is Some(callback) else { return }
     guard self.snapshot(id) is Some(snapshot) else { return }
     guard snapshot.status is Exited(_) ||
@@ -351,9 +407,40 @@ fn BgJob::to_snapshot(self : BgJob) -> BgJobSnapshot {
     had_invalid_utf8: self.exec.had_invalid_utf8(),
     sandboxed_command: self.sandboxed_command,
     read_only_review: self.read_only_review,
+    output_rewrites: self.output_rewrites.copy(),
+    moonrun_policy_active: self.moonrun_policy_active,
     killed_by_output_limit: self.exec.killed_by_output_limit(),
     killed_by_time_limit: self.exec.killed_by_time_limit(),
   }
+}
+
+///|
+/// Classify a terminal job's complete retained output once. Running jobs return
+/// `None`; their recent tail can still be checked cheaply by the caller. The
+/// cached result avoids decoding a log of up to the hard cap on every later
+/// `job_output` call.
+pub async fn BgJobRuntime::terminal_denial_feedback(
+  self : BgJobRuntime,
+  id : String,
+) -> String? {
+  guard self.jobs.get(id) is Some(job) else { return None }
+  guard !(bg_status(job.exec.status()) is Running) else { return None }
+  if job.denial_scanned {
+    return job.denial_feedback
+  }
+  let output = job.exec.read_all()
+  let feedback = if job.moonrun_policy_active &&
+    @sandbox.output_reports_policy_refusal(output) {
+    Some(@sandbox.policy_refusal_feedback)
+  } else if job.sandboxed_command is Some(command) &&
+    command.output_reports_denial(output) {
+    Some(command.denial_feedback())
+  } else {
+    None
+  }
+  job.denial_feedback = feedback
+  job.denial_scanned = true
+  feedback
 }
 
 ///|
@@ -533,6 +620,49 @@ async test "adopt registers an already-running execution as a job" {
     assert_true(rt.snapshot(id).unwrap().read_only_review)
     assert_true(rt.stop(id))
     assert_true(rt.snapshot(id).unwrap().status is Stopped)
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "an adopted job runs terminal cleanup once when stopped" {
+  @async.with_task_group(group => {
+    let scope : @agent_runtime.AgentTaskScope[Unit] = AgentTaskScope(group)
+    let rt = BgJobRuntime::BgJobRuntime(scope)
+    let exec = @shell_exec.ShellExecution::start(scope, program="sleep", args=[
+      "30",
+    ])
+    let mut cleanups = 0
+    let id = rt.adopt(exec, command="sleep 30", on_terminal=() => cleanups += 1)
+    assert_true(rt.stop(id))
+    for _ in 0..<200 {
+      if cleanups == 1 {
+        break
+      }
+      @async.sleep(5)
+    }
+    assert_eq(cleanups, 1)
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "job snapshots do not alias launcher rewrite arrays" {
+  @async.with_task_group(group => {
+    let rt = BgJobRuntime::BgJobRuntime(AgentTaskScope(group))
+    let rewrites = [("temporary", "source")]
+    let id = rt.start(
+      program="sh",
+      args=["-c", "printf done"],
+      command="printf done",
+      output_rewrites=rewrites,
+    )
+    rewrites.push(("later", "mutation"))
+    let first = rt.snapshot(id).unwrap()
+    assert_eq(first.output_rewrites, [("temporary", "source")])
+    first.output_rewrites.push(("snapshot", "mutation"))
+    let second = rt.snapshot(id).unwrap()
+    assert_eq(second.output_rewrites, [("temporary", "source")])
   })
 }
 

--- a/agent_tool/bgjobs/bgjobs.mbt
+++ b/agent_tool/bgjobs/bgjobs.mbt
@@ -428,6 +428,14 @@ pub async fn BgJobRuntime::terminal_denial_feedback(
   if job.denial_scanned {
     return job.denial_feedback
   }
+  // Most non-wasm and escalated jobs have no active denial classifier. Do not
+  // materialize their complete retained log merely to prove there is nothing
+  // to classify; a handed-off job may hold up to the 20MB hard cap while
+  // job_output itself renders only a bounded tail.
+  if !job.moonrun_policy_active && job.sandboxed_command is None {
+    job.denial_scanned = true
+    return None
+  }
   let output = job.exec.read_all()
   let feedback = if job.moonrun_policy_active &&
     @sandbox.output_reports_policy_refusal(output) {

--- a/agent_tool/bgjobs/pkg.generated.mbti
+++ b/agent_tool/bgjobs/pkg.generated.mbti
@@ -17,14 +17,15 @@ pub struct BgJobRuntime {
   // private fields
 }
 pub fn[X] BgJobRuntime::BgJobRuntime(@agent_runtime.AgentTaskScope[X], spill_dir? : String, hard_output_cap? : Int, hard_timeout_ms? : Int, on_job_exit? : (BgJobSnapshot) -> Unit) -> Self
-pub fn BgJobRuntime::adopt(Self, @shell_exec.ShellExecution, command~ : String, cwd? : String, sandboxed_command? : @sandbox.SandboxedCommand, read_only_review? : Bool) -> String
+pub fn BgJobRuntime::adopt(Self, @shell_exec.ShellExecution, command~ : String, cwd? : String, sandboxed_command? : @sandbox.SandboxedCommand, read_only_review? : Bool, output_rewrites? : Array[(String, String)], moonrun_policy_active? : Bool, on_terminal? : async () -> Unit) -> String
 pub fn BgJobRuntime::list(Self) -> Array[BgJobSnapshot]
 pub async fn BgJobRuntime::read_output(Self, String) -> String?
 pub async fn BgJobRuntime::read_output_tail(Self, String, Int) -> String?
 pub fn BgJobRuntime::snapshot(Self, String) -> BgJobSnapshot?
 pub async fn BgJobRuntime::spawn_foreground_retained(Self, String, Array[String], String?, Int, stdin? : &@process.ProcessInput) -> @shell_exec.ShellExecution
-pub async fn BgJobRuntime::start(Self, program~ : String, args~ : Array[String], command~ : String, cwd? : String, max_output_chars? : Int, sandboxed_command? : @sandbox.SandboxedCommand, read_only_review? : Bool, stdin? : &@process.ProcessInput) -> String
+pub async fn BgJobRuntime::start(Self, program~ : String, args~ : Array[String], command~ : String, cwd? : String, max_output_chars? : Int, sandboxed_command? : @sandbox.SandboxedCommand, read_only_review? : Bool, output_rewrites? : Array[(String, String)], moonrun_policy_active? : Bool, stdin? : &@process.ProcessInput) -> String
 pub async fn BgJobRuntime::stop(Self, String) -> Bool
+pub async fn BgJobRuntime::terminal_denial_feedback(Self, String) -> String?
 pub async fn BgJobRuntime::wait_exit(Self, String, Int) -> Bool
 
 pub struct BgJobSnapshot {
@@ -41,6 +42,8 @@ pub struct BgJobSnapshot {
   had_invalid_utf8 : Bool
   sandboxed_command : @sandbox.SandboxedCommand?
   read_only_review : Bool
+  output_rewrites : Array[(String, String)]
+  moonrun_policy_active : Bool
   killed_by_output_limit : Bool
   killed_by_time_limit : Bool
 }

--- a/agent_tool/job_output/README.mbt.md
+++ b/agent_tool/job_output/README.mbt.md
@@ -1,8 +1,8 @@
 # Job Output Tool
 
 `job_output` reads a background job's recent output and status by its
-`job_id` — the id `mbtx` returns when called with
-`run_in_background=true`.
+`job_id` — the id `mbtx` returns when a run is still active after its
+five-second foreground grace period and moves to the background automatically.
 
 The primary consumption path for job results is the **pushed completion
 notice** (a job announces itself when it finishes); `job_output` is for
@@ -42,7 +42,8 @@ Two invariants drove the implementation:
    that appends or exits while the read yields cannot produce a stale footer.
 2. **Foreground error-semantics parity.** A background job read later behaves
    exactly like the same snippet run in the foreground: binary (non-UTF-8)
-   output is a tool error even at exit 0 (`binary_output=true`), and a
-   sandboxed source-write denial is detected by scanning the *full* retained
-   output (the denial line can be earlier than the displayed tail) with the
-   same guidance appended, footer still last.
+   output is a tool error even at exit 0 (`binary_output=true`). While the job
+   is running, denial detection checks only the bounded recent tail; once the
+   job is terminal, the *full* retained output is scanned once and that
+   classification is cached. This catches a denial line earlier than the final
+   displayed tail, with the same guidance appended and the footer still last.

--- a/agent_tool/job_output/job_output.mbt
+++ b/agent_tool/job_output/job_output.mbt
@@ -1,15 +1,15 @@
 ///|
 /// Tool `job_output`: read a background job's output and status by id.
-/// The id comes from `mbtx run_in_background`, or from a foreground command that
-/// was moved to the background when it exceeded its `timeout_ms`.
+/// The id comes from a command automatically moved to the background after its
+/// foreground grace period.
 pub fn definition(
   bg_runtime : @bgjobs.BgJobRuntime,
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="job_output",
     description=(
-      #|Read a background job's recent output and status by its job_id (returned by
-      #|mbtx run_in_background, or by a command moved to the background on timeout).
+      #|Read a background job's recent output and status by its job_id (returned when
+      #|a command moves to the background after its foreground grace period).
       #|Returns the most recent window of captured output (with truncation metadata naming
       #|the total size when output exceeds the window) and whether the job is still
       #|running. If you need the job's result before you can continue and have no other
@@ -68,7 +68,7 @@ async fn execute(
   // with a large job's full log. For output over the window, show the *tail*
   // (recent progress).
   let window = 12000
-  let output = bg_runtime.read_output_tail(job_id, window).unwrap_or("")
+  let raw_output = bg_runtime.read_output_tail(job_id, window).unwrap_or("")
   // Re-snapshot *after* the awaited read: the job may have appended more output
   // or exited while the read yielded, so size/status/binary/truncation in the
   // footer must reflect that post-read state, not a stale pre-read one — else a
@@ -79,6 +79,7 @@ async fn execute(
       is_error=true,
     )
   }
+  let output = apply_output_rewrites(raw_output, snapshot.output_rewrites)
   let (status_label, exit_error) = match snapshot.status {
     Running => ("running", false)
     Exited(code) => ("exit=\{code}", code != 0)
@@ -94,25 +95,22 @@ async fn execute(
   // (non-UTF-8) output and a refused access are tool errors even when the
   // command exited 0.
   //
-  // The moonrun policy refuses on every platform and for every job, so its
-  // wording is looked for first — in the displayed tail, which is where an
-  // uncaught refusal lands because it is what killed the job. A refusal the job
-  // caught and then outran can scroll out of that window; the foreground path's
-  // full-log scan is what covers that case, and it is not worth a full read of
-  // every job's output here.
-  //
-  // A profile denial is then scanned for across the *full* retained output (the
-  // denial line can be earlier than the tail), but only for a sandboxed job — so
-  // a full read happens only in that rarer case.
-  let sandbox_denied = if @sandbox.output_reports_policy_refusal(output) {
-    Some(@sandbox.policy_refusal_feedback)
-  } else if snapshot.sandboxed_command is Some(command) &&
-    command.output_reports_denial(
-      bg_runtime.read_output(job_id).unwrap_or(output),
-    ) {
-    Some(command.denial_feedback())
+  // Running jobs classify only the bounded recent tail. Once terminal, the
+  // runtime scans the retained log and caches the result, so a refusal that
+  // scrolled out of view is still reported without re-decoding up to 20MB on
+  // every later read.
+  let sandbox_denied = if snapshot.status is Running {
+    if snapshot.moonrun_policy_active &&
+      @sandbox.output_reports_policy_refusal(raw_output) {
+      Some(@sandbox.policy_refusal_feedback)
+    } else if snapshot.sandboxed_command is Some(command) &&
+      command.output_reports_denial(raw_output) {
+      Some(command.denial_feedback())
+    } else {
+      None
+    }
   } else {
-    None
+    bg_runtime.terminal_denial_feedback(job_id)
   }
   let is_error = exit_error ||
     snapshot.had_invalid_utf8 ||
@@ -121,7 +119,7 @@ async fn execute(
   // covers the window (large output), a memory-only runtime that dropped output
   // past the budget, and a hard-cap drop — so a prefix is never presented as the
   // complete output.
-  let shown = output.char_length()
+  let shown = raw_output.char_length()
   let truncation = if shown < snapshot.size || snapshot.output_truncated {
     let cap = if snapshot.output_truncated {
       " output_dropped_at_cap=true"
@@ -154,6 +152,19 @@ async fn execute(
   content.write_string(footer)
   let content = content.to_string()
   @agent_tool.respond(content, is_error~)
+}
+
+///|
+fn apply_output_rewrites(
+  text : String,
+  rewrites : Array[(String, String)],
+) -> String {
+  let mut output = text
+  for rewrite in rewrites {
+    let (old, replacement) = rewrite
+    output = output.replace_all(old~, new=replacement)
+  }
+  output
 }
 
 ///|

--- a/agent_tool/job_output/job_output_test.mbt
+++ b/agent_tool/job_output/job_output_test.mbt
@@ -190,6 +190,71 @@ async test "a non-numeric wait_ms is a tool error, not silently ignored" {
 }
 
 ///|
+#cfg(not(platform="windows"))
+async test "job_output applies display rewrites supplied by the launcher" {
+  @async.with_task_group(group => {
+    let bg = @bgjobs.BgJobRuntime::BgJobRuntime(AgentTaskScope(group))
+    let id = bg.start(
+      program="sh",
+      args=["-c", "printf '/tmp/mbtx/snippet.mbtx:1:2: error\\n'"],
+      command="compiler",
+      output_rewrites=[("/tmp/mbtx/snippet.mbtx", "source")],
+    )
+    poll_bg_terminal(bg, id)
+    let output = run_job_output(bg, { "job_id": id })
+    assert_true(output.content.contains("source:1:2: error"))
+    assert_false(output.content.contains("/tmp/mbtx"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "a job with policy disabled does not invent a policy refusal" {
+  @async.with_task_group(group => {
+    let bg = @bgjobs.BgJobRuntime::BgJobRuntime(AgentTaskScope(group))
+    let id = bg.start(
+      program="sh",
+      args=["-c", "printf 'Sandbox policy blocked file write: example\\n'"],
+      command="unconfined",
+      moonrun_policy_active=false,
+    )
+    poll_bg_terminal(bg, id)
+    let output = run_job_output(bg, { "job_id": id })
+    assert_false(output.is_error)
+    assert_true(output.content.contains("Sandbox policy blocked"))
+    assert_false(output.content.contains("mbtx sandbox:"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "a terminal job finds a policy refusal before the displayed tail" {
+  @async.with_task_group(group => {
+    let dir = @fs.tmpdir(prefix="openseek-job-policy-")
+    let bg = @bgjobs.BgJobRuntime::BgJobRuntime(
+      AgentTaskScope(group),
+      spill_dir=dir,
+    )
+    let id = bg.start(
+      program="sh",
+      args=[
+        "-c", "printf 'Sandbox policy blocked file write: example\\n'; seq 1 10000",
+      ],
+      command="policy then output",
+      moonrun_policy_active=true,
+    )
+    poll_bg_terminal(bg, id)
+    let output = run_job_output(bg, { "job_id": id })
+    assert_true(output.is_error)
+    assert_false(output.content.contains("Sandbox policy blocked"))
+    assert_true(output.content.contains("mbtx sandbox:"))
+    @fs.rmdir(dir, recursive=true) catch {
+      _ => ()
+    }
+  })
+}
+
+///|
 /// Mark the platform-gated test imports as used: this binding is `_`-prefixed
 /// (never warned about) and its body is never evaluated.
 let _unused_test_imports : Unit = {

--- a/agent_tool/job_stop/README.mbt.md
+++ b/agent_tool/job_stop/README.mbt.md
@@ -1,7 +1,8 @@
 # Job Stop Tool
 
 `job_stop` cancels a running background job by its `job_id` — the id
-`mbtx` returns when called with `run_in_background=true`.
+`mbtx` returns when a run moves to the background automatically after its
+foreground grace period.
 
 Stopping is a request against the job's shared execution: the child process is
 cancelled and the job lands on the `Stopped` status, which `job_output`

--- a/agent_tool/job_stop/job_stop.mbt
+++ b/agent_tool/job_stop/job_stop.mbt
@@ -6,8 +6,9 @@ pub fn definition(
   AgentToolDefinition(
     name="job_stop",
     description=(
-      #|Stop a running background job by its job_id (from mbtx's
-      #|run_in_background). Cancels the process; a job that already finished is a no-op.
+      #|Stop a running background job by its job_id (returned when a command moves to
+      #|the background after its foreground grace period). Cancels the process; a job
+      #|that already finished is a no-op.
     ),
     schema=JsonSchema({
       "type": "object",

--- a/agent_tool/mbtx/README.mbt.md
+++ b/agent_tool/mbtx/README.mbt.md
@@ -4,21 +4,26 @@ Compile and run a **self-contained MoonBit program** and return its merged
 stdout/stderr and exit status. It is the agent's way to *script in MoonBit* —
 for automation (read and transform files, parse JSON, compute) and for probing
 how a language feature behaves — instead of reaching for shell `python`/`node`.
-The more the agent scripts in MoonBit, the more fluent it gets, and the safe
-wasm backend (planned) makes it the natural sandboxed automation surface.
+The default wasm backend runs under moonrun's policy, making it the natural
+sandboxed automation surface.
 
 ## How it works
 
 The `source` is a `.mbtx` **single-file script** — MoonBit's own one-file
-program format. The tool does nothing clever: it writes `source` to a throwaway
-temp file and runs `moon run <file>.mbtx --target <target> --target-dir <temp>`
-**with your workspace as the working directory**, returns what moon prints,
-removes the temp dir, and enforces a 60s bound. Because the working directory is
-the workspace, relative paths like `@fs.read_file("data.json")` reach workspace
-files and anything the program writes lands in the workspace — while all build
-artifacts stay in the temp dir, so your `_build` is never touched. moon's
-single-file runner handles the inline import block; moon's own compiler
-diagnostics are the error message when something does not build.
+program format. The tool writes it into a throwaway directory and runs
+`moon run <file>.mbtx --target <target> --target-dir <temp>` with the workspace
+(or explicit `cwd`) as the program's working directory. Relative reads therefore
+reach workspace files, while snippet build artifacts stay out of your `_build`.
+Moon's single-file runner handles the inline import block, and compiler
+diagnostics are rewritten to stable `source:LINE:COL` locations.
+
+With the agent's background runtime, every call waits inline for up to five
+seconds. A still-running compile or program is then adopted as the same
+background execution: the call returns its job id, completion is pushed later,
+and the snippet directory is reclaimed when the job becomes terminal. There is
+no foreground/background argument to choose. A standalone definition without a
+job runtime stays in the foreground for up to 300 seconds and is cancelled at
+that deadline.
 
 ## Arguments
 
@@ -26,9 +31,11 @@ diagnostics are the error message when something does not build.
   inline `import { "pkg", "pkg", … }` block (comma-separated module paths),
   then the program including its own `main`. Use `async fn main` for
   filesystem/stdio work.
-- `target` (string, optional, default `native`): the backend — one of
-  `native`, `wasm`, `wasm-gc`, `js`, `llvm`. The async IO packages
-  (`@fs`, `@stdio`, `@process`) require `native`.
+- `target` (string, optional, default `wasm`): one of `wasm`, `wasm-gc`, `js`,
+  or `llvm`. The default wasm backend is the policy-bound command/IO surface;
+  the other targets are intended for pure compute, reject explicit native FFI,
+  and run without that policy. `native` is deliberately unavailable because
+  moonrun cannot apply the policy to it.
 - `cwd` (string, optional, default workspace root): the working directory the
   program runs in. A relative `cwd` resolves against the workspace root, like
   the `shell` tool.
@@ -52,14 +59,21 @@ the workspace, not mbtx. Use it for self-contained scripts; to exercise
 your working-tree code, add a `*_test.mbt` to that package and run `moon test`
 via shell.
 
-## Source-file protection
+## Sandbox policy and source-file protection
 
-Because the program runs in your workspace, on **macOS** the run is wrapped in
-`sandbox-exec` with a profile that **denies direct writes to protected source
-files** (`*.mbt`, `*.mbti`, `*.mbt.md`, `moon.mod`/`moon.pkg`/`moon.work`)
-anywhere except the throwaway build dir — the same profile the `shell` tool
-uses. A snippet can still read anything and write non-source outputs (e.g.
-`people.json`).
+The default wasm run carries a moonrun policy on every platform. The snippet
+may read anywhere but may write only inside its own `@fs.tmpdir()` and any
+caller-provided scratch lab; changing other workspace files belongs to the file
+tools. Process spawning is checked against the implementation's allowlist; the
+live tool description summarizes the command surface the model should use.
+Allowed commands such as `moon fmt` or `git checkout` run as child processes
+and are not subject to the guest filesystem rule.
+
+Read-only review/explore roles add a best-effort macOS `sandbox-exec` profile
+around the runner to deny writes to protected MoonBit source and manifest
+files, including writes attempted by allowed child commands. Worker roles use a
+separate profile that permits their own worktree and denies sibling/shared
+roots. The moonrun policy remains the cross-platform boundary.
 
 A denied write surfaces inside the program as a bare OS error (e.g.
 `OSError("@fs.open(): \"keep.mbt\": Operation not permitted")`), which on its
@@ -69,13 +83,10 @@ sandbox denied the write by design, the snippet should not try to work around
 it, and source changes belong to the `edit` tool. The run is reported as an
 error even if the snippet caught the failure and exited 0, matching `shell`.
 
-This is **best-effort, not a hard boundary**: `shell` also statically preflights
-its command text to catch directory-rename tricks, which is impossible for an
-arbitrary snippet — so a determined program can still smuggle sources in or out
-via directory renames. Treat it as a guard against accidental source clobbering,
-not a security boundary; full containment is the planned wasm backend's job. On
-non-macOS hosts (or inside a nested sandbox that cannot enforce) the run is
-unsandboxed.
+The extra kernel profile is **best-effort** and may be unavailable inside a
+nested sandbox; it is defense in depth, not the cross-platform policy. A denied
+write is surfaced as a tool error with guidance instead of being mistaken for a
+filesystem fault.
 
 ## Escalation
 

--- a/agent_tool/mbtx/internal/decode/README.mbt.md
+++ b/agent_tool/mbtx/internal/decode/README.mbt.md
@@ -2,6 +2,8 @@
 
 Argument decoding for the `mbtx` tool. `decode(Json) -> MbtxInput`
 reads the required `source` string (a `.mbtx` program) and the optional
-`target` backend (default `native`, validated against
-`native`/`wasm`/`wasm-gc`/`js`/`llvm`), naming the offending field on failure so
-the error fed back to the model says exactly what to fix.
+`target` backend (default `wasm`, validated against
+`wasm`/`wasm-gc`/`js`/`llvm`), `cwd`, `warning`, and `escalated` fields. It names
+the offending field on failure so the error fed back to the model says exactly
+what to fix. The removed `run_in_background` field is rejected explicitly with
+migration guidance: handoff is automatic when the caller wires a job runtime.

--- a/agent_tool/mbtx/internal/decode/decode.mbt
+++ b/agent_tool/mbtx/internal/decode/decode.mbt
@@ -44,7 +44,7 @@ pub fn decode(arguments : Json) -> MbtxInput raise {
   // 300s foreground behavior while believing it requested a job.
   if arguments is { "run_in_background": _, .. } {
     fail(
-      "arguments.run_in_background was removed; background handoff is automatic when a job runtime is available",
+      "arguments without run_in_background; that field was removed and background handoff is automatic when a job runtime is available",
     )
   }
   match arguments {

--- a/agent_tool/mbtx/internal/decode/decode.mbt
+++ b/agent_tool/mbtx/internal/decode/decode.mbt
@@ -10,9 +10,6 @@ pub struct MbtxInput {
   /// Whether compiler warnings appear in the run output — decoded from the
   /// `"on"`/`"off"` tool argument, defaulting to `"off"` (suppressed).
   warning : Bool
-  /// Whether to detach the run as a background job instead of waiting for it.
-  /// Only meaningful when the tool was built with a job runtime.
-  run_in_background : Bool
   /// Whether the snippet asked to run with no sandbox policy — no spawn
   /// allowlist and no write-root bound. Decoded here whatever the tool was
   /// built with: a build that offers no approval channel does not advertise
@@ -42,6 +39,14 @@ fn valid_target(target : String) -> Bool {
 /// optional working directory for the program (defaults to the workspace
 /// root). Failures name the offending field.
 pub fn decode(arguments : Json) -> MbtxInput raise {
+  // The local dispatcher does not enforce JSON Schema. Reject the removed
+  // field explicitly so a stale caller cannot silently get the runtime-less
+  // 300s foreground behavior while believing it requested a job.
+  if arguments is { "run_in_background": _, .. } {
+    fail(
+      "arguments.run_in_background was removed; background handoff is automatic when a job runtime is available",
+    )
+  }
   match arguments {
     { "source": String(source), .. } => {
       let target = match arguments {
@@ -67,21 +72,13 @@ pub fn decode(arguments : Json) -> MbtxInput raise {
           fail("arguments.warning to be \"on\" or \"off\"")
         _ => false
       }
-      let run_in_background = match arguments {
-        { "run_in_background": True, .. } => true
-        { "run_in_background": False, .. }
-        | { "run_in_background": Null, .. } => false
-        { "run_in_background": _, .. } =>
-          fail("arguments.run_in_background to be a boolean")
-        _ => false
-      }
       let escalated = match arguments {
         { "escalated": True, .. } => true
         { "escalated": False, .. } | { "escalated": Null, .. } => false
         { "escalated": _, .. } => fail("arguments.escalated to be a boolean")
         _ => false
       }
-      { source, target, cwd, warning, run_in_background, escalated, }
+      { source, target, cwd, warning, escalated, }
     }
     Object(_) => fail("arguments.source")
     _ => fail("object arguments")
@@ -93,6 +90,18 @@ test "decode reads source with the default wasm target" {
   let input = decode({ "source": "fn main { println(1) }" })
   assert_eq(input.source, "fn main { println(1) }")
   assert_eq(input.target, "wasm")
+}
+
+///|
+test "decode rejects the removed background flag with migration guidance" {
+  let message = try {
+    decode({ "source": "x", "run_in_background": true }) |> ignore
+    "accepted"
+  } catch {
+    error => "\{error}"
+  }
+  assert_true(message.contains("was removed"))
+  assert_true(message.contains("automatic"))
 }
 
 ///|

--- a/agent_tool/mbtx/internal/decode/pkg.generated.mbti
+++ b/agent_tool/mbtx/internal/decode/pkg.generated.mbti
@@ -16,7 +16,6 @@ pub struct MbtxInput {
   target : String
   cwd : String?
   warning : Bool
-  run_in_background : Bool
   escalated : Bool
 } derive(@debug.Debug)
 

--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -30,6 +30,17 @@ const OutputCapBytes : Int = 48_000
 const WarnOffList : String = "-a+partial_match@partial_match+multiline_string_escape@multiline_string_escape+invalid_inline_wasm@invalid_inline_wasm+unannotated_ffi@unannotated_ffi"
 
 ///|
+/// Render an injected millisecond bound without losing sub-second precision in
+/// model-facing text or tool results.
+fn duration_label(milliseconds : Int) -> String {
+  if milliseconds % 1000 == 0 {
+    "\{milliseconds / 1000}s"
+  } else {
+    "\{milliseconds}ms"
+  }
+}
+
+///|
 /// Tool definition for `mbtx`: compile and run a self-contained MoonBit
 /// program and return its merged stdout/stderr and exit status.
 ///
@@ -100,6 +111,8 @@ pub fn definition(
     description=description(
       background=bg_runtime is Some(_),
       escalation=approval is Some(_),
+      auto_background_after_ms~,
+      foreground_timeout_ms~,
     ),
     schema=JsonSchema(schema(escalation=approval is Some(_))),
     execute=Async(arguments => {
@@ -266,9 +279,18 @@ async fn execute(
   } else {
     false
   }
+  // One source of truth for whether moonrun's policy actually governs this
+  // execution. The launch argv, adopted-job metadata, and foreground refusal
+  // classifier must not drift: ordinary output from a non-wasm or escalated run
+  // is never evidence of a policy that was not active.
+  let policy_active = input.target == "wasm" && !escalated
+  let handoff_dir_has_owner = job_dir is Some(_) || scratch_dir is Some(_)
   // A directory that an automatic handoff may give to a job must outlive this
-  // call, so it is numbered inside the caller's job dir. The job reclaims it at
-  // terminal status; the session directory remains the teardown fallback.
+  // call, so it is numbered inside a caller-owned job dir or scratch lab when
+  // one exists. Such a job keeps the whole directory until teardown: its `tmp`
+  // subtree is the snippet's writable result area, and deleting it at terminal
+  // status would make paths in completion output unreadable before the model can
+  // act on them.
   let dir = if job_dir is Some(scratch) {
     let dir = "\{scratch}/snippet-\{next_background.val}"
     next_background.val += 1
@@ -312,8 +334,10 @@ async fn execute(
   // artifacts, and output log). `cleanup` runs on every exit path, so the flag
   // decides whether reclaiming the directory is still ours.
   //
-  // Handing it over is sound because the adopted job installs its own terminal
-  // cleanup below. The session-owned job directory is a final teardown fallback.
+  // Handing it over is sound when either caller-owned root is wired: the
+  // standard registry's `job_dir` has a task-group teardown, and a scratch lab
+  // has its own lifecycle. A non-standard caller that wires neither root has no
+  // owner, so its fallback directory is reclaimed by the job at terminal status.
   let mut job_owns_dir = false
   async fn cleanup() -> Unit {
     if job_owns_dir {
@@ -380,7 +404,7 @@ async fn execute(
     // no wildcard, and "any program" has no spelling in `process.allow` short
     // of enumerating one — so "no policy" is both the honest description of
     // what was approved and the only one the runtime can express.
-    ..if input.target == "wasm" && !escalated {
+    ..if policy_active {
       ["--wasm-policy", policy_path]
     },
     ..if !input.warning {
@@ -487,24 +511,29 @@ async fn execute(
     let saw_binary = exec.had_invalid_utf8()
     if finished is None {
       let _ = exec.background()
+      let terminal_cleanup : (async () -> Unit)? = if handoff_dir_has_owner {
+        None
+      } else {
+        Some(() => {
+          @async.protect_from_cancel(() => {
+            @fs.rmdir(dir, recursive=true) catch {
+              _ => ()
+            }
+          })
+        })
+      }
       let id = runtime.adopt(
         exec,
         command="mbtx: \{@agent_tool.brief_line(input.source, limit=64)}",
         cwd?=run_cwd,
         sandboxed_command?,
         output_rewrites=temp_path_rewrites([real, dir]),
-        moonrun_policy_active=input.target == "wasm" && !escalated,
-        on_terminal=() => {
-          @async.protect_from_cancel(() => {
-            @fs.rmdir(dir, recursive=true) catch {
-              _ => ()
-            }
-          })
-        },
+        moonrun_policy_active=policy_active,
+        on_terminal?=terminal_cleanup,
       )
       job_owns_dir = true
       return @agent_tool.respond(
-        "mbtx: still running after \{auto_background_after_ms / 1000}s, so it moved to the background as job \{id} (nothing was lost). Read its output with job_output (job_id=\"\{id}\") and stop it with job_stop (job_id=\"\{id}\").",
+        "mbtx: still running after \{duration_label(auto_background_after_ms)}, so it moved to the background as job \{id} (nothing was lost). Read its output with job_output (job_id=\"\{id}\") and stop it with job_stop (job_id=\"\{id}\").",
         brief="mbtx → bg \{id}",
       )
     }
@@ -523,7 +552,7 @@ async fn execute(
       denial_scan_source,
       raw,
       escalation=approval is Some(_),
-      escalated~,
+      policy_active~,
     )
     exec.discard()
     let text = rewrite_temp_paths(raw, [real, dir])
@@ -535,7 +564,7 @@ async fn execute(
       text
     }
     let body = if output_limit_reached {
-      "\{body}\n[mbtx: output passed \{OutputCapBytes} bytes, so the program was STOPPED and this is only what it printed first. Redirect bulky output with `stdout=ToFile(path)` and read the file instead.]"
+      "\{body}\n[mbtx: output passed the fixed \{OutputCapBytes}-byte inline limit, so the program was STOPPED and this is only what it printed first. Retrying the same call will hit the same limit. Redirect bulky child output with `stdout=ToFile(path)` where `path` is under `@fs.tmpdir()`, then have that same snippet read the file and print only the needed excerpt before it exits.]"
     } else {
       body
     }
@@ -580,7 +609,7 @@ async fn execute(
     Some(log),
     "",
     escalation=approval is Some(_),
-    escalated~,
+    policy_active~,
   )
   let action = match result {
     Some((exit_code, raw)) => {
@@ -614,7 +643,7 @@ async fn execute(
       // instead of discarding it behind a generic timeout message. The status
       // line stays first so it survives the outer result clamp.
       let partial = rewrite_temp_paths(read_capped(log), [real, dir])
-      let head = "mbtx: timed out after \{foreground_timeout_ms / 1000}s and was cancelled — the program did not finish (an infinite loop, or a build that never completed)."
+      let head = "mbtx: timed out after \{duration_label(foreground_timeout_ms)} and was cancelled — the program did not finish (an infinite loop, or a build that never completed)."
       let body = if partial.is_blank() {
         head
       } else {
@@ -650,7 +679,7 @@ async fn refusal_guidance(
   log_path : String?,
   head : String,
   escalation~ : Bool,
-  escalated~ : Bool,
+  policy_active~ : Bool,
 ) -> String? {
   async fn shows(reports : (String) -> Bool) -> Bool {
     match log_path {
@@ -659,12 +688,10 @@ async fn refusal_guidance(
     }
   }
 
-  // An escalated run was given no policy, so nothing it prints can be this
-  // tool's policy refusing something. The spawn marker is only the guest's own
-  // `EPERM` text, which an unsandboxed child can produce for its own reasons —
-  // scanning for it here would report a successful run as an error and tell
-  // the model to ask for the escalation it was already granted.
-  if !escalated && shows(@sandbox.output_reports_policy_refusal) {
+  // A non-wasm or escalated run was given no moonrun policy, so nothing it
+  // prints can be that policy refusing something. The marker is ordinary guest
+  // text in that case; classifying it would turn a successful run into an error.
+  if policy_active && shows(@sandbox.output_reports_policy_refusal) {
     // The escalating variant only where a channel exists AND this is a
     // foreground report: its wording assumes nothing ran, which is true here
     // and false of `job_output`, whose job worked before it was refused.
@@ -927,7 +954,12 @@ fn schema(escalation~ : Bool) -> Json {
 /// around a refusal, and where escalation IS available that advice would be
 /// wrong — there is a sanctioned way to ask. The paragraph that says so must
 /// appear exactly where the way exists.
-fn description(background~ : Bool, escalation~ : Bool) -> String {
+fn description(
+  background~ : Bool,
+  escalation~ : Bool,
+  auto_background_after_ms~ : Int,
+  foreground_timeout_ms~ : Int,
+) -> String {
   // The one sentence here that depends on what this build can actually do.
   //
   // Without an approval channel a refusal really is the end of the road, and
@@ -1036,6 +1068,8 @@ fn description(background~ : Bool, escalation~ : Bool) -> String {
       $|the task needs, and the reason evident in the code itself.
     )
   }
+  let foreground_bound = duration_label(foreground_timeout_ms)
+  let handoff_bound = duration_label(auto_background_after_ms)
   if !background {
     return (
       $|\{base}
@@ -1043,7 +1077,7 @@ fn description(background~ : Bool, escalation~ : Bool) -> String {
       $|## Execution time
       $|
       $|This context has no background-job runtime. A run may stay in the foreground
-      $|for up to 300s; at that deadline it is cancelled and reported as a timeout.
+      $|for up to \{foreground_bound}; at that deadline it is cancelled and reported as a timeout.
     )
   }
   // The blank `$|` line is the paragraph break: without it the section heading
@@ -1053,7 +1087,7 @@ fn description(background~ : Bool, escalation~ : Bool) -> String {
     $|
     $|## Long-running work
     $|
-    $|Every call stays inline for up to 5s. If it is still running, it AUTOMATICALLY
+    $|Every call stays inline for up to \{handoff_bound}. If it is still running, it AUTOMATICALLY
     $|moves to a background job and returns the job id; no background flag or duration
     $|guess is needed. A completion notice arrives when it finishes, so never wait with
     $|sleep loops or repeated polling: keep working and act on the notice. Read recent

--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -1,17 +1,15 @@
 ///|
 /// How long a runtime-backed run stays inline before it is adopted as a job.
-/// Kept at the historical five-minute value in the timeout-policy refactor;
-/// callers and the model-facing contract can shorten it independently without
-/// shortening foreground-only subruns.
-const AutoBackgroundAfterMs : Int = 300_000
+/// Five seconds keeps quick probes inline while moving builds, suites, and
+/// watchers out of the turn without asking the model to predict their duration.
+const AutoBackgroundAfterMs : Int = 5_000
 
 ///|
-/// Non-detachable foreground work is bounded to this wall-clock so a runaway
-/// loop or build cannot block the whole turn. This covers both a runtime-less
-/// snippet and the compile preflight before an explicitly backgrounded run. On
-/// expiry the work is cancelled and reported as a timeout. Sized for commands,
-/// not just compute: a snippet runs whole `moon test` cycles, and a fresh
-/// workspace's first build downloads and compiles its dependencies.
+/// Runtime-less foreground work is bounded to this wall-clock so a runaway loop
+/// or build cannot block the whole turn. On expiry it is cancelled and reported
+/// as a timeout. Sized for commands, not just compute: a snippet runs whole
+/// `moon test` cycles, and a fresh workspace's first build downloads and
+/// compiles its dependencies.
 const ForegroundTimeoutMs : Int = 300_000
 
 ///|
@@ -79,12 +77,8 @@ const WarnOffList : String = "-a+partial_match@partial_match+multiline_string_es
 /// it, so `read_only=true` puts "may not write source" in the kernel.
 ///
 /// `approval` is where a request to run OUTSIDE the sandbox goes. Its presence
-/// is what advertises the `escalated` argument at all — the same rule
-/// `bg_runtime` follows for `run_in_background`: a build with nobody to ask
-/// does not offer an argument whose every use would come back refused.
-///
-/// `run_timeout_ms` is the compatibility fallback for callers of the former
-/// single-timeout API. Either new bound can override it independently.
+/// is what advertises the `escalated` argument at all: a build with nobody to
+/// ask does not offer an argument whose every use would come back refused.
 pub fn definition(
   workspace_root~ : String,
   read_only? : Bool = false,
@@ -92,17 +86,10 @@ pub fn definition(
   job_dir? : String,
   scratch_dir? : String,
   worker_sandbox? : WorkerSandbox,
-  run_timeout_ms? : Int,
-  auto_background_after_ms? : Int,
-  foreground_timeout_ms? : Int,
+  auto_background_after_ms? : Int = AutoBackgroundAfterMs,
+  foreground_timeout_ms? : Int = ForegroundTimeoutMs,
   approval? : @agent_runtime.ApprovalChannel,
 ) -> @agent_tool.AgentToolDefinition {
-  let auto_background_after_ms = auto_background_after_ms.unwrap_or(
-    run_timeout_ms.unwrap_or(AutoBackgroundAfterMs),
-  )
-  let foreground_timeout_ms = foreground_timeout_ms.unwrap_or(
-    run_timeout_ms.unwrap_or(ForegroundTimeoutMs),
-  )
   // Background snippet directories are numbered inside the caller's scratch
   // dir rather than created as fresh system temp dirs: a detached job outlives
   // this call, so its snippet, build artifacts, and output log cannot be
@@ -114,9 +101,7 @@ pub fn definition(
       background=bg_runtime is Some(_),
       escalation=approval is Some(_),
     ),
-    schema=JsonSchema(
-      schema(background=bg_runtime is Some(_), escalation=approval is Some(_)),
-    ),
+    schema=JsonSchema(schema(escalation=approval is Some(_))),
     execute=Async(arguments => {
       execute(
         workspace_root,
@@ -236,12 +221,6 @@ async fn execute(
   // a possibly-large output log when a turn is cancelled mid-run. The timeout
   // wraps only the process body; output is redirected to a file (not buffered in
   // memory) and read back capped, so a flood cannot exhaust memory.
-  if input.run_in_background && bg_runtime is None {
-    return @agent_tool.respond(
-      "error: run_in_background is not available in this context",
-      is_error=true,
-    )
-  }
   // Escalation only means something on the backend the policy binds. The other
   // targets never had `--wasm-policy` passed to them in the first place — they
   // cannot spawn or touch files at all — so asking here would spend a person's
@@ -287,13 +266,9 @@ async fn execute(
   } else {
     false
   }
-  // A directory a job may take over must outlive this call, so it is numbered
-  // inside the caller's job dir — reclaimed when the session's scope ends —
-  // rather than a system temp dir that only this function ever revisits. That
-  // covers BOTH ways a job takes over: an explicit `run_in_background`, and a
-  // foreground run detached at its deadline, which is why this does not test
-  // `run_in_background`.
-  let background = input.run_in_background
+  // A directory that an automatic handoff may give to a job must outlive this
+  // call, so it is numbered inside the caller's job dir. The job reclaims it at
+  // terminal status; the session directory remains the teardown fallback.
   let dir = if job_dir is Some(scratch) {
     let dir = "\{scratch}/snippet-\{next_background.val}"
     next_background.val += 1
@@ -333,16 +308,12 @@ async fn execute(
         )
     }
   }
-  // Set once a background job takes over the directory (snippet, artifacts,
-  // output log): either an explicit `run_in_background`, or a foreground run
-  // detached at its deadline. `cleanup` runs on every exit path, so the flag —
-  // not the request — decides whether reclaiming the directory is still ours.
+  // Set once an automatically handed-off job takes over the directory (snippet,
+  // artifacts, and output log). `cleanup` runs on every exit path, so the flag
+  // decides whether reclaiming the directory is still ours.
   //
-  // Handing it over is sound because a job only ever runs with a `job_dir`
-  // wired, and that directory is reclaimed with the session's scope. The
-  // `@fs.tmpdir` branch above has no such owner, but it is only taken when the
-  // caller wired no job dir — which happens only if the session's own tmpdir
-  // call failed, in which case the one above fails too and returns first.
+  // Handing it over is sound because the adopted job installs its own terminal
+  // cleanup below. The session-owned job directory is a final teardown fallback.
   let mut job_owns_dir = false
   async fn cleanup() -> Unit {
     if job_owns_dir {
@@ -485,67 +456,6 @@ async fn execute(
     Some(command) => (command.program(), command.args())
     None => ("moon", moon_argv)
   }
-  if background && bg_runtime is Some(runtime) {
-    // Compile in the FOREGROUND first. A detached run would otherwise report
-    // a syntax or type error only through job_output, and with the throwaway
-    // temp path instead of `source:LINE:COL` — the two things that make a
-    // compile error readable. `--build-only` is the single-file equivalent of
-    // a check: `moon check`/`moon build` do not accept a `.mbtx` script (the
-    // first reports "no work to do", the second demands a Moon project).
-    // TODO(upstream): teach `moon check` to accept a `.mbtx` script, and use
-    // it here — building is more work than this preflight needs.
-    let build_argv = [..argv]
-    build_argv.push("--build-only")
-    let build_log = "\{dir}/build.log"
-    @fs.write_file(build_log, "", create_mode=CreateOrTruncate)
-    // Bounded like every other run here: a first build downloads and compiles
-    // dependencies, and a wedged fetch would otherwise hold the turn open —
-    // exactly what asking for a background job was meant to avoid.
-    let build_exit = @async.with_timeout_opt(foreground_timeout_ms, () => {
-      @process.run(
-        prog,
-        build_argv,
-        cwd=run_cwd.unwrap_or("."),
-        inherit_env=true,
-        stdin=@process.redirect_from_file(empty_stdin),
-        stdout=@process.redirect_to_file(build_log, append=true),
-        stderr=@process.redirect_to_file(build_log, append=true),
-        no_console_window=true,
-      )
-    })
-    guard build_exit is Some(build_exit) else {
-      let text = rewrite_temp_paths(read_capped(build_log), [real, dir])
-      return @agent_tool.respond(
-        "mbtx: the build did not finish within \{foreground_timeout_ms / 1000}s, so no background job was started.\n\{text}",
-        is_error=true,
-        brief="mbtx (build timeout)",
-      )
-    }
-    if build_exit != 0 {
-      let text = rewrite_temp_paths(read_capped(build_log), [real, dir])
-      return @agent_tool.respond(
-        "[mbtx: the program did not compile, so no background job was started]\n\{text}",
-        is_error=true,
-        brief="mbtx (build failed)",
-      )
-    }
-    let id = runtime.start(
-      program=prog,
-      args=argv,
-      command="mbtx: \{@agent_tool.brief_line(input.source, limit=64)}",
-      cwd?=run_cwd,
-      sandboxed_command?,
-      // Same EOF-on-stdin contract as a foreground run: a detached snippet
-      // must not inherit the engine's fd 0, which under `serve` carries the
-      // JSONL commands.
-      stdin=@process.redirect_from_file(empty_stdin),
-    )
-    job_owns_dir = true
-    return @agent_tool.respond(
-      "started background job \{id} (the program compiled). Read its output with job_output (job_id=\"\{id}\") and stop it with job_stop (job_id=\"\{id}\").",
-      brief="mbtx → bg \{id}",
-    )
-  }
   // With a job runtime wired the foreground run happens ON it, so the
   // deadline can DETACH the still-running program as a background job rather
   // than killing it: a long `moon test` that outlives the bound is then still
@@ -582,6 +492,15 @@ async fn execute(
         command="mbtx: \{@agent_tool.brief_line(input.source, limit=64)}",
         cwd?=run_cwd,
         sandboxed_command?,
+        output_rewrites=temp_path_rewrites([real, dir]),
+        moonrun_policy_active=input.target == "wasm" && !escalated,
+        on_terminal=() => {
+          @async.protect_from_cancel(() => {
+            @fs.rmdir(dir, recursive=true) catch {
+              _ => ()
+            }
+          })
+        },
       )
       job_owns_dir = true
       return @agent_tool.respond(
@@ -769,18 +688,27 @@ async fn refusal_guidance(
 /// both `/` and `\` separators — moon reports the canonical native path (with
 /// backslashes on Windows), so `source:LINE:COL` shows on every host rather than
 /// a random `_build` path leaking through.
-fn rewrite_temp_paths(text : String, bases : Array[String]) -> String {
-  let mut out = text
+fn temp_path_rewrites(bases : Array[String]) -> Array[(String, String)] {
+  let rewrites : Array[(String, String)] = []
   for base in bases {
     for sep in ["/", "\\"] {
       // `.mbtx` first: replacing `snippet.mbt` before it would leave a stray
       // `x` (`sourcex`). `snippet.mbt` is the generated file at the top of the
       // target-dir; `_build/snippet.mbt` covers the older build layout.
-      out = out
-        .replace_all(old="\{base}\{sep}snippet.mbtx", new="source")
-        .replace_all(old="\{base}\{sep}_build\{sep}snippet.mbt", new="source")
-        .replace_all(old="\{base}\{sep}snippet.mbt", new="source")
+      rewrites.push(("\{base}\{sep}snippet.mbtx", "source"))
+      rewrites.push(("\{base}\{sep}_build\{sep}snippet.mbt", "source"))
+      rewrites.push(("\{base}\{sep}snippet.mbt", "source"))
     }
+  }
+  rewrites
+}
+
+///|
+fn rewrite_temp_paths(text : String, bases : Array[String]) -> String {
+  let mut out = text
+  for rewrite in temp_path_rewrites(bases) {
+    let (old, replacement) = rewrite
+    out = out.replace_all(old~, new=replacement)
   }
   out
 }
@@ -915,13 +843,10 @@ async fn read_capped(path : String) -> String {
 }
 
 ///|
-/// The `mbtx` argument schema. `background` adds `run_in_background`,
-/// which a definition without a job runtime must not advertise — the model
-/// would only get an error from a call it cannot execute. `escalation` adds
-/// `escalated` on the same rule: with no approval channel wired, every use of
-/// it would come back refused, and the cheapest way to not waste a turn on
-/// that is for the argument not to exist.
-fn schema(background~ : Bool, escalation~ : Bool) -> Json {
+/// The `mbtx` argument schema. `escalation` adds `escalated` only when an
+/// approval channel is wired; otherwise every use would come back refused, and
+/// the cheapest way not to waste a turn is for the argument not to exist.
+fn schema(escalation~ : Bool) -> Json {
   {
     "type": "object",
     "properties": Json(
@@ -955,22 +880,6 @@ fn schema(background~ : Bool, escalation~ : Bool) -> Json {
               ),
             },
           ),
-          ..if background {
-            [
-              (
-                "run_in_background",
-                Json({
-                  "type": "boolean",
-                  "description": (
-                    #|Run as a background job: returns a job id immediately and a completion
-                    #|notice arrives when it exits. Use for long-running work (full test
-                    #|suites, long builds, watchers) instead of blocking on the 300s
-                    #|foreground bound, which moves the run to a job when it expires.
-                  ),
-                }),
-              ),
-            ]
-          },
           ..if escalation {
             [
               (
@@ -1011,9 +920,9 @@ fn schema(background~ : Bool, escalation~ : Bool) -> Json {
 /// The spawn list is prose about `spawnable_commands`, kept by hand so the
 /// groupings survive; adding an entry there means editing this text too.
 ///
-/// `background` is conditional because without a job runtime the tool must not
-/// advertise `run_in_background`: the model would only get an error.
-/// `escalation` is conditional for the same reason, and matters more: the
+/// `background` selects the execution-time contract the caller actually wired:
+/// automatic handoff with a job runtime, or a longer cancelling timeout without
+/// one. `escalation` is conditional too, and matters more: the
 /// refused-command paragraph above tells the model to say so rather than work
 /// around a refusal, and where escalation IS available that advice would be
 /// wrong — there is a sanctioned way to ask. The paragraph that says so must
@@ -1095,9 +1004,9 @@ fn description(background~ : Bool, escalation~ : Bool) -> String {
     #|  These network rules do not constrain an allowed child process.
     #|- Compiler warnings for the snippet are suppressed; pass `warning: "on"` to
     #|  see them.
-    #|- Bounded to 300s. For independent commands or probes, emit SEVERAL
-    #|  `mbtx` calls in the SAME assistant turn — they run and come back
-    #|  together, saving a model round-trip each.
+    #|- For independent commands or probes, emit SEVERAL `mbtx` calls in the SAME
+    #|  assistant turn — they run and come back together, saving a model round-trip
+    #|  each.
   // Three raw pieces joined at the seam, rather than one interpolating block:
   // the tail carries `\{@fs.tmpdir()}` inside a code sample, which a `$|` block
   // would try to evaluate.
@@ -1128,7 +1037,14 @@ fn description(background~ : Bool, escalation~ : Bool) -> String {
     )
   }
   if !background {
-    return base
+    return (
+      $|\{base}
+      $|
+      $|## Execution time
+      $|
+      $|This context has no background-job runtime. A run may stay in the foreground
+      $|for up to 300s; at that deadline it is cancelled and reported as a timeout.
+    )
   }
   // The blank `$|` line is the paragraph break: without it the section heading
   // runs onto the base text's last line and stops reading as a heading.
@@ -1137,12 +1053,11 @@ fn description(background~ : Bool, escalation~ : Bool) -> String {
     $|
     $|## Long-running work
     $|
-    $|For full test suites, long builds and watchers, set run_in_background=true: the
-    $|call returns a job id immediately and a notice arrives automatically when the job
-    $|finishes — so never block on time (no sleep loops, no polling); keep working and
-    $|act on the completion notice. Read a job's recent output with job_output and
-    $|cancel it with job_stop. A foreground run is bounded to 300s; at that deadline it
-    $|MOVES to a background job rather than dying, so nothing is lost either way —
-    $|asking for a job up front just skips the wait.
+    $|Every call stays inline for up to 5s. If it is still running, it AUTOMATICALLY
+    $|moves to a background job and returns the job id; no background flag or duration
+    $|guess is needed. A completion notice arrives when it finishes, so never wait with
+    $|sleep loops or repeated polling: keep working and act on the notice. Read recent
+    $|output with job_output (use one bounded wait_ms call only when the result is needed
+    $|now), and cancel it with job_stop.
   )
 }

--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -1,10 +1,18 @@
 ///|
-/// A snippet is bounded to this wall-clock so a runaway loop or a build that
-/// never finishes cannot block the whole turn. On expiry the run is cancelled
-/// (which tears down the moon subprocess) and reported as a timeout. Sized for
-/// commands, not just compute: a snippet runs whole `moon test` cycles, and a
-/// fresh workspace's first build downloads and compiles its dependencies.
-const RunTimeoutMs : Int = 300_000
+/// How long a runtime-backed run stays inline before it is adopted as a job.
+/// Kept at the historical five-minute value in the timeout-policy refactor;
+/// callers and the model-facing contract can shorten it independently without
+/// shortening foreground-only subruns.
+const AutoBackgroundAfterMs : Int = 300_000
+
+///|
+/// Non-detachable foreground work is bounded to this wall-clock so a runaway
+/// loop or build cannot block the whole turn. This covers both a runtime-less
+/// snippet and the compile preflight before an explicitly backgrounded run. On
+/// expiry the work is cancelled and reported as a timeout. Sized for commands,
+/// not just compute: a snippet runs whole `moon test` cycles, and a fresh
+/// workspace's first build downloads and compiles its dependencies.
+const ForegroundTimeoutMs : Int = 300_000
 
 ///|
 /// Output is streamed to a file on disk, not buffered in memory, so a snippet
@@ -74,6 +82,9 @@ const WarnOffList : String = "-a+partial_match@partial_match+multiline_string_es
 /// is what advertises the `escalated` argument at all — the same rule
 /// `bg_runtime` follows for `run_in_background`: a build with nobody to ask
 /// does not offer an argument whose every use would come back refused.
+///
+/// `run_timeout_ms` is the compatibility fallback for callers of the former
+/// single-timeout API. Either new bound can override it independently.
 pub fn definition(
   workspace_root~ : String,
   read_only? : Bool = false,
@@ -81,9 +92,17 @@ pub fn definition(
   job_dir? : String,
   scratch_dir? : String,
   worker_sandbox? : WorkerSandbox,
-  run_timeout_ms? : Int = RunTimeoutMs,
+  run_timeout_ms? : Int,
+  auto_background_after_ms? : Int,
+  foreground_timeout_ms? : Int,
   approval? : @agent_runtime.ApprovalChannel,
 ) -> @agent_tool.AgentToolDefinition {
+  let auto_background_after_ms = auto_background_after_ms.unwrap_or(
+    run_timeout_ms.unwrap_or(AutoBackgroundAfterMs),
+  )
+  let foreground_timeout_ms = foreground_timeout_ms.unwrap_or(
+    run_timeout_ms.unwrap_or(ForegroundTimeoutMs),
+  )
   // Background snippet directories are numbered inside the caller's scratch
   // dir rather than created as fresh system temp dirs: a detached job outlives
   // this call, so its snippet, build artifacts, and output log cannot be
@@ -107,7 +126,8 @@ pub fn definition(
         job_dir?,
         scratch_dir?,
         worker_sandbox?,
-        run_timeout_ms~,
+        auto_background_after_ms~,
+        foreground_timeout_ms~,
         next_background~,
         approval?,
       )
@@ -160,9 +180,10 @@ async fn execute(
   job_dir? : String,
   scratch_dir? : String,
   worker_sandbox? : WorkerSandbox,
-  // The wall-clock bound, injectable so a test can exercise the deadline
-  // without waiting out the real one.
-  run_timeout_ms~ : Int,
+  // Independent injectable bounds: a runtime-backed run hands off at the first;
+  // a runtime-less run is cancelled at the second.
+  auto_background_after_ms~ : Int,
+  foreground_timeout_ms~ : Int,
   next_background~ : Ref[Int],
   approval? : @agent_runtime.ApprovalChannel,
 ) -> @agent_tool.ToolAction {
@@ -480,7 +501,7 @@ async fn execute(
     // Bounded like every other run here: a first build downloads and compiles
     // dependencies, and a wedged fetch would otherwise hold the turn open —
     // exactly what asking for a background job was meant to avoid.
-    let build_exit = @async.with_timeout_opt(run_timeout_ms, () => {
+    let build_exit = @async.with_timeout_opt(foreground_timeout_ms, () => {
       @process.run(
         prog,
         build_argv,
@@ -495,7 +516,7 @@ async fn execute(
     guard build_exit is Some(build_exit) else {
       let text = rewrite_temp_paths(read_capped(build_log), [real, dir])
       return @agent_tool.respond(
-        "mbtx: the build did not finish within \{run_timeout_ms / 1000}s, so no background job was started.\n\{text}",
+        "mbtx: the build did not finish within \{foreground_timeout_ms / 1000}s, so no background job was started.\n\{text}",
         is_error=true,
         brief="mbtx (build timeout)",
       )
@@ -550,7 +571,9 @@ async fn execute(
     // code below would be invented. The exit is what this waits for either way,
     // so asking for the early wake only put the rest of the wait outside the
     // deadline. Expiry needs nothing special: it detaches like any other long run.
-    let finished = @async.with_timeout_opt(run_timeout_ms, () => exec.wait())
+    let finished = @async.with_timeout_opt(auto_background_after_ms, () => {
+      exec.wait()
+    })
     let saw_binary = exec.had_invalid_utf8()
     if finished is None {
       let _ = exec.background()
@@ -562,7 +585,7 @@ async fn execute(
       )
       job_owns_dir = true
       return @agent_tool.respond(
-        "mbtx: still running after \{run_timeout_ms / 1000}s, so it moved to the background as job \{id} (nothing was lost). Read its output with job_output (job_id=\"\{id}\") and stop it with job_stop (job_id=\"\{id}\").",
+        "mbtx: still running after \{auto_background_after_ms / 1000}s, so it moved to the background as job \{id} (nothing was lost). Read its output with job_output (job_id=\"\{id}\") and stop it with job_stop (job_id=\"\{id}\").",
         brief="mbtx → bg \{id}",
       )
     }
@@ -615,7 +638,7 @@ async fn execute(
       brief="mbtx (exit=\{exit_code})",
     )
   }
-  let result = @async.with_timeout_opt(run_timeout_ms, () => {
+  let result = @async.with_timeout_opt(foreground_timeout_ms, () => {
     let exit_code = @process.run(
       prog,
       argv,
@@ -672,7 +695,7 @@ async fn execute(
       // instead of discarding it behind a generic timeout message. The status
       // line stays first so it survives the outer result clamp.
       let partial = rewrite_temp_paths(read_capped(log), [real, dir])
-      let head = "mbtx: timed out after \{run_timeout_ms / 1000}s and was cancelled — the program did not finish (an infinite loop, or a build that never completed)."
+      let head = "mbtx: timed out after \{foreground_timeout_ms / 1000}s and was cancelled — the program did not finish (an infinite loop, or a build that never completed)."
       let body = if partial.is_blank() {
         head
       } else {

--- a/agent_tool/mbtx/mbtx_test.mbt
+++ b/agent_tool/mbtx/mbtx_test.mbt
@@ -566,6 +566,11 @@ test "a definition without a job runtime describes its hard timeout" {
   assert_false(definition.description.contains("run_in_background"))
   assert_true(definition.description.contains("no background-job runtime"))
   assert_true(definition.description.contains("up to 300s"))
+  let injected = @mbtx.definition(
+    workspace_root=".",
+    foreground_timeout_ms=12_345,
+  )
+  assert_true(injected.description.contains("up to 12345ms"))
   let JsonSchema(schema) = definition.schema
   assert_false(schema.stringify().contains("run_in_background"))
 }
@@ -602,6 +607,18 @@ test "the schema advertises every decoded argument" {
     assert_true(names.contains(name))
   }
   assert_eq(required, (["source"] : Json))
+}
+
+///|
+/// The removed argument is rejected below JSON Schema enforcement, and its
+/// migration guidance must still read correctly through execute's shared
+/// "mbtx requires ..." decode-error wrapper.
+async test "the removed background field has grammatical migration guidance" {
+  let out = run_in(".", { "source": "fn main {  }", "run_in_background": true })
+  assert_true(out.is_error)
+  assert_true(out.content.contains("mbtx requires arguments without"))
+  assert_true(out.content.contains("field was removed"))
+  assert_true(out.content.contains("handoff is automatic"))
 }
 
 // The EDSL guidance the description carries — how a snippet is shaped, the
@@ -867,6 +884,19 @@ async test "refuses native FFI (extern can bind libc system)" {
 }
 
 ///|
+/// A compute-only backend has no moonrun policy. Text resembling its refusal
+/// marker is ordinary program output even in a runtime-less definition.
+async test "a runtime-less non-wasm run does not invent a policy refusal" {
+  let out = run_in(".", {
+    "source": "fn main { println(\"Sandbox policy blocked file write: example\") }",
+    "target": "js",
+  })
+  assert_false(out.is_error)
+  assert_true(out.content.contains("Sandbox policy blocked"))
+  assert_false(out.content.contains("mbtx sandbox:"))
+}
+
+///|
 async test "snippet stdin is an empty file (EOF), not the engine's inherited fd 0" {
   // A snippet that reads stdin must get immediate EOF, not block on (or steal
   // from) the parent's fd 0 — which under serve/TUI is the control channel.
@@ -902,7 +932,7 @@ async test "a runtime-less run uses its foreground timeout, not the handoff grac
     let definition = @mbtx.definition(
       workspace_root=ws,
       auto_background_after_ms=1,
-      foreground_timeout_ms=10_000,
+      foreground_timeout_ms=300_000,
     )
     let source =
       #|import { "moonbitlang/async" }

--- a/agent_tool/mbtx/mbtx_test.mbt
+++ b/agent_tool/mbtx/mbtx_test.mbt
@@ -894,6 +894,35 @@ async test "a non-zero exit shows the exit code in the content, not just the bri
 }
 
 ///|
+/// The short handoff grace belongs only to a runtime-backed definition. A
+/// foreground-only subrun has no job owner, so it keeps its independent hard
+/// timeout instead of being cancelled at the handoff boundary.
+async test "a runtime-less run uses its foreground timeout, not the handoff grace" {
+  @vfs.with_tmpdir(prefix="mbtx-foreground-timeout-", ws => {
+    let definition = @mbtx.definition(
+      workspace_root=ws,
+      auto_background_after_ms=1,
+      foreground_timeout_ms=10_000,
+    )
+    let source =
+      #|import { "moonbitlang/async" }
+      #|
+      #|async fn main {
+      #|  @async.sleep(100)
+      #|  println("finished inline")
+      #|}
+    let action = match definition.execute {
+      Async(execute) => execute({ "source": source })
+      Sync(_) => fail("mbtx should be async")
+    }
+    guard action is Respond(output) else { fail("expected Respond") }
+    assert_false(output.is_error)
+    assert_true(output.content.contains("finished inline"))
+    assert_false(output.content.contains("moved to the background"))
+  })
+}
+
+///|
 /// Run with an approval channel wired, so the `escalated` argument exists and
 /// `answer` decides what it resolves to.
 async fn run_escalating(

--- a/agent_tool/mbtx/mbtx_test.mbt
+++ b/agent_tool/mbtx/mbtx_test.mbt
@@ -559,13 +559,13 @@ async test "a worker's snippet writes neither its own tree nor a sibling's" {
 }
 
 ///|
-/// Without a job runtime the tool cannot execute a background run, so neither
-/// the description nor the schema may advertise one — the model would only get
-/// an error. (The wired half of this contract is asserted in the `agent`
-/// package, which builds a registry with a real runtime.)
-test "a definition without a job runtime does not advertise background runs" {
+/// Without a job runtime the description names the longer cancelling timeout;
+/// the schema never asks the model to choose foreground versus background.
+test "a definition without a job runtime describes its hard timeout" {
   let definition = @mbtx.definition(workspace_root=".")
   assert_false(definition.description.contains("run_in_background"))
+  assert_true(definition.description.contains("no background-job runtime"))
+  assert_true(definition.description.contains("up to 300s"))
   let JsonSchema(schema) = definition.schema
   assert_false(schema.stringify().contains("run_in_background"))
 }
@@ -948,9 +948,8 @@ async fn run_escalating(
 }
 
 ///|
-/// The argument exists only where something can answer it. This is the same
-/// rule `run_in_background` follows, and it is what keeps a headless run from
-/// spending a call on a field whose every use is refused.
+/// The argument exists only where something can answer it, keeping a headless
+/// run from spending a call on a field whose every use is refused.
 test "the escalated argument is offered only with an approval channel" {
   let plain = @mbtx.definition(workspace_root=".")
   let JsonSchema(plain_schema) = plain.schema

--- a/agent_tool/mbtx/pkg.generated.mbti
+++ b/agent_tool/mbtx/pkg.generated.mbti
@@ -8,7 +8,7 @@ import {
 }
 
 // Values
-pub fn definition(workspace_root~ : String, read_only? : Bool, bg_runtime? : @bgjobs.BgJobRuntime, job_dir? : String, scratch_dir? : String, worker_sandbox? : WorkerSandbox, run_timeout_ms? : Int, approval? : @agent_runtime.ApprovalChannel) -> @agent_tool.AgentToolDefinition
+pub fn definition(workspace_root~ : String, read_only? : Bool, bg_runtime? : @bgjobs.BgJobRuntime, job_dir? : String, scratch_dir? : String, worker_sandbox? : WorkerSandbox, run_timeout_ms? : Int, auto_background_after_ms? : Int, foreground_timeout_ms? : Int, approval? : @agent_runtime.ApprovalChannel) -> @agent_tool.AgentToolDefinition
 
 // Errors
 

--- a/agent_tool/mbtx/pkg.generated.mbti
+++ b/agent_tool/mbtx/pkg.generated.mbti
@@ -8,7 +8,7 @@ import {
 }
 
 // Values
-pub fn definition(workspace_root~ : String, read_only? : Bool, bg_runtime? : @bgjobs.BgJobRuntime, job_dir? : String, scratch_dir? : String, worker_sandbox? : WorkerSandbox, run_timeout_ms? : Int, auto_background_after_ms? : Int, foreground_timeout_ms? : Int, approval? : @agent_runtime.ApprovalChannel) -> @agent_tool.AgentToolDefinition
+pub fn definition(workspace_root~ : String, read_only? : Bool, bg_runtime? : @bgjobs.BgJobRuntime, job_dir? : String, scratch_dir? : String, worker_sandbox? : WorkerSandbox, auto_background_after_ms? : Int, foreground_timeout_ms? : Int, approval? : @agent_runtime.ApprovalChannel) -> @agent_tool.AgentToolDefinition
 
 // Errors
 

--- a/desktop/frontend/transcript/component/mbtx.mbt
+++ b/desktop/frontend/transcript/component/mbtx.mbt
@@ -43,7 +43,9 @@ fn decode_mbtx_call(arguments : String) -> MbtxCall? {
   }
   let chips = scalar_chips(
     fields,
-    // The order the tool's README introduces them in.
+    // The order the tool's README introduces current arguments in. Keep the
+    // removed `run_in_background` last so transcripts recorded by older
+    // versions remain readable; new calls never emit it.
     known=["target", "cwd", "escalated", "warning", "run_in_background"],
     dramatized=["source"],
   )

--- a/desktop/frontend/transcript/component/mbtx_tests.mbt
+++ b/desktop/frontend/transcript/component/mbtx_tests.mbt
@@ -20,7 +20,7 @@ test "an mbtx call decodes to its program and its arguments" {
 /// The chip row is built from a fixed key order rather than the recorded
 /// JSON's, which is whatever the model emitted and is not preserved by the
 /// parsed map — otherwise two identical calls could chip in different orders.
-test "mbtx chips read in a fixed order, whatever the payload's is" {
+test "mbtx chips keep fixed order and render the historical background flag" {
   let arguments =
     #|{"zzz":1,"run_in_background":true,"cwd":null,"source":"fn main {  }","warning":"on","target":"wasm","aaa":"x","extra":{"k":1}}
   guard decode_mbtx_call(arguments) is Some(call) else {
@@ -28,7 +28,8 @@ test "mbtx chips read in a fixed order, whatever the payload's is" {
   }
   // A null is the tool's own spelling of "unset", and a nested value cannot be
   // stated in one line: neither gets a chip, and the Original JSON view is
-  // what carries them.
+  // what carries them. `run_in_background` is no longer accepted by the live
+  // tool, but must remain visible in already-recorded transcripts.
   assert_eq(call.chips, [
     "target: wasm", "warning: on", "run_in_background: true", "aaa: x", "zzz: 1",
   ])

--- a/eval/bgjobs_capability/main.mbt
+++ b/eval/bgjobs_capability/main.mbt
@@ -1,15 +1,15 @@
 ///|
-/// Capability eval: does the agent *choose* background jobs when they are
-/// merely the smart strategy? Unlike `eval/bgjobs_e2e` (which instructs the
-/// model to use `run_in_background` and validates the plumbing), these prompts
-/// never mention background jobs, `job_output`, or notices — the scorecard
-/// measures the model's own judgment:
+/// Capability eval for automatic background handoff. These prompts never
+/// mention background jobs, `job_output`, or notices: the engine must move a
+/// slow `mbtx` call after its foreground grace, while the model must use the
+/// resulting time and job lifecycle sensibly:
 ///
 /// - S1 "overlap": a ~20s command plus quick questions, with an efficiency
-///   hint. Smart play: background the slow command, answer the quick questions
-///   while it runs, fold the result in when it lands.
+///   hint. Expected play: the slow command hands off automatically; answer the
+///   quick questions while it runs, then fold in its result.
 /// - S2 "fire and forget": a ~45s command the user explicitly does not want to
-///   wait for. Smart play: background it and end the turn well under 45s.
+///   wait for. Expected play: let automatic handoff return the job id and end
+///   the turn well under 45s.
 ///
 /// The scorecard is informational (behavior varies run to run); the eval exits
 /// non-zero only when the engine itself misbehaves. Run manually:
@@ -31,7 +31,8 @@ async fn main {
 
 ///|
 /// S1: the model is never told how — only that time matters. Judgment under
-/// measurement: does it background the slow command and overlap the quick work?
+/// measurement: does automatic handoff occur, and does the model overlap the
+/// quick work instead of waiting on the job immediately?
 async fn scenario_overlap(engine : Engine) -> Unit {
   println("== S1 overlap: slow command + quick questions, efficiency hint ==")
   let started_ms = @env.now().reinterpret_as_int64()
@@ -52,7 +53,7 @@ async fn scenario_overlap(engine : Engine) -> Unit {
   let wall_s = (@env.now().reinterpret_as_int64() - started_ms) / 1000
   let backgrounded = seen.search_by(event => {
     event is { "event": String("tool_result"), "content": String(content), .. } &&
-    content.contains("started background job")
+    content.contains("moved to the background")
   })
   // The marker inside a plain `mbtx` result means the slow program ran
   // (and blocked) in the foreground.
@@ -67,7 +68,7 @@ async fn scenario_overlap(engine : Engine) -> Unit {
         ..
       } &&
       content.contains("INTEG-OK-31337") &&
-      !content.contains("started background job")
+      !content.contains("moved to the background")
     })
   // Any tool activity strictly between the job start and the marker retrieval
   // shows the wait was actually used for work.
@@ -97,7 +98,7 @@ async fn scenario_overlap(engine : Engine) -> Unit {
       answer
     _ => ""
   }
-  report("S1 used background job (the core judgment)", backgrounded is Some(_))
+  report("S1 automatically handed off the slow run", backgrounded is Some(_))
   report("S1 did not block the turn on the slow command", !blocked_foreground)
   report("S1 overlapped quick work with the running job", overlapped)
   report(
@@ -135,9 +136,9 @@ async fn scenario_fire_and_forget(engine : Engine) -> Unit {
     .any(event => {
       event
       is { "event": String("tool_result"), "content": String(content), .. } &&
-      content.contains("started background job")
+      content.contains("moved to the background")
     })
-  report("S2 used background job", backgrounded)
+  report("S2 automatically handed off the slow run", backgrounded)
   report(
     "S2 finished well before the 45s job (did not block)",
     finished is Some(_) && wall_s < 35,

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -409,15 +409,14 @@ stderr warning while exit stays 0 — treat skipped blocks as a blind spot.
     of the repository, not only the one you made. Keep worktree paths under
     `.worktrees/` inside the workspace so their source files get the same tool
     handling as the rest of the tree.
-  - For long-running work, set `mbtx`'s `run_in_background: true`: it
-    returns a job id immediately and a notice is pushed to you when the job
-    finishes. Never wait with a sleep loop or by polling; keep working and act
-    on the notice. `job_output` reads a job's recent output; `job_stop` cancels
-    it. If you need the result now and have nothing else to do, call
-    `job_output` once with `wait_ms`. A foreground run is bounded to 300s; at
-    that deadline it MOVES to a background job rather than dying, so nothing is
-    lost either way — asking for a job up front just skips the wait. Background
-    jobs are reaped after thirty minutes of wall clock.
+  - Every `mbtx` call stays inline for up to 5s. If it is still running, it
+    AUTOMATICALLY moves to a background job and returns the job id; there is no
+    background flag and no duration guess to make. A notice is pushed when the
+    job finishes. Never wait with a sleep loop or repeated polling; keep working
+    and act on the notice. `job_output` reads recent output; `job_stop` cancels
+    the job. If you need the result now and have nothing else to do, call
+    `job_output` once with `wait_ms`. Background jobs are reaped after thirty
+    minutes of wall clock.
 - Start `moon check` once `moon.mod` and the relevant `moon.pkg` files exist;
   use `moon build` or `moon test` only when you need artifacts or test results.
 - `multi_edit` example — one edit per distinct line; a line with several matches

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -414,15 +414,14 @@ fn default_prompt() -> String {
     #|    of the repository, not only the one you made. Keep worktree paths under
     #|    `.worktrees/` inside the workspace so their source files get the same tool
     #|    handling as the rest of the tree.
-    #|  - For long-running work, set `mbtx`'s `run_in_background: true`: it
-    #|    returns a job id immediately and a notice is pushed to you when the job
-    #|    finishes. Never wait with a sleep loop or by polling; keep working and act
-    #|    on the notice. `job_output` reads a job's recent output; `job_stop` cancels
-    #|    it. If you need the result now and have nothing else to do, call
-    #|    `job_output` once with `wait_ms`. A foreground run is bounded to 300s; at
-    #|    that deadline it MOVES to a background job rather than dying, so nothing is
-    #|    lost either way — asking for a job up front just skips the wait. Background
-    #|    jobs are reaped after thirty minutes of wall clock.
+    #|  - Every `mbtx` call stays inline for up to 5s. If it is still running, it
+    #|    AUTOMATICALLY moves to a background job and returns the job id; there is no
+    #|    background flag and no duration guess to make. A notice is pushed when the
+    #|    job finishes. Never wait with a sleep loop or repeated polling; keep working
+    #|    and act on the notice. `job_output` reads recent output; `job_stop` cancels
+    #|    the job. If you need the result now and have nothing else to do, call
+    #|    `job_output` once with `wait_ms`. Background jobs are reaped after thirty
+    #|    minutes of wall clock.
     #|- Start `moon check` once `moon.mod` and the relevant `moon.pkg` files exist;
     #|  use `moon build` or `moon test` only when you need artifacts or test results.
     #|- `multi_edit` example — one edit per distinct line; a line with several matches


### PR DESCRIPTION
## Summary

Simplify mbtx execution into one runtime-owned policy:

- with a background runtime, start one retained foreground execution, return inline if it finishes within 5 seconds, otherwise adopt that same process as a background job
- without a background runtime, keep the run in the foreground with an independent 300-second hard timeout
- remove the model-facing foreground/background choice and reject stale `run_in_background` calls with migration guidance

This supersedes #1142, #1143, and #1145 and contains their commits on top of the latest main.

## Resulting behavior

| Context | Up to the boundary | After the boundary |
| --- | --- | --- |
| Runtime available | Wait inline for 5 seconds | The same process becomes a job; no restart and no duplicated execution |
| No runtime | Wait inline for up to 300 seconds | Cancel and return a timeout error |

Jobs remain owned by the existing session task scope. A one-shot CLI run can use an adopted job during that turn, but it does not create a daemon that survives process exit.

The existing 48K foreground output cap is intentionally unchanged: an unusually chatty program can still be stopped before the 5-second handoff. The error now identifies this as a fixed inline limit, warns that an identical retry will fail again, and directs the snippet to redirect bulky child output and read back only the needed excerpt before exiting.

## Commits

### 971046ef — refactor(mbtx): separate handoff and foreground timeouts

- split the old run timeout into `auto_background_after_ms` and `foreground_timeout_ms`
- preserve the original 300-second behavior while separating the two policies
- add coverage proving that runtime-less callers use the foreground timeout rather than the handoff threshold

### 2c934441 — refactor(mbtx): hand off long runs automatically

- set the runtime-backed inline grace to 5 seconds
- remove `run_in_background` from the live schema and decoded input; stale explicit uses fail with migration guidance
- use one retained `ShellExecution` and adopt it after the grace period, avoiding process restart or duplicated result handling
- preserve source-path rewrites, sandbox metadata, binary-output status, hard output/time limits, and completion notices across handoff
- carry launcher-owned cleanup into the adopted job lifecycle
- scan full terminal output once for denial classification and cache the result
- update prompt guidance so the model no longer guesses foreground versus background
- keep runtime-less review, explore, worker, and standalone definitions on the 300-second foreground contract

### f7ca6b81 — docs(mbtx): align collateral with automatic handoff

- document the 5-second automatic handoff and 300-second runtime-less timeout
- update `job_output` and `job_stop` documentation for automatically adopted jobs
- update the background-jobs capability eval to measure automatic routing and useful overlap rather than flag selection
- retain `run_in_background` rendering only for historical saved transcripts, with a regression test

### b6645515 — perf(bgjobs): skip unneeded terminal log scans

- address the first aggregate Codex review finding
- skip materializing a terminal log of up to 20M characters when neither a moonrun policy classifier nor a sandbox command classifier is active
- cache the no-classifier result directly while preserving all `job_output` behavior

### 80eddbd0 — fix(mbtx): harden automatic handoff boundaries

- use one `policy_active` value for launch arguments, adopted-job metadata, and inline refusal classification, preventing non-wasm/escalated output from being misclassified
- retain caller-owned handed-off snippet directories until session or scratch-lab teardown so result files remain readable; nonstandard unowned directories still clean up at terminal status
- render the actual injected handoff and foreground timeout values in descriptions and results, including millisecond precision
- make the fixed 48K cap recovery guidance compatible with inline temp-directory cleanup
- make stale-argument migration guidance grammatical through the shared decode-error wrapper
- harden timing-sensitive tests for cold builds, exercise production completion-notice wiring, and add coverage for result lifetime, policy classification, output-cap guidance, and custom timing descriptions

## Review

Each original slice received an independent fresh Codex CLI review at ultra reasoning. After rebasing the complete series onto the latest main, the aggregate diff was reviewed again with Codex CLI using `gpt-5.6-sol` at ultra reasoning.

The first aggregate review found one P2: terminal jobs without a denial classifier still decoded their complete retained logs. Commit `b6645515` fixes it.

Fable then reviewed the combined PR. Commit `80eddbd0` addresses the findings attributable to the automatic-handoff refactor while keeping the architecture unchanged: one retained execution, one adoption point, and caller-owned lifecycle cleanup. Unrelated legacy concerns remain outside this PR for a separate fix.

The final uncommitted diff received two more `gpt-5.6-sol` ultra Codex CLI reviews. The first found one P2 in the new 48K recovery text: inline cleanup could remove a printed temp path before a later read. The guidance was corrected to read and summarize the redirected file inside the same snippet. The follow-up review reported: **“No actionable regressions were found.”**

## Validation

- `moon test agent_tool/mbtx --target native`: 53/53
- `moon test agent --target native`: 98/98
- `moon check --target native --warn-list +unnecessary_annotation`
- `moon info && moon fmt`
- `just check`
- `just test`: native 3354/3354, JS 3301/3301, cram 28/28
- `just build`: native and JS
- `git diff --check`
