### PR TITLE
feat(mbtx): admit moon search and teach it in the default prompt

### DIFF
--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -1336,8 +1336,8 @@ fn description(
     #|These, and nothing else:
     #|
     #|- `moon` — check, test, build, bench, run, fmt, info, add, remove, update,
-    #|  install, tree, clean, new, ide, doc, explain, coverage, cram, package,
-    #|  version, plus `publish --dry-run`. (Not plain `publish`, `login` or `register`.)
+    #|  install, tree, search, clean, new, ide, doc, explain, coverage, cram,
+    #|  package, version, plus `publish --dry-run`. (Not plain `publish`, `login` or `register`.)
     #|- `proton_cli` — `--version`, `--help`, new, dev, build, package, doctor,
     #|  cef, and updater. Set `Cmd.cwd` for the project directory; the global
     #|  `-C`/`--cwd` options before the subcommand are refused.

--- a/agent_tool/mbtx/mbtx_test.mbt
+++ b/agent_tool/mbtx/mbtx_test.mbt
@@ -416,6 +416,7 @@ async test "the spawn allowlist discriminates between subcommands" {
       #|  println("reconfigured: \{probe("git", ["-c", "core.pager=cat", "status"])}")
       #|  println("moon-version-flag: \{probe("moon", ["--version"])}")
       #|  println("moon-package: \{probe("moon", ["package"])}")
+      #|  println("moon-search: \{probe("moon", ["search", "--help"])}")
       #|  println("moon-bench: \{probe("moon", ["bench"])}")
       #|  println("moon-publish-dry-run: \{probe("moon", ["publish", "--dry-run"])}")
       #|  println("moon-publish: \{probe("moon", ["publish"])}")
@@ -445,6 +446,9 @@ async test "the spawn allowlist discriminates between subcommands" {
   // `package` and the non-publishing validation form may start, while plain
   // `publish` still matches no prefix. `just` has likewise left the surface.
   assert_true(out.content.contains("moon-package: ran"))
+  // Registry search is admitted; `--help` keeps the probe off the network,
+  // since only starting the process is under test.
+  assert_true(out.content.contains("moon-search: ran"))
   assert_true(out.content.contains("moon-bench: ran"))
   assert_true(out.content.contains("moon-publish-dry-run: ran"))
   assert_true(out.content.contains("moon-publish: refused"))

--- a/agent_tool/mbtx/wasm_policy.mbt
+++ b/agent_tool/mbtx/wasm_policy.mbt
@@ -50,6 +50,9 @@ let spawnable_commands : Array[(String, Array[String])] = [
   ("moon", ["update"]),
   ("moon", ["install"]),
   ("moon", ["tree"]),
+  // Registry keyword search: read-only, and the natural first step before
+  // `moon add` when the module name is not known yet.
+  ("moon", ["search"]),
   ("moon", ["clean"]),
   ("moon", ["new"]),
   ("moon", ["ide"]),

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -85,9 +85,9 @@ Use `@shell.Cmd` to run an external program and capture its output. Only
 these programs can be started:
 
 - `moon` — check, test, build, bench, run, fmt, info, add, remove, update,
-  install, tree, clean, new, ide, doc, explain, coverage, cram, package,
-  version, plus `publish --dry-run`. (Not plain `publish`, `login` or
-  `register`.)
+  install, tree, search, clean, new, ide, doc, explain, coverage, cram,
+  package, version, plus `publish --dry-run`. (Not plain `publish`, `login`
+  or `register`.)
 - `proton_cli` — `--version`, `--help`, new, dev, build, package, doctor,
   cef, and updater. Set `Cmd.cwd` for the project directory; the global
   `-C`/`--cwd` options before the subcommand are refused.
@@ -257,6 +257,11 @@ tools that rewrite source as their job (`moon fmt`, `moon info`,
   dependencies and package registry/dependency inspection. Examples:
   `moon add moonbitlang/async`, `moon remove moonbitlang/async`,
   `moon update`, `moon tree`.
+- `moon search`: search the package registry for modules by keyword when
+  the exact module name is not known yet; then add the chosen module with
+  `moon add`. Examples: `moon search base64`,
+  `moon search json --limit 5 --json` (`--json` prints one result set as
+  JSON for parsing).
 - `moon clean`: clear `_build` when stale build output is suspected.
   Example: `moon clean`.
 - `moon bench`: run benchmarks, e.g. `moon bench lib/parser`.

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -90,9 +90,9 @@ fn default_prompt() -> String {
     #|these programs can be started:
     #|
     #|- `moon` — check, test, build, bench, run, fmt, info, add, remove, update,
-    #|  install, tree, clean, new, ide, doc, explain, coverage, cram, package,
-    #|  version, plus `publish --dry-run`. (Not plain `publish`, `login` or
-    #|  `register`.)
+    #|  install, tree, search, clean, new, ide, doc, explain, coverage, cram,
+    #|  package, version, plus `publish --dry-run`. (Not plain `publish`, `login`
+    #|  or `register`.)
     #|- `proton_cli` — `--version`, `--help`, new, dev, build, package, doctor,
     #|  cef, and updater. Set `Cmd.cwd` for the project directory; the global
     #|  `-C`/`--cwd` options before the subcommand are refused.
@@ -262,6 +262,11 @@ fn default_prompt() -> String {
     #|  dependencies and package registry/dependency inspection. Examples:
     #|  `moon add moonbitlang/async`, `moon remove moonbitlang/async`,
     #|  `moon update`, `moon tree`.
+    #|- `moon search`: search the package registry for modules by keyword when
+    #|  the exact module name is not known yet; then add the chosen module with
+    #|  `moon add`. Examples: `moon search base64`,
+    #|  `moon search json --limit 5 --json` (`--json` prints one result set as
+    #|  JSON for parsing).
     #|- `moon clean`: clear `_build` when stale build output is suspected.
     #|  Example: `moon clean`.
     #|- `moon bench`: run benchmarks, e.g. `moon bench lib/parser`.


### PR DESCRIPTION
## What

Adds `moon search` — the registry keyword search — to the agent's command surface, in all three places the policy header requires to move together:

- **`agent_tool/mbtx/wasm_policy.mbt`**: `("moon", ["search"])` in `spawnable_commands`, next to the other registry-facing subcommands (`add`/`remove`/`update`/`install`/`tree`). It is read-only, and the natural first step before `moon add` when the module name is not known yet.
- **`agent_tool/mbtx/mbtx.mbt`**: the tool description's "Which programs a snippet may start" prose list.
- **`prompt/default_prompt.mbt.md`** (+ regenerated `generated_default_prompt.mbt`): the "Only these programs can be started" list, plus a new `moon search` entry in the Common `moon` subcommands catalog with verified examples (`moon search base64`, `moon search json --limit 5 --json`).

The live spawn-allowlist test gains a `probe("moon", ["search", "--help"])` assertion; `--help` keeps the probe off the network, since only process admission is under test.

## Verified

- `moon check` clean repo-wide; `moon fmt --check agent_tool/mbtx prompt` clean.
- `moon test agent_tool/mbtx`: 62/62 (including the extended spawn-discrimination test, which exercises the real `moonrun --policy` admission).
- `moon test prompt`: 20/20.
- Live command probe: `moon search base64 --limit 3 --json` returns a JSON result set, matching the prompt's description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SX85Laj1L5FSAAhRGj6PJN