### PR TITLE
fix(editor): preserve folds on watched-file refresh

### DIFF
--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -1112,6 +1112,9 @@ fn show_file_in_viewer(
     // jump's reveal and annotation still apply below, over the kept document.
     let code_model = viewer.get_model()
     let markdown_model = markdown_viewer.get_model()
+    let same_code_resource = !show_markdown &&
+      code_model is Some(current) &&
+      current.uri.to_string() == uri.to_string()
     let same_document = if show_markdown {
       markdown_model is Some(current) &&
       current.model.uri.to_string() == uri.to_string() &&
@@ -1138,8 +1141,16 @@ fn show_file_in_viewer(
     if viewer_state.search_match_highlights is Some(highlights) {
       highlights.clear()
     }
-    if !same_document {
-      // Park the outgoing document's scroll position for its tab's return.
+    if same_code_resource && !same_document {
+      // VS Code reloads an existing text-file model in place. The readonly
+      // Viewer uses its whole-value flush lane, bracketed by view-state
+      // persistence so folding contribution state survives the decorations
+      // that `set_value` deliberately destroys.
+      let current_view_state = viewer.save_view_state()
+      viewer.set_value(content)
+      viewer.restore_view_state(current_view_state)
+    } else if !same_document {
+      // Park the outgoing document's view state for its tab's return.
       if viewer_state.relative is Some(prev) {
         if code_model is Some(_) && viewer.save_view_state() is Some(view_state) {
           viewer_state.view_states[prev.0] = view_state
@@ -1191,17 +1202,20 @@ fn show_file_in_viewer(
         }
         viewer.set_model(Some(text_model))
         dispose_source_model(code_model)
-        if restore_view_state &&
+        let restored_code_view_state = if restore_view_state &&
           relative is Some(rel) &&
           viewer_state.view_states.get(rel.0) is Some(saved) {
           viewer.restore_view_state(Some(saved))
+          true
+        } else {
+          false
         }
         // Match the reference workbench's host policy: ordinary `.mbt` files
         // open as a top-level outline. `set_model` computes folding ranges
         // synchronously, so this is stable initialization state rather than a
-        // delayed render effect. Keeping it in the fresh-model branch leaves
-        // folding interactions on the current model user-controlled.
-        if should_auto_fold_top_level(text_model) {
+        // delayed render effect. A restored state already carries the user's
+        // fold choices, so the initial policy must not run over it.
+        if !restored_code_view_state && should_auto_fold_top_level(text_model) {
           viewer.fold_top_level()
         }
       }

--- a/editor/internal/shell/workbench/app.mbt
+++ b/editor/internal/shell/workbench/app.mbt
@@ -739,14 +739,21 @@ fn set_workbench_code_model(
     Some(markdown) => markdown.set_model(None) |> ignore
     None => ()
   }
-  match view_state {
+  let restored_view_state = match view_state {
     PreserveScroll => {
       let state = viewer.save_view_state()
       viewer.set_model(Some(text_model))
       viewer.restore_view_state(state)
+      state is Some(_)
     }
-    ResetScroll => viewer.set_model(Some(text_model))
-    RevealDefinition(_) => viewer.set_model(Some(text_model))
+    ResetScroll => {
+      viewer.set_model(Some(text_model))
+      false
+    }
+    RevealDefinition(_) => {
+      viewer.set_model(Some(text_model))
+      false
+    }
   }
   show_workbench_presentation("code")
   // The reference workbench presents `.mbt` sources as a top-level outline.
@@ -754,7 +761,7 @@ fn set_workbench_code_model(
   // other registered languages and external embedders retain expanded models.
   // `set_model` computes folding ranges synchronously, so the collapse is part
   // of the stable initialization state and never needs a timer or render hook.
-  if should_auto_fold_top_level(text_model) {
+  if !restored_view_state && should_auto_fold_top_level(text_model) {
     viewer.fold_top_level()
   }
   // Matches TextFileEditor.setInput: model, restored state/options, then the
@@ -798,9 +805,9 @@ fn set_workbench_code_model(
 /// Folding itself remains language-neutral; the host opts in only for ordinary
 /// MoonBit source files because their top-level declarations are the
 /// workbench's primary reading surface. In particular, `.mbt.md` documents and
-/// extensionless sources remain expanded. Fresh models, including watched-file
-/// replacements, reapply the policy, while in-model folding interactions stay
-/// entirely user-controlled.
+/// extensionless sources remain expanded. A fresh open applies the policy;
+/// watched-file replacements restore their saved view state instead of
+/// applying the initial policy again.
 fn should_auto_fold_top_level(text_model : @model.TextModel) -> Bool {
   text_model.get_language_id() == "moonbit" &&
   text_model.display_name.has_suffix(".mbt")

--- a/editor/internal/viewer/code_editor_widget/folding_host.mbt
+++ b/editor/internal/viewer/code_editor_widget/folding_host.mbt
@@ -188,7 +188,8 @@ fn CodeEditorWidget::folding_on_hidden_ranges_changes(
   hidden_ranges : Array[@base_common.Range],
 ) -> Unit {
   guard self.folding_controller() is Some(controller) else { return }
-  if controller.hidden_range_model is Some(hidden_range_model) &&
+  if !controller.restoring_view_state &&
+    controller.hidden_range_model is Some(hidden_range_model) &&
     hidden_ranges.length() > 0 {
     match self.get_selections() {
       Some(selections) =>

--- a/editor/internal/viewer/code_editor_widget/public_read_api_wbtest.mbt
+++ b/editor/internal/viewer/code_editor_widget/public_read_api_wbtest.mbt
@@ -66,7 +66,7 @@ test "read API: no-model scroll writes no-op and view state is None" {
   assert_eq(viewer.get_scroll_left(), -1.0)
   assert_true(viewer.save_view_state() is None)
   viewer.restore_view_state(
-    Some({ scroll_top: 10.0, scroll_left: 20.0, folding_state: None }),
+    Some({ scroll_top: 10.0, scroll_left: 20.0, folding_state: None, }),
   )
   assert_eq(viewer.get_scroll_top(), -1.0)
   viewer.dispose()

--- a/editor/internal/viewer/code_editor_widget/public_read_api_wbtest.mbt
+++ b/editor/internal/viewer/code_editor_widget/public_read_api_wbtest.mbt
@@ -65,7 +65,9 @@ test "read API: no-model scroll writes no-op and view state is None" {
   assert_eq(viewer.get_scroll_top(), -1.0)
   assert_eq(viewer.get_scroll_left(), -1.0)
   assert_true(viewer.save_view_state() is None)
-  viewer.restore_view_state(Some({ scroll_top: 10.0, scroll_left: 20.0, }))
+  viewer.restore_view_state(
+    Some({ scroll_top: 10.0, scroll_left: 20.0, folding_state: None }),
+  )
   assert_eq(viewer.get_scroll_top(), -1.0)
   viewer.dispose()
 }

--- a/editor/internal/viewer/code_editor_widget/restore_view_state_tokenization_wbtest.mbt
+++ b/editor/internal/viewer/code_editor_widget/restore_view_state_tokenization_wbtest.mbt
@@ -66,7 +66,9 @@ test "restore view state commits scroll before stabilized visible lines" {
   })
   defer listener.dispose()
 
-  viewer.restore_view_state(Some({ scroll_top: 180.0, scroll_left: 120.0, }))
+  viewer.restore_view_state(
+    Some({ scroll_top: 180.0, scroll_left: 120.0, folding_state: None }),
+  )
 
   assert_eq(scroll_positions.length(), 1)
   assert_eq(scroll_positions[0].0, 180.0)
@@ -134,7 +136,9 @@ test "restore view state is a no-op without a model" {
   calls.val = 0
 
   viewer.set_model(None)
-  viewer.restore_view_state(Some({ scroll_top: 360.0, scroll_left: 70.0, }))
+  viewer.restore_view_state(
+    Some({ scroll_top: 360.0, scroll_left: 70.0, folding_state: None }),
+  )
   viewer.flush_render()
   viewer.flush_render()
 

--- a/editor/internal/viewer/code_editor_widget/restore_view_state_tokenization_wbtest.mbt
+++ b/editor/internal/viewer/code_editor_widget/restore_view_state_tokenization_wbtest.mbt
@@ -67,7 +67,7 @@ test "restore view state commits scroll before stabilized visible lines" {
   defer listener.dispose()
 
   viewer.restore_view_state(
-    Some({ scroll_top: 180.0, scroll_left: 120.0, folding_state: None }),
+    Some({ scroll_top: 180.0, scroll_left: 120.0, folding_state: None, }),
   )
 
   assert_eq(scroll_positions.length(), 1)
@@ -137,7 +137,7 @@ test "restore view state is a no-op without a model" {
 
   viewer.set_model(None)
   viewer.restore_view_state(
-    Some({ scroll_top: 360.0, scroll_left: 70.0, folding_state: None }),
+    Some({ scroll_top: 360.0, scroll_left: 70.0, folding_state: None, }),
   )
   viewer.flush_render()
   viewer.flush_render()

--- a/editor/internal/viewer/code_editor_widget/set_value_api_wbtest.mbt
+++ b/editor/internal/viewer/code_editor_widget/set_value_api_wbtest.mbt
@@ -93,6 +93,54 @@ test "set_value keeps headless scroll while folding recomputes" {
 }
 
 ///|
+/// Desktop's watched-file refresh brackets the whole-value flush with this
+/// view-state contract. The expanded provider range stays expanded by absence
+/// from the memento, while its collapsed sibling is reapplied.
+test "save set_value restore preserves mixed folding state" {
+  let before =
+    #|class A {
+    #|  first()
+    #|}
+    #|class B {
+    #|  second()
+    #|}
+    #|tail
+  with_test_viewer(before, viewer => {
+    viewer.fold_top_level()
+    guard viewer.folding_controller() is Some(controller) &&
+      controller.folding_model is Some(folding_model) else {
+      fail("expected folding model")
+    }
+    guard folding_model.get_region_at_line(1) is Some(first) else {
+      fail("expected first top-level region")
+    }
+    folding_model.toggle_collapse_state([first])
+    guard folding_model.get_region_at_line(1) is Some(first_before) &&
+      folding_model.get_region_at_line(4) is Some(second_before) else {
+      fail("expected both top-level regions before refresh")
+    }
+    assert_false(first_before.is_collapsed())
+    assert_true(second_before.is_collapsed())
+
+    guard viewer.save_view_state() is Some(view_state) else {
+      fail("expected viewer state")
+    }
+    viewer.set_value(before + "\nrefreshed")
+    viewer.restore_view_state(Some(view_state))
+
+    guard controller.folding_model is Some(restored) else {
+      fail("expected restored folding model")
+    }
+    guard restored.get_region_at_line(1) is Some(first_after) &&
+      restored.get_region_at_line(4) is Some(second_after) else {
+      fail("expected both top-level regions after refresh")
+    }
+    assert_false(first_after.is_collapsed())
+    assert_true(second_after.is_collapsed())
+  })
+}
+
+///|
 test "set_value preserves the headless model slot without browser state" {
   with_test_viewer("one\ntwo", viewer => {
     guard viewer.model_slot.current is Some(before) else {

--- a/editor/internal/viewer/code_editor_widget/viewer.mbt
+++ b/editor/internal/viewer/code_editor_widget/viewer.mbt
@@ -139,6 +139,7 @@ priv struct HorizontalRevealRangeRequest {
 struct CodeEditorViewState {
   scroll_top : Double
   scroll_left : Double
+  folding_state : @folding_browser.FoldingStateMemento?
 } derive(Debug)
 
 ///|
@@ -832,24 +833,38 @@ pub fn CodeEditorWidget::has_text_focus(self : CodeEditorWidget) -> Bool {
 }
 
 ///|
-/// Returns the current scroll state in host-restorable form — Monaco's
-/// `saveViewState` (`cew:1038-1041`). No model → `None`.
+/// Returns the current scroll and contribution state in host-restorable form
+/// — Monaco's `saveViewState` (`cew:1038-1049`). No model → `None`.
 pub fn CodeEditorWidget::save_view_state(
   self : CodeEditorWidget,
 ) -> CodeEditorViewState? {
   guard self.active_scroll_position() is Some(position) else { return None }
-  Some({ scroll_top: position.scroll_top, scroll_left: position.scroll_left, })
+  let folding_state = match self.folding_controller() {
+    Some(controller) => controller.save_view_state()
+    None => None
+  }
+  Some({
+    scroll_top: position.scroll_top,
+    scroll_left: position.scroll_left,
+    folding_state,
+  })
 }
 
 ///|
-/// Restores a previously captured scroll state — Monaco's `restoreViewState`
-/// (`cew:1052`): a no-op without a model, and `None` state restores nothing.
+/// Restores a previously captured contribution and scroll state — Monaco's
+/// `restoreViewState` (`cew:1052-1071`): contribution state is applied before
+/// the view state; a no-op without a model, and `None` restores nothing.
 pub fn CodeEditorWidget::restore_view_state(
   self : CodeEditorWidget,
   state : CodeEditorViewState?,
 ) -> Unit {
   match state {
     Some(state) => {
+      match (self.folding_controller(), state.folding_state) {
+        (Some(controller), Some(folding_state)) =>
+          controller.restore_view_state(folding_state)
+        _ => ()
+      }
       self.set_active_scroll_position(
         scroll_top=state.scroll_top,
         scroll_left=state.scroll_left,

--- a/editor/internal/viewer/contrib/folding/browser/folding.mbt
+++ b/editor/internal/viewer/contrib/folding/browser/folding.mbt
@@ -12,9 +12,19 @@
 // the internal folding package independent of the root Viewer.
 //
 // Omissions: the syntax range provider (`SyntaxRangeProvider` — no folding
-// range providers in the language registry yet), view-state save/restore
-// (`FoldingStateMemento`), `foldingImportsByDefault` (needs provider kinds),
-// and the update `Delayer`/debounce (the viewer computes synchronously).
+// range providers in the language registry yet), `foldingImportsByDefault`
+// (needs provider kinds), and the update `Delayer`/debounce (the viewer
+// computes synchronously). Folding view-state persistence is retained.
+
+///|
+/// The supported subset of Monaco's `FoldingStateMemento`
+/// (`folding.ts:54-59`). Provider identity and folded-import state are absent
+/// with those unported features; `line_count` remains part of the persisted
+/// shape for source fidelity.
+struct FoldingStateMemento {
+  collapsed_regions : Array[FoldingLineMemento]?
+  line_count : Int?
+} derive(Debug)
 
 ///|
 /// Receives how many ranges a provider computed and whether the limit
@@ -75,6 +85,7 @@ pub(all) struct FoldingController {
   mut folding_decoration_provider : FoldingDecorationProvider?
   mut range_provider : IndentRangeProvider?
   mut mouse_down_info : FoldingMouseDownInfo?
+  mut restoring_view_state : Bool
   /// The model-scoped subscriptions of `localToDispose`.
   local_to_dispose : Array[@base_common.Disposable]
 }
@@ -89,8 +100,40 @@ pub fn FoldingController::FoldingController() -> FoldingController {
     folding_decoration_provider: None,
     range_provider: None,
     mouse_down_info: None,
+    restoring_view_state: false,
     local_to_dispose: [],
   }
+}
+
+///|
+/// `saveViewState` (`folding.ts:188-202`) reduced to the supported folding
+/// state. `None` means no live folding model was available.
+pub fn FoldingController::save_view_state(
+  self : FoldingController,
+) -> FoldingStateMemento? {
+  guard self.folding_model is Some(folding_model) else { return None }
+  Some({
+    collapsed_regions: folding_model.get_memento(),
+    line_count: Some(folding_model.text_model().get_line_count()),
+  })
+}
+
+///|
+/// `restoreViewState` (`folding.ts:204-225`). The restoring flag prevents the
+/// hidden-range listener from moving a selection while persisted folds are
+/// being applied.
+pub fn FoldingController::restore_view_state(
+  self : FoldingController,
+  state : FoldingStateMemento,
+) -> Unit {
+  guard state.collapsed_regions is Some(collapsed_regions) &&
+    !collapsed_regions.is_empty() &&
+    self.folding_model is Some(folding_model) else {
+    return
+  }
+  self.restoring_view_state = true
+  folding_model.apply_memento(collapsed_regions)
+  self.restoring_view_state = false
 }
 
 ///|
@@ -121,4 +164,5 @@ pub fn FoldingController::clear_local(self : FoldingController) -> Unit {
   self.range_provider = None
   self.folding_decoration_provider = None
   self.mouse_down_info = None
+  self.restoring_view_state = false
 }

--- a/editor/internal/viewer/contrib/folding/browser/folding_model.mbt
+++ b/editor/internal/viewer/contrib/folding/browser/folding_model.mbt
@@ -3,8 +3,21 @@
 // `FoldingModel` (regions + their tracking editor decorations + the change
 // emitter) and the reachable collapse-state helpers the commands drive.
 //
-// Omissions: `getMemento`/`applyMemento`/`_getLinesChecksum` (view-state
-// persistence has no consumer in the readonly viewer).
+// The persistence slice (`getMemento`/`applyMemento`/`_getLinesChecksum`) is
+// retained because readonly hosts replace or flush models when disk contents
+// change and must restore the user's fold choices afterward.
+
+///|
+/// One persisted fold range — Monaco's private `ILineMemento`
+/// (`foldingModel.ts:21`). Optional fields retain the source's compatibility
+/// defaults even though states produced by this version fill all three.
+priv struct FoldingLineMemento {
+  start_line_number : Int
+  end_line_number : Int
+  checksum : Int?
+  is_collapsed : Bool?
+  source : FoldSource?
+} derive(Debug)
 
 ///|
 /// The exact decoration capabilities `FoldingModel` writes through — Monaco's
@@ -275,6 +288,98 @@ fn FoldingModel::current_folded_or_manual_ranges(
     }
   }
   folded_ranges
+}
+
+///|
+/// `getMemento` (`foldingModel.ts:188-210`): persist collapsed provider ranges
+/// and every manual range. Expanded provider ranges are deliberately omitted;
+/// a newly computed folding model starts expanded, then `apply_memento`
+/// reapplies only the saved exceptions.
+fn FoldingModel::get_memento(self : FoldingModel) -> Array[FoldingLineMemento]? {
+  let folded_or_manual_ranges = self.current_folded_or_manual_ranges()
+  let result : Array[FoldingLineMemento] = []
+  let max_line_number = self.text_model.get_line_count()
+  for range in folded_or_manual_ranges {
+    if range.start_line_number >= range.end_line_number ||
+      range.start_line_number < 1 ||
+      range.end_line_number > max_line_number {
+      continue
+    }
+    result.push({
+      start_line_number: range.start_line_number,
+      end_line_number: range.end_line_number,
+      is_collapsed: Some(range.is_collapsed),
+      source: Some(range.source),
+      checksum: Some(
+        self.get_lines_checksum(
+          range.start_line_number + 1,
+          range.end_line_number,
+        ),
+      ),
+    })
+  }
+  if result.is_empty() {
+    None
+  } else {
+    Some(result)
+  }
+}
+
+///|
+/// `applyMemento` (`foldingModel.ts:212-239`): validate persisted ranges
+/// against the current document before merging them with freshly computed
+/// provider ranges. A changed boundary checksum drops only that stale range.
+fn FoldingModel::apply_memento(
+  self : FoldingModel,
+  state : Array[FoldingLineMemento],
+) -> Unit {
+  let ranges_to_restore : Array[FoldRange] = []
+  let max_line_number = self.text_model.get_line_count()
+  for range in state {
+    if range.start_line_number >= range.end_line_number ||
+      range.start_line_number < 1 ||
+      range.end_line_number > max_line_number {
+      continue
+    }
+    let checksum = self.get_lines_checksum(
+      range.start_line_number + 1,
+      range.end_line_number,
+    )
+    if range.checksum is None || range.checksum == Some(checksum) {
+      ranges_to_restore.push({
+        start_line_number: range.start_line_number,
+        end_line_number: range.end_line_number,
+        type_: None,
+        is_collapsed: range.is_collapsed.unwrap_or(true),
+        source: range.source.unwrap_or(Provider),
+      })
+    }
+  }
+  let new_ranges = FoldingRegions::sanitize_and_merge(
+    Regions(self.regions),
+    Ranges(ranges_to_restore),
+    Some(max_line_number),
+  )
+  self.update_post(FoldingRegions::from_fold_ranges(new_ranges))
+}
+
+///|
+/// `_getLinesChecksum` (`foldingModel.ts:241-245`) with the pinned
+/// `base/common/hash.ts` string hash: seed `149417`, then multiply by 31 and
+/// add each UTF-16 code unit. Six decimal digits are sufficient for rejecting
+/// stale persisted ranges.
+fn FoldingModel::get_lines_checksum(
+  self : FoldingModel,
+  line_number_1 : Int,
+  line_number_2 : Int,
+) -> Int {
+  let text = self.text_model.get_line_content(line_number_1) +
+    self.text_model.get_line_content(line_number_2)
+  let mut hash = 149417
+  for code_unit in text.code_units() {
+    hash = hash * 31 + code_unit.to_int()
+  }
+  hash % 1000000
 }
 
 ///|

--- a/editor/internal/viewer/contrib/folding/browser/folding_model_reference_wbtest.mbt
+++ b/editor/internal/viewer/contrib/folding/browser/folding_model_reference_wbtest.mbt
@@ -298,6 +298,53 @@ test "collapse" {
 }
 
 ///|
+/// Persistence port of `FoldingModel.getMemento`/`applyMemento` at the pinned
+/// VS Code revision. Expanded provider ranges are represented by absence;
+/// collapsed siblings are restored after a fresh folding model is computed.
+test "folding memento restores only collapsed provider ranges" {
+  let lines = [
+    "class A {", "  first();", "}", "class B {", "  second();", "}", "tail",
+  ]
+  let before = test_folding_model(lines)
+  set_collapse_state_at_level(before, 1, true, [])
+  guard before.get_region_at_line(1) is Some(first) else {
+    fail("expected first top-level region")
+  }
+  before.toggle_collapse_state([first])
+  assert_folded_ranges(before, [(4, 5)], "saved state")
+  guard before.get_memento() is Some(memento) else {
+    fail("expected collapsed range memento")
+  }
+
+  let after = test_folding_model(lines)
+  after.apply_memento(memento)
+  assert_model_ranges(after, [(1, 2, false), (4, 5, true)], "restored state")
+}
+
+///|
+/// The persisted checksum rejects a range whose body boundary changed instead
+/// of applying stale line coordinates to a different fold.
+test "folding memento rejects a stale range checksum" {
+  let before = test_folding_model([
+    "class A {", "  first();", "}", "class B {", "  second();", "}", "tail",
+  ])
+  set_collapse_state_at_level(before, 1, true, [])
+  guard before.get_memento() is Some(memento) else {
+    fail("expected collapsed range memento")
+  }
+
+  let after = test_folding_model([
+    "class A {", "  changed();", "}", "class B {", "  second();", "}", "tail",
+  ])
+  after.apply_memento(memento)
+  assert_model_ranges(
+    after,
+    [(1, 2, false), (4, 5, true)],
+    "only checksum-compatible range restored",
+  )
+}
+
+///|
 test "getRegionsInside" {
   let folding_model = test_folding_model([
     "/**", " * Comment", " */", "class A {", "  void foo() {", "    // comment {",

--- a/editor/internal/viewer/contrib/folding/browser/pkg.generated.mbti
+++ b/editor/internal/viewer/contrib/folding/browser/pkg.generated.mbti
@@ -42,10 +42,13 @@ pub(all) struct FoldingController {
   mut folding_decoration_provider : FoldingDecorationProvider?
   mut range_provider : IndentRangeProvider?
   mut mouse_down_info : FoldingMouseDownInfo?
+  mut restoring_view_state : Bool
   local_to_dispose : Array[@common.Disposable]
 }
 pub fn FoldingController::FoldingController() -> Self
 pub fn FoldingController::clear_local(Self) -> Unit
+pub fn FoldingController::restore_view_state(Self, FoldingStateMemento) -> Unit
+pub fn FoldingController::save_view_state(Self) -> FoldingStateMemento?
 
 type FoldingDecorationAccess
 
@@ -86,6 +89,8 @@ pub fn FoldingRegions::from_fold_ranges(Array[FoldRange]) -> Self
 pub fn FoldingRegions::get_type(Self, Int) -> String?
 pub fn FoldingRegions::length(Self) -> Int
 pub fn FoldingRegions::to_fold_range(Self, Int) -> FoldRange
+
+type FoldingStateMemento derive(@debug.Debug)
 
 type HiddenRangeModel
 pub fn HiddenRangeModel::HiddenRangeModel(FoldingModel) -> Self

--- a/editor/tests/browser/smoke/viewer.spec.js
+++ b/editor/tests/browser/smoke/viewer.spec.js
@@ -9,6 +9,7 @@ import {
 } from '../support/app.js';
 
 const mainFixture = 'tests/fixtures/workspace/src/main.mbt';
+const eventsFixture = 'tests/fixtures/workspace/src/events.mbt';
 
 async function waitForSourceText(page, needle) {
   await expect
@@ -577,6 +578,7 @@ test('updates and recovers watched fixture files from disk changes', async ({ pa
     await page.goto('/');
     await openMainFixture(page);
     await expect(page.locator('.editor-shell')).toHaveAttribute('data-status', 'ready');
+    await unfoldMainBody(page);
 
     await fs.writeFile(
       mainFixture,
@@ -584,7 +586,9 @@ test('updates and recovers watched fixture files from disk changes', async ({ pa
       'utf8',
     );
     await waitForSourceText(page, 'println("synced from disk")');
-    await unfoldMainBody(page);
+    await expect(
+      page.locator('.margin-view-overlays .cldr.codicon-folding-collapsed'),
+    ).toHaveCount(0);
     await expect(page.locator('.mtk5')).toContainText('"synced from disk"', {
       timeout: 7_000,
     });
@@ -610,6 +614,34 @@ test('updates and recovers watched fixture files from disk changes', async ({ pa
     });
   } finally {
     await fs.writeFile(mainFixture, original, 'utf8');
+  }
+});
+
+test('preserves mixed folding state across watched disk changes', async ({ page }) => {
+  const original = await fs.readFile(eventsFixture, 'utf8');
+
+  try {
+    await page.goto('/');
+    await openWorkspaceFile(page, 'src/events.mbt');
+
+    const editor = page.locator('.monaco-editor.readonly-editor');
+    const collapsed = page.locator(
+      '.margin-view-overlays .cldr.codicon-folding-collapsed',
+    );
+    await expect(collapsed).toHaveCount(2);
+    await collapsed.first().click({ force: true });
+    await expect(editor).toContainText('message : String');
+    await expect(editor).not.toContainText('readonly fixture ready');
+    await expect(collapsed).toHaveCount(1);
+
+    await fs.writeFile(eventsFixture, `${original}\n// watched refresh\n`, 'utf8');
+    await waitForSourceText(page, '// watched refresh');
+
+    await expect(editor).toContainText('message : String');
+    await expect(editor).not.toContainText('readonly fixture ready');
+    await expect(collapsed).toHaveCount(1);
+  } finally {
+    await fs.writeFile(eventsFixture, original, 'utf8');
   }
 });
 


### PR DESCRIPTION
## Summary

- port VS Code's folding memento behavior, including range checksums, into the readonly Viewer
- include folding contribution state in editor view-state save and restore
- refresh the same code resource through `set_value` while preserving view state, and avoid reapplying initial top-level folding over restored state
- add unit and browser regressions for expanded and mixed folding states across watched disk changes

## Validation

Revalidated with `moon 0.1.20260827` and `moonc v0.10.11+6ff76a5f9`.

- `moon check --target native --deny-warn`
- `moon check --target js --deny-warn`
- `moon fmt --check`
- `git diff --check`
- `just test` — 3339 native, 3305 JS, and 28 cram tests passed
- `just build`
- `just editor-test` — 1080 wasm, 1867 JS, and 1215 native tests passed
- `just editor-test-browser` — 108 tests passed
- `moon -C desktop run --target native package/macos -- --release --target app --no-open`
- `codesign --verify --deep --strict desktop/dist/SeekMoon.app`
- packaged SeekMoon.app manual QA: expanded one default-folded block, kept a sibling folded, changed the file on disk, and confirmed both choices survived refresh
- PR CI: stable and nightly Editor jobs on macOS and Ubuntu, native and JS checks, browser correctness, and GitGuardian all pass
