### PR TITLE
fix: suppress deprecated implicit impl-method promotion (nightly E0079)

### DIFF
--- a/cmd/viz_app/moon.mod
+++ b/cmd/viz_app/moon.mod
@@ -9,4 +9,4 @@ import {
 
 preferred_target = "js"
 
-warnings = "+missing_doc+unnecessary_view_op+test_unqualified_package+unused_default_value"
+warnings = "+missing_doc+unnecessary_view_op+test_unqualified_package+unused_default_value+implicit_impl_as_method"

--- a/desktop/frontend/composer/contract.mbt
+++ b/desktop/frontend/composer/contract.mbt
@@ -301,6 +301,21 @@ pub fn Action::identity(self : Action) -> Identity {
 }
 
 ///|
+#deprecated("Use `==` or the `Eq` trait directly", skip_current_package=true)
+#doc(hidden)
+pub extend ApprovalNotice with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` or the `Eq` trait directly", skip_current_package=true)
+#doc(hidden)
+pub extend CodexRequestInput with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` or the `Eq` trait directly", skip_current_package=true)
+#doc(hidden)
+pub extend ContextComponent with Eq::{equal, not_equal}
+
+///|
 pub extend Draft with Debug::{to_repr}
 
 ///|
@@ -311,6 +326,11 @@ pub extend FileIndex with Debug::{to_repr}
 
 ///|
 pub extend FileIndex with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` or the `Eq` trait directly", skip_current_package=true)
+#doc(hidden)
+pub extend GitControl with Eq::{equal, not_equal}
 
 ///|
 pub extend GoalInput with Eq::{equal, not_equal}
@@ -335,6 +355,11 @@ pub extend Mention with Debug::{to_repr}
 
 ///|
 pub extend Mention with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` or the `Eq` trait directly", skip_current_package=true)
+#doc(hidden)
+pub extend PermissionControl with Eq::{equal, not_equal}
 
 ///|
 pub extend Presentation with Eq::{equal, not_equal}
@@ -368,3 +393,8 @@ pub extend SlashCommand with Debug::{to_repr}
 
 ///|
 pub extend SlashCommand with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` or the `Eq` trait directly", skip_current_package=true)
+#doc(hidden)
+pub extend StatusComponent with Eq::{equal, not_equal}

--- a/desktop/frontend/composer/view.mbt
+++ b/desktop/frontend/composer/view.mbt
@@ -880,7 +880,37 @@ fn is_submit_shortcut(event : @dom.KeyboardEvent) -> Bool {
 }
 
 ///|
+#deprecated("Use `==` or the `Eq` trait directly", skip_current_package=true)
+#doc(hidden)
+pub extend MissingWorktreeNotice with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` or the `Eq` trait directly", skip_current_package=true)
+#doc(hidden)
+pub extend ModelGroup with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` or the `Eq` trait directly", skip_current_package=true)
+#doc(hidden)
+pub extend ModelOption with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` or the `Eq` trait directly", skip_current_package=true)
+#doc(hidden)
+pub extend ModelSelect with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` or the `Eq` trait directly", skip_current_package=true)
+#doc(hidden)
+pub extend ReasoningSelect with Eq::{equal, not_equal}
+
+///|
 pub extend WorktreeChoice with Debug::{to_repr}
 
 ///|
 pub extend WorktreeChoice with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` or the `Eq` trait directly", skip_current_package=true)
+#doc(hidden)
+pub extend WorktreeControl with Eq::{equal, not_equal}

--- a/desktop/frontend/fileeditor/git_history.mbt
+++ b/desktop/frontend/fileeditor/git_history.mbt
@@ -750,3 +750,13 @@ test "Git graph semantic colors follow refs through the pagination boundary" {
   assert_eq(rows[2].output_swimlanes.map(lane => lane.color), [GraphBaseColor])
   assert_eq(graph_ref_color(snapshot, "remote"), Some(GraphUpstreamColor))
 }
+
+///|
+#deprecated("Use `==` or the `Eq` trait directly", skip_current_package=true)
+#doc(hidden)
+pub extend GraphLane with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` or the `Eq` trait directly", skip_current_package=true)
+#doc(hidden)
+pub extend GraphRow with Eq::{equal, not_equal}

--- a/desktop/frontend/fileeditor/semantic_review_view.mbt
+++ b/desktop/frontend/fileeditor/semantic_review_view.mbt
@@ -1342,3 +1342,13 @@ pub extend SemanticReviewInput with Eq::{equal, not_equal}
 
 ///|
 pub extend SemanticReviewInput with Debug::{to_repr}
+
+///|
+#deprecated("Use `==` or the `Eq` trait directly", skip_current_package=true)
+#doc(hidden)
+pub extend SemanticReviewLiveDocument with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `Debug::to_repr` via the trait or `Repr(value)` instead", skip_current_package=true)
+#doc(hidden)
+pub extend SemanticReviewLiveDocument with Debug::{to_repr}

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -1047,6 +1047,31 @@ pub extend FileEntry with Eq::{equal, not_equal}
 pub extend FileIndex with Eq::{equal, not_equal}
 
 ///|
+#deprecated("Use `==` or the `Eq` trait directly", skip_current_package=true)
+#doc(hidden)
+pub extend GitCommitFiles with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` or the `Eq` trait directly", skip_current_package=true)
+#doc(hidden)
+pub extend GitGraphState with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` or the `Eq` trait directly", skip_current_package=true)
+#doc(hidden)
+pub extend HistoryBlob with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` or the `Eq` trait directly", skip_current_package=true)
+#doc(hidden)
+pub extend HistoryDiffDoc with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` or the `Eq` trait directly", skip_current_package=true)
+#doc(hidden)
+pub extend HistoryDiffSide with Eq::{equal, not_equal}
+
+///|
 pub extend ReconciledPlacement with Eq::{equal, not_equal}
 
 ///|
@@ -1054,6 +1079,16 @@ pub extend ReviewBaseline with Eq::{equal, not_equal}
 
 ///|
 pub extend ReviewDiffLayout with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `Debug::to_repr` via the trait or `Repr(value)` instead", skip_current_package=true)
+#doc(hidden)
+pub extend ReviewDiffMode with Debug::{to_repr}
+
+///|
+#deprecated("Use `==` or the `Eq` trait directly", skip_current_package=true)
+#doc(hidden)
+pub extend ReviewDiffMode with Eq::{equal, not_equal}
 
 ///|
 pub extend ReviewState with Eq::{equal, not_equal}

--- a/desktop/frontend/grep_search/request.mbt
+++ b/desktop/frontend/grep_search/request.mbt
@@ -224,3 +224,8 @@ pub fn State::subscription(
     @sub.SubLoader(search_request_loader),
   )
 }
+
+///|
+#deprecated("Use `==` or the `Eq` trait directly", skip_current_package=true)
+#doc(hidden)
+pub extend SearchRequestIdentity with Eq::{equal, not_equal}

--- a/desktop/frontend/grep_search/types.mbt
+++ b/desktop/frontend/grep_search/types.mbt
@@ -193,4 +193,19 @@ pub extend Phase with Debug::{to_repr}
 pub extend Phase with Eq::{equal, not_equal}
 
 ///|
+#deprecated("Use `==` or the `Eq` trait directly", skip_current_package=true)
+#doc(hidden)
+pub extend SearchResultSummary with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` or the `Eq` trait directly", skip_current_package=true)
+#doc(hidden)
+pub extend SemanticSearchState with Eq::{equal, not_equal}
+
+///|
 pub extend State with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `==` or the `Eq` trait directly", skip_current_package=true)
+#doc(hidden)
+pub extend TextSearchState with Eq::{equal, not_equal}

--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -2109,6 +2109,26 @@ pub extend WorktreeRemovePayload with Eq::{equal, not_equal}
 pub extend WorktreeRemovePayload with ToJson::{to_json}
 
 ///|
+#deprecated("Use `Debug::to_repr` via the trait or `Repr(value)` instead", skip_current_package=true)
+#doc(hidden)
+pub extend AppTitlebarThemePayload with Debug::{to_repr}
+
+///|
+#deprecated("Use `FromJson::from_json` via the trait instead", skip_current_package=true)
+#doc(hidden)
+pub extend AppTitlebarThemePayload with FromJson::{from_json}
+
+///|
+#deprecated("Use `==` or the `Eq` trait directly", skip_current_package=true)
+#doc(hidden)
+pub extend AppTitlebarThemePayload with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `ToJson::to_json` via the trait instead", skip_current_package=true)
+#doc(hidden)
+pub extend AppTitlebarThemePayload with ToJson::{to_json}
+
+///|
 pub extend BrowserThemePayload with Debug::{to_repr}
 
 ///|
@@ -2155,3 +2175,23 @@ pub extend SearchSemanticPayload with Eq::{equal, not_equal}
 
 ///|
 pub extend SearchSemanticPayload with ToJson::{to_json}
+
+///|
+#deprecated("Use `Debug::to_repr` via the trait or `Repr(value)` instead", skip_current_package=true)
+#doc(hidden)
+pub extend SemanticSearchProgressPayload with Debug::{to_repr}
+
+///|
+#deprecated("Use `FromJson::from_json` via the trait instead", skip_current_package=true)
+#doc(hidden)
+pub extend SemanticSearchProgressPayload with FromJson::{from_json}
+
+///|
+#deprecated("Use `==` or the `Eq` trait directly", skip_current_package=true)
+#doc(hidden)
+pub extend SemanticSearchProgressPayload with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `ToJson::to_json` via the trait instead", skip_current_package=true)
+#doc(hidden)
+pub extend SemanticSearchProgressPayload with ToJson::{to_json}

--- a/desktop/moon.mod
+++ b/desktop/moon.mod
@@ -27,6 +27,8 @@ license = "Apache-2.0"
 
 description = "SeekMoon — a Proton + Rabbita desktop client for the OpenSeek agent."
 
+warnings = "+implicit_impl_as_method"
+
 options(
   "--moonbit-unstable-prebuild": "native_link_config.mjs",
   preferred_target: "native",

--- a/editor/internal/viewer/contrib/folding/browser/folding.mbt
+++ b/editor/internal/viewer/contrib/folding/browser/folding.mbt
@@ -166,3 +166,8 @@ pub fn FoldingController::clear_local(self : FoldingController) -> Unit {
   self.mouse_down_info = None
   self.restoring_view_state = false
 }
+
+///|
+#deprecated("Use `Debug::to_repr` via the trait or `Repr(value)` instead", skip_current_package=true)
+#doc(hidden)
+pub extend FoldingStateMemento with Debug::{to_repr}

--- a/editor/moon.mod
+++ b/editor/moon.mod
@@ -16,7 +16,7 @@ supported_targets = "+js+native+wasm"
 
 preferred_target = "js"
 
-warnings = "+prefer_readonly_array"
+warnings = "+prefer_readonly_array+implicit_impl_as_method"
 
 import {
   "moonbit-community/cmark@0.4.5",

--- a/editor/server/moon.mod
+++ b/editor/server/moon.mod
@@ -10,7 +10,7 @@ supported_targets = "native+wasm"
 
 preferred_target = "wasm"
 
-warnings = "+prefer_readonly_array"
+warnings = "+prefer_readonly_array+implicit_impl_as_method"
 
 import {
   "moonbitlang/editor@0.4.4",

--- a/editor/viewer/diff_provider/moondiff/provider.mbt
+++ b/editor/viewer/diff_provider/moondiff/provider.mbt
@@ -393,3 +393,21 @@ pub extend MoonDiffMode with Eq::{equal, not_equal}
 
 ///|
 pub extend MoonDiffMode with Debug::{to_repr}
+
+///|
+#deprecated("Use `==` or the `Eq` trait directly", skip_current_package=true)
+#doc(hidden)
+pub extend MoonFragmentDiffProvider with Eq::{equal, not_equal}
+
+///|
+#deprecated("Use `Debug::to_repr` via the trait or `Repr(value)` instead", skip_current_package=true)
+#doc(hidden)
+pub extend MoonFragmentDiffProvider with Debug::{to_repr}
+
+///|
+#deprecated("Use the `@diff.DocumentDiffProvider` trait instead", skip_current_package=true)
+#doc(hidden)
+pub extend MoonFragmentDiffProvider with @diff.DocumentDiffProvider::{
+  compute_diff,
+  on_did_change,
+}

--- a/inspect/moon.mod
+++ b/inspect/moon.mod
@@ -9,4 +9,4 @@ import {
 
 preferred_target = "wasm"
 
-warnings = "+missing_doc+unnecessary_view_op+test_unqualified_package+unused_default_value"
+warnings = "+missing_doc+unnecessary_view_op+test_unqualified_package+unused_default_value+implicit_impl_as_method"

--- a/moon.mod
+++ b/moon.mod
@@ -26,7 +26,7 @@ description = "DeepSeek-backed MoonBit coding agent"
 
 preferred_target = "native"
 
-warnings = "+missing_doc+unnecessary_view_op+test_unqualified_package+unused_default_value"
+warnings = "+missing_doc+unnecessary_view_op+test_unqualified_package+unused_default_value+implicit_impl_as_method"
 
 rule(
   name: "md_to_mbt_string",

--- a/protocol/moon.mod
+++ b/protocol/moon.mod
@@ -13,3 +13,5 @@ repository = "https://github.com/bobzhang/openseek"
 license = "Apache-2.0"
 
 description = "Typed engine event stream: the openseek run/serve stdout wire contract."
+
+warnings = "+implicit_impl_as_method"


### PR DESCRIPTION
## What

The nightly toolchain (`moonc v0.10.11-nightly`, 2026-08-29) emits `E0079 implicit_impl_as_method` warnings: methods from `impl Trait for Type` are implicitly promoted onto `Type`, and that promotion is deprecated and will be removed.

Two commits:

1. **`fix:`** clears all 40 sites across 10 files.
2. **`chore:`** pins `+implicit_impl_as_method` in the `warnings` field of all seven buildable modules, so this can't regress silently.

| | before | after |
|---|---|---|
| `moon check --target all --deny-warn` | 40 E0079 | **0 warnings, 0 errors** |
| `moon fmt --check` | clean | clean |
| `moon info` `.mbti` drift | — | **zero** |
| `moon test --target native` | — | 3382 / 3383 † |
| `moon test --target js` | — | **3329 / 3329** |

† The one failure is `deepseek/client/client_realworld_test.mbt`, a live Kimi API call gated on `$KIMI`. This PR touches zero `deepseek/` files, and the package passes 26/26 in isolation.

## Why `#deprecated` + `#doc(hidden)` rather than plain `pub extend`

The compiler offers two fixes: declare the promotion explicitly, or — "if the promotion is not desirable" — suppress it. This takes the second, because nothing calls the promoted methods:

- `==` dispatches through `impl Eq for X`, never through `X::equal`.
- A repo-wide grep finds **zero** `.equal(`, `.not_equal(`, `.to_repr(` call sites in `desktop/` or `editor/`.
- The `compute_diff` / `on_did_change` callers go through `&@diff.DocumentDiffProvider` trait objects, not the concrete type.

Declaring them instead would have made 40 methods nobody uses a permanent public commitment. Follows the precedent set in db5d3c0b for `MbtxInput::to_repr`, `skip_current_package=true` included.

```moonbit
///|
#deprecated("Use `==` or the `Eq` trait directly", skip_current_package=true)
#doc(hidden)
pub extend StatusComponent with Eq::{equal, not_equal}
```

## The interface-drift trap this avoids

Because the promotions stay hidden, **no `pkg.generated.mbti` changes at all**. That matters more than it looks.

Three of the touched packages — `desktop/frontend/{composer,fileeditor,grep_search}` — are `supported_targets = "js"`, while `desktop/moon.mod` sets `preferred_target: "native"`. `moon info` therefore **skips them entirely**, and CI's "Check generated interfaces" step is gated on `matrix.target == 'native'` (`ci.yml:88`). Their committed interfaces are never validated.

An earlier draft used plain `pub extend` and did widen those interfaces — 24 unrecorded methods added to `composer`, 20 to `fileeditor`, invisible to CI. Suppressing the promotion sidesteps the problem instead of papering over it. (Separately: `grep_search/pkg.generated.mbti` is already stale on `main` for unrelated reasons — untouched here, worth its own fix.)

## On the `moon.mod` pin

`desktop` and `protocol` had no `warnings` field at all; `desktop` owned 35 of the original 37 sites.

Two things verified rather than assumed:

- **The name is real, not silently ignored.** Substituting a bogus name makes `moonc` reject the entire flag list; `implicit_impl_as_method` is accepted.
- **The guard bites.** A probe type with a bare `derive(Eq)` and no suppression fails `moon check --deny-warn` with `Error [0079] ... implicit promoted as regular method`, and passes once removed.

Note this is the `+` (enable) form, matching surrounding entries. E0079 is already on by compiler default, so practical enforcement still comes from `--deny-warn`; `@implicit_impl_as_method` would make it an error independently of that flag. Easy to switch if reviewers prefer the stronger form.

**The pin already earned its keep.** Rebasing onto current `main` pulled in code that introduced 5 fresh E0079 sites (`MoonFragmentDiffProvider` ×3, `SemanticReviewLiveDocument` ×2). The pin turned them into build errors instead of letting them land silently; both are fixed here.

## Review notes

- **Purely additive to source**: 207 insertions, 5 deletions — all 5 in `moon.mod` `warnings` strings. No logic, no renames, no changed `derive`, no touched tests.
- **Errors here are loud**: a wrong method name, duplicate `type+trait`, or bad trait alias is a compile error. Clean `--target all` covers every backend.
- **Worth a second opinion**: the four `ToJson`/`FromJson` shims on `AppTitlebarThemePayload` / `SemanticSearchProgressPayload`, and `compute_diff`/`on_did_change` on `MoonFragmentDiffProvider`. Nothing calls those as methods today, but `.to_json()` is idiomatic enough that future code might reach for it and get a deprecation warning (in-package use is exempt). Happy to leave those promoted as real API if preferred.
- **Not run locally**: the editor Playwright browser-correctness suite. CI covers it.

Nightly is `continue-on-error` (`editor.yml:31`), so these warnings aren't failing anything today — this gets ahead of the deprecation before it becomes a hard error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzM4uMAweve6SyjzvusKXU
