### PR TITLE
refactor(editor): rename Core diff to Line diff

### DIFF
--- a/desktop/frontend/fileeditor/diff_provider_policy_wbtest.mbt
+++ b/desktop/frontend/fileeditor/diff_provider_policy_wbtest.mbt
@@ -7,7 +7,7 @@ test "semantic review is available only for MoonBit source files" {
 ///|
 test "selecting a Moon semantic algorithm enters Diff view and retains policy" {
   let initial = State::empty()
-  assert_true(initial.review_diff_mode is ReviewDiffCore)
+  assert_true(initial.review_diff_mode is ReviewDiffLine)
   assert_true(initial.review_diff_ignore_comments)
   assert_true(initial.review_diff_ignore_tests)
 
@@ -26,13 +26,13 @@ test "selecting a Moon semantic algorithm enters Diff view and retains policy" {
   }
   let state = { ..owned_state(), docs, review_view_mode: ReviewSource, }
   let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path), }
-  let (_, core_unchanged) = update(
+  let (_, line_unchanged) = update(
     test_emit(),
     ToggleReviewDiffIgnoreTests,
     state,
     ctx,
   )
-  assert_true(core_unchanged == state)
+  assert_true(line_unchanged == state)
   let (_, tree) = update(
     test_emit(),
     ReviewDiffModeSelected(ReviewDiffTree),

--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -1,5 +1,5 @@
 // The embedded read-only code viewer (moonbitlang/editor). Rabbita has
-// no escape hatch for a foreign DOM widget, so the source viewer and Core
+// no escape hatch for a foreign DOM widget, so the source viewer and Line
 // full-file comparison each own a stable, never-diffed host element. The view
 // renders those hosts empty, and after the first paint each widget attaches its
 // imperative DOM. Token/Tree uses a fourth stable sibling containing keyed,

--- a/desktop/frontend/fileeditor/git_history_wbtest.mbt
+++ b/desktop/frontend/fileeditor/git_history_wbtest.mbt
@@ -219,7 +219,7 @@ test "historical tabs use only the inert diff surface and history controls" {
     render_review_control(review_diff_mode_toolbar(test_emit(), state, ctx)),
     content=(
       #|<div role="toolbar" aria-label="Comparison algorithm" class="review-mode-toolbar review-history-mode-toolbar">
-      #|<button data-diff-mode="core" aria-label="Line diff" aria-pressed="true" title="Use Line diff" type="button" class="review-mode-button active">Line</button>
+      #|<button data-diff-mode="line" aria-label="Line diff" aria-pressed="true" title="Use Line diff" type="button" class="review-mode-button active">Line</button>
       #|<button data-diff-mode="token" aria-label="Token diff" aria-pressed="false" title="Use Token diff" type="button" class="review-mode-button">Token</button>
       #|<button data-diff-mode="tree" aria-label="Tree diff" aria-pressed="false" title="Use Tree diff" type="button" class="review-mode-button">Tree</button>
       #|</div>

--- a/desktop/frontend/fileeditor/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/pkg.generated.mbti
@@ -255,6 +255,7 @@ pub(all) enum Msg {
   ReviewDiffNavigationAvailabilityChanged(Bool)
   RevealPreviousReviewDiffChange
   RevealNextReviewDiffChange
+  RevealSemanticReviewSectionChange(String, Bool)
   ToggleReviewProgress
   GitOriginalLoaded(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, generation~ : Int, background~ : Bool, original~ : @protocol.GitOriginalFileReply)
   GitOriginalFailed(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, generation~ : Int, background~ : Bool, message~ : String)
@@ -305,7 +306,7 @@ pub fn ReviewDiffLayout::equal(Self, Self) -> Bool
 pub fn ReviewDiffLayout::not_equal(Self, Self) -> Bool
 
 pub(all) enum ReviewDiffMode {
-  ReviewDiffCore
+  ReviewDiffLine
   ReviewDiffToken
   ReviewDiffTree
 } derive(Eq, @debug.Debug)
@@ -335,6 +336,7 @@ pub(all) struct SemanticReviewInput {
   mode : @moondiff.MoonDiffMode
   ignore_comments : Bool
   ignore_tests : Bool
+  feedback_file : @pathx.Relative?
   live_modified : SemanticReviewLiveDocument?
 } derive(Eq, @debug.Debug)
 pub fn SemanticReviewInput::equal(Self, Self) -> Bool

--- a/desktop/frontend/fileeditor/review_surfaces_wbtest.mbt
+++ b/desktop/frontend/fileeditor/review_surfaces_wbtest.mbt
@@ -79,7 +79,7 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
       #|<button data-review-mode="file" aria-label="File view" aria-pressed="true" title="Show file" type="button" class="review-mode-button active">File</button>
       #|<span aria-hidden="true" class="review-mode-divider">
       #|</span>
-      #|<button data-diff-mode="core" aria-label="Line diff" aria-pressed="false" title="Use Line diff" type="button" class="review-mode-button">Line</button>
+      #|<button data-diff-mode="line" aria-label="Line diff" aria-pressed="false" title="Use Line diff" type="button" class="review-mode-button">Line</button>
       #|<button data-diff-mode="token" aria-label="Token diff" aria-pressed="false" title="Use Token diff" type="button" class="review-mode-button">Token</button>
       #|<button data-diff-mode="tree" aria-label="Tree diff" aria-pressed="false" title="Use Tree diff" type="button" class="review-mode-button">Tree</button>
       #|</div>
@@ -163,7 +163,7 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
       #|<button data-review-mode="file" aria-label="File view" aria-pressed="false" title="Show file" type="button" class="review-mode-button">File</button>
       #|<span aria-hidden="true" class="review-mode-divider">
       #|</span>
-      #|<button data-diff-mode="core" aria-label="Line diff" aria-pressed="true" title="Use Line diff" type="button" class="review-mode-button active">Line</button>
+      #|<button data-diff-mode="line" aria-label="Line diff" aria-pressed="true" title="Use Line diff" type="button" class="review-mode-button active">Line</button>
       #|<button data-diff-mode="token" aria-label="Token diff" aria-pressed="false" title="Use Token diff" type="button" class="review-mode-button">Token</button>
       #|<button data-diff-mode="tree" aria-label="Tree diff" aria-pressed="false" title="Use Tree diff" type="button" class="review-mode-button">Tree</button>
       #|</div>
@@ -410,7 +410,7 @@ test "desktop explicitly routes Markdown source while DiffEditor stays code-only
 }
 
 ///|
-test "non-MoonBit review keeps File and Line on the Core surface" {
+test "non-MoonBit review keeps File and Line on the Line surface" {
   let path = @pathx.Relative("README.md")
   let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path), }
   let selected = test_modified_change(path)
@@ -452,7 +452,7 @@ test "non-MoonBit review keeps File and Line on the Core surface" {
       #|<button data-review-mode="file" aria-label="File view" aria-pressed="false" title="Show file" type="button" class="review-mode-button">File</button>
       #|<span aria-hidden="true" class="review-mode-divider">
       #|</span>
-      #|<button data-diff-mode="core" aria-label="Line diff" aria-pressed="true" title="Use Line diff" type="button" class="review-mode-button active">Line</button>
+      #|<button data-diff-mode="line" aria-label="Line diff" aria-pressed="true" title="Use Line diff" type="button" class="review-mode-button active">Line</button>
       #|</div>
     ),
   )

--- a/desktop/frontend/fileeditor/semantic_review_view.mbt
+++ b/desktop/frontend/fileeditor/semantic_review_view.mbt
@@ -34,7 +34,7 @@ fn ReviewDiffMode::semantic_mode(
   self : ReviewDiffMode,
 ) -> @moon_diff_provider.MoonDiffMode? {
   match self {
-    ReviewDiffCore => None
+    ReviewDiffLine => None
     ReviewDiffToken => Some(@moon_diff_provider.Token)
     ReviewDiffTree => Some(@moon_diff_provider.Tree)
   }
@@ -42,7 +42,7 @@ fn ReviewDiffMode::semantic_mode(
 
 ///|
 /// Extract the visible semantic comparison from either a working-tree review
-/// or Git history. Core, source mode, non-MoonBit files, and unavailable text
+/// or Git history. Line, source mode, non-MoonBit files, and unavailable text
 /// deliberately produce no input.
 fn semantic_review_input(state : State, ctx : Ctx) -> SemanticReviewInput? {
   guard state.review_diff_mode.semantic_mode() is Some(mode) else {
@@ -336,7 +336,7 @@ fn semantic_status_empty_view(
       Some(
         semantic_empty_view(
           if input.mode is @moon_diff_provider.Tree {
-            "No structural changes found. Switch to Token or Core to inspect text."
+            "No structural changes found. Switch to Token or Line to inspect text."
           } else {
             "No token changes found."
           },
@@ -348,7 +348,7 @@ fn semantic_status_empty_view(
           if input.mode is @moon_diff_provider.Tree {
             "No structural changes found. Switch to Token to view text changes."
           } else {
-            "No declaration-owned token changes found. Switch to Core to inspect the complete file."
+            "No declaration-owned token changes found. Switch to Line to inspect the complete file."
           },
         ),
       )
@@ -395,7 +395,7 @@ fn semantic_plan_view(
   }
   if sections.is_empty() {
     semantic_empty_view(
-      "No semantic section changes found. Switch to Core to inspect the complete file.",
+      "No semantic section changes found. Switch to Line to inspect the complete file.",
     )
   } else {
     @html.div(class="semantic-document", sections)
@@ -413,7 +413,7 @@ pub fn semantic_review_view(
   guard state.semantic_review_plan is Some(plan) else {
     return @html.div(class="semantic-review", [
       semantic_empty_view(
-        "The semantic result was invalid. Switch to Core to inspect the complete file.",
+        "The semantic result was invalid. Switch to Line to inspect the complete file.",
       ),
     ])
   }
@@ -549,7 +549,7 @@ fn semantic_review_navigation_subscription(
   dispatch : @cmd.Emit[Msg],
 ) -> @sub.Sub {
   guard review_diff_navigation_enabled(state, ctx) &&
-    !core_diff_ready(state, ctx) else {
+    !line_diff_ready(state, ctx) else {
     return @sub.none
   }
   @sub.custom_sub(
@@ -623,7 +623,7 @@ fn semantic_diff_options(
     render_markdown_comments=true,
     handle_mouse_wheel=false,
     // Token/Tree use the same rich, initially folded Markdown-comment
-    // presentation as ordinary code reading and Core diff. MoonDiff has already
+    // presentation as ordinary code reading and Line diff. MoonDiff has already
     // decided which sections exist, so presentation must not fall back to raw
     // `///` rows. The outer MultiDiff scroll plane owns wheel input, matching
     // VS Code's per-item `handleMouseWheel: false` configuration.
@@ -1038,7 +1038,7 @@ fn create_semantic_review_editor(
     "\{semantic_estimated_height(section, layout)}px",
   )
   let (editor, provider) = match section.diff {
-    @moon_diff_provider.SemanticReviewDiff::Core =>
+    @moon_diff_provider.SemanticReviewDiff::Line =>
       (
         @viewer.DiffEditor::create(
           host,

--- a/desktop/frontend/fileeditor/semantic_review_view_wbtest.mbt
+++ b/desktop/frontend/fileeditor/semantic_review_view_wbtest.mbt
@@ -40,7 +40,7 @@ fn semantic_test_section(
     fallbacks: [],
     original_source,
     modified_source,
-    diff: @moon_diff_provider.SemanticReviewDiff::Core,
+    diff: @moon_diff_provider.SemanticReviewDiff::Line,
   }
 }
 
@@ -244,7 +244,7 @@ test "semantic input follows active MoonBit review and ignores layout" {
   assert_eq(deleted_input.feedback_file, Some(path))
   assert_eq(deleted_input.live_modified, None)
   assert_eq(
-    semantic_review_input({ ..state, review_diff_mode: ReviewDiffCore, }, ctx),
+    semantic_review_input({ ..state, review_diff_mode: ReviewDiffLine, }, ctx),
     None,
   )
 }

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -84,7 +84,7 @@ pub(all) enum ReviewViewMode {
 } derive(Eq)
 
 ///|
-/// The layout shared by Core and sectioned semantic comparison. This
+/// The layout shared by Line and sectioned semantic comparison. This
 /// panel-level preference is independent from `ReviewViewMode`: returning to
 /// source keeps it for the next review and the next changed file.
 pub(all) enum ReviewDiffLayout {
@@ -93,11 +93,11 @@ pub(all) enum ReviewDiffLayout {
 } derive(Eq)
 
 ///|
-/// Desktop-owned comparison algorithm preference. Core keeps the complete
+/// Desktop-owned comparison algorithm preference. Line keeps the complete
 /// file DiffEditor; Token and Tree select the sectioned semantic review.
-/// Non-MoonBit comparisons keep using Core without overwriting this preference.
+/// Non-MoonBit comparisons keep using Line without overwriting this preference.
 pub(all) enum ReviewDiffMode {
-  ReviewDiffCore
+  ReviewDiffLine
   ReviewDiffToken
   ReviewDiffTree
 } derive(Eq, Debug)
@@ -399,11 +399,11 @@ pub(all) struct State {
   // not force the reviewer to request the full diff again.
   review_view_mode : ReviewViewMode
   // Side-by-side/inline is likewise a reviewer preference rather than
-  // document state. Core applies it to its retained models; Token/Tree update
+  // document state. Line applies it to its retained models; Token/Tree update
   // the DiffEditor mounted inside every semantic section.
   review_diff_layout : ReviewDiffLayout
   // The requested MoonBit-aware algorithm and filtering policy are desktop
-  // preferences. Other file types keep rendering the Core surface while
+  // preferences. Other file types keep rendering the Line surface while
   // these values remain parked for the next `.mbt` comparison.
   review_diff_mode : ReviewDiffMode
   review_diff_ignore_comments : Bool
@@ -532,7 +532,7 @@ pub fn State::empty() -> State {
     search: @grep_search.State::empty(),
     review_view_mode: ReviewDiff,
     review_diff_layout: ReviewSideBySide,
-    review_diff_mode: ReviewDiffCore,
+    review_diff_mode: ReviewDiffLine,
     // Token/Tree starts from semantic production changes. Both explicit
     // toggles can restore comments/blank lines or test blocks when needed.
     review_diff_ignore_comments: true,
@@ -835,7 +835,7 @@ pub(all) enum Msg {
   ToggleReviewDiffLayout
   // Select the desktop-owned comparison mode. Token and Tree are accepted
   // only for a visible `.mbt` comparison; other files keep the preference
-  // parked while rendering Core.
+  // parked while rendering Line.
   ReviewDiffModeSelected(ReviewDiffMode)
   ToggleReviewDiffIgnoreComments
   ToggleReviewDiffIgnoreTests

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -2303,7 +2303,7 @@ pub fn update(
     }
     ToggleReviewDiffIgnoreComments => {
       guard moon_diff_ready(state, ctx) &&
-        state.review_diff_mode != ReviewDiffCore else {
+        state.review_diff_mode != ReviewDiffLine else {
         return (@cmd.none, state)
       }
       let ignore_comments = !state.review_diff_ignore_comments
@@ -2311,7 +2311,7 @@ pub fn update(
     }
     ToggleReviewDiffIgnoreTests => {
       guard moon_diff_ready(state, ctx) &&
-        state.review_diff_mode != ReviewDiffCore else {
+        state.review_diff_mode != ReviewDiffLine else {
         return (@cmd.none, state)
       }
       let ignore_tests = !state.review_diff_ignore_tests
@@ -2340,7 +2340,7 @@ pub fn update(
       guard review_diff_navigation_enabled(state, ctx) else {
         return (@cmd.none, state)
       }
-      if core_diff_ready(state, ctx) {
+      if line_diff_ready(state, ctx) {
         (reveal_previous_review_diff_change(), state)
       } else {
         (
@@ -2357,7 +2357,7 @@ pub fn update(
       guard review_diff_navigation_enabled(state, ctx) else {
         return (@cmd.none, state)
       }
-      if core_diff_ready(state, ctx) {
+      if line_diff_ready(state, ctx) {
         (reveal_next_review_diff_change(), state)
       } else {
         (
@@ -2371,7 +2371,7 @@ pub fn update(
       }
     }
     RevealSemanticReviewSectionChange(key, reveal_last) => {
-      guard !core_diff_ready(state, ctx) &&
+      guard !line_diff_ready(state, ctx) &&
         semantic_sections(state.semantic_review_plan).any(section => {
           section.key == key
         }) else {

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -310,7 +310,7 @@ pub fn body_view(
   ctx : Ctx,
   semantic_review? : @html.Html = @html.nothing,
 ) -> @html.Html {
-  // The stable elements the code Viewer, MarkdownViewer, and switchable Core
+  // The stable elements the code Viewer, MarkdownViewer, and switchable Line
   // DiffEditor attach their imperative DOM into. Semantic review owns keyed
   // empty child hosts under its stable sibling.
   // (see editor_panel.mbt).
@@ -340,7 +340,7 @@ pub fn body_view(
       None => false
     })
   let use_semantic_surface = use_diff_surface &&
-    state.review_diff_mode != ReviewDiffCore &&
+    state.review_diff_mode != ReviewDiffLine &&
     (match ctx.active_history_diff {
       Some(diff) => supports_moon_diff(diff.path.0)
       None =>
@@ -1896,20 +1896,20 @@ fn moon_diff_ready(state : State, ctx : Ctx) -> Bool {
 }
 
 ///|
-/// Whether the visible comparison is the complete Core DiffEditor. A parked
+/// Whether the visible comparison is the complete Line DiffEditor. A parked
 /// Token/Tree preference does not affect non-MoonBit files, which always keep
-/// the Core surface.
-fn core_diff_ready(state : State, ctx : Ctx) -> Bool {
+/// the Line surface.
+fn line_diff_ready(state : State, ctx : Ctx) -> Bool {
   full_diff_ready(state, ctx) &&
-  (state.review_diff_mode == ReviewDiffCore || !moon_diff_ready(state, ctx))
+  (state.review_diff_mode == ReviewDiffLine || !moon_diff_ready(state, ctx))
 }
 
 ///|
-/// Core receives availability from its mounted provider. Token/Tree plans are
+/// Line receives availability from its mounted provider. Token/Tree plans are
 /// already nonempty change documents, so their aggregate navigation is ready
 /// once at least one semantic item exists.
 fn review_diff_navigation_enabled(state : State, ctx : Ctx) -> Bool {
-  if core_diff_ready(state, ctx) {
+  if line_diff_ready(state, ctx) {
     state.review_diff_navigation_available
   } else {
     full_diff_ready(state, ctx) &&
@@ -1920,7 +1920,7 @@ fn review_diff_navigation_enabled(state : State, ctx : Ctx) -> Bool {
 ///|
 fn ReviewDiffMode::label(self : ReviewDiffMode) -> String {
   match self {
-    ReviewDiffCore => "Line"
+    ReviewDiffLine => "Line"
     ReviewDiffToken => "Token"
     ReviewDiffTree => "Tree"
   }
@@ -1929,7 +1929,7 @@ fn ReviewDiffMode::label(self : ReviewDiffMode) -> String {
 ///|
 fn ReviewDiffMode::attribute(self : ReviewDiffMode) -> String {
   match self {
-    ReviewDiffCore => "core"
+    ReviewDiffLine => "line"
     ReviewDiffToken => "token"
     ReviewDiffTree => "tree"
   }
@@ -1994,10 +1994,10 @@ fn review_mode_toolbar(
       "",
     ),
     review_diff_mode_button(
-      ReviewDiffCore,
-      diff && (!moon || state.review_diff_mode == ReviewDiffCore),
+      ReviewDiffLine,
+      diff && (!moon || state.review_diff_mode == ReviewDiffLine),
       if moon {
-        dispatch(ReviewDiffModeSelected(ReviewDiffCore))
+        dispatch(ReviewDiffModeSelected(ReviewDiffLine))
       } else if diff {
         @cmd.none
       } else {
@@ -2046,9 +2046,9 @@ fn review_diff_mode_toolbar(
       .aria_label("Comparison algorithm"),
     [
       review_diff_mode_button(
-        ReviewDiffCore,
-        state.review_diff_mode == ReviewDiffCore,
-        dispatch(ReviewDiffModeSelected(ReviewDiffCore)),
+        ReviewDiffLine,
+        state.review_diff_mode == ReviewDiffLine,
+        dispatch(ReviewDiffModeSelected(ReviewDiffLine)),
       ),
       review_diff_mode_button(
         ReviewDiffToken,
@@ -2074,7 +2074,7 @@ fn review_comments_control(
     return @html.span(class="review-comments-control hidden", "")
   }
   let enabled = full_diff_ready(state, ctx) &&
-    state.review_diff_mode != ReviewDiffCore
+    state.review_diff_mode != ReviewDiffLine
   @html.button(
     type_="button",
     class=if enabled && state.review_diff_ignore_comments {
@@ -2084,7 +2084,7 @@ fn review_comments_control(
     },
     title=if !full_diff_ready(state, ctx) {
       "Available in diff view"
-    } else if state.review_diff_mode == ReviewDiffCore {
+    } else if state.review_diff_mode == ReviewDiffLine {
       "Available in Token and Tree diff"
     } else if state.review_diff_ignore_comments {
       "Include comments in the comparison"
@@ -2114,7 +2114,7 @@ fn review_tests_control(
     return @html.span(class="review-tests-control hidden", "")
   }
   let enabled = full_diff_ready(state, ctx) &&
-    state.review_diff_mode != ReviewDiffCore
+    state.review_diff_mode != ReviewDiffLine
   @html.button(
     type_="button",
     class=if enabled && state.review_diff_ignore_tests {
@@ -2124,7 +2124,7 @@ fn review_tests_control(
     },
     title=if !full_diff_ready(state, ctx) {
       "Available in diff view"
-    } else if state.review_diff_mode == ReviewDiffCore {
+    } else if state.review_diff_mode == ReviewDiffLine {
       "Available in Token and Tree diff"
     } else if state.review_diff_ignore_tests {
       "Include tests in the comparison"
@@ -2193,7 +2193,7 @@ fn review_diff_navigation(
 }
 
 ///|
-/// Core keeps its two models mounted while Token/Tree reuse one section plan;
+/// Line keeps its two models mounted while Token/Tree reuse one section plan;
 /// this explicit pair changes either presentation. File mode preserves the
 /// preference but disables both choices until the next review reveal.
 fn review_diff_layout_toggle(

--- a/editor/internal/viewer/code_editor_widget/quick_diff_host_wbtest.mbt
+++ b/editor/internal/viewer/code_editor_widget/quick_diff_host_wbtest.mbt
@@ -1,5 +1,5 @@
 // Headless end-to-end tests for the quick-diff contribution: service
-// original → Core-diff-backed computer → gutter decorations on the model,
+// original → Line-diff-backed computer → gutter decorations on the model,
 // through the registered `quickDiff.decorator` contribution.
 
 ///|

--- a/editor/internal/viewer/contrib/quick_diff/browser/quick_diff_model.mbt
+++ b/editor/internal/viewer/contrib/quick_diff/browser/quick_diff_model.mbt
@@ -4,7 +4,7 @@
 // resource, so the source's reference-counted per-resource model (throttled
 // recompute, provider merge, `compareChanges` sort) collapses to
 // `compute_changes` — the `_diff` method's pipeline (`quickDiffModel.ts:348`:
-// `editorWorkerService.computeDiff`) over the Core-diff-backed default computer.
+// `editorWorkerService.computeDiff`) over the Line-diff-backed default computer.
 // The decoration layer consumes its detailed line mappings directly, so the
 // source's intermediate line-change re-encoding is unnecessary.
 //
@@ -19,14 +19,14 @@
 /// line-level changes between the original document and the modified one.
 /// The trim-whitespace default mirrors
 /// `scm.diffDecorationsIgnoreTrimWhitespace`'s `'false'` default
-/// (`scm.contribution.ts:239`). The local Core provider is synchronous and
+/// (`scm.contribution.ts:239`). The local Line provider is synchronous and
 /// has no wall-clock budget option.
 pub fn compute_changes(
   original_lines : Array[String],
   modified_lines : Array[String],
   ignore_trim_whitespace? : Bool = false,
 ) -> Array[@diff.DetailedLineRangeMapping] {
-  @diff.CoreDocumentDiffProvider().compute_diff(
+  @diff.LineDocumentDiffProvider().compute_diff(
     TextSnapshot(original_lines.join("\n")),
     TextSnapshot(modified_lines.join("\n")),
     { ignore_trim_whitespace, },

--- a/editor/internal/viewer/contrib/quick_diff/common/quick_diff_wbtest.mbt
+++ b/editor/internal/viewer/contrib/quick_diff/common/quick_diff_wbtest.mbt
@@ -3,7 +3,7 @@ fn test_change(
   original : Array[String],
   modified : Array[String],
 ) -> @diff.DetailedLineRangeMapping raise {
-  let changes = @diff.CoreDocumentDiffProvider().compute_diff(
+  let changes = @diff.LineDocumentDiffProvider().compute_diff(
       TextSnapshot(original.join("\n")),
       TextSnapshot(modified.join("\n")),
       { ignore_trim_whitespace: false, },

--- a/editor/internal/viewer/diff_editor/view_model_wbtest.mbt
+++ b/editor/internal/viewer/diff_editor/view_model_wbtest.mbt
@@ -386,8 +386,8 @@ test "DiffEditorViewModel converts provider errors and invalid mappings to Faile
 }
 
 ///|
-test "validator accepts Core inner anchors on empty hunk sides" {
-  let provider = @diff.get_core_document_diff_provider()
+test "validator accepts Line inner anchors on empty hunk sides" {
+  let provider = @diff.get_line_document_diff_provider()
   let original = @model.TextSnapshot(
     [
       "fn navigation_anchors() {", "  let stable_head = 0", "  let deleted_only = 1",
@@ -444,7 +444,7 @@ test "validator accepts Core inner anchors on empty hunk sides" {
 ///|
 test "ViewModel accepts pinned newline mapping for a pure deletion" {
   let timer = DiffViewModelFakeTimer::DiffViewModelFakeTimer()
-  let provider = @diff.get_core_document_diff_provider()
+  let provider = @diff.get_line_document_diff_provider()
   let view_model = new_diff_view_model_for_test(provider, timer)
   let original = diff_view_model_test_model(
     "newline-deletion-original", "deleted\n\nkeep",
@@ -475,7 +475,7 @@ test "ViewModel accepts pinned newline mapping for a pure deletion" {
 ///|
 test "ViewModel accepts pinned newline mapping for a pure insertion" {
   let timer = DiffViewModelFakeTimer::DiffViewModelFakeTimer()
-  let provider = @diff.get_core_document_diff_provider()
+  let provider = @diff.get_line_document_diff_provider()
   let view_model = new_diff_view_model_for_test(provider, timer)
   let original = diff_view_model_test_model(
     "newline-insertion-original", "\nkeep",

--- a/editor/tests/browser/moonbit/component/diff_editor_lifecycle_scenario.mbt
+++ b/editor/tests/browser/moonbit/component/diff_editor_lifecycle_scenario.mbt
@@ -129,7 +129,7 @@ fn run_diff_editor_lifecycle_test() -> Unit {
   host.set_attribute("class", "diff-lifecycle-host")
   host.set_attribute("style", "width:700px;height:420px;")
   app.append_child(host.as_node())
-  let provider = @diff.CoreDocumentDiffProvider()
+  let provider = @diff.LineDocumentDiffProvider()
   let provider_object : &@diff.DocumentDiffProvider = provider
   let failing_provider = FailingDiffLifecycleProvider::FailingDiffLifecycleProvider()
   let failing_provider_object : &@diff.DocumentDiffProvider = failing_provider

--- a/editor/viewer/README.mbt.md
+++ b/editor/viewer/README.mbt.md
@@ -98,8 +98,8 @@ Hosts own every `TextModel`, DOM host, and explicitly supplied
 
 ## Diff editor contract
 
-`DiffEditor` accepts a synchronous `DocumentDiffProvider`. The default provider
-uses the Core Myers implementation in `viewer/common/diff`. A diff result has
+`DiffEditor` accepts a synchronous `DocumentDiffProvider`. The default line-diff
+provider lives in `viewer/common/diff`. A diff result has
 two distinct inputs:
 
 - `changes` drive decorations, overview markers, and change navigation; and

--- a/editor/viewer/common/diff/README.mbt.md
+++ b/editor/viewer/common/diff/README.mbt.md
@@ -24,7 +24,7 @@ let strict_options : @diff.DocumentDiffOptions = {
 
 ///|
 test "an edited line maps original and modified ranges" {
-  let result = @diff.get_core_document_diff_provider().compute_diff(
+  let result = @diff.get_line_document_diff_provider().compute_diff(
     TextSnapshot("fn main {\n  println(1)\n}"),
     TextSnapshot("fn main {\n  println(2)\n}"),
     strict_options,
@@ -42,7 +42,7 @@ range. Identical inputs produce no changes.
 ```mbt check
 ///|
 test "insertions keep half-open line-range semantics" {
-  let inserted = @diff.get_core_document_diff_provider().compute_diff(
+  let inserted = @diff.get_line_document_diff_provider().compute_diff(
     TextSnapshot("a\nc"),
     TextSnapshot("a\nb\nc"),
     strict_options,
@@ -53,9 +53,9 @@ test "insertions keep half-open line-range semantics" {
 }
 ```
 
-## Advanced readability core
+## Advanced line diff
 
-`CoreDocumentDiffProvider` keeps its established public name and
+`LineDocumentDiffProvider` exposes the built-in line-diff implementation and
 `DocumentDiff` contract, but its private pipeline ports the readability-critical
 parts of VS Code's Advanced diff from pinned revision
 `07c20d96cf3f2cbc8142ac7079ba9048cf7f6134`. The port mode is
@@ -88,7 +88,7 @@ option: providers expose only semantics they implement.
 ```mbt check
 ///|
 test "trim whitespace can ignore re-indentation" {
-  let provider = @diff.CoreDocumentDiffProvider()
+  let provider = @diff.LineDocumentDiffProvider()
   let original = @model.TextSnapshot("fn main {\nprintln(1)\n}")
   let modified = @model.TextSnapshot("fn main {\n  println(1)\n}")
   let strict = provider.compute_diff(original, modified, strict_options)

--- a/editor/viewer/common/diff/advanced_diff_reference_wbtest.mbt
+++ b/editor/viewer/common/diff/advanced_diff_reference_wbtest.mbt
@@ -11,7 +11,7 @@
 
 ///|
 fn advanced_compute(original : String, modified : String) -> DocumentDiff {
-  get_core_document_diff_provider().compute_diff(
+  get_line_document_diff_provider().compute_diff(
     TextSnapshot(original),
     TextSnapshot(modified),
     { ignore_trim_whitespace: false, },

--- a/editor/viewer/common/diff/default_lines_diff_computer.mbt
+++ b/editor/viewer/common/diff/default_lines_diff_computer.mbt
@@ -6,12 +6,12 @@
 
 ///|
 /// Stateless built-in document diff provider.
-pub struct CoreDocumentDiffProvider {
+pub struct LineDocumentDiffProvider {
   _unit : Unit
 } derive(Eq, Debug)
 
 ///|
-pub fn CoreDocumentDiffProvider::CoreDocumentDiffProvider() -> CoreDocumentDiffProvider {
+pub fn LineDocumentDiffProvider::LineDocumentDiffProvider() -> LineDocumentDiffProvider {
   { _unit: (), }
 }
 
@@ -25,8 +25,8 @@ fn snapshot_lines(snapshot : @model.TextSnapshot) -> Array[String] {
 }
 
 ///|
-pub fn CoreDocumentDiffProvider::compute_diff(
-  self : CoreDocumentDiffProvider,
+pub fn LineDocumentDiffProvider::compute_diff(
+  self : LineDocumentDiffProvider,
   original : @model.TextSnapshot,
   modified : @model.TextSnapshot,
   options : DocumentDiffOptions,
@@ -39,8 +39,8 @@ pub fn CoreDocumentDiffProvider::compute_diff(
 }
 
 ///|
-fn CoreDocumentDiffProvider::compute_lines_diff(
-  self : CoreDocumentDiffProvider,
+fn LineDocumentDiffProvider::compute_lines_diff(
+  self : LineDocumentDiffProvider,
   original_lines : Array[String],
   modified_lines : Array[String],
   options : DocumentDiffOptions,
@@ -119,7 +119,7 @@ fn CoreDocumentDiffProvider::compute_lines_diff(
 }
 
 ///|
-pub impl DocumentDiffProvider for CoreDocumentDiffProvider with fn compute_diff(
+pub impl DocumentDiffProvider for LineDocumentDiffProvider with fn compute_diff(
   self,
   original,
   modified,
@@ -129,7 +129,7 @@ pub impl DocumentDiffProvider for CoreDocumentDiffProvider with fn compute_diff(
 }
 
 ///|
-pub impl DocumentDiffProvider for CoreDocumentDiffProvider with fn on_did_change(
+pub impl DocumentDiffProvider for LineDocumentDiffProvider with fn on_did_change(
   _self,
   _listener,
 ) {
@@ -137,10 +137,10 @@ pub impl DocumentDiffProvider for CoreDocumentDiffProvider with fn on_did_change
 }
 
 ///|
-pub extend CoreDocumentDiffProvider with Debug::{to_repr}
+pub extend LineDocumentDiffProvider with Debug::{to_repr}
 
 ///|
-pub extend CoreDocumentDiffProvider with Eq::{equal, not_equal}
+pub extend LineDocumentDiffProvider with Eq::{equal, not_equal}
 
 ///|
-pub extend CoreDocumentDiffProvider with DocumentDiffProvider::{on_did_change}
+pub extend LineDocumentDiffProvider with DocumentDiffProvider::{on_did_change}

--- a/editor/viewer/common/diff/default_lines_diff_computer_wbtest.mbt
+++ b/editor/viewer/common/diff/default_lines_diff_computer_wbtest.mbt
@@ -1,4 +1,4 @@
-// White-box behavior tests for `CoreDocumentDiffProvider`.
+// White-box behavior tests for `LineDocumentDiffProvider`.
 //
 // These local contract/property cases complement the traceable Advanced-diff
 // cases in `advanced_diff_reference_wbtest.mbt`. They do not byte-compare every
@@ -18,7 +18,7 @@ fn compute(
   modified : Array[String],
   options? : DocumentDiffOptions = default_options,
 ) -> DocumentDiff {
-  get_core_document_diff_provider().compute_diff(
+  get_line_document_diff_provider().compute_diff(
     TextSnapshot(original.join("\n")),
     TextSnapshot(modified.join("\n")),
     options,
@@ -36,9 +36,9 @@ fn compute_with_provider(
 }
 
 ///|
-test "Core provider satisfies the public provider contract" {
-  let core = CoreDocumentDiffProvider()
-  let provider : &DocumentDiffProvider = core
+test "Line provider satisfies the public provider contract" {
+  let line = LineDocumentDiffProvider()
+  let provider : &DocumentDiffProvider = line
   let result = try! compute_with_provider(
     provider,
     TextSnapshot("same\nbefore"),
@@ -312,7 +312,7 @@ test "trim whitespace treats whitespace-only and empty documents as equal" {
 
 ///|
 test "snapshot normalization makes CRLF and LF equal" {
-  let provider = CoreDocumentDiffProvider()
+  let provider = LineDocumentDiffProvider()
   let result = provider.compute_diff(
     TextSnapshot("one\r\ntwo\r\n"),
     TextSnapshot("one\ntwo\n"),

--- a/editor/viewer/common/diff/document_diff_validation.mbt
+++ b/editor/viewer/common/diff/document_diff_validation.mbt
@@ -311,7 +311,7 @@ fn valid_document_diff(
 /// Canonicalize a provider result and accept it only when every mapping follows
 /// the shared document-diff invariants. Optional providers should use this
 /// helper before settling a specialized mode so rejected output can fall back
-/// to Core; the DiffEditor calls it again as the final consumer boundary.
+/// to Line; the DiffEditor calls it again as the final consumer boundary.
 pub fn normalize_and_validate_document_diff(
   result : DocumentDiff,
   original : @model.TextSnapshot,

--- a/editor/viewer/common/diff/inner_changes.mbt
+++ b/editor/viewer/common/diff/inner_changes.mbt
@@ -1,4 +1,4 @@
-// Character-level refinement for one line-level diff hunk. Core diff compares
+// Character-level refinement for one line-level diff hunk. Line diff compares
 // Unicode scalar values so a supplementary character remains atomic, while
 // the parallel boundary table retains the Viewer's one-based UTF-16 columns.
 // Newline sentinels let matching continue across a multi-line replacement.

--- a/editor/viewer/common/diff/lines_diff_computers.mbt
+++ b/editor/viewer/common/diff/lines_diff_computers.mbt
@@ -3,6 +3,6 @@
 // DiffEditor boundary.
 
 ///|
-pub fn get_core_document_diff_provider() -> CoreDocumentDiffProvider {
-  CoreDocumentDiffProvider()
+pub fn get_line_document_diff_provider() -> LineDocumentDiffProvider {
+  LineDocumentDiffProvider()
 }

--- a/editor/viewer/common/diff/pkg.generated.mbti
+++ b/editor/viewer/common/diff/pkg.generated.mbti
@@ -8,24 +8,13 @@ import {
 }
 
 // Values
-pub fn get_core_document_diff_provider() -> CoreDocumentDiffProvider
+pub fn get_line_document_diff_provider() -> LineDocumentDiffProvider
 
 pub fn normalize_and_validate_document_diff(DocumentDiff, @model.TextSnapshot, @model.TextSnapshot) -> DocumentDiff?
 
 // Errors
 
 // Types and methods
-pub struct CoreDocumentDiffProvider {
-  _unit : Unit
-} derive(Eq, @debug.Debug)
-pub fn CoreDocumentDiffProvider::CoreDocumentDiffProvider() -> Self
-pub fn CoreDocumentDiffProvider::compute_diff(Self, @model.TextSnapshot, @model.TextSnapshot, DocumentDiffOptions) -> DocumentDiff
-pub fn CoreDocumentDiffProvider::equal(Self, Self) -> Bool
-pub fn CoreDocumentDiffProvider::not_equal(Self, Self) -> Bool
-pub fn CoreDocumentDiffProvider::on_did_change(Self, () -> Unit) -> @common.Disposable
-pub fn CoreDocumentDiffProvider::to_repr(Self) -> @debug.Repr
-pub impl DocumentDiffProvider for CoreDocumentDiffProvider
-
 pub(all) struct DetailedLineRangeMapping {
   original : @common.LineRange
   modified : @common.LineRange
@@ -52,6 +41,17 @@ pub(all) struct DocumentDiffOptions {
 pub fn DocumentDiffOptions::equal(Self, Self) -> Bool
 pub fn DocumentDiffOptions::not_equal(Self, Self) -> Bool
 pub fn DocumentDiffOptions::to_repr(Self) -> @debug.Repr
+
+pub struct LineDocumentDiffProvider {
+  _unit : Unit
+} derive(Eq, @debug.Debug)
+pub fn LineDocumentDiffProvider::LineDocumentDiffProvider() -> Self
+pub fn LineDocumentDiffProvider::compute_diff(Self, @model.TextSnapshot, @model.TextSnapshot, DocumentDiffOptions) -> DocumentDiff
+pub fn LineDocumentDiffProvider::equal(Self, Self) -> Bool
+pub fn LineDocumentDiffProvider::not_equal(Self, Self) -> Bool
+pub fn LineDocumentDiffProvider::on_did_change(Self, () -> Unit) -> @common.Disposable
+pub fn LineDocumentDiffProvider::to_repr(Self) -> @debug.Repr
+pub impl DocumentDiffProvider for LineDocumentDiffProvider
 
 pub(all) struct LineRangeMapping {
   original : @common.LineRange

--- a/editor/viewer/common/diff/range_mapping.mbt
+++ b/editor/viewer/common/diff/range_mapping.mbt
@@ -1,4 +1,4 @@
-// Renderer-neutral mapping values used by both the built-in Core provider and
+// Renderer-neutral mapping values used by both the built-in Line provider and
 // external providers. They intentionally expose their representation: a
 // provider package must be able to construct validated output without a
 // viewer-layer adapter.

--- a/editor/viewer/diff_editor_facade.mbt
+++ b/editor/viewer/diff_editor_facade.mbt
@@ -155,7 +155,7 @@ fn DiffEditorOptions::internal(
 /// directly owns two CodeEditorWidget kernels and the shared diff ViewModel.
 struct DiffEditor {
   widget : @diff_editor.DiffEditorWidget
-  owned_core_provider : @diff.CoreDocumentDiffProvider?
+  owned_line_provider : @diff.LineDocumentDiffProvider?
 }
 
 ///|
@@ -165,12 +165,12 @@ pub fn DiffEditor::create(
   options? : DiffEditorOptions = DiffEditorOptions::default(),
   provider? : &@diff.DocumentDiffProvider,
 ) -> DiffEditor {
-  let (provider, owned_core_provider) = match provider {
+  let (provider, owned_line_provider) = match provider {
     Some(provider) => (provider, None)
     None => {
-      let core = @diff.CoreDocumentDiffProvider()
-      let provider : &@diff.DocumentDiffProvider = core
-      (provider, Some(core))
+      let line = @diff.LineDocumentDiffProvider()
+      let provider : &@diff.DocumentDiffProvider = line
+      (provider, Some(line))
     }
   }
   let widget = match services {
@@ -190,7 +190,7 @@ pub fn DiffEditor::create(
         options=options.internal(),
       )
   }
-  { widget, owned_core_provider, }
+  { widget, owned_line_provider, }
 }
 
 ///|
@@ -339,9 +339,9 @@ pub fn DiffEditor::focus(self : DiffEditor) -> Unit {
 ///|
 pub fn DiffEditor::dispose(self : DiffEditor) -> Unit {
   self.widget.dispose()
-  // The empty Core provider has no disposal work; touching the field here
+  // The empty Line provider has no disposal work; touching the field here
   // documents and preserves its lifetime until after the ViewModel is gone.
-  match self.owned_core_provider {
+  match self.owned_line_provider {
     Some(_) => ()
     None => ()
   }

--- a/editor/viewer/diff_provider/moondiff/pkg.generated.mbti
+++ b/editor/viewer/diff_provider/moondiff/pkg.generated.mbti
@@ -15,7 +15,7 @@ pub fn compute_sectioned_semantic_review_plan(String, String, MoonDiffMode, old_
 
 // Types and methods
 pub(all) enum MoonDiffMode {
-  Core
+  Line
   Token
   Tree
 } derive(Eq, @debug.Debug)
@@ -42,7 +42,7 @@ pub fn SectionedSemanticReviewPlan::not_equal(Self, Self) -> Bool
 pub fn SectionedSemanticReviewPlan::to_repr(Self) -> @debug.Repr
 
 pub(all) enum SemanticReviewDiff {
-  Core
+  Line
   Fragment(@diff.DocumentDiff)
 } derive(Eq, @debug.Debug)
 pub fn SemanticReviewDiff::equal(Self, Self) -> Bool

--- a/editor/viewer/diff_provider/moondiff/provider.mbt
+++ b/editor/viewer/diff_provider/moondiff/provider.mbt
@@ -1,9 +1,9 @@
 ///|
-/// MoonDiff mode selected by the desktop review host. Core is intentionally
-/// absent from the fragment provider below: Core continues to use the normal
+/// MoonDiff mode selected by the desktop review host. Line is intentionally
+/// absent from the fragment provider below: Line continues to use the normal
 /// full-file DiffEditor provider.
 pub(all) enum MoonDiffMode {
-  Core
+  Line
   Token
   Tree
 } derive(Eq, Debug)

--- a/editor/viewer/diff_provider/moondiff/semantic_review_plan.mbt
+++ b/editor/viewer/diff_provider/moondiff/semantic_review_plan.mbt
@@ -25,10 +25,10 @@ pub(all) enum SemanticReviewSectionKind {
 
 ///|
 /// The provider used inside one section DiffEditor. Inserted and deleted
-/// declarations use Core because one model is intentionally empty; matched
+/// declarations use Line because one model is intentionally empty; matched
 /// and whole fragments retain MoonDiff's local intraline result.
 pub(all) enum SemanticReviewDiff {
-  Core
+  Line
   Fragment(@diff.DocumentDiff)
 } derive(Eq, Debug)
 
@@ -185,7 +185,7 @@ fn section_diff(
   one_sided : Bool,
 ) -> SemanticReviewDiff? {
   if one_sided {
-    return Some(Core)
+    return Some(Line)
   }
   fragment_document_diff(fragment.document, original_source, modified_source).map(diff => {
       Fragment(diff)
@@ -381,7 +381,7 @@ fn top_level_plan(
 
 ///|
 /// Compute section ownership and fragment-local DiffEditor inputs for Token or
-/// Tree mode. Core remains the ordinary full-file DiffEditor path.
+/// Tree mode. Line remains the ordinary full-file DiffEditor path.
 pub fn compute_sectioned_semantic_review_plan(
   old_source : String,
   new_source : String,
@@ -392,7 +392,7 @@ pub fn compute_sectioned_semantic_review_plan(
   ignore_tests? : Bool = true,
 ) -> SectionedSemanticReviewPlan? {
   let diff_mode = match mode {
-    Core => return None
+    Line => return None
     Token => @mbtdiff.DiffMode::Lexical
     Tree => Ast
   }

--- a/editor/viewer/diff_provider/moondiff/semantic_review_plan_wbtest.mbt
+++ b/editor/viewer/diff_provider/moondiff/semantic_review_plan_wbtest.mbt
@@ -20,9 +20,9 @@ fn semantic_plan_or_fail(
 }
 
 ///|
-test "Core remains the ordinary full-file DiffEditor path" {
+test "Line remains the ordinary full-file DiffEditor path" {
   assert_eq(
-    compute_sectioned_semantic_review_plan("fn old() {}", "fn new() {}", Core),
+    compute_sectioned_semantic_review_plan("fn old() {}", "fn new() {}", Line),
     None,
   )
 }
@@ -56,7 +56,7 @@ test "insertions and deletions retain separate source slices" {
   assert_eq(inserted.modified_source, "fn inserted() {}")
   assert_eq(inserted.old_range, None)
   assert_eq(inserted.new_range, Some({ start_line_number: 1, line_count: 1, }))
-  assert_true(inserted.diff is Core)
+  assert_true(inserted.diff is Line)
 
   guard plan.deleted_sections is [deleted] else {
     fail("expected one deleted section")
@@ -66,7 +66,7 @@ test "insertions and deletions retain separate source slices" {
   assert_eq(deleted.modified_source, "")
   assert_eq(deleted.old_range, Some({ start_line_number: 2, line_count: 1, }))
   assert_eq(deleted.new_range, None)
-  assert_true(deleted.diff is Core)
+  assert_true(deleted.diff is Line)
 }
 
 ///|


### PR DESCRIPTION
## Summary

- Rename the review UI full-file Core diff mode to Line diff alongside Token and Tree.
- Rename the built-in document diff provider and related desktop/editor APIs to match the Line terminology.
- Update docs, generated interfaces, and tests for the new names while retaining the moonbitlang/core/diff dependency name.

## Testing

- just check
- just test
- just build
- just editor-test
- just editor-test-browser