### PR TITLE
docs(prompt): add automatic CI monitor example

### DIFF
--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -518,6 +518,48 @@ stderr warning while exit stays 0 — treat skipped blocks as a blind spot.
     pending, or newly appeared as unfinished work rather than a green PR.
     Then keep working or finish the turn; a completion notice arrives.
     Never call a PR done while a check is pending or unreported.
+    This bounded monitor discovers the current branch's PR, watches registered
+    checks, then gives late workflows one settle interval to appear:
+
+    ```mbtx
+    import {
+      "moonbitlang/async",
+      "moonbitlang/async/shell",
+    }
+
+    async fn main {
+      @shell.Cmd("gh", ["pr", "view", "--json", "number"]).output().check()
+      for pass in 0..<12; previous = None {
+        ignore(
+          @shell.Cmd("gh", ["pr", "checks", "--watch"]).output(),
+        )
+        let snapshot = @shell.Cmd("gh", ["pr", "checks"]).output()
+        let stdout = snapshot.stdout()
+        let count = [..stdout.split("\n")]
+          .filter(line => !line.is_blank())
+          .length()
+        println("CI monitor pass \{pass + 1}: \{count} check(s)")
+        let stable = count > 0 && previous == Some(count)
+        if stable || pass == 11 {
+          let output = [stdout, snapshot.stderr()]
+            .filter(text => !text.is_blank())
+            .join("\n")
+          if !stable {
+            println("CI monitor reached its 12-pass bound; inspect the output below.")
+          }
+          println <| (
+            $|\{output}
+            $|gh pr checks exit=\{snapshot.exit_code()}
+          )
+          return
+        }
+        @async.sleep(10_000)
+        continue Some(count)
+      }
+    }
+    ```
+
+    The single `mbtx` call hands itself off after five seconds; do not poll it.
   - Treat a red check exactly like a failing local test, with MORE
     authority: local checks passing is not the last word (a repository can
     gate on things your local loop never ran). Read the FAILING run's log,

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -523,6 +523,48 @@ fn default_prompt() -> String {
     #|    pending, or newly appeared as unfinished work rather than a green PR.
     #|    Then keep working or finish the turn; a completion notice arrives.
     #|    Never call a PR done while a check is pending or unreported.
+    #|    This bounded monitor discovers the current branch's PR, watches registered
+    #|    checks, then gives late workflows one settle interval to appear:
+    #|
+    #|    ```mbtx
+    #|    import {
+    #|      "moonbitlang/async",
+    #|      "moonbitlang/async/shell",
+    #|    }
+    #|
+    #|    async fn main {
+    #|      @shell.Cmd("gh", ["pr", "view", "--json", "number"]).output().check()
+    #|      for pass in 0..<12; previous = None {
+    #|        ignore(
+    #|          @shell.Cmd("gh", ["pr", "checks", "--watch"]).output(),
+    #|        )
+    #|        let snapshot = @shell.Cmd("gh", ["pr", "checks"]).output()
+    #|        let stdout = snapshot.stdout()
+    #|        let count = [..stdout.split("\n")]
+    #|          .filter(line => !line.is_blank())
+    #|          .length()
+    #|        println("CI monitor pass \{pass + 1}: \{count} check(s)")
+    #|        let stable = count > 0 && previous == Some(count)
+    #|        if stable || pass == 11 {
+    #|          let output = [stdout, snapshot.stderr()]
+    #|            .filter(text => !text.is_blank())
+    #|            .join("\n")
+    #|          if !stable {
+    #|            println("CI monitor reached its 12-pass bound; inspect the output below.")
+    #|          }
+    #|          println <| (
+    #|            $|\{output}
+    #|            $|gh pr checks exit=\{snapshot.exit_code()}
+    #|          )
+    #|          return
+    #|        }
+    #|        @async.sleep(10_000)
+    #|        continue Some(count)
+    #|      }
+    #|    }
+    #|    ```
+    #|
+    #|    The single `mbtx` call hands itself off after five seconds; do not poll it.
     #|  - Treat a red check exactly like a failing local test, with MORE
     #|    authority: local checks passing is not the last word (a repository can
     #|    gate on things your local loop never ran). Read the FAILING run's log,


### PR DESCRIPTION
## Summary

- add a compact system-prompt example for monitoring the current branch pull request with gh
- handle late check registration with one bounded loop and an optional previous count
- rely on automatic mbtx background handoff for the long-running monitor
- keep the generated default prompt synchronized

## Verification

- ran the exact simplified mbtx example against PR #1159 for two passes; all 4 checks stayed stable and gh pr checks exited 0
- moon check --target native --deny-warn prompt
- moon test prompt (20 passed)
- moon info && moon fmt

This PR is intentionally limited to the prompt example so it can be reviewed independently from the mbtx resource cleanup merged in #1158.