### PR TITLE
refactor: shrink internal package public surfaces (zero-usage export sweep)

### DIFF
--- a/agent_explore/pkg.generated.mbti
+++ b/agent_explore/pkg.generated.mbti
@@ -20,11 +20,7 @@ pub async fn run_child(Json, api_key~ : String, model~ : @deepseek.Model, max_st
 // Errors
 
 // Types and methods
-pub struct Citation {
-  file : String
-  line : Int?
-  note : String?
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+type Citation derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn Citation::equal(Self, Self) -> Bool
 pub fn Citation::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn Citation::not_equal(Self, Self) -> Bool
@@ -32,10 +28,9 @@ pub fn Citation::to_json(Self) -> Json
 pub fn Citation::to_repr(Self) -> @debug.Repr
 
 pub struct ExploreReport {
-  schema_version : Int
   answer : String
   citations : Array[Citation]
-  unresolved : String?
+  // private fields
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn ExploreReport::equal(Self, Self) -> Bool
 pub fn ExploreReport::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError

--- a/agent_explore/types.mbt
+++ b/agent_explore/types.mbt
@@ -32,7 +32,7 @@ let max_unresolved_chars : Int = 1_000
 ///|
 /// One supporting reference: a workspace `file:line`, or the source/`.mbti`
 /// path `moon ide doc` reported for a stdlib or dependency claim.
-pub struct Citation {
+struct Citation {
   file : String
   line : Int?
   note : String?
@@ -42,10 +42,10 @@ pub struct Citation {
 /// The child's full answer. `unresolved` names what it could NOT determine —
 /// stated ignorance beats a fabricated claim.
 pub struct ExploreReport {
-  schema_version : Int
+  priv schema_version : Int
   answer : String
   citations : Array[Citation]
-  unresolved : String?
+  priv unresolved : String?
 } derive(Debug, Eq, ToJson, FromJson)
 
 ///|

--- a/agent_review/pkg.generated.mbti
+++ b/agent_review/pkg.generated.mbti
@@ -26,13 +26,8 @@ pub suberror ReviewError {
 
 // Types and methods
 pub struct Finding {
-  file : String
-  line : Int?
   severity : String
-  category : String
-  title : String
-  detail : String
-  suggestion : String?
+  // private fields
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn Finding::equal(Self, Self) -> Bool
 pub fn Finding::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
@@ -41,11 +36,8 @@ pub fn Finding::to_json(Self) -> Json
 pub fn Finding::to_repr(Self) -> @debug.Repr
 
 pub struct ReviewReport {
-  schema_version : Int
-  scope : ReviewScope
   findings : Array[Finding]
-  summary : String
-  stats : ReviewStats
+  // private fields
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn ReviewReport::digest(Self) -> String
 pub fn ReviewReport::equal(Self, Self) -> Bool
@@ -57,23 +49,14 @@ pub fn ReviewReport::to_json_string(Self) -> String
 pub fn ReviewReport::to_repr(Self) -> @debug.Repr
 pub fn ReviewReport::validate(Self) -> Array[String]
 
-pub struct ReviewScope {
-  base : String
-  head : String
-  files : Array[String]
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+type ReviewScope derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn ReviewScope::equal(Self, Self) -> Bool
 pub fn ReviewScope::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn ReviewScope::not_equal(Self, Self) -> Bool
 pub fn ReviewScope::to_json(Self) -> Json
 pub fn ReviewScope::to_repr(Self) -> @debug.Repr
 
-pub struct ReviewStats {
-  files_reviewed : Int
-  findings : Int
-  build : String
-  tests : String
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+type ReviewStats derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn ReviewStats::equal(Self, Self) -> Bool
 pub fn ReviewStats::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn ReviewStats::not_equal(Self, Self) -> Bool

--- a/agent_review/types.mbt
+++ b/agent_review/types.mbt
@@ -7,18 +7,18 @@
 ///|
 /// A single review finding at an optional source location.
 pub struct Finding {
-  file : String
-  line : Int?
+  priv file : String
+  priv line : Int?
   severity : String
-  category : String
-  title : String
-  detail : String
-  suggestion : String?
+  priv category : String
+  priv title : String
+  priv detail : String
+  priv suggestion : String?
 } derive(Debug, Eq, ToJson, FromJson)
 
 ///|
 /// The change set the review covered.
-pub struct ReviewScope {
+struct ReviewScope {
   base : String
   head : String
   files : Array[String]
@@ -27,7 +27,7 @@ pub struct ReviewScope {
 ///|
 /// Deterministic preflight signals that ground the review in the compiler/tests
 /// rather than model opinion.
-pub struct ReviewStats {
+struct ReviewStats {
   files_reviewed : Int
   findings : Int
   build : String
@@ -37,11 +37,11 @@ pub struct ReviewStats {
 ///|
 /// The full review report.
 pub struct ReviewReport {
-  schema_version : Int
-  scope : ReviewScope
+  priv schema_version : Int
+  priv scope : ReviewScope
   findings : Array[Finding]
-  summary : String
-  stats : ReviewStats
+  priv summary : String
+  priv stats : ReviewStats
 } derive(Debug, Eq, ToJson, FromJson)
 
 ///|

--- a/agent_subrun/budget.mbt
+++ b/agent_subrun/budget.mbt
@@ -27,7 +27,7 @@ let min_useful_subrun_steps : Int = 8
 /// The owner is the CLI layer: it creates one budget per session, passes
 /// it to every subrun tool definition, and calls `reset_turn` at each turn
 /// start. Enforcement is reserve-BEFORE-launch.
-pub struct SubrunBudget {
+struct SubrunBudget {
   max_calls_per_turn : Int
   mut used_calls : Int
 }

--- a/agent_subrun/pkg.generated.mbti
+++ b/agent_subrun/pkg.generated.mbti
@@ -25,28 +25,17 @@ pub fn[T] validated(Result[T, String], (T) -> Array[String]) -> Result[T, Array[
 
 // Types and methods
 pub struct ChildSession {
-  root : String
   parent : String
-  first_free : Int
+  // private fields
 }
 pub fn ChildSession::ChildSession(root~ : String, parent~ : String, first_free? : Int) -> Self
 
-pub struct SubrunBudget {
-  max_calls_per_turn : Int
-  mut used_calls : Int
-}
+type SubrunBudget
 pub fn SubrunBudget::SubrunBudget(max_calls_per_turn? : Int) -> Self
 pub fn SubrunBudget::reserve(Self, Int) -> Int?
 pub fn SubrunBudget::reset_turn(Self) -> Unit
 
-pub struct SubrunResult[T] {
-  value : T?
-  terminal : SubrunTerminal
-  steps_used : Int
-  prompt_tokens : Int
-  completion_tokens : Int
-  subrun_id : String
-} derive(@debug.Debug)
+type SubrunResult[T] derive(@debug.Debug)
 pub fn[T] SubrunResult::completion_tokens(Self[T]) -> Int
 pub fn[T] SubrunResult::prompt_tokens(Self[T]) -> Int
 pub fn[T] SubrunResult::steps_used(Self[T]) -> Int

--- a/agent_subrun/runner.mbt
+++ b/agent_subrun/runner.mbt
@@ -33,7 +33,7 @@ pub enum SubrunTerminal {
 /// cost the child actually spent — observed from the child's own event
 /// stream (`usage` summed, `agent_step` maxed), so it is exact for the
 /// requests the child made.
-pub struct SubrunResult[T] {
+struct SubrunResult[T] {
   value : T?
   terminal : SubrunTerminal
   steps_used : Int
@@ -363,9 +363,9 @@ pub async fn[T] run_subrun(
 /// session would reuse `sr-1` — and the fresh child session would die on
 /// its first append against the old child's file (stale-snapshot check).
 pub struct ChildSession {
-  root : String
+  priv root : String
   parent : String
-  first_free : Int
+  priv first_free : Int
 }
 
 ///|

--- a/agent_tool/agent_tool.mbt
+++ b/agent_tool/agent_tool.mbt
@@ -66,7 +66,7 @@ pub struct AgentToolDefinition {
   /// serializing. Like `control`, this is a BUILT-IN-ONLY privilege:
   /// never set it on a definition built from dynamic input (MCP listings,
   /// config-supplied tools).
-  concurrent_safe : Bool
+  priv concurrent_safe : Bool
 } derive(Debug(ignore=ToolExecutor))
 
 ///|

--- a/agent_tool/bgjobs/bgjobs.mbt
+++ b/agent_tool/bgjobs/bgjobs.mbt
@@ -92,7 +92,6 @@ pub struct BgJobRuntime {
 priv struct BgJob {
   id : String
   command : String
-  cwd : String?
   exec : @shell_exec.ShellExecution
   // The opaque prepared command is carried from launch so a reader can apply
   // the same source-write-denial detection the foreground path does.
@@ -123,19 +122,17 @@ priv struct BgJob {
 pub struct BgJobSnapshot {
   id : String
   command : String
-  cwd : String?
   status : BgJobStatus
-  output : String
+  priv output : String
   output_truncated : Bool
-  over_inline_cap : Bool
+  priv over_inline_cap : Bool
   size : Int
-  seq : Int
-  exit_code : Int?
+  priv exit_code : Int?
   // Preserved so a reader can match the foreground path's error semantics: mark
   // binary output as an error, and detect a sandboxed source-write denial.
   had_invalid_utf8 : Bool
   sandboxed_command : @sandbox.SandboxedCommand?
-  read_only_review : Bool
+  priv read_only_review : Bool
   output_rewrites : Array[(String, String)]
   moonrun_policy_active : Bool
   // The job was killed by the output-limit watchdog (flooded past the hard cap),
@@ -273,7 +270,6 @@ pub async fn BgJobRuntime::start(
     id,
     exec,
     command~,
-    cwd?,
     sandboxed_command?,
     read_only_review~,
     output_rewrites~,
@@ -292,7 +288,6 @@ pub fn BgJobRuntime::adopt(
   self : BgJobRuntime,
   exec : @shell_exec.ShellExecution,
   command~ : String,
-  cwd? : String,
   sandboxed_command? : @sandbox.SandboxedCommand,
   read_only_review? : Bool = false,
   output_rewrites? : Array[(String, String)] = [],
@@ -304,7 +299,6 @@ pub fn BgJobRuntime::adopt(
     id,
     exec,
     command~,
-    cwd?,
     sandboxed_command?,
     read_only_review~,
     output_rewrites~,
@@ -321,7 +315,6 @@ fn BgJobRuntime::register(
   id : String,
   exec : @shell_exec.ShellExecution,
   command~ : String,
-  cwd? : String,
   sandboxed_command? : @sandbox.SandboxedCommand,
   read_only_review~ : Bool,
   output_rewrites~ : Array[(String, String)],
@@ -331,7 +324,6 @@ fn BgJobRuntime::register(
   self.jobs[id] = {
     id,
     command,
-    cwd,
     exec,
     sandboxed_command,
     read_only_review,
@@ -396,13 +388,11 @@ fn BgJob::to_snapshot(self : BgJob) -> BgJobSnapshot {
   {
     id: self.id,
     command: self.command,
-    cwd: self.cwd,
     status: bg_status(self.exec.status()),
     output: self.exec.head(),
     output_truncated: self.exec.output_truncated(),
     over_inline_cap: self.exec.over_inline_cap(),
     size: self.exec.size(),
-    seq: self.exec.seq(),
     exit_code: self.exec.exit_code(),
     had_invalid_utf8: self.exec.had_invalid_utf8(),
     sandboxed_command: self.sandboxed_command,

--- a/agent_tool/bgjobs/pkg.generated.mbti
+++ b/agent_tool/bgjobs/pkg.generated.mbti
@@ -17,7 +17,7 @@ pub struct BgJobRuntime {
   // private fields
 }
 pub fn[X] BgJobRuntime::BgJobRuntime(@agent_runtime.AgentTaskScope[X], spill_dir? : String, hard_output_cap? : Int, hard_timeout_ms? : Int, on_job_exit? : (BgJobSnapshot) -> Unit) -> Self
-pub fn BgJobRuntime::adopt(Self, @shell_exec.ShellExecution, command~ : String, cwd? : String, sandboxed_command? : @sandbox.SandboxedCommand, read_only_review? : Bool, output_rewrites? : Array[(String, String)], moonrun_policy_active? : Bool, on_terminal? : async () -> Unit) -> String
+pub fn BgJobRuntime::adopt(Self, @shell_exec.ShellExecution, command~ : String, sandboxed_command? : @sandbox.SandboxedCommand, read_only_review? : Bool, output_rewrites? : Array[(String, String)], moonrun_policy_active? : Bool, on_terminal? : async () -> Unit) -> String
 pub fn BgJobRuntime::list(Self) -> Array[BgJobSnapshot]
 pub async fn BgJobRuntime::read_output(Self, String) -> String?
 pub async fn BgJobRuntime::read_output_tail(Self, String, Int) -> String?
@@ -31,21 +31,16 @@ pub async fn BgJobRuntime::wait_exit(Self, String, Int) -> Bool
 pub struct BgJobSnapshot {
   id : String
   command : String
-  cwd : String?
   status : BgJobStatus
-  output : String
   output_truncated : Bool
-  over_inline_cap : Bool
   size : Int
-  seq : Int
-  exit_code : Int?
   had_invalid_utf8 : Bool
   sandboxed_command : @sandbox.SandboxedCommand?
-  read_only_review : Bool
   output_rewrites : Array[(String, String)]
   moonrun_policy_active : Bool
   killed_by_output_limit : Bool
   killed_by_time_limit : Bool
+  // private fields
 }
 
 pub enum BgJobStatus {

--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -627,7 +627,6 @@ async fn execute(
         } else {
           "mbtx: \{@agent_tool.brief_line(input.source, limit=64)}"
         },
-        cwd?=run_cwd,
         sandboxed_command?,
         output_rewrites=temp_path_rewrites([real, build_dir]),
         moonrun_policy_active=policy_active,

--- a/agent_tool/pkg.generated.mbti
+++ b/agent_tool/pkg.generated.mbti
@@ -38,7 +38,7 @@ pub struct AgentToolDefinition {
   schema : JsonSchema
   execute : ToolExecutor
   control : Bool
-  concurrent_safe : Bool
+  // private fields
 } derive(@debug.Debug)
 pub fn AgentToolDefinition::AgentToolDefinition(name~ : String, description~ : String, schema~ : JsonSchema, execute~ : ToolExecutor, control? : Bool, concurrent_safe? : Bool) -> Self
 pub fn AgentToolDefinition::is_concurrent_safe(Self) -> Bool

--- a/agent_tool/shell/internal/shell_parse/pkg.generated.mbti
+++ b/agent_tool/shell/internal/shell_parse/pkg.generated.mbti
@@ -43,7 +43,7 @@ pub struct SimpleCommand {
   env : Array[EnvAssignment]
   redirects : Array[Redirect]
   separator_before : String?
-  source : String
+  // private fields
 } derive(Eq, @debug.Debug)
 pub fn SimpleCommand::command_index(Self) -> Int?
 pub fn SimpleCommand::command_name(Self) -> String?

--- a/agent_tool/shell/internal/shell_parse/types.mbt
+++ b/agent_tool/shell/internal/shell_parse/types.mbt
@@ -26,7 +26,7 @@ pub struct SimpleCommand {
   env : Array[EnvAssignment]
   redirects : Array[Redirect]
   separator_before : String?
-  source : String
+  priv source : String
 } derive(Debug, Eq)
 
 ///|

--- a/agent_tool/shell/pkg.generated.mbti
+++ b/agent_tool/shell/pkg.generated.mbti
@@ -4,17 +4,12 @@ package "bobzhang/openseek/agent_tool/shell"
 import {
   "bobzhang/openseek/agent_tool",
   "bobzhang/openseek/agent_tool/bgjobs",
-  "bobzhang/openseek/agent_tool/internal/sandbox",
 }
 
 // Values
 pub async fn collect_shell_output(String, cwd? : String, max_output_chars? : Int) -> ShellOutput
 
-pub fn contextual_source_write_denial_feedback(@sandbox.SandboxedCommand, String, read_only_review? : Bool) -> String
-
 pub fn definition(workspace_root? : String, read_only? : Bool, bg_runtime? : @bgjobs.BgJobRuntime, default_timeout_ms? : Int, scratch_dir? : String, worker_sandbox? : WorkerSandbox) -> @agent_tool.AgentToolDefinition
-
-pub fn source_write_denial_feedback() -> String
 
 // Errors
 

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -5479,24 +5479,3 @@ fn agent_output_has_shell_sandbox_denial(
   agent_output.sandboxed_command is Some(command) &&
   command.output_reports_denial(agent_output.output.text)
 }
-
-///|
-/// The generic guidance appended for a sandboxed source-write denial.
-pub fn source_write_denial_feedback() -> String {
-  SandboxSourceWriteFeedback
-}
-
-///|
-/// Contextual guidance exposed so `shell_output` gives background jobs the same
-/// recovery advice as foreground commands.
-pub fn contextual_source_write_denial_feedback(
-  command : @sandbox.SandboxedCommand,
-  output : String,
-  read_only_review? : Bool = false,
-) -> String {
-  shell_sandbox_denial_feedback(
-    command.allows_standalone_trusted_writer(),
-    read_only_review,
-    output,
-  )
-}

--- a/agent_tool/shell/shell.mbt
+++ b/agent_tool/shell/shell.mbt
@@ -380,7 +380,6 @@ async fn shell(
         runtime.adopt(
           exec,
           command=input.cmd,
-          cwd?,
           sandboxed_command?=launch.sandboxed_command,
           read_only_review=read_only,
         )

--- a/agent_tool/write_scope/pkg.generated.mbti
+++ b/agent_tool/write_scope/pkg.generated.mbti
@@ -6,11 +6,7 @@ package "bobzhang/openseek/agent_tool/write_scope"
 // Errors
 
 // Types and methods
-pub struct WriteScope {
-  root : String
-  allowed : Array[Array[String]]
-  allowed_display : String
-}
+type WriteScope
 pub async fn WriteScope::create(root~ : String, allowed_paths? : Array[String]) -> Result[Self, String]
 pub async fn WriteScope::deny_reason(Self, String) -> String?
 pub fn WriteScope::root(Self) -> String

--- a/agent_tool/write_scope/write_scope.mbt
+++ b/agent_tool/write_scope/write_scope.mbt
@@ -16,7 +16,7 @@
 /// Creating parent directories for an admitted target needs no separate gate:
 /// ancestors of an allowed path are implied, and a symlinked ancestor is
 /// already caught by the resolved-location check on the target itself.
-pub struct WriteScope {
+struct WriteScope {
   /// Canonical (realpath'd) absolute root every write must stay under.
   root : String
   /// Component-wise relative prefixes; empty means root-only confinement.

--- a/agent_worker/pkg.generated.mbti
+++ b/agent_worker/pkg.generated.mbti
@@ -19,13 +19,8 @@ pub async fn run_child(Json, api_key~ : String, model~ : @deepseek.Model, max_st
 
 // Types and methods
 pub struct WorkerInput {
-  task : String
-  context : String?
-  worker_root : String
-  worker_admin_dir : String
-  deny_roots : Array[String]
   allowed_paths : Array[String]
-  base_oid : String
+  // private fields
 } derive(Eq, @debug.Debug)
 pub fn WorkerInput::equal(Self, Self) -> Bool
 pub fn WorkerInput::not_equal(Self, Self) -> Bool
@@ -33,10 +28,10 @@ pub fn WorkerInput::parse(Json) -> Result[Self, String]
 pub fn WorkerInput::to_repr(Self) -> @debug.Repr
 
 pub struct WorkerReport {
-  schema_version : Int
   status : String
   summary : String
   verification : String
+  // private fields
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn WorkerReport::equal(Self, Self) -> Bool
 pub fn WorkerReport::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError

--- a/agent_worker/tool.mbt
+++ b/agent_worker/tool.mbt
@@ -26,13 +26,13 @@ pub let default_worker_deadline_ms : Int = 2_700_000
 /// canonical (the controller realpaths at provision time) — the child does
 /// not re-derive geometry, it enforces with what it was handed.
 pub struct WorkerInput {
-  task : String
-  context : String?
-  worker_root : String
-  worker_admin_dir : String
-  deny_roots : Array[String]
+  priv task : String
+  priv context : String?
+  priv worker_root : String
+  priv worker_admin_dir : String
+  priv deny_roots : Array[String]
   allowed_paths : Array[String]
-  base_oid : String
+  priv base_oid : String
 } derive(Debug, Eq)
 
 ///|

--- a/agent_worker/types.mbt
+++ b/agent_worker/types.mbt
@@ -24,7 +24,7 @@ let max_verification_chars : Int = 2_000
 /// names the commands the worker ran and their outcomes — a claim without
 /// verification is a guess.
 pub struct WorkerReport {
-  schema_version : Int
+  priv schema_version : Int
   status : String
   summary : String
   verification : String

--- a/cmd/openseek/internal/subtask/geometry.mbt
+++ b/cmd/openseek/internal/subtask/geometry.mbt
@@ -10,7 +10,7 @@ pub struct Geometry {
   /// Canonical common git dir (shared objects/refs/config).
   common_git_dir : String
   /// Every registered worktree root, canonicalized, origin included.
-  worktree_roots : Array[String]
+  priv worktree_roots : Array[String]
 }
 
 ///|

--- a/cmd/openseek/internal/subtask/gitrun.mbt
+++ b/cmd/openseek/internal/subtask/gitrun.mbt
@@ -7,7 +7,7 @@
 /// merely unusual parent environment might carry are simply not inherited.
 /// Only `PATH` (to find git) and `HOME` (commit identity, global config)
 /// pass through.
-pub struct GitOutcome {
+priv struct GitOutcome {
   exit_code : Int
   output : String
 }
@@ -17,7 +17,7 @@ pub struct GitOutcome {
 /// the child and reports exit -1 with a synthetic diagnostic — callers
 /// treat any nonzero exit as the phase failing and inspect postconditions
 /// rather than trusting the code alone.
-pub async fn git_run(
+async fn git_run(
   args : Array[String],
   cwd~ : String,
   timeout_ms? : Int = 30_000,

--- a/cmd/openseek/internal/subtask/pkg.generated.mbti
+++ b/cmd/openseek/internal/subtask/pkg.generated.mbti
@@ -13,10 +13,6 @@ pub async fn discard(Geometry, SubtaskEntry) -> Result[Unit, String]
 
 pub async fn git_require(Array[String], cwd~ : String, timeout_ms? : Int) -> Result[String, String]
 
-pub async fn git_run(Array[String], cwd~ : String, timeout_ms? : Int) -> GitOutcome
-
-pub fn gitlink_introductions_in_raw_z(String) -> Array[String]
-
 pub async fn integrate(Geometry, SubtaskEntry) -> IntegrateOutcome
 
 pub async fn integrate_abort(Geometry, SubtaskEntry) -> IntegrateOutcome
@@ -25,25 +21,11 @@ pub async fn integrate_continue(Geometry, SubtaskEntry) -> IntegrateOutcome
 
 pub async fn load_entries(String) -> (Array[SubtaskEntry], Array[String])
 
-pub fn parse_diff_name_status_z(String) -> Array[Change]
-
-pub fn parse_status_z(String) -> Array[Change]
-
-pub fn paths_overlap(Array[String], Array[String]) -> Bool
-
 pub async fn provision(String, name~ : String, allowed_paths~ : Array[String], nonce~ : String, parent_session? : String) -> Result[Provisioned, String]
-
-pub fn registry_dir(String) -> String
 
 pub async fn resolve_geometry(String) -> Result[Geometry, String]
 
 pub async fn resume_running(Geometry, String) -> Result[SubtaskEntry, String]
-
-pub async fn rollback_provision(Geometry, SubtaskEntry) -> Unit
-
-pub async fn save_entry(String, SubtaskEntry) -> Result[Unit, String]
-
-pub fn scope_violations(Array[Change], Array[String]) -> Array[String]
 
 // Errors
 
@@ -54,10 +36,7 @@ pub struct CaptureOutcome {
   defects : Array[String]
 }
 
-pub struct Change {
-  path : String
-  kind : String
-} derive(Eq, @debug.Debug)
+type Change derive(Eq, @debug.Debug)
 pub fn Change::equal(Self, Self) -> Bool
 pub fn Change::not_equal(Self, Self) -> Bool
 pub fn Change::to_repr(Self) -> @debug.Repr
@@ -65,14 +44,9 @@ pub fn Change::to_repr(Self) -> @debug.Repr
 pub struct Geometry {
   origin_root : String
   common_git_dir : String
-  worktree_roots : Array[String]
+  // private fields
 }
 pub fn Geometry::worker_deny_roots(Self) -> Array[String]
-
-pub struct GitOutcome {
-  exit_code : Int
-  output : String
-}
 
 pub struct IntegrateOutcome {
   entry : SubtaskEntry
@@ -86,19 +60,15 @@ pub struct Provisioned {
 }
 
 pub struct SubtaskEntry {
-  schema_version : Int
   name : String
-  nonce : String
   branch : String
   state : SubtaskState
   base_oid : String
   worker_root : String
   worker_admin_dir : String
   allowed_paths : Array[String]
-  parent_session : String?
   commit_oid : String?
-  origin_head_before : String?
-  conflict_paths : Array[String]
+  // private fields
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn SubtaskEntry::equal(Self, Self) -> Bool
 pub fn SubtaskEntry::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
@@ -106,7 +76,7 @@ pub fn SubtaskEntry::not_equal(Self, Self) -> Bool
 pub fn SubtaskEntry::to_json(Self) -> Json
 pub fn SubtaskEntry::to_repr(Self) -> @debug.Repr
 
-pub(all) enum SubtaskState {
+pub enum SubtaskState {
   Provisioning
   Running
   Captured

--- a/cmd/openseek/internal/subtask/provision.mbt
+++ b/cmd/openseek/internal/subtask/provision.mbt
@@ -192,10 +192,7 @@ async fn provision_locked(
 ///|
 /// Undo a partial provision: worktree directory, bookkeeping, branch, and
 /// registry entry, in that order, each best-effort.
-pub async fn rollback_provision(
-  geometry : Geometry,
-  entry : SubtaskEntry,
-) -> Unit {
+async fn rollback_provision(geometry : Geometry, entry : SubtaskEntry) -> Unit {
   @fs.rmdir(entry.worker_root, recursive=true) catch {
     error if @async.is_being_cancelled() => raise error
     _ => ()

--- a/cmd/openseek/internal/subtask/registry.mbt
+++ b/cmd/openseek/internal/subtask/registry.mbt
@@ -9,7 +9,7 @@
 /// Writes go through temp-file + rename: atomic against torn reads, NOT a
 /// cross-process lock — two engines driving one repository can still race
 /// silently (documented residual; the single-engine-per-repo assumption).
-pub(all) enum SubtaskState {
+pub enum SubtaskState {
   Provisioning
   Running
   Captured
@@ -29,19 +29,19 @@ pub fn SubtaskState::is_terminal(self : SubtaskState) -> Bool {
 ///|
 /// One subtask's durable lifecycle record; see the file comment.
 pub struct SubtaskEntry {
-  schema_version : Int
+  priv schema_version : Int
   name : String
-  nonce : String
+  priv nonce : String
   branch : String
   state : SubtaskState
   base_oid : String
   worker_root : String
   worker_admin_dir : String
   allowed_paths : Array[String]
-  parent_session : String?
+  priv parent_session : String?
   commit_oid : String?
-  origin_head_before : String?
-  conflict_paths : Array[String]
+  priv origin_head_before : String?
+  priv conflict_paths : Array[String]
 } derive(Debug, Eq, ToJson, FromJson)
 
 ///|
@@ -49,7 +49,7 @@ let registry_schema_version : Int = 1
 
 ///|
 /// Where entries live under the canonical common git dir.
-pub fn registry_dir(common_git_dir : String) -> String {
+fn registry_dir(common_git_dir : String) -> String {
   "\{common_git_dir}/openseek/subtasks"
 }
 
@@ -60,7 +60,7 @@ fn entry_path(common_git_dir : String, entry : SubtaskEntry) -> String {
 
 ///|
 /// Persist `entry` atomically (temp + rename in the registry directory).
-pub async fn save_entry(
+async fn save_entry(
   common_git_dir : String,
   entry : SubtaskEntry,
 ) -> Result[Unit, String] {
@@ -139,7 +139,7 @@ pub async fn load_entries(
 ///|
 /// Component-wise prefix overlap between two allowed-path sets: `src`
 /// overlaps `src/lexer` and `src`, never `src2`.
-pub fn paths_overlap(a : Array[String], b : Array[String]) -> Bool {
+fn paths_overlap(a : Array[String], b : Array[String]) -> Bool {
   fn components(prefix : String) -> Array[String] {
     prefix.split("/").map(part => part.to_owned()).collect()
   }

--- a/cmd/openseek/internal/subtask/scope.mbt
+++ b/cmd/openseek/internal/subtask/scope.mbt
@@ -8,14 +8,14 @@
 ///|
 /// One changed path with how it changed. Renames yield TWO records (source
 /// and target) — both sides must be in scope for the change to merge.
-pub struct Change {
+struct Change {
   path : String
   kind : String
 } derive(Debug, Eq)
 
 ///|
 /// Parse `git status --porcelain=v1 -z --untracked-files=all` output.
-pub fn parse_status_z(output : String) -> Array[Change] {
+fn parse_status_z(output : String) -> Array[Change] {
   let changes : Array[Change] = []
   let fields = output.split("\u{0}").map(f => f.to_owned()).collect()
   let mut index = 0
@@ -42,7 +42,7 @@ pub fn parse_status_z(output : String) -> Array[Change] {
 
 ///|
 /// Parse `git diff --name-status -z` output.
-pub fn parse_diff_name_status_z(output : String) -> Array[Change] {
+fn parse_diff_name_status_z(output : String) -> Array[Change] {
   let changes : Array[Change] = []
   let fields = output.split("\u{0}").map(f => f.to_owned()).collect()
   let mut index = 0
@@ -71,7 +71,7 @@ pub fn parse_diff_name_status_z(output : String) -> Array[Change] {
 ///|
 /// Every change must fall under one of the allowed component-wise prefixes.
 /// Returns the violating paths (empty = in scope).
-pub fn scope_violations(
+fn scope_violations(
   changes : Array[Change],
   allowed_paths : Array[String],
 ) -> Array[String] {
@@ -102,7 +102,7 @@ pub fn scope_violations(
 /// embedded repository swallowed as a pointer, whether added over nothing
 /// (`:000000 160000 ... A`) or replacing a regular file (`:100644 160000
 /// ... T`). Pre-existing gitlinks (source already 160000) pass.
-pub fn gitlink_introductions_in_raw_z(output : String) -> Array[String] {
+fn gitlink_introductions_in_raw_z(output : String) -> Array[String] {
   let links : Array[String] = []
   let fields = output.split("\u{0}").map(f => f.to_owned()).collect()
   let mut index = 0

--- a/eval/file_edit/harness/config.mbt
+++ b/eval/file_edit/harness/config.mbt
@@ -13,8 +13,8 @@ pub struct Config {
   concurrency : Int
   min_successes : Int
   max_steps : Int
-  out_dir : String
-  repo_root : String
+  priv out_dir : String
+  priv repo_root : String
   prompt_label : String
   system_prompt_file : String
   system_prompt_addendum_file : String

--- a/eval/file_edit/harness/harness.mbt
+++ b/eval/file_edit/harness/harness.mbt
@@ -6,7 +6,7 @@
 /// its work across shell, edit, write, …), and the case's two
 /// gates — the workspace matched the expected files (`validation_passed`)
 /// and the required marker text was produced (`marker_present`).
-pub struct TrialResult {
+priv struct TrialResult {
   index : Int
   case_id : String
   prompt_label : String
@@ -36,7 +36,7 @@ pub struct TrialResult {
 /// One file-edit eval run's outcome: the configuration that defined it, the
 /// success tally against `min_successes`, where artifacts were written, and
 /// every trial's result.
-pub struct EvalReport {
+struct EvalReport {
   model : String
   prompt_label : String
   runs : Int

--- a/eval/file_edit/harness/pkg.generated.mbti
+++ b/eval/file_edit/harness/pkg.generated.mbti
@@ -18,53 +18,17 @@ pub struct Config {
   concurrency : Int
   min_successes : Int
   max_steps : Int
-  out_dir : String
-  repo_root : String
   prompt_label : String
   system_prompt_file : String
   system_prompt_addendum_file : String
+  // private fields
 }
 pub fn Config::Config(api_key~ : String, model~ : @deepseek.Model, runs~ : Int, concurrency~ : Int, min_successes~ : Int, max_steps~ : Int, out_dir~ : String, repo_root~ : String, prompt_label~ : String, system_prompt_file~ : String, system_prompt_addendum_file~ : String) -> Self
 
-pub struct EvalReport {
-  model : String
-  prompt_label : String
-  runs : Int
-  concurrency : Int
-  min_successes : Int
-  successes : Int
-  out_dir : String
-  results : Array[TrialResult]
-}
+type EvalReport
 pub fn EvalReport::failure_message(Self) -> String
 pub fn EvalReport::markdown(Self) -> String
 pub fn EvalReport::passed(Self) -> Bool
-
-pub struct TrialResult {
-  index : Int
-  case_id : String
-  prompt_label : String
-  success : Bool
-  reason : String
-  workspace : String
-  log_path : String
-  exit_code : Int
-  steps : Int
-  tool_errors : Int
-  shell_uses : Int
-  moon_cmd_uses : Int
-  moon_run_e_mentions : Int
-  moon_run_c_mentions : Int
-  moon_check_uses : Int
-  moon_test_uses : Int
-  moon_info_uses : Int
-  moon_fmt_uses : Int
-  edit_successes : Int
-  write_successes : Int
-  validation_passed : Bool
-  marker_present : Bool
-  warnings : String
-}
 
 // Type aliases
 

--- a/eval/prompt_task/harness/analyzer.mbt
+++ b/eval/prompt_task/harness/analyzer.mbt
@@ -1,7 +1,7 @@
 ///|
 /// Verdict of one behavioral probe run against a trial's workspace, with the
 /// `reason` it failed ("ok" when it passed).
-pub struct ProbeResult {
+priv struct ProbeResult {
   name : String
   passed : Bool
   reason : String
@@ -19,7 +19,7 @@ fn ProbeResult::ProbeResult(
 
 ///|
 /// Validation verdict for one trial's finished workspace.
-pub struct ValidationResult {
+priv struct ValidationResult {
   ran : Bool
   passed : Bool
   reason : String
@@ -82,7 +82,7 @@ pub fn default_toml_validation_probes() -> Array[ValidationProbeSpec] {
 /// Everything recorded about one analyzed agent session. Harness metadata and
 /// workspace validation are attached when the session came from a prompt-task
 /// trial.
-pub struct EvalResult {
+priv struct EvalResult {
   index : Int
   prompt_label : String
   success : Bool
@@ -123,7 +123,7 @@ pub struct EvalResult {
 
 ///|
 /// One prompt-task eval analysis report.
-pub struct EvalReport {
+struct EvalReport {
   model : String
   prompt_label : String
   task_file : String

--- a/eval/prompt_task/harness/config.mbt
+++ b/eval/prompt_task/harness/config.mbt
@@ -12,19 +12,19 @@
 pub struct Config {
   api_key : String
   model : @deepseek.Model
-  problem_id : String
+  priv problem_id : String
   runs : Int
   concurrency : Int
   min_successes : Int
   max_steps : Int
-  out_dir : String
-  repo_root : String
-  engine : String
+  priv out_dir : String
+  priv repo_root : String
+  priv engine : String
   prompt_label : String
   task_file : String
-  validation_probes : Array[ValidationProbeSpec]
+  priv validation_probes : Array[ValidationProbeSpec]
   system_prompt_file : String
-  system_prompt_addendum_file : String
+  priv system_prompt_addendum_file : String
 }
 
 ///|

--- a/eval/prompt_task/harness/manifest.mbt
+++ b/eval/prompt_task/harness/manifest.mbt
@@ -6,7 +6,7 @@ let manifest_file_name : String = "run_manifest.json"
 /// executes from the trial workspace. Optional `stdin` is supplied through a
 /// temporary file, optional `write_file`/`write_content` creates an input file
 /// before the command runs, and expectations are checked after process exit.
-pub struct ValidationProbeSpec {
+struct ValidationProbeSpec {
   name : String
   command : Array[String]
   stdin : String
@@ -51,7 +51,7 @@ fn ValidationProbeSpec::ValidationProbeSpec(
 /// Durable artifact record for one prompt-task trial. The runner writes these
 /// fields once; analyzers can replay report generation from them without
 /// rerunning the agent.
-pub struct TrialArtifact {
+priv struct TrialArtifact {
   index : Int
   workspace : String
   log_path : String
@@ -76,17 +76,17 @@ fn TrialArtifact::TrialArtifact(
 ///|
 /// Manifest for one prompt-task experiment run.
 pub struct RunManifest {
-  model : String
-  problem_id : String
-  prompt_label : String
-  task_file : String
-  runs : Int
-  concurrency : Int
-  min_successes : Int
-  max_steps : Int
+  priv model : String
+  priv problem_id : String
+  priv prompt_label : String
+  priv task_file : String
+  priv runs : Int
+  priv concurrency : Int
+  priv min_successes : Int
+  priv max_steps : Int
   out_dir : String
-  validation_probes : Array[ValidationProbeSpec]
-  trials : Array[TrialArtifact]
+  priv validation_probes : Array[ValidationProbeSpec]
+  priv trials : Array[TrialArtifact]
 }
 
 ///|

--- a/eval/prompt_task/harness/pkg.generated.mbti
+++ b/eval/prompt_task/harness/pkg.generated.mbti
@@ -27,187 +27,43 @@ pub fn suite_manifest_path(String) -> String
 // Errors
 
 // Types and methods
-pub struct ComboRun {
-  model : String
-  problem_id : String
-  prompt_label : String
-  task_file : String
-  out_dir : String
-  manifest_path : String
-}
-
 pub struct Config {
   api_key : String
   model : @deepseek.Model
-  problem_id : String
   runs : Int
   concurrency : Int
   min_successes : Int
   max_steps : Int
-  out_dir : String
-  repo_root : String
-  engine : String
   prompt_label : String
   task_file : String
-  validation_probes : Array[ValidationProbeSpec]
   system_prompt_file : String
-  system_prompt_addendum_file : String
+  // private fields
 }
 pub fn Config::Config(api_key~ : String, model~ : @deepseek.Model, problem_id~ : String, runs~ : Int, concurrency~ : Int, min_successes~ : Int, max_steps~ : Int, out_dir~ : String, repo_root~ : String, engine? : String, prompt_label~ : String, task_file~ : String, validation_probes~ : Array[ValidationProbeSpec], system_prompt_file~ : String, system_prompt_addendum_file~ : String) -> Self
 
-pub struct EvalReport {
-  model : String
-  prompt_label : String
-  task_file : String
-  runs : Int
-  concurrency : Int
-  min_successes : Int
-  successes : Int
-  out_dir : String
-  results : Array[EvalResult]
-}
+type EvalReport
 pub fn EvalReport::failure_message(Self) -> String
 pub fn EvalReport::markdown(Self) -> String
 pub fn EvalReport::passed(Self) -> Bool
 
-pub struct EvalResult {
-  index : Int
-  prompt_label : String
-  success : Bool
-  reason : String
-  workspace : String
-  log_path : String
-  session_id : String
-  events_path : String
-  exit_code : Int
-  steps : Int
-  tool_results : Int
-  tool_errors : Int
-  shell_uses : Int
-  shell_failures : Int
-  runtime_notices : Int
-  finished : Bool
-  finish_message : String
-  terminal_status : String
-  terminal_message : String
-  validation : ValidationResult
-  parse_errors : Int
-  partial_tail : Bool
-  moon_check_uses : Int
-  moon_test_uses : Int
-  moon_run_e_mentions : Int
-  moon_run_c_mentions : Int
-  bad_run_e_mentions : Int
-  from_str_mentions : Int
-  parse_int_mentions : Int
-  argparse_mentions : Int
-  old_argparse_mentions : Int
-  c_ffi_mentions : Int
-  env_args_mentions : Int
-  result_style_mentions : Int
-  try_mentions : Int
-  warnings : String
-}
-
-pub struct ProbeResult {
-  name : String
-  passed : Bool
-  reason : String
-}
-
-pub struct ProblemSpec {
-  id : String
-  prompt_label : String
-  task_file : String
-  validation_probes : Array[ValidationProbeSpec]
-}
-
 pub struct RunManifest {
-  model : String
-  problem_id : String
-  prompt_label : String
-  task_file : String
-  runs : Int
-  concurrency : Int
-  min_successes : Int
-  max_steps : Int
   out_dir : String
-  validation_probes : Array[ValidationProbeSpec]
-  trials : Array[TrialArtifact]
+  // private fields
 }
 
-pub struct SuiteConfig {
-  api_key : String
-  name : String
-  models : Array[@deepseek.Model]
-  runs_per_combo : Int
-  concurrency : Int
-  min_successes : Int
-  max_steps : Int
-  out_dir : String
-  repo_root : String
-  engine : String
-  system_prompt_file : String
-  system_prompt_addendum_file : String
-  problems : Array[ProblemSpec]
-}
+type SuiteConfig
 
 pub struct SuiteManifest {
-  name : String
   out_dir : String
-  runs_per_combo : Int
-  concurrency : Int
-  min_successes : Int
-  max_steps : Int
-  models : Array[String]
-  problems : Array[ProblemSpec]
-  combos : Array[ComboRun]
+  // private fields
 }
 
-pub struct SuiteReport {
-  name : String
-  out_dir : String
-  runs_per_combo : Int
-  concurrency : Int
-  reports : Array[EvalReport]
-}
+type SuiteReport
 pub fn SuiteReport::failure_message(Self) -> String
 pub fn SuiteReport::markdown(Self) -> String
 pub fn SuiteReport::passed(Self) -> Bool
 
-pub struct TrialArtifact {
-  index : Int
-  workspace : String
-  log_path : String
-  session_id : String
-  events_path : String
-  exit_code : Int
-}
-
-pub struct ValidationProbeSpec {
-  name : String
-  command : Array[String]
-  stdin : String
-  write_file : String
-  write_content : String
-  expect_exit : Int
-  output_contains : String
-  stdout_contains : String
-  stderr_contains : String
-  stdout_json : Bool
-}
-
-pub struct ValidationResult {
-  ran : Bool
-  passed : Bool
-  reason : String
-  moon_check : Bool
-  moon_test : Bool
-  file_probe : Bool
-  stdin_probe : Bool
-  duplicate_probe : Bool
-  probes : Array[ProbeResult]
-}
+type ValidationProbeSpec
 
 // Type aliases
 

--- a/eval/prompt_task/harness/suite.mbt
+++ b/eval/prompt_task/harness/suite.mbt
@@ -3,7 +3,7 @@ let suite_manifest_file_name : String = "suite_manifest.json"
 
 ///|
 /// One benchmark problem in a prompt-task suite.
-pub struct ProblemSpec {
+priv struct ProblemSpec {
   id : String
   prompt_label : String
   task_file : String
@@ -33,7 +33,7 @@ fn ProblemSpec::ProblemSpec(
 ///|
 /// Configuration for running many prompt-task experiments with one global
 /// concurrency limit.
-pub struct SuiteConfig {
+struct SuiteConfig {
   api_key : String
   name : String
   models : Array[@deepseek.Model]
@@ -85,7 +85,7 @@ fn SuiteConfig::SuiteConfig(
 
 ///|
 /// One completed model/problem combo inside a suite manifest.
-pub struct ComboRun {
+priv struct ComboRun {
   model : String
   problem_id : String
   prompt_label : String
@@ -111,15 +111,15 @@ fn ComboRun::ComboRun(
 /// Durable manifest for a completed suite run. It points at normal per-combo
 /// run manifests so analysis can be replayed without rerunning agents.
 pub struct SuiteManifest {
-  name : String
+  priv name : String
   out_dir : String
-  runs_per_combo : Int
-  concurrency : Int
-  min_successes : Int
-  max_steps : Int
-  models : Array[String]
-  problems : Array[ProblemSpec]
-  combos : Array[ComboRun]
+  priv runs_per_combo : Int
+  priv concurrency : Int
+  priv min_successes : Int
+  priv max_steps : Int
+  priv models : Array[String]
+  priv problems : Array[ProblemSpec]
+  priv combos : Array[ComboRun]
 }
 
 ///|
@@ -166,7 +166,7 @@ priv struct SuiteTrialArtifact {
 ///|
 /// Analyze a suite run by replaying each combo's normal run manifest, then
 /// write a combined suite report under the suite output directory.
-pub struct SuiteReport {
+struct SuiteReport {
   name : String
   out_dir : String
   runs_per_combo : Int

--- a/eval/report/pkg.generated.mbti
+++ b/eval/report/pkg.generated.mbti
@@ -7,17 +7,12 @@ pub async fn write_files(String, String, Json, html? : String) -> Unit
 // Errors
 
 // Types and methods
-pub struct Metric {
-  name : String
-  value : String
-}
+type Metric
 pub fn Metric::Metric(name~ : String, value~ : String) -> Self
 
 pub struct Report {
-  title : String
-  summary : Array[Metric]
-  metric_columns : Array[String]
   rows : Array[ReportRow]
+  // private fields
 }
 pub fn Report::Report(title~ : String, summary? : Array[Metric], metric_columns? : Array[String], rows? : Array[ReportRow]) -> Self
 pub fn Report::all_passed(Self) -> Bool
@@ -27,14 +22,8 @@ pub fn Report::successes(Self) -> Int
 pub async fn Report::write_files(Self, String) -> Unit
 
 pub struct ReportRow {
-  index : Int
-  name : String
   success : Bool
-  reason : String
-  warnings : String
-  metrics : Array[Metric]
-  details : Array[Metric]
-  log_path : String
+  // private fields
 }
 pub fn ReportRow::ReportRow(index~ : Int, name~ : String, success~ : Bool, reason? : String, warnings? : String, metrics? : Array[Metric], details? : Array[Metric], log_path? : String) -> Self
 

--- a/eval/report/report.mbt
+++ b/eval/report/report.mbt
@@ -1,7 +1,7 @@
 ///|
 /// One named measurement, already rendered to display text — the shared cell
 /// format for report summaries and per-row metric columns.
-pub struct Metric {
+struct Metric {
   name : String
   value : String
 }
@@ -19,14 +19,14 @@ pub fn Metric::Metric(name~ : String, value~ : String) -> Metric {
 /// non-fatal `warnings`, its `metrics` cells, and the path of its full
 /// transcript log when one was kept.
 pub struct ReportRow {
-  index : Int
-  name : String
+  priv index : Int
+  priv name : String
   success : Bool
-  reason : String
-  warnings : String
-  metrics : Array[Metric]
-  details : Array[Metric]
-  log_path : String
+  priv reason : String
+  priv warnings : String
+  priv metrics : Array[Metric]
+  priv details : Array[Metric]
+  priv log_path : String
 }
 
 ///|
@@ -50,9 +50,9 @@ pub fn ReportRow::ReportRow(
 /// ordered `metric_columns` every row renders under, and one `ReportRow` per
 /// trial. Renders to markdown for humans and JSON for tooling.
 pub struct Report {
-  title : String
-  summary : Array[Metric]
-  metric_columns : Array[String]
+  priv title : String
+  priv summary : Array[Metric]
+  priv metric_columns : Array[String]
   rows : Array[ReportRow]
 }
 

--- a/viz_export/export.mbt
+++ b/viz_export/export.mbt
@@ -3,7 +3,9 @@
 ///
 /// The fields mirror the two HTTP responses consumed by `cmd/viz_app`: the
 /// session-list row and the raw JSONL envelope for that row.
-pub struct Session {
+/// The fields mirror the two HTTP responses consumed by `cmd/viz_app`: the
+/// session-list row and the raw JSONL envelope for that row.
+struct Session {
   key : String
   id : String
   root : String
@@ -59,7 +61,7 @@ fn Session::envelope_json(self : Session) -> Json {
 
 ///|
 /// The static shell and compiled `viz_app` bundle used to build an export.
-pub struct StandaloneExport {
+struct StandaloneExport {
   shell_html : String
   bundle_js : String
 }

--- a/viz_export/pkg.generated.mbti
+++ b/viz_export/pkg.generated.mbti
@@ -6,22 +6,10 @@ package "bobzhang/openseek/viz_export"
 // Errors
 
 // Types and methods
-pub struct Session {
-  key : String
-  id : String
-  root : String
-  root_label : String
-  is_marker : Bool
-  last_active : Double?
-  first_prompt : String
-  events : String
-}
+type Session
 pub fn Session::Session(key~ : String, id~ : String, root~ : String, root_label~ : String, is_marker~ : Bool, last_active~ : Double?, first_prompt~ : String, events~ : String) -> Self
 
-pub struct StandaloneExport {
-  shell_html : String
-  bundle_js : String
-}
+type StandaloneExport
 pub fn StandaloneExport::StandaloneExport(String, String) -> Self
 pub fn StandaloneExport::render(Self, Array[Session]) -> String raise
 


### PR DESCRIPTION
## What

Shrinks the public surfaces of internal packages by sweeping zero-real-usage exports (`moon ide analyze`: `usage: N (M in test)` with `N == M`), one package at a time:

- 9 same-package-only helpers de-pubbed (`cmd/openseek/internal/subtask`)
- ~200 struct fields made private where no code outside the package reads them
- 16 records converted to opaque `type X` (construction already flowed through constructors)
- 9 internal record types fully hidden (`priv struct`, invisible in interfaces)
- 2 genuinely dead fields deleted (`BgJobSnapshot.cwd`/`seq` — compiler-flagged as never read), with their storage chain and the now-unused `adopt(cwd?)` parameter
- 2 dead exported fns deleted (`agent_tool/shell` denial-feedback text, superseded by the generated prompts)

Generated interfaces (`.mbti`) shrink by ~300 lines. Enum variants are untouched — MoonBit has no per-constructor visibility.

## Not included (deliberate)

- Fields with real or test-only readers stay public (the two `Config` test seams, `BgJobSnapshot` status fields, `Finding.severity`, `ReviewReport.findings`, ...)
- Published-library packages (`deepseek`, `agent_session`, `mcp`, `tui`, `testkit`), the `editor`/`desktop` modules, and `exports.mbt` keeps — those need separate API-compat decisions

## Verified locally

- `moon check --target native --deny-warn` and `--target js --deny-warn` clean
- `moon test --target native` (full workspace suite) passes
- `moon info` regenerated all interfaces; `moon fmt` clean

Generated with SeekMoon