### PR TITLE
style(desktop): unify native scrollbars

### DIFF
--- a/desktop/styles/base.css
+++ b/desktop/styles/base.css
@@ -179,30 +179,33 @@ samp,
   background: var(--color-text-selection);
 }
 
-/* quiet scrollbars */
+/* Shared native scrollbar geometry and visible-thumb inset. */
+html {
+  scrollbar-color: var(--color-scrollbar-thumb) transparent;
+}
+
 ::-webkit-scrollbar {
-  width: 9px;
-  height: 9px;
+  width: var(--scrollbar-size);
+  height: var(--scrollbar-size);
 }
 ::-webkit-scrollbar-thumb {
-  background: color-mix(
-    in srgb,
-    var(--color-text-primary) 14%,
-    transparent
-  );
+  background: var(--color-scrollbar-thumb);
   border-radius: var(--radius-pill);
-  border: 2px solid transparent;
+  border: 1px solid transparent;
   background-clip: padding-box;
 }
 ::-webkit-scrollbar-thumb:hover {
-  background: color-mix(
-    in srgb,
-    var(--color-text-primary) 26%,
-    transparent
-  );
+  background: var(--color-scrollbar-thumb-hover);
+  background-clip: padding-box;
+}
+::-webkit-scrollbar-thumb:active {
+  background: var(--color-scrollbar-thumb-active);
   background-clip: padding-box;
 }
 ::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-corner {
   background: transparent;
 }
 

--- a/desktop/styles/file_panel.css
+++ b/desktop/styles/file_panel.css
@@ -947,6 +947,7 @@ html.is-resizing * {
   flex: 1 1 auto;
   min-height: 0;
   overflow: auto;
+  scrollbar-gutter: stable;
   padding: 4px 0 8px;
 }
 

--- a/desktop/styles/sidebar.css
+++ b/desktop/styles/sidebar.css
@@ -45,10 +45,9 @@ aside {
   min-height: 0;
   overflow-y: auto;
   overflow-x: hidden;
-  /* The scroll box spans to the sidebar's edge; the right inset is the
-     reserved scrollbar gutter (9px) plus 3px of clearance — 12px in
-     total, matching the other sections whether or not the bar shows. */
-  padding-right: 3px;
+  /* The scroll box spans to the sidebar's edge. Its stable 12px gutter matches
+     the sections' left inset whether or not the bar shows. */
+  padding-right: 0;
   scrollbar-gutter: stable;
 }
 
@@ -57,8 +56,8 @@ aside {
   gap: 4px;
   min-width: 0;
   /* The outer scroll lane already reserves the 12px right inset through its
-     stable scrollbar gutter and clearance. Keep only the matching left inset
-     here so nested sections do not double the empty space on the right. */
+     stable scrollbar gutter. Keep only the matching left inset here so nested
+     sections do not double the empty space on the right. */
   padding: 0 0 0 12px;
 }
 

--- a/desktop/styles/tokens.css
+++ b/desktop/styles/tokens.css
@@ -91,6 +91,25 @@
     transparent
   );
 
+  /* Native overflow panes use a 12px hit lane; a 1px inset leaves a 10px
+     visible thumb. */
+  --scrollbar-size: 12px;
+  --color-scrollbar-thumb: color-mix(
+    in srgb,
+    var(--color-text-primary) 32%,
+    transparent
+  );
+  --color-scrollbar-thumb-hover: color-mix(
+    in srgb,
+    var(--color-text-primary) 48%,
+    transparent
+  );
+  --color-scrollbar-thumb-active: color-mix(
+    in srgb,
+    var(--color-text-primary) 64%,
+    transparent
+  );
+
   /* Shape and elevation */
   --radius-xs: 4px;
   --radius-sm: 6px;

--- a/desktop/styles/transcript.css
+++ b/desktop/styles/transcript.css
@@ -3,6 +3,9 @@
 .transcript {
   min-height: 0;
   overflow: auto;
+  /* Reserve both edges so the centered stream does not shift when overflow
+     appears and the native scrollbar claims its lane. */
+  scrollbar-gutter: stable both-edges;
   padding: 24px 24px 22px;
   background: transparent;
   /* The overview rail's container: its cq units measure this scroller's


### PR DESCRIPTION
## Summary

- standardize native overflow scrollbars on a 12px lane with clearer default, hover, and active thumbs
- reserve stable scrollbar gutters for the sidebar, file tree, and centered transcript
- keep the embedded Viewer scrollbar behavior unchanged

## Testing

- just check
- just test
- just build
- just editor-test
- just editor-test-browser