### PR TITLE
feat(desktop): render SKILL.md frontmatter as metadata table

### DIFF
--- a/desktop/frontend/skills/document.mbt
+++ b/desktop/frontend/skills/document.mbt
@@ -17,7 +17,7 @@ fn parse_skill_document(source : String) -> SkillDocument {
   }
   let first = first.trim()
   let first = if first.has_prefix("\u{feff}") {
-    first[3:].trim()
+    first[1:].trim()
   } else {
     first
   }

--- a/desktop/frontend/skills/document.mbt
+++ b/desktop/frontend/skills/document.mbt
@@ -1,0 +1,92 @@
+///|
+/// A SKILL.md split into its YAML frontmatter and Markdown body.
+priv struct SkillDocument {
+  metadata : Array[(String, String)]
+  body : String
+}
+
+///|
+/// Split the common, top-level frontmatter form used by SKILL.md files. This is
+/// deliberately not a YAML evaluator: unknown values remain display strings,
+/// and an unterminated header is kept as ordinary Markdown instead of being
+/// silently removed.
+fn parse_skill_document(source : String) -> SkillDocument {
+  let lines = source.split("\n").map(line => line.to_owned()).collect()
+  guard lines is [first, .. rest] else {
+    return { metadata: [], body: source, }
+  }
+  let first = first.trim()
+  let first = if first.has_prefix("\u{feff}") {
+    first[3:].trim()
+  } else {
+    first
+  }
+  let rest_array : Array[String] = []
+  for line in rest {
+    rest_array.push(line)
+  }
+  let rest = rest_array
+  guard first == "---" else { return { metadata: [], body: source, } }
+  let closing = find_frontmatter_close(rest)
+  guard closing is Some(index) else { return { metadata: [], body: source, } }
+  let metadata : Array[(String, String)] = []
+  for line in rest[0:index] {
+    let line = line.trim()
+    guard !line.is_empty() && !line.has_prefix("#") else { continue }
+    guard line.find(":") is Some(colon) else { continue }
+    let key = line[0:colon].trim().to_owned()
+    guard !key.is_empty() else { continue }
+    metadata.push((key, line[colon + 1:].trim().to_owned()))
+  }
+  let body_lines : Array[String] = []
+  for body_line in rest[index + 1:] {
+    body_lines.push(body_line)
+  }
+  { metadata, body: lines_to_string(body_lines), }
+}
+
+///|
+fn find_frontmatter_close(lines : Array[String]) -> Int? {
+  for index, line in lines {
+    let marker = line.trim()
+    if marker == "---" || marker == "..." {
+      return Some(index)
+    }
+  }
+  None
+}
+
+///|
+fn lines_to_string(lines : Array[String]) -> String {
+  let out = StringBuilder()
+  for index, line in lines {
+    if index > 0 {
+      out.write_char('\n')
+    }
+    out.write_string(line)
+  }
+  out.to_string()
+}
+
+///|
+test "skill documents separate closed frontmatter" {
+  let document = parse_skill_document(
+    "\u{feff}---\r\nname: widget\r\ndescription: Build widgets\r\nlicense: MIT\r\n---\r\n\r\n# Instructions\r\nUse it.",
+  )
+  assert_eq(document.metadata, [
+    ("name", "widget"),
+    ("description", "Build widgets"),
+    ("license", "MIT"),
+  ])
+  assert_eq(document.body, "\r\n# Instructions\r\nUse it.")
+}
+
+///|
+test "skill documents keep ordinary markdown and unterminated headers" {
+  let plain = parse_skill_document("# Title\nbody")
+  assert_eq(plain.metadata.length(), 0)
+  assert_eq(plain.body, "# Title\nbody")
+  let open = parse_skill_document("---\nname: widget\n# missing close\n# body")
+  assert_eq(open.metadata.length(), 0)
+  assert_eq(open.body, "---\nname: widget\n# missing close\n# body")
+}

--- a/desktop/frontend/skills/view.mbt
+++ b/desktop/frontend/skills/view.mbt
@@ -162,9 +162,7 @@ fn skill_document_view(source : String) -> @html.Html {
   let document = parse_skill_document(source)
   let nodes : Array[@html.Html] = []
   if !document.metadata.is_empty() {
-    let rows : Array[@html.Html] = [
-      @html.tr([@html.th("Field"), @html.th("Value")]),
-    ]
+    let rows : Array[@html.Html] = []
     for entry in document.metadata {
       let (key, value) = entry
       rows.push(@html.tr([@html.th(key), @html.td(value)]))

--- a/desktop/frontend/skills/view.mbt
+++ b/desktop/frontend/skills/view.mbt
@@ -145,16 +145,7 @@ fn detail_page(
         emit,
       )
     Ready(target~, content~, ..) =>
-      detail_shell(
-        target,
-        @html.div(
-          class="skill-preview-markdown msg-content markdown",
-          @markdown.markdown_nodes(content),
-        ),
-        input,
-        state,
-        emit,
-      )
+      detail_shell(target, skill_document_view(content), input, state, emit)
     Failed(target~, message~, ..) =>
       detail_shell(
         target,
@@ -164,6 +155,37 @@ fn detail_page(
         emit,
       )
   }
+}
+
+///|
+fn skill_document_view(source : String) -> @html.Html {
+  let document = parse_skill_document(source)
+  let nodes : Array[@html.Html] = []
+  if !document.metadata.is_empty() {
+    let rows : Array[@html.Html] = []
+    for entry in document.metadata {
+      let (key, value) = entry
+      rows.push(
+        @html.div(class="skill-metadata-row", [
+          @html.span(class="skill-metadata-key", key),
+          @html.span(class="skill-metadata-value", value),
+        ]),
+      )
+    }
+    nodes.push(
+      @html.div(class="skill-metadata", [
+        @html.div(class="skill-metadata-title", "Metadata"),
+        @html.div(class="skill-metadata-rows", rows),
+      ]),
+    )
+  }
+  nodes.push(
+    @html.div(
+      class="skill-preview-markdown msg-content markdown",
+      @markdown.markdown_nodes(document.body),
+    ),
+  )
+  @html.div(nodes)
 }
 
 ///|

--- a/desktop/frontend/skills/view.mbt
+++ b/desktop/frontend/skills/view.mbt
@@ -162,20 +162,19 @@ fn skill_document_view(source : String) -> @html.Html {
   let document = parse_skill_document(source)
   let nodes : Array[@html.Html] = []
   if !document.metadata.is_empty() {
-    let rows : Array[@html.Html] = []
+    let rows : Array[@html.Html] = [
+      @html.tr([@html.th("Field"), @html.th("Value")]),
+    ]
     for entry in document.metadata {
       let (key, value) = entry
-      rows.push(
-        @html.div(class="skill-metadata-row", [
-          @html.span(class="skill-metadata-key", key),
-          @html.span(class="skill-metadata-value", value),
-        ]),
-      )
+      rows.push(@html.tr([@html.th(key), @html.td(value)]))
     }
     nodes.push(
       @html.div(class="skill-metadata", [
         @html.div(class="skill-metadata-title", "Metadata"),
-        @html.div(class="skill-metadata-rows", rows),
+        @html.div(class="skill-metadata-scroll", [
+          @html.table(class="skill-metadata-table", rows),
+        ]),
       ]),
     )
   }

--- a/desktop/styles/pages.css
+++ b/desktop/styles/pages.css
@@ -530,42 +530,64 @@ h2 {
 }
 
 .skill-metadata {
-  margin-bottom: 20px;
-  padding: 12px 14px;
+  margin-bottom: 24px;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
   background: var(--color-bg-subtle);
+  overflow: hidden;
 }
 
 .skill-metadata-title {
-  margin-bottom: 8px;
+  padding: 12px 14px 10px;
   color: var(--color-text-primary);
   font-size: var(--font-size-sm);
   font-weight: 600;
 }
 
-.skill-metadata-rows {
-  display: grid;
-  gap: 5px;
+.skill-metadata-scroll {
+  overflow-x: auto;
 }
 
-.skill-metadata-row {
-  display: grid;
-  grid-template-columns: minmax(110px, 0.35fr) 1fr;
-  gap: 14px;
+.skill-metadata-table {
+  width: 100%;
+  min-width: 460px;
+  margin: 0;
+  border: 0;
+  border-collapse: collapse;
+  background: var(--color-bg-surface);
+  font-size: var(--font-size-sm);
+}
+
+.skill-metadata-table th,
+.skill-metadata-table td {
+  padding: 10px 14px;
+  border: 1px solid var(--color-border);
   line-height: var(--line-height-normal);
+  text-align: left;
+  vertical-align: top;
 }
 
-.skill-metadata-key {
-  color: var(--color-text-muted);
+.skill-metadata-table thead th {
+  background: var(--color-bg-subtle);
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.skill-metadata-table tbody th {
+  width: 28%;
+  min-width: 130px;
+  background: var(--color-bg-subtle);
+  color: var(--color-text-primary);
   font-family: var(--font-family-mono);
   font-size: var(--font-size-xs);
   overflow-wrap: anywhere;
 }
 
-.skill-metadata-value {
+.skill-metadata-table tbody td {
   color: var(--color-text-secondary);
-  font-size: var(--font-size-sm);
   overflow-wrap: anywhere;
   white-space: pre-wrap;
 }

--- a/desktop/styles/pages.css
+++ b/desktop/styles/pages.css
@@ -554,6 +554,7 @@ h2 {
   margin: 0;
   border: 0;
   border-collapse: collapse;
+  table-layout: auto;
   background: var(--color-bg-surface);
   font-size: var(--font-size-sm);
 }
@@ -567,23 +568,14 @@ h2 {
   vertical-align: top;
 }
 
-.skill-metadata-table thead th {
-  background: var(--color-bg-subtle);
-  color: var(--color-text-secondary);
-  font-size: var(--font-size-xs);
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
-.skill-metadata-table tbody th {
-  width: 28%;
-  min-width: 130px;
-  background: var(--color-bg-subtle);
-  color: var(--color-text-primary);
+.skill-metadata-table th {
+  width: 1%;
+  color: var(--color-text-muted);
   font-family: var(--font-family-mono);
   font-size: var(--font-size-xs);
-  overflow-wrap: anywhere;
+  white-space: nowrap;
+  text-align: center;
+  vertical-align: middle;
 }
 
 .skill-metadata-table tbody td {

--- a/desktop/styles/pages.css
+++ b/desktop/styles/pages.css
@@ -529,6 +529,47 @@ h2 {
   line-height: var(--line-height-relaxed);
 }
 
+.skill-metadata {
+  margin-bottom: 20px;
+  padding: 12px 14px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg-subtle);
+}
+
+.skill-metadata-title {
+  margin-bottom: 8px;
+  color: var(--color-text-primary);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+}
+
+.skill-metadata-rows {
+  display: grid;
+  gap: 5px;
+}
+
+.skill-metadata-row {
+  display: grid;
+  grid-template-columns: minmax(110px, 0.35fr) 1fr;
+  gap: 14px;
+  line-height: var(--line-height-normal);
+}
+
+.skill-metadata-key {
+  color: var(--color-text-muted);
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-xs);
+  overflow-wrap: anywhere;
+}
+
+.skill-metadata-value {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
 .skill-detail-page {
   max-width: 840px;
 }


### PR DESCRIPTION
## Summary

Render `SKILL.md` YAML frontmatter separately from the Markdown content in the Skills detail view.

## Changes

- Parse common top-level frontmatter fields from `SKILL.md`.
- Handle UTF-8 BOMs before the opening `---` marker.
- Support both `---` and `...` as the closing frontmatter marker.
- Preserve ordinary Markdown when frontmatter is absent or unterminated.
- Display frontmatter fields in a dedicated metadata table.
- Style field names with centered, muted text.
- Size the field column based on the longest field name instead of using a fixed width.
- Keep long metadata values readable with wrapping and horizontal overflow support.
- Render the remaining document body through the existing Markdown renderer.
- Preserve the original source content for the existing copy functionality.

## Testing

- `moon fmt`
- `moon check --target js --deny-warn --package-path desktop/frontend/skills`
- `git diff --check`