### PR TITLE
refactor: functional for-loop state in desktop + eval counters

### DIFF
--- a/desktop/frontend/markdown/markdown.mbt
+++ b/desktop/frontend/markdown/markdown.mbt
@@ -354,14 +354,16 @@ fn trim_unmatched_closer(
   suffix : String,
 ) -> String {
   guard url.has_suffix(suffix) else { return url }
-  let mut opens = 0
-  let mut closes = 0
-  for ch in url {
+  let (opens, closes) = for ch in url; opens = 0, closes = 0 {
     if ch == opener {
-      opens += 1
+      continue opens + 1, closes
     } else if ch == closer {
-      closes += 1
+      continue opens, closes + 1
+    } else {
+      continue opens, closes
     }
+  } nobreak {
+    (opens, closes)
   }
   if closes > opens {
     url.view(end_offset=url.length() - 1).to_owned()

--- a/desktop/internal/engine/follower.mbt
+++ b/desktop/internal/engine/follower.mbt
@@ -1024,11 +1024,13 @@ async test "abrupt EOF leaves a failed drain for a later caller to retry" {
     // `run` returning is retirement: the dead handle left its slot, and its
     // run was closed without a record position it could not read.
     assert_true(slot.engine is None)
-    let mut finishes = 0
-    for event in emitted {
+    let finishes = for event in emitted; finishes = 0 {
       if event is Finished(payload) && payload.run_id == "r-abrupt-eof" {
-        finishes += 1
+        continue finishes + 1
       }
+      continue finishes
+    } nobreak {
+      finishes
     }
     assert_eq(finishes, 1)
     // The follower outlived the engine precisely so a later caller can drain

--- a/desktop/internal/engine/ops.mbt
+++ b/desktop/internal/engine/ops.mbt
@@ -1121,11 +1121,13 @@ async test "setup failure retires the writer before an immediate next start" {
       is Some(_),
     )
     assert_eq(@fs.read_file(count.to_string()).text(), "2")
-    let mut first_finishes = 0
-    for event in emitted {
+    let first_finishes = for event in emitted; first_finishes = 0 {
       if event is Finished(payload) && payload.run_id == first {
-        first_finishes += 1
+        continue first_finishes + 1
       }
+      continue first_finishes
+    } nobreak {
+      first_finishes
     }
     assert_eq(first_finishes, 1)
     group.return_immediately(())
@@ -1218,11 +1220,13 @@ async test "a prompt bigger than the pipe still settles exactly once" {
     )
     // Both the writer's failed write and the consumer's EOF want to settle
     // this run; they share the engine's phase, so only one of them does.
-    let mut finishes = 0
-    for event in emitted {
+    let finishes = for event in emitted; finishes = 0 {
       if event is Finished(payload) && payload.run_id == run_id {
-        finishes += 1
+        continue finishes + 1
       }
+      continue finishes
+    } nobreak {
+      finishes
     }
     assert_eq(finishes, 1)
     assert_true(open_run_engine(manager, run_id~) is None)

--- a/desktop/internal/host/github_ops.mbt
+++ b/desktop/internal/host/github_ops.mbt
@@ -247,16 +247,17 @@ fn parse_checks(rollup : Json?) -> GitChecks? {
   guard rollup is Some(Array(entries)) && !entries.is_empty() else {
     return None
   }
-  let mut passed = 0
-  let mut failed = 0
-  let mut pending = 0
-  for entry in entries {
-    guard entry is Object(fields) else { continue }
+  let (passed, failed, pending) = for
+    entry in entries
+    passed = 0, failed = 0, pending = 0 {
+    guard entry is Object(fields) else { continue passed, failed, pending }
     match check_state(fields) {
-      Passed => passed += 1
-      Failed => failed += 1
-      Pending => pending += 1
+      Passed => continue passed + 1, failed, pending
+      Failed => continue passed, failed + 1, pending
+      Pending => continue passed, failed, pending + 1
     }
+  } nobreak {
+    (passed, failed, pending)
   }
   Some({ passed, failed, pending, })
 }

--- a/eval/prompt_task/harness/suite.mbt
+++ b/eval/prompt_task/harness/suite.mbt
@@ -782,11 +782,10 @@ fn suite_report_row(
 
 ///|
 fn suite_success_summary(report : SuiteReport) -> String {
-  let mut successes = 0
-  let mut runs = 0
-  for combo in report.reports {
-    successes += combo.successes
-    runs += combo.runs
+  let (successes, runs) = for combo in report.reports; successes = 0, runs = 0 {
+    continue successes + combo.successes, runs + combo.runs
+  } nobreak {
+    (successes, runs)
   }
   "\{successes}/\{runs} successful trials"
 }


### PR DESCRIPTION
## What

Continue the stateful for-loop refactor (#1147, #1149) into the remaining
packages where the accumulator is the loop's result.

-
 `desktop/internal/host/github_ops.mbt` — `parse_checks`: `passed` /
  `failed` / `pending` become a three-state loop; the `GitChecks` result
  is the loop value.
-
 `desktop/frontend/markdown/markdown.mbt` — `trim_unmatched_closer`:
  `opens` / `closes` become a two-state loop.
-
 `desktop/internal/engine/ops.mbt` + `follower.mbt` — the three
  `Finished`-event counters (`first_finishes`, `finishes` ×2) become
  loop state.
-
 `eval/prompt_task/harness/suite.mbt` — `suite_success_summary`:
  `successes` / `runs` become a two-state loop.

## Deliberately not converted

- `viz/view.mbt`: a tag counter whose final state is unused, and a
  counter accumulated across two separate loops in `match` arms.
- `mcp/tools/tools.mbt`, `desktop/internal/shellenv`: budget loops with
  plain `continue`s and side effects.
- `desktop/internal/remote/serve.mbt`: `for ;;` has no iterator, so the
  stateful form does not apply.

## Verification

- `moon check` clean
- `moon test desktop/internal/host desktop/frontend/markdown
  desktop/internal/engine eval/prompt_task/harness` — 232/232 pass
- `moon fmt --check` clean

Generated with SeekMoon