### PR TITLE
fix(viz): de-duplicate the build stage word; make the filter discoverable

### DIFF
--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -1428,9 +1428,15 @@ fn session_pane(
     // scroll area so they stay reachable while reading a long log.
     @html.div(class="sticky-toolbar") <| [
       mode_row(emit, model, parsed, @viz.step_scrubber(session)),
-      error_bar(emit, model, error_count),
-      escalated_bar(emit, model, escalated_count),
-      build_error_bar(emit, model, build_error_count, present=mbtx_present),
+      // One shared row for every filter bar: stacking them as separate rows
+      // grew the sticky toolbar past the fixed scroll offsets the anchor
+      // navigation accounts for, which parked jump targets beneath it. Side
+      // by side, the common one-or-two-bar case keeps today's height.
+      @html.div(class="filter-bars") <| [
+        error_bar(emit, model, error_count),
+        escalated_bar(emit, model, escalated_count),
+        build_error_bar(emit, model, build_error_count, present=mbtx_present),
+      ],
     ],
     @viz.render_notices(parsed),
     session_log_view(

--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -1421,6 +1421,7 @@ fn session_pane(
     session,
     model.view_mode,
   )
+  let mbtx_present = @viz.session_has_mbtx_activity(session)
   @html.div(class=session_view_class(model)) <| [
     header_strip(model, id, root_label),
     // Pin the view/args toggles and the error bar to the top of the
@@ -1429,7 +1430,7 @@ fn session_pane(
       mode_row(emit, model, parsed, @viz.step_scrubber(session)),
       error_bar(emit, model, error_count),
       escalated_bar(emit, model, escalated_count),
-      build_error_bar(emit, model, build_error_count),
+      build_error_bar(emit, model, build_error_count, present=mbtx_present),
     ],
     @viz.render_notices(parsed),
     session_log_view(
@@ -1754,14 +1755,19 @@ fn escalated_bar(
 /// Build-error counterpart of `escalated_bar`: a count of mbtx BUILD-stage
 /// failures (the staged engine's `mbtx (build …)` briefs), a filter toggle,
 /// and viewport-relative prev/next jumps — the way to find compile errors in
-/// a long log without reading it. Stays visible at zero while active so the
-/// filter can always be switched back off.
+/// a long log without reading it. Unlike its siblings it shows whenever the
+/// session has ANY mbtx activity (`present`), not only at nonzero count:
+/// hidden-at-zero chrome made the control undiscoverable on exactly the
+/// sessions a user would reach for it in. It still stays visible at zero
+/// while active so the filter can always be switched back off, and a session
+/// with no mbtx at all keeps a clean toolbar.
 fn build_error_bar(
   emit : @cmd.Emit[Msg],
   model : Model,
   count : Int,
+  present~ : Bool,
 ) -> @html.Html {
-  if count == 0 && !model.build_errors_only {
+  if !present && count == 0 && !model.build_errors_only {
     return @html.nothing
   }
   let toggle_class = class_with(
@@ -2463,19 +2469,30 @@ test "escalated toolbar mirrors errors-only controls" {
 ///|
 test "build-error toolbar mirrors the other filter controls" {
   let model = init_model()
-  let html = render_html(build_error_bar(stub_emit(), model, 2))
+  let html = render_html(build_error_bar(stub_emit(), model, 2, present=true))
   assert_true(html.contains("2 build errors"))
   assert_true(html.contains("Build errors only"))
   assert_true(html.contains("↑ prev"))
   assert_true(html.contains("↓ next"))
-  // Hidden entirely for a clean view with the filter off; kept visible at
-  // zero while active so it can always be switched back off.
-  assert_false(
-    render_html(build_error_bar(stub_emit(), model, 0)).contains("Build errors"),
+  // DISCOVERABLE: the toggle shows whenever the session has mbtx activity,
+  // even at zero failures — hidden-at-zero chrome made the control invisible
+  // on exactly the sessions a user would reach for it in. Only a session
+  // with no mbtx at all keeps a clean toolbar.
+  let clean_with_mbtx = render_html(
+    build_error_bar(stub_emit(), model, 0, present=true),
   )
+  assert_true(clean_with_mbtx.contains("Build errors only"))
+  assert_false(clean_with_mbtx.contains("build error<"))
+  assert_false(clean_with_mbtx.contains("↑ prev"))
+  assert_false(
+    render_html(build_error_bar(stub_emit(), model, 0, present=false)).contains(
+      "Build errors",
+    ),
+  )
+  // Kept visible while active so the filter can always be switched back off.
   let active = { ..init_model(), build_errors_only: true, }
   assert_true(
-    render_html(build_error_bar(stub_emit(), active, 0)).contains(
+    render_html(build_error_bar(stub_emit(), active, 0, present=false)).contains(
       "Build errors only: on",
     ),
   )

--- a/viz/pkg.generated.mbti
+++ b/viz/pkg.generated.mbti
@@ -23,6 +23,8 @@ pub fn rendered_escalated_count(@agent_session.Session, ViewMode) -> Int
 
 pub fn session_from_parse(@log.ParsedLog, id~ : String, system_prompt~ : String) -> @agent_session.Session
 
+pub fn session_has_mbtx_activity(@agent_session.Session) -> Bool
+
 pub fn step_scrubber(@agent_session.Session) -> @html.Html
 
 pub fn subrun_child_ids(@agent_session.Session, String) -> Array[String]

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -910,8 +910,12 @@ fn tool_call_view(
     (true, true) => "tool-call tool-call-failed tool-call-escalated"
   }
   // A failed mbtx call names its STAGE — a build error is fixed in the
-  // source, a runtime error in the program's behavior — as a visible word
-  // beside the brief and as a class the build-errors-only filter keys on.
+  // source, a runtime error in the program's behavior. A build-failed row
+  // says it through its own brief, which already reads "build failed" /
+  // "build timeout": appending a word there repeated the brief verbatim
+  // ("· mbtx (build failed, exit=1) build error"), so the stage rides the
+  // class alone and the stylesheet turns the brief amber. The runtime word
+  // stays — "exit=1" never names the stage.
   let build_failed = tool_call_is_build_failed(call, briefs, failed, tags)
   let run_failed = !build_failed &&
     tool_call_is_run_failed(call, briefs, failed, tags)
@@ -922,11 +926,7 @@ fn tool_call_view(
   } else {
     cls
   }
-  if build_failed {
-    name_row.push(
-      @html.span(class="tool-stage tool-stage-build") <| " build error",
-    )
-  } else if run_failed {
+  if run_failed {
     name_row.push(
       @html.span(class="tool-stage tool-stage-run") <| " runtime error",
     )
@@ -2080,6 +2080,26 @@ pub fn rendered_build_error_count(
       })
     }
   }
+}
+
+///|
+/// Whether the session used `mbtx` at all — a call by that name, or a durable
+/// result naming it. This is what makes the build-errors-only control
+/// DISCOVERABLE: hidden-at-zero chrome told a user nothing when a session had
+/// mbtx work but no build failures, so the toolbar shows whenever mbtx was in
+/// play, and only a session with no mbtx activity stays chrome-free.
+pub fn session_has_mbtx_activity(session : @agent_session.Session) -> Bool {
+  for event in session.events() {
+    match event.item() {
+      Assistant(message) =>
+        if message.tool_calls().any(call => call.name == "mbtx") {
+          return true
+        }
+      Tool(result) => if result.tool_name() == "mbtx" { return true }
+      _ => ()
+    }
+  }
+  false
 }
 
 ///|

--- a/viz/viz_test.mbt
+++ b/viz/viz_test.mbt
@@ -540,7 +540,10 @@ fn mbtx_stage_session() -> @agent_session.Session {
 test "mbtx rows name their failure stage and tag the filter hooks" {
   let raw = render(@viz.render_session(mbtx_stage_session(), RawLog))
   assert_true(raw.contains("tool-call-build-failed"))
-  assert_true(raw.contains("build error"))
+  // The build-failed CALL row appends no stage word: its own brief already
+  // reads "build failed", so a word there repeated the label verbatim. The
+  // stage word lives on the RESULT flag, whose label carries no brief.
+  assert_false(raw.contains("tool-stage tool-stage-build"))
   assert_true(raw.contains("card tool error build-failed"))
   assert_true(raw.contains("🚩 build error"))
   assert_true(raw.contains("tool-call-run-failed"))
@@ -557,6 +560,20 @@ test "mbtx rows name their failure stage and tag the filter hooks" {
   let clean = render(@viz.render_session(clean_sample_session(), RawLog))
   assert_false(clean.contains("tool-call-build-failed"))
   assert_false(clean.contains("tool-call-run-failed"))
+}
+
+///|
+/// Presence, not failure, is what makes the build-errors toolbar appear: a
+/// session that used mbtx cleanly still advertises the control, and one that
+/// never touched mbtx stays chrome-free.
+test "session_has_mbtx_activity reads calls and orphan results" {
+  assert_true(@viz.session_has_mbtx_activity(mbtx_stage_session()))
+  assert_false(@viz.session_has_mbtx_activity(clean_sample_session()))
+  let orphan_only = @agent_session.Session(
+    SessionId("orphan-only"),
+    system_prompt="",
+  ).append(Tool(ToolResult(tool_call_id="g", tool_name="mbtx", content="ok")))
+  assert_true(@viz.session_has_mbtx_activity(orphan_only))
 }
 
 ///|

--- a/web/index.html
+++ b/web/index.html
@@ -259,9 +259,14 @@
       border-bottom: 1px solid var(--border);
     }
     .sticky-toolbar .mode-row { margin-bottom: 0; }
-    .sticky-toolbar .error-bar,
-    .sticky-toolbar .escalated-bar,
-    .sticky-toolbar .build-error-bar { margin: 10px 0 0; }
+    .sticky-toolbar .filter-bars { margin: 10px 0 0; }
+    /* All filter bars share one wrapping row so the sticky toolbar keeps the
+       height the anchor offsets account for; the bars' standalone margins
+       are the container's job here. */
+    .filter-bars { display: flex; flex-wrap: wrap; align-items: center; gap: 8px 20px; }
+    .filter-bars .error-bar,
+    .filter-bars .escalated-bar,
+    .filter-bars .build-error-bar { margin: 0; }
     .mode-row {
       display: flex;
       align-items: center;

--- a/web/index.html
+++ b/web/index.html
@@ -379,6 +379,9 @@
     /* mbtx failure-stage words: a build error is a source problem (amber),
        a runtime error keeps the failure red. */
     .tool-stage-build { color: var(--warn); font-weight: 600; }
+    /* A build-failed call row says its stage through its own brief ("build
+       failed" is in the label), tinted amber — no appended word repeats it. */
+    .tool-call-build-failed .tool-call-brief { color: var(--warn); font-weight: 600; }
     .tool-stage-run { color: var(--error); font-weight: 600; }
     .tool-flag.tool-stage-build { color: var(--warn); }
 


### PR DESCRIPTION
Viz half of the dogfooding feedback (desktop half: #1172).

**De-duplication**: a build-failed call row read `· mbtx (build failed, exit=1) build error` — the word repeated the row's own brief. Call rows now append nothing; the stage rides the `tool-call-build-failed` class and the stylesheet turns the brief amber. The RESULT card keeps `🚩 build error` (its label carries no brief). The `runtime error` word stays on call rows — `exit=1` never names the stage.

**Discoverability**: `Build errors only` inherited the family's hidden-at-zero chrome rule, making it invisible on exactly the sessions you'd reach for it in. It now shows whenever the session has **any mbtx activity** (new `session_has_mbtx_activity`, counting calls and orphan results); sessions with no mbtx keep a clean toolbar; active-at-zero stays visible as before.

101/101 viz + viz_app tests (dedup pinned: no stage span adjacent to a brief; presence-driven bar visibility incl. present-and-clean, absent, and active-at-zero cases); deny-warn + fmt clean; bundle builds. `viz/pkg.generated.mbti` hand-updated (moon info skips the js-only package — pre-existing condition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Qu3wgL9g7Z9V4umSU97RD