### PR TITLE
feat(desktop): highlight active historical diff row

### DIFF
--- a/desktop/frontend/fileeditor/git_history_wbtest.mbt
+++ b/desktop/frontend/fileeditor/git_history_wbtest.mbt
@@ -107,6 +107,28 @@ test "Review tree renders VS Code-style Git Graph and inline commit files" {
 }
 
 ///|
+test "active historical diff highlights its commit file row" {
+  let diff : @dock.GitHistoryDiff = {
+    commit: "1111111111111111111111111111111111111111",
+    parent: Some("2222222222222222222222222222222222222222"),
+    path: @pathx.Relative("src/main.mbt"),
+    original_path: None,
+    status: "modified",
+    kind: "file",
+  }
+  let ctx = {
+    ..test_ctx(),
+    open_history_diffs: [diff],
+    active_history_diff: Some(diff),
+  }
+  let html = render_review_html(
+    tree_pane(test_emit(), graph_fixture_state(), ctx),
+  )
+  assert_true(html.contains("class=\"git-history-file selected\""))
+  assert_true(html.contains("aria-current=\"page\""))
+}
+
+///|
 test "Git graph SVG ports VS Code merge and duplicate-lane curves" {
   let merge = render_review_html(
     git_graph_cell(

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -729,7 +729,7 @@ fn review_git_layout(
                 }
                 dispatch(GitHistoryLoadMoreRequested)
               }),
-            git_graph_inventory(dispatch, state),
+            git_graph_inventory(dispatch, state, ctx),
           ),
         ],
       ),
@@ -781,6 +781,7 @@ fn focus_git_commit_after_render(index : Int) -> @cmd.Cmd {
 fn git_graph_inventory(
   dispatch : @cmd.Emit[Msg],
   state : State,
+  ctx : Ctx,
 ) -> Array[@html.Html] {
   match state.git_graph {
     GitGraphIdle | GitGraphLoading =>
@@ -823,6 +824,7 @@ fn git_graph_inventory(
           git_commit_row(
             dispatch,
             state,
+            ctx,
             commit,
             layouts[index],
             index,
@@ -1148,6 +1150,7 @@ fn git_commit_refs(
 fn git_commit_row(
   dispatch : @cmd.Emit[Msg],
   state : State,
+  ctx : Ctx,
   commit : @protocol.GitHistoryCommit,
   layout : GraphRow,
   index : Int,
@@ -1224,7 +1227,7 @@ fn git_commit_row(
     ),
   ]
   if expanded {
-    children.push(git_commit_files(dispatch, state, commit, layout))
+    children.push(git_commit_files(dispatch, state, ctx, commit, layout))
   }
   @html.div(class="git-commit-entry", children)
 }
@@ -1245,6 +1248,7 @@ fn historical_status_label(status : String) -> String {
 fn git_commit_files(
   dispatch : @cmd.Emit[Msg],
   state : State,
+  ctx : Ctx,
   commit : @protocol.GitHistoryCommit,
   layout : GraphRow,
 ) -> @html.Html {
@@ -1285,6 +1289,15 @@ fn git_commit_files(
           let selectable = file.kind == "file" &&
             !(["renamed", "copied"].contains(file.status) &&
             file.original_path is None)
+          let diff : @dock.GitHistoryDiff = {
+            commit: commit.id,
+            parent,
+            path: @pathx.Relative(file.path),
+            original_path: file.original_path.map(path => @pathx.Relative(path)),
+            status: file.status,
+            kind: file.kind,
+          }
+          let selected = ctx.active_history_diff == Some(diff)
           let contents : Array[@html.Html] = [
             git_graph_placeholder(columns, highlight_index),
             @html.span(class="git-history-file-path", file.path),
@@ -1295,21 +1308,16 @@ fn git_commit_files(
           ]
           if selectable {
             @html.button(
-              class="git-history-file",
+              class=if selected {
+                "git-history-file selected"
+              } else {
+                "git-history-file"
+              },
               title="Open historical diff for \{file.path}",
-              on_click=dispatch(
-                HistoricalFileSelected({
-                  commit: commit.id,
-                  parent,
-                  path: @pathx.Relative(file.path),
-                  original_path: file.original_path.map(path => {
-                    @pathx.Relative(path)
-                  }),
-                  status: file.status,
-                  kind: file.kind,
-                }),
-              ),
-              attrs=@html.Attrs::build().role("treeitem"),
+              on_click=dispatch(HistoricalFileSelected(diff)),
+              attrs=@html.Attrs::build()
+                .role("treeitem")
+                .aria_current(if selected { "page" } else { "false" }),
               contents,
             )
           } else {

--- a/desktop/styles/file_panel.css
+++ b/desktop/styles/file_panel.css
@@ -1464,6 +1464,11 @@ button.git-history-file:focus-visible {
   background: var(--color-bg-subtle);
 }
 
+button.git-history-file.selected {
+  color: var(--color-accent-strong);
+  background: var(--color-accent-soft);
+}
+
 .git-history-file.unavailable {
   color: var(--color-text-muted);
   cursor: default;


### PR DESCRIPTION
## Summary

- keep the matching commit-history file row highlighted while its historical diff is active
- match the complete immutable diff identity so identical paths in other commits are not selected
- reuse the existing accent tokens and expose the state with aria-current

## Verification

- moon test desktop/frontend/fileeditor --target js
- just check
- repeated both commands in an isolated worktree at the committed revision