### PR TITLE
feat(mbtx): classify compile-time vs runtime failures structurally

### DIFF
--- a/agent/tool_definition.mbt
+++ b/agent/tool_definition.mbt
@@ -699,11 +699,11 @@ async test "a finished background job queues a notice and wakes the controller" 
 }
 
 ///|
-/// A compile error that only surfaces AFTER the handoff is still classified:
+/// A build failure that only surfaces AFTER the handoff is still classified:
 /// the adopted job's exit note is computed at terminal time (before the build
 /// dir is reclaimed) and rides the completion notice, so the model learns the
 /// snippet never built without spending another tool call.
-async test "a handed-off compile error is classified in its completion notice" {
+async test "a handed-off build failure is classified in its completion notice" {
   @async.with_task_group(group => {
     let scope = @agent_runtime.AgentTaskScope(group)
     let notices : Array[String] = []
@@ -734,7 +734,7 @@ async test "a handed-off compile error is classified in its completion notice" {
       @async.sleep(25)
     }
     guard notices is [notice, ..] else { fail("no completion notice arrived") }
-    assert_true(notice.contains("COMPILE error"))
+    assert_true(notice.contains("BUILD failed"))
     assert_true(notice.contains("never ran"))
     @fs.rmdir(spill_dir, recursive=true) catch {
       _ => ()

--- a/agent/tool_definition.mbt
+++ b/agent/tool_definition.mbt
@@ -16,11 +16,14 @@ fn background_notice_text(snapshot : @bgjobs.BgJobSnapshot) -> String {
     Running => "running"
   }
   // The launcher's exit classification rides along (e.g. mbtx naming a failed
-  // job a compile error vs a runtime failure): the notice is where the model
+  // job a build failure vs a runtime one): the notice is where the model
   // first learns the outcome, and the snapshot's cached note is reliable here
-  // because on_job_exit fires only after the exit watcher computed it.
+  // because on_job_exit fires only after the exit watcher computed it. A
+  // failed classification is named as such rather than shown as a note.
   let note = match snapshot.exit_note {
-    Some(note) => " \{note}"
+    Some(Note(note)) => " \{note}"
+    Some(ClassificationFailed(reason)) =>
+      " (exit-stage classification failed: \{reason})"
     None => ""
   }
   "background job \{snapshot.id} finished (\{status}): `\{snapshot.command}` — read its output with job_output (job_id=\"\{snapshot.id}\").\{note}"

--- a/agent/tool_definition.mbt
+++ b/agent/tool_definition.mbt
@@ -15,7 +15,15 @@ fn background_notice_text(snapshot : @bgjobs.BgJobSnapshot) -> String {
       }
     Running => "running"
   }
-  "background job \{snapshot.id} finished (\{status}): `\{snapshot.command}` — read its output with job_output (job_id=\"\{snapshot.id}\")."
+  // The launcher's exit classification rides along (e.g. mbtx naming a failed
+  // job a compile error vs a runtime failure): the notice is where the model
+  // first learns the outcome, and the snapshot's cached note is reliable here
+  // because on_job_exit fires only after the exit watcher computed it.
+  let note = match snapshot.exit_note {
+    Some(note) => " \{note}"
+    None => ""
+  }
+  "background job \{snapshot.id} finished (\{status}): `\{snapshot.command}` — read its output with job_output (job_id=\"\{snapshot.id}\").\{note}"
 }
 
 ///|
@@ -687,6 +695,50 @@ async test "a finished background job queues a notice and wakes the controller" 
     assert_true(woke)
     let steers = runtime.drain_steers()
     assert_true(steers.any(s => s is Notice(_)))
+  })
+}
+
+///|
+/// A compile error that only surfaces AFTER the handoff is still classified:
+/// the adopted job's exit note is computed at terminal time (before the build
+/// dir is reclaimed) and rides the completion notice, so the model learns the
+/// snippet never built without spending another tool call.
+async test "a handed-off compile error is classified in its completion notice" {
+  @async.with_task_group(group => {
+    let scope = @agent_runtime.AgentTaskScope(group)
+    let notices : Array[String] = []
+    let spill_dir = @fs.tmpdir(prefix="openseek-jobs-note-")
+    let bg_runtime = @bgjobs.BgJobRuntime(scope, spill_dir~, on_job_exit=snapshot => {
+      notices.push(background_notice_text(snapshot))
+    })
+    let mbtx = @mbtx.definition(
+      workspace_root=".",
+      bg_runtime~,
+      job_dir=spill_dir,
+      // Hand off before the compiler can possibly finish, so the failure is
+      // only discoverable at the job's terminal transition.
+      auto_background_after_ms=1,
+    )
+    let action = match mbtx.execute {
+      Async(execute) =>
+        execute({ "source": "fn main { let _x : Int = 1 + \"nope\" }" })
+      Sync(_) => fail("mbtx should be async")
+    }
+    guard action is Respond(output) else { fail("expected Respond") }
+    assert_true(output.content.contains("moved to the background"))
+    // Generous budget: the job still runs the whole (failing) build.
+    for _ in 0..<2400 {
+      if notices.length() > 0 {
+        break
+      }
+      @async.sleep(25)
+    }
+    guard notices is [notice, ..] else { fail("no completion notice arrived") }
+    assert_true(notice.contains("COMPILE error"))
+    assert_true(notice.contains("never ran"))
+    @fs.rmdir(spill_dir, recursive=true) catch {
+      _ => ()
+    }
   })
 }
 

--- a/agent/tool_definition.mbt
+++ b/agent/tool_definition.mbt
@@ -611,6 +611,12 @@ async test "the inline output cap gives actionable retry guidance" {
     assert_true(output.content.contains("Retrying the same call"))
     assert_true(output.content.contains("stdout=ToFile(path)"))
     assert_true(output.content.contains("same snippet read the file"))
+    // A cap kill has NO exit status: the report must not invent one ("exit
+    // -1") or hang a stage label off it — the STOPPED note above is the
+    // whole story.
+    assert_false(output.content.contains("-1"))
+    assert_false(output.content.contains("at RUNTIME"))
+    assert_true(output.brief is Some("mbtx (killed)"))
     @fs.rmdir(spill_dir, recursive=true) catch {
       _ => ()
     }

--- a/agent_tool/bgjobs/bgjobs.mbt
+++ b/agent_tool/bgjobs/bgjobs.mbt
@@ -111,18 +111,39 @@ priv struct BgJob {
   // observers are added later.
   mut on_terminal : (async () -> Unit)?
   // Optional launcher-supplied classification of a terminal exit (mbtx uses it
-  // to separate "the snippet never built" from "the program ran and failed").
-  // Called with the exit code (`None` for a killed job) once the process is
-  // terminal — BEFORE `on_terminal`, because the classifier's evidence is
-  // often exactly what that cleanup deletes. It must settle promptly: a
-  // waiter (the exit watcher included, so cleanup too) blocks on an in-flight
-  // computation.
-  exit_note_fn : (async (Int?) -> String?)?
+  // to separate "the snippet never built" from "the failure came from the
+  // run"). Called with the job's `BgJobExit` once the process is terminal —
+  // BEFORE `on_terminal`, because the classifier's evidence is often exactly
+  // what that cleanup deletes. It must settle promptly: a waiter (the exit
+  // watcher included, so cleanup too) blocks on an in-flight computation.
+  exit_note_fn : (async (BgJobExit) -> String?)?
   mut exit_note_state : ExitNoteState
   // A terminal denial scan may read a large retained log. Cache its
   // classification so repeated job_output calls do not repeat that allocation.
   mut denial_scanned : Bool
   mut denial_feedback : String?
+}
+
+///|
+/// What a launcher's exit classifier is given: the exit code (`None` when the
+/// process was killed rather than exiting) plus which watchdog, if any, did
+/// the killing — so a classifier can still name the failed stage for a job
+/// the reaper or the output cap terminated, while staying silent for a
+/// requested stop.
+pub struct BgJobExit {
+  exit_code : Int?
+  killed_by_output_limit : Bool
+  killed_by_time_limit : Bool
+}
+
+///|
+/// A launcher's exit classification as readers receive it: the note itself,
+/// or the fact that classification FAILED — a distinct variant, because a
+/// failure folded into an ordinary note string could never be told apart
+/// from a launcher that legitimately had something to say.
+pub enum BgJobExitNote {
+  Note(String)
+  ClassificationFailed(String)
 }
 
 ///|
@@ -134,7 +155,7 @@ priv struct BgJob {
 priv enum ExitNoteState {
   NotComputed
   Computing
-  Cached(String?)
+  Cached(BgJobExitNote?)
 }
 
 ///|
@@ -168,7 +189,7 @@ pub struct BgJobSnapshot {
   // The launcher's cached classification of a terminal exit, `None` until the
   // exit watcher computes it (or when there is nothing to say). Readers that
   // must not race that computation use `BgJobRuntime::exit_note` instead.
-  exit_note : String?
+  exit_note : BgJobExitNote?
 }
 
 ///|
@@ -316,10 +337,11 @@ pub async fn BgJobRuntime::start(
 /// and the completion notice see it like any explicit background job.
 ///
 /// `exit_note` lets the launcher classify the exit for readers of the finished
-/// job (the completion notice, `job_output`): it is called with the exit code
-/// (`None` for a killed job) once the process is terminal, before `on_terminal`
-/// reclaims launcher resources — so it may still read evidence that cleanup is
-/// about to delete — and its answer is cached on the job.
+/// job (the completion notice, `job_output`): it is called with the job's
+/// `BgJobExit` (exit code plus watchdog-kill flags, so a reaped or flooding
+/// job can still be classified) once the process is terminal, before
+/// `on_terminal` reclaims launcher resources — so it may still read evidence
+/// that cleanup is about to delete — and its answer is cached on the job.
 pub fn BgJobRuntime::adopt(
   self : BgJobRuntime,
   exec : @shell_exec.ShellExecution,
@@ -330,7 +352,7 @@ pub fn BgJobRuntime::adopt(
   output_rewrites? : Array[(String, String)] = [],
   moonrun_policy_active? : Bool = false,
   on_terminal? : async () -> Unit,
-  exit_note? : async (Int?) -> String?,
+  exit_note? : async (BgJobExit) -> String?,
 ) -> String {
   let id = self.next_id()
   self.register(
@@ -361,7 +383,7 @@ fn BgJobRuntime::register(
   output_rewrites~ : Array[(String, String)],
   moonrun_policy_active~ : Bool,
   on_terminal~ : (async () -> Unit)?,
-  exit_note_fn~ : (async (Int?) -> String?)?,
+  exit_note_fn~ : (async (BgJobExit) -> String?)?,
 ) -> Unit {
   self.jobs[id] = {
     id,
@@ -474,7 +496,7 @@ fn BgJob::to_snapshot(self : BgJob) -> BgJobSnapshot {
 pub async fn BgJobRuntime::exit_note(
   self : BgJobRuntime,
   id : String,
-) -> String? {
+) -> BgJobExitNote? {
   guard self.jobs.get(id) is Some(job) else { return None }
   guard !(bg_status(job.exec.status()) is Running) else { return None }
   for ;; {
@@ -490,7 +512,12 @@ pub async fn BgJobRuntime::exit_note(
           return None
         }
         job.exit_note_state = Computing
-        let note = classify(job.exec.exit_code()) catch {
+        let exit : BgJobExit = {
+          exit_code: job.exec.exit_code(),
+          killed_by_output_limit: job.exec.killed_by_output_limit(),
+          killed_by_time_limit: job.exec.killed_by_time_limit(),
+        }
+        let note = classify(exit).map(text => BgJobExitNote::Note(text)) catch {
           error if @async.is_being_cancelled() => {
             // A cancelled computation decided nothing: release the flight so
             // the next caller (usually the exit watcher) computes, instead of
@@ -498,10 +525,10 @@ pub async fn BgJobRuntime::exit_note(
             job.exit_note_state = NotComputed
             raise error
           }
-          // A real classifier failure is an answer of its own — caching it as
-          // "nothing to say" would silently erase the failure stage from the
-          // notice and job_output.
-          error => Some("exit-stage classification failed (\{error}).")
+          // A real classifier failure is an answer of its own, and a TYPED
+          // one: folded into an ordinary note string it could never be told
+          // apart from a launcher that had something to say.
+          error => Some(ClassificationFailed("\{error}"))
         }
         job.exit_note_state = Cached(note)
         return note
@@ -746,8 +773,8 @@ async test "the exit note is computed before terminal cleanup" {
     let id = rt.adopt(
       exec,
       command="exit 3",
-      exit_note=code => {
-        received.push(code)
+      exit_note=exit => {
+        received.push(exit.exit_code)
         Some("cleaned=\{cleaned}")
       },
       on_terminal=() => cleaned = true,
@@ -759,11 +786,13 @@ async test "the exit note is computed before terminal cleanup" {
       @async.sleep(5)
     }
     assert_true(cleaned)
-    assert_true(rt.exit_note(id) is Some("cleaned=false"))
+    assert_true(rt.exit_note(id) is Some(Note("cleaned=false")))
     // The classifier saw the real exit code, exactly once.
     assert_true(received is [Some(3)])
     // The cached note is also on the snapshot for sync readers (the notice).
-    assert_true(rt.snapshot(id).unwrap().exit_note is Some("cleaned=false"))
+    assert_true(
+      rt.snapshot(id).unwrap().exit_note is Some(Note("cleaned=false")),
+    )
   })
 }
 
@@ -802,8 +831,8 @@ async test "a reader racing the exit watcher joins its flight, never recomputes"
       }
       @async.sleep(5)
     }
-    assert_true(rt.exit_note(id) is Some("present"))
-    assert_true(rt.snapshot(id).unwrap().exit_note is Some("present"))
+    assert_true(rt.exit_note(id) is Some(Note("present")))
+    assert_true(rt.snapshot(id).unwrap().exit_note is Some(Note("present")))
     assert_eq(calls, 1)
   })
 }
@@ -824,11 +853,33 @@ async test "a failing classifier is reported, not silently dropped" {
       fail("probe exploded")
     })
     let _ = rt.wait_exit(id, 30_000)
-    guard rt.exit_note(id) is Some(note) else {
-      fail("expected a tagged failure note")
+    // The failure arrives as its own VARIANT, never mistakable for a note the
+    // launcher chose to write.
+    guard rt.exit_note(id) is Some(ClassificationFailed(reason)) else {
+      fail("expected a typed classification failure")
     }
-    assert_true(note.contains("classification failed"))
-    assert_true(note.contains("probe exploded"))
+    assert_true(reason.contains("probe exploded"))
+  })
+}
+
+///|
+/// A watchdog kill still reaches the classifier, with the flag that lets it
+/// name the failed stage — a job reaped mid-build and one reaped mid-run look
+/// identical in the kill status alone.
+#cfg(not(platform="windows"))
+async test "a watchdog kill is classified with its flag set" {
+  @async.with_task_group(group => {
+    let scope : @agent_runtime.AgentTaskScope[Unit] = AgentTaskScope(group)
+    let rt = BgJobRuntime::BgJobRuntime(scope, hard_timeout_ms=80)
+    let exec = @shell_exec.ShellExecution::start(scope, program="sleep", args=[
+      "30",
+    ])
+    let id = rt.adopt(exec, command="sleep 30", exit_note=exit => {
+      Some("time_capped=\{exit.killed_by_time_limit}")
+    })
+    let snapshot = poll_until_terminal(rt, id)
+    assert_true(snapshot.killed_by_time_limit)
+    assert_true(rt.exit_note(id) is Some(Note("time_capped=true")))
   })
 }
 
@@ -841,15 +892,19 @@ async test "exit_note is None while running and a kill carries no exit code" {
     let exec = @shell_exec.ShellExecution::start(scope, program="sleep", args=[
       "30",
     ])
-    let id = rt.adopt(exec, command="sleep 30", exit_note=code => {
-      Some("code=\{Repr(code)}")
+    let id = rt.adopt(exec, command="sleep 30", exit_note=exit => {
+      Some(
+        "code=\{Repr(exit.exit_code)} watchdog=\{exit.killed_by_output_limit || exit.killed_by_time_limit}",
+      )
     })
     @async.sleep(50)
     // No classification before the job is terminal.
     assert_true(rt.exit_note(id) is None)
     assert_true(rt.stop(id))
-    // A killed job has no exit code of its own to classify.
-    assert_true(rt.exit_note(id) is Some("code=None"))
+    // A killed job has no exit code of its own to classify, and a REQUESTED
+    // stop raises neither watchdog flag — the metadata a launcher needs to
+    // stay silent here while still classifying reaped or flooding jobs.
+    assert_true(rt.exit_note(id) is Some(Note("code=None watchdog=false")))
     // A job whose launcher supplied no classifier stays unclassified.
     let plain = rt.start(program="sh", args=["-c", "exit 2"], command="exit 2")
     let _ = poll_until_terminal(rt, plain)

--- a/agent_tool/bgjobs/bgjobs.mbt
+++ b/agent_tool/bgjobs/bgjobs.mbt
@@ -111,19 +111,30 @@ priv struct BgJob {
   // observers are added later.
   mut on_terminal : (async () -> Unit)?
   // Optional launcher-supplied classification of a terminal exit (mbtx uses it
-  // to separate "the snippet never compiled" from "the program ran and
-  // failed"). Called with the exit code (`None` for a killed job) once the
-  // process is terminal — BEFORE `on_terminal`, because the classifier's
-  // evidence is often exactly what that cleanup deletes. Deliberately NOT
-  // cleared after use: a concurrent first computation must find the same
-  // closure and cache the same answer, never a spurious `None`.
+  // to separate "the snippet never built" from "the program ran and failed").
+  // Called with the exit code (`None` for a killed job) once the process is
+  // terminal — BEFORE `on_terminal`, because the classifier's evidence is
+  // often exactly what that cleanup deletes. It must settle promptly: a
+  // waiter (the exit watcher included, so cleanup too) blocks on an in-flight
+  // computation.
   exit_note_fn : (async (Int?) -> String?)?
-  mut exit_note_cached : Bool
-  mut exit_note : String?
+  mut exit_note_state : ExitNoteState
   // A terminal denial scan may read a large retained log. Cache its
   // classification so repeated job_output calls do not repeat that allocation.
   mut denial_scanned : Bool
   mut denial_feedback : String?
+}
+
+///|
+/// Lifecycle of a job's launcher-supplied exit classification. Single-flight
+/// on purpose: exactly one task may run the classifier, because a second
+/// computation could start before the terminal cleanup deletes the
+/// classifier's evidence, finish after it, and overwrite a correct cached
+/// answer with one read from the emptied directory.
+priv enum ExitNoteState {
+  NotComputed
+  Computing
+  Cached(String?)
 }
 
 ///|
@@ -363,8 +374,7 @@ fn BgJobRuntime::register(
     moonrun_policy_active,
     on_terminal,
     exit_note_fn,
-    exit_note_cached: false,
-    exit_note: None,
+    exit_note_state: NotComputed,
     denial_scanned: false,
     denial_feedback: None,
   }
@@ -444,38 +454,60 @@ fn BgJob::to_snapshot(self : BgJob) -> BgJobSnapshot {
     moonrun_policy_active: self.moonrun_policy_active,
     killed_by_output_limit: self.exec.killed_by_output_limit(),
     killed_by_time_limit: self.exec.killed_by_time_limit(),
-    exit_note: self.exit_note,
+    exit_note: match self.exit_note_state {
+      Cached(note) => note
+      NotComputed | Computing => None
+    },
   }
 }
 
 ///|
 /// The launcher's classification of a terminal job's exit — `None` while the
 /// job still runs, when the launcher supplied no classifier, or when it had
-/// nothing to say. Computed once and cached: the exit watcher calls this
-/// before `on_terminal`, so the classifier may read launcher resources that
-/// cleanup is about to reclaim, and every later reader hits the cache. A
-/// caller racing that first computation recomputes from the same still-intact
-/// evidence and caches the same answer, so the race is benign.
+/// nothing to say. Computed exactly once (single-flight) and cached: the exit
+/// watcher calls this before `on_terminal`, so the classifier reads launcher
+/// resources that cleanup is about to reclaim, and every other caller —
+/// including one racing that first computation — waits for its answer rather
+/// than recomputing. Recomputing was a live bug: a reader that entered before
+/// the watcher's answer landed could finish AFTER cleanup emptied the
+/// evidence directory and overwrite the correct note with a wrong one.
 pub async fn BgJobRuntime::exit_note(
   self : BgJobRuntime,
   id : String,
 ) -> String? {
   guard self.jobs.get(id) is Some(job) else { return None }
   guard !(bg_status(job.exec.status()) is Running) else { return None }
-  if job.exit_note_cached {
-    return job.exit_note
-  }
-  let note = match job.exit_note_fn {
-    Some(classify) =>
-      classify(job.exec.exit_code()) catch {
-        error if @async.is_being_cancelled() => raise error
-        _ => None
+  for ;; {
+    match job.exit_note_state {
+      Cached(note) => return note
+      // Another task holds the flight; await its answer. (The single-threaded
+      // scheduler makes the NotComputed→Computing transition below atomic, so
+      // two tasks can never both claim it.)
+      Computing => @async.sleep(5)
+      NotComputed => {
+        guard job.exit_note_fn is Some(classify) else {
+          job.exit_note_state = Cached(None)
+          return None
+        }
+        job.exit_note_state = Computing
+        let note = classify(job.exec.exit_code()) catch {
+          error if @async.is_being_cancelled() => {
+            // A cancelled computation decided nothing: release the flight so
+            // the next caller (usually the exit watcher) computes, instead of
+            // caching a guess or wedging every waiter.
+            job.exit_note_state = NotComputed
+            raise error
+          }
+          // A real classifier failure is an answer of its own — caching it as
+          // "nothing to say" would silently erase the failure stage from the
+          // notice and job_output.
+          error => Some("exit-stage classification failed (\{error}).")
+        }
+        job.exit_note_state = Cached(note)
+        return note
       }
-    None => None
+    }
   }
-  job.exit_note = note
-  job.exit_note_cached = true
-  note
 }
 
 ///|
@@ -732,6 +764,71 @@ async test "the exit note is computed before terminal cleanup" {
     assert_true(received is [Some(3)])
     // The cached note is also on the snapshot for sync readers (the notice).
     assert_true(rt.snapshot(id).unwrap().exit_note is Some("cleaned=false"))
+  })
+}
+
+///|
+/// Regression (review finding): a reader that entered classification while
+/// the watcher's flight was still running used to RECOMPUTE — finishing after
+/// terminal cleanup had emptied the evidence directory and overwriting the
+/// correct cached note with one read from the emptied state. Single-flight
+/// means the late reader waits for the flight's answer and the classifier
+/// runs exactly once, strictly before cleanup.
+#cfg(not(platform="windows"))
+async test "a reader racing the exit watcher joins its flight, never recomputes" {
+  @async.with_task_group(group => {
+    let scope : @agent_runtime.AgentTaskScope[Unit] = AgentTaskScope(group)
+    let rt = BgJobRuntime::BgJobRuntime(scope)
+    let exec = @shell_exec.ShellExecution::start(scope, program="sh", args=[
+      "-c", "exit 3",
+    ])
+    let mut calls = 0
+    let mut cleaned = false
+    let id = rt.adopt(
+      exec,
+      command="exit 3",
+      exit_note=_ => {
+        calls += 1
+        // Hold the flight open long enough for the reader below to land in it.
+        @async.sleep(100)
+        Some(if cleaned { "missing" } else { "present" })
+      },
+      on_terminal=() => cleaned = true,
+    )
+    // Enter the accessor while the watcher's classification is in flight.
+    for _ in 0..<200 {
+      if calls == 1 {
+        break
+      }
+      @async.sleep(5)
+    }
+    assert_true(rt.exit_note(id) is Some("present"))
+    assert_true(rt.snapshot(id).unwrap().exit_note is Some("present"))
+    assert_eq(calls, 1)
+  })
+}
+
+///|
+/// A classifier failure is an answer of its own: folding it into "nothing to
+/// say" would silently erase the failure stage from the completion notice and
+/// job_output.
+#cfg(not(platform="windows"))
+async test "a failing classifier is reported, not silently dropped" {
+  @async.with_task_group(group => {
+    let scope : @agent_runtime.AgentTaskScope[Unit] = AgentTaskScope(group)
+    let rt = BgJobRuntime::BgJobRuntime(scope)
+    let exec = @shell_exec.ShellExecution::start(scope, program="sh", args=[
+      "-c", "exit 3",
+    ])
+    let id = rt.adopt(exec, command="exit 3", exit_note=_ => {
+      fail("probe exploded")
+    })
+    let _ = rt.wait_exit(id, 30_000)
+    guard rt.exit_note(id) is Some(note) else {
+      fail("expected a tagged failure note")
+    }
+    assert_true(note.contains("classification failed"))
+    assert_true(note.contains("probe exploded"))
   })
 }
 

--- a/agent_tool/bgjobs/bgjobs.mbt
+++ b/agent_tool/bgjobs/bgjobs.mbt
@@ -110,6 +110,16 @@ priv struct BgJob {
   // Cleared before invocation so cleanup is exactly once even if more terminal
   // observers are added later.
   mut on_terminal : (async () -> Unit)?
+  // Optional launcher-supplied classification of a terminal exit (mbtx uses it
+  // to separate "the snippet never compiled" from "the program ran and
+  // failed"). Called with the exit code (`None` for a killed job) once the
+  // process is terminal — BEFORE `on_terminal`, because the classifier's
+  // evidence is often exactly what that cleanup deletes. Deliberately NOT
+  // cleared after use: a concurrent first computation must find the same
+  // closure and cache the same answer, never a spurious `None`.
+  exit_note_fn : (async (Int?) -> String?)?
+  mut exit_note_cached : Bool
+  mut exit_note : String?
   // A terminal denial scan may read a large retained log. Cache its
   // classification so repeated job_output calls do not repeat that allocation.
   mut denial_scanned : Bool
@@ -144,6 +154,10 @@ pub struct BgJobSnapshot {
   // The job was killed by the wall-clock reaper (outlived hard_timeout_ms),
   // not stopped on request — surfaced for the same reason.
   killed_by_time_limit : Bool
+  // The launcher's cached classification of a terminal exit, `None` until the
+  // exit watcher computes it (or when there is nothing to say). Readers that
+  // must not race that computation use `BgJobRuntime::exit_note` instead.
+  exit_note : String?
 }
 
 ///|
@@ -279,6 +293,7 @@ pub async fn BgJobRuntime::start(
     output_rewrites~,
     moonrun_policy_active~,
     on_terminal=None,
+    exit_note_fn=None,
   )
   id
 }
@@ -288,6 +303,12 @@ pub async fn BgJobRuntime::start(
 /// its id. Used by detach-on-timeout: a foreground command that outlived its
 /// timeout is `background()`-ed and adopted here, so `shell_output`/`shell_stop`
 /// and the completion notice see it like any explicit background job.
+///
+/// `exit_note` lets the launcher classify the exit for readers of the finished
+/// job (the completion notice, `job_output`): it is called with the exit code
+/// (`None` for a killed job) once the process is terminal, before `on_terminal`
+/// reclaims launcher resources — so it may still read evidence that cleanup is
+/// about to delete — and its answer is cached on the job.
 pub fn BgJobRuntime::adopt(
   self : BgJobRuntime,
   exec : @shell_exec.ShellExecution,
@@ -298,6 +319,7 @@ pub fn BgJobRuntime::adopt(
   output_rewrites? : Array[(String, String)] = [],
   moonrun_policy_active? : Bool = false,
   on_terminal? : async () -> Unit,
+  exit_note? : async (Int?) -> String?,
 ) -> String {
   let id = self.next_id()
   self.register(
@@ -310,6 +332,7 @@ pub fn BgJobRuntime::adopt(
     output_rewrites~,
     moonrun_policy_active~,
     on_terminal~,
+    exit_note_fn=exit_note,
   )
   id
 }
@@ -327,6 +350,7 @@ fn BgJobRuntime::register(
   output_rewrites~ : Array[(String, String)],
   moonrun_policy_active~ : Bool,
   on_terminal~ : (async () -> Unit)?,
+  exit_note_fn~ : (async (Int?) -> String?)?,
 ) -> Unit {
   self.jobs[id] = {
     id,
@@ -338,6 +362,9 @@ fn BgJobRuntime::register(
     output_rewrites: output_rewrites.copy(),
     moonrun_policy_active,
     on_terminal,
+    exit_note_fn,
+    exit_note_cached: false,
+    exit_note: None,
     denial_scanned: false,
     denial_feedback: None,
   }
@@ -350,6 +377,12 @@ fn BgJobRuntime::register(
   // `snapshot(id)` always resolves.
   (self.spawn_watcher)(() => {
     exec.wait()
+    // Compute (and cache) the launcher's exit note FIRST: its evidence — an
+    // mbtx build artifact, say — is often exactly what the terminal cleanup
+    // below deletes. Advisory, so a failed or cancelled classification must
+    // not skip that cleanup.
+    let _ = self.exit_note(id) catch { _ => None }
+
     // The output spill belongs to the runtime, but a launcher may also have
     // handed the job a separate build directory. Reclaim that directory for
     // natural exit, watchdog kills, and requested stops alike.
@@ -411,7 +444,38 @@ fn BgJob::to_snapshot(self : BgJob) -> BgJobSnapshot {
     moonrun_policy_active: self.moonrun_policy_active,
     killed_by_output_limit: self.exec.killed_by_output_limit(),
     killed_by_time_limit: self.exec.killed_by_time_limit(),
+    exit_note: self.exit_note,
   }
+}
+
+///|
+/// The launcher's classification of a terminal job's exit — `None` while the
+/// job still runs, when the launcher supplied no classifier, or when it had
+/// nothing to say. Computed once and cached: the exit watcher calls this
+/// before `on_terminal`, so the classifier may read launcher resources that
+/// cleanup is about to reclaim, and every later reader hits the cache. A
+/// caller racing that first computation recomputes from the same still-intact
+/// evidence and caches the same answer, so the race is benign.
+pub async fn BgJobRuntime::exit_note(
+  self : BgJobRuntime,
+  id : String,
+) -> String? {
+  guard self.jobs.get(id) is Some(job) else { return None }
+  guard !(bg_status(job.exec.status()) is Running) else { return None }
+  if job.exit_note_cached {
+    return job.exit_note
+  }
+  let note = match job.exit_note_fn {
+    Some(classify) =>
+      classify(job.exec.exit_code()) catch {
+        error if @async.is_being_cancelled() => raise error
+        _ => None
+      }
+    None => None
+  }
+  job.exit_note = note
+  job.exit_note_cached = true
+  note
 }
 
 ///|
@@ -628,6 +692,72 @@ async test "adopt registers an already-running execution as a job" {
     assert_true(rt.snapshot(id).unwrap().read_only_review)
     assert_true(rt.stop(id))
     assert_true(rt.snapshot(id).unwrap().status is Stopped)
+  })
+}
+
+///|
+/// The exit note must be computed while the launcher's evidence still exists:
+/// the classifier here observes the cleanup flag that `on_terminal` flips, and
+/// a note computed after cleanup would misclassify every launcher whose
+/// evidence lives in the directory that cleanup reclaims (mbtx's build
+/// artifact probe is exactly that).
+#cfg(not(platform="windows"))
+async test "the exit note is computed before terminal cleanup" {
+  @async.with_task_group(group => {
+    let scope : @agent_runtime.AgentTaskScope[Unit] = AgentTaskScope(group)
+    let rt = BgJobRuntime::BgJobRuntime(scope)
+    let exec = @shell_exec.ShellExecution::start(scope, program="sh", args=[
+      "-c", "exit 3",
+    ])
+    let received : Array[Int?] = []
+    let mut cleaned = false
+    let id = rt.adopt(
+      exec,
+      command="exit 3",
+      exit_note=code => {
+        received.push(code)
+        Some("cleaned=\{cleaned}")
+      },
+      on_terminal=() => cleaned = true,
+    )
+    for _ in 0..<200 {
+      if cleaned {
+        break
+      }
+      @async.sleep(5)
+    }
+    assert_true(cleaned)
+    assert_true(rt.exit_note(id) is Some("cleaned=false"))
+    // The classifier saw the real exit code, exactly once.
+    assert_true(received is [Some(3)])
+    // The cached note is also on the snapshot for sync readers (the notice).
+    assert_true(rt.snapshot(id).unwrap().exit_note is Some("cleaned=false"))
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "exit_note is None while running and a kill carries no exit code" {
+  @async.with_task_group(group => {
+    let scope : @agent_runtime.AgentTaskScope[Unit] = AgentTaskScope(group)
+    let rt = BgJobRuntime::BgJobRuntime(scope)
+    let exec = @shell_exec.ShellExecution::start(scope, program="sleep", args=[
+      "30",
+    ])
+    let id = rt.adopt(exec, command="sleep 30", exit_note=code => {
+      Some("code=\{Repr(code)}")
+    })
+    @async.sleep(50)
+    // No classification before the job is terminal.
+    assert_true(rt.exit_note(id) is None)
+    assert_true(rt.stop(id))
+    // A killed job has no exit code of its own to classify.
+    assert_true(rt.exit_note(id) is Some("code=None"))
+    // A job whose launcher supplied no classifier stays unclassified.
+    let plain = rt.start(program="sh", args=["-c", "exit 2"], command="exit 2")
+    let _ = poll_until_terminal(rt, plain)
+    assert_true(rt.exit_note(plain) is None)
+    assert_true(rt.exit_note("nope") is None)
   })
 }
 

--- a/agent_tool/bgjobs/pkg.generated.mbti
+++ b/agent_tool/bgjobs/pkg.generated.mbti
@@ -17,7 +17,8 @@ pub struct BgJobRuntime {
   // private fields
 }
 pub fn[X] BgJobRuntime::BgJobRuntime(@agent_runtime.AgentTaskScope[X], spill_dir? : String, hard_output_cap? : Int, hard_timeout_ms? : Int, on_job_exit? : (BgJobSnapshot) -> Unit) -> Self
-pub fn BgJobRuntime::adopt(Self, @shell_exec.ShellExecution, command~ : String, cwd? : String, sandboxed_command? : @sandbox.SandboxedCommand, read_only_review? : Bool, output_rewrites? : Array[(String, String)], moonrun_policy_active? : Bool, on_terminal? : async () -> Unit) -> String
+pub fn BgJobRuntime::adopt(Self, @shell_exec.ShellExecution, command~ : String, cwd? : String, sandboxed_command? : @sandbox.SandboxedCommand, read_only_review? : Bool, output_rewrites? : Array[(String, String)], moonrun_policy_active? : Bool, on_terminal? : async () -> Unit, exit_note? : async (Int?) -> String?) -> String
+pub async fn BgJobRuntime::exit_note(Self, String) -> String?
 pub fn BgJobRuntime::list(Self) -> Array[BgJobSnapshot]
 pub async fn BgJobRuntime::read_output(Self, String) -> String?
 pub async fn BgJobRuntime::read_output_tail(Self, String, Int) -> String?
@@ -46,6 +47,7 @@ pub struct BgJobSnapshot {
   moonrun_policy_active : Bool
   killed_by_output_limit : Bool
   killed_by_time_limit : Bool
+  exit_note : String?
 }
 
 pub enum BgJobStatus {

--- a/agent_tool/bgjobs/pkg.generated.mbti
+++ b/agent_tool/bgjobs/pkg.generated.mbti
@@ -13,12 +13,23 @@ import {
 // Errors
 
 // Types and methods
+pub struct BgJobExit {
+  exit_code : Int?
+  killed_by_output_limit : Bool
+  killed_by_time_limit : Bool
+}
+
+pub enum BgJobExitNote {
+  Note(String)
+  ClassificationFailed(String)
+}
+
 pub struct BgJobRuntime {
   // private fields
 }
 pub fn[X] BgJobRuntime::BgJobRuntime(@agent_runtime.AgentTaskScope[X], spill_dir? : String, hard_output_cap? : Int, hard_timeout_ms? : Int, on_job_exit? : (BgJobSnapshot) -> Unit) -> Self
-pub fn BgJobRuntime::adopt(Self, @shell_exec.ShellExecution, command~ : String, cwd? : String, sandboxed_command? : @sandbox.SandboxedCommand, read_only_review? : Bool, output_rewrites? : Array[(String, String)], moonrun_policy_active? : Bool, on_terminal? : async () -> Unit, exit_note? : async (Int?) -> String?) -> String
-pub async fn BgJobRuntime::exit_note(Self, String) -> String?
+pub fn BgJobRuntime::adopt(Self, @shell_exec.ShellExecution, command~ : String, cwd? : String, sandboxed_command? : @sandbox.SandboxedCommand, read_only_review? : Bool, output_rewrites? : Array[(String, String)], moonrun_policy_active? : Bool, on_terminal? : async () -> Unit, exit_note? : async (BgJobExit) -> String?) -> String
+pub async fn BgJobRuntime::exit_note(Self, String) -> BgJobExitNote?
 pub fn BgJobRuntime::list(Self) -> Array[BgJobSnapshot]
 pub async fn BgJobRuntime::read_output(Self, String) -> String?
 pub async fn BgJobRuntime::read_output_tail(Self, String, Int) -> String?
@@ -47,7 +58,7 @@ pub struct BgJobSnapshot {
   moonrun_policy_active : Bool
   killed_by_output_limit : Bool
   killed_by_time_limit : Bool
-  exit_note : String?
+  exit_note : BgJobExitNote?
 }
 
 pub enum BgJobStatus {

--- a/agent_tool/job_output/job_output.mbt
+++ b/agent_tool/job_output/job_output.mbt
@@ -113,9 +113,9 @@ async fn execute(
     bg_runtime.terminal_denial_feedback(job_id)
   }
   // The launcher's classification of a terminal exit (mbtx separating a
-  // compile error from a runtime failure). The async accessor, not the
-  // snapshot field: a read racing the exit must compute the note itself
-  // rather than silently show none.
+  // build failure from a runtime one). The async accessor, not the snapshot
+  // field: a read racing the exit must join the in-flight computation rather
+  // than silently show none.
   let exit_note = bg_runtime.exit_note(job_id)
   let is_error = exit_error ||
     snapshot.had_invalid_utf8 ||
@@ -152,9 +152,20 @@ async fn execute(
       content.write_string("\n")
     }
   }
-  if exit_note is Some(note) {
-    content.write_string(note)
-    content.write_string("\n")
+  match exit_note {
+    Some(Note(note)) => {
+      content.write_string(note)
+      content.write_string("\n")
+    }
+    // A failed classification is reported AS a failure, never disguised as a
+    // note the launcher chose to write. It does not flip `is_error`: the
+    // job's own outcome above is intact, and erroring the read would send
+    // the model chasing a job that may have exited 0.
+    Some(ClassificationFailed(reason)) => {
+      content.write_string("[exit-stage classification failed: \{reason}]")
+      content.write_string("\n")
+    }
+    None => ()
   }
   if sandbox_denied is Some(guidance) {
     content.write_string(guidance)

--- a/agent_tool/job_output/job_output.mbt
+++ b/agent_tool/job_output/job_output.mbt
@@ -112,6 +112,11 @@ async fn execute(
   } else {
     bg_runtime.terminal_denial_feedback(job_id)
   }
+  // The launcher's classification of a terminal exit (mbtx separating a
+  // compile error from a runtime failure). The async accessor, not the
+  // snapshot field: a read racing the exit must compute the note itself
+  // rather than silently show none.
+  let exit_note = bg_runtime.exit_note(job_id)
   let is_error = exit_error ||
     snapshot.had_invalid_utf8 ||
     sandbox_denied is Some(_)
@@ -136,14 +141,20 @@ async fn execute(
     ""
   }
   let footer = "<system>job=\{job_id} \{status_label}\{truncation}\{binary}</system>"
-  // Assemble: output, then the source-write denial guidance (like the foreground
-  // path), then the `<system>` footer LAST so it stays the trailing metadata line.
+  // Assemble: output, then the launcher's exit classification (it frames the
+  // output just shown), then the source-write denial guidance (like the
+  // foreground path), then the `<system>` footer LAST so it stays the trailing
+  // metadata line.
   let content = StringBuilder()
   if output != "" {
     content.write_string(output)
     if !output.has_suffix("\n") {
       content.write_string("\n")
     }
+  }
+  if exit_note is Some(note) {
+    content.write_string(note)
+    content.write_string("\n")
   }
   if sandbox_denied is Some(guidance) {
     content.write_string(guidance)

--- a/agent_tool/job_output/job_output_test.mbt
+++ b/agent_tool/job_output/job_output_test.mbt
@@ -123,6 +123,35 @@ async test "job_output marks binary background output as a tool error" {
 }
 
 ///|
+/// The launcher's exit classification (mbtx separating a compile error from a
+/// runtime failure) is a line of its own between the output and the footer.
+#cfg(not(platform="windows"))
+async test "job_output surfaces the launcher's exit note for a finished job" {
+  @async.with_task_group(group => {
+    let scope : @agent_runtime.AgentTaskScope[Unit] = AgentTaskScope(group)
+    let bg = @bgjobs.BgJobRuntime(scope)
+    let exec = @shell_exec.ShellExecution::start(scope, program="sh", args=[
+      "-c", "printf trace; exit 3",
+    ])
+    let id = bg.adopt(exec, command="job", exit_note=code => {
+      match code {
+        Some(code) if code != 0 => Some("launcher: exit \{code} classified.")
+        _ => None
+      }
+    })
+    poll_bg_terminal(bg, id)
+    let output = run_job_output(bg, { "job_id": id })
+    assert_true(output.is_error)
+    // Output first, then the note, then the metadata footer.
+    assert_true(
+      output.content.contains(
+        "trace\nlauncher: exit 3 classified.\n<system>job=",
+      ),
+    )
+  })
+}
+
+///|
 #cfg(not(platform="windows"))
 async test "job_output errors on an unknown job id" {
   @async.with_task_group(group => {

--- a/agent_tool/job_output/job_output_test.mbt
+++ b/agent_tool/job_output/job_output_test.mbt
@@ -133,8 +133,8 @@ async test "job_output surfaces the launcher's exit note for a finished job" {
     let exec = @shell_exec.ShellExecution::start(scope, program="sh", args=[
       "-c", "printf trace; exit 3",
     ])
-    let id = bg.adopt(exec, command="job", exit_note=code => {
-      match code {
+    let id = bg.adopt(exec, command="job", exit_note=exit => {
+      match exit.exit_code {
         Some(code) if code != 0 => Some("launcher: exit \{code} classified.")
         _ => None
       }

--- a/agent_tool/job_output/moon.pkg
+++ b/agent_tool/job_output/moon.pkg
@@ -7,6 +7,7 @@ import {
 
 import {
   "bobzhang/openseek/agent_runtime",
+  "bobzhang/openseek/agent_tool/shell_exec",
   "moonbitlang/async",
   "moonbitlang/async/fs",
 } for "test"

--- a/agent_tool/mbtx/README.mbt.md
+++ b/agent_tool/mbtx/README.mbt.md
@@ -30,9 +30,11 @@ build or the run is what never finished. A probe fault claims neither stage and 
 report. The probe is structural on purpose: a snippet legitimately runs
 `moon check` as a child process, so compiler-diagnostic text in the output
 proves nothing about the snippet itself. For a run that was handed off, the
-same classification is computed when the job exits (before its build dir is
-reclaimed, and single-flight so a racing `job_output` read can never cache a
-stale answer) and rides the completion notice and `job_output`.
+same classification is computed when the job becomes terminal (before its
+build dir is reclaimed, and single-flight so a racing `job_output` read can
+never cache a stale answer) and rides the completion notice and `job_output` —
+including for a watchdog-killed job, where it says whether the kill landed on
+a still-running build or on the run; only a requested stop goes unclassified.
 
 With the agent's background runtime, every call waits inline for up to five
 seconds. A still-running compile or program is then adopted as the same

--- a/agent_tool/mbtx/README.mbt.md
+++ b/agent_tool/mbtx/README.mbt.md
@@ -23,9 +23,10 @@ dir for the runnable artifact moon links only after a successful build
 (`single/single.wasm`/`.js`/`.exe`): absence means the **build failed and the
 program never ran** (most often compiler diagnostics about `source`, though
 the output itself says whether it was that or a toolchain/dependency fault),
-presence means the program **compiled, ran, and failed at runtime** — and a
-foreground timeout likewise says whether the build or the program is what
-never finished. A probe fault claims neither stage and keeps the plain exit
+presence means the **build completed and the failure came from the run** —
+the program failing at runtime, or its runner failing to launch; either way
+not a compile problem — and a foreground timeout likewise says whether the
+build or the run is what never finished. A probe fault claims neither stage and keeps the plain exit
 report. The probe is structural on purpose: a snippet legitimately runs
 `moon check` as a child process, so compiler-diagnostic text in the output
 proves nothing about the snippet itself. For a run that was handed off, the

--- a/agent_tool/mbtx/README.mbt.md
+++ b/agent_tool/mbtx/README.mbt.md
@@ -17,6 +17,18 @@ reach workspace files, while snippet build artifacts stay out of your `_build`.
 Moon's single-file runner handles the inline import block, and compiler
 diagnostics are rewritten to stable `source:LINE:COL` locations.
 
+A failed run says **which stage failed**. `moon run` exits 1 for a rejected
+build and for a trapped program alike, so the tool probes the throwaway target
+dir for the runnable artifact moon links only after a successful build
+(`single/single.wasm`/`.js`/`.exe`): absence means a **compile error** (the
+program never ran), presence means the program **compiled, ran, and failed at
+runtime** — and a foreground timeout likewise says whether the build or the
+program is what never finished. The probe is structural on purpose: a snippet
+legitimately runs `moon check` as a child process, so compiler-diagnostic text
+in the output proves nothing about the snippet itself. For a run that was
+handed off, the same classification is computed when the job exits (before its
+build dir is reclaimed) and rides the completion notice and `job_output`.
+
 With the agent's background runtime, every call waits inline for up to five
 seconds. A still-running compile or program is then adopted as the same
 background execution: the call returns its job id, completion is pushed later,

--- a/agent_tool/mbtx/README.mbt.md
+++ b/agent_tool/mbtx/README.mbt.md
@@ -18,18 +18,22 @@ Moon's single-file runner handles the inline import block, and compiler
 diagnostics are rewritten to stable `source:LINE:COL` locations.
 
 A failed run says **which stage failed**. `moon run` exits 1 for a rejected
-build and for a trapped program alike, so the tool probes the throwaway target
-dir for the runnable artifact moon links only after a successful build
-(`single/single.wasm`/`.js`/`.exe`): absence means the **build failed and the
-program never ran** (most often compiler diagnostics about `source`, though
-the output itself says whether it was that or a toolchain/dependency fault),
-presence means the **build completed and the failure came from the run** —
-the program failing at runtime, or its runner failing to launch; either way
-not a compile problem — and a foreground timeout likewise says whether the
-build or the run is what never finished. A probe fault claims neither stage and keeps the plain exit
-report. The probe is structural on purpose: a snippet legitimately runs
-`moon check` as a child process, so compiler-diagnostic text in the output
-proves nothing about the snippet itself. For a run that was handed off, the
+build and for a trapped program alike, so the tool reads the throwaway target
+dir for evidence. The runnable artifact moon links only after a successful
+build (`single/single.wasm`/`.js`/`.exe`) means the **build completed and the
+failure came from the run** — the program failing at runtime, or its runner
+failing to launch; either way not a compile problem. No artifact but moon's
+own `all_pkgs.json` plan file means the **build failed and the program never
+ran** (most often compiler diagnostics about `source`, though the output
+itself says whether it was that or a toolchain fault). A foreground timeout
+likewise says whether the build or the run is what never finished. A bare
+tree — moon failing before it wrote anything, a probe fault, or a snippet
+that wiped its own build tree through an allowed child process — claims
+**neither stage** and keeps the plain exit report: the label is diagnostic,
+and sabotage can only unclassify a failure, never relabel it. The evidence is
+structural on purpose: a snippet legitimately runs `moon check` as a child
+process, so compiler-diagnostic text in the output proves nothing about the
+snippet itself. For a run that was handed off, the
 same classification is computed when the job becomes terminal (before its
 build dir is reclaimed, and single-flight so a racing `job_output` read can
 never cache a stale answer) and rides the completion notice and `job_output` —

--- a/agent_tool/mbtx/README.mbt.md
+++ b/agent_tool/mbtx/README.mbt.md
@@ -20,14 +20,18 @@ diagnostics are rewritten to stable `source:LINE:COL` locations.
 A failed run says **which stage failed**. `moon run` exits 1 for a rejected
 build and for a trapped program alike, so the tool probes the throwaway target
 dir for the runnable artifact moon links only after a successful build
-(`single/single.wasm`/`.js`/`.exe`): absence means a **compile error** (the
-program never ran), presence means the program **compiled, ran, and failed at
-runtime** — and a foreground timeout likewise says whether the build or the
-program is what never finished. The probe is structural on purpose: a snippet
-legitimately runs `moon check` as a child process, so compiler-diagnostic text
-in the output proves nothing about the snippet itself. For a run that was
-handed off, the same classification is computed when the job exits (before its
-build dir is reclaimed) and rides the completion notice and `job_output`.
+(`single/single.wasm`/`.js`/`.exe`): absence means the **build failed and the
+program never ran** (most often compiler diagnostics about `source`, though
+the output itself says whether it was that or a toolchain/dependency fault),
+presence means the program **compiled, ran, and failed at runtime** — and a
+foreground timeout likewise says whether the build or the program is what
+never finished. A probe fault claims neither stage and keeps the plain exit
+report. The probe is structural on purpose: a snippet legitimately runs
+`moon check` as a child process, so compiler-diagnostic text in the output
+proves nothing about the snippet itself. For a run that was handed off, the
+same classification is computed when the job exits (before its build dir is
+reclaimed, and single-flight so a racing `job_output` read can never cache a
+stale answer) and rides the completion notice and `job_output`.
 
 With the agent's background runtime, every call waits inline for up to five
 seconds. A still-running compile or program is then adopted as the same

--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -545,6 +545,26 @@ async fn execute(
         sandboxed_command?,
         output_rewrites=temp_path_rewrites([real, build_dir]),
         moonrun_policy_active=policy_active,
+        // Classify the exit for whoever reads the finished job (the completion
+        // notice, job_output). The runtime calls this before `terminal_cleanup`
+        // reclaims the build subtree, while the artifact is still on disk.
+        exit_note=exit_code => {
+          match exit_code {
+            Some(code) if code != 0 =>
+              if snippet_compiled(build_dir, input.target) {
+                Some(
+                  "mbtx: exit \{code} is a RUNTIME failure — the snippet compiled and the program ran.",
+                )
+              } else {
+                Some(
+                  "mbtx: this is a COMPILE error — the snippet did not build, so the program never ran.",
+                )
+              }
+            // A success needs no classifying, and a killed job's stop reason is
+            // already named by the reader.
+            Some(_) | None => None
+          }
+        },
         on_terminal=terminal_cleanup,
       )
       job_owns_cleanup = true
@@ -572,13 +592,10 @@ async fn execute(
     )
     exec.discard()
     let text = rewrite_temp_paths(raw, [real, build_dir])
-    let body = if text.is_blank() {
-      "mbtx: program exited \{exit_code} with no output"
-    } else if exit_code != 0 {
-      "[mbtx: exited \{exit_code}]\n\{text}"
-    } else {
-      text
-    }
+    // A zero exit already proves the program ran; only a failure needs the
+    // artifact probe to say which stage it failed at.
+    let compiled = exit_code == 0 || snippet_compiled(build_dir, input.target)
+    let body = finished_body(text, exit_code, compiled~)
     let body = if output_limit_reached {
       "\{body}\n[mbtx: output passed the fixed \{OutputCapBytes}-byte inline limit, so the program was STOPPED and this is only what it printed first. Retrying the same call will hit the same limit. Redirect bulky child output with `stdout=ToFile(path)` where `path` is under `@fs.tmpdir()`, then have that same snippet read the file and print only the needed excerpt before it exits.]"
     } else {
@@ -599,7 +616,7 @@ async fn execute(
       is_error=exit_code != 0 ||
         sandbox_denied is Some(_) ||
         output_limit_reached,
-      brief="mbtx (exit=\{exit_code})",
+      brief=finished_brief(exit_code, compiled~),
     )
   }
   let result = @async.with_timeout_opt(foreground_timeout_ms, () => {
@@ -632,16 +649,11 @@ async fn execute(
       // Rewrite the throwaway temp path to `source` so the model reads
       // `source:LINE:COL` about its own input, not a random temp path.
       let text = rewrite_temp_paths(raw, [real, build_dir])
+      let compiled = exit_code == 0 || snippet_compiled(build_dir, input.target)
       // PREPEND the exit status so it survives the agent loop's outer 60k
       // result clamp (which cuts the tail); the output cap is below 60k so
       // both the status line and the body are retained.
-      let body = if text.is_blank() {
-        "mbtx: program exited \{exit_code} with no output"
-      } else if exit_code != 0 {
-        "[mbtx: exited \{exit_code}]\n\{text}"
-      } else {
-        text
-      }
+      let body = finished_body(text, exit_code, compiled~)
       let body = if sandbox_denied is Some(guidance) {
         "\{body}\n\n\{guidance}"
       } else {
@@ -650,7 +662,7 @@ async fn execute(
       @agent_tool.respond(
         body,
         is_error=exit_code != 0 || sandbox_denied is Some(_),
-        brief="mbtx (exit=\{exit_code})",
+        brief=finished_brief(exit_code, compiled~),
       )
     }
     None => {
@@ -659,7 +671,10 @@ async fn execute(
       // instead of discarding it behind a generic timeout message. The status
       // line stays first so it survives the outer result clamp.
       let partial = rewrite_temp_paths(read_capped(log), [real, build_dir])
-      let head = "mbtx: timed out after \{duration_label(foreground_timeout_ms)} and was cancelled — the program did not finish (an infinite loop, or a build that never completed)."
+      let head = timeout_head(
+        foreground_timeout_ms,
+        compiled=snippet_compiled(build_dir, input.target),
+      )
       let body = if partial.is_blank() {
         head
       } else {
@@ -674,6 +689,90 @@ async fn execute(
     }
   }
   action
+}
+
+///|
+/// Whether the snippet's runnable artifact exists under the throwaway
+/// `--target-dir` — the structural line between "the compiler rejected the
+/// program" and "the program ran". moon's single-file mode builds the snippet
+/// as package `single` and writes `single/single.<ext>` only once it compiled
+/// AND linked, and the directory is fresh for every call, so presence proves
+/// the program was launched, and absence after a failed run means the build
+/// rejected it before anything ran.
+///
+/// Structural on purpose: the OUTPUT cannot make this distinction. moon exits
+/// 1 for a rejected build and for a trapped program alike, and a snippet
+/// legitimately runs `moon check`/`moon test` as child processes, so compiler
+/// diagnostics in the log are routinely the program's own (successful) output.
+async fn snippet_compiled(build_dir : String, target : String) -> Bool {
+  let ext = match target {
+    "js" => "js"
+    "llvm" => "exe"
+    // wasm and wasm-gc
+    _ => "wasm"
+  }
+  // moon run builds the debug profile today. The release path is probed too so
+  // a future default flip degrades this to an extra stat, not to every runtime
+  // failure being reported as a compile error.
+  for profile in ["debug", "release"] {
+    if @fs.exists(
+        "\{build_dir}/\{target}/\{profile}/build/single/single.\{ext}",
+      ) {
+      return true
+    }
+  }
+  false
+}
+
+///|
+/// The status framing for a finished run's body. Success passes the output
+/// through; a failure names WHICH failure it was — with `moon run`'s exit code
+/// identical for both, `compiled` (the artifact probe) is what separates "fix
+/// the source" from "debug the program", and saying so saves the model from
+/// misreading a runtime trap as a build it must re-check.
+fn finished_body(text : String, exit_code : Int, compiled~ : Bool) -> String {
+  if exit_code == 0 {
+    return if text.is_blank() {
+      "mbtx: program exited 0 with no output"
+    } else {
+      text
+    }
+  }
+  if !compiled {
+    // The build's own exit code (always 1) adds nothing over the diagnostics.
+    return if text.is_blank() {
+      "mbtx: COMPILE error with no diagnostics — the snippet did not build, so the program never ran"
+    } else {
+      "[mbtx: COMPILE error — the snippet did not build, so the program never ran]\n\{text}"
+    }
+  }
+  if text.is_blank() {
+    "mbtx: the program compiled and ran, then exited \{exit_code} with no output"
+  } else {
+    "[mbtx: exited \{exit_code} at RUNTIME — the program compiled and ran]\n\{text}"
+  }
+}
+
+///|
+fn finished_brief(exit_code : Int, compiled~ : Bool) -> String {
+  if exit_code != 0 && !compiled {
+    "mbtx (compile error)"
+  } else {
+    "mbtx (exit=\{exit_code})"
+  }
+}
+
+///|
+/// The first line of a foreground timeout report: the artifact probe says
+/// which half of the run never finished, so the model knows whether to
+/// suspect its program or the build.
+fn timeout_head(foreground_timeout_ms : Int, compiled~ : Bool) -> String {
+  let bound = duration_label(foreground_timeout_ms)
+  if compiled {
+    "mbtx: timed out after \{bound} and was cancelled — the program compiled but did not finish (an infinite loop, or waiting on something that never arrived)."
+  } else {
+    "mbtx: timed out after \{bound} and was cancelled — the BUILD never completed (compilation or a dependency download stalled), so the program never ran."
+  }
 }
 
 ///|

--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -554,7 +554,7 @@ async fn execute(
               match snippet_compiled(build_dir, input.target) {
                 Some(true) =>
                   Some(
-                    "mbtx: exit \{code} is a RUNTIME failure — the snippet compiled and the program ran.",
+                    "mbtx: exit \{code} came after a successful BUILD — the failure is from the run, not the build.",
                   )
                 Some(false) =>
                   Some(
@@ -704,16 +704,17 @@ async fn execute(
 
 ///|
 /// Whether the snippet's runnable artifact exists under the throwaway
-/// `--target-dir` — the structural line between "the run failed at BUILD
-/// time" and "the program ran". moon's single-file mode builds the snippet as
-/// package `single` and writes `single/single.<ext>` only once it compiled
-/// AND linked, and the directory is fresh for every call, so `Some(true)`
-/// proves the program was launched, and `Some(false)` after a failed run
-/// means the failure came from the build — most often the compiler rejecting
-/// `source`, but the diagnostics themselves say whether it was that or a
-/// toolchain/dependency fault; absence alone cannot tell those apart, so the
-/// framing never claims more than "the program never ran". `None` means the
-/// probe itself failed and the stage is unknown.
+/// `--target-dir` — the structural line between the BUILD stage and the run.
+/// moon's single-file mode builds the snippet as package `single` and writes
+/// `single/single.<ext>` only once it compiled AND linked, and the directory
+/// is fresh for every call, so `Some(true)` proves the build completed and a
+/// failure then belongs to the run step (the program failing, or its runner
+/// failing to launch — either way not a `source` compile problem), while
+/// `Some(false)` after a failed run means the failure came from the build —
+/// most often the compiler rejecting `source`, but the diagnostics themselves
+/// say whether it was that or a toolchain/dependency fault; each side's
+/// framing claims exactly that much and no more. `None` means the probe
+/// itself failed and the stage is unknown.
 ///
 /// Structural on purpose: the OUTPUT cannot make this distinction. moon exits
 /// 1 for a rejected build and for a trapped program alike, and a snippet
@@ -772,11 +773,14 @@ fn finished_body(text : String, exit_code : Int, compiled~ : Bool?) -> String {
       } else {
         "[mbtx: BUILD failed — the program never ran; the output below is the build's]\n\{text}"
       }
+    // "From the run, not the build" is all presence proves: the run step
+    // includes launching the runner, so a missing `node` lands here too —
+    // which the output says, and which is still not a `source` problem.
     Some(true) =>
       if text.is_blank() {
-        "mbtx: the program compiled and ran, then exited \{exit_code} with no output"
+        "mbtx: the snippet built, then the run exited \{exit_code} with no output"
       } else {
-        "[mbtx: exited \{exit_code} at RUNTIME — the program compiled and ran]\n\{text}"
+        "[mbtx: exited \{exit_code} at RUNTIME — the snippet built, so this failure is from the run, not the build]\n\{text}"
       }
     None =>
       if text.is_blank() {
@@ -805,7 +809,7 @@ fn timeout_head(foreground_timeout_ms : Int, compiled~ : Bool?) -> String {
   let bound = duration_label(foreground_timeout_ms)
   match compiled {
     Some(true) =>
-      "mbtx: timed out after \{bound} and was cancelled — the program compiled but did not finish (an infinite loop, or waiting on something that never arrived)."
+      "mbtx: timed out after \{bound} and was cancelled — the BUILD completed but the run did not finish (an infinite loop, or waiting on something that never arrived)."
     Some(false) =>
       "mbtx: timed out after \{bound} and was cancelled — the BUILD never completed (compilation or a dependency download stalled), so the program never ran."
     None =>

--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -723,23 +723,35 @@ async fn execute(
 }
 
 ///|
-/// Whether the snippet's runnable artifact exists under the throwaway
-/// `--target-dir` — the structural line between the BUILD stage and the run.
-/// moon's single-file mode builds the snippet as package `single` and writes
-/// `single/single.<ext>` only once it compiled AND linked, and the directory
-/// is fresh for every call, so `Some(true)` proves the build completed and a
-/// failure then belongs to the run step (the program failing, or its runner
-/// failing to launch — either way not a `source` compile problem), while
-/// `Some(false)` after a failed run means the failure came from the build —
-/// most often the compiler rejecting `source`, but the diagnostics themselves
-/// say whether it was that or a toolchain/dependency fault; each side's
-/// framing claims exactly that much and no more. `None` means the probe
-/// itself failed and the stage is unknown.
+/// What the throwaway `--target-dir` proves about the failed run's stage.
+/// moon's single-file mode builds the snippet as package `single`, writing
+/// `<target>/<profile>/build/all_pkgs.json` when it starts planning the build
+/// and `single/single.<ext>` only once the snippet compiled AND linked; the
+/// directory is fresh for every call. Three evidence states:
+///
+/// - `Some(true)` — the runnable artifact exists: the build completed, so the
+///   failure belongs to the run step (the program failing, or its runner
+///   failing to launch — either way not a `source` compile problem).
+/// - `Some(false)` — no artifact, but moon's own `all_pkgs.json` shows a
+///   build was attempted and its tree is intact: the build failed. The
+///   diagnostics say whether the compiler rejected `source` or the toolchain
+///   faulted.
+/// - `None` — no moon trace at all (or the probe itself failed): claim
+///   NOTHING. This is deliberate, twice over. moon can fail before writing
+///   anything (a dependency-resolution fault exits 255 leaving an empty
+///   tree), and a snippet can spawn an allowed `moon clean --target-dir` at
+///   its own build tree — child processes are outside the wasm policy's fs
+///   rules — then fail; requiring residue keeps that wipe from being read as
+///   "the build failed" when in truth the build succeeded.
 ///
 /// Structural on purpose: the OUTPUT cannot make this distinction. moon exits
 /// 1 for a rejected build and for a trapped program alike, and a snippet
 /// legitimately runs `moon check`/`moon test` as child processes, so compiler
 /// diagnostics in the log are routinely the program's own (successful) output.
+/// The label stays diagnostic, not a security boundary: a snippet determined
+/// to misdescribe its own failure stage can only UNclassify itself (the wipe
+/// lands in `None`), never turn one stage's label into the other's without
+/// fabricating moon's residue.
 async fn snippet_compiled(build_dir : String, target : String) -> Bool? {
   let ext = match target {
     "js" => "js"
@@ -747,13 +759,8 @@ async fn snippet_compiled(build_dir : String, target : String) -> Bool? {
     // wasm and wasm-gc
     _ => "wasm"
   }
-  // moon run builds the debug profile today. The release path is probed too so
-  // a future default flip degrades this to an extra stat, not to every runtime
-  // failure being reported as a build failure.
-  for profile in ["debug", "release"] {
-    let present = @fs.exists(
-      "\{build_dir}/\{target}/\{profile}/build/single/single.\{ext}",
-    ) catch {
+  async fn present(relative : String) -> Bool? {
+    let exists = @fs.exists("\{build_dir}/\{target}/\{relative}") catch {
       error if @async.is_being_cancelled() => raise error
       // A probe fault (EIO, EACCES on the tool's own throwaway dir) must
       // neither fail a run that already finished nor masquerade as an answer:
@@ -761,19 +768,35 @@ async fn snippet_compiled(build_dir : String, target : String) -> Bool? {
       // wording rather than folding the fault into "did not build".
       _ => return None
     }
-    if present {
-      return Some(true)
+    Some(exists)
+  }
+
+  // moon run builds the debug profile today. The release path is probed too so
+  // a future default flip degrades this to an extra stat, not to every runtime
+  // failure being reported as a build failure.
+  for profile in ["debug", "release"] {
+    match present("\{profile}/build/single/single.\{ext}") {
+      Some(true) => return Some(true)
+      Some(false) => ()
+      None => return None
     }
   }
-  Some(false)
+  for profile in ["debug", "release"] {
+    match present("\{profile}/build/all_pkgs.json") {
+      Some(true) => return Some(false)
+      Some(false) => ()
+      None => return None
+    }
+  }
+  None
 }
 
 ///|
 /// The status framing for a finished run's body. Success passes the output
 /// through; a failure names WHICH stage failed — with `moon run`'s exit code
-/// identical for both, `compiled` (the artifact probe) is what separates "fix
-/// the build input" from "debug the program". `None` (the probe itself
-/// failed) keeps the pre-classification wording, claiming nothing.
+/// identical for both, `compiled` (the evidence probe) is what separates
+/// "fix the build input" from "debug the program". `None` (no usable
+/// evidence) keeps the pre-classification wording, claiming nothing.
 fn finished_body(text : String, exit_code : Int, compiled~ : Bool?) -> String {
   if exit_code == 0 {
     return if text.is_blank() {
@@ -783,11 +806,11 @@ fn finished_body(text : String, exit_code : Int, compiled~ : Bool?) -> String {
     }
   }
   match compiled {
-    // The exit code is moon's here, and it is kept: it is NOT always 1 (a
-    // dependency-cache fault exits 255), and distinct codes are diagnostic.
-    // "BUILD failed", not "compile error": no artifact proves the program
-    // never ran, while the output below is what says whether the compiler
-    // rejected `source` or the toolchain/dependencies faulted.
+    // The exit code is moon's here, and it is kept: build-stage faults are
+    // not all exit 1, and distinct codes are diagnostic. "BUILD failed", not
+    // "compile error": the evidence proves the program never ran, while the
+    // output below is what says whether the compiler rejected `source` or
+    // the toolchain faulted.
     Some(false) =>
       if text.is_blank() {
         "mbtx: the BUILD failed (exit \{exit_code}) with no output — the program never ran"

--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -548,8 +548,8 @@ async fn execute(
         // Classify the exit for whoever reads the finished job (the completion
         // notice, job_output). The runtime calls this before `terminal_cleanup`
         // reclaims the build subtree, while the artifact is still on disk.
-        exit_note=exit_code => {
-          match exit_code {
+        exit_note=exit => {
+          match exit.exit_code {
             Some(code) if code != 0 =>
               match snippet_compiled(build_dir, input.target) {
                 Some(true) =>
@@ -563,9 +563,29 @@ async fn execute(
                 // The probe itself failed: claim nothing rather than guess.
                 None => None
               }
-            // A success needs no classifying, and a killed job's stop reason is
-            // already named by the reader.
-            Some(_) | None => None
+            // A success needs no classifying.
+            Some(_) => None
+            // A watchdog kill (the wall-clock reaper, the output cap) still
+            // deserves a stage: a build stalled for the whole cap and a
+            // program that hung after a clean build are different problems
+            // hiding behind the same kill status. A REQUESTED stop says
+            // nothing about the work and is left unclassified.
+            None =>
+              if exit.killed_by_output_limit || exit.killed_by_time_limit {
+                match snippet_compiled(build_dir, input.target) {
+                  Some(true) =>
+                    Some(
+                      "mbtx: the BUILD had completed — the kill landed on the run.",
+                    )
+                  Some(false) =>
+                    Some(
+                      "mbtx: the job was killed while still BUILDING — the build never completed, so the program never ran.",
+                    )
+                  None => None
+                }
+              } else {
+                None
+              }
           }
         },
         on_terminal=terminal_cleanup,
@@ -763,15 +783,16 @@ fn finished_body(text : String, exit_code : Int, compiled~ : Bool?) -> String {
     }
   }
   match compiled {
-    // The build's own exit code (always 1) adds nothing over its diagnostics.
+    // The exit code is moon's here, and it is kept: it is NOT always 1 (a
+    // dependency-cache fault exits 255), and distinct codes are diagnostic.
     // "BUILD failed", not "compile error": no artifact proves the program
     // never ran, while the output below is what says whether the compiler
     // rejected `source` or the toolchain/dependencies faulted.
     Some(false) =>
       if text.is_blank() {
-        "mbtx: the BUILD failed with no output — the program never ran"
+        "mbtx: the BUILD failed (exit \{exit_code}) with no output — the program never ran"
       } else {
-        "[mbtx: BUILD failed — the program never ran; the output below is the build's]\n\{text}"
+        "[mbtx: BUILD failed (exit \{exit_code}) — the program never ran; the output below is the build's]\n\{text}"
       }
     // "From the run, not the build" is all presence proves: the run step
     // includes launching the runner, so a missing `node` lands here too —
@@ -794,7 +815,7 @@ fn finished_body(text : String, exit_code : Int, compiled~ : Bool?) -> String {
 ///|
 fn finished_brief(exit_code : Int, compiled~ : Bool?) -> String {
   if exit_code != 0 && compiled is Some(false) {
-    "mbtx (build failed)"
+    "mbtx (build failed, exit=\{exit_code})"
   } else {
     "mbtx (exit=\{exit_code})"
   }

--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -597,7 +597,11 @@ async fn execute(
       )
     }
     let raw = exec.head()
-    let exit_code = exec.exit_code().unwrap_or(-1)
+    // `None` is a KILLED run — on this path, the output-cap kill below. It
+    // stays `None`: the old `-1` stand-in flowed into the stage labels as a
+    // real-looking status ("exit -1") that then contradicted the STOPPED
+    // note appended for the cap.
+    let exit_code = exec.exit_code()
     // The retained execution is KILLED once output passes the inline cap, so a
     // clipped head means a stopped program, not a quiet one — say which.
     let output_limit_reached = exec.over_inline_cap() || exec.output_truncated()
@@ -615,14 +619,34 @@ async fn execute(
     )
     exec.discard()
     let text = rewrite_temp_paths(raw, [real, build_dir])
-    // A zero exit already proves the program ran; only a failure needs the
-    // artifact probe to say which stage it failed at.
-    let compiled = if exit_code == 0 {
-      Some(true)
-    } else {
-      snippet_compiled(build_dir, input.target)
+    let (body, brief, run_failed) = match exit_code {
+      Some(code) => {
+        // A zero exit already proves the program ran; only a failure needs
+        // the evidence probe to say which stage it failed at.
+        let compiled = if code == 0 {
+          Some(true)
+        } else {
+          snippet_compiled_or_unknown(build_dir, input.target)
+        }
+        (
+          finished_body(text, code, compiled~),
+          finished_brief(code, compiled~),
+          code != 0,
+        )
+      }
+      // A killed run has no exit status and gets no stage label — the cap
+      // note appended below is what tells the story.
+      None =>
+        (
+          if text.is_blank() {
+            "mbtx: the run was killed with no output"
+          } else {
+            text
+          },
+          "mbtx (killed)",
+          true,
+        )
     }
-    let body = finished_body(text, exit_code, compiled~)
     let body = if output_limit_reached {
       "\{body}\n[mbtx: output passed the fixed \{OutputCapBytes}-byte inline limit, so the program was STOPPED and this is only what it printed first. Retrying the same call will hit the same limit. Redirect bulky child output with `stdout=ToFile(path)` where `path` is under `@fs.tmpdir()`, then have that same snippet read the file and print only the needed excerpt before it exits.]"
     } else {
@@ -640,10 +664,8 @@ async fn execute(
     }
     return @agent_tool.respond(
       body,
-      is_error=exit_code != 0 ||
-        sandbox_denied is Some(_) ||
-        output_limit_reached,
-      brief=finished_brief(exit_code, compiled~),
+      is_error=run_failed || sandbox_denied is Some(_) || output_limit_reached,
+      brief~,
     )
   }
   let result = @async.with_timeout_opt(foreground_timeout_ms, () => {
@@ -679,7 +701,7 @@ async fn execute(
       let compiled = if exit_code == 0 {
         Some(true)
       } else {
-        snippet_compiled(build_dir, input.target)
+        snippet_compiled_or_unknown(build_dir, input.target)
       }
       // PREPEND the exit status so it survives the agent loop's outer 60k
       // result clamp (which cuts the tail); the output cap is below 60k so
@@ -704,7 +726,7 @@ async fn execute(
       let partial = rewrite_temp_paths(read_capped(log), [real, build_dir])
       let head = timeout_head(
         foreground_timeout_ms,
-        compiled=snippet_compiled(build_dir, input.target),
+        compiled=snippet_compiled_or_unknown(build_dir, input.target),
       )
       let body = if partial.is_blank() {
         head
@@ -736,13 +758,13 @@ async fn execute(
 ///   build was attempted and its tree is intact: the build failed. The
 ///   diagnostics say whether the compiler rejected `source` or the toolchain
 ///   faulted.
-/// - `None` — no moon trace at all (or the probe itself failed): claim
-///   NOTHING. This is deliberate, twice over. moon can fail before writing
-///   anything (a dependency-resolution fault exits 255 leaving an empty
-///   tree), and a snippet can spawn an allowed `moon clean --target-dir` at
-///   its own build tree — child processes are outside the wasm policy's fs
-///   rules — then fail; requiring residue keeps that wipe from being read as
-///   "the build failed" when in truth the build succeeded.
+/// - `None` — no moon trace at all: claim NOTHING. This is deliberate, twice
+///   over. moon can fail before writing anything (a dependency-resolution
+///   fault exits 255 leaving an empty tree), and a snippet can spawn an
+///   allowed `moon clean --target-dir` at its own build tree — child
+///   processes are outside the wasm policy's fs rules — then fail; requiring
+///   residue keeps that wipe from being read as "the build failed" when in
+///   truth the build succeeded.
 ///
 /// Structural on purpose: the OUTPUT cannot make this distinction. moon exits
 /// 1 for a rejected build and for a trapped program alike, and a snippet
@@ -752,6 +774,11 @@ async fn execute(
 /// to misdescribe its own failure stage can only UNclassify itself (the wipe
 /// lands in `None`), never turn one stage's label into the other's without
 /// fabricating moon's residue.
+///
+/// A probe FAULT (EIO, EACCES on the tool's own throwaway dir) raises rather
+/// than posing as any of the three states: the background classifier lets it
+/// propagate into a typed `ClassificationFailed`, while the foreground call
+/// sites catch it into "unclassified" via `snippet_compiled_or_unknown`.
 async fn snippet_compiled(build_dir : String, target : String) -> Bool? {
   let ext = match target {
     "js" => "js"
@@ -759,36 +786,39 @@ async fn snippet_compiled(build_dir : String, target : String) -> Bool? {
     // wasm and wasm-gc
     _ => "wasm"
   }
-  async fn present(relative : String) -> Bool? {
-    let exists = @fs.exists("\{build_dir}/\{target}/\{relative}") catch {
-      error if @async.is_being_cancelled() => raise error
-      // A probe fault (EIO, EACCES on the tool's own throwaway dir) must
-      // neither fail a run that already finished nor masquerade as an answer:
-      // the stage is unknown, and the report falls back to the unclassified
-      // wording rather than folding the fault into "did not build".
-      _ => return None
-    }
-    Some(exists)
-  }
-
   // moon run builds the debug profile today. The release path is probed too so
   // a future default flip degrades this to an extra stat, not to every runtime
   // failure being reported as a build failure.
   for profile in ["debug", "release"] {
-    match present("\{profile}/build/single/single.\{ext}") {
-      Some(true) => return Some(true)
-      Some(false) => ()
-      None => return None
+    if @fs.exists(
+        "\{build_dir}/\{target}/\{profile}/build/single/single.\{ext}",
+      ) {
+      return Some(true)
     }
   }
   for profile in ["debug", "release"] {
-    match present("\{profile}/build/all_pkgs.json") {
-      Some(true) => return Some(false)
-      Some(false) => ()
-      None => return None
+    if @fs.exists("\{build_dir}/\{target}/\{profile}/build/all_pkgs.json") {
+      return Some(false)
     }
   }
   None
+}
+
+///|
+/// The foreground call sites' probe: a fault folds into "no evidence" HERE,
+/// as an explicit per-site choice — the run already finished, and its report
+/// must neither fail nor misclassify over a stat error on the tool's own
+/// throwaway dir. The unclassified wording claims nothing, so no falsehood
+/// can result. (The background classifier makes the opposite choice; see
+/// `snippet_compiled`.)
+async fn snippet_compiled_or_unknown(
+  build_dir : String,
+  target : String,
+) -> Bool? {
+  snippet_compiled(build_dir, target) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => None
+  }
 }
 
 ///|

--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -551,14 +551,17 @@ async fn execute(
         exit_note=exit_code => {
           match exit_code {
             Some(code) if code != 0 =>
-              if snippet_compiled(build_dir, input.target) {
-                Some(
-                  "mbtx: exit \{code} is a RUNTIME failure — the snippet compiled and the program ran.",
-                )
-              } else {
-                Some(
-                  "mbtx: this is a COMPILE error — the snippet did not build, so the program never ran.",
-                )
+              match snippet_compiled(build_dir, input.target) {
+                Some(true) =>
+                  Some(
+                    "mbtx: exit \{code} is a RUNTIME failure — the snippet compiled and the program ran.",
+                  )
+                Some(false) =>
+                  Some(
+                    "mbtx: the BUILD failed — the program never ran; the job's output is the build's own.",
+                  )
+                // The probe itself failed: claim nothing rather than guess.
+                None => None
               }
             // A success needs no classifying, and a killed job's stop reason is
             // already named by the reader.
@@ -594,7 +597,11 @@ async fn execute(
     let text = rewrite_temp_paths(raw, [real, build_dir])
     // A zero exit already proves the program ran; only a failure needs the
     // artifact probe to say which stage it failed at.
-    let compiled = exit_code == 0 || snippet_compiled(build_dir, input.target)
+    let compiled = if exit_code == 0 {
+      Some(true)
+    } else {
+      snippet_compiled(build_dir, input.target)
+    }
     let body = finished_body(text, exit_code, compiled~)
     let body = if output_limit_reached {
       "\{body}\n[mbtx: output passed the fixed \{OutputCapBytes}-byte inline limit, so the program was STOPPED and this is only what it printed first. Retrying the same call will hit the same limit. Redirect bulky child output with `stdout=ToFile(path)` where `path` is under `@fs.tmpdir()`, then have that same snippet read the file and print only the needed excerpt before it exits.]"
@@ -649,7 +656,11 @@ async fn execute(
       // Rewrite the throwaway temp path to `source` so the model reads
       // `source:LINE:COL` about its own input, not a random temp path.
       let text = rewrite_temp_paths(raw, [real, build_dir])
-      let compiled = exit_code == 0 || snippet_compiled(build_dir, input.target)
+      let compiled = if exit_code == 0 {
+        Some(true)
+      } else {
+        snippet_compiled(build_dir, input.target)
+      }
       // PREPEND the exit status so it survives the agent loop's outer 60k
       // result clamp (which cuts the tail); the output cap is below 60k so
       // both the status line and the body are retained.
@@ -693,18 +704,22 @@ async fn execute(
 
 ///|
 /// Whether the snippet's runnable artifact exists under the throwaway
-/// `--target-dir` — the structural line between "the compiler rejected the
-/// program" and "the program ran". moon's single-file mode builds the snippet
-/// as package `single` and writes `single/single.<ext>` only once it compiled
-/// AND linked, and the directory is fresh for every call, so presence proves
-/// the program was launched, and absence after a failed run means the build
-/// rejected it before anything ran.
+/// `--target-dir` — the structural line between "the run failed at BUILD
+/// time" and "the program ran". moon's single-file mode builds the snippet as
+/// package `single` and writes `single/single.<ext>` only once it compiled
+/// AND linked, and the directory is fresh for every call, so `Some(true)`
+/// proves the program was launched, and `Some(false)` after a failed run
+/// means the failure came from the build — most often the compiler rejecting
+/// `source`, but the diagnostics themselves say whether it was that or a
+/// toolchain/dependency fault; absence alone cannot tell those apart, so the
+/// framing never claims more than "the program never ran". `None` means the
+/// probe itself failed and the stage is unknown.
 ///
 /// Structural on purpose: the OUTPUT cannot make this distinction. moon exits
 /// 1 for a rejected build and for a trapped program alike, and a snippet
 /// legitimately runs `moon check`/`moon test` as child processes, so compiler
 /// diagnostics in the log are routinely the program's own (successful) output.
-async fn snippet_compiled(build_dir : String, target : String) -> Bool {
+async fn snippet_compiled(build_dir : String, target : String) -> Bool? {
   let ext = match target {
     "js" => "js"
     "llvm" => "exe"
@@ -713,24 +728,32 @@ async fn snippet_compiled(build_dir : String, target : String) -> Bool {
   }
   // moon run builds the debug profile today. The release path is probed too so
   // a future default flip degrades this to an extra stat, not to every runtime
-  // failure being reported as a compile error.
+  // failure being reported as a build failure.
   for profile in ["debug", "release"] {
-    if @fs.exists(
-        "\{build_dir}/\{target}/\{profile}/build/single/single.\{ext}",
-      ) {
-      return true
+    let present = @fs.exists(
+      "\{build_dir}/\{target}/\{profile}/build/single/single.\{ext}",
+    ) catch {
+      error if @async.is_being_cancelled() => raise error
+      // A probe fault (EIO, EACCES on the tool's own throwaway dir) must
+      // neither fail a run that already finished nor masquerade as an answer:
+      // the stage is unknown, and the report falls back to the unclassified
+      // wording rather than folding the fault into "did not build".
+      _ => return None
+    }
+    if present {
+      return Some(true)
     }
   }
-  false
+  Some(false)
 }
 
 ///|
 /// The status framing for a finished run's body. Success passes the output
-/// through; a failure names WHICH failure it was — with `moon run`'s exit code
+/// through; a failure names WHICH stage failed — with `moon run`'s exit code
 /// identical for both, `compiled` (the artifact probe) is what separates "fix
-/// the source" from "debug the program", and saying so saves the model from
-/// misreading a runtime trap as a build it must re-check.
-fn finished_body(text : String, exit_code : Int, compiled~ : Bool) -> String {
+/// the build input" from "debug the program". `None` (the probe itself
+/// failed) keeps the pre-classification wording, claiming nothing.
+fn finished_body(text : String, exit_code : Int, compiled~ : Bool?) -> String {
   if exit_code == 0 {
     return if text.is_blank() {
       "mbtx: program exited 0 with no output"
@@ -738,25 +761,36 @@ fn finished_body(text : String, exit_code : Int, compiled~ : Bool) -> String {
       text
     }
   }
-  if !compiled {
-    // The build's own exit code (always 1) adds nothing over the diagnostics.
-    return if text.is_blank() {
-      "mbtx: COMPILE error with no diagnostics — the snippet did not build, so the program never ran"
-    } else {
-      "[mbtx: COMPILE error — the snippet did not build, so the program never ran]\n\{text}"
-    }
-  }
-  if text.is_blank() {
-    "mbtx: the program compiled and ran, then exited \{exit_code} with no output"
-  } else {
-    "[mbtx: exited \{exit_code} at RUNTIME — the program compiled and ran]\n\{text}"
+  match compiled {
+    // The build's own exit code (always 1) adds nothing over its diagnostics.
+    // "BUILD failed", not "compile error": no artifact proves the program
+    // never ran, while the output below is what says whether the compiler
+    // rejected `source` or the toolchain/dependencies faulted.
+    Some(false) =>
+      if text.is_blank() {
+        "mbtx: the BUILD failed with no output — the program never ran"
+      } else {
+        "[mbtx: BUILD failed — the program never ran; the output below is the build's]\n\{text}"
+      }
+    Some(true) =>
+      if text.is_blank() {
+        "mbtx: the program compiled and ran, then exited \{exit_code} with no output"
+      } else {
+        "[mbtx: exited \{exit_code} at RUNTIME — the program compiled and ran]\n\{text}"
+      }
+    None =>
+      if text.is_blank() {
+        "mbtx: program exited \{exit_code} with no output"
+      } else {
+        "[mbtx: exited \{exit_code}]\n\{text}"
+      }
   }
 }
 
 ///|
-fn finished_brief(exit_code : Int, compiled~ : Bool) -> String {
-  if exit_code != 0 && !compiled {
-    "mbtx (compile error)"
+fn finished_brief(exit_code : Int, compiled~ : Bool?) -> String {
+  if exit_code != 0 && compiled is Some(false) {
+    "mbtx (build failed)"
   } else {
     "mbtx (exit=\{exit_code})"
   }
@@ -765,13 +799,17 @@ fn finished_brief(exit_code : Int, compiled~ : Bool) -> String {
 ///|
 /// The first line of a foreground timeout report: the artifact probe says
 /// which half of the run never finished, so the model knows whether to
-/// suspect its program or the build.
-fn timeout_head(foreground_timeout_ms : Int, compiled~ : Bool) -> String {
+/// suspect its program or the build. An unknown probe result keeps the
+/// original hedge.
+fn timeout_head(foreground_timeout_ms : Int, compiled~ : Bool?) -> String {
   let bound = duration_label(foreground_timeout_ms)
-  if compiled {
-    "mbtx: timed out after \{bound} and was cancelled — the program compiled but did not finish (an infinite loop, or waiting on something that never arrived)."
-  } else {
-    "mbtx: timed out after \{bound} and was cancelled — the BUILD never completed (compilation or a dependency download stalled), so the program never ran."
+  match compiled {
+    Some(true) =>
+      "mbtx: timed out after \{bound} and was cancelled — the program compiled but did not finish (an infinite loop, or waiting on something that never arrived)."
+    Some(false) =>
+      "mbtx: timed out after \{bound} and was cancelled — the BUILD never completed (compilation or a dependency download stalled), so the program never ran."
+    None =>
+      "mbtx: timed out after \{bound} and was cancelled — the program did not finish (an infinite loop, or a build that never completed)."
   }
 }
 

--- a/agent_tool/mbtx/mbtx_test.mbt
+++ b/agent_tool/mbtx/mbtx_test.mbt
@@ -53,7 +53,7 @@ async test "a runtime trap is classified as runtime, whatever the output says" {
   )
   assert_true(out.is_error)
   assert_true(out.content.contains("at RUNTIME"))
-  assert_true(out.content.contains("compiled and ran"))
+  assert_true(out.content.contains("from the run, not the build"))
   assert_false(out.content.contains("BUILD failed"))
 }
 
@@ -982,16 +982,19 @@ async test "a runtime-less run uses its foreground timeout, not the handoff grac
 }
 
 ///|
-/// A timeout during the BUILD is named as such: with a bound far below what
-/// any compile takes, the artifact probe finds nothing, and the report blames
-/// the build instead of hinting at an infinite loop in a program that never
-/// existed. (The compiled-side timeout wording is pinned by the `timeout_head`
-/// whitebox test; reaching it live would cost a full foreground timeout.)
+/// A timeout during the BUILD is named as such: the artifact probe finds
+/// nothing, and the report blames the build instead of hinting at an infinite
+/// loop in a program that never existed. The 1ms bound is a physical
+/// impossibility for the build, not a latency guess: within it `moon` cannot
+/// even be spawned and waited on, let alone compile, link, and write the
+/// artifact the probe would have to find. (The other timeout arms are pinned
+/// by the `timeout_head` whitebox test; reaching the built-side arm live
+/// would cost a real foreground timeout after a completed build.)
 async test "a timeout before the build completes blames the build" {
   @vfs.with_tmpdir(prefix="mbtx-timeout-build-", ws => {
     let definition = @mbtx.definition(
       workspace_root=ws,
-      foreground_timeout_ms=50,
+      foreground_timeout_ms=1,
     )
     let action = match definition.execute {
       Async(execute) => execute({ "source": "fn main { println(1) }" })

--- a/agent_tool/mbtx/mbtx_test.mbt
+++ b/agent_tool/mbtx/mbtx_test.mbt
@@ -34,6 +34,34 @@ async test "surfaces a compile error via moon's own diagnostics" {
   assert_true(
     out.content.to_lower().contains("type") || out.content.contains("String"),
   )
+  // ...and CLASSIFIED as one: moon exits 1 for a rejected build and a trapped
+  // program alike, so the report itself must say the program never ran.
+  assert_true(out.content.contains("COMPILE error"))
+  assert_true(out.content.contains("never ran"))
+  assert_true(out.brief is Some("mbtx (compile error)"))
+}
+
+///|
+/// The classifier is structural (the build artifact probe), so program OUTPUT
+/// cannot sway it: compiler-diagnostic-shaped text is routinely a snippet's
+/// legitimate output — a child `moon check` run prints exactly that — and must
+/// not turn a runtime trap into a "compile error" or taint a clean exit.
+async test "a runtime trap is classified as runtime, whatever the output says" {
+  let out = run(
+    "fn main { println(\"Error: [4014] fake diagnostic\"); panic() }",
+  )
+  assert_true(out.is_error)
+  assert_true(out.content.contains("at RUNTIME"))
+  assert_true(out.content.contains("compiled and ran"))
+  assert_false(out.content.contains("COMPILE error"))
+}
+
+///|
+async test "diagnostic-shaped output with a clean exit stays unclassified" {
+  let out = run("fn main { println(\"Error: [4014] fake diagnostic\") }")
+  assert_false(out.is_error)
+  assert_false(out.content.contains("COMPILE error"))
+  assert_false(out.content.contains("at RUNTIME"))
 }
 
 ///|
@@ -949,6 +977,30 @@ async test "a runtime-less run uses its foreground timeout, not the handoff grac
     assert_false(output.is_error)
     assert_true(output.content.contains("finished inline"))
     assert_false(output.content.contains("moved to the background"))
+  })
+}
+
+///|
+/// A timeout during the BUILD is named as such: with a bound far below what
+/// any compile takes, the artifact probe finds nothing, and the report blames
+/// the build instead of hinting at an infinite loop in a program that never
+/// existed. (The compiled-side timeout wording is pinned by the `timeout_head`
+/// whitebox test; reaching it live would cost a full foreground timeout.)
+async test "a timeout before the build completes blames the build" {
+  @vfs.with_tmpdir(prefix="mbtx-timeout-build-", ws => {
+    let definition = @mbtx.definition(
+      workspace_root=ws,
+      foreground_timeout_ms=50,
+    )
+    let action = match definition.execute {
+      Async(execute) => execute({ "source": "fn main { println(1) }" })
+      Sync(_) => fail("mbtx should be async")
+    }
+    guard action is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("timed out"))
+    assert_true(output.content.contains("BUILD never completed"))
+    assert_true(output.content.contains("never ran"))
   })
 }
 

--- a/agent_tool/mbtx/mbtx_test.mbt
+++ b/agent_tool/mbtx/mbtx_test.mbt
@@ -39,7 +39,7 @@ async test "surfaces a compile error via moon's own diagnostics" {
   // program never ran.
   assert_true(out.content.contains("BUILD failed"))
   assert_true(out.content.contains("never ran"))
-  assert_true(out.brief is Some("mbtx (build failed)"))
+  assert_true(out.brief is Some("mbtx (build failed, exit=1)"))
 }
 
 ///|

--- a/agent_tool/mbtx/mbtx_test.mbt
+++ b/agent_tool/mbtx/mbtx_test.mbt
@@ -982,15 +982,15 @@ async test "a runtime-less run uses its foreground timeout, not the handoff grac
 }
 
 ///|
-/// A timeout during the BUILD is named as such: the artifact probe finds
-/// nothing, and the report blames the build instead of hinting at an infinite
-/// loop in a program that never existed. The 1ms bound is a physical
-/// impossibility for the build, not a latency guess: within it `moon` cannot
-/// even be spawned and waited on, let alone compile, link, and write the
-/// artifact the probe would have to find. (The other timeout arms are pinned
-/// by the `timeout_head` whitebox test; reaching the built-side arm live
-/// would cost a real foreground timeout after a completed build.)
-async test "a timeout before the build completes blames the build" {
+/// A timeout with NO build evidence keeps the two-sided hedge: at this bound
+/// moon has not even written its `all_pkgs.json` plan, so the probe finds no
+/// trace and the report claims neither stage. The 1ms bound is a physical
+/// impossibility, not a latency guess: within it `moon` cannot be spawned and
+/// waited on, let alone write anything the probe would find. (The evidence
+/// arms of the timeout wording are pinned by the `timeout_head` whitebox
+/// test; reaching them live would need a real mid-build or post-build
+/// timeout.)
+async test "a timeout with no build evidence keeps the two-sided hedge" {
   @vfs.with_tmpdir(prefix="mbtx-timeout-build-", ws => {
     let definition = @mbtx.definition(
       workspace_root=ws,
@@ -1003,9 +1003,40 @@ async test "a timeout before the build completes blames the build" {
     guard action is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_true(output.content.contains("timed out"))
-    assert_true(output.content.contains("BUILD never completed"))
-    assert_true(output.content.contains("never ran"))
+    assert_true(output.content.contains("did not finish"))
+    assert_true(output.content.contains("a build that never completed"))
+    assert_false(output.content.contains("BUILD never completed"))
   })
+}
+
+///|
+/// Regression (review finding): a snippet can learn its own artifact path
+/// from argv[0] and wipe its build tree through an allowed `moon clean`
+/// child — child processes sit outside the wasm policy's fs rules — then
+/// fail. Requiring moon's residue for the build-failed label means that wipe
+/// UNclassifies the failure (plain exit report) instead of relabeling a
+/// runtime failure as a build one.
+async test "wiping the build tree unclassifies a failure, never relabels it" {
+  let out = run(
+    (
+      #|import { "bobzhang/myshell", "moonbitlang/async", "moonbitlang/core/env" }
+      #|
+      #|async fn main {
+      #|  let target_dir = @env.args()[0].replace_all(old="/wasm/debug/build/single/single.wasm", new="")
+      #|  // moon clean needs a module context; make one, then point it at the
+      #|  // snippet's own build tree.
+      #|  @myshell.Cmd("moon", ["new", "ctx"]).output() |> ignore
+      #|  @myshell.Cmd("moon", ["clean", "--target-dir", target_dir], cwd="ctx").output() |> ignore
+      #|  panic()
+      #|}
+    ),
+  )
+  assert_true(out.is_error)
+  // The failure is still reported with its exit code, but with no stage
+  // label in either direction.
+  assert_true(out.content.contains("exited"))
+  assert_false(out.content.contains("BUILD failed"))
+  assert_false(out.content.contains("at RUNTIME"))
 }
 
 ///|

--- a/agent_tool/mbtx/mbtx_test.mbt
+++ b/agent_tool/mbtx/mbtx_test.mbt
@@ -34,18 +34,19 @@ async test "surfaces a compile error via moon's own diagnostics" {
   assert_true(
     out.content.to_lower().contains("type") || out.content.contains("String"),
   )
-  // ...and CLASSIFIED as one: moon exits 1 for a rejected build and a trapped
-  // program alike, so the report itself must say the program never ran.
-  assert_true(out.content.contains("COMPILE error"))
+  // ...and CLASSIFIED as a build-stage failure: moon exits 1 for a rejected
+  // build and a trapped program alike, so the report itself must say the
+  // program never ran.
+  assert_true(out.content.contains("BUILD failed"))
   assert_true(out.content.contains("never ran"))
-  assert_true(out.brief is Some("mbtx (compile error)"))
+  assert_true(out.brief is Some("mbtx (build failed)"))
 }
 
 ///|
 /// The classifier is structural (the build artifact probe), so program OUTPUT
 /// cannot sway it: compiler-diagnostic-shaped text is routinely a snippet's
 /// legitimate output — a child `moon check` run prints exactly that — and must
-/// not turn a runtime trap into a "compile error" or taint a clean exit.
+/// not turn a runtime trap into a build failure or taint a clean exit.
 async test "a runtime trap is classified as runtime, whatever the output says" {
   let out = run(
     "fn main { println(\"Error: [4014] fake diagnostic\"); panic() }",
@@ -53,14 +54,14 @@ async test "a runtime trap is classified as runtime, whatever the output says" {
   assert_true(out.is_error)
   assert_true(out.content.contains("at RUNTIME"))
   assert_true(out.content.contains("compiled and ran"))
-  assert_false(out.content.contains("COMPILE error"))
+  assert_false(out.content.contains("BUILD failed"))
 }
 
 ///|
 async test "diagnostic-shaped output with a clean exit stays unclassified" {
   let out = run("fn main { println(\"Error: [4014] fake diagnostic\") }")
   assert_false(out.is_error)
-  assert_false(out.content.contains("COMPILE error"))
+  assert_false(out.content.contains("BUILD failed"))
   assert_false(out.content.contains("at RUNTIME"))
 }
 

--- a/agent_tool/mbtx/mbtx_wbtest.mbt
+++ b/agent_tool/mbtx/mbtx_wbtest.mbt
@@ -96,8 +96,12 @@ test "finished_body and finished_brief name the failure stage" {
   assert_true(build_failed.contains("BUILD failed"))
   assert_true(build_failed.contains("never ran"))
   assert_true(build_failed.contains("diagnostics"))
+  // The run-side wording claims exactly what presence proves: the build
+  // completed — not that the program itself launched (a missing runner also
+  // lands here, and is likewise not a `source` problem).
   let runtime_failure = finished_body("trace", 3, compiled=Some(true))
   assert_true(runtime_failure.contains("exited 3 at RUNTIME"))
+  assert_true(runtime_failure.contains("from the run, not the build"))
   assert_true(runtime_failure.contains("trace"))
   // The blank-output corners still name the stage.
   assert_true(
@@ -118,7 +122,9 @@ test "finished_body and finished_brief name the failure stage" {
 ///|
 test "timeout_head says which half of the run never finished" {
   let program_hung = timeout_head(5_000, compiled=Some(true))
-  assert_true(program_hung.contains("compiled but did not finish"))
+  assert_true(
+    program_hung.contains("BUILD completed but the run did not finish"),
+  )
   let build_hung = timeout_head(5_000, compiled=Some(false))
   assert_true(build_hung.contains("BUILD never completed"))
   assert_true(build_hung.contains("never ran"))

--- a/agent_tool/mbtx/mbtx_wbtest.mbt
+++ b/agent_tool/mbtx/mbtx_wbtest.mbt
@@ -92,10 +92,17 @@ test "finished_body and finished_brief name the failure stage" {
       "exited 0 with no output",
     ),
   )
+  // The build's exit status is preserved: moon is NOT always 1 here (a
+  // dependency-cache fault exits 255), and distinct codes are diagnostic.
   let build_failed = finished_body("diagnostics", 1, compiled=Some(false))
-  assert_true(build_failed.contains("BUILD failed"))
+  assert_true(build_failed.contains("BUILD failed (exit 1)"))
   assert_true(build_failed.contains("never ran"))
   assert_true(build_failed.contains("diagnostics"))
+  assert_true(
+    finished_body("lock fault", 255, compiled=Some(false)).contains(
+      "BUILD failed (exit 255)",
+    ),
+  )
   // The run-side wording claims exactly what presence proves: the build
   // completed — not that the program itself launched (a missing runner also
   // lands here, and is likewise not a `source` problem).
@@ -113,7 +120,14 @@ test "finished_body and finished_brief name the failure stage" {
   assert_true(unknown.contains("exited 3"))
   assert_false(unknown.contains("BUILD failed"))
   assert_false(unknown.contains("RUNTIME"))
-  assert_eq(finished_brief(1, compiled=Some(false)), "mbtx (build failed)")
+  assert_eq(
+    finished_brief(1, compiled=Some(false)),
+    "mbtx (build failed, exit=1)",
+  )
+  assert_eq(
+    finished_brief(255, compiled=Some(false)),
+    "mbtx (build failed, exit=255)",
+  )
   assert_eq(finished_brief(3, compiled=Some(true)), "mbtx (exit=3)")
   assert_eq(finished_brief(3, compiled=None), "mbtx (exit=3)")
   assert_eq(finished_brief(0, compiled=Some(true)), "mbtx (exit=0)")

--- a/agent_tool/mbtx/mbtx_wbtest.mbt
+++ b/agent_tool/mbtx/mbtx_wbtest.mbt
@@ -40,11 +40,13 @@ async test "denial scan is bounded to the log's head and tail" {
 }
 
 ///|
-/// Pin the probe's per-target artifact table. The wasm row is exercised end to
-/// end by the classification tests; the other rows — llvm cannot even be built
-/// by this toolchain — and the release-profile fallback are pinned here with
-/// fabricated artifacts in the layout moon's own build plan names.
-async test "snippet_compiled reads moon's per-target runnable artifact" {
+/// Pin the probe's per-target evidence table: the runnable artifact decides
+/// run-stage, moon's `all_pkgs.json` residue is what a failed build leaves,
+/// and a bare tree claims nothing. The wasm row is exercised end to end by
+/// the classification tests; the other rows — llvm cannot even be built by
+/// this toolchain — and the release-profile fallback are pinned here with
+/// fabricated files in the layout moon's own build plan names.
+async test "snippet_compiled reads moon's per-target build evidence" {
   @vfs.with_tmpdir(prefix="mbtx-artifact-probe-", dir => {
     async fn plant(parent : String, file : String) -> Unit {
       @fs.mkdir("\{dir}/\{parent}", recursive=true)
@@ -55,20 +57,30 @@ async test "snippet_compiled reads moon's per-target runnable artifact" {
       )
     }
 
-    // A failed build's leftovers (moon writes all_pkgs.json before compiling
-    // anything) are not a runnable artifact.
+    // An empty tree claims nothing: moon can fail before writing anything
+    // (a dependency-resolution fault leaves the dir bare), and a wiped tree
+    // must not read as "build failed".
+    assert_true(snippet_compiled(dir, "wasm") is None)
+    // moon's plan file without the artifact is a failed build...
     plant("wasm/debug/build", "all_pkgs.json")
     assert_true(snippet_compiled(dir, "wasm") is Some(false))
+    // ...and the artifact decides run-stage.
     plant("wasm/debug/build/single", "single.wasm")
     assert_true(snippet_compiled(dir, "wasm") is Some(true))
-    // Target dirs are disjoint: one target's artifact proves nothing about
+    // Target dirs are disjoint: one target's evidence proves nothing about
     // another's.
+    assert_true(snippet_compiled(dir, "wasm-gc") is None)
+    plant("wasm-gc/debug/build", "all_pkgs.json")
     assert_true(snippet_compiled(dir, "wasm-gc") is Some(false))
     plant("wasm-gc/debug/build/single", "single.wasm")
     assert_true(snippet_compiled(dir, "wasm-gc") is Some(true))
+    assert_true(snippet_compiled(dir, "js") is None)
+    plant("js/debug/build", "all_pkgs.json")
     assert_true(snippet_compiled(dir, "js") is Some(false))
     plant("js/debug/build/single", "single.js")
     assert_true(snippet_compiled(dir, "js") is Some(true))
+    assert_true(snippet_compiled(dir, "llvm") is None)
+    plant("llvm/debug/build", "all_pkgs.json")
     assert_true(snippet_compiled(dir, "llvm") is Some(false))
     plant("llvm/debug/build/single", "single.exe")
     assert_true(snippet_compiled(dir, "llvm") is Some(true))
@@ -77,6 +89,10 @@ async test "snippet_compiled reads moon's per-target runnable artifact" {
     plant("js/release/build/single", "single.js")
     @fs.rmdir("\{dir}/js/debug", recursive=true)
     assert_true(snippet_compiled(dir, "js") is Some(true))
+    // Wiping a target's whole tree UNclassifies it — the sabotage direction
+    // can only remove a label, never flip one stage's label to the other's.
+    @fs.rmdir("\{dir}/wasm", recursive=true)
+    assert_true(snippet_compiled(dir, "wasm") is None)
   })
 }
 

--- a/agent_tool/mbtx/mbtx_wbtest.mbt
+++ b/agent_tool/mbtx/mbtx_wbtest.mbt
@@ -40,6 +40,80 @@ async test "denial scan is bounded to the log's head and tail" {
 }
 
 ///|
+/// Pin the probe's per-target artifact table. The wasm row is exercised end to
+/// end by the classification tests; the other rows — llvm cannot even be built
+/// by this toolchain — and the release-profile fallback are pinned here with
+/// fabricated artifacts in the layout moon's own build plan names.
+async test "snippet_compiled reads moon's per-target runnable artifact" {
+  @vfs.with_tmpdir(prefix="mbtx-artifact-probe-", dir => {
+    async fn plant(parent : String, file : String) -> Unit {
+      @fs.mkdir("\{dir}/\{parent}", recursive=true)
+      @fs.write_file(
+        "\{dir}/\{parent}/\{file}",
+        "",
+        create_mode=CreateOrTruncate,
+      )
+    }
+
+    // A failed build's leftovers (moon writes all_pkgs.json before compiling
+    // anything) are not a runnable artifact.
+    plant("wasm/debug/build", "all_pkgs.json")
+    assert_false(snippet_compiled(dir, "wasm"))
+    plant("wasm/debug/build/single", "single.wasm")
+    assert_true(snippet_compiled(dir, "wasm"))
+    // Target dirs are disjoint: one target's artifact proves nothing about
+    // another's.
+    assert_false(snippet_compiled(dir, "wasm-gc"))
+    plant("wasm-gc/debug/build/single", "single.wasm")
+    assert_true(snippet_compiled(dir, "wasm-gc"))
+    assert_false(snippet_compiled(dir, "js"))
+    plant("js/debug/build/single", "single.js")
+    assert_true(snippet_compiled(dir, "js"))
+    assert_false(snippet_compiled(dir, "llvm"))
+    plant("llvm/debug/build/single", "single.exe")
+    assert_true(snippet_compiled(dir, "llvm"))
+    // The release profile is the fallback for a future moon default flip, so a
+    // release-only artifact still counts.
+    plant("js/release/build/single", "single.js")
+    @fs.rmdir("\{dir}/js/debug", recursive=true)
+    assert_true(snippet_compiled(dir, "js"))
+  })
+}
+
+///|
+/// The body/brief framing names the failure stage. A compile error drops the
+/// exit code — moon's is always 1 there and says nothing the diagnostics do
+/// not — while a runtime failure keeps the program's own code.
+test "finished_body and finished_brief name the failure stage" {
+  assert_eq(finished_body("out\n", 0, compiled=true), "out\n")
+  assert_true(
+    finished_body("", 0, compiled=true).contains("exited 0 with no output"),
+  )
+  let compile_error = finished_body("diagnostics", 1, compiled=false)
+  assert_true(compile_error.contains("COMPILE error"))
+  assert_true(compile_error.contains("never ran"))
+  assert_true(compile_error.contains("diagnostics"))
+  let runtime_failure = finished_body("trace", 3, compiled=true)
+  assert_true(runtime_failure.contains("exited 3 at RUNTIME"))
+  assert_true(runtime_failure.contains("trace"))
+  // The blank-output corners still name the stage.
+  assert_true(finished_body("", 1, compiled=false).contains("COMPILE error"))
+  assert_true(finished_body("", 3, compiled=true).contains("exited 3"))
+  assert_eq(finished_brief(1, compiled=false), "mbtx (compile error)")
+  assert_eq(finished_brief(3, compiled=true), "mbtx (exit=3)")
+  assert_eq(finished_brief(0, compiled=true), "mbtx (exit=0)")
+}
+
+///|
+test "timeout_head says which half of the run never finished" {
+  let program_hung = timeout_head(5_000, compiled=true)
+  assert_true(program_hung.contains("compiled but did not finish"))
+  let build_hung = timeout_head(5_000, compiled=false)
+  assert_true(build_hung.contains("BUILD never completed"))
+  assert_true(build_hung.contains("never ran"))
+}
+
+///|
 /// Proton CLI is admitted one subcommand at a time. In particular, there is no
 /// bare rule and no global working-directory prefix: callers set the child
 /// process cwd instead of letting the command redirect itself elsewhere.

--- a/agent_tool/mbtx/mbtx_wbtest.mbt
+++ b/agent_tool/mbtx/mbtx_wbtest.mbt
@@ -58,59 +58,73 @@ async test "snippet_compiled reads moon's per-target runnable artifact" {
     // A failed build's leftovers (moon writes all_pkgs.json before compiling
     // anything) are not a runnable artifact.
     plant("wasm/debug/build", "all_pkgs.json")
-    assert_false(snippet_compiled(dir, "wasm"))
+    assert_true(snippet_compiled(dir, "wasm") is Some(false))
     plant("wasm/debug/build/single", "single.wasm")
-    assert_true(snippet_compiled(dir, "wasm"))
+    assert_true(snippet_compiled(dir, "wasm") is Some(true))
     // Target dirs are disjoint: one target's artifact proves nothing about
     // another's.
-    assert_false(snippet_compiled(dir, "wasm-gc"))
+    assert_true(snippet_compiled(dir, "wasm-gc") is Some(false))
     plant("wasm-gc/debug/build/single", "single.wasm")
-    assert_true(snippet_compiled(dir, "wasm-gc"))
-    assert_false(snippet_compiled(dir, "js"))
+    assert_true(snippet_compiled(dir, "wasm-gc") is Some(true))
+    assert_true(snippet_compiled(dir, "js") is Some(false))
     plant("js/debug/build/single", "single.js")
-    assert_true(snippet_compiled(dir, "js"))
-    assert_false(snippet_compiled(dir, "llvm"))
+    assert_true(snippet_compiled(dir, "js") is Some(true))
+    assert_true(snippet_compiled(dir, "llvm") is Some(false))
     plant("llvm/debug/build/single", "single.exe")
-    assert_true(snippet_compiled(dir, "llvm"))
+    assert_true(snippet_compiled(dir, "llvm") is Some(true))
     // The release profile is the fallback for a future moon default flip, so a
     // release-only artifact still counts.
     plant("js/release/build/single", "single.js")
     @fs.rmdir("\{dir}/js/debug", recursive=true)
-    assert_true(snippet_compiled(dir, "js"))
+    assert_true(snippet_compiled(dir, "js") is Some(true))
   })
 }
 
 ///|
-/// The body/brief framing names the failure stage. A compile error drops the
+/// The body/brief framing names the failure stage. A build failure drops the
 /// exit code — moon's is always 1 there and says nothing the diagnostics do
-/// not — while a runtime failure keeps the program's own code.
+/// not — while a runtime failure keeps the program's own code, and an unknown
+/// probe result keeps the pre-classification wording, claiming nothing.
 test "finished_body and finished_brief name the failure stage" {
-  assert_eq(finished_body("out\n", 0, compiled=true), "out\n")
+  assert_eq(finished_body("out\n", 0, compiled=Some(true)), "out\n")
   assert_true(
-    finished_body("", 0, compiled=true).contains("exited 0 with no output"),
+    finished_body("", 0, compiled=Some(true)).contains(
+      "exited 0 with no output",
+    ),
   )
-  let compile_error = finished_body("diagnostics", 1, compiled=false)
-  assert_true(compile_error.contains("COMPILE error"))
-  assert_true(compile_error.contains("never ran"))
-  assert_true(compile_error.contains("diagnostics"))
-  let runtime_failure = finished_body("trace", 3, compiled=true)
+  let build_failed = finished_body("diagnostics", 1, compiled=Some(false))
+  assert_true(build_failed.contains("BUILD failed"))
+  assert_true(build_failed.contains("never ran"))
+  assert_true(build_failed.contains("diagnostics"))
+  let runtime_failure = finished_body("trace", 3, compiled=Some(true))
   assert_true(runtime_failure.contains("exited 3 at RUNTIME"))
   assert_true(runtime_failure.contains("trace"))
   // The blank-output corners still name the stage.
-  assert_true(finished_body("", 1, compiled=false).contains("COMPILE error"))
-  assert_true(finished_body("", 3, compiled=true).contains("exited 3"))
-  assert_eq(finished_brief(1, compiled=false), "mbtx (compile error)")
-  assert_eq(finished_brief(3, compiled=true), "mbtx (exit=3)")
-  assert_eq(finished_brief(0, compiled=true), "mbtx (exit=0)")
+  assert_true(
+    finished_body("", 1, compiled=Some(false)).contains("BUILD failed"),
+  )
+  assert_true(finished_body("", 3, compiled=Some(true)).contains("exited 3"))
+  // An unknown probe result claims no stage in either direction.
+  let unknown = finished_body("out", 3, compiled=None)
+  assert_true(unknown.contains("exited 3"))
+  assert_false(unknown.contains("BUILD failed"))
+  assert_false(unknown.contains("RUNTIME"))
+  assert_eq(finished_brief(1, compiled=Some(false)), "mbtx (build failed)")
+  assert_eq(finished_brief(3, compiled=Some(true)), "mbtx (exit=3)")
+  assert_eq(finished_brief(3, compiled=None), "mbtx (exit=3)")
+  assert_eq(finished_brief(0, compiled=Some(true)), "mbtx (exit=0)")
 }
 
 ///|
 test "timeout_head says which half of the run never finished" {
-  let program_hung = timeout_head(5_000, compiled=true)
+  let program_hung = timeout_head(5_000, compiled=Some(true))
   assert_true(program_hung.contains("compiled but did not finish"))
-  let build_hung = timeout_head(5_000, compiled=false)
+  let build_hung = timeout_head(5_000, compiled=Some(false))
   assert_true(build_hung.contains("BUILD never completed"))
   assert_true(build_hung.contains("never ran"))
+  // The probe failing keeps the original both-ways hedge.
+  let unknown = timeout_head(5_000, compiled=None)
+  assert_true(unknown.contains("a build that never completed"))
 }
 
 ///|


### PR DESCRIPTION
## Problem

A failed `mbtx` call reported `[mbtx: exited 1]` whether the **build rejected the snippet** or the **program ran and trapped** — `moon run` exits 1 for both. The model couldn't tell "fix the source" from "debug the program", and nothing in the output can say either: a snippet legitimately runs `moon check`/`moon test` as child processes, so compiler-diagnostic text in the log is routinely the program's own *successful* output. Any output-based classifier would misfire exactly there.

## Design: a structural signal

After `moon run` exits, probe the throwaway `--target-dir` for the runnable artifact moon links **only after a successful build** — verified against moon's own build plan (`--dry-run`) for all four targets:

| target | artifact |
|---|---|
| wasm / wasm-gc | `<target>/debug/build/single/single.wasm` |
| js | `js/debug/build/single/single.js` |
| llvm | `llvm/debug/build/single/single.exe` |

The dir is fresh per call, so **presence proves the program was launched**, and **absence on a failed run proves the failure came from the build** — the framing deliberately claims no more than that (`BUILD failed — the program never ran`), since absence alone cannot distinguish compiler rejection from a toolchain/dependency fault; the diagnostics below the label say which. The probe is tri-state (`Bool?`): a probe fault (EIO/EACCES) claims **neither** stage and keeps the plain exit report, per the repo rule against folding unrelated errors into the "missing" case. The release profile is probed as a fallback so a future `moon run` default flip degrades to an extra stat.

## What changes

- **Foreground failures** are labeled: `[mbtx: BUILD failed — the program never ran; the output below is the build's]` vs `[mbtx: exited N at RUNTIME — the program compiled and ran]`, with briefs `mbtx (build failed)` / `mbtx (exit=N)`. Success output is untouched.
- **Foreground timeouts** say *which half* never finished: build vs program (probe-unknown keeps the original hedge).
- **Handed-off jobs**: `BgJobRuntime::adopt` gains an optional launcher-supplied `exit_note` classifier. The exit watcher computes it at terminal time **before** `on_terminal` reclaims the build dir (the classifier's evidence), caches it, and it rides both the completion notice and `job_output`.
- The exit note is **single-flight** (`NotComputed → Computing → Cached`): exactly one task runs the classifier; a `job_output` read racing the exit joins the watcher's flight instead of recomputing — a second computation could finish after cleanup emptied the evidence directory and overwrite the correct answer (found by codex xhigh review with a deterministic failing repro; that repro is now a regression test). A cancelled flight resets so the watcher still computes and cleanup is never wedged.
- A **raising classifier is reported, not silenced**: the failure is cached as a tagged note (`exit-stage classification failed (…)`) instead of being indistinguishable from "nothing to say".
- Kills carry no exit code (`None`) into the classifier; mbtx declines to classify them since the stop reason is already named by the reader.

## Review

codex CLI (subal) xhigh reviewed the initial commit and raised 2×P1 + 1×P2 (evidence-overclaiming wording; the recompute-after-cleanup cache race; silent classifier-failure collapse) — all three addressed in the second commit, then the full branch was re-reviewed.

## Tests (all real-`moon` e2e unless noted)

- build failure → labeled + brief; runtime trap → labeled runtime; **negative control**: a snippet that *prints* compiler-diagnostic-shaped text is classified by what it *did*, not what it printed (trap → runtime; clean exit → no label).
- timeout at 50ms (below any possible compile) → "BUILD never completed"; compiled/unknown timeout wording pinned by whitebox tests.
- the per-target artifact table pinned with fabricated artifacts (llvm cannot even build on this toolchain: missing core bundle) incl. the all_pkgs.json non-artifact and the release fallback.
- bgjobs: note computed **before** terminal cleanup; the reviewer's race repro as a regression test (racing reader joins the flight, classifier runs exactly once); a raising classifier yields the tagged note; `None` exit code for kills; no classifier → no note.
- `job_output` renders the note between output and footer; a handed-off build failure (handoff at 1ms) is classified in its completion notice.

`moon check --deny-warn` clean repo-wide; 191/191 tests green across the four touched packages; `moon fmt --check` clean; only the intended `bgjobs` mbti surface changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Qu3wgL9g7Z9V4umSU97RD
