### PR TITLE
fix(package): copy directory trees natively instead of shelling out to cp

### DIFF
--- a/desktop/package/internal/packaging/packaging.mbt
+++ b/desktop/package/internal/packaging/packaging.mbt
@@ -618,13 +618,21 @@ async fn Workspace::require_fresh_prebuilt_artifacts(
 }
 
 ///|
-/// Recursively copy a directory tree, replacing the destination. Uses the
-/// host's `cp -R`; packaging runs on the build host so this stays simple.
+/// Recursively copy a directory tree, replacing the destination. Walks the
+/// tree with `@asyncfs` instead of shelling out to `cp`, which stock Windows
+/// does not have on PATH.
 pub async fn copy_tree(source : String, destination : String) -> Unit {
   remove_path_if_exists(destination)
-  let parent = (destination : @path.Path).dirname().to_string()
-  ensure_dir(parent)
-  run_checked("cp", ["-R", source, destination], dir=parent)
+  ensure_dir(destination)
+  for entry in @asyncfs.readdir(source, sort=true) {
+    let entry_source = join_path(source, entry)
+    let entry_destination = join_path(destination, entry)
+    if @asyncfs.kind(entry_source) is Directory {
+      copy_tree(entry_source, entry_destination)
+    } else {
+      copy_file(entry_source, entry_destination)
+    }
+  }
 }
 
 ///|

--- a/desktop/package/internal/packaging/packaging.mbt
+++ b/desktop/package/internal/packaging/packaging.mbt
@@ -631,6 +631,13 @@ pub async fn copy_tree(source : String, destination : String) -> Unit {
       copy_tree(entry_source, entry_destination)
     } else {
       copy_file(entry_source, entry_destination)
+      // `cp -R` preserved the executable bit, and bundled helpers such as
+      // the CEF runtime's `bin/cef_process` rely on it. Windows has no
+      // executable bit and `@asyncfs.chmod` raises there.
+      if !(@platform.win32 || @platform.win64) &&
+        @asyncfs.can_execute(entry_source) {
+        @asyncfs.chmod(entry_destination, 0o755)
+      }
     }
   }
 }


### PR DESCRIPTION
## Problem

`moon run desktop/package/windows` fails on a stock Windows host with:

```
OSError("@process.run(): The system cannot find the file specified.")
```

The build itself succeeds; the failure happens at the mermaid asset staging step because `@packaging.copy_tree` shells out to `cp -R`, and `cp` is not on a stock Windows PATH (unlike `tar`, which Windows ships natively — which is why every earlier packaging step works).

## Fix

Rewrite `copy_tree` as a native recursive copy using `@asyncfs` (`readdir` + `kind`, recursing into directories and reusing the existing `copy_file` helper). Packaging no longer depends on a host `cp` binary on any platform, which also removes one external dependency from the macOS/Linux packagers that share the helper.

`readdir` includes hidden files by default, matching the previous `cp -R` semantics; the destination is still removed and recreated first, so replace semantics are unchanged. The public signature is identical, so `pkg.generated.mbti` is unchanged.

## Validation

- `moon check package/internal/packaging --target native` — clean
- `moon run desktop/package/windows` on Windows 11 — completes end to end (exit 0), producing the app bundle, portable zip, and `SeekMoon-Setup.exe`
- `moon fmt` / `moon info` — no further changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NsAEZ3LfzaAJq9wmEWmu81