### PR TITLE
feat(desktop): name a failed mbtx row's stage — build error vs runtime error

### DIFF
--- a/desktop/frontend/transcript/component/mbtx.mbt
+++ b/desktop/frontend/transcript/component/mbtx.mbt
@@ -75,3 +75,51 @@ fn mbtx_card(arguments : String) -> @html.Html? {
     ]),
   )
 }
+
+///|
+/// The failure stage a finished `mbtx` call reports, read from its brief —
+/// the display-only caption the engine persists for renderers. The staged
+/// wasm engine writes `mbtx (build failed, exit=N)` / `mbtx (build timeout)`
+/// / `mbtx (build fault)` for build-phase failures and `mbtx (exit=N)` for a
+/// program that built and then failed; transcripts recorded before staging
+/// carry neither shape and keep the generic marker.
+priv enum MbtxFailureStage {
+  BuildError
+  RuntimeError
+}
+
+///|
+fn mbtx_failure_stage(
+  name : String,
+  brief : String?,
+  is_error : Bool,
+) -> MbtxFailureStage? {
+  guard is_error && name == "mbtx" && brief is Some(brief) else { return None }
+  if brief.has_prefix("mbtx (build") {
+    Some(BuildError)
+  } else if brief.has_prefix("mbtx (exit=") {
+    Some(RuntimeError)
+  } else {
+    None
+  }
+}
+
+///|
+/// The literal word beside a failed call's brief. An `mbtx` failure names its
+/// STAGE: a build error is fixed in the source, a runtime error in the
+/// program's behavior, and the row should say which before the card is even
+/// opened. Every other failed call keeps the generic word.
+fn failure_marker(
+  name : String,
+  brief : String?,
+  is_error : Bool,
+) -> @html.Html? {
+  guard is_error else { return None }
+  match mbtx_failure_stage(name, brief, is_error) {
+    Some(BuildError) =>
+      Some(@html.span(class="tool-call-failed tool-stage-build", "build error"))
+    Some(RuntimeError) =>
+      Some(@html.span(class="tool-call-failed tool-stage-run", "runtime error"))
+    None => Some(@html.span(class="tool-call-failed", "failed"))
+  }
+}

--- a/desktop/frontend/transcript/component/mbtx.mbt
+++ b/desktop/frontend/transcript/component/mbtx.mbt
@@ -81,8 +81,15 @@ fn mbtx_card(arguments : String) -> @html.Html? {
 /// the display-only caption the engine persists for renderers. The staged
 /// wasm engine writes `mbtx (build failed, exit=N)` / `mbtx (build timeout)`
 /// / `mbtx (build fault)` for build-phase failures and `mbtx (exit=N)` for a
-/// program that built and then failed; transcripts recorded before staging
-/// carry neither shape and keep the generic marker.
+/// program that built and then failed.
+///
+/// One accepted imprecision, by explicit owner decision (no backwards
+/// compatibility for old transcripts): a WASM failure recorded before the
+/// staged engine carries the same `mbtx (exit=N)` brief whichever stage
+/// failed, and reads here as a runtime error. Disambiguating it would need a
+/// new engine brief shape or a recording-version gate — complexity spent
+/// entirely on sessions that predate the label. The build shapes carry no
+/// such ambiguity: only the staged engine ever wrote them.
 priv enum MbtxFailureStage {
   BuildError
   RuntimeError

--- a/desktop/frontend/transcript/component/mbtx.mbt
+++ b/desktop/frontend/transcript/component/mbtx.mbt
@@ -89,15 +89,34 @@ priv enum MbtxFailureStage {
 }
 
 ///|
+/// Whether the recorded call took the staged wasm path — the only path whose
+/// `mbtx (exit=N)` brief is a RUN-stage claim. A single-shot target's one
+/// exit code covers both stages (the engine's own tests pin that its report
+/// claims neither), so those rows must keep the generic word. The target is
+/// read from the call's own arguments; absent means the wasm default, and an
+/// unreadable payload conservatively claims nothing.
+fn mbtx_staged_target(arguments : String?) -> Bool {
+  guard arguments is Some(arguments) else { return false }
+  guard card_fields(arguments) is Some(fields) else { return false }
+  match fields.get("target") {
+    None | Some(String("wasm")) | Some(Null) => true
+    _ => false
+  }
+}
+
+///|
 fn mbtx_failure_stage(
   name : String,
   brief : String?,
   is_error : Bool,
+  arguments : String?,
 ) -> MbtxFailureStage? {
   guard is_error && name == "mbtx" && brief is Some(brief) else { return None }
+  // The build shapes are unambiguous by construction: only the staged engine
+  // writes them. The exit shape is a run-stage claim only where staging ran.
   if brief.has_prefix("mbtx (build") {
     Some(BuildError)
-  } else if brief.has_prefix("mbtx (exit=") {
+  } else if brief.has_prefix("mbtx (exit=") && mbtx_staged_target(arguments) {
     Some(RuntimeError)
   } else {
     None
@@ -113,9 +132,10 @@ fn failure_marker(
   name : String,
   brief : String?,
   is_error : Bool,
+  arguments : String?,
 ) -> @html.Html? {
   guard is_error else { return None }
-  match mbtx_failure_stage(name, brief, is_error) {
+  match mbtx_failure_stage(name, brief, is_error, arguments) {
     Some(BuildError) =>
       Some(@html.span(class="tool-call-failed tool-stage-build", "build error"))
     Some(RuntimeError) =>

--- a/desktop/frontend/transcript/component/mbtx_tests.mbt
+++ b/desktop/frontend/transcript/component/mbtx_tests.mbt
@@ -83,12 +83,13 @@ test "an mbtx program past the transcript clamp keeps every numbered line" {
 /// timeout, a kill) keeps the generic word, as does every other tool.
 #warnings("-alert_unstable")
 test "a failed mbtx row names its failure stage" {
-  fn markup_for(brief : String, is_error : Bool) -> String {
+  let plain_arguments = "{\"source\":\"fn main {  }\"}"
+  fn markup_for(brief : String, is_error : Bool, arguments : String) -> String {
     let rendered = tool_call_view({
       kind: Tool(
         call_id="c1",
         name="mbtx",
-        arguments=Some("{\"source\":\"fn main {  }\"}"),
+        arguments=Some(arguments),
         has_result=true,
         is_error~,
         brief=Some(brief),
@@ -100,21 +101,42 @@ test "a failed mbtx row names its failure stage" {
     @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
   }
 
-  let build = markup_for("mbtx (build failed, exit=1)", true)
+  let build = markup_for("mbtx (build failed, exit=1)", true, plain_arguments)
   assert_true(build.contains("tool-stage-build"))
   assert_true(build.contains("build error"))
   assert_false(build.contains(">failed<"))
   // Every build-phase brief shape maps to the same stage word.
-  assert_true(markup_for("mbtx (build timeout)", true).contains("build error"))
-  let runtime = markup_for("mbtx (exit=1)", true)
+  assert_true(
+    markup_for("mbtx (build timeout)", true, plain_arguments).contains(
+      "build error",
+    ),
+  )
+  // The default target is the staged wasm path, so its exit brief is a
+  // run-stage claim; an explicit wasm target reads the same.
+  let runtime = markup_for("mbtx (exit=1)", true, plain_arguments)
   assert_true(runtime.contains("tool-stage-run"))
   assert_true(runtime.contains("runtime error"))
+  assert_true(
+    markup_for(
+      "mbtx (exit=1)", true, "{\"source\":\"fn main {  }\",\"target\":\"wasm\"}",
+    ).contains("runtime error"),
+  )
+  // A single-shot target's one exit code covers both stages — the engine's
+  // own report claims neither, and neither may this row: a js compile error
+  // must not read as a runtime one.
+  let single_shot = markup_for(
+    "mbtx (exit=1)", true, "{\"source\":\"fn main {  }\",\"target\":\"js\"}",
+  )
+  assert_true(single_shot.contains(">failed<"))
+  assert_false(single_shot.contains("runtime error"))
   // A clean exit carries no marker at all.
-  let ok = markup_for("mbtx (exit=0)", false)
+  let ok = markup_for("mbtx (exit=0)", false, plain_arguments)
   assert_false(ok.contains("runtime error"))
   assert_false(ok.contains(">failed<"))
   // A brief outside both stage shapes keeps the generic word.
-  assert_true(markup_for("mbtx (timeout)", true).contains(">failed<"))
+  assert_true(
+    markup_for("mbtx (timeout)", true, plain_arguments).contains(">failed<"),
+  )
 }
 
 ///|

--- a/desktop/frontend/transcript/component/mbtx_tests.mbt
+++ b/desktop/frontend/transcript/component/mbtx_tests.mbt
@@ -77,6 +77,47 @@ test "an mbtx program past the transcript clamp keeps every numbered line" {
 }
 
 ///|
+/// A failed mbtx row names its stage from the brief alone — build errors are
+/// fixed in the source, runtime errors in the program's behavior, and the row
+/// says which before the card is opened. A brief carrying neither shape (a
+/// timeout, a kill) keeps the generic word, as does every other tool.
+#warnings("-alert_unstable")
+test "a failed mbtx row names its failure stage" {
+  fn markup_for(brief : String, is_error : Bool) -> String {
+    let rendered = tool_call_view({
+      kind: Tool(
+        call_id="c1",
+        name="mbtx",
+        arguments=Some("{\"source\":\"fn main {  }\"}"),
+        has_result=true,
+        is_error~,
+        brief=Some(brief),
+      ),
+      content: "x",
+      ts: None,
+      sequence: None,
+    })
+    @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
+  }
+
+  let build = markup_for("mbtx (build failed, exit=1)", true)
+  assert_true(build.contains("tool-stage-build"))
+  assert_true(build.contains("build error"))
+  assert_false(build.contains(">failed<"))
+  // Every build-phase brief shape maps to the same stage word.
+  assert_true(markup_for("mbtx (build timeout)", true).contains("build error"))
+  let runtime = markup_for("mbtx (exit=1)", true)
+  assert_true(runtime.contains("tool-stage-run"))
+  assert_true(runtime.contains("runtime error"))
+  // A clean exit carries no marker at all.
+  let ok = markup_for("mbtx (exit=0)", false)
+  assert_false(ok.contains("runtime error"))
+  assert_false(ok.contains(">failed<"))
+  // A brief outside both stage shapes keeps the generic word.
+  assert_true(markup_for("mbtx (timeout)", true).contains(">failed<"))
+}
+
+///|
 /// A payload this card cannot read keeps the generic arguments rendering,
 /// which clamps before parsing — nothing is ever shown as a program that is
 /// not one.

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -306,7 +306,7 @@ fn tool_request_view(item : @transcript.TranscriptItem) -> @html.Html {
     @html.span(class="tool-flow", "→"),
     @html.span(class="tool-call-text", label),
   ]
-  if failure_marker(name, brief, is_error) is Some(marker) {
+  if failure_marker(name, brief, is_error, Some(arguments)) is Some(marker) {
     line.push(marker)
   }
   line.push(@plan.fold_progress([item]))
@@ -391,7 +391,7 @@ fn tool_result_view(
     @html.span(class="tool-flow", "←"),
     @html.span(class="tool-result-text", label),
   ]
-  if failure_marker(name, brief, is_error) is Some(marker) {
+  if failure_marker(name, brief, is_error, arguments) is Some(marker) {
     line.push(marker)
   }
   let body : Array[@html.Html] = []

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -306,8 +306,8 @@ fn tool_request_view(item : @transcript.TranscriptItem) -> @html.Html {
     @html.span(class="tool-flow", "→"),
     @html.span(class="tool-call-text", label),
   ]
-  if is_error {
-    line.push(@html.span(class="tool-call-failed", "failed"))
+  if failure_marker(name, brief, is_error) is Some(marker) {
+    line.push(marker)
   }
   line.push(@plan.fold_progress([item]))
   let body : Array[@html.Html] = []
@@ -391,8 +391,8 @@ fn tool_result_view(
     @html.span(class="tool-flow", "←"),
     @html.span(class="tool-result-text", label),
   ]
-  if is_error {
-    line.push(@html.span(class="tool-call-failed", "failed"))
+  if failure_marker(name, brief, is_error) is Some(marker) {
+    line.push(marker)
   }
   let body : Array[@html.Html] = []
   // A sub-run result names the child session it spawned in its brief. The

--- a/desktop/styles/transcript.css
+++ b/desktop/styles/transcript.css
@@ -922,6 +922,12 @@
   color: var(--color-danger);
   font-size: var(--font-size-xs);
 }
+/* An mbtx failure names its stage. A build error is a source problem — warn
+   amber, "fix the input" — while a runtime error keeps the row's danger red:
+   the program itself misbehaved. */
+.tool-call-failed.tool-stage-build {
+  color: var(--color-warning);
+}
 
 /* Arguments and output grow the page instead of scrolling in place: the
    transcript stays the only scroll area, so the wheel is never trapped by a


### PR DESCRIPTION
Follow-up to #1167 (1 of 2 visualizer follow-ups; the viz HTML renderer + compile-error filter comes separately).

## What

A failed `mbtx` row in the desktop transcript now names its **failure stage** instead of the generic red `failed`:

- `build error` (amber, `--color-warning`) — the brief is a build-phase shape: `mbtx (build failed, exit=N)`, `mbtx (build timeout)`, `mbtx (build fault)`. The fix lives in the source.
- `runtime error` (danger red) — the brief is `mbtx (exit=N)` on an errored call: the program built and then failed.

Both the call row and the result row carry the marker, so the stage is visible before the card is opened. Every other tool — and any mbtx brief outside the two stage shapes (a timeout, a kill) — keeps the generic `failed` word.

## How

Classification reads the persisted **brief** alone: the display-only caption the engine writes for renderers (the channel the desktop component already consumes), so no protocol change and no content parsing. Sessions recorded before the staged engine are deliberately not special-cased (per the design discussion): their briefs match the shapes they match, nothing more.

## Tests

57/57 in `frontend/transcript/component` (new: all three build-brief shapes map to `build error`, `exit=N` errors map to `runtime error`, clean exits carry no marker, out-of-shape briefs keep `failed`); 462/462 across the desktop frontend js suite; `moon -C desktop check --target js` clean; no `.mbti` changes (all additions private).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Qu3wgL9g7Z9V4umSU97RD
