### PR TITLE
fix(desktop): synchronize semantic diff hunk navigation

### DIFF
--- a/desktop/frontend/fileeditor/semantic_review_view.mbt
+++ b/desktop/frontend/fileeditor/semantic_review_view.mbt
@@ -465,6 +465,8 @@ priv struct SemanticReviewEditorHost {
   provider : @moon_diff_provider.MoonFragmentDiffProvider?
   diff_subscription : @common.Disposable
   content_height_subscription : @common.Disposable
+  navigation_reveal_subscription : @common.Disposable
+  pending_navigation_reveal_generation : Ref[Int?]
   focus_subscription : @common.Disposable
 }
 
@@ -476,6 +478,11 @@ let semantic_review_order : Array[String] = []
 
 ///|
 let semantic_review_active_key : Ref[String?] = Ref(None)
+
+///|
+/// Fences deferred reveal events and animation frames across rapid navigation,
+/// section replacement, and surface teardown.
+let semantic_review_navigation_generation : Ref[Int] = Ref(0)
 
 ///|
 priv enum SemanticReviewNavigationDirection {
@@ -935,6 +942,203 @@ fn semantic_estimated_height(
 }
 
 ///|
+/// The child scroll target produced by Line diff's `Center` reveal for an
+/// explicit viewport. This is the relevant subset of
+/// `ViewLayout::compute_scroll_top_to_reveal_range`: oversized ranges align at
+/// the top, ordinary ranges center, and the result clamps to the child extent.
+fn semantic_review_child_scroll_top_to_reveal(
+  viewport_height : Double,
+  content_height : Double,
+  reveal_top : Double,
+  reveal_bottom : Double,
+) -> Double {
+  if viewport_height <= 0.0 {
+    return 0.0
+  }
+  let box_start = reveal_top
+  let box_end = reveal_bottom.max(reveal_top)
+  let target = if box_end - box_start > viewport_height {
+    box_start
+  } else {
+    (box_start + box_end - viewport_height) / 2.0
+  }
+  target.clamp(min=0.0, max=(content_height - viewport_height).max(0.0))
+}
+
+///|
+/// Apply the child reveal as a delta to Token/Tree's outer scroll position.
+/// VS Code's `diffEditorItemTemplate.ts` forwards exactly
+/// `newChildScrollTop - lastChildScrollTop` to the MultiDiff parent, while
+/// `multiDiffEditorWidgetImpl.ts::render` constrains each child to the outer
+/// viewport minus its item chrome. Our items use natural DOM flow instead of
+/// virtualization, so this function reconstructs those same current/target
+/// child offsets and returns the resulting outer scroll position.
+fn semantic_review_scroll_top_after_child_reveal(
+  outer_scroll_top : Double,
+  outer_viewport_height : Double,
+  item_content_top : Double,
+  item_content_height : Double,
+  editor_content_top : Double,
+  sticky_chrome_height : Double,
+  reveal_top : Double,
+  reveal_bottom : Double,
+) -> Double {
+  let item_viewport_height = item_content_height
+    .min(outer_viewport_height)
+    .max(0.0)
+  let child_viewport_height = (item_viewport_height - sticky_chrome_height).max(
+    0.0,
+  )
+  if child_viewport_height <= 0.0 {
+    return outer_scroll_top.max(0.0)
+  }
+  // Notices before the editor are ordinary scrolling content, not sticky
+  // chrome. Shift the editor-local reveal box through that prefix while only
+  // reserving the actual sticky header from the child viewport.
+  let scrolling_prefix_height = (editor_content_top -
+  item_content_top -
+  sticky_chrome_height).max(0.0)
+  let child_content_height = (item_content_height - sticky_chrome_height).max(
+    0.0,
+  )
+  let max_child_scroll = (child_content_height - child_viewport_height).max(0.0)
+  let needs_origin = semantic_review_item_needs_navigation_origin(
+    outer_scroll_top, outer_viewport_height, item_content_top, item_content_height,
+  )
+  let projection_outer_scroll_top = if needs_origin {
+    item_content_top
+  } else {
+    outer_scroll_top
+  }
+  let current_child_scroll = if needs_origin {
+    0.0
+  } else {
+    (outer_scroll_top - item_content_top).clamp(min=0.0, max=max_child_scroll)
+  }
+  let target_child_scroll = semantic_review_child_scroll_top_to_reveal(
+    child_viewport_height,
+    child_content_height,
+    scrolling_prefix_height + reveal_top,
+    scrolling_prefix_height + reveal_bottom,
+  )
+  (projection_outer_scroll_top + target_child_scroll - current_child_scroll).max(
+    0.0,
+  )
+}
+
+///|
+/// Project one child DiffEditor's centered reveal into Token/Tree's single
+/// outer vertical scroll plane. Two frame boundaries let the reveal's paired
+/// content-height publication and editor layout commit first; pixel bounds are
+/// deliberately re-measured in the second frame so Markdown/ViewZone geometry
+/// cannot go stale between the reveal event and the parent scroll.
+fn schedule_semantic_review_reveal_scroll(
+  key : String,
+  editor_host : @dom.Element,
+  editor : @viewer.DiffEditor,
+  event : @viewer.DiffEditorRevealEvent,
+  generation : Int,
+) -> Unit {
+  @dom.window().request_animation_frame(_ => {
+    guard semantic_review_navigation_generation.val == generation &&
+      semantic_review_active_key.val == Some(key) &&
+      @base_browser.element_is_connected(editor_host) else {
+      return
+    }
+    @dom.window().request_animation_frame(_ => {
+      guard semantic_review_navigation_generation.val == generation &&
+        semantic_review_active_key.val == Some(key) &&
+        @base_browser.element_is_connected(editor_host) &&
+        @dom.document().get_element_by_id(SemanticReviewHostId).to_option()
+        is Some(scroll_host) &&
+        editor_host.closest(".semantic-diff-entry") is Some(item) &&
+        item.query_selector(".semantic-entry-header") is Some(header) &&
+        editor.get_modified_vertical_reveal_bounds(event.modified_range)
+        is Some((reveal_top, reveal_bottom)) else {
+        return
+      }
+      let viewport_height = scroll_host.get_client_height()
+      let editor_content_height = editor.get_content_height()
+      if viewport_height <= 0.0 ||
+        item.get_client_height() <= 0.0 ||
+        editor_host.get_client_height() <= 0.0 ||
+        editor_content_height <= 0.0 {
+        return
+      }
+      let outer_scroll_top = scroll_host.get_scroll_top()
+      let scroll_rect = scroll_host.get_bounding_client_rect()
+      let item_rect = item.get_bounding_client_rect()
+      let editor_rect = editor_host.get_bounding_client_rect()
+      let item_content_top = outer_scroll_top +
+        item_rect.get_top() -
+        scroll_rect.get_top()
+      let editor_content_top = outer_scroll_top +
+        editor_rect.get_top() -
+        scroll_rect.get_top()
+      scroll_host.set_scroll_top(
+        semantic_review_scroll_top_after_child_reveal(
+          outer_scroll_top,
+          viewport_height,
+          item_content_top,
+          item.get_client_height(),
+          editor_content_top,
+          header.get_client_height(),
+          reveal_top,
+          reveal_bottom,
+        ),
+      )
+    })
+    |> ignore
+  })
+  |> ignore
+}
+
+///|
+/// VS Code's cross-item `_goToFile` first reveals the destination item at its
+/// content start; the child editor's subsequent centered reveal contributes a
+/// local scroll delta. Do the same before requesting first/last in a section.
+fn reveal_semantic_review_item_start(editor_host : @dom.Element) -> Unit {
+  guard @dom.document().get_element_by_id(SemanticReviewHostId).to_option()
+    is Some(scroll_host) &&
+    editor_host.closest(".semantic-diff-entry") is Some(item) else {
+    return
+  }
+  let scroll_rect = scroll_host.get_bounding_client_rect()
+  let item_rect = item.get_bounding_client_rect()
+  scroll_host.set_scroll_top(
+    scroll_host.get_scroll_top() + item_rect.get_top() - scroll_rect.get_top(),
+  )
+}
+
+///|
+/// A focused MultiDiff item can be moved out of the outer viewport with the
+/// wheel while remaining the active navigation item. VS Code materializes and
+/// reveals such an item before asking its child to navigate. A short item also
+/// needs to be fully visible because it has no child scroll range with which to
+/// contribute a corrective delta.
+fn semantic_review_item_needs_navigation_origin(
+  outer_scroll_top : Double,
+  outer_viewport_height : Double,
+  item_content_top : Double,
+  item_content_height : Double,
+) -> Bool {
+  if outer_viewport_height <= 0.0 || item_content_height <= 0.0 {
+    return false
+  }
+  let outer_bottom = outer_scroll_top + outer_viewport_height
+  let item_bottom = item_content_top + item_content_height
+  if item_content_height <= outer_viewport_height {
+    item_content_top < outer_scroll_top || item_bottom > outer_bottom
+  } else {
+    // Delta projection is valid only while the parent's local offset lies in
+    // the long child's real scroll band, i.e. while the viewport is fully
+    // contained by the item. A sliver at either edge still represents a
+    // clamped child offset and must be re-originated first.
+    outer_scroll_top < item_content_top || outer_bottom > item_bottom
+  }
+}
+
+///|
 /// Commit one final DiffEditor height to its MultiDiff item. The content-height
 /// event can arrive while `create_semantic_review_editor` is still constructing
 /// the map entry, so this helper deliberately captures the concrete host and
@@ -972,8 +1176,11 @@ fn schedule_semantic_review_scroll_width_update() -> Unit {
 
 ///|
 fn dispose_semantic_review_editor(entry : SemanticReviewEditorHost) -> Unit {
+  semantic_review_navigation_generation.val += 1
   entry.diff_subscription.dispose()
   entry.content_height_subscription.dispose()
+  entry.pending_navigation_reveal_generation.val = None
+  entry.navigation_reveal_subscription.dispose()
   entry.focus_subscription.dispose()
   match entry.editor.set_model(None) {
     Some(previous) => {
@@ -1075,6 +1282,14 @@ fn create_semantic_review_editor(
     apply_semantic_review_editor_height(host, editor, content_height)
     update_semantic_review_scroll_width()
   })
+  let pending_navigation_reveal_generation : Ref[Int?] = Ref(None)
+  let navigation_reveal_subscription = editor.on_did_reveal_change(event => {
+    guard pending_navigation_reveal_generation.val is Some(generation) else {
+      return
+    }
+    pending_navigation_reveal_generation.val = None
+    schedule_semantic_review_reveal_scroll(key, host, editor, event, generation)
+  })
   let focus_listener : @dom.Listener = _ => {
     semantic_review_active_key.val = Some(key)
   }
@@ -1111,6 +1326,8 @@ fn create_semantic_review_editor(
     provider,
     diff_subscription,
     content_height_subscription,
+    navigation_reveal_subscription,
+    pending_navigation_reveal_generation,
     focus_subscription,
   })
 }
@@ -1160,6 +1377,7 @@ fn refresh_semantic_review_editor_options() -> Unit {
 
 ///|
 fn clear_semantic_review_editors() -> Unit {
+  semantic_review_navigation_generation.val += 1
   let keys = semantic_review_editors.to_array().map(pair => pair.0)
   for key in keys {
     if semantic_review_editors.get(key) is Some(entry) {
@@ -1180,6 +1398,16 @@ fn semantic_review_navigation_index(current : String?) -> Int {
 }
 
 ///|
+fn arm_semantic_review_navigation_reveal(
+  entry : SemanticReviewEditorHost,
+) -> Unit {
+  semantic_review_navigation_generation.val += 1
+  entry.pending_navigation_reveal_generation.val = Some(
+    semantic_review_navigation_generation.val,
+  )
+}
+
+///|
 /// Move within the focused DiffEditor first, then cycle across Token/Tree
 /// items exactly like VS Code's MultiDiffEditor navigation action.
 fn navigate_semantic_review_change(
@@ -1193,6 +1421,7 @@ fn navigate_semantic_review_change(
     let current = semantic_review_order[index]
     if !collapsed.contains(current) &&
       semantic_review_editors.get(current) is Some(entry) {
+      arm_semantic_review_navigation_reveal(entry)
       let revealed = match direction {
         SemanticReviewPrevious =>
           entry.editor.reveal_previous_change_without_wrap()
@@ -1200,13 +1429,10 @@ fn navigate_semantic_review_change(
       }
       if revealed {
         semantic_review_active_key.val = Some(current)
-        entry.host.scroll_into_view_with_options(
-          block="nearest",
-          inline="nearest",
-        )
         entry.editor.focus()
         return
       }
+      entry.pending_navigation_reveal_generation.val = None
     }
     let target_index = match direction {
       SemanticReviewPrevious =>
@@ -1242,10 +1468,8 @@ fn reveal_semantic_review_section_change(
         return
       }
       semantic_review_active_key.val = Some(key)
-      entry.host.scroll_into_view_with_options(
-        block="nearest",
-        inline="nearest",
-      )
+      reveal_semantic_review_item_start(entry.host)
+      arm_semantic_review_navigation_reveal(entry)
       if reveal_last {
         entry.editor.reveal_last_diff()
       } else {

--- a/desktop/frontend/fileeditor/semantic_review_view_wbtest.mbt
+++ b/desktop/frontend/fileeditor/semantic_review_view_wbtest.mbt
@@ -512,3 +512,87 @@ test "semantic multi-diff entry collapse is tab-local retained state" {
   )
   assert_true(unknown == expanded)
 }
+
+///|
+test "semantic hunk reveal projects the VS Code child scroll delta" {
+  // The active item has 40px of sticky chrome, leaving a 360px editor
+  // viewport. Its child target is 430; starting at child scroll 0 moves the
+  // outer viewport from 500 to 930.
+  assert_eq(
+    semantic_review_scroll_top_after_child_reveal(
+      500.0, 400.0, 500.0, 1040.0, 540.0, 40.0, 600.0, 620.0,
+    ),
+    930.0,
+  )
+  // Repeating the same reveal from a child scroll of 200 lands at the same
+  // absolute target by applying only the remaining delta.
+  assert_eq(
+    semantic_review_scroll_top_after_child_reveal(
+      700.0, 400.0, 500.0, 1040.0, 540.0, 40.0, 600.0, 620.0,
+    ),
+    930.0,
+  )
+  // An oversized line range aligns immediately below the 40px sticky chrome,
+  // matching the child editor's top reveal rather than hiding it underneath.
+  assert_eq(
+    semantic_review_scroll_top_after_child_reveal(
+      240.0, 300.0, 240.0, 700.0, 280.0, 40.0, 80.0, 480.0,
+    ),
+    320.0,
+  )
+  // A short item has no child scroll range. Same-item navigation therefore
+  // preserves the parent position, as VS Code's zero scroll delta does.
+  assert_eq(
+    semantic_review_scroll_top_after_child_reveal(
+      0.0, 400.0, 20.0, 200.0, 60.0, 40.0, 10.0, 30.0,
+    ),
+    0.0,
+  )
+  // A non-sticky notice before the editor shifts the target through the
+  // child's scrolling content; it does not shrink the viewport like chrome.
+  assert_eq(
+    semantic_review_scroll_top_after_child_reveal(
+      500.0, 400.0, 500.0, 1080.0, 580.0, 40.0, 600.0, 620.0,
+    ),
+    970.0,
+  )
+  // If a long active item only clips the viewport edge, its clamped child
+  // offset is not a valid delta origin. Re-origin at the item before applying
+  // the target so the hunk still lands below the sticky header.
+  assert_eq(
+    semantic_review_scroll_top_after_child_reveal(
+      100.0, 400.0, 450.0, 1040.0, 490.0, 40.0, 600.0, 620.0,
+    ),
+    880.0,
+  )
+}
+
+///|
+test "semantic navigation restores an active item that left the viewport" {
+  // A short item must be entirely visible because its child has no scroll
+  // range. Partial visibility therefore restores the item origin.
+  assert_true(
+    semantic_review_item_needs_navigation_origin(100.0, 400.0, 450.0, 100.0),
+  )
+  assert_true(
+    !semantic_review_item_needs_navigation_origin(100.0, 400.0, 200.0, 100.0),
+  )
+  // A long item keeps its current child offset while it fully contains the
+  // viewport. Partial overlap at either edge is outside the child's valid
+  // scroll band and must be re-established too.
+  assert_true(
+    !semantic_review_item_needs_navigation_origin(300.0, 400.0, 100.0, 800.0),
+  )
+  assert_true(
+    semantic_review_item_needs_navigation_origin(900.0, 400.0, 100.0, 800.0),
+  )
+  assert_true(
+    semantic_review_item_needs_navigation_origin(100.0, 400.0, 500.0, 800.0),
+  )
+  assert_true(
+    semantic_review_item_needs_navigation_origin(100.0, 400.0, 450.0, 800.0),
+  )
+  assert_true(
+    semantic_review_item_needs_navigation_origin(450.0, 400.0, 100.0, 700.0),
+  )
+}

--- a/editor/internal/viewer/code_editor_widget/pkg.generated.mbti
+++ b/editor/internal/viewer/code_editor_widget/pkg.generated.mbti
@@ -227,6 +227,7 @@ pub fn CodeEditorWidget::get_selections(Self) -> Array[@core.Selection]?
 pub fn CodeEditorWidget::get_top_for_line_number(Self, Int, include_view_zones? : Bool) -> Double
 pub fn CodeEditorWidget::get_top_for_position(Self, Int, Int) -> Double
 pub fn CodeEditorWidget::get_value(Self) -> String
+pub fn CodeEditorWidget::get_vertical_reveal_bounds(Self, @common.Range) -> (Double, Double)?
 pub fn CodeEditorWidget::get_visible_column_from_position(Self, @common.Position) -> Int
 pub fn CodeEditorWidget::get_visible_ranges(Self) -> Array[@common.Range]
 pub fn CodeEditorWidget::get_width_of_line(Self, Int) -> Double

--- a/editor/internal/viewer/code_editor_widget/public_read_api.mbt
+++ b/editor/internal/viewer/code_editor_widget/public_read_api.mbt
@@ -111,6 +111,30 @@ pub fn CodeEditorWidget::get_top_for_line_number(
 }
 
 ///|
+/// Content-space box used by the vertical reveal pipeline for `model_range`.
+/// This deliberately uses the first view line's rendered top, rather than the
+/// top of any preceding ViewZone: it is the same box consumed by
+/// `ViewLayout::compute_scroll_top_to_reveal_range`. ViewZones before or inside
+/// the range still shift/expand these coordinates, and model-to-view conversion
+/// keeps the result correct under wrapping.
+pub fn CodeEditorWidget::get_vertical_reveal_bounds(
+  self : CodeEditorWidget,
+  model_range : @base_common.Range,
+) -> (Double, Double)? {
+  guard self.is_code_presentation() else { return None }
+  guard self.get_view_model() is Some(view_model) else { return None }
+  let view_range = view_model
+    .coordinates_converter()
+    .model_range_to_view_range(model_range)
+  let start_line = view_range.start_line_number
+  let end_line = view_range.end_line_number
+  let top = view_model.view_layout.vertical_offset_for_line(start_line)
+  let bottom = view_model.view_layout.vertical_offset_for_line(end_line) +
+    view_model.view_layout.get_line_height_for_line_number(end_line).to_double()
+  Some((top, bottom))
+}
+
+///|
 /// 1-based "Col" value for a status bar (tabs snap to tab stops, code points),
 /// Monaco's `getStatusbarColumn` (`cew:652`). No model → the raw input column.
 fn CodeEditorWidget::get_statusbar_column(

--- a/editor/internal/viewer/code_editor_widget/public_read_api_wbtest.mbt
+++ b/editor/internal/viewer/code_editor_widget/public_read_api_wbtest.mbt
@@ -177,6 +177,33 @@ test "read API: include_view_zones shifts the vertical offset past a zone" {
 }
 
 ///|
+/// Reveal bounds use the same line box as the ordinary reveal pipeline. A zone
+/// before the start shifts the whole box; a zone inside a multi-line range
+/// expands that box without changing its first-line anchor.
+test "read API: vertical reveal bounds match line reveal geometry" {
+  with_test_viewer(
+    (
+      #|a
+      #|b
+      #|c
+      #|d
+      #|e
+    ),
+    viewer => {
+      viewer.test_set_layout_view_zones([(2, 30)])
+      assert_eq(
+        viewer.get_vertical_reveal_bounds(Range(3, 1, 3, 1)),
+        Some((66.0, 84.0)),
+      )
+      assert_eq(
+        viewer.get_vertical_reveal_bounds(Range(2, 1, 3, 1)),
+        Some((18.0, 84.0)),
+      )
+    },
+  )
+}
+
+///|
 /// Scroll and content extents over a known content size and scroll position.
 test "read API: scroll and content extents" {
   with_test_viewer(long_document(200), viewer => {

--- a/editor/internal/viewer/diff_editor/pkg.generated.mbti
+++ b/editor/internal/viewer/diff_editor/pkg.generated.mbti
@@ -63,6 +63,13 @@ pub(all) struct DiffEditorOptions {
 pub fn DiffEditorOptions::DiffEditorOptions(layout? : DiffEditorLayout, automatic_inline? : Bool, automatic_inline_width? : Double, sash_enabled? : Bool, split_ratio? : Double, diff_word_wrap? : DiffWordWrap, overview_ruler? : Bool, render_indicators? : Bool, render_markdown_comments? : Bool, handle_mouse_wheel? : Bool, ignore_trim_whitespace? : Bool) -> Self
 pub fn DiffEditorOptions::default() -> Self
 
+pub(all) struct DiffEditorRevealEvent {
+  modified_range : @common.Range
+} derive(Eq, @debug.Debug)
+pub fn DiffEditorRevealEvent::equal(Self, Self) -> Bool
+pub fn DiffEditorRevealEvent::not_equal(Self, Self) -> Bool
+pub fn DiffEditorRevealEvent::to_repr(Self) -> @debug.Repr
+
 pub struct DiffEditorViewModel {
   mut provider : &@diff.DocumentDiffProvider
   mut provider_subscription : @common.Disposable?
@@ -131,6 +138,7 @@ pub struct DiffEditorWidget {
   mut modified_alignment_geometry : PaneGeometrySnapshot?
   mut diff_state : DiffState?
   did_change_content_height : @common.Emitter[Double]
+  did_reveal_change : @common.Emitter[DiffEditorRevealEvent]
   mut last_published_content_height : Double?
   mut pending_reveal_first_diff_generation : Int?
   mut pending_reveal_last_diff_generation : Int?
@@ -159,10 +167,12 @@ pub fn DiffEditorWidget::get_diff(Self) -> @diff.DocumentDiff?
 pub fn DiffEditorWidget::get_layout(Self) -> DiffEditorLayout
 pub fn DiffEditorWidget::get_max_scroll_left(Self) -> Double
 pub fn DiffEditorWidget::get_model(Self) -> DiffEditorModelData?
+pub fn DiffEditorWidget::get_modified_vertical_reveal_bounds(Self, @common.Range) -> (Double, Double)?
 pub fn DiffEditorWidget::is_diff_up_to_date(Self) -> Bool
 pub fn DiffEditorWidget::layout(Self) -> Unit
 pub fn DiffEditorWidget::lifecycle_snapshot(Self) -> DiffEditorWidgetLifecycleSnapshot
 pub fn DiffEditorWidget::on_did_change_content_height(Self, (Double) -> Unit) -> @common.Disposable
+pub fn DiffEditorWidget::on_did_reveal_change(Self, (DiffEditorRevealEvent) -> Unit) -> @common.Disposable
 pub fn DiffEditorWidget::on_did_update_diff(Self, () -> Unit) -> @common.Disposable
 pub fn DiffEditorWidget::reveal_first_diff(Self) -> Unit
 pub fn DiffEditorWidget::reveal_last_diff(Self) -> Unit

--- a/editor/internal/viewer/diff_editor/widget.mbt
+++ b/editor/internal/viewer/diff_editor/widget.mbt
@@ -5,6 +5,21 @@ priv enum DiffEditorScrollPane {
 }
 
 ///|
+/// The exact modified model range passed to one programmatic centered reveal.
+/// Composite hosts retain the range, wait for their item layout to settle, and
+/// then measure its current pixel geometry before projecting the child scroll
+/// into their outer scroll plane.
+pub(all) struct DiffEditorRevealEvent {
+  modified_range : @base_common.Range
+} derive(Eq, Debug)
+
+///|
+pub extend DiffEditorRevealEvent with Eq::{equal, not_equal}
+
+///|
+pub extend DiffEditorRevealEvent with Debug::{to_repr}
+
+///|
 /// A first-class diff widget that owns two code-editor kernels and one shared
 /// diff ViewModel. Product-specific algorithm controls and document
 /// presentation routing are intentionally outside this package.
@@ -42,6 +57,9 @@ pub struct DiffEditorWidget {
   /// last value prevents a host height write followed by `layout()` from
   /// feeding the same height back into the host.
   did_change_content_height : @base_common.Emitter[Double]
+  /// Fires only after a concrete hunk reveal has updated the modified cursor
+  /// and requested the child editor's own centered reveal.
+  did_reveal_change : @base_common.Emitter[DiffEditorRevealEvent]
   mut last_published_content_height : Double?
   /// One VS Code-style `revealFirstDiff` request, bound to the model-pair
   /// generation that was current when the host made it. The request survives
@@ -216,6 +234,7 @@ pub fn DiffEditorWidget::create(
     modified_alignment_geometry: None,
     diff_state: None,
     did_change_content_height: Emitter(),
+    did_reveal_change: Emitter(),
     last_published_content_height: None,
     pending_reveal_first_diff_generation: None,
     pending_reveal_last_diff_generation: None,
@@ -1473,6 +1492,27 @@ pub fn DiffEditorWidget::on_did_change_content_height(
 }
 
 ///|
+/// Fires after a first/last/next/previous hunk reveal with the exact modified
+/// model range sent through the centered reveal pipeline.
+pub fn DiffEditorWidget::on_did_reveal_change(
+  self : DiffEditorWidget,
+  listener : (DiffEditorRevealEvent) -> Unit,
+) -> @base_common.Disposable {
+  self.did_reveal_change.event(listener)
+}
+
+///|
+/// Re-measure a reveal range against the modified pane's latest wrapping and
+/// ViewZone layout. MultiDiff hosts call this after their own section height
+/// has committed instead of retaining stale event-time pixel coordinates.
+pub fn DiffEditorWidget::get_modified_vertical_reveal_bounds(
+  self : DiffEditorWidget,
+  range : @base_common.Range,
+) -> (Double, Double)? {
+  self.editors.modified.get_vertical_reveal_bounds(range)
+}
+
+///|
 /// Largest horizontal overflow of either code pane. MultiDiffEditor uses one
 /// outer horizontal scrollbar and projects its offset into every item, just as
 /// VS Code's DiffEditorItemTemplate reports `maxScroll` to its parent widget.
@@ -1641,8 +1681,10 @@ fn DiffEditorWidget::reveal_change(
     return false
   }
   match plan.pane {
-    ModifiedNavigationPane =>
+    ModifiedNavigationPane => {
       self.editors.modified.reveal_range_in_center(plan.range)
+      self.did_reveal_change.fire({ modified_range: plan.range, })
+    }
   }
   true
 }
@@ -1688,6 +1730,11 @@ pub fn DiffEditorWidget::reveal_first_diff(self : DiffEditorWidget) -> Unit {
   if self.disposed || self.view_model.get_model() is None {
     return
   }
+  // Deferred edge reveals are one last-writer-wins request. A MultiDiff host
+  // can request the last hunk while this initial first-hunk request is waiting
+  // for diff/layout readiness; allowing both to fire would leave the cursor at
+  // the last hunk while the parent consumes the first hunk's scroll event.
+  self.pending_reveal_last_diff_generation = None
   self.pending_reveal_first_diff_generation = Some(
     self.editors.committed_model_generation(),
   )
@@ -1733,6 +1780,7 @@ pub fn DiffEditorWidget::reveal_last_diff(self : DiffEditorWidget) -> Unit {
   if self.disposed || self.view_model.get_model() is None {
     return
   }
+  self.pending_reveal_first_diff_generation = None
   self.pending_reveal_last_diff_generation = Some(
     self.editors.committed_model_generation(),
   )
@@ -1965,5 +2013,6 @@ pub fn DiffEditorWidget::dispose(self : DiffEditorWidget) -> Unit {
   self.inline_original_strip_width = -1.0
   self.clear_pending_scroll_echoes()
   self.did_change_content_height.dispose()
+  self.did_reveal_change.dispose()
   self.host.remove_child(self.root.as_node())
 }

--- a/editor/tests/browser/component/diff_editor_lifecycle.spec.js
+++ b/editor/tests/browser/component/diff_editor_lifecycle.spec.js
@@ -200,6 +200,42 @@ test('defers a one-shot first-diff reveal through computation and hidden layout'
   await disposeDiffLifecycle(page);
 });
 
+test('the latest deferred edge reveal supersedes an earlier request', async ({ page }) => {
+  const root = await openDiffLifecycle(page);
+  const host = page.locator('.diff-lifecycle-host');
+  const modified = root.locator('.moonbit-diff-editor-modified');
+
+  // Semantic MultiDiff items request their initial first hunk while hidden.
+  // Shift+F7 can supersede that with a last-hunk request before the diff and
+  // layout become ready. Only the later request may move the cursor/viewport.
+  await host.evaluate((node) => {
+    node.style.display = 'none';
+  });
+  await page.evaluate(() => {
+    globalThis.__diffEditorLifecycleControls.set_fixture('late');
+    globalThis.__diffEditorLifecycleControls.reveal_first_diff();
+    globalThis.__diffEditorLifecycleControls.reveal_last_diff();
+  });
+  await expect
+    .poll(() => page.evaluate(() =>
+      globalThis.__diffEditorLifecycleControls.snapshot().diffUpToDate,
+    ))
+    .toBe(true);
+  await host.evaluate((node) => {
+    node.style.display = 'block';
+  });
+  await waitForDiffLifecycleIdle(page);
+
+  await expect(
+    modified.locator('.line-numbers.active-line-number'),
+  ).toHaveText('190');
+  await expect(
+    modified.locator('.view-line').filter({ hasText: 'new second hunk' }),
+  ).toBeVisible();
+
+  await disposeDiffLifecycle(page);
+});
+
 test('owns and tears down exactly two kernels and one shared diff view model', async ({ page }) => {
   await page.goto('/browser-tests/component.html?diffLifecycle=1');
   await page.waitForFunction(() => Boolean(globalThis.__diffEditorLifecycleControls));

--- a/editor/viewer/diff_editor_facade.mbt
+++ b/editor/viewer/diff_editor_facade.mbt
@@ -14,6 +14,13 @@ pub fn DiffEditorModel::DiffEditorModel(
 }
 
 ///|
+/// The exact modified model range passed to one diff navigation reveal.
+/// MultiDiff hosts can re-measure this range after their item layout settles.
+pub(all) struct DiffEditorRevealEvent {
+  modified_range : @base_common.Range
+} derive(Eq, Debug)
+
+///|
 pub(all) enum DiffEditorLayout {
   SideBySide
   Inline
@@ -256,6 +263,28 @@ pub fn DiffEditor::on_did_change_content_height(
 }
 
 ///|
+/// Fires after a concrete first/last/next/previous hunk reveal. MultiDiff hosts
+/// can project the child reveal into their shared outer vertical scroll plane.
+pub fn DiffEditor::on_did_reveal_change(
+  self : DiffEditor,
+  listener : (DiffEditorRevealEvent) -> Unit,
+) -> @base_common.Disposable {
+  self.widget.on_did_reveal_change(event => {
+    listener({ modified_range: event.modified_range, })
+  })
+}
+
+///|
+/// Current modified-pane pixel bounds for a model range, using the same
+/// model-to-view conversion and line box as a centered Line diff reveal.
+pub fn DiffEditor::get_modified_vertical_reveal_bounds(
+  self : DiffEditor,
+  range : @base_common.Range,
+) -> (Double, Double)? {
+  self.widget.get_modified_vertical_reveal_bounds(range)
+}
+
+///|
 /// Horizontal overflow exposed for VS Code-shaped MultiDiffEditor hosts.
 pub fn DiffEditor::get_max_scroll_left(self : DiffEditor) -> Double {
   self.widget.get_max_scroll_left()
@@ -352,6 +381,12 @@ pub extend DiffEditorLayout with Eq::{equal, not_equal}
 
 ///|
 pub extend DiffEditorLayout with Debug::{to_repr}
+
+///|
+pub extend DiffEditorRevealEvent with Eq::{equal, not_equal}
+
+///|
+pub extend DiffEditorRevealEvent with Debug::{to_repr}
 
 ///|
 pub extend DiffWordWrap with Eq::{equal, not_equal}

--- a/editor/viewer/pkg.generated.mbti
+++ b/editor/viewer/pkg.generated.mbti
@@ -39,9 +39,11 @@ pub fn DiffEditor::get_diff(Self) -> @diff.DocumentDiff?
 pub fn DiffEditor::get_layout(Self) -> DiffEditorLayout
 pub fn DiffEditor::get_max_scroll_left(Self) -> Double
 pub fn DiffEditor::get_model(Self) -> DiffEditorModel?
+pub fn DiffEditor::get_modified_vertical_reveal_bounds(Self, @common.Range) -> (Double, Double)?
 pub fn DiffEditor::is_diff_up_to_date(Self) -> Bool
 pub fn DiffEditor::layout(Self) -> Unit
 pub fn DiffEditor::on_did_change_content_height(Self, (Double) -> Unit) -> @common.Disposable
+pub fn DiffEditor::on_did_reveal_change(Self, (DiffEditorRevealEvent) -> Unit) -> @common.Disposable
 pub fn DiffEditor::on_did_update_diff(Self, () -> Unit) -> @common.Disposable
 pub fn DiffEditor::reveal_first_diff(Self) -> Unit
 pub fn DiffEditor::reveal_last_diff(Self) -> Unit
@@ -75,6 +77,13 @@ pub fn DiffEditorOptions::layout(Self) -> DiffEditorLayout
 pub fn DiffEditorOptions::with_editor_options(Self, ViewerOptions) -> Self
 pub fn DiffEditorOptions::with_layout(Self, DiffEditorLayout) -> Self
 pub fn DiffEditorOptions::with_render_indicators(Self, Bool) -> Self
+
+pub(all) struct DiffEditorRevealEvent {
+  modified_range : @common.Range
+} derive(Eq, @debug.Debug)
+pub fn DiffEditorRevealEvent::equal(Self, Self) -> Bool
+pub fn DiffEditorRevealEvent::not_equal(Self, Self) -> Bool
+pub fn DiffEditorRevealEvent::to_repr(Self) -> @debug.Repr
 
 pub(all) enum DiffWordWrap {
   Inherit


### PR DESCRIPTION
## Summary

- expose diff reveal events and current modified-range geometry so composite hosts can mirror the child editor reveal
- project Token/Tree hunk navigation into the shared outer scroll plane, matching VS Code MultiDiff behavior across ViewZones, wrapping, sticky headers, and cross-item navigation
- fence deferred reveals during rapid navigation or teardown, make pending first/last reveals last-writer-wins, and add regression coverage

## Testing

- fileeditor JS tests: 162/162 passed
- code_editor_widget tests: 300/300 passed
- `moon fmt --check`
- `git diff --check`
- `moon -C desktop run --target native package/macos -- --target app --no-open`