### PR TITLE
feat(desktop): move skill marketplace to the archive-based registry API

### DIFF
--- a/desktop/internal/skillmarket/archive.mbt
+++ b/desktop/internal/skillmarket/archive.mbt
@@ -1,8 +1,8 @@
 // Decoding a downloaded skill archive into the files an install writes:
 // the SKILL.md instructions plus any supporting files, as validated
 // library-relative paths. The archive's bytes were already verified against
-// the registry's digest; this half guards the extraction — per-entry CRCs,
-// wrapper stripping, and path safety.
+// the registry's digest; this half guards the extraction — per-entry CRCs
+// and path safety.
 
 ///|
 /// The instruction file every skill archive must carry at its root.
@@ -18,9 +18,9 @@ priv struct SkillArchive {
 }
 
 ///|
-/// Decode the members of one skill archive. Publishers may zip the skill's
-/// files directly or a single wrapping directory; the wrapper is stripped so
-/// the SKILL.md always lands at the installed root. Every payload is checked
+/// Decode the members of one skill archive. The registry's `skills.zip`
+/// carries the skill's files with the SKILL.md at the archive root; entries
+/// extract verbatim, with no layout guessing. Every payload is checked
 /// against its stored CRC-32 and every path validated as a safe relative
 /// path, so a corrupt or hostile archive can neither smuggle bad data nor
 /// escape the staged directory.
@@ -28,7 +28,8 @@ fn skill_files(
   archive : @zip.Archive,
   entry : String,
 ) -> SkillArchive raise SkillMarketError {
-  let members : Array[(String, Bytes)] = []
+  let files : Map[String, Bytes] = Map([])
+  let mut skill_md : Bytes? = None
   for item in archive.entries() {
     let name = item.name()
     if name.has_suffix("/") {
@@ -41,82 +42,35 @@ fn skill_files(
         "the archive for \{entry} is corrupt: \{name} fails its checksum",
       )
     }
-    members.push((name, item.data().to_owned()))
-  }
-  let prefix = wrapper_prefix(members, entry)
-  let files : Map[String, Bytes] = Map([])
-  let mut skill_md : Bytes? = None
-  for item in members {
-    let (name, content) = item
-    guard name.strip_prefix(prefix) is Some(relative) else { continue }
-    let relative = relative.to_owned()
-    guard safe_archive_path(relative) else {
+    guard safe_archive_path(name) else {
       raise SkillMarketError(
         "the archive for \{entry} contains an unsafe path: \{name}",
       )
     }
-    if relative == SidecarFile {
+    if name == SidecarFile {
       // The provenance sidecar is this library's own record; an archive can
       // never supply it.
       continue
     }
     // Duplicate names are a classic parser-differential vector; refuse them
     // rather than letting the last occurrence win silently.
-    guard !files.contains(relative) else {
+    guard !files.contains(name) else {
       raise SkillMarketError(
-        "the archive for \{entry} names \{relative} more than once",
+        "the archive for \{entry} names \{name} more than once",
       )
     }
-    if relative == SkillFile {
+    let content = item.data().to_owned()
+    if name == SkillFile {
       skill_md = Some(content)
     }
-    files[relative] = content
+    files[name] = content
   }
   guard skill_md is Some(skill_md) else {
     raise SkillMarketError(
-      "the archive for \{entry} does not contain a SKILL.md",
+      "the archive for \{entry} does not contain a SKILL.md at its root",
     )
   }
   { skill_md, files, }
-}
-
-///|
-/// The directory prefix to strip from every archive entry: `""` when the SKILL.md
-/// sits at the archive root, `"<dir>/"` when all members share one wrapping
-/// directory that carries it. Anything else is not a skill archive.
-fn wrapper_prefix(
-  members : Array[(String, Bytes)],
-  entry : String,
-) -> String raise SkillMarketError {
-  for item in members {
-    if item.0 == SkillFile {
-      return ""
-    }
-  }
-  let mut wrapper : String? = None
-  for item in members {
-    guard item.0.split_once("/") is Some((top, rest)) && !rest.is_empty() else {
-      wrapper = None
-      break
-    }
-    let top = top.to_owned()
-    match wrapper {
-      None => wrapper = Some(top)
-      Some(existing) =>
-        if existing != top {
-          wrapper = None
-          break
-        }
-    }
-  }
-  if wrapper is Some(wrapper) {
-    for item in members {
-      if item.0 == "\{wrapper}/\{SkillFile}" {
-        return "\{wrapper}/"
-      }
-    }
-  }
-  raise SkillMarketError("the archive for \{entry} does not contain a SKILL.md")
 }
 
 ///|
@@ -142,7 +96,7 @@ fn safe_archive_path(path : String) -> Bool {
 }
 
 ///|
-test "skill files accept a flat archive and skip a smuggled sidecar" {
+test "skill files accept a root-level archive and skip a smuggled sidecar" {
   let archive = @zip.Archive::Archive()
   archive.add("SKILL.md", b"instructions")
   archive.add("reference/usage.md", b"notes")
@@ -168,17 +122,8 @@ test "an archive naming one path twice is refused" {
 }
 
 ///|
-test "skill files strip a single wrapping directory" {
-  let archive = @zip.Archive::Archive()
-  archive.add("widget/SKILL.md", b"instructions")
-  archive.add("widget/scripts/run.sh", b"echo")
-  let skill = skill_files(archive, "acme/widget@1.0.0")
-  assert_eq(skill.skill_md, b"instructions")
-  assert_eq(skill.files.keys().collect(), ["SKILL.md", "scripts/run.sh"])
-}
-
-///|
-test "an archive without a SKILL.md is refused" {
+test "an archive without a root SKILL.md is refused" {
+  // No SKILL.md at all.
   let archive = @zip.Archive::Archive()
   archive.add("README.md", b"no instructions")
   try {
@@ -189,15 +134,16 @@ test "an archive without a SKILL.md is refused" {
       assert_true(message.contains("does not contain a SKILL.md"))
     error => raise error
   }
-  // Two top-level directories are not a single wrapper either.
+  // A SKILL.md wrapped in a directory is not at the root; there is exactly
+  // one accepted layout and no guessing.
   let archive = @zip.Archive::Archive()
-  archive.add("one/SKILL.md", b"a")
-  archive.add("two/other.md", b"b")
+  archive.add("widget/SKILL.md", b"instructions")
   try {
     let _ = skill_files(archive, "acme/widget@1.0.0")
-    fail("a multi-root archive must be refused")
+    fail("a wrapped archive must be refused")
   } catch {
-    SkillMarketError(_) => ()
+    SkillMarketError(message) =>
+      assert_true(message.contains("does not contain a SKILL.md"))
     error => raise error
   }
 }

--- a/desktop/internal/skillmarket/archive.mbt
+++ b/desktop/internal/skillmarket/archive.mbt
@@ -1,0 +1,231 @@
+// Decoding a downloaded skill archive into the files an install writes:
+// the SKILL.md instructions plus any supporting files, as validated
+// library-relative paths. The archive's bytes were already verified against
+// the registry's digest; this half guards the extraction — per-entry CRCs,
+// wrapper stripping, and path safety.
+
+///|
+/// The instruction file every skill archive must carry at its root.
+const SkillFile = "SKILL.md"
+
+///|
+/// The decoded contents of one skill archive. `files` holds every entry to
+/// stage — SKILL.md included — while `skill_md` gives the instructions their
+/// own handle for frontmatter parsing and preview.
+priv struct SkillArchive {
+  skill_md : Bytes
+  files : Map[String, Bytes]
+}
+
+///|
+/// Decode the members of one skill archive. Publishers may zip the skill's
+/// files directly or a single wrapping directory; the wrapper is stripped so
+/// the SKILL.md always lands at the installed root. Every payload is checked
+/// against its stored CRC-32 and every path validated as a safe relative
+/// path, so a corrupt or hostile archive can neither smuggle bad data nor
+/// escape the staged directory.
+fn skill_files(
+  archive : @zip.Archive,
+  entry : String,
+) -> SkillArchive raise SkillMarketError {
+  let members : Array[(String, Bytes)] = []
+  for item in archive.entries() {
+    let name = item.name()
+    if name.has_suffix("/") {
+      // Directory placeholders carry no data; directories are recreated from
+      // file paths at staging time.
+      continue
+    }
+    guard @checksum.crc32(item.data()) == item.crc32() else {
+      raise SkillMarketError(
+        "the archive for \{entry} is corrupt: \{name} fails its checksum",
+      )
+    }
+    members.push((name, item.data().to_owned()))
+  }
+  let prefix = wrapper_prefix(members, entry)
+  let files : Map[String, Bytes] = Map([])
+  let mut skill_md : Bytes? = None
+  for item in members {
+    let (name, content) = item
+    guard name.strip_prefix(prefix) is Some(relative) else { continue }
+    let relative = relative.to_owned()
+    guard safe_archive_path(relative) else {
+      raise SkillMarketError(
+        "the archive for \{entry} contains an unsafe path: \{name}",
+      )
+    }
+    if relative == SidecarFile {
+      // The provenance sidecar is this library's own record; an archive can
+      // never supply it.
+      continue
+    }
+    // Duplicate names are a classic parser-differential vector; refuse them
+    // rather than letting the last occurrence win silently.
+    guard !files.contains(relative) else {
+      raise SkillMarketError(
+        "the archive for \{entry} names \{relative} more than once",
+      )
+    }
+    if relative == SkillFile {
+      skill_md = Some(content)
+    }
+    files[relative] = content
+  }
+  guard skill_md is Some(skill_md) else {
+    raise SkillMarketError(
+      "the archive for \{entry} does not contain a SKILL.md",
+    )
+  }
+  { skill_md, files, }
+}
+
+///|
+/// The directory prefix to strip from every archive entry: `""` when the SKILL.md
+/// sits at the archive root, `"<dir>/"` when all members share one wrapping
+/// directory that carries it. Anything else is not a skill archive.
+fn wrapper_prefix(
+  members : Array[(String, Bytes)],
+  entry : String,
+) -> String raise SkillMarketError {
+  for item in members {
+    if item.0 == SkillFile {
+      return ""
+    }
+  }
+  let mut wrapper : String? = None
+  for item in members {
+    guard item.0.split_once("/") is Some((top, rest)) && !rest.is_empty() else {
+      wrapper = None
+      break
+    }
+    let top = top.to_owned()
+    match wrapper {
+      None => wrapper = Some(top)
+      Some(existing) =>
+        if existing != top {
+          wrapper = None
+          break
+        }
+    }
+  }
+  if wrapper is Some(wrapper) {
+    for item in members {
+      if item.0 == "\{wrapper}/\{SkillFile}" {
+        return "\{wrapper}/"
+      }
+    }
+  }
+  raise SkillMarketError("the archive for \{entry} does not contain a SKILL.md")
+}
+
+///|
+/// Whether `path` can safely be written below the staged skill directory:
+/// `/`-separated non-empty segments, no `.` or `..`, and none of the
+/// characters that switch directories or drives on any supported platform.
+fn safe_archive_path(path : String) -> Bool {
+  if path.is_empty() || path.length() > 512 {
+    return false
+  }
+  for segment in path.split("/") {
+    let segment = segment.to_owned()
+    if segment.is_empty() || segment == "." || segment == ".." {
+      return false
+    }
+    for ch in segment {
+      if ch is ('\\' | ':' | '\u{0}') {
+        return false
+      }
+    }
+  }
+  true
+}
+
+///|
+test "skill files accept a flat archive and skip a smuggled sidecar" {
+  let archive = @zip.Archive::Archive()
+  archive.add("SKILL.md", b"instructions")
+  archive.add("reference/usage.md", b"notes")
+  archive.add(".mooncakes.json", b"{\"module\":\"fake\"}")
+  archive.add("reference/", b"")
+  let skill = skill_files(archive, "acme/widget@1.0.0")
+  assert_eq(skill.skill_md, b"instructions")
+  assert_eq(skill.files.keys().collect(), ["SKILL.md", "reference/usage.md"])
+}
+
+///|
+test "an archive naming one path twice is refused" {
+  let archive = @zip.Archive::Archive()
+  archive.add("SKILL.md", b"one")
+  archive.add("SKILL.md", b"two")
+  try {
+    let _ = skill_files(archive, "acme/widget@1.0.0")
+    fail("duplicate archive entries must be refused")
+  } catch {
+    SkillMarketError(message) => assert_true(message.contains("more than once"))
+    error => raise error
+  }
+}
+
+///|
+test "skill files strip a single wrapping directory" {
+  let archive = @zip.Archive::Archive()
+  archive.add("widget/SKILL.md", b"instructions")
+  archive.add("widget/scripts/run.sh", b"echo")
+  let skill = skill_files(archive, "acme/widget@1.0.0")
+  assert_eq(skill.skill_md, b"instructions")
+  assert_eq(skill.files.keys().collect(), ["SKILL.md", "scripts/run.sh"])
+}
+
+///|
+test "an archive without a SKILL.md is refused" {
+  let archive = @zip.Archive::Archive()
+  archive.add("README.md", b"no instructions")
+  try {
+    let _ = skill_files(archive, "acme/widget@1.0.0")
+    fail("an archive without a SKILL.md must be refused")
+  } catch {
+    SkillMarketError(message) =>
+      assert_true(message.contains("does not contain a SKILL.md"))
+    error => raise error
+  }
+  // Two top-level directories are not a single wrapper either.
+  let archive = @zip.Archive::Archive()
+  archive.add("one/SKILL.md", b"a")
+  archive.add("two/other.md", b"b")
+  try {
+    let _ = skill_files(archive, "acme/widget@1.0.0")
+    fail("a multi-root archive must be refused")
+  } catch {
+    SkillMarketError(_) => ()
+    error => raise error
+  }
+}
+
+///|
+test "an archive with an unsafe entry path is refused" {
+  let archive = @zip.Archive::Archive()
+  archive.add("SKILL.md", b"instructions")
+  archive.add("../evil.md", b"escape")
+  try {
+    let _ = skill_files(archive, "acme/widget@1.0.0")
+    fail("a path-escaping archive must be refused")
+  } catch {
+    SkillMarketError(message) => assert_true(message.contains("unsafe path"))
+    error => raise error
+  }
+}
+
+///|
+test "archive path safety rejects everything that could leave the staging dir" {
+  assert_true(safe_archive_path("SKILL.md"))
+  assert_true(safe_archive_path("reference/usage.md"))
+  assert_false(safe_archive_path(""))
+  assert_false(safe_archive_path("/etc/passwd"))
+  assert_false(safe_archive_path("../evil.md"))
+  assert_false(safe_archive_path("a/../b.md"))
+  assert_false(safe_archive_path("a/./b.md"))
+  assert_false(safe_archive_path("a//b.md"))
+  assert_false(safe_archive_path("a\\b.md"))
+  assert_false(safe_archive_path("C:evil.md"))
+}

--- a/desktop/internal/skillmarket/library.mbt
+++ b/desktop/internal/skillmarket/library.mbt
@@ -1,9 +1,10 @@
-// The local skills library: installing a registry skill into the engine's
-// global skills directory, listing what is there, and removing what this
-// app installed. The directory layout and frontmatter rules deliberately
+// The local skills library: installing a registry skill archive into the
+// engine's global skills directory, listing what is there, and removing what
+// this app installed. The directory layout and frontmatter rules deliberately
 // mirror the engine's `agent_skill` discovery (`<name>.md` flat files and
-// `<name>/SKILL.md` directories), so the panel lists exactly what the
-// engine advertises to the model.
+// `<name>/SKILL.md` directories, here with the archive's supporting files
+// beside the SKILL.md), so the panel lists exactly what the engine
+// advertises to the model.
 
 ///|
 /// The provenance marker written next to an installed SKILL.md. The engine's
@@ -90,9 +91,9 @@ fn slugify(name : String) -> String {
 }
 
 ///|
-/// The `sha256:`-prefixed hex digest of `content`, recorded in an install's
-/// provenance sidecar. The registry's per-skill API exposes no SKILL.md digest
-/// to verify against, so this is our own record of what we wrote, not a check.
+/// The `sha256:`-prefixed hex digest of `content`: how a downloaded skill
+/// archive is checked against the digest the registry declares, and what an
+/// install's provenance sidecar records.
 fn content_digest(content : Bytes) -> String {
   "sha256:\{@crypto.bytes_to_hex_string(@crypto.sha256(content))}"
 }
@@ -151,14 +152,15 @@ fn decode_sidecar(text : String) -> String {
 }
 
 ///|
-/// Download one registry skill and install it as `<library>/<slug>/SKILL.md`.
-/// The per-skill API confirms `entry` is a skill; the slug is derived from the
-/// skill's `owner/name` identity (so the registry's own name can never
-/// path-escape the library), and the SKILL.md is fetched from the skill's
-/// assets. A same-named entry the user wrote by hand (no sidecar) is never
-/// overwritten; one we installed is — that is a reinstall or an upgrade.
-/// `on_committed` runs after the complete staged directory becomes live, while
-/// the library lock and cancellation shield are still held.
+/// Download one skill archive and install it as `<library>/<slug>/` — its
+/// SKILL.md plus any supporting files. The per-skill API locates the archive
+/// and its digest; the download is verified against that digest before any
+/// entry is unpacked. The slug is derived from the skill's `owner/name`
+/// identity, so registry data can never path-escape the library. A same-named
+/// entry the user wrote by hand (no sidecar) is never overwritten; one we
+/// installed is — that is a reinstall or an upgrade. `on_committed` runs after
+/// the complete staged directory becomes live, while the library lock and
+/// cancellation shield are still held.
 pub async fn install_skill(
   module_name~ : String,
   version~ : String,
@@ -168,7 +170,7 @@ pub async fn install_skill(
   on_committed? : () -> Unit,
 ) -> InstalledSkill {
   let entry = entry_path(module_name, version, package_path)
-  let download_url = skill_md_url(registry, entry)
+  let source = fetch_archive_source(registry, entry)
   let identity = if package_path.is_empty() {
     module_name
   } else {
@@ -186,15 +188,13 @@ pub async fn install_skill(
       "a skill named \{slug} already exists in your library; not overwriting it",
     )
   }
-  let (code, data) = fetch_response(download_url)
-  if code == 404 {
-    raise SkillMarketError("\{entry} does not publish a SKILL.md")
+  let skill = skill_files(fetch_archive(entry, source), entry)
+  let text = @utf8.decode(skill.skill_md) catch {
+    _ =>
+      raise SkillMarketError(
+        "the archive for \{entry} holds an unreadable SKILL.md",
+      )
   }
-  guard code == 200 else {
-    raise SkillMarketError("SKILL.md download returned HTTP \{code}")
-  }
-  let content = data.binary()
-  let text = data.text() catch { _ => "" }
   let (name, description) = parse_frontmatter(text, slug)
   let installed = {
     id: slug,
@@ -206,7 +206,7 @@ pub async fn install_skill(
     "module": module_name,
     "version": version,
     "package": package_path,
-    "digest": content_digest(content),
+    "digest": source.digest,
   }
   library_lock.acquire()
   defer library_lock.release()
@@ -219,7 +219,7 @@ pub async fn install_skill(
       "a skill named \{slug} already exists in your library; not overwriting it",
     )
   }
-  library.stage(slug, content, provenance.stringify())
+  library.stage(slug, skill.files, provenance.stringify())
   library.activate(slug, on_committed?)
   installed
 }

--- a/desktop/internal/skillmarket/moon.pkg
+++ b/desktop/internal/skillmarket/moon.pkg
@@ -1,8 +1,11 @@
 import {
+  "moonbit-community/flate/checksum",
+  "moonbit-community/flate/zip",
   "moonbitlang/async",
   "moonbitlang/async/fs",
   "moonbitlang/async/http",
   "moonbitlang/async/io",
+  "moonbitlang/core/encoding/utf8",
   "moonbitlang/core/json",
   "moonbitlang/x/crypto",
   "openseek_desktop/internal/env",
@@ -12,11 +15,13 @@ import {
 }
 
 import {
+  "moonbit-community/flate/zip",
   "moonbitlang/async",
   "moonbitlang/async/fs",
   "moonbitlang/async/http",
   "moonbitlang/async/socket",
   "moonbitlang/core/json",
+  "moonbitlang/x/crypto",
 } for "test"
 
 warnings = "+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"

--- a/desktop/internal/skillmarket/registry.mbt
+++ b/desktop/internal/skillmarket/registry.mbt
@@ -13,15 +13,37 @@ const DefaultRegistry = "https://mooncakes.io"
 const MaxPreviewBytes : Int = 512 * 1024
 
 ///|
-/// Bound the packaged archive download, and separately its decompressed
-/// contents, so a hostile or malformed archive cannot exhaust memory.
-const MaxArchiveBytes : Int = 32 * 1024 * 1024
+/// Decompression floor and ratio for one downloaded archive. How large a
+/// published archive may be is the registry's publish policy, not ours — but
+/// a zip's decompressed size is not bounded by its packaged size (deflate
+/// reaches ~1000:1), publishing is open to anyone, and this reader inflates
+/// in memory, so a small hostile package must not expand without limit. A
+/// generous multiple of the packaged bytes never brakes a legitimately large
+/// skill, while the floor keeps small archives clear of the edge.
+const ArchiveExpansionFloorBytes : Int = 256 * 1024 * 1024
 
 ///|
-const MaxArchiveTotalBytes : Int = 64 * 1024 * 1024
+const ArchiveExpansionRatio : Int = 64
 
 ///|
-const MaxArchiveEntries : Int = 512
+const MaxArchiveEntries : Int = 65536
+
+///|
+/// Decompression ceilings for an archive of `package_bytes` packaged size.
+fn archive_limits(package_bytes : Int) -> @zip.ReadLimits {
+  let saturation = 0x7fff_ffff / ArchiveExpansionRatio
+  let scaled = if package_bytes >= saturation {
+    0x7fff_ffff
+  } else if package_bytes * ArchiveExpansionRatio > ArchiveExpansionFloorBytes {
+    package_bytes * ArchiveExpansionRatio
+  } else {
+    ArchiveExpansionFloorBytes
+  }
+  @zip.ReadLimits::default()
+  .with_entries_limit(MaxArchiveEntries)
+  .with_entry_limit(scaled)
+  .with_total_limit(scaled)
+}
 
 ///|
 /// A registry or library failure with a user-facing message; the host's op
@@ -244,7 +266,9 @@ async fn fetch_archive_source(
 ///|
 /// Download the archive behind `source` and decode it. Every byte is checked
 /// against the digest the registry declared before any entry is trusted, and
-/// decompression runs under explicit size and entry-count ceilings.
+/// decompression runs under ceilings scaled to the packaged size. The
+/// download itself is not size-capped here: publish limits are the
+/// registry's policy, and the digest pins the content either way.
 async fn fetch_archive(entry : String, source : ArchiveSource) -> @zip.Archive {
   let (code, data) = fetch_response(source.url)
   if code == 404 {
@@ -256,19 +280,12 @@ async fn fetch_archive(entry : String, source : ArchiveSource) -> @zip.Archive {
     raise SkillMarketError("skill archive download returned HTTP \{code}")
   }
   let bytes = data.binary()
-  guard bytes.length() <= MaxArchiveBytes else {
-    raise SkillMarketError("the archive for \{entry} is too large to install")
-  }
   guard content_digest(bytes) == source.digest else {
     raise SkillMarketError(
       "the archive for \{entry} does not match its published digest",
     )
   }
-  let limits = @zip.ReadLimits::default()
-    .with_package_limit(MaxArchiveBytes)
-    .with_entries_limit(MaxArchiveEntries)
-    .with_entry_limit(MaxArchiveTotalBytes)
-    .with_total_limit(MaxArchiveTotalBytes)
+  let limits = archive_limits(bytes.length())
   @zip.read(bytes, limits~, cancelled=@async.is_being_cancelled) catch {
     error if @async.is_being_cancelled() => raise error
     ZipError(_, message) =>
@@ -382,6 +399,26 @@ test "a wrapped catalog response decodes like a bare one" {
     fail("expected one entry from the wrapped catalog")
   }
   assert_eq(skill.name, "alice/alpha")
+}
+
+///|
+test "archive decompression ceilings scale with the packaged size" {
+  // Small packages get the floor; big ones the ratio; near Int range the
+  // ceiling saturates instead of overflowing.
+  assert_eq(
+    archive_limits(1024).max_total_uncompressed_bytes,
+    ArchiveExpansionFloorBytes,
+  )
+  let big = 16 * 1024 * 1024
+  assert_eq(
+    archive_limits(big).max_total_uncompressed_bytes,
+    big * ArchiveExpansionRatio,
+  )
+  assert_eq(
+    archive_limits(0x7fff_ffff).max_total_uncompressed_bytes,
+    0x7fff_ffff,
+  )
+  assert_eq(archive_limits(1024).max_entries, MaxArchiveEntries)
 }
 
 ///|

--- a/desktop/internal/skillmarket/registry.mbt
+++ b/desktop/internal/skillmarket/registry.mbt
@@ -78,9 +78,10 @@ const MaxRedirects = 5
 /// GET `url`, following redirects, and return the final status code and
 /// body. Transport failures (DNS, TLS, a refused connection) become a
 /// `SkillMarketError`; non-200 final codes are returned for the caller to
-/// judge with context of its own. A hop onto plain http is accepted:
-/// integrity never rests on the transport, since archives are verified
-/// against the registry's declared digest after download.
+/// judge with context of its own. A redirect hop from https onto plain
+/// http is always refused: metadata and preview content take their whole
+/// trust from the channel, and even the digest-checked archive download
+/// has no reason to leave TLS.
 async fn fetch_response(url : String) -> (Int, &@io.Data) {
   let mut current = url
   for _ in 0..<MaxRedirects {
@@ -93,9 +94,21 @@ async fn fetch_response(url : String) -> (Int, &@io.Data) {
       response.headers.get("Location") is Some(location) else {
       return (response.code, data)
     }
-    current = redirect_target(current, location)
+    let target = redirect_target(current, location)
+    guard !insecure_downgrade(current, target) else {
+      raise SkillMarketError(
+        "the skill registry redirected to an insecure address",
+      )
+    }
+    current = target
   }
   raise SkillMarketError("the skill registry redirected too many times")
+}
+
+///|
+/// Whether following a redirect from `current` to `target` drops TLS.
+fn insecure_downgrade(current : String, target : String) -> Bool {
+  current.has_prefix("https://") && target.has_prefix("http://")
 }
 
 ///|
@@ -297,6 +310,10 @@ async fn fetch_archive(entry : String, source : ArchiveSource) -> @zip.Archive {
 
 ///|
 /// Fetch the published instructions without changing the local library.
+/// The registry publishes each skill's bare SKILL.md under its assets tree,
+/// and that one small fetch is the whole preview: an archive can inflate to
+/// arbitrarily much work for the sake of one file, so preview never touches
+/// it, and a 404 already answers "no such skill instructions".
 pub async fn fetch_skill_content(
   module_name~ : String,
   version~ : String,
@@ -304,15 +321,20 @@ pub async fn fetch_skill_content(
   registry? : String = DefaultRegistry,
 ) -> String {
   let entry = entry_path(module_name, version, package_path)
-  let source = fetch_archive_source(registry, entry)
-  let skill = skill_files(fetch_archive(entry, source), entry)
-  guard skill.skill_md.length() <= MaxPreviewBytes else {
+  let (code, data) = fetch_response("\{registry}/assets/\{entry}/SKILL.md")
+  if code == 404 {
+    raise SkillMarketError("\{entry} does not publish a SKILL.md")
+  }
+  guard code == 200 else {
+    raise SkillMarketError("SKILL.md request returned HTTP \{code}")
+  }
+  guard data.binary().length() <= MaxPreviewBytes else {
     raise SkillMarketError("SKILL.md is too large to preview")
   }
-  @utf8.decode(skill.skill_md) catch {
+  data.text() catch {
     _ =>
       raise SkillMarketError(
-        "the archive for \{entry} holds an unreadable SKILL.md",
+        "the registry serves an unreadable SKILL.md for \{entry}",
       )
   }
 }
@@ -419,6 +441,13 @@ test "archive decompression ceilings scale with the packaged size" {
     0x7fff_ffff,
   )
   assert_eq(archive_limits(1024).max_entries, MaxArchiveEntries)
+}
+
+///|
+test "a redirect that drops TLS is recognized" {
+  assert_true(insecure_downgrade("https://a.example/x", "http://b.example/y"))
+  assert_false(insecure_downgrade("http://a.example/x", "http://b.example/y"))
+  assert_false(insecure_downgrade("https://a.example/x", "https://b.example/y"))
 }
 
 ///|

--- a/desktop/internal/skillmarket/registry.mbt
+++ b/desktop/internal/skillmarket/registry.mbt
@@ -47,15 +47,55 @@ pub struct MarketSkill {
 } derive(ToJson)
 
 ///|
-/// GET `url`, returning the status code and body. Transport failures (DNS,
-/// TLS, a refused connection) become a `SkillMarketError`; non-200 codes are
-/// returned for the caller to judge with context of its own.
+/// Redirect hops one fetch will follow. The registry's download host hands
+/// archives to its object store through a redirect; the cap keeps a
+/// misconfigured server from looping forever.
+const MaxRedirects = 5
+
+///|
+/// GET `url`, following redirects, and return the final status code and
+/// body. Transport failures (DNS, TLS, a refused connection) become a
+/// `SkillMarketError`; non-200 final codes are returned for the caller to
+/// judge with context of its own. A hop onto plain http is accepted:
+/// integrity never rests on the transport, since archives are verified
+/// against the registry's declared digest after download.
 async fn fetch_response(url : String) -> (Int, &@io.Data) {
-  let (response, data) = @http.get(url) catch {
-    error if @async.is_being_cancelled() => raise error
-    error => raise SkillMarketError("cannot reach the skill registry: \{error}")
+  let mut current = url
+  for _ in 0..<MaxRedirects {
+    let (response, data) = @http.get(current) catch {
+      error if @async.is_being_cancelled() => raise error
+      error =>
+        raise SkillMarketError("cannot reach the skill registry: \{error}")
+    }
+    guard response.code is (301 | 302 | 303 | 307 | 308) &&
+      response.headers.get("Location") is Some(location) else {
+      return (response.code, data)
+    }
+    current = redirect_target(current, location)
   }
-  (response.code, data)
+  raise SkillMarketError("the skill registry redirected too many times")
+}
+
+///|
+/// The absolute URL a redirect points at. `Location` may be absolute or
+/// host-relative — the only forms real registries emit; anything else is
+/// refused rather than guessed at.
+fn redirect_target(
+  current : String,
+  location : String,
+) -> String raise SkillMarketError {
+  if location.has_prefix("http://") || location.has_prefix("https://") {
+    return location
+  }
+  if location.has_prefix("/") && current.find("://") is Some(scheme_end) {
+    let host_start = scheme_end + 3
+    let origin_end = match current[host_start:].to_owned().find("/") {
+      Some(offset) => host_start + offset
+      None => current.length()
+    }
+    return "\{current[0:origin_end].to_owned()}\{location}"
+  }
+  raise SkillMarketError("the skill registry sent an unsupported redirect")
 }
 
 ///|
@@ -342,6 +382,34 @@ test "a wrapped catalog response decodes like a bare one" {
     fail("expected one entry from the wrapped catalog")
   }
   assert_eq(skill.name, "alice/alpha")
+}
+
+///|
+test "redirect targets resolve absolute and host-relative locations" {
+  assert_eq(
+    redirect_target(
+      "https://download.example/skills/a.zip", "http://store.example:9002/blob/a.zip",
+    ),
+    "http://store.example:9002/blob/a.zip",
+  )
+  assert_eq(
+    redirect_target("https://download.example/skills/a.zip", "/blob/a.zip"),
+    "https://download.example/blob/a.zip",
+  )
+  assert_eq(
+    redirect_target("https://download.example", "/blob/a.zip"),
+    "https://download.example/blob/a.zip",
+  )
+  // A relative or garbage location is refused, not guessed at.
+  try {
+    let _ = redirect_target(
+      "https://download.example/skills/a.zip", "blob/a.zip",
+    )
+    fail("a relative redirect must be refused")
+  } catch {
+    SkillMarketError(_) => ()
+    error => raise error
+  }
 }
 
 ///|

--- a/desktop/internal/skillmarket/registry.mbt
+++ b/desktop/internal/skillmarket/registry.mbt
@@ -265,15 +265,29 @@ async fn fetch_archive_source(
   }
   let json = data.json() catch {
     _ =>
-      raise SkillMarketError("skill registry returned a malformed skill entry")
+      raise SkillMarketError(
+        "skill registry returned a malformed entry for \{entry}",
+      )
   }
-  guard json
-    is { "archive_url": String(url), "archive_digest": String(digest), .. } &&
-    !url.is_empty() &&
-    !digest.is_empty() else {
-    raise SkillMarketError("\{entry} does not publish a skill archive")
+  guard json is Object(fields) else {
+    raise SkillMarketError(
+      "skill registry returned a malformed entry for \{entry}",
+    )
   }
-  { url, digest: digest.trim().to_owned().to_lower(), }
+  // Absent coordinates are the one legitimate "no archive" shape; a present
+  // field of the wrong type or an empty string is registry corruption, not
+  // absence, and deserves its own diagnosis.
+  match (fields.get("archive_url"), fields.get("archive_digest")) {
+    (None, None) =>
+      raise SkillMarketError("\{entry} does not publish a skill archive")
+    (Some(String(url)), Some(String(digest))) if !url.is_empty() &&
+      !digest.is_empty() =>
+      { url, digest: digest.trim().to_owned().to_lower(), }
+    _ =>
+      raise SkillMarketError(
+        "skill registry returned a malformed entry for \{entry}",
+      )
+  }
 }
 
 ///|

--- a/desktop/internal/skillmarket/registry.mbt
+++ b/desktop/internal/skillmarket/registry.mbt
@@ -1,6 +1,6 @@
-// The mooncakes.io skill registry client: the catalog of published skills and
-// the per-skill API that confirms one entry is a skill and locates its
-// SKILL.md.
+// The mooncakes.io skill registry client: the catalog of published skills,
+// and the per-skill API that locates one skill's archive (`skills.zip`) and
+// the digest the download is verified against.
 
 ///|
 /// The registry every fetch defaults to. Overridable per call so tests can
@@ -13,6 +13,17 @@ const DefaultRegistry = "https://mooncakes.io"
 const MaxPreviewBytes : Int = 512 * 1024
 
 ///|
+/// Bound the packaged archive download, and separately its decompressed
+/// contents, so a hostile or malformed archive cannot exhaust memory.
+const MaxArchiveBytes : Int = 32 * 1024 * 1024
+
+///|
+const MaxArchiveTotalBytes : Int = 64 * 1024 * 1024
+
+///|
+const MaxArchiveEntries : Int = 512
+
+///|
 /// A registry or library failure with a user-facing message; the host's op
 /// boundary unwraps it into the error the webview displays.
 pub(all) suberror SkillMarketError {
@@ -20,8 +31,8 @@ pub(all) suberror SkillMarketError {
 }
 
 ///|
-/// One installable catalog entry: a published MoonBit package whose doc
-/// build shipped a SKILL.md next to its wasm entry point.
+/// One installable catalog entry: a published MoonBit package that shipped a
+/// skill archive next to its wasm entry point.
 pub struct MarketSkill {
   // Registry entry name, `module_name` plus the subpackage path when the skill
   // lives in one (e.g. "alice/alpha/cmd/run").
@@ -65,13 +76,18 @@ pub async fn fetch_catalog(
 
 ///|
 /// Decode the `/api/v0/skills` payload. The registry catalogs every wasm
-/// entry point; only entries with a description are kept — the registry's
-/// doc builder extracts it from SKILL.md frontmatter, so a present
-/// description marks an entry that actually ships a SKILL.md. (Install
-/// confirms the SKILL.md is really there before writing anything.)
+/// entry point; only entries that publish a skill archive — non-empty
+/// `archive_url` and `archive_digest` — and carry a description are kept.
+/// (Install re-resolves the archive through the per-skill API rather than
+/// trusting catalog data.)
 fn decode_catalog(json : Json) -> Array[MarketSkill] raise SkillMarketError {
-  guard json is Array(items) else {
-    raise SkillMarketError("skill registry returned a malformed catalog")
+  // The plain catalog is a bare array; filtered responses (`?recent=N`)
+  // arrive wrapped in an object. Accept both so a server-side default change
+  // cannot break the panel.
+  let items = match json {
+    Array(items) => items
+    { "all": Array(items), .. } => items
+    _ => raise SkillMarketError("skill registry returned a malformed catalog")
   }
   let skills : Array[MarketSkill] = []
   for item in items {
@@ -84,8 +100,24 @@ fn decode_catalog(json : Json) -> Array[MarketSkill] raise SkillMarketError {
       } else {
       continue
     }
-    guard item is { "metadata": { "description": String(description), .. }, .. } &&
-      !description.is_blank() else {
+    guard item
+      is {
+        "archive_url": String(archive_url),
+        "archive_digest": String(archive_digest),
+        ..
+      } &&
+      !archive_url.is_empty() &&
+      !archive_digest.is_empty() else {
+      continue
+    }
+    let description = if item
+      is { "metadata": { "description": String(description), .. }, .. } &&
+      !description.is_blank() {
+      description
+    } else if item is { "description": String(description), .. } &&
+      !description.is_blank() {
+      description
+    } else {
       continue
     }
     let package_path = if item is { "package": String(package_path), .. } {
@@ -134,19 +166,76 @@ fn entry_path(
 }
 
 ///|
+/// Where one published skill's archive lives and the digest it must hash to.
+priv struct ArchiveSource {
+  url : String
+  digest : String
+}
+
+///|
 /// Confirm `entry` (`module@version[/package]`) is a published skill via the
-/// registry's per-skill API, and return where its SKILL.md lives. The skills
-/// API 404s for anything that is not a registered skill; the SKILL.md itself
-/// sits beside the skill's assets, so its URL is derived from the entry.
-async fn skill_md_url(registry : String, entry : String) -> String {
-  let (code, _data) = fetch_response("\{registry}/api/v0/skills/\{entry}")
+/// registry's per-skill API, and return where its archive lives. The skills
+/// API 404s for anything that is not a registered skill; a registered skill
+/// without archive coordinates has nothing this client can install.
+async fn fetch_archive_source(
+  registry : String,
+  entry : String,
+) -> ArchiveSource {
+  let (code, data) = fetch_response("\{registry}/api/v0/skills/\{entry}")
   if code == 404 {
     raise SkillMarketError("\{entry} is not a published skill")
   }
   guard code == 200 else {
     raise SkillMarketError("skill lookup for \{entry} returned HTTP \{code}")
   }
-  "\{registry}/assets/\{entry}/SKILL.md"
+  let json = data.json() catch {
+    _ =>
+      raise SkillMarketError("skill registry returned a malformed skill entry")
+  }
+  guard json
+    is { "archive_url": String(url), "archive_digest": String(digest), .. } &&
+    !url.is_empty() &&
+    !digest.is_empty() else {
+    raise SkillMarketError("\{entry} does not publish a skill archive")
+  }
+  { url, digest: digest.trim().to_owned().to_lower(), }
+}
+
+///|
+/// Download the archive behind `source` and decode it. Every byte is checked
+/// against the digest the registry declared before any entry is trusted, and
+/// decompression runs under explicit size and entry-count ceilings.
+async fn fetch_archive(entry : String, source : ArchiveSource) -> @zip.Archive {
+  let (code, data) = fetch_response(source.url)
+  if code == 404 {
+    raise SkillMarketError(
+      "the archive for \{entry} is missing from the registry",
+    )
+  }
+  guard code == 200 else {
+    raise SkillMarketError("skill archive download returned HTTP \{code}")
+  }
+  let bytes = data.binary()
+  guard bytes.length() <= MaxArchiveBytes else {
+    raise SkillMarketError("the archive for \{entry} is too large to install")
+  }
+  guard content_digest(bytes) == source.digest else {
+    raise SkillMarketError(
+      "the archive for \{entry} does not match its published digest",
+    )
+  }
+  let limits = @zip.ReadLimits::default()
+    .with_package_limit(MaxArchiveBytes)
+    .with_entries_limit(MaxArchiveEntries)
+    .with_entry_limit(MaxArchiveTotalBytes)
+    .with_total_limit(MaxArchiveTotalBytes)
+  @zip.read(bytes, limits~, cancelled=@async.is_being_cancelled) catch {
+    error if @async.is_being_cancelled() => raise error
+    ZipError(_, message) =>
+      raise SkillMarketError(
+        "the archive for \{entry} cannot be unpacked: \{message}",
+      )
+  }
 }
 
 ///|
@@ -157,19 +246,17 @@ pub async fn fetch_skill_content(
   package_path~ : String,
   registry? : String = DefaultRegistry,
 ) -> String {
-  let url = skill_md_url(
-    registry,
-    entry_path(module_name, version, package_path),
-  )
-  let (code, data) = fetch_response(url)
-  guard code == 200 else {
-    raise SkillMarketError("SKILL.md request returned HTTP \{code}")
-  }
-  guard data.binary().length() <= MaxPreviewBytes else {
+  let entry = entry_path(module_name, version, package_path)
+  let source = fetch_archive_source(registry, entry)
+  let skill = skill_files(fetch_archive(entry, source), entry)
+  guard skill.skill_md.length() <= MaxPreviewBytes else {
     raise SkillMarketError("SKILL.md is too large to preview")
   }
-  data.text() catch {
-    _ => raise SkillMarketError("skill registry returned unreadable SKILL.md")
+  @utf8.decode(skill.skill_md) catch {
+    _ =>
+      raise SkillMarketError(
+        "the archive for \{entry} holds an unreadable SKILL.md",
+      )
   }
 }
 
@@ -177,7 +264,7 @@ pub async fn fetch_skill_content(
 // digest and slug checks, frontmatter parsing.
 
 ///|
-test "catalog decoding keeps only entries that ship a SKILL.md" {
+test "catalog decoding keeps only entries that publish a skill archive" {
   let json : Json = [
     {
       "module": "alice/alpha",
@@ -187,18 +274,27 @@ test "catalog decoding keeps only entries that ship a SKILL.md" {
       "author": "alice",
       "repository": "https://github.com/alice/alpha",
       "metadata": { "description": "Run alpha commands" },
+      "archive_url": "https://download.example/skills/alice/alpha@0.2.0/cmd/run/skills.zip",
+      "archive_digest": "sha256:abc",
     },
-    // No description: a bare wasm entry without a SKILL.md.
+    // No archive: a bare wasm entry without a published skill archive.
     {
       "module": "bob/beta",
       "version": "0.1.0",
       "name": "bob/beta",
       "package": "",
       "author": "bob",
+      "metadata": { "description": "Not installable" },
+    },
+    // An archive whose description never made it into the registry metadata.
+    {
+      "module": "carol/gamma",
+      "version": "0.1.0",
+      "name": "carol/gamma",
+      "archive_url": "https://download.example/skills/carol/gamma@0.1.0/skills.zip",
+      "archive_digest": "sha256:def",
       "metadata": { "description": "" },
     },
-    // No metadata at all.
-    { "module": "carol/gamma", "version": "0.1.0", "name": "carol/gamma" },
     // Malformed entry: skipped, not fatal.
     "nonsense",
   ]
@@ -220,13 +316,32 @@ test "catalog decoding fills optional fields from the module name" {
       "module": "alice/alpha",
       "version": "0.2.0",
       "name": "alice/alpha",
-      "metadata": { "description": "Root skill" },
+      "archive_url": "https://download.example/skills/alice/alpha@0.2.0/skills.zip",
+      "archive_digest": "sha256:abc",
+      "description": "Root skill",
     },
   ]
   guard decode_catalog(json) is [skill] else { fail("expected one entry") }
   assert_eq(skill.package_path, "")
   assert_eq(skill.author, "alice")
   assert_eq(skill.repository, "")
+  assert_eq(skill.description, "Root skill")
+}
+
+///|
+test "a wrapped catalog response decodes like a bare one" {
+  let entry : Json = {
+    "module": "alice/alpha",
+    "version": "0.2.0",
+    "name": "alice/alpha",
+    "archive_url": "https://download.example/skills/alice/alpha@0.2.0/skills.zip",
+    "archive_digest": "sha256:abc",
+    "metadata": { "description": "Root skill" },
+  }
+  guard decode_catalog({ "all": [entry] }) is [skill] else {
+    fail("expected one entry from the wrapped catalog")
+  }
+  assert_eq(skill.name, "alice/alpha")
 }
 
 ///|

--- a/desktop/internal/skillmarket/skillmarket_test.mbt
+++ b/desktop/internal/skillmarket/skillmarket_test.mbt
@@ -187,6 +187,14 @@ async fn fake_registry(
         if path == "/api/v0/skills" {
           conn.send_response(200, "OK", extra_headers=json_headers)
           conn.write_string(catalog_body(base, widget_digest))
+        } else if path == "/api/v0/skills/acme/bare@1.0.0" {
+          // A registered entry that legitimately publishes no archive.
+          conn.send_response(200, "OK", extra_headers=json_headers)
+          conn.write_string("{\"module\":\"acme/bare\"}")
+        } else if path == "/api/v0/skills/acme/malformed@1.0.0" {
+          // Empty-string coordinates: registry corruption, not absence.
+          conn.send_response(200, "OK", extra_headers=json_headers)
+          conn.write_string("{\"archive_url\":\"\",\"archive_digest\":\"\"}")
         } else if path.strip_prefix(SkillsPrefix) is Some(entry) &&
           skills.get(entry.to_owned()) is Some(skill) {
           conn.send_response(200, "OK", extra_headers=json_headers)
@@ -551,6 +559,28 @@ async test "a non-skill module is refused" {
       "acme/nothing",
     )
     assert_true(message.contains("is not a published skill"))
+  }
+}
+
+///|
+async test "a skill without archive coordinates is not installable" {
+  @async.with_task_group() <| group => {
+    guard fake_registry(group) is Some(base) else { return }
+    let lib = @fs.tmpdir(prefix="skillmarket-")
+    let message = install_failure(base, lib, "acme/bare")
+    assert_true(message.contains("does not publish a skill archive"))
+    assert_false(@fs.exists("\{lib}/acme-bare"))
+  }
+}
+
+///|
+async test "malformed archive coordinates are a registry error, not absence" {
+  @async.with_task_group() <| group => {
+    guard fake_registry(group) is Some(base) else { return }
+    let lib = @fs.tmpdir(prefix="skillmarket-")
+    let message = install_failure(base, lib, "acme/malformed")
+    assert_true(message.contains("malformed"))
+    assert_false(@fs.exists("\{lib}/acme-malformed"))
   }
 }
 

--- a/desktop/internal/skillmarket/skillmarket_test.mbt
+++ b/desktop/internal/skillmarket/skillmarket_test.mbt
@@ -193,6 +193,11 @@ async fn fake_registry(
           conn.write_string(
             skill_entry_body(base, entry.to_owned(), skill.digest),
           )
+        } else if path == "/assets/acme/widget@1.0.0/SKILL.md" {
+          // The bare preview asset exists for v1 only; v2 covers the
+          // missing-asset refusal.
+          conn.send_response(200, "OK")
+          conn.write(skill_body)
         } else if path.strip_prefix(DownloadPrefix) is Some(download) &&
           download.strip_suffix(ZipSuffix) is Some(entry) &&
           skills.get(entry.to_owned()) is Some(skill) &&
@@ -334,7 +339,7 @@ async test "a redirect loop on the archive download is refused" {
 }
 
 ///|
-async test "preview fetches the published SKILL.md from the archive" {
+async test "preview fetches the bare SKILL.md from the registry assets tree" {
   @async.with_task_group() <| group => {
     guard fake_registry(group) is Some(base) else { return }
     let content = @skillmarket.fetch_skill_content(
@@ -345,6 +350,26 @@ async test "preview fetches the published SKILL.md from the archive" {
     )
     assert_true(content.contains("Build widgets fast."))
     assert_true(content.contains("Use moon runwasm acme/widget."))
+  }
+}
+
+///|
+async test "a skill without a bare SKILL.md has no preview" {
+  @async.with_task_group() <| group => {
+    guard fake_registry(group) is Some(base) else { return }
+    try {
+      let _ = @skillmarket.fetch_skill_content(
+        module_name="acme/widget",
+        version="2.0.0",
+        package_path="",
+        registry=base,
+      )
+      fail("preview without a bare SKILL.md should have failed")
+    } catch {
+      @skillmarket.SkillMarketError(message) =>
+        assert_true(message.contains("does not publish a SKILL.md"))
+      error => raise error
+    }
   }
 }
 

--- a/desktop/internal/skillmarket/skillmarket_test.mbt
+++ b/desktop/internal/skillmarket/skillmarket_test.mbt
@@ -108,13 +108,20 @@ const SkillsPrefix = "/api/v0/skills/"
 const DownloadPrefix = "/download/"
 
 ///|
+const BlobPrefix = "/blob/"
+
+///|
 const ZipSuffix = "/skills.zip"
+
+///|
+/// The one fake entry whose download redirects to itself forever.
+const LoopEntry = "acme/loop@1.0.0"
 
 ///|
 /// A local mooncakes.io stand-in. Returns its base URL, or None when the
 /// sandbox forbids binding a local TCP port. `acme/widget` publishes real
-/// archives (v1 flat, v2 wrapped in a directory); the other entries cover
-/// each way an install must fail; everything else is not a skill.
+/// archives; the other entries cover each way an install must fail;
+/// everything else is not a skill.
 async fn fake_registry(
   group : @async.TaskGroup[Unit],
   probe? : RegistryProbe,
@@ -131,7 +138,8 @@ async fn fake_registry(
     ("SKILL.md", skill_body),
     ("reference/usage.md", reference_body),
   ])
-  let widget_v2 = zip_of([("widget/SKILL.md", skill_body_v2)])
+  let widget_v2 = zip_of([("SKILL.md", skill_body_v2)])
+  let wrapped = zip_of([("widget/SKILL.md", skill_body)])
   let no_md = zip_of([("README.md", b"no instructions here\n")])
   let slip = zip_of([("SKILL.md", skill_body), ("../evil.md", b"escape\n")])
   let not_text = zip_of([("SKILL.md", b"\xff\xfe\xfd")])
@@ -150,10 +158,18 @@ async fn fake_registry(
       digest: "sha256:deadbeef",
     },
     "acme/nomd@1.0.0": { archive: Some(no_md), digest: digest_of(no_md), },
+    "acme/wrapped@1.0.0": {
+      archive: Some(wrapped),
+      digest: digest_of(wrapped),
+    },
     "acme/slip@1.0.0": { archive: Some(slip), digest: digest_of(slip), },
     "acme/binary@1.0.0": {
       archive: Some(not_text),
       digest: digest_of(not_text),
+    },
+    "acme/loop@1.0.0": {
+      archive: Some(widget_v1),
+      digest: digest_of(widget_v1),
     },
   }
   let widget_digest = digest_of(widget_v1)
@@ -179,6 +195,21 @@ async fn fake_registry(
           )
         } else if path.strip_prefix(DownloadPrefix) is Some(download) &&
           download.strip_suffix(ZipSuffix) is Some(entry) &&
+          skills.get(entry.to_owned()) is Some(skill) &&
+          skill.archive is Some(_) {
+          // The real registry's download host hands the archive to its
+          // object store through a redirect; mirror that, including one
+          // entry that loops forever.
+          let entry = entry.to_owned()
+          let location = if entry == LoopEntry {
+            path
+          } else {
+            "\{BlobPrefix}\{entry}\{ZipSuffix}"
+          }
+          let redirect_headers : @http.Headers = { "Location": location }
+          conn.send_response(302, "Found", extra_headers=redirect_headers)
+        } else if path.strip_prefix(BlobPrefix) is Some(blob) &&
+          blob.strip_suffix(ZipSuffix) is Some(entry) &&
           skills.get(entry.to_owned()) is Some(skill) &&
           skill.archive is Some(archive) {
           conn.send_response(200, "OK")
@@ -281,23 +312,24 @@ async test "install verifies the archive and writes every file it holds" {
 }
 
 ///|
-async test "an archive wrapped in a single directory installs at the root" {
+async test "an archive that wraps its files in a directory is refused" {
   @async.with_task_group() <| group => {
     guard fake_registry(group) is Some(base) else { return }
     let lib = @fs.tmpdir(prefix="skillmarket-")
-    let installed = @skillmarket.install_skill(
-      module_name="acme/widget",
-      version="2.0.0",
-      package_path="",
-      registry=base,
-      library_dir=lib,
-    )
-    assert_eq(installed.description, "Build widgets better.")
-    assert_eq(
-      @fs.read_file("\{lib}/acme-widget/SKILL.md").binary(),
-      skill_body_v2,
-    )
-    assert_false(@fs.exists("\{lib}/acme-widget/widget"))
+    let message = install_failure(base, lib, "acme/wrapped")
+    assert_true(message.contains("does not contain a SKILL.md"))
+    assert_false(@fs.exists("\{lib}/acme-wrapped"))
+  }
+}
+
+///|
+async test "a redirect loop on the archive download is refused" {
+  @async.with_task_group() <| group => {
+    guard fake_registry(group) is Some(base) else { return }
+    let lib = @fs.tmpdir(prefix="skillmarket-")
+    let message = install_failure(base, lib, "acme/loop")
+    assert_true(message.contains("redirected too many times"))
+    assert_false(@fs.exists("\{lib}/acme-loop"))
   }
 }
 

--- a/desktop/internal/skillmarket/skillmarket_test.mbt
+++ b/desktop/internal/skillmarket/skillmarket_test.mbt
@@ -1,15 +1,19 @@
 // End-to-end tests against a local stand-in for mooncakes.io: a real HTTP
-// server serving the catalog, the per-skill API, and SKILL.md bodies, with a
+// server serving the catalog, the per-skill API, and skill archives, with a
 // temporary directory as the skills library.
 
 ///|
-/// The SKILL.md every fake asset serves.
+/// The SKILL.md inside every v1 fake archive.
 let skill_body : Bytes = b"---\nname: widget\ndescription: Build widgets fast.\n---\n\nUse moon runwasm acme/widget.\n"
 
 ///|
 /// A distinct upgrade body lets the concurrent-install test verify that the
 /// installed instructions and provenance came from the same request.
 let skill_body_v2 : Bytes = b"---\nname: widget\ndescription: Build widgets better.\n---\n\nUse moon run acme/widget.\n"
+
+///|
+/// A supporting file installed beside the SKILL.md.
+let reference_body : Bytes = b"Extra reference notes.\n"
 
 ///|
 /// Test-only request concurrency observed by one fake registry.
@@ -37,7 +41,31 @@ async fn RegistryProbe::leave(self : RegistryProbe) -> Unit {
 }
 
 ///|
-fn catalog_body() -> String {
+/// Wire bytes of a zip archive holding `files`.
+fn zip_of(files : Array[(String, Bytes)]) -> Bytes raise {
+  let archive = @zip.Archive::Archive()
+  for file in files {
+    archive.add(file.0, file.1)
+  }
+  @zip.write(archive)
+}
+
+///|
+/// The `sha256:`-prefixed digest the fake registry declares for `bytes`.
+fn digest_of(bytes : Bytes) -> String {
+  "sha256:\{@crypto.bytes_to_hex_string(@crypto.sha256(bytes))}"
+}
+
+///|
+/// One fake registry entry: the archive its download URL serves (`None`
+/// 404s the download) and the digest its API declares.
+struct FakeSkill {
+  archive : Bytes?
+  digest : String
+}
+
+///|
+fn catalog_body(base : String, widget_digest : String) -> String {
   let json : Json = [
     {
       "module": "acme/widget",
@@ -47,33 +75,46 @@ fn catalog_body() -> String {
       "author": "acme",
       "repository": "https://example.com/acme/widget",
       "metadata": { "description": "Build widgets fast." },
+      "archive_url": "\{base}/download/acme/widget@1.0.0/skills.zip",
+      "archive_digest": widget_digest,
     },
+    // A bare wasm entry point: no published skill archive, not installable.
     {
       "module": "acme/bare-wasm",
       "version": "1.0.0",
       "name": "acme/bare-wasm",
       "package": "",
       "author": "acme",
-      "metadata": { "description": "" },
+      "metadata": { "description": "A wasm tool without a skill." },
     },
   ]
   json.stringify()
 }
 
 ///|
+fn skill_entry_body(base : String, entry : String, digest : String) -> String {
+  (
+    {
+      "module": "acme/widget",
+      "archive_url": "\{base}/download/\{entry}/skills.zip",
+      "archive_digest": digest,
+    } : Json).stringify()
+}
+
+///|
 const SkillsPrefix = "/api/v0/skills/"
 
 ///|
-const AssetsPrefix = "/assets/"
+const DownloadPrefix = "/download/"
 
 ///|
-const SkillMdSuffix = "/SKILL.md"
+const ZipSuffix = "/skills.zip"
 
 ///|
 /// A local mooncakes.io stand-in. Returns its base URL, or None when the
-/// sandbox forbids binding a local TCP port. `acme/widget@1.0.0` is a skill
-/// with a SKILL.md; `acme/nomd@1.0.0` is a skill whose SKILL.md asset is
-/// missing; everything else is not a skill.
+/// sandbox forbids binding a local TCP port. `acme/widget` publishes real
+/// archives (v1 flat, v2 wrapped in a directory); the other entries cover
+/// each way an install must fail; everything else is not a skill.
 async fn fake_registry(
   group : @async.TaskGroup[Unit],
   probe? : RegistryProbe,
@@ -86,12 +127,36 @@ async fn fake_registry(
     error => raise error
   }
   let base = "http://127.0.0.1:\{server.addr.port()}"
-  // entry -> whether its SKILL.md asset exists.
-  let skills : Map[String, Bool] = {
-    "acme/widget@1.0.0": true,
-    "acme/widget@2.0.0": true,
-    "acme/nomd@1.0.0": false,
+  let widget_v1 = zip_of([
+    ("SKILL.md", skill_body),
+    ("reference/usage.md", reference_body),
+  ])
+  let widget_v2 = zip_of([("widget/SKILL.md", skill_body_v2)])
+  let no_md = zip_of([("README.md", b"no instructions here\n")])
+  let slip = zip_of([("SKILL.md", skill_body), ("../evil.md", b"escape\n")])
+  let not_text = zip_of([("SKILL.md", b"\xff\xfe\xfd")])
+  let skills : Map[String, FakeSkill] = {
+    "acme/widget@1.0.0": {
+      archive: Some(widget_v1),
+      digest: digest_of(widget_v1),
+    },
+    "acme/widget@2.0.0": {
+      archive: Some(widget_v2),
+      digest: digest_of(widget_v2),
+    },
+    "acme/noarchive@1.0.0": { archive: None, digest: digest_of(b""), },
+    "acme/badsum@1.0.0": {
+      archive: Some(widget_v1),
+      digest: "sha256:deadbeef",
+    },
+    "acme/nomd@1.0.0": { archive: Some(no_md), digest: digest_of(no_md), },
+    "acme/slip@1.0.0": { archive: Some(slip), digest: digest_of(slip), },
+    "acme/binary@1.0.0": {
+      archive: Some(not_text),
+      digest: digest_of(not_text),
+    },
   }
+  let widget_digest = digest_of(widget_v1)
   group.spawn_bg(no_wait=true) <| () => {
     let json_headers : @http.Headers = { "Content-Type": "application/json" }
     server.run_forever(
@@ -105,22 +170,19 @@ async fn fake_registry(
         let path = request.path
         if path == "/api/v0/skills" {
           conn.send_response(200, "OK", extra_headers=json_headers)
-          conn.write_string(catalog_body())
-        } else if path.strip_prefix(SkillsPrefix) is Some(skill) &&
-          skills.contains(skill.to_owned()) {
-          // The per-skill API only confirms the entry is a skill; the install
-          // ignores the body.
+          conn.write_string(catalog_body(base, widget_digest))
+        } else if path.strip_prefix(SkillsPrefix) is Some(entry) &&
+          skills.get(entry.to_owned()) is Some(skill) {
           conn.send_response(200, "OK", extra_headers=json_headers)
-          conn.write_string("{}")
-        } else if path.strip_prefix(AssetsPrefix) is Some(asset) &&
-          asset.strip_suffix(SkillMdSuffix) is Some(skill) &&
-          skills.get(skill.to_owned()) is Some(true) {
+          conn.write_string(
+            skill_entry_body(base, entry.to_owned(), skill.digest),
+          )
+        } else if path.strip_prefix(DownloadPrefix) is Some(download) &&
+          download.strip_suffix(ZipSuffix) is Some(entry) &&
+          skills.get(entry.to_owned()) is Some(skill) &&
+          skill.archive is Some(archive) {
           conn.send_response(200, "OK")
-          if skill == "acme/widget@2.0.0" {
-            conn.write(skill_body_v2)
-          } else {
-            conn.write(skill_body)
-          }
+          conn.write(archive)
         } else {
           conn.send_response(404, "Not Found", extra_headers=json_headers)
           conn.write_string("{\"detail\":\"Skill not found\"}")
@@ -179,7 +241,7 @@ async test "the catalog lists installable skills only" {
 }
 
 ///|
-async test "install downloads the SKILL.md, writes the library and lists the skill" {
+async test "install verifies the archive and writes every file it holds" {
   @async.with_task_group() <| group => {
     guard fake_registry(group) is Some(base) else { return }
     let lib = @fs.tmpdir(prefix="skillmarket-")
@@ -194,8 +256,13 @@ async test "install downloads the SKILL.md, writes the library and lists the ski
     assert_eq(installed.name, "widget")
     assert_eq(installed.description, "Build widgets fast.")
     assert_eq(installed.source, "acme/widget@1.0.0")
-    // The exact wire bytes landed on disk where the engine discovers them.
+    // The exact archive bytes landed on disk where the engine discovers them,
+    // supporting files included.
     assert_eq(@fs.read_file("\{lib}/acme-widget/SKILL.md").binary(), skill_body)
+    assert_eq(
+      @fs.read_file("\{lib}/acme-widget/reference/usage.md").binary(),
+      reference_body,
+    )
     guard @skillmarket.installed_skills(library_dir=lib) is [listed] else {
       fail("expected one installed skill")
     }
@@ -210,6 +277,42 @@ async test "install downloads the SKILL.md, writes the library and lists the ski
       library_dir=lib,
     )
     assert_eq(again.id, "acme-widget")
+  }
+}
+
+///|
+async test "an archive wrapped in a single directory installs at the root" {
+  @async.with_task_group() <| group => {
+    guard fake_registry(group) is Some(base) else { return }
+    let lib = @fs.tmpdir(prefix="skillmarket-")
+    let installed = @skillmarket.install_skill(
+      module_name="acme/widget",
+      version="2.0.0",
+      package_path="",
+      registry=base,
+      library_dir=lib,
+    )
+    assert_eq(installed.description, "Build widgets better.")
+    assert_eq(
+      @fs.read_file("\{lib}/acme-widget/SKILL.md").binary(),
+      skill_body_v2,
+    )
+    assert_false(@fs.exists("\{lib}/acme-widget/widget"))
+  }
+}
+
+///|
+async test "preview fetches the published SKILL.md from the archive" {
+  @async.with_task_group() <| group => {
+    guard fake_registry(group) is Some(base) else { return }
+    let content = @skillmarket.fetch_skill_content(
+      module_name="acme/widget",
+      version="1.0.0",
+      package_path="",
+      registry=base,
+    )
+    assert_true(content.contains("Build widgets fast."))
+    assert_true(content.contains("Use moon runwasm acme/widget."))
   }
 }
 
@@ -395,13 +498,57 @@ async test "a non-skill module is refused" {
 }
 
 ///|
-async test "a skill whose SKILL.md is missing reports it plainly" {
+async test "a skill whose archive is missing reports it plainly" {
+  @async.with_task_group() <| group => {
+    guard fake_registry(group) is Some(base) else { return }
+    let lib = @fs.tmpdir(prefix="skillmarket-")
+    let message = install_failure(base, lib, "acme/noarchive")
+    assert_true(message.contains("missing from the registry"))
+    assert_false(@fs.exists("\{lib}/acme-noarchive"))
+  }
+}
+
+///|
+async test "an archive that fails its digest check is refused" {
+  @async.with_task_group() <| group => {
+    guard fake_registry(group) is Some(base) else { return }
+    let lib = @fs.tmpdir(prefix="skillmarket-")
+    let message = install_failure(base, lib, "acme/badsum")
+    assert_true(message.contains("does not match its published digest"))
+    assert_false(@fs.exists("\{lib}/acme-badsum"))
+  }
+}
+
+///|
+async test "an archive without a SKILL.md is refused at install" {
   @async.with_task_group() <| group => {
     guard fake_registry(group) is Some(base) else { return }
     let lib = @fs.tmpdir(prefix="skillmarket-")
     let message = install_failure(base, lib, "acme/nomd")
-    assert_true(message.contains("does not publish a SKILL.md"))
+    assert_true(message.contains("does not contain a SKILL.md"))
     assert_false(@fs.exists("\{lib}/acme-nomd"))
+  }
+}
+
+///|
+async test "an archive whose SKILL.md is not text is refused" {
+  @async.with_task_group() <| group => {
+    guard fake_registry(group) is Some(base) else { return }
+    let lib = @fs.tmpdir(prefix="skillmarket-")
+    let message = install_failure(base, lib, "acme/binary")
+    assert_true(message.contains("unreadable SKILL.md"))
+    assert_false(@fs.exists("\{lib}/acme-binary"))
+  }
+}
+
+///|
+async test "a path-escaping archive is refused" {
+  @async.with_task_group() <| group => {
+    guard fake_registry(group) is Some(base) else { return }
+    let lib = @fs.tmpdir(prefix="skillmarket-")
+    let message = install_failure(base, lib, "acme/slip")
+    assert_true(message.contains("unsafe path"))
+    assert_false(@fs.exists("\{lib}/acme-slip"))
   }
 }
 

--- a/desktop/internal/skillmarket/transaction.mbt
+++ b/desktop/internal/skillmarket/transaction.mbt
@@ -122,13 +122,14 @@ async fn SkillLibrary::recover(self : SkillLibrary) -> Unit {
 }
 
 ///|
-/// Write one complete candidate without changing the live entry. Cancellation
-/// or an I/O error may leave an incomplete staging directory; `recover`
-/// removes it before any later read or mutation.
+/// Write one complete candidate without changing the live entry: every
+/// archive file below one staged directory, then the provenance sidecar.
+/// Cancellation or an I/O error may leave an incomplete staging directory;
+/// `recover` removes it before any later read or mutation.
 async fn SkillLibrary::stage(
   self : SkillLibrary,
   id : String,
-  content : Bytes,
+  files : Map[String, Bytes],
   provenance : String,
 ) -> Unit {
   let staging = self.staging(id)
@@ -137,7 +138,11 @@ async fn SkillLibrary::stage(
     @fsx.rmdir(staging, recursive=true)
   }
   @fsx.ensure_dir(staging)
-  @fsx.write_bytes(staging.join("SKILL.md"), content)
+  for path, content in files {
+    let target = staging.join(path)
+    @fsx.ensure_dir(target.dirname())
+    @fsx.write_bytes(target, content)
+  }
   @fsx.write_text(staging.join(SidecarFile), provenance)
 }
 

--- a/desktop/moon.mod
+++ b/desktop/moon.mod
@@ -8,6 +8,7 @@ import {
   "moonbit-community/cmark@0.4.5",
   "moonbit-community/pty@0.4.1",
   "moonbit-community/fuzzy_match@0.2.6",
+  "moonbit-community/flate@0.7.1",
   "moonbit-community/rabbita@0.14.3",
   "moonbitlang/x@0.4.50",
   "moonbitlang/async@0.21.0",


### PR DESCRIPTION
## What

mooncakes.io is changing its skills API: skills are now distributed as digested archives (`skills.zip` + `sha256:` digest) instead of bare `SKILL.md` assets, discovered alongside `wasm_url`/`checksum_url` on each catalog entry. This reworks `desktop/internal/skillmarket` for the new interface, with no backward compatibility (as agreed).

## How

- **Catalog** (`GET /api/v0/skills`): an entry is installable when it carries non-empty `archive_url` + `archive_digest` (and a description) — replacing the old description-presence heuristic. Both the bare-array response and the wrapped `{"all": [...]}` shape (observed with `?recent=N`) decode.
- **Install / preview**: the per-skill API (`GET /api/v0/skills/{module}@{version}[/{package}]`, 404 semantics unchanged) resolves the archive URL and digest → download (following up to 5 redirects — the registry's download host hands archives to its object store through a 302, which `@http.get` does not follow) → verify sha256 against the declared digest → unpack with `moonbit-community/flate@0.7.1`'s `zip` reader under `ReadLimits` scaled to the packaged size (max(256MB, 64× the package), entry count ≤ 65536). Download size itself is not client-capped: publish limits are the registry's policy, and the digest pins the content — but a zip's decompressed size is not bounded by its packaged size, so the decompression ceilings stay client-side as the zip-bomb guard.
- **Archive layout is pinned**: `SKILL.md` must sit at the archive root (verified against the staging registry — see below). No wrapper-directory guessing; a wrapped archive is refused with a message naming the root requirement.
- **Extraction guards** (new `archive.mbt`): per-entry CRC-32 verification, zip-slip path validation (`..`, absolute paths, `\`, `:` all rejected), duplicate entry names refused (parser-differential vector), and an archive-supplied `.mooncakes.json` is ignored so provenance can only be written by us.
- **Library**: installs now stage every archive file (SKILL.md plus supporting files) through the existing staging/backup/trash transaction; the provenance sidecar records the verified archive digest. A SKILL.md that is not valid UTF-8 is refused at install instead of degrading silently.

Host ops, the wire protocol, and the frontend are untouched — `skillmarket`'s public interface (`pkg.generated.mbti`) has no diff.

## Verified against the staging registry (mooncakes.test)

- `/api/v0/skills` serves `archive_url`/`archive_digest` exactly as decoded here.
- `archive_digest` is `sha256:`-prefixed lowercase hex; a downloaded `skills.zip` hashed byte-for-byte to its declared digest.
- `skills.zip` layout is flat with `SKILL.md` at the root (e.g. `Yoorkin/grill-me@0.2.5`: SKILL.md, moon.pkg, main.mbt, moon.mod, pkg.generated.mbti, LICENSE).
- `download.mooncakes.test/.../skills.zip` 302-redirects to the object store (`http://…:9002/...`), hence the redirect support.
- The `.well-known/agent-skills/index.json` discovery endpoints exist (schema `agentskills.io/discovery/0.2.0`) but were deliberately not used: the per-skill API carries the same information on a single injectable registry base URL, which keeps the fake-registry tests simple.

Note: production mooncakes.io does not serve the archive fields yet, so against it the catalog lists nothing until the server rollout — correct by design (nothing is installable until archives exist), but worth remembering during E2E. In-app E2E against mooncakes.test additionally needs the `/etc/hosts` entries and the staging site's self-signed certificate trusted in the system keychain.

## Testing

- `moon test internal/skillmarket --target native`: 33/33, including digest mismatch, missing archive, archive without root SKILL.md, wrapped archive refusal, zip-slip, duplicate entries, non-UTF-8 SKILL.md, redirect following and redirect-loop refusal, and preview-from-archive.
- Full `moon test --target native`: all green except the pre-existing `bobzhang/openseek` realworld DeepSeek smoke test (402 insufficient balance — external account state, unrelated). `moon check` clean on native and js; `moon fmt` + `moon info` run (no interface drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SfjgS5Jm91eRsLJnbwYW3N
