### PR TITLE
fix(desktop): keep the stage word on result rows, whose label has no brief

### DIFF
--- a/desktop/frontend/transcript/component/mbtx.mbt
+++ b/desktop/frontend/transcript/component/mbtx.mbt
@@ -131,22 +131,33 @@ fn mbtx_failure_stage(
 }
 
 ///|
-/// The literal word beside a failed call's brief — only where it ADDS one. A
-/// build-stage brief already reads "build failed" / "build timeout" in the
-/// row's own label, so appending a marker repeated the brief verbatim
-/// ("mbtx (build failed, exit=1) build error"); those rows carry no marker
-/// and say their state through the brief itself, restyled amber by
-/// `failure_stage_class`. A runtime marker stays: "exit=1" alone does not
-/// name the stage. Every other failed call keeps the generic word.
+/// The literal word beside a failed row's label — only where it ADDS one.
+/// `brief_shown` says whether this row's label IS the brief: there a
+/// build-stage marker would repeat the label verbatim ("mbtx (build failed,
+/// exit=1) build error"), so the row says its state through the brief itself,
+/// restyled amber by `failure_stage_class`. A result row labeled
+/// "Tool error · mbtx" shows no brief, so it keeps the "build error" word —
+/// in a parallel burst the result rows sit apart from their requests, and
+/// amber alone must not carry the stage there. A runtime marker always
+/// stays: "exit=1" never names the stage. Every other failed row keeps the
+/// generic word.
 fn failure_marker(
   name : String,
   brief : String?,
   is_error : Bool,
   arguments : String?,
+  brief_shown~ : Bool,
 ) -> @html.Html? {
   guard is_error else { return None }
   match mbtx_failure_stage(name, brief, is_error, arguments) {
-    Some(BuildError) => None
+    Some(BuildError) =>
+      if brief_shown {
+        None
+      } else {
+        Some(
+          @html.span(class="tool-call-failed tool-stage-build", "build error"),
+        )
+      }
     Some(RuntimeError) =>
       Some(@html.span(class="tool-call-failed tool-stage-run", "runtime error"))
     None => Some(@html.span(class="tool-call-failed", "failed"))

--- a/desktop/frontend/transcript/component/mbtx_tests.mbt
+++ b/desktop/frontend/transcript/component/mbtx_tests.mbt
@@ -101,18 +101,25 @@ test "a failed mbtx row names its failure stage" {
     @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
   }
 
-  // A build brief already reads "build failed" in the row's own label, so no
-  // marker word is appended — the earlier appended marker made the row read
-  // "mbtx (build failed, exit=1) build error". The stage rides the container
-  // class instead, which the stylesheet turns amber.
+  // This view renders the whole exchange: a REQUEST row whose label is the
+  // brief, then a RESULT row labeled "Tool error · mbtx". The request row
+  // appends no marker — one there read "mbtx (build failed, exit=1) build
+  // error", repeating its own label — while the result row keeps the word,
+  // since its label carries no brief. So the stage word appears exactly
+  // once, and never adjacent to the brief label.
   let build = markup_for("mbtx (build failed, exit=1)", true, plain_arguments)
   assert_true(build.contains("error stage-build"))
-  assert_false(build.contains("build error"))
+  assert_false(build.contains("exit=1)</span><span class=\"tool-call-failed"))
+  assert_eq(build.split("build error").length(), 2)
+  assert_true(build.contains("Tool error · mbtx"))
   assert_false(build.contains(">failed<"))
   assert_true(build.contains("mbtx (build failed, exit=1)"))
   // Every build-phase brief shape gets the same treatment.
   let timeout_row = markup_for("mbtx (build timeout)", true, plain_arguments)
   assert_true(timeout_row.contains("error stage-build"))
+  assert_false(
+    timeout_row.contains("timeout)</span><span class=\"tool-call-failed"),
+  )
   assert_false(timeout_row.contains(">failed<"))
   // The default target is the staged wasm path, so its exit brief is a
   // run-stage claim; an explicit wasm target reads the same.
@@ -140,6 +147,32 @@ test "a failed mbtx row names its failure stage" {
   assert_true(
     markup_for("mbtx (timeout)", true, plain_arguments).contains(">failed<"),
   )
+}
+
+///|
+/// The RESULT row's label is "Tool error · mbtx" — no brief — so it keeps the
+/// "build error" word: in a parallel burst the result rows sit apart from
+/// their requests, and the amber color must not carry the stage alone there.
+#warnings("-alert_unstable")
+test "a build-failure result row keeps its stage word" {
+  let rendered = tool_result_view({
+    kind: Tool(
+      call_id="c1",
+      name="mbtx",
+      arguments=Some("{\"source\":\"fn main {  }\"}"),
+      has_result=true,
+      is_error=true,
+      brief=Some("mbtx (build failed, exit=1)"),
+    ),
+    content: "diag",
+    ts: None,
+    sequence: None,
+  })
+  let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
+  assert_true(markup.contains("Tool error · mbtx"))
+  assert_true(markup.contains("build error"))
+  assert_true(markup.contains("error stage-build"))
+  assert_false(markup.contains(">failed<"))
 }
 
 ///|

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -307,7 +307,15 @@ fn tool_request_view(item : @transcript.TranscriptItem) -> @html.Html {
     @html.span(class="tool-flow", "→"),
     @html.span(class="tool-call-text", label),
   ]
-  if failure_marker(name, brief, is_error, Some(arguments)) is Some(marker) {
+  if failure_marker(
+      name,
+      brief,
+      is_error,
+      Some(arguments),
+      // The request row's label is the brief whenever one exists.
+      brief_shown=brief is Some(brief) && !brief.is_blank(),
+    )
+    is Some(marker) {
     line.push(marker)
   }
   line.push(@plan.fold_progress([item]))
@@ -393,7 +401,17 @@ fn tool_result_view(
     @html.span(class="tool-flow", "←"),
     @html.span(class="tool-result-text", label),
   ]
-  if failure_marker(name, brief, is_error, arguments) is Some(marker) {
+  if failure_marker(
+      name,
+      brief,
+      is_error,
+      arguments,
+      // The result row shows the brief as its label only for the
+      // argument-less shape (the first `label` arm above); the common
+      // "Tool error · mbtx" label carries no brief, so the stage word stays.
+      brief_shown=arguments is None && brief is Some(brief) && !brief.is_blank(),
+    )
+    is Some(marker) {
     line.push(marker)
   }
   let body : Array[@html.Html] = []

--- a/desktop/styles/transcript.css
+++ b/desktop/styles/transcript.css
@@ -933,6 +933,10 @@
 .tool-result.error.stage-build > .tool-result-summary {
   color: var(--color-warning);
 }
+/* The result row's own "build error" word (its label shows no brief). */
+.tool-call-failed.tool-stage-build {
+  color: var(--color-warning);
+}
 
 /* Arguments and output grow the page instead of scrolling in place: the
    transcript stays the only scroll area, so the wheel is never trapped by a


### PR DESCRIPTION
Lands the review-round fix that #1172's merge raced past: the branch's second commit (`cf3f34e4e`) was pushed while GitHub's PR sync lagged, and the merge took only the first commit.

Content is exactly what #1172's verification round already reviewed **clean** (its verdict: *“consistently suppresses redundant build-stage markers only when the brief is already displayed, while preserving explicit markers on separated result rows”*): the marker is suppressed only where the row's label IS the brief (request rows); result rows — labeled `Tool error · mbtx`, no brief — keep the `build error` word, which matters in parallel bursts where results sit apart from their requests. Without this, main currently drops the marker on result rows and leaves amber color as the only stage carrier there.

457/457 desktop frontend js tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Qu3wgL9g7Z9V4umSU97RD