### PR TITLE
fix(desktop): stop repeating a build brief in its own failure marker

### DIFF
--- a/desktop/frontend/transcript/component/mbtx.mbt
+++ b/desktop/frontend/transcript/component/mbtx.mbt
@@ -131,10 +131,13 @@ fn mbtx_failure_stage(
 }
 
 ///|
-/// The literal word beside a failed call's brief. An `mbtx` failure names its
-/// STAGE: a build error is fixed in the source, a runtime error in the
-/// program's behavior, and the row should say which before the card is even
-/// opened. Every other failed call keeps the generic word.
+/// The literal word beside a failed call's brief — only where it ADDS one. A
+/// build-stage brief already reads "build failed" / "build timeout" in the
+/// row's own label, so appending a marker repeated the brief verbatim
+/// ("mbtx (build failed, exit=1) build error"); those rows carry no marker
+/// and say their state through the brief itself, restyled amber by
+/// `failure_stage_class`. A runtime marker stays: "exit=1" alone does not
+/// name the stage. Every other failed call keeps the generic word.
 fn failure_marker(
   name : String,
   brief : String?,
@@ -143,10 +146,25 @@ fn failure_marker(
 ) -> @html.Html? {
   guard is_error else { return None }
   match mbtx_failure_stage(name, brief, is_error, arguments) {
-    Some(BuildError) =>
-      Some(@html.span(class="tool-call-failed tool-stage-build", "build error"))
+    Some(BuildError) => None
     Some(RuntimeError) =>
       Some(@html.span(class="tool-call-failed tool-stage-run", "runtime error"))
     None => Some(@html.span(class="tool-call-failed", "failed"))
+  }
+}
+
+///|
+/// The stage modifier for a failed row's container class: build failures read
+/// amber (the fix lives in the source, and their brief carries the literal
+/// stage words), runtime failures keep the error red.
+fn failure_stage_class(
+  name : String,
+  brief : String?,
+  is_error : Bool,
+  arguments : String?,
+) -> String {
+  match mbtx_failure_stage(name, brief, is_error, arguments) {
+    Some(BuildError) => " stage-build"
+    Some(RuntimeError) | None => ""
   }
 }

--- a/desktop/frontend/transcript/component/mbtx_tests.mbt
+++ b/desktop/frontend/transcript/component/mbtx_tests.mbt
@@ -101,16 +101,19 @@ test "a failed mbtx row names its failure stage" {
     @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
   }
 
+  // A build brief already reads "build failed" in the row's own label, so no
+  // marker word is appended — the earlier appended marker made the row read
+  // "mbtx (build failed, exit=1) build error". The stage rides the container
+  // class instead, which the stylesheet turns amber.
   let build = markup_for("mbtx (build failed, exit=1)", true, plain_arguments)
-  assert_true(build.contains("tool-stage-build"))
-  assert_true(build.contains("build error"))
+  assert_true(build.contains("error stage-build"))
+  assert_false(build.contains("build error"))
   assert_false(build.contains(">failed<"))
-  // Every build-phase brief shape maps to the same stage word.
-  assert_true(
-    markup_for("mbtx (build timeout)", true, plain_arguments).contains(
-      "build error",
-    ),
-  )
+  assert_true(build.contains("mbtx (build failed, exit=1)"))
+  // Every build-phase brief shape gets the same treatment.
+  let timeout_row = markup_for("mbtx (build timeout)", true, plain_arguments)
+  assert_true(timeout_row.contains("error stage-build"))
+  assert_false(timeout_row.contains(">failed<"))
   // The default target is the staged wasm path, so its exit brief is a
   // run-stage claim; an explicit wasm target reads the same.
   let runtime = markup_for("mbtx (exit=1)", true, plain_arguments)

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -297,11 +297,12 @@ fn tool_request_view(item : @transcript.TranscriptItem) -> @html.Html {
   } else {
     name
   }
-  let error_class = if is_error { " error" } else { "" }
-  // The row's always-visible line: the brief, a literal `failed` marker when
-  // the result errored (the row's red must not carry the state alone), and —
-  // for an applied `plan` call — the compact progress meter. `fold_progress`
-  // renders nothing for every other call.
+  let error_class = (if is_error { " error" } else { "" }) +
+    failure_stage_class(name, brief, is_error, Some(arguments))
+  // The row's always-visible line: the brief, a literal marker when the
+  // result errored and the brief does not already carry the state in words
+  // (see `failure_marker`), and — for an applied `plan` call — the compact
+  // progress meter. `fold_progress` renders nothing for every other call.
   let line : Array[@html.Html] = [
     @html.span(class="tool-flow", "→"),
     @html.span(class="tool-call-text", label),
@@ -385,7 +386,8 @@ fn tool_result_view(
     _ if is_error => "Tool error · \{name}"
     _ => "Tool result · \{name}"
   }
-  let error_class = if is_error { " error" } else { "" }
+  let error_class = (if is_error { " error" } else { "" }) +
+    failure_stage_class(name, brief, is_error, arguments)
   let pending_class = if has_result { "" } else { " pending" }
   let line : Array[@html.Html] = [
     @html.span(class="tool-flow", "←"),

--- a/desktop/styles/transcript.css
+++ b/desktop/styles/transcript.css
@@ -922,10 +922,15 @@
   color: var(--color-danger);
   font-size: var(--font-size-xs);
 }
-/* An mbtx failure names its stage. A build error is a source problem — warn
-   amber, "fix the input" — while a runtime error keeps the row's danger red:
-   the program itself misbehaved. */
-.tool-call-failed.tool-stage-build {
+/* An mbtx build failure reads amber, not the error red: the fix lives in the
+   source, and its BRIEF already carries the literal stage words ("build
+   failed", "build timeout"), so the row appends no marker — appending one
+   repeated the brief verbatim. Runtime failures keep the red row plus the
+   "runtime error" marker, which does add a word the brief lacks. */
+.tool-call-label.error.stage-build,
+.tool-call.error.stage-build > .tool-call-summary,
+.tool-result-label.error.stage-build,
+.tool-result.error.stage-build > .tool-result-summary {
   color: var(--color-warning);
 }
 


### PR DESCRIPTION
Dogfooding feedback on #1168: a build-failure row read `mbtx (build failed, exit=1) build error` — the marker repeated the brief verbatim, since build-stage briefs already carry their literal state words. Build rows now append no marker; the stage rides the container class (`stage-build`), styled amber, with the words living in the brief itself so state never rests on color alone. Runtime rows keep the `runtime error` marker (`exit=1` alone does not name the stage); other tools keep `failed`. 457/457 desktop frontend js tests.

Viz counterpart (same de-duplication + filter discoverability) is a separate PR, per convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Qu3wgL9g7Z9V4umSU97RD