### PR TITLE
fix(inspect): set reuse_addr to be true

### DIFF
--- a/inspect/main.mbt
+++ b/inspect/main.mbt
@@ -153,7 +153,7 @@ async fn main {
   }
   println("openseek viz: shell from '\{shell[0]}'")
   print_open_urls(config.host, config.port)
-  let server = @http.Server(addr)
+  let server = @http.Server(addr, reuse_addr=true)
   server.run_forever((request, _body, conn) => {
     handle(request, conn, catalog, shell, bundle_paths)
   })


### PR DESCRIPTION
So that when we accidentally kill the inspect server we can instantly jump back to it without waiting for the TCP timeout.