### PR TITLE
docs(prompt): update moongrep scan exclusions for the new version

### DIFF
--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -297,8 +297,12 @@ async fn main {
 `scan` (and `lint`, which prepends the embedded builtin rules) scans
 recursively from the scan root — a directory or a single `.mbt` file; the
 default root `.` means the whole repository, which is the typical use.
-`.git`, `_build`, `.mooncakes`, and `target` are skipped by default;
-`--exclude <name-or-path>` skips more entries. Use `--output-json` for
+Hidden entries — any child name beginning with `.` (case-independent) —
+plus `_build`, `node_modules`, and `target` are skipped by default;
+`--exclude <name-or-path>` skips more entries. These exclusions apply to
+child entries during traversal: an explicitly selected scan root is still
+inspected even when its final path component matches one of the rules.
+Use `--output-json` for
 agent-friendly output: one JSON object per finding with `file` (relative to
 the scan root, often `./`-prefixed), `rule_id`, `description`, `range`
 (1-based `line`/`column`), `matched_source`, and `source_context`; a scan
@@ -337,13 +341,13 @@ Exit codes: 0 for help, dump, findings, no-findings, and parse warnings
 failure; 5 invalid rule content (including a `--pattern` that is not a valid
 MoonBit expression); 6 missing/unreadable scan input; 7 output failure. The
 scanner follows symlinks, so a broken symlink anywhere under the scan root
-aborts the whole scan with 6. Tool/eval/worktree directories are also NOT
-in the default exclusions: a whole-repo scan descends into them and
+aborts the whole scan with 6. Non-hidden tool/eval/worktree directories
+are NOT in the default exclusions: a whole-repo scan descends into them and
 duplicates findings across nested checkouts, or aborts on a dangling
-symlink inside one. When such directories exist under the scan root,
-exclude them up front — in this checkout: `--exclude .claude --exclude
-.worktrees --exclude .moonagent --exclude .repos --exclude
-editor/codemirror/demo`. Source blocks whose syntax the bundled parser does
+symlink inside one. Hidden ones (`.claude`, `.worktrees`, `.moonagent`,
+`.repos`) are already covered by the leading-dot rule; exclude the rest up
+front — in this checkout: `--exclude editor/codemirror/demo`. Source blocks
+whose syntax the bundled parser does
 not know yet (e.g. nested record-spread `is` patterns) are skipped with a
 stderr warning while exit stays 0 — treat skipped blocks as a blind spot.
 

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -302,8 +302,12 @@ fn default_prompt() -> String {
     #|`scan` (and `lint`, which prepends the embedded builtin rules) scans
     #|recursively from the scan root — a directory or a single `.mbt` file; the
     #|default root `.` means the whole repository, which is the typical use.
-    #|`.git`, `_build`, `.mooncakes`, and `target` are skipped by default;
-    #|`--exclude <name-or-path>` skips more entries. Use `--output-json` for
+    #|Hidden entries — any child name beginning with `.` (case-independent) —
+    #|plus `_build`, `node_modules`, and `target` are skipped by default;
+    #|`--exclude <name-or-path>` skips more entries. These exclusions apply to
+    #|child entries during traversal: an explicitly selected scan root is still
+    #|inspected even when its final path component matches one of the rules.
+    #|Use `--output-json` for
     #|agent-friendly output: one JSON object per finding with `file` (relative to
     #|the scan root, often `./`-prefixed), `rule_id`, `description`, `range`
     #|(1-based `line`/`column`), `matched_source`, and `source_context`; a scan
@@ -342,13 +346,13 @@ fn default_prompt() -> String {
     #|failure; 5 invalid rule content (including a `--pattern` that is not a valid
     #|MoonBit expression); 6 missing/unreadable scan input; 7 output failure. The
     #|scanner follows symlinks, so a broken symlink anywhere under the scan root
-    #|aborts the whole scan with 6. Tool/eval/worktree directories are also NOT
-    #|in the default exclusions: a whole-repo scan descends into them and
+    #|aborts the whole scan with 6. Non-hidden tool/eval/worktree directories
+    #|are NOT in the default exclusions: a whole-repo scan descends into them and
     #|duplicates findings across nested checkouts, or aborts on a dangling
-    #|symlink inside one. When such directories exist under the scan root,
-    #|exclude them up front — in this checkout: `--exclude .claude --exclude
-    #|.worktrees --exclude .moonagent --exclude .repos --exclude
-    #|editor/codemirror/demo`. Source blocks whose syntax the bundled parser does
+    #|symlink inside one. Hidden ones (`.claude`, `.worktrees`, `.moonagent`,
+    #|`.repos`) are already covered by the leading-dot rule; exclude the rest up
+    #|front — in this checkout: `--exclude editor/codemirror/demo`. Source blocks
+    #|whose syntax the bundled parser does
     #|not know yet (e.g. nested record-spread `is` patterns) are skipped with a
     #|stderr warning while exit stays 0 — treat skipped blocks as a blind spot.
     #|


### PR DESCRIPTION
## Summary

Updates the moongrep section of the built-in system prompt for the newly
published moongrep
([moonbit-community/moongrep#74](https://github.com/moonbit-community/moongrep/pull/74),
"feat(scan): ignore hidden entries and node_modules").

The new scan defaults are:

- every dot-prefixed child entry is skipped (case-independent leading-dot
  check) — this now covers `.git`, `.mooncakes`, etc.;
- exact names `_build`, `node_modules`, and `target` are skipped;
- exclusions apply to child entries during traversal; an explicitly
  selected scan root is still inspected.

Prompt changes:

- restate the default exclusion list in `prompt/default_prompt.mbt.md`;
- simplify the scan-root advice: `.claude`, `.worktrees`, `.moonagent`,
  and `.repos` are now auto-skipped by the leading-dot rule, so only
  `editor/codemirror/demo` still needs an explicit `--exclude` in this
  checkout;
- regenerate `prompt/generated_default_prompt.mbt` via the
  `md_to_mbt_string` dev_build rule so the served prompt matches the
  source.

## Testing

- `moon check prompt` — clean (in a fresh worktree).
- `moon run scripts/md_to_mbt_string -- prompt/default_prompt.mbt.md
  prompt/generated_default_prompt.mbt` — regeneration is idempotent; the
  generated file matches the source.
- A root-level `moon check` is currently blocked by a pre-existing,
  unrelated environment issue: the gitignored
  `desktop/dist/SeekMoon.app.backup` app bundle vendors a moon toolchain
  that breaks workspace build-plan resolution. A fresh worktree without
  `desktop/dist` checks cleanly.

Generated with SeekMoon