### PR TITLE
fix(desktop): diff markdown documents as unhighlighted source

### DIFF
--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -327,6 +327,18 @@ fn markdown_resource_kind(name : String) -> @viewer.MarkdownResourceKind {
 }
 
 ///|
+/// The language for diff-editor models. Markdown documents diff as
+/// unhighlighted source: tokenizing them as code (e.g. `.mbt.md` as MoonBit)
+/// would paint prose like source code.
+fn diff_language_id(name : String) -> String {
+  if uses_markdown_presentation(name) {
+    "markdown"
+  } else {
+    language_id(name)
+  }
+}
+
+///|
 /// Create the viewer in its host element after the next paint, once (the
 /// tokenizers and hover provider register with it). A no-op if already
 /// mounted or the host element is not in the DOM yet.
@@ -763,7 +775,7 @@ fn show_diff_comparison(
     services.feedback.clear_feedback(previous.original.uri)
   }
   let model_version = viewer_state.version
-  let language = language_id(name)
+  let language = diff_language_id(name)
   let original_model = @model.TextModel(
     original_uri,
     name,
@@ -855,7 +867,7 @@ fn show_history_diff_in_viewer(
     viewer_state.version += 1
     let version = viewer_state.version
     let name = basename(diff.path)
-    let language = language_id(name)
+    let language = diff_language_id(name)
     let original_model = @model.TextModel(
       original_uri,
       name,

--- a/desktop/frontend/fileeditor/markdown_presentation_wbtest.mbt
+++ b/desktop/frontend/fileeditor/markdown_presentation_wbtest.mbt
@@ -8,6 +8,10 @@ test "desktop selects Markdown presentation and resource kind explicitly" {
   assert_eq(language_id("tour.mbt.md"), "moonbit")
   assert_true(markdown_resource_kind("README.md") is @viewer.OrdinaryMarkdown)
   assert_true(markdown_resource_kind("tour.MBT.MD") is @viewer.MoonBitMarkdown)
+  assert_eq(diff_language_id("README.md"), "markdown")
+  assert_eq(diff_language_id("tour.mbt.md"), "markdown")
+  assert_eq(diff_language_id("main.mbt"), "moonbit")
+  assert_eq(diff_language_id("moon.pkg"), "moonbit-config")
 }
 
 ///|


### PR DESCRIPTION
## Summary

Fixes the `.mbt.md` half of #1044.

The review and history diff surfaces built their editor models with `language_id()`, which maps `.mbt.md` to `"moonbit"` (pinned by test). The MoonBit tokenizer then painted markdown prose like source code in the diff view — the symptom in the #1044 screenshot. The normal (non-diff) view is unaffected: it goes through the MarkdownViewer rich presentation.

This routes diff-editor models through a new `diff_language_id()`: markdown documents (`.md`, `.mbt.md`) diff as unhighlighted source, while `.mbt`/`.mbti`/JS/JSON/config files keep their tokenizers. `language_id()` itself is deliberately unchanged — the rich MarkdownViewer relies on `.mbt.md` models carrying the `moonbit` language so unlabeled fences in MoonBit markdown tokenize as MoonBit.

## Notes

- Pinned by new assertions in `markdown_presentation_wbtest.mbt`; `moon check` and `moon test desktop/frontend/fileeditor --target js` pass locally (144/144).
- The `.md` half of #1044: plain `.md` diffs already rendered as unhighlighted source before this change (no markdown tokenizer is registered), so their behavior is unchanged here. If the remaining complaint is that `.md` diffs should render as rich markdown, that is a larger diff-surface feature and out of scope for this fix — happy to follow up if maintainers want it.
- Not visually verified in a full desktop build on my side; the change is limited to the diff model language selection.