### PR TITLE
refactor(agent_tool): use functional for-loop state in edit/multi_edit/plan scan counters

### DIFF
--- a/agent_tool/edit/edit.mbt
+++ b/agent_tool/edit/edit.mbt
@@ -897,13 +897,14 @@ fn inserted_line_span(new_string : String) -> Int {
 ///|
 fn line_number_at_offset(content : String, offset : Int) -> Int {
   let bounded_offset = offset.clamp(min=0, max=content.length())
-  let mut line = 1
-  for cursor in 0..<bounded_offset {
+  for cursor in 0..<bounded_offset; line = 1 {
     if content[cursor] == '\n' {
-      line += 1
+      continue line + 1
     }
+    continue line
+  } nobreak {
+    line
   }
-  line
 }
 
 ///|

--- a/agent_tool/multi_edit/multi_edit.mbt
+++ b/agent_tool/multi_edit/multi_edit.mbt
@@ -1010,13 +1010,14 @@ fn line_start_offset(content : String, line : Int) -> Int {
 ///|
 fn line_end_offset(content : String, line : Int) -> Int {
   let len = content.length()
-  let mut current_line = 1
-  for cursor in 0..<len {
+  for cursor in 0..<len; current_line = 1 {
     if content[cursor] == '\n' {
       if current_line == line {
         break cursor + 1
       }
-      current_line += 1
+      continue current_line + 1
+    } else {
+      continue current_line
     }
   } nobreak {
     len

--- a/agent_tool/plan/steps/decode.mbt
+++ b/agent_tool/plan/steps/decode.mbt
@@ -92,16 +92,17 @@ pub fn decode(arguments : Json) -> PlanInput raise {
     )
   }
   let steps : Array[PlanStep] = []
-  let mut in_progress_count = 0
-  for index, item in items {
+  for index, item in items; in_progress_count = 0 {
     let step = decode_step(index, item)
+    steps.push(step)
     if step.status is InProgress {
-      in_progress_count += 1
-      if in_progress_count > 1 {
+      if in_progress_count > 0 {
         fail("arguments.steps to contain at most one in_progress step")
       }
+      continue in_progress_count + 1
+    } else {
+      continue in_progress_count
     }
-    steps.push(step)
   }
   { steps, }
 }


### PR DESCRIPTION
## What

Generalize the stateful for-loop refactor from #1147 to the remaining
clean scan counters in the `agent_tool` package family.

-
 `agent_tool/edit/edit.mbt` — `line_number_at_offset`: the newline counter
  becomes loop state (`for cursor in 0..<bounded_offset; line = 1 { ... }`
  with `continue line + 1` and `nobreak { line }`).
-
 `agent_tool/multi_edit/multi_edit.mbt` — `line_end_offset`: an exact
  duplicate of the function converted in #1147, given the same treatment
  so the two stay in sync.
-
 `agent_tool/plan/steps/decode.mbt` — `in_progress_count`: becomes loop
  state; the at-most-one-in-progress validation is preserved (`count > 0`
  before increment is the same condition as `count > 1` after it).

## Deliberately not converted

- `agent_tool/read/read.mbt`: a budget loop with two early `break`s and
  three coupled mutables (`shown_lines`/`remaining`/`truncated`).
- `agent_tool/internal/auto_check/auto_check.mbt`: a tally with plain
  `continue`s and a push side effect; state threading would add noise.

Both are control-flow-heavy loops where the mutable accumulator is
incidental, so the stateful form would not be clearer.

## Verification

- `moon check` clean
- `moon test agent_tool/edit agent_tool/multi_edit agent_tool/plan/steps`
  — 125/125 pass
- `moon fmt --check` clean

Generated with SeekMoon