### PR TITLE
feat(mbtx): stage wasm runs — synchronous build, auto-backgrounded run

### DIFF
--- a/agent/tool_definition.mbt
+++ b/agent/tool_definition.mbt
@@ -210,10 +210,13 @@ async test "a compile error reached inside the grace reports inline" {
 }
 
 ///|
-/// If compilation itself crosses the grace, the same process becomes a job.
-/// Its later diagnostic must still name the submitted `source`, not the
-/// session-owned throwaway directory.
-async test "a compile error after handoff keeps source diagnostics" {
+/// Compilation can no longer cross the grace: the wasm build phase runs
+/// synchronously by design — its time does not count against the run's
+/// inline allowance — so even under the smallest possible handoff bound a
+/// compile error is reported INLINE, labeled as the build's, naming the
+/// submitted `source`, and no job is ever created for it. What the runtime
+/// adopts is always a running program.
+async test "a compile error never becomes a job, whatever the grace" {
   @async.with_task_group(group => {
     let spill_dir = @fs.tmpdir(prefix="openseek-compile-job-")
     let bg_runtime = @bgjobs.BgJobRuntime::BgJobRuntime(
@@ -232,20 +235,13 @@ async test "a compile error after handoff keeps source diagnostics" {
       Sync(_) => fail("mbtx should be async")
     }
     guard action is Respond(output) else { fail("expected Respond") }
-    assert_false(output.is_error)
-    assert_true(output.content.contains("moved to the background"))
-    guard bg_runtime.list() is [job, ..] else { fail("no job registered") }
-    let read = match @job_output.definition(bg_runtime).execute {
-      Async(execute) => execute({ "job_id": job.id, "wait_ms": 30_000 })
-      Sync(_) => fail("job_output should be async")
-    }
-    guard read is Respond(result) else { fail("expected Respond") }
-    assert_true(result.is_error)
-    assert_true(result.content.contains("source:"))
-    assert_false(result.content.contains("openseek-compile-job-"))
-    // The session-owned result container remains until teardown even though the
-    // disposable build subtree is reclaimed at terminal status.
-    assert_true(@fs.exists("\{spill_dir}/snippet-0"))
+    assert_true(output.is_error)
+    assert_false(output.content.contains("moved to the background"))
+    assert_true(output.content.contains("BUILD failed"))
+    // The diagnostic points at the model's own input, not the throwaway dir.
+    assert_true(output.content.contains("source:"))
+    assert_false(output.content.contains("openseek-compile-job-"))
+    assert_true(bg_runtime.list() is [])
     @fs.rmdir(spill_dir, recursive=true) catch {
       _ => ()
     }

--- a/agent/tool_definition.mbt
+++ b/agent/tool_definition.mbt
@@ -210,6 +210,47 @@ async test "a compile error reached inside the grace reports inline" {
 }
 
 ///|
+/// A handed-off run still carries the build phase's voice: requested compiler
+/// warnings exist only in the build capture, so the handoff response is their
+/// one ride to the model — and the job's label says the build succeeded, so a
+/// later nonzero exit reads as the program's own.
+async test "a handoff carries build warnings and the build-ok label" {
+  @async.with_task_group(group => {
+    let spill_dir = @fs.tmpdir(prefix="openseek-handoff-warn-")
+    let bg_runtime = @bgjobs.BgJobRuntime(AgentTaskScope(group), spill_dir~)
+    let mbtx = @mbtx.definition(
+      workspace_root=".",
+      bg_runtime~,
+      job_dir=spill_dir,
+      auto_background_after_ms=1500,
+    )
+    let source =
+      #|import { "moonbitlang/async" }
+      #|
+      #|async fn main {
+      #|  let unused = 1
+      #|  @async.sleep(60_000)
+      #|}
+    let action = match mbtx.execute {
+      Async(execute) => execute({ "source": source, "warning": "on" })
+      Sync(_) => fail("mbtx should be async")
+    }
+    guard action is Respond(output) else { fail("expected Respond") }
+    assert_false(output.is_error)
+    assert_true(output.content.contains("moved to the background"))
+    assert_true(output.content.contains("Unused variable"))
+    // Warnings name the model's `source`, not the throwaway build dir.
+    assert_true(output.content.contains("source:"))
+    guard bg_runtime.list() is [job, ..] else { fail("no job was registered") }
+    assert_true(job.command.contains("build ok"))
+    let _ = bg_runtime.stop(job.id)
+    @fs.rmdir(spill_dir, recursive=true) catch {
+      _ => ()
+    }
+  })
+}
+
+///|
 /// Compilation can no longer cross the grace: the wasm build phase runs
 /// synchronously by design — its time does not count against the run's
 /// inline allowance — so even under the smallest possible handoff bound a

--- a/agent_tool/mbtx/README.mbt.md
+++ b/agent_tool/mbtx/README.mbt.md
@@ -10,22 +10,38 @@ sandboxed automation surface.
 ## How it works
 
 The `source` is a `.mbtx` **single-file script** — MoonBit's own one-file
-program format. The tool writes it into a throwaway directory and runs
-`moon run <file>.mbtx --target <target> --target-dir <temp>` with the workspace
-(or explicit `cwd`) as the program's working directory. Relative reads therefore
-reach workspace files, while snippet build artifacts stay out of your `_build`.
-Moon's single-file runner handles the inline import block, and compiler
-diagnostics are rewritten to stable `source:LINE:COL` locations.
+program format. The tool writes it into a throwaway directory and, for the
+default wasm target, runs it in **two phases**. The BUILD runs first,
+synchronously: `moon run <file>.mbtx --build-only --target wasm --target-dir
+<temp>`, bounded by its own wall clock (10s by default) so a hung dependency
+download cannot hold the turn. A nonzero exit here is reported immediately as
+`BUILD failed (exit N)` — a build failure **by construction**, since the run
+phase never starts; no exit-code or output archaeology is needed to tell the
+stages apart, which matters because `moon run` alone exits 1 for a rejected
+build and a trapped program alike, and diagnostics in a merged stream prove
+nothing (a snippet legitimately runs `moon check` as a child process). On
+success the RUN phase execs `moonrun` directly on the artifact moon reported
+in its `{"artifacts_path":[…]}` line — the same process `moon run` would have
+exec'd — with the workspace (or explicit `cwd`) as the program's working
+directory, so relative reads reach workspace files while build artifacts stay
+out of your `_build`. A failure there is labeled `at RUNTIME — … from the
+run, not the build`. Compiler diagnostics are rewritten to stable
+`source:LINE:COL` locations, and build output (warnings under
+`warning: "on"`) is kept apart from program output by construction. The
+non-wasm targets keep the single-shot `moon run` and their reports claim no
+stage.
 
-With the agent's background runtime, every call waits inline for up to five
-seconds. A still-running compile or program is then adopted as the same
-background execution: the call returns its job id, completion is pushed later,
-and its compiler inputs and build artifacts are reclaimed when the job becomes
-terminal. Files the snippet writes under its temporary result directory remain
-readable until session teardown, so paths printed in completion output stay
-valid. There is no foreground/background argument to choose. A standalone
-definition without a job runtime stays in the foreground for up to 300 seconds
-and is cancelled at that deadline.
+With the agent's background runtime, every call's RUN waits inline for up to
+five seconds — build time deliberately does not count against that allowance.
+A still-running program is then adopted as the same background execution: the
+call returns its job id, completion is pushed later, and its compiler inputs
+and build artifacts are reclaimed when the job becomes terminal. An adopted
+job is therefore always a running program, never a build. Files the snippet
+writes under its temporary result directory remain readable until session
+teardown, so paths printed in completion output stay valid. There is no
+foreground/background argument to choose. A standalone definition without a
+job runtime stays in the foreground for up to 300 seconds of run time and is
+cancelled at that deadline.
 
 ## Arguments
 

--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -13,6 +13,15 @@ const AutoBackgroundAfterMs : Int = 5_000
 const ForegroundTimeoutMs : Int = 300_000
 
 ///|
+/// Ceiling on the build notes carried into a report, in characters. Warnings
+/// are for reading, not archiving: the run's own body may already reach the
+/// 48KB `OutputCapBytes`, which is sized to keep the whole result under the
+/// agent loop's outer 60k clamp — a clamp that cuts the TAIL, exactly where
+/// the stop/retry and sandbox guidance live. An uncapped prepend would spend
+/// that margin; this cap preserves it.
+const BuildNotesCapChars : Int = 8_000
+
+///|
 /// Wall-clock bound for the synchronous BUILD phase of a wasm run. The build
 /// runs inline on purpose — its duration does not count against the program's
 /// own foreground allowance — so it needs a bound of its own: a hung
@@ -881,7 +890,16 @@ async fn build_snippet(
       ),
     )
   }
-  Built(artifact~, notes=strip_artifact_report(text))
+  Built(artifact~, notes=cap_build_notes(strip_artifact_report(text)))
+}
+
+///|
+fn cap_build_notes(notes : String) -> String {
+  if notes.length() <= BuildNotesCapChars {
+    notes
+  } else {
+    "\{notes.clamped_view(end=BuildNotesCapChars)}\n[mbtx: build warnings truncated at \{BuildNotesCapChars} characters]"
+  }
 }
 
 ///|
@@ -893,8 +911,12 @@ async fn build_snippet(
 /// absent one, not surfaced as a fault: both degrade to the single-file
 /// layout fallback, and the existence check that follows validates WHICHEVER
 /// path was chosen — a wrong guess surfaces as a named build fault, never as
-/// a silent misrun. Failing the call on a report the fallback would have
-/// covered would only make the tool more brittle.
+/// a silent misrun. That holds even if the layout fallback is itself stale:
+/// the guard then reports a missing artifact, still a correctly-classified
+/// build-stage fault — only the diagnostic detail differs, and naming the
+/// parse failure instead would matter only on a moon that broke its report
+/// line AND its layout at once. Failing the call on a report the fallback
+/// would have covered would only make the tool more brittle.
 fn parse_artifacts_path(output : String) -> String? {
   let mut found : String? = None
   for line in output.split("\n") {

--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -13,6 +13,16 @@ const AutoBackgroundAfterMs : Int = 5_000
 const ForegroundTimeoutMs : Int = 300_000
 
 ///|
+/// Wall-clock bound for the synchronous BUILD phase of a wasm run. The build
+/// runs inline on purpose — its duration does not count against the program's
+/// own foreground allowance — so it needs a bound of its own: a hung
+/// dependency download must not hold the turn. Generous by an order of
+/// magnitude: a trivial wasm build measures ~100ms and one pulling several
+/// registry modules well under a second on a warm cache, and a timed-out
+/// build's retry is faster still (moon caches downloaded modules).
+const BuildTimeoutMs : Int = 10_000
+
+///|
 /// Output is streamed to a file on disk, not buffered in memory, so a snippet
 /// that floods stdout (e.g. `while true { println(…) }`) cannot exhaust the
 /// agent's memory before the timeout fires. A FOREGROUND run is STOPPED once it
@@ -99,6 +109,7 @@ pub fn definition(
   worker_sandbox? : WorkerSandbox,
   auto_background_after_ms? : Int = AutoBackgroundAfterMs,
   foreground_timeout_ms? : Int = ForegroundTimeoutMs,
+  build_timeout_ms? : Int = BuildTimeoutMs,
   approval? : @agent_runtime.ApprovalChannel,
 ) -> @agent_tool.AgentToolDefinition {
   // Background snippet directories are numbered inside the caller's scratch
@@ -113,6 +124,7 @@ pub fn definition(
       escalation=approval is Some(_),
       auto_background_after_ms~,
       foreground_timeout_ms~,
+      build_timeout_ms~,
     ),
     schema=JsonSchema(schema(escalation=approval is Some(_))),
     execute=Async(arguments => {
@@ -126,6 +138,7 @@ pub fn definition(
         worker_sandbox?,
         auto_background_after_ms~,
         foreground_timeout_ms~,
+        build_timeout_ms~,
         next_background~,
         approval?,
       )
@@ -178,10 +191,12 @@ async fn execute(
   job_dir? : String,
   scratch_dir? : String,
   worker_sandbox? : WorkerSandbox,
-  // Independent injectable bounds: a runtime-backed run hands off at the first;
-  // a runtime-less run is cancelled at the second.
+  // Independent injectable bounds: a runtime-backed run hands off at the
+  // first; a runtime-less run is cancelled at the second; a wasm target's
+  // synchronous build phase is cancelled at the third.
   auto_background_after_ms~ : Int,
   foreground_timeout_ms~ : Int,
+  build_timeout_ms~ : Int,
   next_background~ : Ref[Int],
   approval? : @agent_runtime.ApprovalChannel,
 ) -> @agent_tool.ToolAction {
@@ -402,35 +417,16 @@ async fn execute(
     extra_roots=[..scratch_dir.map(l => [l]).unwrap_or([])],
   )
   @fs.write_file(policy_path, policy.stringify(), create_mode=CreateOrTruncate)
-  let moon_argv = [
-    "run",
-    "\{build_dir}/snippet.mbtx",
-    "--target",
-    input.target,
-    "--target-dir",
-    build_dir,
-    // An approved escalation is exactly this: the policy file is still
-    // written, and simply not passed. Widening the document instead was not
-    // available — its `fs.write` roots are canonicalized existing paths with
-    // no wildcard, and "any program" has no spelling in `process.allow` short
-    // of enumerating one — so "no policy" is both the honest description of
-    // what was approved and the only one the runtime can express.
-    ..if policy_active {
-      ["--wasm-policy", policy_path]
-    },
-    ..if !input.warning {
-      ["--warn-list", WarnOffList]
-    },
-  ]
-  // Wrap `moon run` in sandbox-exec for the roles that need a rule the wasm
-  // policy cannot state: "may not write source". The policy's `fs` rules bind
-  // the snippet and stop at the process boundary, so a spawned `moon fmt` is
-  // beyond them, and a role defined by holding no editing tool needs that
-  // covered in the kernel. The main agent is not such a role and takes no
-  // profile — see below. Off macOS, or in a nested sandbox where a profile
-  // cannot be applied, every role runs with the policy as its only bound.
-  // The prepared command carries what it needs to classify its own denials, so
-  // one showing up in the program's output can be recognized and explained.
+  // Wrap each phase's command in sandbox-exec for the roles that need a rule
+  // the wasm policy cannot state: "may not write source". The policy's `fs`
+  // rules bind the snippet and stop at the process boundary, so a spawned
+  // `moon fmt` is beyond them, and a role defined by holding no editing tool
+  // needs that covered in the kernel. The main agent is not such a role and
+  // takes no profile — see below. Off macOS, or in a nested sandbox where a
+  // profile cannot be applied, every role runs with the policy as its only
+  // bound. The prepared command carries what it needs to classify its own
+  // denials, so one showing up in the program's output can be recognized and
+  // explained.
   // The throwaway snippet container is the writable subtree: if it falls INSIDE
   // the workspace root (e.g. `workspace_root=/tmp`, where `@fs.tmpdir` lands
   // under it) the shared deny would otherwise block moon's own generated
@@ -444,53 +440,126 @@ async fn execute(
     Some(lab) if dir.has_prefix(lab) => lab
     _ => dir
   }
-  let sandboxed_command = match worker_sandbox {
-    // Worker mode replaces the workspace source-write profile rather than
-    // adding to it: a worker is supposed to write source, just only its own,
-    // so the kernel denies its siblings' trees and the shared git dir instead
-    // of denying source writes as such.
-    Some(scope) =>
-      @sandbox.SandboxedCommand::create_worker_if_available(
-        Exec("moon", moon_argv),
-        deny_roots=scope.deny_roots,
-        worker_root=scope.worker_root,
-        worker_admin_dir=scope.worker_admin_dir,
-      )
-    // The read-only roles (explore/review/audit) hold no editing tool, so "may
-    // not write source" is the guarantee that defines them and it stays
-    // kernel-enforced. The profile suits them for a second reason — it is
-    // `(allow default)` minus source, so `moon check` can still write its
-    // target dir inside the workspace, which a boundary profile denying the
-    // workspace would take away.
-    //
-    // Read-only is its own parameter rather than being read off `scratch_dir`:
-    // a caller that forgets the lab should lose the lab, not the sandbox.
-    None if read_only =>
-      @sandbox.SandboxedCommand::create_if_available(
-        workspace_root,
-        Exec("moon", moon_argv),
-        writable_subtree~,
-      )
-    // The main agent runs with no kernel profile at all. Forbidding source
-    // writes here would break the very commands it needs — `moon fmt`,
-    // `moon info`, `git checkout` all rewrite source by definition — and the
-    // other shape, denying writes globally and re-allowing an enumerated set,
-    // was tried and withdrawn: every root it missed (`/dev` for git's
-    // `/dev/null`, `/tmp` for `@fs.tmpdir`, the toolchain root, gh's cache)
-    // surfaced as a bare EPERM in a live turn rather than in a test, and the
-    // list only ever protected macOS.
-    //
-    // What is left bounding a child is the allowlist, which works everywhere:
-    // it admits no shell, no interpreter and no ad-hoc rewriter, and it refuses
-    // the git options that would point a command at another repository. That is
-    // a bound on which commands exist, not on where they may write — the file
-    // tools are not path-confined for this role either, so a profile here would
-    // have been the only such rule in the tool set.
-    None => None
+  async fn confine(
+    program : String,
+    command_argv : Array[String],
+  ) -> @sandbox.SandboxedCommand? {
+    match worker_sandbox {
+      // Worker mode replaces the workspace source-write profile rather than
+      // adding to it: a worker is supposed to write source, just only its own,
+      // so the kernel denies its siblings' trees and the shared git dir instead
+      // of denying source writes as such.
+      Some(scope) =>
+        @sandbox.SandboxedCommand::create_worker_if_available(
+          Exec(program, command_argv),
+          deny_roots=scope.deny_roots,
+          worker_root=scope.worker_root,
+          worker_admin_dir=scope.worker_admin_dir,
+        )
+      // The read-only roles (explore/review/audit) hold no editing tool, so
+      // "may not write source" is the guarantee that defines them and it stays
+      // kernel-enforced. The profile suits them for a second reason — it is
+      // `(allow default)` minus source, so `moon check` can still write its
+      // target dir inside the workspace, which a boundary profile denying the
+      // workspace would take away.
+      //
+      // Read-only is its own parameter rather than being read off
+      // `scratch_dir`: a caller that forgets the lab should lose the lab, not
+      // the sandbox.
+      None if read_only =>
+        @sandbox.SandboxedCommand::create_if_available(
+          workspace_root,
+          Exec(program, command_argv),
+          writable_subtree~,
+        )
+      // The main agent runs with no kernel profile at all. Forbidding source
+      // writes here would break the very commands it needs — `moon fmt`,
+      // `moon info`, `git checkout` all rewrite source by definition — and the
+      // other shape, denying writes globally and re-allowing an enumerated
+      // set, was tried and withdrawn: every root it missed (`/dev` for git's
+      // `/dev/null`, `/tmp` for `@fs.tmpdir`, the toolchain root, gh's cache)
+      // surfaced as a bare EPERM in a live turn rather than in a test, and the
+      // list only ever protected macOS.
+      //
+      // What is left bounding a child is the allowlist, which works
+      // everywhere: it admits no shell, no interpreter and no ad-hoc rewriter,
+      // and it refuses the git options that would point a command at another
+      // repository. That is a bound on which commands exist, not on where they
+      // may write — the file tools are not path-confined for this role either,
+      // so a profile here would have been the only such rule in the tool set.
+      None => None
+    }
   }
+
+  // The wasm target runs in TWO phases. The BUILD runs first, synchronously,
+  // on its own bound: build time deliberately does not count against the
+  // program's foreground allowance, a failed build returns immediately and is
+  // a build failure BY CONSTRUCTION (the run phase never starts — no exit
+  // code or output archaeology can confuse the two stages), and what the
+  // background runtime may later adopt is exactly the running program. The
+  // RUN phase then execs `moonrun` directly on the artifact the build
+  // reported — the same process `moon run` would exec, with `--policy` being
+  // moonrun's spelling of `--wasm-policy` (confirmed against moon's own
+  // `--dry-run` plan).
+  //
+  // The other targets keep the single-shot `moon run`: they are compute-only
+  // (no policy to stage around), their runners are not moonrun, and they are
+  // rare enough that a second execution shape is not worth carrying.
+  let staged_run = if input.target == "wasm" {
+    match
+      build_snippet(
+        build_dir~,
+        run_cwd~,
+        warning=input.warning,
+        build_timeout_ms~,
+        empty_stdin~,
+        rewrite_bases=[real, build_dir],
+        confine~,
+      ) {
+      NotBuilt(action) => return action
+      Built(artifact~, notes~) => {
+        // An approved escalation is exactly this: the policy file is still
+        // written, and simply not passed. Widening the document instead was
+        // not available — its `fs.write` roots are canonicalized existing
+        // paths with no wildcard, and "any program" has no spelling in
+        // `process.allow` short of enumerating one — so "no policy" is both
+        // the honest description of what was approved and the only one the
+        // runtime can express.
+        let run_argv : Array[String] = [
+          ..if policy_active {
+            ["--policy", policy_path]
+          },
+          artifact,
+          "--",
+        ]
+        Some(("moonrun", run_argv, notes))
+      }
+    }
+  } else {
+    None
+  }
+  let (spawn_program, spawn_argv, build_notes) = staged_run.unwrap_or(
+    (
+      "moon",
+      [
+        "run",
+        "\{build_dir}/snippet.mbtx",
+        "--target",
+        input.target,
+        "--target-dir",
+        build_dir,
+        ..if !input.warning {
+          ["--warn-list", WarnOffList]
+        },
+      ],
+      "",
+    ),
+  )
+  let staged = staged_run is Some(_)
+  let sandboxed_command = confine(spawn_program, spawn_argv)
   let (prog, argv) = match sandboxed_command {
     Some(command) => (command.program(), command.args())
-    None => ("moon", moon_argv)
+    None => (spawn_program, spawn_argv)
   }
   // With a job runtime wired the foreground run happens ON it, so the
   // deadline can DETACH the still-running program as a background job rather
@@ -572,13 +641,10 @@ async fn execute(
     )
     exec.discard()
     let text = rewrite_temp_paths(raw, [real, build_dir])
-    let body = if text.is_blank() {
-      "mbtx: program exited \{exit_code} with no output"
-    } else if exit_code != 0 {
-      "[mbtx: exited \{exit_code}]\n\{text}"
-    } else {
-      text
-    }
+    let body = with_build_notes(
+      build_notes,
+      finished_body(text, exit_code, staged~),
+    )
     let body = if output_limit_reached {
       "\{body}\n[mbtx: output passed the fixed \{OutputCapBytes}-byte inline limit, so the program was STOPPED and this is only what it printed first. Retrying the same call will hit the same limit. Redirect bulky child output with `stdout=ToFile(path)` where `path` is under `@fs.tmpdir()`, then have that same snippet read the file and print only the needed excerpt before it exits.]"
     } else {
@@ -635,13 +701,10 @@ async fn execute(
       // PREPEND the exit status so it survives the agent loop's outer 60k
       // result clamp (which cuts the tail); the output cap is below 60k so
       // both the status line and the body are retained.
-      let body = if text.is_blank() {
-        "mbtx: program exited \{exit_code} with no output"
-      } else if exit_code != 0 {
-        "[mbtx: exited \{exit_code}]\n\{text}"
-      } else {
-        text
-      }
+      let body = with_build_notes(
+        build_notes,
+        finished_body(text, exit_code, staged~),
+      )
       let body = if sandbox_denied is Some(guidance) {
         "\{body}\n\n\{guidance}"
       } else {
@@ -659,7 +722,7 @@ async fn execute(
       // instead of discarding it behind a generic timeout message. The status
       // line stays first so it survives the outer result clamp.
       let partial = rewrite_temp_paths(read_capped(log), [real, build_dir])
-      let head = "mbtx: timed out after \{duration_label(foreground_timeout_ms)} and was cancelled — the program did not finish (an infinite loop, or a build that never completed)."
+      let head = timeout_head(foreground_timeout_ms, staged~)
       let body = if partial.is_blank() {
         head
       } else {
@@ -674,6 +737,199 @@ async fn execute(
     }
   }
   action
+}
+
+///|
+/// Result of the synchronous wasm BUILD phase: the runnable artifact plus any
+/// build output worth carrying into the final report (compiler warnings under
+/// `warning: "on"`), or a ready-to-return report for a build that failed,
+/// timed out, or produced no artifact.
+priv enum BuildOutcome {
+  Built(artifact~ : String, notes~ : String)
+  NotBuilt(@agent_tool.ToolAction)
+}
+
+///|
+/// PHASE 1 of a wasm run: build the snippet with `moon run --build-only`,
+/// synchronously, on its own wall-clock bound. A nonzero exit here is a BUILD
+/// failure by construction — the run phase never starts — which is what makes
+/// the stage labels trustworthy without probing artifacts or parsing output:
+/// `moon run` alone exits 1 for a rejected build and a trapped program alike,
+/// and diagnostics in a merged stream prove nothing (a snippet legitimately
+/// runs `moon check` as a child process).
+///
+/// On success moon prints `{"artifacts_path":[…]}` naming the runnable; that
+/// line is consumed here — moon's own statement of the layout, so the tool
+/// assumes none — with the single-file layout as a fallback for a moon
+/// without the report line.
+async fn build_snippet(
+  build_dir~ : String,
+  run_cwd~ : String?,
+  warning~ : Bool,
+  build_timeout_ms~ : Int,
+  empty_stdin~ : String,
+  rewrite_bases~ : Array[String],
+  confine~ : async (String, Array[String]) -> @sandbox.SandboxedCommand?,
+) -> BuildOutcome {
+  let build_argv = [
+    "run",
+    "\{build_dir}/snippet.mbtx",
+    "--build-only",
+    "--target",
+    "wasm",
+    "--target-dir",
+    build_dir,
+    ..if !warning {
+      ["--warn-list", WarnOffList]
+    },
+  ]
+  let (prog, argv) = match confine("moon", build_argv) {
+    Some(command) => (command.program(), command.args())
+    None => ("moon", build_argv)
+  }
+  // Its own log file, so build diagnostics and program output never share a
+  // stream: warnings stay attributable to the build, and the run phase's
+  // policy-refusal scan never reads build chatter.
+  let build_log = "\{build_dir}/build.log"
+  @fs.write_file(build_log, "", create_mode=CreateOrTruncate)
+  let result = @async.with_timeout_opt(build_timeout_ms, () => {
+    let exit_code = @process.run(
+      prog,
+      argv,
+      cwd=run_cwd.unwrap_or("."),
+      inherit_env=true,
+      stdin=@process.redirect_from_file(empty_stdin),
+      stdout=@process.redirect_to_file(build_log, append=true),
+      stderr=@process.redirect_to_file(build_log, append=true),
+      no_console_window=true,
+    )
+    (exit_code, read_capped(build_log))
+  })
+  guard result is Some((exit_code, raw)) else {
+    return NotBuilt(
+      @agent_tool.respond(
+        "mbtx: the BUILD did not finish within \{duration_label(build_timeout_ms)} and was cancelled — the program never ran. Compilation or a dependency download stalled; retrying is faster than it looks (downloaded modules are cached).",
+        is_error=true,
+        brief="mbtx (build timeout)",
+      ),
+    )
+  }
+  let text = rewrite_temp_paths(raw, rewrite_bases)
+  if exit_code != 0 {
+    // The exit code is moon's and it is kept: build-stage faults are not all
+    // exit 1 (a dependency-resolution fault exits 255), and distinct codes
+    // are diagnostic. The output below says whether the compiler rejected
+    // `source` or the toolchain faulted.
+    return NotBuilt(
+      @agent_tool.respond(
+        if text.is_blank() {
+          "mbtx: the BUILD failed (exit \{exit_code}) with no output — the program never ran"
+        } else {
+          "[mbtx: BUILD failed (exit \{exit_code}) — the program never ran; the output below is the build's]\n\{text}"
+        },
+        is_error=true,
+        brief="mbtx (build failed, exit=\{exit_code})",
+      ),
+    )
+  }
+  let artifact = parse_artifacts_path(raw).unwrap_or(
+    "\{build_dir}/wasm/debug/build/single/single.wasm",
+  )
+  let artifact_present = @fs.exists(artifact) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => false
+  }
+  guard artifact_present else {
+    return NotBuilt(
+      @agent_tool.respond(
+        "mbtx: the build reported success but its artifact is missing (\{artifact}) — a toolchain fault, not a problem in `source`; retry, and report it if it persists.",
+        is_error=true,
+        brief="mbtx (build fault)",
+      ),
+    )
+  }
+  Built(artifact~, notes=strip_artifact_report(text))
+}
+
+///|
+/// The artifact path `moon run --build-only` reports on success, read from
+/// the last `{"artifacts_path":[…]}` line of its output. `None` for a moon
+/// that does not print one.
+fn parse_artifacts_path(output : String) -> String? {
+  let mut found : String? = None
+  for line in output.split("\n") {
+    let line = line.trim()
+    guard line.has_prefix("{\"artifacts_path\"") else { continue }
+    let parsed = @json.parse(line.to_owned()) catch { _ => continue }
+    if parsed is { "artifacts_path": [String(path), ..], .. } {
+      found = Some(path)
+    }
+  }
+  found
+}
+
+///|
+/// A successful build's output with moon's machine-facing artifact report
+/// removed: what remains — compiler warnings under `warning: "on"`, usually
+/// nothing — is for the model to read.
+fn strip_artifact_report(text : String) -> String {
+  [..text.split("\n")]
+  .filter(line => !line.trim().has_prefix("{\"artifacts_path\""))
+  .join("\n")
+  .trim()
+  .to_owned()
+}
+
+///|
+/// The status framing for a finished run. `staged` is the wasm two-phase
+/// path, where the build already succeeded synchronously before this process
+/// started — so a failure here is from the RUN by construction, and saying so
+/// is what keeps the model from re-reading a runtime trap as a compile error.
+/// The single-shot targets keep the plain framing: their one exit code covers
+/// both stages and claims neither.
+fn finished_body(text : String, exit_code : Int, staged~ : Bool) -> String {
+  if exit_code == 0 {
+    return if text.is_blank() {
+      "mbtx: program exited 0 with no output"
+    } else {
+      text
+    }
+  }
+  if staged {
+    if text.is_blank() {
+      "mbtx: the build succeeded, then the run exited \{exit_code} with no output"
+    } else {
+      "[mbtx: exited \{exit_code} at RUNTIME — the build succeeded; this failure is from the run, not the build]\n\{text}"
+    }
+  } else if text.is_blank() {
+    "mbtx: program exited \{exit_code} with no output"
+  } else {
+    "[mbtx: exited \{exit_code}]\n\{text}"
+  }
+}
+
+///|
+/// The first line of a foreground timeout report. On the staged wasm path the
+/// build had already succeeded, so only the program can be what never
+/// finished; a single-shot target keeps the two-sided hedge.
+fn timeout_head(foreground_timeout_ms : Int, staged~ : Bool) -> String {
+  let bound = duration_label(foreground_timeout_ms)
+  if staged {
+    "mbtx: timed out after \{bound} and was cancelled — the build had already succeeded, so it is the PROGRAM that did not finish (an infinite loop, or waiting on something that never arrived)."
+  } else {
+    "mbtx: timed out after \{bound} and was cancelled — the program did not finish (an infinite loop, or a build that never completed)."
+  }
+}
+
+///|
+/// Prepend the build phase's surviving output (warnings) to the run's report,
+/// so `warning: "on"` still shows the compiler's voice ahead of the program's.
+fn with_build_notes(notes : String, body : String) -> String {
+  if notes.is_blank() {
+    body
+  } else {
+    "\{notes}\n\{body}"
+  }
 }
 
 ///|
@@ -975,6 +1231,7 @@ fn description(
   escalation~ : Bool,
   auto_background_after_ms~ : Int,
   foreground_timeout_ms~ : Int,
+  build_timeout_ms~ : Int,
 ) -> String {
   // The one sentence here that depends on what this build can actually do.
   //
@@ -1086,11 +1343,22 @@ fn description(
   }
   let foreground_bound = duration_label(foreground_timeout_ms)
   let handoff_bound = duration_label(auto_background_after_ms)
+  let build_bound = duration_label(build_timeout_ms)
+  // The staged-execution paragraph is shared by both execution-time variants:
+  // the build/run split and its failure labels hold with or without a job
+  // runtime; only what happens to a long RUN differs.
+  let staging =
+    $|On the default wasm target the snippet is BUILT first, synchronously (up to
+    $|\{build_bound}): a failed build returns immediately, labeled `BUILD failed`, and the
+    $|program never starts — so a failure labeled `at RUNTIME` really is from the
+    $|run. Build time does not count against the run's own allowance below.
   if !background {
     return (
       $|\{base}
       $|
       $|## Execution time
+      $|
+      $|\{staging}
       $|
       $|This context has no background-job runtime. A run may stay in the foreground
       $|for up to \{foreground_bound}; at that deadline it is cancelled and reported as a timeout.
@@ -1103,7 +1371,9 @@ fn description(
     $|
     $|## Long-running work
     $|
-    $|Every call stays inline for up to \{handoff_bound}. If it is still running, it AUTOMATICALLY
+    $|\{staging}
+    $|
+    $|Every call's RUN stays inline for up to \{handoff_bound}. If it is still running, it AUTOMATICALLY
     $|moves to a background job and returns the job id; no background flag or duration
     $|guess is needed. A completion notice arrives when it finishes, so never wait with
     $|sleep loops or repeated polling: keep working and act on the notice. Read recent

--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -607,9 +607,17 @@ async fn execute(
           }
         })
       }
+      // A staged job's label carries the phase marker: the notice and the job
+      // listing then say on their face that the build already succeeded, so a
+      // later nonzero exit reads as the program's — job_output shows pure
+      // program output and its `exit=N` is the program's own by construction.
       let id = runtime.adopt(
         exec,
-        command="mbtx: \{@agent_tool.brief_line(input.source, limit=64)}",
+        command=if staged {
+          "mbtx run (build ok): \{@agent_tool.brief_line(input.source, limit=64)}"
+        } else {
+          "mbtx: \{@agent_tool.brief_line(input.source, limit=64)}"
+        },
         cwd?=run_cwd,
         sandboxed_command?,
         output_rewrites=temp_path_rewrites([real, build_dir]),
@@ -617,8 +625,16 @@ async fn execute(
         on_terminal=terminal_cleanup,
       )
       job_owns_cleanup = true
+      let handoff = if staged {
+        "mbtx: the build succeeded and the RUNNING PROGRAM was still going after \{duration_label(auto_background_after_ms)}, so it moved to the background as job \{id} (nothing was lost; any later nonzero exit is the program's own). Read its output with job_output (job_id=\"\{id}\") and stop it with job_stop (job_id=\"\{id}\")."
+      } else {
+        "mbtx: still running after \{duration_label(auto_background_after_ms)}, so it moved to the background as job \{id} (nothing was lost). Read its output with job_output (job_id=\"\{id}\") and stop it with job_stop (job_id=\"\{id}\")."
+      }
+      // Explicitly requested compiler warnings must not vanish because the
+      // program outlived the grace: they exist only in the build phase's
+      // capture, so this response is their one ride to the model.
       return @agent_tool.respond(
-        "mbtx: still running after \{duration_label(auto_background_after_ms)}, so it moved to the background as job \{id} (nothing was lost). Read its output with job_output (job_id=\"\{id}\") and stop it with job_stop (job_id=\"\{id}\").",
+        with_build_notes(build_notes, handoff),
         brief="mbtx → bg \{id}",
       )
     }
@@ -733,7 +749,13 @@ async fn execute(
       } else {
         body
       }
-      @agent_tool.respond(body, is_error=true, brief="mbtx (timeout)")
+      // Requested compiler warnings live only in the build phase's capture, so
+      // a run that never finished must still carry them out.
+      @agent_tool.respond(
+        with_build_notes(build_notes, body),
+        is_error=true,
+        brief="mbtx (timeout)",
+      )
     }
   }
   action
@@ -837,7 +859,18 @@ async fn build_snippet(
   )
   let artifact_present = @fs.exists(artifact) catch {
     error if @async.is_being_cancelled() => raise error
-    _ => false
+    // A stat FAULT is not absence (AGENTS.md: never fold unrelated errors
+    // into the missing case): name the filesystem failure instead of
+    // reporting a missing artifact. Either way the run cannot proceed, so
+    // both are build-stage faults — they just say different true things.
+    error =>
+      return NotBuilt(
+        @agent_tool.respond(
+          "mbtx: the build succeeded but its artifact could not be verified (\{error}) — a filesystem fault, not a problem in `source`.",
+          is_error=true,
+          brief="mbtx (build fault)",
+        ),
+      )
   }
   guard artifact_present else {
     return NotBuilt(
@@ -855,6 +888,13 @@ async fn build_snippet(
 /// The artifact path `moon run --build-only` reports on success, read from
 /// the last `{"artifacts_path":[…]}` line of its output. `None` for a moon
 /// that does not print one.
+///
+/// A malformed or truncated report line is deliberately treated like an
+/// absent one, not surfaced as a fault: both degrade to the single-file
+/// layout fallback, and the existence check that follows validates WHICHEVER
+/// path was chosen — a wrong guess surfaces as a named build fault, never as
+/// a silent misrun. Failing the call on a report the fallback would have
+/// covered would only make the tool more brittle.
 fn parse_artifacts_path(output : String) -> String? {
   let mut found : String? = None
   for line in output.split("\n") {
@@ -1375,9 +1415,11 @@ fn description(
     $|
     $|Every call's RUN stays inline for up to \{handoff_bound}. If it is still running, it AUTOMATICALLY
     $|moves to a background job and returns the job id; no background flag or duration
-    $|guess is needed. A completion notice arrives when it finishes, so never wait with
-    $|sleep loops or repeated polling: keep working and act on the notice. Read recent
-    $|output with job_output (use one bounded wait_ms call only when the result is needed
-    $|now), and cancel it with job_stop.
+    $|guess is needed. A wasm job is always the RUNNING PROGRAM — its build already
+    $|succeeded, so the job's output and exit code are the program's own. A completion
+    $|notice arrives when it finishes, so never wait with sleep loops or repeated
+    $|polling: keep working and act on the notice. Read recent output with job_output
+    $|(use one bounded wait_ms call only when the result is needed now), and cancel it
+    $|with job_stop.
   )
 }

--- a/agent_tool/mbtx/mbtx_test.mbt
+++ b/agent_tool/mbtx/mbtx_test.mbt
@@ -87,6 +87,36 @@ async test "a build that outlives its bound is reported as the build's" {
 }
 
 ///|
+/// A run that never finishes still carries the build phase's warnings: they
+/// exist only in the build capture, and the timeout report is their one ride
+/// to the model — alongside the staged wording that only the PROGRAM can be
+/// what hung, since the build had already succeeded.
+async test "a run timeout carries build warnings and blames only the program" {
+  @vfs.with_tmpdir(prefix="mbtx-timeout-warn-", ws => {
+    let definition = @mbtx.definition(
+      workspace_root=ws,
+      foreground_timeout_ms=500,
+    )
+    let source =
+      #|import { "moonbitlang/async" }
+      #|
+      #|async fn main {
+      #|  let unused = 1
+      #|  @async.sleep(60_000)
+      #|}
+    let action = match definition.execute {
+      Async(execute) => execute({ "source": source, "warning": "on" })
+      Sync(_) => fail("mbtx should be async")
+    }
+    guard action is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("timed out"))
+    assert_true(output.content.contains("the PROGRAM that did not finish"))
+    assert_true(output.content.contains("Unused variable"))
+  })
+}
+
+///|
 /// Only the wasm target is staged; a single-shot target's one exit code
 /// covers both phases and its report deliberately claims neither.
 async test "a non-wasm failure carries no stage label" {

--- a/agent_tool/mbtx/mbtx_test.mbt
+++ b/agent_tool/mbtx/mbtx_test.mbt
@@ -34,6 +34,70 @@ async test "surfaces a compile error via moon's own diagnostics" {
   assert_true(
     out.content.to_lower().contains("type") || out.content.contains("String"),
   )
+  // ...and labeled as the BUILD phase failing: the synchronous build phase
+  // returned nonzero, so the program never started — by construction, not by
+  // probing artifacts or parsing diagnostics.
+  assert_true(out.content.contains("BUILD failed"))
+  assert_true(out.content.contains("never ran"))
+  assert_true(out.brief is Some("mbtx (build failed, exit=1)"))
+}
+
+///|
+/// The stage labels are structural (which phase's process failed), so program
+/// OUTPUT cannot sway them: compiler-diagnostic-shaped text is routinely a
+/// snippet's legitimate output — a child `moon check` run prints exactly that
+/// — and must not turn a runtime trap into a build failure or taint a clean
+/// exit.
+async test "a runtime trap is labeled as the run, whatever the output says" {
+  let out = run(
+    "fn main { println(\"Error: [4014] fake diagnostic\"); panic() }",
+  )
+  assert_true(out.is_error)
+  assert_true(out.content.contains("at RUNTIME"))
+  assert_true(out.content.contains("from the run, not the build"))
+  assert_false(out.content.contains("BUILD failed"))
+}
+
+///|
+async test "diagnostic-shaped output with a clean exit stays unlabeled" {
+  let out = run("fn main { println(\"Error: [4014] fake diagnostic\") }")
+  assert_false(out.is_error)
+  assert_false(out.content.contains("BUILD failed"))
+  assert_false(out.content.contains("at RUNTIME"))
+}
+
+///|
+/// The build phase has its own bound, and hitting it is reported as the build
+/// never finishing — the program is never blamed, because it never existed.
+/// The 1ms bound is a physical impossibility, not a latency guess: `moon`
+/// cannot even be spawned and waited on within it.
+async test "a build that outlives its bound is reported as the build's" {
+  @vfs.with_tmpdir(prefix="mbtx-build-bound-", ws => {
+    let definition = @mbtx.definition(workspace_root=ws, build_timeout_ms=1)
+    let action = match definition.execute {
+      Async(execute) => execute({ "source": "fn main { println(1) }" })
+      Sync(_) => fail("mbtx should be async")
+    }
+    guard action is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("BUILD did not finish"))
+    assert_true(output.content.contains("never ran"))
+    assert_true(output.brief is Some("mbtx (build timeout)"))
+  })
+}
+
+///|
+/// Only the wasm target is staged; a single-shot target's one exit code
+/// covers both phases and its report deliberately claims neither.
+async test "a non-wasm failure carries no stage label" {
+  let out = run_in(".", {
+    "source": "fn main { println(\"before\"); panic() }",
+    "target": "js",
+  })
+  assert_true(out.is_error)
+  assert_true(out.content.contains("exited"))
+  assert_false(out.content.contains("at RUNTIME"))
+  assert_false(out.content.contains("BUILD failed"))
 }
 
 ///|
@@ -573,6 +637,11 @@ test "a definition without a job runtime describes its hard timeout" {
   assert_true(injected.description.contains("up to 12345ms"))
   let JsonSchema(schema) = definition.schema
   assert_false(schema.stringify().contains("run_in_background"))
+  // Both execution-time variants teach the staged wasm contract: the build
+  // runs first, synchronously, on its own bound.
+  assert_true(definition.description.contains("BUILT first, synchronously"))
+  let staged_bound = @mbtx.definition(workspace_root=".", build_timeout_ms=777)
+  assert_true(staged_bound.description.contains("777ms"))
 }
 
 ///|

--- a/agent_tool/mbtx/mbtx_wbtest.mbt
+++ b/agent_tool/mbtx/mbtx_wbtest.mbt
@@ -66,6 +66,18 @@ test "strip_artifact_report keeps only the human-facing build output" {
 }
 
 ///|
+/// Build notes are bounded so the prepend cannot spend the margin between the
+/// run's 48KB output cap and the agent loop's 60k tail-cutting clamp — the
+/// margin that keeps the trailing stop/retry and sandbox guidance readable.
+test "cap_build_notes bounds a warning flood and marks the cut" {
+  assert_eq(cap_build_notes("short"), "short")
+  let flood = String::make(20_000, 'w')
+  let capped = cap_build_notes(flood)
+  assert_true(capped.length() < 9_000)
+  assert_true(capped.contains("build warnings truncated"))
+}
+
+///|
 /// The run-phase framing: on the staged wasm path a failure is from the run
 /// by construction and says so; single-shot targets keep the plain wording
 /// that claims neither stage.

--- a/agent_tool/mbtx/mbtx_wbtest.mbt
+++ b/agent_tool/mbtx/mbtx_wbtest.mbt
@@ -40,6 +40,59 @@ async test "denial scan is bounded to the log's head and tail" {
 }
 
 ///|
+/// The build phase's artifact report is moon's own `{"artifacts_path":[…]}`
+/// line: the tool takes the LAST well-formed one (a child moon invocation
+/// cannot print into the build phase's dedicated log, so lines here are the
+/// outer build's) and assumes no target-dir layout when it is present.
+test "parse_artifacts_path reads moon's report line" {
+  assert_true(
+    parse_artifacts_path(
+      "Downloading x@1.0\n{\"artifacts_path\":[\"/tmp/b/wasm/debug/build/single/single.wasm\"]}\n",
+    )
+    is Some("/tmp/b/wasm/debug/build/single/single.wasm"),
+  )
+  // The last report wins; malformed candidates are skipped, not fatal.
+  let two = "{\"artifacts_path\":[\"/old\"]}\n{\"artifacts_path\":\"garbage\"\n{\"artifacts_path\":[\"/new\"]}"
+  assert_true(parse_artifacts_path(two) is Some("/new"))
+  assert_true(parse_artifacts_path("no report here\n") is None)
+  assert_true(parse_artifacts_path("{\"artifacts_path\":[]}") is None)
+}
+
+///|
+test "strip_artifact_report keeps only the human-facing build output" {
+  let mixed = "Warning: [0002] unused\n{\"artifacts_path\":[\"/x\"]}\n"
+  assert_eq(strip_artifact_report(mixed), "Warning: [0002] unused")
+  assert_eq(strip_artifact_report("{\"artifacts_path\":[\"/x\"]}\n"), "")
+}
+
+///|
+/// The run-phase framing: on the staged wasm path a failure is from the run
+/// by construction and says so; single-shot targets keep the plain wording
+/// that claims neither stage.
+test "finished_body and timeout_head are stage-aware only when staged" {
+  assert_eq(finished_body("out\n", 0, staged=true), "out\n")
+  let staged_failure = finished_body("trace", 3, staged=true)
+  assert_true(staged_failure.contains("exited 3 at RUNTIME"))
+  assert_true(staged_failure.contains("from the run, not the build"))
+  assert_true(
+    finished_body("", 3, staged=true).contains(
+      "the build succeeded, then the run exited 3",
+    ),
+  )
+  let plain_failure = finished_body("trace", 3, staged=false)
+  assert_true(plain_failure.contains("exited 3"))
+  assert_false(plain_failure.contains("RUNTIME"))
+  assert_true(
+    timeout_head(5_000, staged=true).contains("the PROGRAM that did not finish"),
+  )
+  assert_true(
+    timeout_head(5_000, staged=false).contains("a build that never completed"),
+  )
+  assert_eq(with_build_notes("", "body"), "body")
+  assert_eq(with_build_notes("warn", "body"), "warn\nbody")
+}
+
+///|
 /// Proton CLI is admitted one subcommand at a time. In particular, there is no
 /// bare rule and no global working-directory prefix: callers set the child
 /// process cwd instead of letting the command redirect itself elsewhere.

--- a/agent_tool/mbtx/pkg.generated.mbti
+++ b/agent_tool/mbtx/pkg.generated.mbti
@@ -8,7 +8,7 @@ import {
 }
 
 // Values
-pub fn definition(workspace_root~ : String, read_only? : Bool, bg_runtime? : @bgjobs.BgJobRuntime, job_dir? : String, scratch_dir? : String, worker_sandbox? : WorkerSandbox, auto_background_after_ms? : Int, foreground_timeout_ms? : Int, approval? : @agent_runtime.ApprovalChannel) -> @agent_tool.AgentToolDefinition
+pub fn definition(workspace_root~ : String, read_only? : Bool, bg_runtime? : @bgjobs.BgJobRuntime, job_dir? : String, scratch_dir? : String, worker_sandbox? : WorkerSandbox, auto_background_after_ms? : Int, foreground_timeout_ms? : Int, build_timeout_ms? : Int, approval? : @agent_runtime.ApprovalChannel) -> @agent_tool.AgentToolDefinition
 
 // Errors
 


### PR DESCRIPTION
## Design

Split the default wasm target into **two phases**, per the co-design discussion:

1. **BUILD — synchronous, own bound** (10s default, injectable): `moon run --build-only --target wasm --target-dir <temp>`. A nonzero exit reports immediately as `BUILD failed (exit N) — the program never ran`. This classification is **by construction** — the run phase never starts — so no exit-code or output archaeology is needed to tell the stages apart. (`moon run` alone exits 1 for a rejected build and a trapped program alike, and diagnostics in a merged stream prove nothing: a snippet legitimately runs `moon check` as a child process, so compiler-diagnostic text is routinely a snippet's own successful output.)
2. **RUN — auto-backgrounded**: exec `moonrun` directly on the artifact moon names in its `{"artifacts_path":[…]}` report line (single-file layout as fallback) — the same process `moon run` would have exec'd; `--policy` is moonrun's spelling of `--wasm-policy` (verified against moon's `--dry-run` plan). The 5s handoff grace times **this phase only**: build time no longer counts against the run's inline allowance, cold-cache probes stop handing off spuriously, and **an adopted job is always a running program** — never a build.

Phase-2 failures are labeled `exited N at RUNTIME — the build succeeded; this failure is from the run, not the build`. Non-wasm targets (compute-only, rare) keep the single-shot `moon run` and their reports claim no stage.

## Empirical validation done before implementing

- `--build-only`: exit 0 + machine-readable `{"artifacts_path":[…]}` on success; exit 1 + diagnostics (no report line) on compile errors; ~90ms trivial build, ~0.7s with several registry imports (warm cache) — the 10s bound has 10× headroom.
- `moonrun --policy`: identical policy semantics to `moon run --wasm-policy` (TMPDIR redirect, `Sandbox policy blocked file write` / `… process spawn` phrases the existing refusal classifier keys on, allowlist prefix admit/deny); program exit codes pass through (`exit 3` → 3); traps → exit 1 + trace; 8ms startup.
- Warnings surface in the build phase and are carried into the report as build notes — build output and program output are separate captures by construction.

## What this simplifies

Classification by process boundary replaces classification by evidence inference. Relative to the approach in #1165 (which this supersedes): no artifact/residue probe, no bgjobs exit-note plumbing (`BgJobExit`/`BgJobExitNote`/single-flight), no delete-before-read race to manage — this PR touches **only mbtx and one agent test**, and the review-round failure modes from #1165 mostly become unaskable (output spoofing, evidence sabotage, cache races).

Both phases run under the same worker/read-only `sandbox-exec` confinement (wrapping extracted into a per-command helper). The escalation contract is unchanged: a grant means the policy file is simply not passed to moonrun.

## Contract change (intended)

- Build time is excluded from the inline grace; the turn now waits out the build synchronously, bounded at 10s (`build_timeout_ms`, injectable). A timed-out build reports `BUILD did not finish` — retries are warmer (moon caches downloaded modules).
- One test updated: *"a compile error after handoff keeps source diagnostics"* pinned the old behavior where a slow compile crossed the grace and became a job. That scenario is now impossible by design; its replacement pins the successor contract: a compile error is inline, labeled, `source`-named, and never a job.

## Tests

60/60 in `agent_tool/mbtx` (7 new: build-failure labeling + brief, runtime-trap labeling with a fake-diagnostics negative control, clean-exit unlabeled, 1ms build-bound timeout, non-wasm unlabeled, description staging, artifact-report parser/stripper + label helpers in whitebox), 158/158 including `agent`'s handoff e2e suite; `moon check --deny-warn` and `moon fmt --check` clean; the only interface change is the new optional `build_timeout_ms` parameter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Qu3wgL9g7Z9V4umSU97RD
