### PR TITLE
feat(viz): name mbtx failure stages and add a build-errors-only filter

### DIFF
--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -498,7 +498,10 @@ fn update(emit : @cmd.Emit[Msg], msg : Msg, model : Model) -> (@cmd.Cmd, Model) 
       } else {
         (
           @cmd.effect(() => {
-            scroll_to_card_from_viewport(".tool-call-build-failed", direction)
+            // Result cards, not call rows: every build failure has exactly
+            // one tagged result card — orphans included — so the jump set
+            // matches the count.
+            scroll_to_card_from_viewport(".card.build-failed", direction)
           }),
           model,
         )

--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -48,6 +48,9 @@ struct Model {
   // "Escalated only" keeps tool calls whose durable arguments explicitly carry
   // top-level `escalated: true`, plus their matching result cards.
   escalated_only : Bool
+  // "Build errors only" keeps mbtx calls whose result brief reports a
+  // BUILD-stage failure, plus their matching result cards.
+  build_errors_only : Bool
   // Tool-call arguments rendering: the human-friendly form (values shown verbatim,
   // no JSON quoting) by default, or the original pretty-printed JSON for debugging.
   show_original_args : Bool
@@ -102,6 +105,8 @@ enum Msg {
   JumpToError(Int)
   ToggleEscalatedOnly
   JumpToEscalated(Int)
+  ToggleBuildErrorsOnly
+  JumpToBuildError(Int)
   UnfoldCurrent
 }
 
@@ -185,6 +190,7 @@ fn init_model() -> Model {
     loading: false,
     status: "loading sessions…",
     errors_only: false,
+    build_errors_only: false,
     escalated_only: false,
     show_original_args: false,
     subrun_children: Map([]),
@@ -429,7 +435,12 @@ fn update(emit : @cmd.Emit[Msg], msg : Msg, model : Model) -> (@cmd.Cmd, Model) 
     ToggleErrorsOnly =>
       (
         @cmd.none,
-        { ..model, errors_only: !model.errors_only, escalated_only: false, },
+        {
+          ..model,
+          errors_only: !model.errors_only,
+          escalated_only: false,
+          build_errors_only: false,
+        },
       )
     // Scroll to the next/previous failed-tool card, cycling. The count is
     // recomputed for the active view, while the browser chooses the target
@@ -450,7 +461,12 @@ fn update(emit : @cmd.Emit[Msg], msg : Msg, model : Model) -> (@cmd.Cmd, Model) 
     ToggleEscalatedOnly =>
       (
         @cmd.none,
-        { ..model, escalated_only: !model.escalated_only, errors_only: false, },
+        {
+          ..model,
+          escalated_only: !model.escalated_only,
+          errors_only: false,
+          build_errors_only: false,
+        },
       )
     JumpToEscalated(direction) => {
       let count = current_escalated_count(model)
@@ -460,6 +476,29 @@ fn update(emit : @cmd.Emit[Msg], msg : Msg, model : Model) -> (@cmd.Cmd, Model) 
         (
           @cmd.effect(() => {
             scroll_to_card_from_viewport(".tool-call-escalated", direction)
+          }),
+          model,
+        )
+      }
+    }
+    ToggleBuildErrorsOnly =>
+      (
+        @cmd.none,
+        {
+          ..model,
+          build_errors_only: !model.build_errors_only,
+          errors_only: false,
+          escalated_only: false,
+        },
+      )
+    JumpToBuildError(direction) => {
+      let count = current_build_error_count(model)
+      if count <= 0 {
+        (@cmd.none, model)
+      } else {
+        (
+          @cmd.effect(() => {
+            scroll_to_card_from_viewport(".tool-call-build-failed", direction)
           }),
           model,
         )
@@ -1375,6 +1414,10 @@ fn session_pane(
   )
   let error_count = @viz.rendered_error_count(session, model.view_mode)
   let escalated_count = @viz.rendered_escalated_count(session, model.view_mode)
+  let build_error_count = @viz.rendered_build_error_count(
+    session,
+    model.view_mode,
+  )
   @html.div(class=session_view_class(model)) <| [
     header_strip(model, id, root_label),
     // Pin the view/args toggles and the error bar to the top of the
@@ -1383,9 +1426,12 @@ fn session_pane(
       mode_row(emit, model, parsed, @viz.step_scrubber(session)),
       error_bar(emit, model, error_count),
       escalated_bar(emit, model, escalated_count),
+      build_error_bar(emit, model, build_error_count),
     ],
     @viz.render_notices(parsed),
-    session_log_view(model, session, error_count, escalated_count),
+    session_log_view(
+      model, session, error_count, escalated_count, build_error_count,
+    ),
   ]
 }
 
@@ -1596,7 +1642,12 @@ fn session_view_class(model : Model) -> String {
     "escalated-only",
     model.escalated_only,
   )
-  class_with(with_escalated, "show-original", model.show_original_args)
+  let with_build = class_with(
+    with_escalated,
+    "build-errors-only",
+    model.build_errors_only,
+  )
+  class_with(with_build, "show-original", model.show_original_args)
 }
 
 ///|
@@ -1697,6 +1748,61 @@ fn escalated_bar(
 }
 
 ///|
+/// Build-error counterpart of `escalated_bar`: a count of mbtx BUILD-stage
+/// failures (the staged engine's `mbtx (build …)` briefs), a filter toggle,
+/// and viewport-relative prev/next jumps — the way to find compile errors in
+/// a long log without reading it. Stays visible at zero while active so the
+/// filter can always be switched back off.
+fn build_error_bar(
+  emit : @cmd.Emit[Msg],
+  model : Model,
+  count : Int,
+) -> @html.Html {
+  if count == 0 && !model.build_errors_only {
+    return @html.nothing
+  }
+  let toggle_class = class_with(
+    "build-error-toggle",
+    "active",
+    model.build_errors_only,
+  )
+  let children : Array[@html.Html] = []
+  if count > 0 {
+    children.push(
+      @html.span(class="build-error-count") <| "🔨 \{count} build error\{plural_s(count)}",
+    )
+  }
+  children.push(
+    @html.button(
+      class=toggle_class,
+      title="Show only mbtx calls whose build failed, with their results",
+      on_click=emit(ToggleBuildErrorsOnly),
+    ) <| (if model.build_errors_only {
+      "Build errors only: on"
+    } else {
+      "Build errors only"
+    }),
+  )
+  if count > 0 {
+    children.push(
+      @html.button(
+        class="build-error-jump",
+        title="Scroll to the previous build error",
+        on_click=emit(JumpToBuildError(-1)),
+      ) <| "↑ prev",
+    )
+    children.push(
+      @html.button(
+        class="build-error-jump",
+        title="Scroll to the next build error",
+        on_click=emit(JumpToBuildError(1)),
+      ) <| "↓ next",
+    )
+  }
+  @html.div(class="build-error-bar") <| children
+}
+
+///|
 /// The log, or a hint when the errors-only filter would hide everything (so the
 /// pane never looks empty/broken when a clean view is filtered).
 fn session_log_view(
@@ -1704,11 +1810,14 @@ fn session_log_view(
   session : @agent_session.Session,
   error_count : Int,
   escalated_count : Int,
+  build_error_count : Int,
 ) -> @html.Html {
   if model.errors_only && error_count == 0 {
     @html.div(class="errors-only-empty") <| "No failed tool results in this view."
   } else if model.escalated_only && escalated_count == 0 {
     @html.div(class="escalated-only-empty") <| "No escalated tool calls in this view."
+  } else if model.build_errors_only && build_error_count == 0 {
+    @html.div(class="build-errors-only-empty") <| "No mbtx build errors in this view."
   } else {
     @viz.render_session(
       session,
@@ -1742,6 +1851,17 @@ fn current_escalated_count(model : Model) -> Int {
     system_prompt=model.system_prompt,
   )
   @viz.rendered_escalated_count(session, model.view_mode)
+}
+
+///|
+fn current_build_error_count(model : Model) -> Int {
+  guard model.parsed is Some(parsed) else { return 0 }
+  let session = @viz.session_from_parse(
+    parsed,
+    id="",
+    system_prompt=model.system_prompt,
+  )
+  @viz.rendered_build_error_count(session, model.view_mode)
 }
 
 ///|
@@ -2338,6 +2458,27 @@ test "escalated toolbar mirrors errors-only controls" {
 }
 
 ///|
+test "build-error toolbar mirrors the other filter controls" {
+  let model = init_model()
+  let html = render_html(build_error_bar(stub_emit(), model, 2))
+  assert_true(html.contains("2 build errors"))
+  assert_true(html.contains("Build errors only"))
+  assert_true(html.contains("↑ prev"))
+  assert_true(html.contains("↓ next"))
+  // Hidden entirely for a clean view with the filter off; kept visible at
+  // zero while active so it can always be switched back off.
+  assert_false(
+    render_html(build_error_bar(stub_emit(), model, 0)).contains("Build errors"),
+  )
+  let active = { ..init_model(), build_errors_only: true, }
+  assert_true(
+    render_html(build_error_bar(stub_emit(), active, 0)).contains(
+      "Build errors only: on",
+    ),
+  )
+}
+
+///|
 test "error and escalated filters are mutually exclusive" {
   let emit = stub_emit()
   let errors = { ..init_model(), errors_only: true, }
@@ -2347,6 +2488,24 @@ test "error and escalated filters are mutually exclusive" {
   let (_, errors_again) = update(emit, ToggleErrorsOnly, escalated)
   assert_true(errors_again.errors_only)
   assert_false(errors_again.escalated_only)
+  // The build-error filter joins the same exclusivity group in both
+  // directions: switching it on clears the others, and vice versa.
+  let (_, build) = update(emit, ToggleBuildErrorsOnly, errors_again)
+  assert_true(build.build_errors_only)
+  assert_false(build.errors_only)
+  assert_false(build.escalated_only)
+  let (_, back) = update(emit, ToggleErrorsOnly, build)
+  assert_true(back.errors_only)
+  assert_false(back.build_errors_only)
+}
+
+///|
+test "session view class includes the build-error filter" {
+  let filtered = { ..init_model(), build_errors_only: true, }
+  inspect(
+    session_view_class(filtered),
+    content="session-view build-errors-only",
+  )
 }
 
 ///|

--- a/viz/pkg.generated.mbti
+++ b/viz/pkg.generated.mbti
@@ -15,6 +15,8 @@ pub fn render_notices(@log.ParsedLog) -> @html.Html
 
 pub fn render_session(@agent_session.Session, ViewMode, subrun_children? : Map[String, @agent_session.Session]) -> @html.Html
 
+pub fn rendered_build_error_count(@agent_session.Session, ViewMode) -> Int
+
 pub fn rendered_error_count(@agent_session.Session, ViewMode) -> Int
 
 pub fn rendered_escalated_count(@agent_session.Session, ViewMode) -> Int

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -912,9 +912,9 @@ fn tool_call_view(
   // A failed mbtx call names its STAGE — a build error is fixed in the
   // source, a runtime error in the program's behavior — as a visible word
   // beside the brief and as a class the build-errors-only filter keys on.
-  let build_failed = tool_call_is_build_failed(call, briefs, failed)
+  let build_failed = tool_call_is_build_failed(call, briefs, failed, tags)
   let run_failed = !build_failed &&
-    tool_call_is_run_failed(call, briefs, failed)
+    tool_call_is_run_failed(call, briefs, failed, tags)
   let cls = if build_failed {
     "\{cls} tool-call-build-failed"
   } else if run_failed {
@@ -1685,7 +1685,13 @@ fn tool_call_is_build_failed(
   call : @deepseek.ToolCall,
   briefs : Map[String, String],
   failed : Map[String, Unit],
+  tags : Map[String, Int],
 ) -> Bool {
+  // `tags` holds exactly the unambiguous 1:1 call/result pairs. A duplicated
+  // id collapses briefs into one map entry, which would make a call's stage
+  // depend on event order — so an ambiguous call is labeled with no stage at
+  // all. Its RESULT cards still carry their own per-result tags.
+  tags.contains(call.id) &&
   call.name == "mbtx" &&
   failed.contains(call.id) &&
   briefs.get(call.id) is Some(brief) &&
@@ -1703,8 +1709,10 @@ fn tool_call_is_run_failed(
   call : @deepseek.ToolCall,
   briefs : Map[String, String],
   failed : Map[String, Unit],
+  tags : Map[String, Int],
 ) -> Bool {
-  guard call.name == "mbtx" &&
+  guard tags.contains(call.id) &&
+    call.name == "mbtx" &&
     failed.contains(call.id) &&
     briefs.get(call.id) is Some(brief) &&
     brief.has_prefix("mbtx (exit=") else {
@@ -2033,41 +2041,37 @@ pub fn rendered_escalated_count(
 }
 
 ///|
-/// How many rendered `mbtx` calls failed in the BUILD stage, per view mode —
-/// what the build-errors-only toolbar counts and jumps between. Derived from
-/// the same per-mode brief/failure maps the cards themselves render from, so
-/// the count and the tags can never disagree; the model view's maps already
-/// pass everything through `model_shown_result`.
+/// How many rendered BUILD-stage mbtx failures each view mode shows — what
+/// the build-errors-only toolbar counts and jumps between. Counted from the
+/// RESULTS, the same per-result test that tags their cards `build-failed`, so
+/// the count and the visible tags can never disagree — including for an
+/// orphan result with no matching call, which the raw renderer still shows
+/// and the filter must not hide behind a zero count. The model view counts
+/// only results the projection shows (`model_shown_result`).
 pub fn rendered_build_error_count(
   session : @agent_session.Session,
   mode : ViewMode,
 ) -> Int {
-  let mut count = 0
   match mode {
     RawLog => {
-      let briefs = tool_call_briefs(session)
-      let failed = raw_failed_call_ids(session)
+      let mut count = 0
       for event in session.events() {
-        if event.item() is Assistant(message) {
-          count += message
-            .tool_calls()
-            .count_if(call => tool_call_is_build_failed(call, briefs, failed))
+        if event.item() is Tool(result) && result_is_build_failed(result) {
+          count += 1
         }
       }
+      count
     }
     ModelView => {
-      let messages = session.chat_messages()
       let tool_results = tool_results_by_id(session)
-      let briefs = model_tool_call_briefs(messages, tool_results)
-      let failed = model_failed_call_ids(messages, tool_results)
-      for message in messages {
-        count += message.tool_calls.count_if(call => {
-          tool_call_is_build_failed(call, briefs, failed)
-        })
-      }
+      session
+      .chat_messages()
+      .count_if(message => {
+        model_shown_result(message, tool_results) is Some(result) &&
+        result_is_build_failed(result)
+      })
     }
   }
-  count
 }
 
 ///|

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -1691,8 +1691,13 @@ fn tool_call_is_build_failed(
   // id collapses briefs into one map entry, which would make a call's stage
   // depend on event order — so an ambiguous call is labeled with no stage at
   // all. Its RESULT cards still carry their own per-result tags.
+  //
+  // The BRIEF is the whole identity here, deliberately: the brief map is
+  // result data, and `result_is_build_failed` reads the same field, so call
+  // tags, result tags, and the toolbar count classify one way even when a
+  // hand-edited log's call name and result tool_name disagree. Re-checking a
+  // name on either side is what would let them diverge.
   tags.contains(call.id) &&
-  call.name == "mbtx" &&
   failed.contains(call.id) &&
   briefs.get(call.id) is Some(brief) &&
   brief.has_prefix("mbtx (build")
@@ -1730,12 +1735,15 @@ fn tool_call_is_run_failed(
 }
 
 ///|
-/// Whether a durable `mbtx` result reports a BUILD-stage failure, read from
+/// Whether a durable result reports an mbtx BUILD-stage failure, read from
 /// the fields the result itself carries — no call lookup needed, so result
 /// cards stay tagged in both view modes without extra threading.
 fn result_is_build_failed(result : @agent_session.ToolResult) -> Bool {
+  // Brief-only, matching `tool_call_is_build_failed`: one identity for both
+  // sides of a pair keeps the tags and the toolbar count consistent even on
+  // logs whose call name and result tool_name disagree. The `mbtx (build`
+  // shape is written only by the staged engine.
   result.is_error() &&
-  result.tool_name() == "mbtx" &&
   result.brief() is Some(brief) &&
   brief.has_prefix("mbtx (build")
 }

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -909,6 +909,28 @@ fn tool_call_view(
     (false, true) => "tool-call tool-call-escalated"
     (true, true) => "tool-call tool-call-failed tool-call-escalated"
   }
+  // A failed mbtx call names its STAGE — a build error is fixed in the
+  // source, a runtime error in the program's behavior — as a visible word
+  // beside the brief and as a class the build-errors-only filter keys on.
+  let build_failed = tool_call_is_build_failed(call, briefs, failed)
+  let run_failed = !build_failed &&
+    tool_call_is_run_failed(call, briefs, failed)
+  let cls = if build_failed {
+    "\{cls} tool-call-build-failed"
+  } else if run_failed {
+    "\{cls} tool-call-run-failed"
+  } else {
+    cls
+  }
+  if build_failed {
+    name_row.push(
+      @html.span(class="tool-stage tool-stage-build") <| " build error",
+    )
+  } else if run_failed {
+    name_row.push(
+      @html.span(class="tool-stage tool-stage-run") <| " runtime error",
+    )
+  }
   let original = pretty_json(call.arguments)
   if is_blank_args(original) {
     return @html.div(id?=anchor, class=cls) <| [
@@ -1146,12 +1168,19 @@ fn tool_card(
     (false, true) => "tool escalated"
     (true, true) => "tool error escalated"
   }
+  // Tag mbtx build failures so the build-errors-only filter keeps this result
+  // card — the diagnostics live here — beside its originating call.
+  let kind = if result_is_build_failed(result) {
+    "\{kind} build-failed"
+  } else {
+    kind
+  }
   let label = if is_error {
     "Tool error · \{result.tool_name()}"
   } else {
     "Tool result · \{result.tool_name()}"
   }
-  let flag = failed_flag(is_error)
+  let flag = result_flag(result)
   // Pair this result back to the call that produced it (same `call N` tag).
   // The pair anchor wins the element's single id (the cross-link targets
   // it); an unpaired result anchors at its sequence like every other card —
@@ -1188,6 +1217,20 @@ fn failed_flag(is_error : Bool) -> @html.Html {
     @html.span(class="tool-flag") <| "🚩 failed"
   } else {
     @html.nothing
+  }
+}
+
+///|
+/// The collapsed-card flag for a durable result: an mbtx build failure names
+/// its stage (the fix lives in the source, not the program), every other
+/// failure keeps the generic word. The run stage is deliberately not named
+/// here — the result alone cannot see the call's target, and the call card
+/// beside it already says it.
+fn result_flag(result : @agent_session.ToolResult) -> @html.Html {
+  if result_is_build_failed(result) {
+    @html.span(class="tool-flag tool-stage-build") <| "🚩 build error"
+  } else {
+    failed_flag(result.is_error())
   }
 }
 
@@ -1634,6 +1677,62 @@ fn tool_call_is_escalated(call : @deepseek.ToolCall) -> Bool {
 }
 
 ///|
+/// Whether a failed `mbtx` call's brief reports a BUILD-stage failure — the
+/// staged engine's `mbtx (build …)` shapes (`build failed`, `build timeout`,
+/// `build fault`), which only it ever writes, so the tag carries no
+/// pre-staging or single-shot ambiguity.
+fn tool_call_is_build_failed(
+  call : @deepseek.ToolCall,
+  briefs : Map[String, String],
+  failed : Map[String, Unit],
+) -> Bool {
+  call.name == "mbtx" &&
+  failed.contains(call.id) &&
+  briefs.get(call.id) is Some(brief) &&
+  brief.has_prefix("mbtx (build")
+}
+
+///|
+/// Whether a failed `mbtx` call reads as a RUN-stage failure: an exit brief
+/// on the staged wasm path (target absent or `"wasm"` in the call's own
+/// arguments). A single-shot target's one exit code covers both stages and
+/// claims neither. A wasm failure recorded before the staged engine shares
+/// the brief shape and reads as runtime — an accepted imprecision, by
+/// explicit owner decision (no backwards compatibility for old transcripts).
+fn tool_call_is_run_failed(
+  call : @deepseek.ToolCall,
+  briefs : Map[String, String],
+  failed : Map[String, Unit],
+) -> Bool {
+  guard call.name == "mbtx" &&
+    failed.contains(call.id) &&
+    briefs.get(call.id) is Some(brief) &&
+    brief.has_prefix("mbtx (exit=") else {
+    return false
+  }
+  let json = @json.parse(call.arguments) catch { _ => return false }
+  match json {
+    Object(fields) =>
+      match fields.get("target") {
+        None | Some(String("wasm")) | Some(Null) => true
+        _ => false
+      }
+    _ => false
+  }
+}
+
+///|
+/// Whether a durable `mbtx` result reports a BUILD-stage failure, read from
+/// the fields the result itself carries — no call lookup needed, so result
+/// cards stay tagged in both view modes without extra threading.
+fn result_is_build_failed(result : @agent_session.ToolResult) -> Bool {
+  result.is_error() &&
+  result.tool_name() == "mbtx" &&
+  result.brief() is Some(brief) &&
+  brief.has_prefix("mbtx (build")
+}
+
+///|
 /// Escalated call ids whose result can be identified unambiguously in the raw
 /// view. `tags` already contains exactly the 1:1 call/result pairs, so using it
 /// avoids attaching an escalation marker to a result when duplicate ids make
@@ -1934,6 +2033,44 @@ pub fn rendered_escalated_count(
 }
 
 ///|
+/// How many rendered `mbtx` calls failed in the BUILD stage, per view mode —
+/// what the build-errors-only toolbar counts and jumps between. Derived from
+/// the same per-mode brief/failure maps the cards themselves render from, so
+/// the count and the tags can never disagree; the model view's maps already
+/// pass everything through `model_shown_result`.
+pub fn rendered_build_error_count(
+  session : @agent_session.Session,
+  mode : ViewMode,
+) -> Int {
+  let mut count = 0
+  match mode {
+    RawLog => {
+      let briefs = tool_call_briefs(session)
+      let failed = raw_failed_call_ids(session)
+      for event in session.events() {
+        if event.item() is Assistant(message) {
+          count += message
+            .tool_calls()
+            .count_if(call => tool_call_is_build_failed(call, briefs, failed))
+        }
+      }
+    }
+    ModelView => {
+      let messages = session.chat_messages()
+      let tool_results = tool_results_by_id(session)
+      let briefs = model_tool_call_briefs(messages, tool_results)
+      let failed = model_failed_call_ids(messages, tool_results)
+      for message in messages {
+        count += message.tool_calls.count_if(call => {
+          tool_call_is_build_failed(call, briefs, failed)
+        })
+      }
+    }
+  }
+  count
+}
+
+///|
 /// Model-view tool result, folded by default like the raw view. `result` is the
 /// durable `ToolResult` looked up by id, which lets this recover the tool name
 /// and red-flag failures even though the projection drops `is_error`. A non-zero
@@ -1968,6 +2105,13 @@ fn model_tool_card(
     (false, true) => "tool escalated"
     (true, true) => "tool error escalated"
   }
+  // Same build-failure tag as the raw view's result card, derived only from
+  // the result the projection actually shows.
+  let kind = if shown is Some(r) && result_is_build_failed(r) {
+    "\{kind} build-failed"
+  } else {
+    kind
+  }
   let label = match (is_error, name.is_empty()) {
     (_, true) => "Tool result"
     (true, false) => "Tool error · \{name}"
@@ -1986,7 +2130,11 @@ fn model_tool_card(
     Some(n) => Some(tool_result_anchor(n))
     None => anchor
   }
-  let summary = model_card_head(label, time~, flag=failed_flag(is_error), link~)
+  let flag = match shown {
+    Some(r) => result_flag(r)
+    None => failed_flag(is_error)
+  }
+  let summary = model_card_head(label, time~, flag~, link~)
   // Chip only, no nested transcript: the model view shows what the model
   // was fed, and the child's transcript never was.
   if shown is Some(result) &&

--- a/viz/viz_test.mbt
+++ b/viz/viz_test.mbt
@@ -471,6 +471,103 @@ test "a failed tool call is tagged so errors-only keeps its call card" {
 }
 
 ///|
+/// mbtx failure-stage fixtures: a build-stage failure (staged brief), a
+/// wasm-default runtime failure, and a js single-shot failure whose one exit
+/// code must claim neither stage.
+fn mbtx_stage_session() -> @agent_session.Session {
+  @agent_session.Session(SessionId("mbtx-stage"), system_prompt="")
+  .append(
+    Assistant(
+      AssistantMessage("", tool_calls=[
+        ToolCall(
+          id="b1",
+          name="mbtx",
+          arguments="{\"source\":\"fn main {  }\"}",
+        ),
+        ToolCall(
+          id="r1",
+          name="mbtx",
+          arguments="{\"source\":\"fn main {  }\"}",
+        ),
+        ToolCall(
+          id="j1",
+          name="mbtx",
+          arguments="{\"source\":\"fn main {  }\",\"target\":\"js\"}",
+        ),
+      ]),
+    ),
+  )
+  .append(
+    Tool(
+      ToolResult(
+        tool_call_id="b1",
+        tool_name="mbtx",
+        content="diag",
+        is_error=true,
+        brief="mbtx (build failed, exit=1)",
+      ),
+    ),
+  )
+  .append(
+    Tool(
+      ToolResult(
+        tool_call_id="r1",
+        tool_name="mbtx",
+        content="trap",
+        is_error=true,
+        brief="mbtx (exit=1)",
+      ),
+    ),
+  )
+  .append(
+    Tool(
+      ToolResult(
+        tool_call_id="j1",
+        tool_name="mbtx",
+        content="js diag",
+        is_error=true,
+        brief="mbtx (exit=1)",
+      ),
+    ),
+  )
+}
+
+///|
+/// The stage words and the filter hooks: a build failure tags its call
+/// (`tool-call-build-failed`) and its result card (`build-failed`) — what the
+/// build-errors-only stylesheet keys on — while the wasm runtime failure gets
+/// the run word and the js single-shot failure claims neither stage.
+test "mbtx rows name their failure stage and tag the filter hooks" {
+  let raw = render(@viz.render_session(mbtx_stage_session(), RawLog))
+  assert_true(raw.contains("tool-call-build-failed"))
+  assert_true(raw.contains("build error"))
+  assert_true(raw.contains("card tool error build-failed"))
+  assert_true(raw.contains("🚩 build error"))
+  assert_true(raw.contains("tool-call-run-failed"))
+  assert_true(raw.contains("runtime error"))
+  // Exactly one call carries each stage class: the js failure is neither.
+  assert_eq(raw.split("tool-call-build-failed").length(), 2)
+  assert_eq(raw.split("tool-call-run-failed").length(), 2)
+  // The model view renders the same tags from the projected maps.
+  let model = render(@viz.render_session(mbtx_stage_session(), ModelView))
+  assert_true(model.contains("tool-call-build-failed"))
+  assert_true(model.contains("card tool error build-failed"))
+  assert_true(model.contains("🚩 build error"))
+  // A clean session tags nothing.
+  let clean = render(@viz.render_session(clean_sample_session(), RawLog))
+  assert_false(clean.contains("tool-call-build-failed"))
+  assert_false(clean.contains("tool-call-run-failed"))
+}
+
+///|
+test "rendered_build_error_count counts staged build failures per mode" {
+  let session = mbtx_stage_session()
+  assert_eq(@viz.rendered_build_error_count(session, RawLog), 1)
+  assert_eq(@viz.rendered_build_error_count(session, ModelView), 1)
+  assert_eq(@viz.rendered_build_error_count(clean_sample_session(), RawLog), 0)
+}
+
+///|
 test "failed tool result is folded and red-flagged" {
   let html = render(@viz.render_session(error_tool_session(), RawLog))
   // Folded by default (a <details> with no `open`), tagged as an error, and the

--- a/viz/viz_test.mbt
+++ b/viz/viz_test.mbt
@@ -568,6 +568,91 @@ test "rendered_build_error_count counts staged build failures per mode" {
 }
 
 ///|
+/// An orphan build-failed result — no matching call, a shape the raw renderer
+/// still shows — must be counted, or an active filter would replace visible
+/// diagnostics with an empty-state message.
+test "an orphan build-failed result is counted and tagged" {
+  let session = @agent_session.Session(SessionId("orphan"), system_prompt="").append(
+    Tool(
+      ToolResult(
+        tool_call_id="ghost",
+        tool_name="mbtx",
+        content="diag",
+        is_error=true,
+        brief="mbtx (build failed, exit=1)",
+      ),
+    ),
+  )
+  assert_eq(@viz.rendered_build_error_count(session, RawLog), 1)
+  let raw = render(@viz.render_session(session, RawLog))
+  assert_true(raw.contains("card tool error build-failed"))
+}
+
+///|
+/// A duplicated tool_call_id makes call/result pairing ambiguous, and the
+/// brief maps collapse to whichever result came last — so a call's stage
+/// would depend on event order. An ambiguous call is labeled with no stage;
+/// its per-result cards keep their own tags and the count stays order-free.
+test "duplicated ids label no call stage but still count their results" {
+  fn session_with(first : String, second : String) -> @agent_session.Session {
+    @agent_session.Session(SessionId("dup"), system_prompt="")
+    .append(
+      Assistant(
+        AssistantMessage("", tool_calls=[
+          ToolCall(
+            id="d1",
+            name="mbtx",
+            arguments="{\"source\":\"fn main {  }\"}",
+          ),
+          ToolCall(
+            id="d1",
+            name="mbtx",
+            arguments="{\"source\":\"fn main {  }\"}",
+          ),
+        ]),
+      ),
+    )
+    .append(
+      Tool(
+        ToolResult(
+          tool_call_id="d1",
+          tool_name="mbtx",
+          content="a",
+          is_error=true,
+          brief=first,
+        ),
+      ),
+    )
+    .append(
+      Tool(
+        ToolResult(
+          tool_call_id="d1",
+          tool_name="mbtx",
+          content="b",
+          is_error=true,
+          brief=second,
+        ),
+      ),
+    )
+  }
+
+  for
+    briefs in [
+      ("mbtx (build failed, exit=1)", "mbtx (exit=1)"),
+      ("mbtx (exit=1)", "mbtx (build failed, exit=1)"),
+    ] {
+    let (first, second) = briefs
+    let session = session_with(first, second)
+    // Order-free: exactly the one build RESULT counts either way.
+    assert_eq(@viz.rendered_build_error_count(session, RawLog), 1)
+    let raw = render(@viz.render_session(session, RawLog))
+    assert_false(raw.contains("tool-call-build-failed"))
+    assert_false(raw.contains("tool-call-run-failed"))
+    assert_true(raw.contains("card tool error build-failed"))
+  }
+}
+
+///|
 test "failed tool result is folded and red-flagged" {
   let html = render(@viz.render_session(error_tool_session(), RawLog))
   // Folded by default (a <details> with no `open`), tagged as an error, and the

--- a/viz/viz_test.mbt
+++ b/viz/viz_test.mbt
@@ -653,6 +653,41 @@ test "duplicated ids label no call stage but still count their results" {
 }
 
 ///|
+/// One identity for both sides of a pair: classification reads the BRIEF, so
+/// a log whose call name and result tool_name disagree still tags the call
+/// row, the result card, and the count the same way — never a visible tag
+/// with a zero count.
+test "a name-mismatched pair classifies consistently from the brief" {
+  let session = @agent_session.Session(SessionId("mismatch"), system_prompt="")
+    .append(
+      Assistant(
+        AssistantMessage("", tool_calls=[
+          ToolCall(
+            id="m1",
+            name="mbtx",
+            arguments="{\"source\":\"fn main {  }\"}",
+          ),
+        ]),
+      ),
+    )
+    .append(
+      Tool(
+        ToolResult(
+          tool_call_id="m1",
+          tool_name="shell",
+          content="diag",
+          is_error=true,
+          brief="mbtx (build failed, exit=1)",
+        ),
+      ),
+    )
+  let raw = render(@viz.render_session(session, RawLog))
+  assert_true(raw.contains("tool-call-build-failed"))
+  assert_true(raw.contains("build-failed"))
+  assert_eq(@viz.rendered_build_error_count(session, RawLog), 1)
+}
+
+///|
 test "failed tool result is folded and red-flagged" {
   let html = render(@viz.render_session(error_tool_session(), RawLog))
   // Folded by default (a <details> with no `open`), tagged as an error, and the

--- a/web/index.html
+++ b/web/index.html
@@ -394,7 +394,7 @@
     }
     .build-error-jump { padding: 4px 11px; font-family: ui-monospace, monospace; }
     .build-error-toggle:hover, .build-error-jump:hover { border-color: var(--warn); }
-    .build-error-toggle.active { background: var(--warn); color: #fff; border-color: var(--warn); }
+    .build-error-toggle.active { background: var(--warn); color: var(--on-accent); border-color: var(--warn); }
     .build-errors-only-empty { color: var(--muted); margin-top: 24px; }
     .session-view.build-errors-only .card:not(.assistant):not(.tool.build-failed) { display: none; }
     .session-view.build-errors-only .card.assistant:not(:has(.tool-call-build-failed)) { display: none; }

--- a/web/index.html
+++ b/web/index.html
@@ -23,6 +23,7 @@
       --assistant: #1a8f63;
       --tool: #8a6d10;
       --error: #c2334a;
+      --warn: #9a6700;
       --added: #1a8f63;
       --runtime: #6d4fb0;
       --summary: #b5701f;
@@ -55,6 +56,7 @@
       --assistant: #36c08a;
       --tool: #c9a227;
       --error: #e0556b;
+      --warn: #d4a72c;
       --added: #36c08a;
       --runtime: #9a7bd6;
       --summary: #d98a3a;
@@ -88,6 +90,7 @@
         --assistant: #36c08a;
         --tool: #c9a227;
         --error: #e0556b;
+      --warn: #d4a72c;
         --added: #36c08a;
         --runtime: #9a7bd6;
         --summary: #d98a3a;
@@ -257,7 +260,8 @@
     }
     .sticky-toolbar .mode-row { margin-bottom: 0; }
     .sticky-toolbar .error-bar,
-    .sticky-toolbar .escalated-bar { margin: 10px 0 0; }
+    .sticky-toolbar .escalated-bar,
+    .sticky-toolbar .build-error-bar { margin: 10px 0 0; }
     .mode-row {
       display: flex;
       align-items: center;
@@ -371,6 +375,31 @@
     .session-view.escalated-only .card.assistant:not(:has(.tool-call-escalated)) { display: none; }
     .session-view.escalated-only .card.assistant .tool-call:not(.tool-call-escalated) { display: none; }
     .session-view.escalated-only .turn:not(:has(.tool-call-escalated)):not(:has(.card.tool.escalated)) { display: none; }
+
+    /* mbtx failure-stage words: a build error is a source problem (amber),
+       a runtime error keeps the failure red. */
+    .tool-stage-build { color: var(--warn); font-weight: 600; }
+    .tool-stage-run { color: var(--error); font-weight: 600; }
+    .tool-flag.tool-stage-build { color: var(--warn); }
+
+    /* build-errors-only: find compile errors. Keep each mbtx call whose result
+       brief says the BUILD failed, its paired result card (tagged build-failed),
+       and their turns; hide everything else. */
+    .build-error-bar { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; margin: -6px 0 16px; }
+    .build-error-count { color: var(--warn); font-size: 12px; font-weight: 600; margin-right: 2px; }
+    .build-error-toggle, .build-error-jump {
+      background: var(--panel); color: var(--text);
+      border: 1px solid var(--border); border-radius: 999px;
+      padding: 4px 12px; cursor: pointer; font-size: 12px;
+    }
+    .build-error-jump { padding: 4px 11px; font-family: ui-monospace, monospace; }
+    .build-error-toggle:hover, .build-error-jump:hover { border-color: var(--warn); }
+    .build-error-toggle.active { background: var(--warn); color: #fff; border-color: var(--warn); }
+    .build-errors-only-empty { color: var(--muted); margin-top: 24px; }
+    .session-view.build-errors-only .card:not(.assistant):not(.tool.build-failed) { display: none; }
+    .session-view.build-errors-only .card.assistant:not(:has(.tool-call-build-failed)) { display: none; }
+    .session-view.build-errors-only .card.assistant .tool-call:not(.tool-call-build-failed) { display: none; }
+    .session-view.build-errors-only .turn:not(:has(.tool-call-build-failed)):not(:has(.card.tool.build-failed)) { display: none; }
 
     /* notices */
     .notices { margin-bottom: 16px; }


### PR DESCRIPTION
Follow-up 2 of 2 to the staged mbtx engine (#1167); desktop counterpart: #1168.

## Rendering

A failed `mbtx` call row in the HTML session render names its **failure stage**:

- **`build error`** (amber, new `--warn` token in all three theme palettes) — the staged engine's `mbtx (build …)` briefs. The paired result card is tagged `build-failed` and its collapsed flag reads `🚩 build error` — derived from fields the durable `ToolResult` itself carries (`tool_name`/`is_error`/`brief`), so both view modes work with zero extra map threading and the model view stays inside the `model_shown_result` projection invariant.
- **`runtime error`** — exit briefs on the staged wasm path only (target absent or `"wasm"` in the call's own durable arguments). A single-shot target's one exit code covers both stages and claims neither, matching the engine's contract and #1168's gating.

## Filter: find compile errors

A **"Build errors only"** toolbar — count (`🔨 N build errors`), toggle, viewport-relative prev/next jumps — cloned from the escalated-only mechanism and mutually exclusive with the other two filters. The stylesheet keeps each tagged call, its unambiguously paired result card, and their turns; the count comes from the same per-mode brief/failure maps the cards render from (`rendered_build_error_count`), so the toolbar and the tags cannot disagree. Scoped to build errors only, per the design discussion.

Pre-staging wasm recordings share the exit-brief shape and read as runtime errors — the same accepted owner decision as #1168 (no backwards compatibility for old transcripts).

## Notes

- `viz/pkg.generated.mbti` is updated by hand in canonical style: `moon info` skips the js-only `viz` package at the native canonical backend (pre-existing repo condition; the file's history shows the same maintenance path).
- 64/64 `viz` + 33/33 `cmd/viz_app` tests (new: stage tags + words in both view modes with a js-target negative case, per-mode count, toolbar mirror/visibility, three-way filter exclusivity, view-class); `moon check --deny-warn` and `moon fmt --check` clean; `moon build cmd/viz_app --target js` (the bundle CI builds) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Qu3wgL9g7Z9V4umSU97RD
