### PR TITLE
feat(desktop): adapt Codex transcript items

### DIFF
--- a/desktop/e2e/tests/rabbita_dom.spec.js
+++ b/desktop/e2e/tests/rabbita_dom.spec.js
@@ -1419,7 +1419,7 @@ test('Codex account login can be started and cancelled from Settings', async ({ 
   expect(app.pageErrors).toEqual([]);
 });
 
-test('Codex creates a thread, sends its first turn, and stops it', async ({ page }) => {
+test('Codex preserves usage when reconnect history replaces the thread', async ({ page }) => {
   const app = new DesktopBrowserHarness(page);
   app.codexModels = [
     {
@@ -1461,6 +1461,53 @@ test('Codex creates a thread, sends its first turn, and stops it', async ({ page
         input: [{ type: 'text', text: 'Run the Codex browser E2E turn' }],
       },
     });
+
+  app.codexThreadHistory = {
+    thread: {
+      id: 'codex-thread-e2e',
+      cwd: '/workspace',
+      projectRoot: '/workspace',
+      preview: 'Codex reconnect fixture',
+      status: { type: 'active' },
+      turns: [
+        {
+          id: 'codex-turn-e2e',
+          status: 'inProgress',
+          items: [
+            {
+              type: 'agentMessage',
+              id: 'codex-agent-reconnected',
+              text: 'Reconnect snapshot arrived',
+            },
+          ],
+        },
+      ],
+    },
+  };
+  app.rpcDelays.set('codex.thread.history.read', 250);
+  app.notify('codex.status_changed', { status: 'starting' });
+  app.notify('codex.status_changed', { status: 'ready' });
+  await expect.poll(() => app.requests.some(request =>
+    request.method === 'codex.thread.history.read' &&
+    request.params?.threadId === 'codex-thread-e2e')).toBe(true);
+
+  // The usage event lands while the reconnect snapshot reply is delayed.
+  app.notify('codex.notification', {
+    method: 'thread/tokenUsage/updated',
+    params: {
+      threadId: 'codex-thread-e2e',
+      turnId: 'codex-turn-e2e',
+      tokenUsage: { last: { totalTokens: 12345 } },
+    },
+    generation: 1,
+  });
+  const running = page.locator('.composer-running');
+  await expect(running).toContainText('12.3k tokens');
+
+  // Seeing snapshot-only transcript content proves the delayed reply was
+  // installed; the composer must still retain the earlier usage notification.
+  await expect(page.getByText('Reconnect snapshot arrived')).toBeVisible();
+  await expect(running).toContainText('12.3k tokens');
 
   await page.getByTitle('Stop', { exact: true }).click();
   await expect.poll(() => app.requests.find(request =>

--- a/desktop/e2e/tests/support/desktop_browser_harness.js
+++ b/desktop/e2e/tests/support/desktop_browser_harness.js
@@ -55,6 +55,7 @@ export class DesktopBrowserHarness {
     ];
     this.codexRequiresAuth = false;
     this.codexModels = [];
+    this.codexThreadHistory = null;
     // Review and Git Graph share these immutable commit identities. Keeping
     // the file snapshots beside the graph data makes every fixture response
     // describe one coherent repository instead of isolated RPC examples.
@@ -623,6 +624,10 @@ export class DesktopBrowserHarness {
         return { data: this.codexModels };
       case 'codex.thread.list':
         return { data: [] };
+      case 'codex.thread.history.read':
+        return this.codexThreadHistory || {
+          thread: { id: request.params?.threadId, turns: [] },
+        };
       case 'codex.draft.open':
         return {
           draftId: request.params?.draft_id,

--- a/desktop/frontend/codex/activity.mbt
+++ b/desktop/frontend/codex/activity.mbt
@@ -58,6 +58,17 @@ fn CodexActivityLedger::entry(
 }
 
 ///|
+/// Whether ordered lifecycle evidence says this task is still running.
+/// Consumers use this semantic fact directly; sidebar marks and composer
+/// heartbeats remain separate presentations of it.
+fn CodexActivityLedger::is_running(
+  self : CodexActivityLedger,
+  thread_id : String,
+) -> Bool {
+  self.entry(thread_id).running
+}
+
+///|
 /// Replace one entry and advance the causal revision in the same operation.
 /// Keeping the mutable Map copy here prevents any lifecycle caller from
 /// aliasing an earlier State snapshot or forgetting the ordering fence.
@@ -154,8 +165,7 @@ fn CodexActivityLedger::presentation(
   self : CodexActivityLedger,
   thread_id : String,
 ) -> @conversation.RunMark {
-  let entry = self.entry(thread_id)
-  if entry.running {
+  if self.is_running(thread_id) {
     @conversation.RunningMark
   } else {
     @conversation.NoRunMark

--- a/desktop/frontend/codex/bridge.mbt
+++ b/desktop/frontend/codex/bridge.mbt
@@ -430,12 +430,18 @@ fn State::send(
   guard self.active_thread() is Some(active) else { return @cmd.none }
   guard !self.input_empty() else { return @cmd.none }
   let inputs = self.turn_inputs()
+  let client_user_message_id = self.client_user_message_id()
   if self.active_turn_id() is Some(turn_id) {
     CodexTurnSteerReply(active.id).request(
       dispatch,
       channel,
       @commands.codex_turn_steer,
-      { thread_id: active.id, input: inputs, expected_turn_id: turn_id, },
+      {
+        thread_id: active.id,
+        input: inputs,
+        client_user_message_id,
+        expected_turn_id: turn_id,
+      },
     )
   } else {
     if self.placement.wants_fresh() && active.turns.is_empty() {
@@ -443,7 +449,7 @@ fn State::send(
         active.cwd.unwrap_or("")
       })
       return self.start_turn_in_new_worktree(
-        dispatch, channel, active, workspace, inputs,
+        dispatch, channel, active, workspace, inputs, client_user_message_id,
       )
     }
     let model = self.selected_model.trim().to_owned()
@@ -455,6 +461,7 @@ fn State::send(
       {
         thread_id: active.id,
         input: inputs,
+        client_user_message_id,
         model: if model.is_empty() {
           None
         } else {
@@ -493,6 +500,17 @@ fn State::turn_inputs(self : State) -> Array[Json] {
 }
 
 ///|
+/// Prefix the next submission number with this Desktop page's opaque id.
+/// App-server echoes the result on the canonical User item. The counter
+/// advances only after a successful reply, so a failed request may retry the
+/// same human submission without changing ids.
+fn State::client_user_message_id(self : State) -> String? {
+  self.client_namespace.map(client_scope => {
+    "\{client_scope}-codex-submission-\{self.submission_sequence + 1}"
+  })
+}
+
+///|
 /// The shared first-send placement flow's Codex adapter: invoke the same
 /// owner-aware `worktree.create` used by OpenSeek, then differ only at the
 /// final backend call by starting an app-server turn with that exact cwd.
@@ -505,6 +523,7 @@ fn State::start_turn_in_new_worktree(
   active : CodexThread,
   workspace : String,
   inputs : Array[Json],
+  client_user_message_id : String?,
 ) -> @cmd.Cmd {
   let thread_id = active.id
   let model = self.selected_model.trim().to_owned()
@@ -560,6 +579,7 @@ fn State::start_turn_in_new_worktree(
             {
               thread_id,
               input: inputs,
+              client_user_message_id,
               model: if model.is_empty() {
                 None
               } else {

--- a/desktop/frontend/codex/completion.mbt
+++ b/desktop/frontend/codex/completion.mbt
@@ -285,7 +285,7 @@ fn CodexPermissionPicker::confirmation_dialog(
 /// while the turn fallback covers an item observed before its lifecycle event.
 fn State::composer_run(self : State) -> @composer.RunHeartbeat? {
   if self.waiting_for_first_user_item() {
-    return Some({ stage: @composer.Starting, started_ms: None, tokens: 0, })
+    return Some({ stage: @composer.Starting, started_ms: None, tokens: None, })
   }
   let active_turn = self.active_turn()
   guard self.is_running() else { return None }
@@ -294,7 +294,7 @@ fn State::composer_run(self : State) -> @composer.RunHeartbeat? {
     started_ms: active_turn
     .bind(turn => turn.started_at)
     .map(seconds => seconds.to_double() * 1000.0),
-    tokens: active_turn.map(turn => turn.latest_usage_tokens).unwrap_or(0),
+    tokens: active_turn.bind(turn => turn.latest_usage_tokens),
   })
 }
 

--- a/desktop/frontend/codex/completion.mbt
+++ b/desktop/frontend/codex/completion.mbt
@@ -110,7 +110,8 @@ fn State::input_empty(self : State) -> Bool {
 ///|
 /// Interpret a submitted shared-composer draft through thread creation,
 /// direct steering, or resume. Running tasks steer their reported active turn;
-/// idle stored tasks resume before starting a new turn.
+/// a status-only running task waits for that turn id instead of starting a
+/// competing turn, while idle stored tasks resume before starting a new turn.
 fn State::submit_composer(
   self : State,
   dispatch : @cmd.Emit[Msg],
@@ -142,15 +143,16 @@ fn State::submit_composer(
       next.start_draft_thread(dispatch, channel),
       next.begin_foreground(CodexDraftThreadReply(draft.id)),
     )
-  } else if ready.active_turn_id() is Some(_) {
+  } else if ready.is_running() {
+    guard ready.active_turn_id() is Some(turn_id) else {
+      return (@cmd.none, ready)
+    }
     guard ready.active_thread() is Some(active) else {
       return (@cmd.none, ready)
     }
-    let next = (if ready.active_turn_id() is Some(turn_id) {
-      ready.with_pending_steer(turn_id)
-    } else {
-      ready
-    }).begin_foreground(CodexTurnSteerReply(active.id))
+    let next = ready
+      .with_pending_steer(turn_id)
+      .begin_foreground(CodexTurnSteerReply(active.id))
     // Dispatch from the state that minted the receipt so both the local row
     // and app-server request carry the same client user-message id.
     (next.send(dispatch, channel), next)
@@ -286,10 +288,7 @@ fn State::composer_run(self : State) -> @composer.RunHeartbeat? {
     return Some({ stage: @composer.Starting, started_ms: None, tokens: 0, })
   }
   let active_turn = self.active_turn()
-  guard self.active_thread() is Some(active) &&
-    (self.activity.is_running(active.id) || active_turn is Some(_)) else {
-    return None
-  }
+  guard self.is_running() else { return None }
   Some({
     stage: @composer.Working,
     started_ms: active_turn
@@ -363,14 +362,16 @@ pub fn State::composer_input(
     )
   }
   let active_turn = self.active_turn_id()
+  let task_running = self.is_running()
   let missing_worktree = self.has_missing_worktree()
   let can_edit = self.can_prompt() &&
     self.connection is CodexReady &&
     !missing_worktree
-  let primary_action = if active_turn is Some(_) {
+  let primary_action = if task_running {
+    let turn_loaded = active_turn is Some(_)
     @composer.Running(
-      steer_available=can_edit,
-      can_stop=true,
+      steer_available=can_edit && turn_loaded,
+      can_stop=turn_loaded,
       submit=@composer.Steer,
     )
   } else {

--- a/desktop/frontend/codex/completion.mbt
+++ b/desktop/frontend/codex/completion.mbt
@@ -136,6 +136,7 @@ fn State::submit_composer(
         task: self.draft,
         mentions: self.mentions.copy(),
       }),
+      submitted_first_prompt_client_id: self.client_user_message_id(),
     }
     (
       next.start_draft_thread(dispatch, channel),
@@ -150,7 +151,9 @@ fn State::submit_composer(
     } else {
       ready
     }).begin_foreground(CodexTurnSteerReply(active.id))
-    (ready.send(dispatch, channel), next)
+    // Dispatch from the state that minted the receipt so both the local row
+    // and app-server request carry the same client user-message id.
+    (next.send(dispatch, channel), next)
   } else {
     guard ready.active_thread() is Some(active) else {
       return (@cmd.none, ready)
@@ -272,6 +275,31 @@ fn CodexPermissionPicker::confirmation_dialog(
 }
 
 ///|
+/// Project the selected task's run state into the shared composer heartbeat.
+/// Codex does not expose OpenSeek's live phase, so an active task reports the
+/// generic fact that it is working. A loaded turn contributes its protocol
+/// start time and latest model-call usage; a status-only adopted task reports
+/// neither rather than inventing facts. The activity ledger covers reconnect,
+/// while the turn fallback covers an item observed before its lifecycle event.
+fn State::composer_run(self : State) -> @composer.RunHeartbeat? {
+  if self.waiting_for_first_user_item() {
+    return Some({ stage: @composer.Starting, started_ms: None, tokens: 0, })
+  }
+  let active_turn = self.active_turn()
+  guard self.active_thread() is Some(active) &&
+    (self.activity.is_running(active.id) || active_turn is Some(_)) else {
+    return None
+  }
+  Some({
+    stage: @composer.Working,
+    started_ms: active_turn
+    .bind(turn => turn.started_at)
+    .map(seconds => seconds.to_double() * 1000.0),
+    tokens: active_turn.map(turn => turn.latest_usage_tokens).unwrap_or(0),
+  })
+}
+
+///|
 /// Project Codex's canonical task state and app-server-specific controls into
 /// the shared composer component. No editable or completion state is retained
 /// in this view projection.
@@ -351,14 +379,7 @@ pub fn State::composer_input(
   {
     identity: self.composer_identity(context.channel),
     draft: { task: self.draft, mentions: self.mentions, },
-    // Before the first real User item arrives, the only honest progress fact
-    // is that this accepted local submission is starting. Later Codex turns
-    // can overlap, so no broader single-turn heartbeat is inferred here.
-    run: if self.waiting_for_first_user_item() {
-      Some({ stage: @composer.Starting, started_ms: None, tokens: 0, })
-    } else {
-      None
-    },
+    run: self.composer_run(),
     goal: { draft: None, standing: None, pending: None, },
     slash_commands: [
       {

--- a/desktop/frontend/codex/completion_test.mbt
+++ b/desktop/frontend/codex/completion_test.mbt
@@ -1,0 +1,167 @@
+///|
+test "Codex composer reports selected task run status" {
+  let context : @codex.ComposerContext = {
+    channel: @interop.ChannelId::Local,
+    model_control: {
+      id: "codex-model-picker",
+      groups: [],
+      selected: "",
+      disabled: true,
+      open: false,
+      title: "Model",
+    },
+    reasoning_control: None,
+    file_candidates: [],
+    open_files: [],
+    active_file: None,
+    file_index: @composer.FileIndexReady(epoch=1, truncated=false),
+  }
+
+  // A loaded in-progress turn is enough even when a lifecycle notification
+  // was missed before this page attached.
+  let turn_running = @codex.State::from_thread_snapshot({
+    "thread": {
+      "id": "thread-turn-running",
+      "turns": [
+        {
+          "id": "turn-1",
+          "status": "inProgress",
+          "startedAt": 1000,
+          "items": [],
+        },
+      ],
+    },
+  })
+  guard turn_running.composer_input(context).run is Some(turn_run) else {
+    fail("an in-progress Codex turn should produce a composer heartbeat")
+  }
+  assert_true(turn_run.stage is @composer.Working)
+  assert_eq(turn_run.started_ms, Some(1_000_000.0))
+  assert_eq(turn_run.tokens, 0)
+
+  // The task-level status also covers an adopted run whose turns have not
+  // been loaded yet, such as immediately after reconnect.
+  let task_running = @codex.State::from_thread_snapshot({
+    "thread": {
+      "id": "thread-task-running",
+      "status": { "type": "active", "activeFlags": [] },
+      "turns": [],
+    },
+  })
+  guard task_running.composer_input(context).run is Some(task_run) else {
+    fail("an active Codex task should produce a composer heartbeat")
+  }
+  assert_true(task_run.stage is @composer.Working)
+
+  let idle = @codex.State::from_thread_snapshot({
+    "thread": {
+      "id": "thread-idle",
+      "status": { "type": "idle" },
+      "turns": [{ "id": "turn-1", "status": "completed", "items": [] }],
+    },
+  })
+  assert_eq(idle.composer_input(context).run, None)
+
+  // Live lifecycle notifications drive the same projection used by the
+  // mounted composer, then remove the row when the turn completes.
+  let emit : @cmd.Emit[@codex.Msg] = @cmd.Emit(_ => @cmd.none)
+  let open_external = (_ : String) => @cmd.none
+  let (_, started) = @codex.update(
+    emit,
+    @codex.Msg::notification(
+      "turn/started",
+      {
+        "threadId": "thread-idle",
+        "turn": {
+          "id": "turn-2",
+          "status": "inProgress",
+          "startedAt": 2000,
+          "items": [],
+        },
+      },
+      1,
+    ),
+    idle,
+    @interop.ChannelId::Local,
+    open_external,
+  )
+  guard started.composer_input(context).run is Some(live_run) else {
+    fail("a live Codex turn should produce a composer heartbeat")
+  }
+  assert_true(live_run.stage is @composer.Working)
+  assert_eq(live_run.started_ms, Some(2_000_000.0))
+  assert_eq(live_run.tokens, 0)
+
+  let usage = @codex.Msg::notification(
+    "thread/tokenUsage/updated",
+    {
+      "threadId": "thread-idle",
+      "turnId": "turn-2",
+      "tokenUsage": {
+        "total": { "totalTokens": 50000 },
+        "last": { "totalTokens": 12345 },
+        "modelContextWindow": 200000,
+      },
+    },
+    2,
+  )
+  let (_, with_usage) = @codex.update(
+    emit,
+    usage,
+    started,
+    @interop.ChannelId::Local,
+    open_external,
+  )
+  let (_, with_usage_again) = @codex.update(
+    emit,
+    usage,
+    started,
+    @interop.ChannelId::Local,
+    open_external,
+  )
+  assert_true(with_usage == with_usage_again)
+  guard with_usage.composer_input(context).run is Some(usage_run) else {
+    fail("Codex token usage should update the active composer heartbeat")
+  }
+  assert_eq(usage_run.tokens, 12345)
+
+  let (_, replaced_usage) = @codex.update(
+    emit,
+    @codex.Msg::notification(
+      "thread/tokenUsage/updated",
+      {
+        "threadId": "thread-idle",
+        "turnId": "turn-2",
+        "tokenUsage": {
+          "total": { "totalTokens": 50321 },
+          "last": { "totalTokens": 321 },
+          "modelContextWindow": 200000,
+        },
+      },
+      3,
+    ),
+    with_usage,
+    @interop.ChannelId::Local,
+    open_external,
+  )
+  guard replaced_usage.composer_input(context).run is Some(replaced_run) else {
+    fail("replacement token usage should keep the composer heartbeat")
+  }
+  assert_eq(replaced_run.tokens, 321)
+
+  let (_, completed) = @codex.update(
+    emit,
+    @codex.Msg::notification(
+      "turn/completed",
+      {
+        "threadId": "thread-idle",
+        "turn": { "id": "turn-2", "status": "completed", "items": [] },
+      },
+      4,
+    ),
+    replaced_usage,
+    @interop.ChannelId::Local,
+    open_external,
+  )
+  assert_eq(completed.composer_input(context).run, None)
+}

--- a/desktop/frontend/codex/completion_test.mbt
+++ b/desktop/frontend/codex/completion_test.mbt
@@ -38,7 +38,7 @@ test "Codex composer reports selected task run status" {
   }
   assert_true(turn_run.stage is @composer.Working)
   assert_eq(turn_run.started_ms, Some(1_000_000.0))
-  assert_eq(turn_run.tokens, 0)
+  assert_eq(turn_run.tokens, None)
   assert_true(
     turn_input.presentation.primary_action
     is @composer.Running(can_stop=true, ..),
@@ -58,6 +58,7 @@ test "Codex composer reports selected task run status" {
     fail("an active Codex task should produce a composer heartbeat")
   }
   assert_true(task_run.stage is @composer.Working)
+  assert_eq(task_run.tokens, None)
   guard task_input.presentation.primary_action
     is @composer.Running(steer_available~, can_stop~, ..) else {
     fail("an active Codex task without a turn id must keep running controls")
@@ -102,7 +103,7 @@ test "Codex composer reports selected task run status" {
   }
   assert_true(live_run.stage is @composer.Working)
   assert_eq(live_run.started_ms, Some(2_000_000.0))
-  assert_eq(live_run.tokens, 0)
+  assert_eq(live_run.tokens, None)
 
   let usage = @codex.Msg::notification(
     "thread/tokenUsage/updated",
@@ -135,7 +136,7 @@ test "Codex composer reports selected task run status" {
   guard with_usage.composer_input(context).run is Some(usage_run) else {
     fail("Codex token usage should update the active composer heartbeat")
   }
-  assert_eq(usage_run.tokens, 12345)
+  assert_eq(usage_run.tokens, Some(12345))
 
   let (_, replaced_usage) = @codex.update(
     emit,
@@ -145,8 +146,8 @@ test "Codex composer reports selected task run status" {
         "threadId": "thread-idle",
         "turnId": "turn-2",
         "tokenUsage": {
-          "total": { "totalTokens": 50321 },
-          "last": { "totalTokens": 321 },
+          "total": { "totalTokens": 50000 },
+          "last": { "totalTokens": 0 },
           "modelContextWindow": 200000,
         },
       },
@@ -159,7 +160,7 @@ test "Codex composer reports selected task run status" {
   guard replaced_usage.composer_input(context).run is Some(replaced_run) else {
     fail("replacement token usage should keep the composer heartbeat")
   }
-  assert_eq(replaced_run.tokens, 321)
+  assert_eq(replaced_run.tokens, Some(0))
 
   let (_, completed) = @codex.update(
     emit,

--- a/desktop/frontend/codex/completion_test.mbt
+++ b/desktop/frontend/codex/completion_test.mbt
@@ -32,12 +32,17 @@ test "Codex composer reports selected task run status" {
       ],
     },
   })
-  guard turn_running.composer_input(context).run is Some(turn_run) else {
+  let turn_input = turn_running.composer_input(context)
+  guard turn_input.run is Some(turn_run) else {
     fail("an in-progress Codex turn should produce a composer heartbeat")
   }
   assert_true(turn_run.stage is @composer.Working)
   assert_eq(turn_run.started_ms, Some(1_000_000.0))
   assert_eq(turn_run.tokens, 0)
+  assert_true(
+    turn_input.presentation.primary_action
+    is @composer.Running(can_stop=true, ..),
+  )
 
   // The task-level status also covers an adopted run whose turns have not
   // been loaded yet, such as immediately after reconnect.
@@ -48,10 +53,17 @@ test "Codex composer reports selected task run status" {
       "turns": [],
     },
   })
-  guard task_running.composer_input(context).run is Some(task_run) else {
+  let task_input = task_running.composer_input(context)
+  guard task_input.run is Some(task_run) else {
     fail("an active Codex task should produce a composer heartbeat")
   }
   assert_true(task_run.stage is @composer.Working)
+  guard task_input.presentation.primary_action
+    is @composer.Running(steer_available~, can_stop~, ..) else {
+    fail("an active Codex task without a turn id must keep running controls")
+  }
+  assert_false(steer_available)
+  assert_false(can_stop)
 
   let idle = @codex.State::from_thread_snapshot({
     "thread": {

--- a/desktop/frontend/codex/model.mbt
+++ b/desktop/frontend/codex/model.mbt
@@ -203,8 +203,9 @@ priv struct CodexTurn {
   started_at : Int?
   completed_at : Int?
   // The latest upstream model response, not this turn's cumulative usage.
-  // `thread/tokenUsage/updated` replaces it by exact turn id.
-  latest_usage_tokens : Int
+  // `None` means app-server has not reported it; an explicit zero remains a
+  // real report. `thread/tokenUsage/updated` replaces it by exact turn id.
+  latest_usage_tokens : Int?
   items : Array[CodexItem]
   // App-server's own statement of how complete `items` is: "full" is the
   // whole history, while "summary" (a `turn/completed` envelope drops the
@@ -1334,7 +1335,7 @@ fn CodexTurn::decode(value : Json) -> CodexTurn? {
     status: @jsonx.json_text(fields, "status").unwrap_or("completed"),
     started_at: @jsonx.json_int(fields, "startedAt"),
     completed_at: @jsonx.json_int(fields, "completedAt"),
-    latest_usage_tokens: 0,
+    latest_usage_tokens: None,
     items,
     items_view: @jsonx.json_text(fields, "itemsView"),
     error,
@@ -2301,7 +2302,7 @@ fn CodexThread::with_latest_usage(
     ..self,
     turns: self.turns.map(turn => {
       if turn.id == turn_id {
-        { ..turn, latest_usage_tokens: tokens, }
+        { ..turn, latest_usage_tokens: Some(tokens), }
       } else {
         turn
       }
@@ -2425,7 +2426,7 @@ fn CodexThread::with_item(
       status: "inProgress",
       started_at: None,
       completed_at: None,
-      latest_usage_tokens: 0,
+      latest_usage_tokens: None,
       items: [item],
       // Locally minted to hold an early item; the server never stated an
       // items view for it.
@@ -2493,7 +2494,7 @@ fn CodexThread::with_plan_update(
       status: "inProgress",
       started_at: None,
       completed_at: None,
-      latest_usage_tokens: 0,
+      latest_usage_tokens: None,
       items: [item],
       items_view: None,
       error: None,
@@ -3786,7 +3787,7 @@ test "Codex completed items replace streamed presentation state" {
     status: "inProgress",
     started_at: None,
     completed_at: None,
-    latest_usage_tokens: 0,
+    latest_usage_tokens: None,
     items: [started],
     items_view: None,
     error: None,

--- a/desktop/frontend/codex/model.mbt
+++ b/desktop/frontend/codex/model.mbt
@@ -1301,7 +1301,20 @@ fn CodexItem::decode(
     @jsonx.json_text(fields, "type") is Some(kind) else {
     return None
   }
-  Some({
+  Some(CodexItem(id, kind, value, completed~, ts?))
+}
+
+///|
+/// A freshly observed item: nothing streamed yet, and its reasoning sections
+/// still empty until their deltas arrive.
+fn CodexItem::CodexItem(
+  id : String,
+  kind : String,
+  value : Json,
+  completed? : Bool = true,
+  ts? : Double,
+) -> CodexItem {
+  {
     id,
     kind,
     value,
@@ -1310,7 +1323,7 @@ fn CodexItem::decode(
     streamed: "",
     reasoning_summary: CodexReasoningParts([]),
     reasoning_content: CodexReasoningParts([]),
-  })
+  }
 }
 
 ///|
@@ -2141,24 +2154,6 @@ fn CodexTurn::with_item(
 }
 
 ///|
-fn CodexTurn::with_delta(
-  self : CodexTurn,
-  item_id : String,
-  delta : String,
-) -> CodexTurn {
-  {
-    ..self,
-    items: self.items.map(item => {
-      if item.id == item_id {
-        { ..item, streamed: item.streamed + delta, }
-      } else {
-        item
-      }
-    }),
-  }
-}
-
-///|
 /// Ensure an indexed section exists without changing an already accumulated
 /// section. `summaryPartAdded` reaches this method before its text deltas.
 fn CodexReasoningParts::with_part(
@@ -2206,72 +2201,70 @@ fn CodexReasoningParts::text(self : CodexReasoningParts) -> String {
 }
 
 ///|
-fn CodexTurn::with_reasoning_summary_part(
-  self : CodexTurn,
-  item_id : String,
-  summary_index : Int?,
-) -> CodexTurn {
+/// Apply one change to the turn with this id. Unknown turn ids stay inert: a
+/// notification-only fact must not invent a turn, its transcript, or Stop
+/// authority.
+fn CodexThread::update_turn(
+  self : CodexThread,
+  turn_id : String,
+  f : (CodexTurn) -> CodexTurn,
+) -> CodexThread {
   {
     ..self,
-    items: self.items.map(item => {
-      if item.id == item_id && item.kind == "reasoning" {
-        {
-          ..item,
-          reasoning_summary: item.reasoning_summary.with_part(summary_index),
-        }
+    turns: self.turns.map(turn => {
+      if turn.id == turn_id {
+        f(turn)
       } else {
-        item
+        turn
       }
     }),
   }
 }
 
 ///|
-fn CodexTurn::with_reasoning_summary_delta(
-  self : CodexTurn,
+/// Apply one change to the item with this id inside the turn with that id.
+/// Unknown turn or item ids stay inert until their lifecycle item arrives.
+fn CodexThread::update_item(
+  self : CodexThread,
+  turn_id : String,
   item_id : String,
-  summary_index : Int?,
-  delta : String,
-) -> CodexTurn {
-  {
-    ..self,
-    items: self.items.map(item => {
-      if item.id == item_id && item.kind == "reasoning" {
-        {
-          ..item,
-          reasoning_summary: item.reasoning_summary.with_delta(
-            summary_index, delta,
-          ),
-        }
+  f : (CodexItem) -> CodexItem,
+) -> CodexThread {
+  self.update_turn(turn_id, turn => {
+    ..turn,
+    items: turn.items.map(item => {
+      if item.id == item_id {
+        f(item)
       } else {
         item
       }
     }),
-  }
+  })
 }
 
 ///|
-fn CodexTurn::with_reasoning_content_delta(
-  self : CodexTurn,
-  item_id : String,
-  content_index : Int?,
-  delta : String,
-) -> CodexTurn {
-  {
-    ..self,
-    items: self.items.map(item => {
-      if item.id == item_id && item.kind == "reasoning" {
-        {
-          ..item,
-          reasoning_content: item.reasoning_content.with_delta(
-            content_index, delta,
-          ),
-        }
-      } else {
-        item
-      }
-    }),
+/// Apply one change to the turn with this id, minting a local in-progress
+/// turn first when an item arrives before its lifecycle envelope. The server
+/// never stated an items view for a minted turn.
+fn CodexThread::update_or_mint_turn(
+  self : CodexThread,
+  turn_id : String,
+  f : (CodexTurn) -> CodexTurn,
+) -> CodexThread {
+  if self.turns.iter().any(turn => turn.id == turn_id) {
+    return self.update_turn(turn_id, f)
   }
+  let minted : CodexTurn = {
+    id: turn_id,
+    status: "inProgress",
+    started_at: None,
+    completed_at: None,
+    latest_usage_tokens: None,
+    items: [],
+    items_view: None,
+    error: None,
+  }
+  { ..self, turns: [..self.turns, f(minted)], }
 }
 
 ///|
@@ -2320,26 +2313,6 @@ fn CodexThread::with_turn(self : CodexThread, turn : CodexTurn) -> CodexThread {
     turns.push(turn)
   }
   { ..self, turns, }
-}
-
-///|
-/// Replace one turn's latest model-call usage. Unknown turn ids stay inert:
-/// accounting data must not invent transcript or Stop authority.
-fn CodexThread::with_latest_usage(
-  self : CodexThread,
-  turn_id : String,
-  tokens : Int,
-) -> CodexThread {
-  {
-    ..self,
-    turns: self.turns.map(turn => {
-      if turn.id == turn_id {
-        { ..turn, latest_usage_tokens: Some(tokens), }
-      } else {
-        turn
-      }
-    }),
-  }
 }
 
 ///|
@@ -2443,30 +2416,7 @@ fn CodexThread::with_item(
   item : CodexItem,
   completed~ : Bool,
 ) -> CodexThread {
-  let mut found = false
-  let turns = self.turns.map(turn => {
-    if turn.id == turn_id {
-      found = true
-      turn.with_item(item, completed~)
-    } else {
-      turn
-    }
-  })
-  if !found {
-    turns.push({
-      id: turn_id,
-      status: "inProgress",
-      started_at: None,
-      completed_at: None,
-      latest_usage_tokens: None,
-      items: [item],
-      // Locally minted to hold an early item; the server never stated an
-      // items view for it.
-      items_view: None,
-      error: None,
-    })
-  }
-  { ..self, turns, }
+  self.update_or_mint_turn(turn_id, turn => turn.with_item(item, completed~))
 }
 
 ///|
@@ -2493,46 +2443,19 @@ fn CodexThread::with_plan_update(
     steps.push({ "title": title, "status": status })
   }
   let id = "openseek-plan:\{turn_id}"
-  let value : Json = {
+  let item = CodexItem(id, "planUpdate", {
     "id": id,
     "type": "planUpdate",
     "steps": Json::array(steps),
     "explanation": fields.get("explanation").unwrap_or(Json::null()),
-  }
-  let item : CodexItem = {
-    id,
-    kind: "planUpdate",
-    value,
-    completed: true,
-    ts: None,
-    streamed: "",
-    reasoning_summary: CodexReasoningParts([]),
-    reasoning_content: CodexReasoningParts([]),
-  }
-  let mut found = false
-  let turns = self.turns.map(turn => {
-    if turn.id == turn_id {
-      found = true
-      let items = turn.items.filter(existing => existing.kind != "planUpdate")
-      items.push(item)
-      { ..turn, items, }
-    } else {
-      turn
-    }
   })
-  if !found {
-    turns.push({
-      id: turn_id,
-      status: "inProgress",
-      started_at: None,
-      completed_at: None,
-      latest_usage_tokens: None,
-      items: [item],
-      items_view: None,
-      error: None,
-    })
-  }
-  { ..self, turns, }
+  self.update_or_mint_turn(turn_id, turn => {
+    ..turn,
+    items: [
+      ..turn.items.filter(existing => existing.kind != "planUpdate"),
+      item,
+    ],
+  })
 }
 
 ///|
@@ -2542,112 +2465,10 @@ fn CodexThread::with_delta(
   item_id : String,
   delta : String,
 ) -> CodexThread {
-  {
-    ..self,
-    turns: self.turns.map(turn => {
-      if turn.id == turn_id {
-        turn.with_delta(item_id, delta)
-      } else {
-        turn
-      }
-    }),
-  }
-}
-
-///|
-/// Preserve app-server's indexed reasoning summary boundaries on the owning
-/// turn. Unknown turn or item ids stay inert until their lifecycle item arrives.
-fn CodexThread::with_reasoning_summary_part(
-  self : CodexThread,
-  turn_id : String,
-  item_id : String,
-  summary_index : Int?,
-) -> CodexThread {
-  {
-    ..self,
-    turns: self.turns.map(turn => {
-      if turn.id == turn_id {
-        turn.with_reasoning_summary_part(item_id, summary_index)
-      } else {
-        turn
-      }
-    }),
-  }
-}
-
-///|
-fn CodexThread::with_reasoning_summary_delta(
-  self : CodexThread,
-  turn_id : String,
-  item_id : String,
-  summary_index : Int?,
-  delta : String,
-) -> CodexThread {
-  {
-    ..self,
-    turns: self.turns.map(turn => {
-      if turn.id == turn_id {
-        turn.with_reasoning_summary_delta(item_id, summary_index, delta)
-      } else {
-        turn
-      }
-    }),
-  }
-}
-
-///|
-fn CodexThread::with_reasoning_content_delta(
-  self : CodexThread,
-  turn_id : String,
-  item_id : String,
-  content_index : Int?,
-  delta : String,
-) -> CodexThread {
-  {
-    ..self,
-    turns: self.turns.map(turn => {
-      if turn.id == turn_id {
-        turn.with_reasoning_content_delta(item_id, content_index, delta)
-      } else {
-        turn
-      }
-    }),
-  }
-}
-
-///|
-/// Adopt app-server's authoritative live patch for one file-change item. The
-/// item id and all lifecycle fields stay untouched; only the `changes` payload
-/// that the shared diff card reads is replaced.
-fn CodexThread::with_file_changes(
-  self : CodexThread,
-  turn_id : String,
-  item_id : String,
-  changes : Json,
-) -> CodexThread {
-  {
-    ..self,
-    turns: self.turns.map(turn => {
-      if turn.id == turn_id {
-        {
-          ..turn,
-          items: turn.items.map(item => {
-            if item.id == item_id &&
-              item.kind == "fileChange" &&
-              item.value is Object(fields) {
-              let fields = fields.copy()
-              fields["changes"] = changes
-              { ..item, value: Json::object(fields), }
-            } else {
-              item
-            }
-          }),
-        }
-      } else {
-        turn
-      }
-    }),
-  }
+  self.update_item(turn_id, item_id, item => {
+    ..item,
+    streamed: item.streamed + delta,
+  })
 }
 
 ///|
@@ -2700,164 +2521,139 @@ fn State::with_notification(
     thread_id.unwrap_or(active.id) == active.id else {
     return observed
   }
-  let next = match method_ {
-    "thread/name/updated" =>
+  // Every per-turn notification below lands in the selected stored task.
+  let with_active = (thread : CodexThread) => {
+    ..observed,
+    selection: CodexStoredTask(thread),
+  }
+  let turn_id = @jsonx.json_text(fields, "turnId")
+  let item_id = @jsonx.json_text(fields, "itemId")
+  let delta = @jsonx.json_text(fields, "delta")
+  let next = match (method_, turn_id, item_id) {
+    ("thread/name/updated", _, _) =>
       if @jsonx.json_text(fields, "name") is Some(title) {
-        { ..observed, selection: CodexStoredTask({ ..active, title, }), }
+        with_active({ ..active, title, })
       } else {
         observed
       }
-    "turn/started" | "turn/completed" =>
+    ("turn/started" | "turn/completed", _, _) =>
       if fields.get("turn") is Some(value) &&
         CodexTurn::decode(value) is Some(turn) {
-        { ..observed, selection: CodexStoredTask(active.with_turn(turn)), }
+        with_active(active.with_turn(turn))
       } else {
         observed
       }
-    "thread/tokenUsage/updated" =>
-      if @jsonx.json_text(fields, "turnId") is Some(turn_id) &&
-        fields.get("tokenUsage") is Some(Object(usage)) &&
+    ("thread/tokenUsage/updated", Some(turn_id), _) =>
+      if fields.get("tokenUsage") is Some(Object(usage)) &&
         usage.get("last") is Some(Object(last)) &&
         @jsonx.json_int(last, "totalTokens") is Some(tokens) &&
         tokens >= 0 {
-        {
-          ..observed,
-          selection: CodexStoredTask(active.with_latest_usage(turn_id, tokens)),
-        }
+        with_active(
+          active.update_turn(turn_id, turn => {
+            ..turn,
+            latest_usage_tokens: Some(tokens),
+          }),
+        )
       } else {
         observed
       }
-    "turn/plan/updated" =>
-      if @jsonx.json_text(fields, "turnId") is Some(turn_id) {
-        {
-          ..observed,
-          selection: CodexStoredTask(active.with_plan_update(turn_id, fields)),
-        }
+    ("turn/plan/updated", Some(turn_id), _) =>
+      with_active(active.with_plan_update(turn_id, fields))
+    ("item/started" | "item/completed", Some(turn_id), _) => {
+      let completed = method_ == "item/completed"
+      let ts = match
+        fields.get(if completed { "completedAtMs" } else { "startedAtMs" }) {
+        Some(Number(value, ..)) => Some(value)
+        _ => None
+      }
+      if fields.get("item") is Some(value) &&
+        CodexItem::decode(value, completed~, ts?) is Some(item) {
+        with_active(active.with_item(turn_id, item, completed~))
       } else {
         observed
       }
-    "item/started" | "item/completed" =>
-      if @jsonx.json_text(fields, "turnId") is Some(turn_id) &&
-        fields.get("item") is Some(value) {
-        let completed = method_ == "item/completed"
-        let ts = match
-          fields.get(if completed { "completedAtMs" } else { "startedAtMs" }) {
-          Some(Number(value, ..)) => Some(value)
-          _ => None
-        }
-        if CodexItem::decode(value, completed~, ts?) is Some(item) {
-          {
-            ..observed,
-            selection: CodexStoredTask(
-              active.with_item(turn_id, item, completed~),
-            ),
-          }
-        } else {
-          observed
-        }
+    }
+    (
+      "item/agentMessage/delta"
+      | "item/plan/delta"
+      | "item/commandExecution/outputDelta"
+      | "item/fileChange/outputDelta",
+      Some(turn_id),
+      Some(item_id),
+    ) =>
+      if delta is Some(delta) {
+        with_active(active.with_delta(turn_id, item_id, delta))
       } else {
         observed
       }
-    "item/agentMessage/delta"
-    | "item/plan/delta"
-    | "item/commandExecution/outputDelta"
-    | "item/fileChange/outputDelta" =>
-      if @jsonx.json_text(fields, "turnId") is Some(turn_id) &&
-        @jsonx.json_text(fields, "itemId") is Some(item_id) &&
-        @jsonx.json_text(fields, "delta") is Some(delta) {
-        {
-          ..observed,
-          selection: CodexStoredTask(active.with_delta(turn_id, item_id, delta)),
-        }
+    ("item/mcpToolCall/progress", Some(turn_id), Some(item_id)) =>
+      if @jsonx.json_text(fields, "message") is Some(message) {
+        with_active(active.with_delta(turn_id, item_id, "\{message}\n"))
       } else {
         observed
       }
-    "item/reasoning/summaryPartAdded" =>
-      if @jsonx.json_text(fields, "turnId") is Some(turn_id) &&
-        @jsonx.json_text(fields, "itemId") is Some(item_id) {
-        {
-          ..observed,
-          selection: CodexStoredTask(
-            active.with_reasoning_summary_part(
-              turn_id,
-              item_id,
-              @jsonx.json_int(fields, "summaryIndex"),
-            ),
+    // Indexed reasoning sections accumulate on the item; the summary and raw
+    // streams stay separate so neither can interleave into the other.
+    ("item/reasoning/summaryPartAdded", Some(turn_id), Some(item_id)) =>
+      with_active(
+        active.update_item(turn_id, item_id, item => {
+          ..item,
+          reasoning_summary: item.reasoning_summary.with_part(
+            @jsonx.json_int(fields, "summaryIndex"),
           ),
-        }
-      } else {
-        observed
-      }
-    "item/reasoning/summaryTextDelta" =>
-      if @jsonx.json_text(fields, "turnId") is Some(turn_id) &&
-        @jsonx.json_text(fields, "itemId") is Some(item_id) &&
-        @jsonx.json_text(fields, "delta") is Some(delta) {
-        {
-          ..observed,
-          selection: CodexStoredTask(
-            active.with_reasoning_summary_delta(
-              turn_id,
-              item_id,
+        }),
+      )
+    ("item/reasoning/summaryTextDelta", Some(turn_id), Some(item_id)) =>
+      if delta is Some(delta) {
+        with_active(
+          active.update_item(turn_id, item_id, item => {
+            ..item,
+            reasoning_summary: item.reasoning_summary.with_delta(
               @jsonx.json_int(fields, "summaryIndex"),
               delta,
             ),
-          ),
-        }
+          }),
+        )
       } else {
         observed
       }
-    "item/reasoning/textDelta" =>
-      if @jsonx.json_text(fields, "turnId") is Some(turn_id) &&
-        @jsonx.json_text(fields, "itemId") is Some(item_id) &&
-        @jsonx.json_text(fields, "delta") is Some(delta) {
-        {
-          ..observed,
-          selection: CodexStoredTask(
-            active.with_reasoning_content_delta(
-              turn_id,
-              item_id,
+    ("item/reasoning/textDelta", Some(turn_id), Some(item_id)) =>
+      if delta is Some(delta) {
+        with_active(
+          active.update_item(turn_id, item_id, item => {
+            ..item,
+            reasoning_content: item.reasoning_content.with_delta(
               @jsonx.json_int(fields, "contentIndex"),
               delta,
             ),
-          ),
-        }
+          }),
+        )
       } else {
         observed
       }
-    "item/mcpToolCall/progress" =>
-      if @jsonx.json_text(fields, "turnId") is Some(turn_id) &&
-        @jsonx.json_text(fields, "itemId") is Some(item_id) &&
-        @jsonx.json_text(fields, "message") is Some(message) {
-        {
-          ..observed,
-          selection: CodexStoredTask(
-            active.with_delta(turn_id, item_id, "\{message}\n"),
-          ),
-        }
+    // App-server's live patch is authoritative for the `changes` payload the
+    // shared diff card reads; the item id and lifecycle fields stay untouched.
+    ("item/fileChange/patchUpdated", Some(turn_id), Some(item_id)) =>
+      if fields.get("changes") is Some(changes) {
+        with_active(
+          active.update_item(turn_id, item_id, item => {
+            guard item.value is Object(value) else { return item }
+            let value = value.copy()
+            value["changes"] = changes
+            { ..item, value: Json::object(value), }
+          }),
+        )
       } else {
         observed
       }
-    "item/fileChange/patchUpdated" =>
-      if @jsonx.json_text(fields, "turnId") is Some(turn_id) &&
-        @jsonx.json_text(fields, "itemId") is Some(item_id) &&
-        fields.get("changes") is Some(changes) {
-        {
-          ..observed,
-          selection: CodexStoredTask(
-            active.with_file_changes(turn_id, item_id, changes),
-          ),
-        }
-      } else {
-        observed
-      }
-    "error" =>
+    ("error", _, _) =>
       if fields.get("error") is Some(Object(error)) &&
         @jsonx.json_text(error, "message") is Some(message) {
         { ..observed, notice: message, }
       } else {
         observed
       }
-    "warning" =>
+    ("warning", _, _) =>
       if @jsonx.json_text(fields, "message") is Some(message) {
         { ..observed, notice: message, }
       } else {
@@ -3296,24 +3092,13 @@ fn CodexItem::tool_arguments(self : CodexItem) -> String? {
   }
   match self.kind {
     "commandExecution" => {
-      // app-server omits metadata it does not know. Keep that absence in the
-      // shared arguments object instead of inventing empty-string values.
-      let arguments : Map[String, Json] = Map([])
-      if self.command_read_action() is Some(action) {
-        if @jsonx.json_text(action, "path") is Some(path) {
-          arguments["path"] = Json(path)
-        }
-        if @jsonx.json_text(action, "name") is Some(name) {
-          arguments["name"] = Json(name)
-        }
-        if @jsonx.json_text(action, "command") is Some(command) {
-          arguments["command"] = Json(command)
-        }
-      } else if @jsonx.json_text(fields, "command") is Some(command) {
-        arguments["command"] = Json(command)
+      let arguments = if self.command_read_action() is Some(action) {
+        supplied(action, ["path", "name", "command"])
+      } else {
+        supplied(fields, ["command"])
       }
-      if @jsonx.json_text(fields, "cwd") is Some(cwd) {
-        arguments["cwd"] = Json(cwd)
+      if fields.get("cwd") is Some(cwd) {
+        arguments["cwd"] = cwd
       }
       Some(Json::object(arguments).stringify())
     }
@@ -3330,85 +3115,79 @@ fn CodexItem::tool_arguments(self : CodexItem) -> String? {
       }
     "mcpToolCall" | "dynamicToolCall" =>
       fields.get("arguments").map(value => value.stringify())
-    "collabAgentToolCall" => {
-      let arguments : Map[String, Json] = Map([])
-      if @jsonx.json_text(fields, "tool") is Some(tool) {
-        arguments["tool"] = Json(tool)
-      }
-      for
-        key in [
-          "prompt", "model", "reasoningEffort", "senderThreadId", "receiverThreadIds",
-        ] {
-        if fields.get(key) is Some(value) {
-          arguments[key] = value
-        }
-      }
-      Some(Json::object(arguments).stringify())
-    }
-    "subAgentActivity" => {
-      let arguments : Map[String, Json] = Map([])
-      for key in ["agentPath", "agentThreadId", "kind"] {
-        if @jsonx.json_text(fields, key) is Some(value) {
-          arguments[key] = Json(value)
-        }
-      }
-      Some(Json::object(arguments).stringify())
-    }
+    "collabAgentToolCall" =>
+      Some(
+        Json::object(
+          supplied(fields, [
+            "tool", "prompt", "model", "reasoningEffort", "senderThreadId", "receiverThreadIds",
+          ]),
+        ).stringify(),
+      )
+    "subAgentActivity" =>
+      Some(
+        Json::object(supplied(fields, ["agentPath", "agentThreadId", "kind"])).stringify(),
+      )
     "hookPrompt" =>
       fields
       .get("fragments")
-      .map(fragments => {
-        let arguments : Json = { "fragments": fragments }
-        arguments.stringify()
-      })
-    "webSearch" => {
-      let arguments : Map[String, Json] = Map([])
-      if @jsonx.json_text(fields, "query") is Some(query) {
-        arguments["query"] = Json(query)
-      }
-      if fields.get("action") is Some(action) {
-        arguments["action"] = action
-      }
-      Some(Json::object(arguments).stringify())
-    }
-    "imageView" => {
-      let arguments : Map[String, Json] = Map([])
-      if @jsonx.json_text(fields, "path") is Some(path) {
-        arguments["path"] = Json(path)
-      }
-      Some(Json::object(arguments).stringify())
-    }
+      .map(fragments => Json::object({ "fragments": fragments }).stringify())
+    "webSearch" =>
+      Some(Json::object(supplied(fields, ["query", "action"])).stringify())
+    "imageView" => Some(Json::object(supplied(fields, ["path"])).stringify())
     "sleep" =>
       fields
       .get("durationMs")
-      .map(duration => {
-        let arguments : Json = { "durationMs": duration }
-        arguments.stringify()
-      })
-    "imageGeneration" => {
-      let arguments : Map[String, Json] = Map([])
-      for key in ["revisedPrompt", "transparentBackground"] {
-        if fields.get(key) is Some(value) {
-          arguments[key] = value
-        }
-      }
-      Some(Json::object(arguments).stringify())
-    }
-    "enteredReviewMode" | "exitedReviewMode" => {
-      let arguments : Map[String, Json] = Map([])
-      if @jsonx.json_text(fields, "review") is Some(review) {
-        arguments["review"] = Json(review)
-      }
-      Some(Json::object(arguments).stringify())
-    }
+      .map(duration => Json::object({ "durationMs": duration }).stringify())
+    "imageGeneration" =>
+      Some(
+        Json::object(
+          supplied(fields, ["revisedPrompt", "transparentBackground"]),
+        ).stringify(),
+      )
+    "enteredReviewMode" | "exitedReviewMode" =>
+      Some(Json::object(supplied(fields, ["review"])).stringify())
     "planUpdate" =>
       fields
       .get("steps")
-      .map(steps => {
-        let arguments : Json = { "steps": steps }
-        arguments.stringify()
-      })
+      .map(steps => Json::object({ "steps": steps }).stringify())
     _ => Some(self.value.stringify())
+  }
+}
+
+///|
+/// The listed keys app-server actually supplied, in that order. Absent
+/// metadata stays absent: an empty string, null, or empty collection can be a
+/// real supplied value and must not be invented as a missing-field marker.
+fn supplied(
+  fields : Map[String, Json],
+  keys : Array[String],
+) -> Map[String, Json] {
+  let picked : Map[String, Json] = Map([])
+  for key in keys {
+    if fields.get(key) is Some(value) {
+      picked[key] = value
+    }
+  }
+  picked
+}
+
+///|
+/// The joined text of a content list whose every block is text of this type,
+/// or `None` when any block is something the shared row must show as JSON.
+fn text_blocks(blocks : Array[Json], type_ : String) -> String? {
+  let text : Array[String] = []
+  for block in blocks {
+    guard block is Object(content) &&
+      @jsonx.json_text(content, "type") == Some(type_) &&
+      @jsonx.json_text(content, "text") is Some(value) else {
+      return None
+    }
+    text.push(value)
+  }
+  if text.is_empty() {
+    None
+  } else {
+    Some(text.join("\n"))
   }
 }
 
@@ -3460,47 +3239,23 @@ fn CodexItem::tool_output(self : CodexItem) -> String {
         return message
       }
       if fields.get("result") is Some(Object(result)) &&
-        result.get("content") is Some(Array(blocks)) {
-        let text : Array[String] = []
-        let mut text_only = true
-        for block in blocks {
-          if block is Object(content) &&
-            @jsonx.json_text(content, "type") is Some("text") &&
-            @jsonx.json_text(content, "text") is Some(value) {
-            text.push(value)
-          } else {
-            text_only = false
-          }
-        }
-        if text_only && !text.is_empty() {
-          return text.join("\n")
-        }
+        result.get("content") is Some(Array(blocks)) &&
+        text_blocks(blocks, "text") is Some(text) {
+        return text
       }
       match fields.get("result") {
         Some(Null) | None => self.streamed
         Some(result) => result.stringify(indent=2)
       }
     }
-    "dynamicToolCall" => {
+    "dynamicToolCall" =>
       if fields.get("contentItems") is Some(Array(items)) {
-        let text : Array[String] = []
-        let mut text_only = true
-        for item in items {
-          if item is Object(content) &&
-            @jsonx.json_text(content, "type") is Some("inputText") &&
-            @jsonx.json_text(content, "text") is Some(value) {
-            text.push(value)
-          } else {
-            text_only = false
-          }
-        }
-        if text_only && !text.is_empty() {
-          return text.join("\n")
-        }
-        return Json::array(items).stringify(indent=2)
+        text_blocks(items, "inputText").unwrap_or_else(() => {
+          Json::array(items).stringify(indent=2)
+        })
+      } else {
+        ""
       }
-      ""
-    }
     "collabAgentToolCall" =>
       fields
       .get("agentsStates")
@@ -3814,17 +3569,16 @@ test "Codex completed items replace streamed presentation state" {
     "type": "agentMessage",
     "text": "",
   }).unwrap()
-  let turn : CodexTurn = {
+  let streamed : CodexTurn = {
     id: "turn-1",
     status: "inProgress",
     started_at: None,
     completed_at: None,
     latest_usage_tokens: None,
-    items: [started],
+    items: [{ ..started, streamed: "partial", }],
     items_view: None,
     error: None,
   }
-  let streamed = turn.with_delta("item-1", "partial")
   assert_eq(streamed.items[0].text(), "partial")
   let completed = CodexItem::decode({
     "id": "item-1",

--- a/desktop/frontend/codex/model.mbt
+++ b/desktop/frontend/codex/model.mbt
@@ -1767,6 +1767,14 @@ fn State::with_thread_reply(
       notice: "Codex returned thread \{active.id} for requested thread \{requested}",
     }
   }
+  // A reconnect history read can race a token-usage notification for the
+  // selected task. Snapshot turns do not contain that notification-only
+  // field, so retain it before replacing the otherwise-authoritative thread.
+  let active = match self.active_thread() {
+    Some(previous) if previous.id == active.id =>
+      active.with_snapshot_usage_from(previous)
+    _ => active
+  }
   // Selecting a stored thread must not promote it to the top of the sidebar.
   // Replace its row in place; only `thread/start`, whose id is genuinely new,
   // is prepended until the authoritative catalog refresh arrives.
@@ -2262,6 +2270,30 @@ fn CodexTurn::with_reasoning_content_delta(
       } else {
         item
       }
+    }),
+  }
+}
+
+///|
+/// Copy notification-only usage into a replacement snapshot by app-server
+/// turn id. Transcript and lifecycle fields remain owned by the new snapshot.
+fn CodexThread::with_snapshot_usage_from(
+  self : CodexThread,
+  previous : CodexThread,
+) -> CodexThread {
+  {
+    ..self,
+    turns: self.turns.map(turn => {
+      let mut latest_usage_tokens = turn.latest_usage_tokens
+      if latest_usage_tokens is None {
+        for existing in previous.turns {
+          if existing.id == turn.id {
+            latest_usage_tokens = existing.latest_usage_tokens
+            break
+          }
+        }
+      }
+      { ..turn, latest_usage_tokens, }
     }),
   }
 }

--- a/desktop/frontend/codex/model.mbt
+++ b/desktop/frontend/codex/model.mbt
@@ -160,6 +160,20 @@ priv struct CodexArchiveConfirm {
 } derive(Eq)
 
 ///|
+/// One indexed reasoning section accumulated from app-server deltas. The
+/// index is optional only for compatibility with stored/live envelopes that
+/// predate the indexed protocol; it is never replaced with a sentinel number.
+priv struct CodexReasoningPart {
+  index : Int?
+  text : String
+} derive(Eq)
+
+///|
+/// Ordered reasoning sections. Summary and raw reasoning use separate values
+/// so receiving both streams can never interleave them into one document.
+priv struct CodexReasoningParts(Array[CodexReasoningPart]) derive(Eq)
+
+///|
 priv struct CodexItem {
   id : String
   kind : String
@@ -175,6 +189,8 @@ priv struct CodexItem {
   // Deltas are presentation-only. `item/completed` replaces `value` and
   // clears this field because the completed item is authoritative.
   streamed : String
+  reasoning_summary : CodexReasoningParts
+  reasoning_content : CodexReasoningParts
 } derive(Eq)
 
 ///|
@@ -186,6 +202,9 @@ priv struct CodexTurn {
   // live turn; it does not identify which process owns the writer.
   started_at : Int?
   completed_at : Int?
+  // The latest upstream model response, not this turn's cumulative usage.
+  // `thread/tokenUsage/updated` replaces it by exact turn id.
+  latest_usage_tokens : Int
   items : Array[CodexItem]
   // App-server's own statement of how complete `items` is: "full" is the
   // whole history, while "summary" (a `turn/completed` envelope drops the
@@ -278,10 +297,13 @@ priv struct CodexPendingRequest {
 /// App-server owns the durable `userMessage` item and its id. This local value
 /// is never inserted into `CodexTurn.items`, never used to retry a request, and
 /// disappears only on a definite request failure or when the corresponding
-/// canonical item is observed under the single-client FIFO rule documented in
-/// `State::with_observed_steer_item`.
+/// canonical item echoes its client user-message id. Older records without
+/// that field retain the compatibility rule documented by reconciliation.
 priv struct CodexSteerReceipt {
   submission_id : Int
+  // Echoed by the canonical User item's `clientId`. Production pages always
+  // supply one; `None` keeps imported tests and older snapshots explicit.
+  client_user_message_id : String?
   turn_id : String
   submitted : @composer.Draft
   known_user_item_ids : Array[String]
@@ -579,6 +601,11 @@ pub fn Msg::server_request(
 
 ///|
 struct State {
+  // An opaque id for this Desktop page instance, supplied by the root model.
+  // It is not a Codex task id or connection id. Combined with the accepted-
+  // submission counter, it prevents two open pages writing to the same task
+  // from generating the same `clientUserMessageId`.
+  client_namespace : String?
   connection : CodexConnection
   account : CodexAccount
   login_id : String?
@@ -617,10 +644,13 @@ struct State {
   // request construction continues to read `draft` and `mentions`, and no
   // retry or history read is derived from this field.
   submitted_first_prompt : @composer.Draft?
+  // The exact id sent beside `submitted_first_prompt`. It survives RPC
+  // acceptance so the later canonical User item can replace only its own row.
+  submitted_first_prompt_client_id : String?
   // Later inputs sent into an in-progress turn get the same immediate visual
   // receipt as the first prompt. These receipts remain separate from canonical
-  // turn items because app-server does not return the new user item id from
-  // `turn/steer`.
+  // turn items because `turn/steer` does not return the canonical item id;
+  // its later User item instead echoes our client user-message id.
   pending_steers : Array[CodexSteerReceipt]
   next_steer_submission_id : Int
   // The shared component advances only after app-server accepts a submission.
@@ -642,8 +672,12 @@ struct State {
 } derive(Eq)
 
 ///|
-pub fn State::State(loading? : Bool = false) -> State {
+pub fn State::State(
+  loading? : Bool = false,
+  client_namespace? : String,
+) -> State {
   {
+    client_namespace,
     connection: CodexStarting,
     account: CodexAccountUnknown,
     login_id: None,
@@ -667,6 +701,7 @@ pub fn State::State(loading? : Bool = false) -> State {
     draft: "",
     mentions: [],
     submitted_first_prompt: None,
+    submitted_first_prompt_client_id: None,
     pending_steers: [],
     next_steer_submission_id: 1,
     submission_sequence: 0,
@@ -1265,7 +1300,16 @@ fn CodexItem::decode(
     @jsonx.json_text(fields, "type") is Some(kind) else {
     return None
   }
-  Some({ id, kind, value, completed, ts, streamed: "", })
+  Some({
+    id,
+    kind,
+    value,
+    completed,
+    ts,
+    streamed: "",
+    reasoning_summary: CodexReasoningParts([]),
+    reasoning_content: CodexReasoningParts([]),
+  })
 }
 
 ///|
@@ -1290,6 +1334,7 @@ fn CodexTurn::decode(value : Json) -> CodexTurn? {
     status: @jsonx.json_text(fields, "status").unwrap_or("completed"),
     started_at: @jsonx.json_int(fields, "startedAt"),
     completed_at: @jsonx.json_int(fields, "completedAt"),
+    latest_usage_tokens: 0,
     items,
     items_view: @jsonx.json_text(fields, "itemsView"),
     error,
@@ -1781,6 +1826,11 @@ fn State::with_thread_reply(
     } else {
       self.submitted_first_prompt
     },
+    submitted_first_prompt_client_id: if requested_thread is Some(_) {
+      None
+    } else {
+      self.submitted_first_prompt_client_id
+    },
     // A selected-history snapshot is authoritative for its visible transcript
     // and owns none of the previous task's local receipts. Thread creation has
     // no steer receipts yet and may preserve only the first-prompt preview.
@@ -1974,6 +2024,11 @@ fn State::without_thread(self : State, thread_id : String) -> State {
     } else {
       self.submitted_first_prompt
     },
+    submitted_first_prompt_client_id: if removing_active {
+      None
+    } else {
+      self.submitted_first_prompt_client_id
+    },
     pending_steers: if removing_active {
       []
     } else {
@@ -2025,10 +2080,18 @@ fn CodexTurn::is_running(self : CodexTurn) -> Bool {
 
 ///|
 fn State::active_turn_id(self : State) -> String? {
+  self.active_turn().map(turn => turn.id)
+}
+
+///|
+/// The newest in-progress turn selected for Stop, steering, and composer
+/// status. Keeping one selection rule prevents those controls from describing
+/// different turns if an imported task contains more than one live envelope.
+fn State::active_turn(self : State) -> CodexTurn? {
   guard self.active_thread() is Some(active) else { return None }
   for index = active.turns.length() - 1; index >= 0; index = index - 1 {
     if active.turns[index].status == "inProgress" {
-      return Some(active.turns[index].id)
+      return Some(active.turns[index])
     }
   }
   None
@@ -2047,7 +2110,12 @@ fn CodexTurn::with_item(
       if completed {
         item
       } else {
-        { ..item, streamed: existing.streamed, }
+        {
+          ..item,
+          streamed: existing.streamed,
+          reasoning_summary: existing.reasoning_summary,
+          reasoning_content: existing.reasoning_content,
+        }
       }
     } else {
       existing
@@ -2078,11 +2146,130 @@ fn CodexTurn::with_delta(
 }
 
 ///|
+/// Ensure an indexed section exists without changing an already accumulated
+/// section. `summaryPartAdded` reaches this method before its text deltas.
+fn CodexReasoningParts::with_part(
+  self : CodexReasoningParts,
+  index : Int?,
+) -> CodexReasoningParts {
+  if self.0.iter().any(part => part.index == index) {
+    return self
+  }
+  CodexReasoningParts([..self.0, { index, text: "", }])
+}
+
+///|
+/// Append one delta to its indexed section while preserving the arrival order
+/// of sections. The copied array keeps prior Rabbita model snapshots immutable.
+fn CodexReasoningParts::with_delta(
+  self : CodexReasoningParts,
+  index : Int?,
+  delta : String,
+) -> CodexReasoningParts {
+  let mut found = false
+  let parts = self.0.map(part => {
+    if part.index == index {
+      found = true
+      { ..part, text: part.text + delta, }
+    } else {
+      part
+    }
+  })
+  if !found {
+    parts.push({ index, text: delta, })
+  }
+  CodexReasoningParts(parts)
+}
+
+///|
+/// Join section documents without exposing empty boundary notifications as
+/// blank cards. Two newlines preserve the section boundary in plain text and
+/// become separate paragraphs after the completed item renders as Markdown.
+fn CodexReasoningParts::text(self : CodexReasoningParts) -> String {
+  self.0
+  .filter(part => !part.text.is_blank())
+  .map(part => part.text)
+  .join("\n\n")
+}
+
+///|
+fn CodexTurn::with_reasoning_summary_part(
+  self : CodexTurn,
+  item_id : String,
+  summary_index : Int?,
+) -> CodexTurn {
+  {
+    ..self,
+    items: self.items.map(item => {
+      if item.id == item_id && item.kind == "reasoning" {
+        {
+          ..item,
+          reasoning_summary: item.reasoning_summary.with_part(summary_index),
+        }
+      } else {
+        item
+      }
+    }),
+  }
+}
+
+///|
+fn CodexTurn::with_reasoning_summary_delta(
+  self : CodexTurn,
+  item_id : String,
+  summary_index : Int?,
+  delta : String,
+) -> CodexTurn {
+  {
+    ..self,
+    items: self.items.map(item => {
+      if item.id == item_id && item.kind == "reasoning" {
+        {
+          ..item,
+          reasoning_summary: item.reasoning_summary.with_delta(
+            summary_index, delta,
+          ),
+        }
+      } else {
+        item
+      }
+    }),
+  }
+}
+
+///|
+fn CodexTurn::with_reasoning_content_delta(
+  self : CodexTurn,
+  item_id : String,
+  content_index : Int?,
+  delta : String,
+) -> CodexTurn {
+  {
+    ..self,
+    items: self.items.map(item => {
+      if item.id == item_id && item.kind == "reasoning" {
+        {
+          ..item,
+          reasoning_content: item.reasoning_content.with_delta(
+            content_index, delta,
+          ),
+        }
+      } else {
+        item
+      }
+    }),
+  }
+}
+
+///|
 fn CodexThread::with_turn(self : CodexThread, turn : CodexTurn) -> CodexThread {
   let mut found = false
   let turns = self.turns.map(existing => {
     if existing.id == turn.id {
       found = true
+      // Turn envelopes do not carry token usage. Preserve the latest
+      // notification when a lifecycle or history envelope updates this turn.
+      let turn = { ..turn, latest_usage_tokens: existing.latest_usage_tokens, }
       if turn.items_authoritative() {
         turn
       } else {
@@ -2099,13 +2286,42 @@ fn CodexThread::with_turn(self : CodexThread, turn : CodexTurn) -> CodexThread {
 }
 
 ///|
+/// Replace one turn's latest model-call usage. Unknown turn ids stay inert:
+/// accounting data must not invent transcript or Stop authority.
+fn CodexThread::with_latest_usage(
+  self : CodexThread,
+  turn_id : String,
+  tokens : Int,
+) -> CodexThread {
+  {
+    ..self,
+    turns: self.turns.map(turn => {
+      if turn.id == turn_id {
+        { ..turn, latest_usage_tokens: tokens, }
+      } else {
+        turn
+      }
+    }),
+  }
+}
+
+///|
 /// Whether the app-server transcript has supplied the real presentation of
 /// the first submitted input. Item ids stay app-server-owned; the local
 /// preview needs only this semantic boundary and never tries to match text.
-fn CodexThread::has_user_item(self : CodexThread) -> Bool {
+fn CodexThread::has_user_item(
+  self : CodexThread,
+  client_user_message_id : String?,
+) -> Bool {
   for turn in self.turns {
-    if turn.items.iter().any(item => item.kind == "userMessage") {
-      return true
+    for item in turn.items {
+      if item.kind == "userMessage" {
+        match client_user_message_id {
+          Some(client_id) if item.client_id() == Some(client_id) => return true
+          None => return true
+          _ => ()
+        }
+      }
     }
   }
   false
@@ -2118,10 +2334,14 @@ fn CodexThread::has_user_item(self : CodexThread) -> Bool {
 fn State::with_observed_first_prompt(self : State) -> State {
   guard self.submitted_first_prompt is Some(_) &&
     self.active_thread() is Some(active) &&
-    active.has_user_item() else {
+    active.has_user_item(self.submitted_first_prompt_client_id) else {
     return self
   }
-  { ..self, submitted_first_prompt: None, }
+  {
+    ..self,
+    submitted_first_prompt: None,
+    submitted_first_prompt_client_id: None,
+  }
 }
 
 ///|
@@ -2129,7 +2349,24 @@ fn State::with_observed_first_prompt(self : State) -> State {
 /// first input locally and the composer should say `Starting…`.
 fn State::waiting_for_first_user_item(self : State) -> Bool {
   self.submitted_first_prompt is Some(_) &&
-  self.active_thread().map(thread => !thread.has_user_item()).unwrap_or(true)
+  self
+  .active_thread()
+  .map(thread => !thread.has_user_item(self.submitted_first_prompt_client_id))
+  .unwrap_or(true)
+}
+
+///|
+/// A partial turn envelope may repeat an item without the lifecycle timestamp
+/// delivered by its earlier item notification. The repeated payload remains
+/// authoritative; only an absent presentation timestamp is retained.
+fn CodexItem::merged_onto(self : CodexItem, existing : CodexItem) -> CodexItem {
+  {
+    ..self,
+    ts: match self.ts {
+      Some(ts) => Some(ts)
+      None => existing.ts
+    },
+  }
 }
 
 ///|
@@ -2148,7 +2385,7 @@ fn CodexTurn::merged_onto(self : CodexTurn, existing : CodexTurn) -> CodexTurn {
     let mut merged = item
     for incoming in self.items {
       if incoming.id == item.id {
-        merged = incoming
+        merged = incoming.merged_onto(item)
         break
       }
     }
@@ -2184,6 +2421,7 @@ fn CodexThread::with_item(
       status: "inProgress",
       started_at: None,
       completed_at: None,
+      latest_usage_tokens: 0,
       items: [item],
       // Locally minted to hold an early item; the server never stated an
       // items view for it.
@@ -2231,6 +2469,8 @@ fn CodexThread::with_plan_update(
     completed: true,
     ts: None,
     streamed: "",
+    reasoning_summary: CodexReasoningParts([]),
+    reasoning_content: CodexReasoningParts([]),
   }
   let mut found = false
   let turns = self.turns.map(turn => {
@@ -2249,6 +2489,7 @@ fn CodexThread::with_plan_update(
       status: "inProgress",
       started_at: None,
       completed_at: None,
+      latest_usage_tokens: 0,
       items: [item],
       items_view: None,
       error: None,
@@ -2269,6 +2510,67 @@ fn CodexThread::with_delta(
     turns: self.turns.map(turn => {
       if turn.id == turn_id {
         turn.with_delta(item_id, delta)
+      } else {
+        turn
+      }
+    }),
+  }
+}
+
+///|
+/// Preserve app-server's indexed reasoning summary boundaries on the owning
+/// turn. Unknown turn or item ids stay inert until their lifecycle item arrives.
+fn CodexThread::with_reasoning_summary_part(
+  self : CodexThread,
+  turn_id : String,
+  item_id : String,
+  summary_index : Int?,
+) -> CodexThread {
+  {
+    ..self,
+    turns: self.turns.map(turn => {
+      if turn.id == turn_id {
+        turn.with_reasoning_summary_part(item_id, summary_index)
+      } else {
+        turn
+      }
+    }),
+  }
+}
+
+///|
+fn CodexThread::with_reasoning_summary_delta(
+  self : CodexThread,
+  turn_id : String,
+  item_id : String,
+  summary_index : Int?,
+  delta : String,
+) -> CodexThread {
+  {
+    ..self,
+    turns: self.turns.map(turn => {
+      if turn.id == turn_id {
+        turn.with_reasoning_summary_delta(item_id, summary_index, delta)
+      } else {
+        turn
+      }
+    }),
+  }
+}
+
+///|
+fn CodexThread::with_reasoning_content_delta(
+  self : CodexThread,
+  turn_id : String,
+  item_id : String,
+  content_index : Int?,
+  delta : String,
+) -> CodexThread {
+  {
+    ..self,
+    turns: self.turns.map(turn => {
+      if turn.id == turn_id {
+        turn.with_reasoning_content_delta(item_id, content_index, delta)
       } else {
         turn
       }
@@ -2375,6 +2677,19 @@ fn State::with_notification(
       } else {
         observed
       }
+    "thread/tokenUsage/updated" =>
+      if @jsonx.json_text(fields, "turnId") is Some(turn_id) &&
+        fields.get("tokenUsage") is Some(Object(usage)) &&
+        usage.get("last") is Some(Object(last)) &&
+        @jsonx.json_int(last, "totalTokens") is Some(tokens) &&
+        tokens >= 0 {
+        {
+          ..observed,
+          selection: CodexStoredTask(active.with_latest_usage(turn_id, tokens)),
+        }
+      } else {
+        observed
+      }
     "turn/plan/updated" =>
       if @jsonx.json_text(fields, "turnId") is Some(turn_id) {
         {
@@ -2408,8 +2723,6 @@ fn State::with_notification(
       }
     "item/agentMessage/delta"
     | "item/plan/delta"
-    | "item/reasoning/summaryTextDelta"
-    | "item/reasoning/textDelta"
     | "item/commandExecution/outputDelta"
     | "item/fileChange/outputDelta" =>
       if @jsonx.json_text(fields, "turnId") is Some(turn_id) &&
@@ -2418,6 +2731,58 @@ fn State::with_notification(
         {
           ..observed,
           selection: CodexStoredTask(active.with_delta(turn_id, item_id, delta)),
+        }
+      } else {
+        observed
+      }
+    "item/reasoning/summaryPartAdded" =>
+      if @jsonx.json_text(fields, "turnId") is Some(turn_id) &&
+        @jsonx.json_text(fields, "itemId") is Some(item_id) {
+        {
+          ..observed,
+          selection: CodexStoredTask(
+            active.with_reasoning_summary_part(
+              turn_id,
+              item_id,
+              @jsonx.json_int(fields, "summaryIndex"),
+            ),
+          ),
+        }
+      } else {
+        observed
+      }
+    "item/reasoning/summaryTextDelta" =>
+      if @jsonx.json_text(fields, "turnId") is Some(turn_id) &&
+        @jsonx.json_text(fields, "itemId") is Some(item_id) &&
+        @jsonx.json_text(fields, "delta") is Some(delta) {
+        {
+          ..observed,
+          selection: CodexStoredTask(
+            active.with_reasoning_summary_delta(
+              turn_id,
+              item_id,
+              @jsonx.json_int(fields, "summaryIndex"),
+              delta,
+            ),
+          ),
+        }
+      } else {
+        observed
+      }
+    "item/reasoning/textDelta" =>
+      if @jsonx.json_text(fields, "turnId") is Some(turn_id) &&
+        @jsonx.json_text(fields, "itemId") is Some(item_id) &&
+        @jsonx.json_text(fields, "delta") is Some(delta) {
+        {
+          ..observed,
+          selection: CodexStoredTask(
+            active.with_reasoning_content_delta(
+              turn_id,
+              item_id,
+              @jsonx.json_int(fields, "contentIndex"),
+              delta,
+            ),
+          ),
         }
       } else {
         observed
@@ -2603,6 +2968,43 @@ fn CodexPendingRequest::response(
 }
 
 ///|
+fn CodexItem::reasoning_text(self : CodexItem) -> String {
+  let summary = self.reasoning_summary.text()
+  if !summary.is_empty() {
+    return summary
+  }
+  let content = self.reasoning_content.text()
+  if !content.is_empty() {
+    return content
+  }
+  guard self.value is Object(fields) else { return "" }
+  for field in ["summary", "content"] {
+    match fields.get(field) {
+      Some(String(text)) if !text.is_blank() => return text
+      Some(Array(parts)) => {
+        let text : Array[String] = []
+        for part in parts {
+          match part {
+            String(value) if !value.is_blank() => text.push(value)
+            Object(fields) =>
+              if @jsonx.json_text(fields, "text") is Some(value) &&
+                !value.is_blank() {
+                text.push(value)
+              }
+            _ => ()
+          }
+        }
+        if !text.is_empty() {
+          return text.join("\n\n")
+        }
+      }
+      _ => ()
+    }
+  }
+  ""
+}
+
+///|
 fn CodexItem::text(self : CodexItem) -> String {
   let streamed = self.streamed
   guard self.value is Object(fields) else { return self.value.stringify() }
@@ -2671,29 +3073,7 @@ fn CodexItem::text(self : CodexItem) -> String {
         text
       }
     }
-    "reasoning" =>
-      if !streamed.is_empty() {
-        streamed
-      } else {
-        match fields.get("summary") {
-          Some(String(text)) => text
-          Some(Array(parts)) => {
-            let text : Array[String] = []
-            for part in parts {
-              match part {
-                String(value) => text.push(value)
-                Object(fields) =>
-                  if @jsonx.json_text(fields, "text") is Some(value) {
-                    text.push(value)
-                  }
-                _ => ()
-              }
-            }
-            text.join("\n")
-          }
-          _ => ""
-        }
-      }
+    "reasoning" => self.reasoning_text()
     "commandExecution" => {
       let command = @jsonx.json_text(fields, "command").unwrap_or("Command")
       let output = @jsonx.json_text(fields, "aggregatedOutput").unwrap_or(
@@ -2725,27 +3105,28 @@ fn CodexItem::text(self : CodexItem) -> String {
 /// Convert one app-server semantic item into the display model consumed by
 /// OpenSeek's transcript renderer. This is the only place that knows both
 /// vocabularies; the shared view never switches on Codex JSON item names.
-fn CodexItem::transcript_item(self : CodexItem) -> @transcript.TranscriptItem {
+fn CodexItem::transcript_item(
+  self : CodexItem,
+  final_answer? : Bool = false,
+  fallback_ts? : Double,
+) -> @transcript.TranscriptItem {
   // Every app-server item is one response-shaped item: prose, a thought, or
   // one tool call, each with the other two parts empty. Codex commits them
-  // separately, so they are never folded into one numbered step.
+  // separately; `CodexTurn::transcript_rows` retains their inferred shared
+  // step identity for the renderer.
   let response = (
     reasoning : String?,
     prose : String?,
     calls : Array[@transcript.ToolCall],
+    finished : Bool,
   ) => {
-    @transcript.Assistant(
-      reasoning~,
-      prose~,
-      calls~,
-      replay=false,
-      finished=false,
-    )
+    @transcript.Assistant(reasoning~, prose~, calls~, replay=false, finished~)
   }
   let kind = match self.kind {
     "userMessage" => @transcript.User(self.text())
-    "agentMessage" | "plan" => response(None, Some(self.text()), [])
-    "reasoning" => response(Some(self.text()), None, [])
+    "agentMessage" => response(None, Some(self.text()), [], final_answer)
+    "plan" => response(None, Some(self.text()), [], false)
+    "reasoning" => response(Some(self.text()), None, [], false)
     "contextCompaction" => @transcript.Summary(self.text())
     _ => {
       // A command still running may have streamed part of its output; the
@@ -2762,14 +3143,19 @@ fn CodexItem::transcript_item(self : CodexItem) -> @transcript.TranscriptItem {
       } else {
         Pending(output=Some(output))
       }
-      response(None, None, [
-        {
-          call_id: self.id,
-          name: self.tool_name(),
-          arguments: self.tool_arguments(),
-          outcome,
-        },
-      ])
+      response(
+        None,
+        None,
+        [
+          {
+            call_id: self.id,
+            name: self.tool_name(),
+            arguments: self.tool_arguments(),
+            outcome,
+          },
+        ],
+        false,
+      )
     }
   }
   {
@@ -2777,11 +3163,36 @@ fn CodexItem::transcript_item(self : CodexItem) -> @transcript.TranscriptItem {
     // Live notifications carry exact item lifecycle stamps. Reloaded snapshots
     // do not, so those items continue to omit the clock instead of borrowing a
     // turn-level time that may belong to a different model step.
-    ts: self.ts,
+    ts: match self.ts {
+      Some(ts) => Some(ts)
+      None => fallback_ts
+    },
     // App-server items have their own ids but no OpenSeek store sequence. The
     // transcript overview therefore derives a stable fallback turn key.
     sequence: None,
   }
+}
+
+///|
+/// App-server labels only the response intended as the turn's final answer.
+/// Background delivery is not terminal transcript prose even if its phase is
+/// final-shaped, so it remains an ordinary Assistant row.
+fn CodexItem::is_explicit_final_answer(self : CodexItem) -> Bool {
+  guard self.kind == "agentMessage" && self.value is Object(fields) else {
+    return false
+  }
+  @jsonx.json_text(fields, "phase") is Some("final_answer") &&
+  @jsonx.json_text(fields, "delivery") != Some("async")
+}
+
+///|
+/// The canonical User item echoes the request's `clientUserMessageId` under
+/// `clientId`; keeping extraction on the item prevents text-based matching.
+fn CodexItem::client_id(self : CodexItem) -> String? {
+  guard self.kind == "userMessage" && self.value is Object(fields) else {
+    return None
+  }
+  @jsonx.json_text(fields, "clientId")
 }
 
 ///|
@@ -2851,20 +3262,26 @@ fn CodexItem::tool_arguments(self : CodexItem) -> String? {
   }
   match self.kind {
     "commandExecution" => {
-      let arguments : Json = if self.command_read_action() is Some(action) {
-        {
-          "path": @jsonx.json_text(action, "path").unwrap_or(""),
-          "name": @jsonx.json_text(action, "name").unwrap_or(""),
-          "command": @jsonx.json_text(action, "command").unwrap_or(""),
-          "cwd": @jsonx.json_text(fields, "cwd").unwrap_or(""),
+      // app-server omits metadata it does not know. Keep that absence in the
+      // shared arguments object instead of inventing empty-string values.
+      let arguments : Map[String, Json] = Map([])
+      if self.command_read_action() is Some(action) {
+        if @jsonx.json_text(action, "path") is Some(path) {
+          arguments["path"] = Json(path)
         }
-      } else {
-        {
-          "command": @jsonx.json_text(fields, "command").unwrap_or(""),
-          "cwd": @jsonx.json_text(fields, "cwd").unwrap_or(""),
+        if @jsonx.json_text(action, "name") is Some(name) {
+          arguments["name"] = Json(name)
         }
+        if @jsonx.json_text(action, "command") is Some(command) {
+          arguments["command"] = Json(command)
+        }
+      } else if @jsonx.json_text(fields, "command") is Some(command) {
+        arguments["command"] = Json(command)
       }
-      Some(arguments.stringify())
+      if @jsonx.json_text(fields, "cwd") is Some(cwd) {
+        arguments["cwd"] = Json(cwd)
+      }
+      Some(Json::object(arguments).stringify())
     }
     "fileChange" =>
       if fields.get("changes") is Some(Array(changes)) {
@@ -3071,6 +3488,7 @@ fn CodexItem::tool_output(self : CodexItem) -> String {
     }
     "enteredReviewMode" | "exitedReviewMode" =>
       @jsonx.json_text(fields, "review").unwrap_or("")
+    "planUpdate" => @jsonx.json_text(fields, "explanation").unwrap_or("")
     _ => {
       for key in ["output", "result", "content"] {
         match fields.get(key) {
@@ -3167,62 +3585,182 @@ fn CodexItem::tool_brief(self : CodexItem) -> String? {
 }
 
 ///|
-/// The root shell consumes this display-only snapshot with the same transcript
+/// Whether this item participates in one numbered model step. User inputs and
+/// context checkpoints remain independent rows; every other Codex item maps to
+/// response prose, reasoning, or tool activity in the shared renderer.
+fn CodexItem::participates_in_step(self : CodexItem) -> Bool {
+  self.kind != "userMessage" && self.kind != "contextCompaction"
+}
+
+///|
+fn CodexItem::is_tool_item(self : CodexItem) -> Bool {
+  self.participates_in_step() &&
+  self.kind != "agentMessage" &&
+  self.kind != "plan" &&
+  self.kind != "reasoning"
+}
+
+///|
+/// Older app-server snapshots omitted `phase`. On a successfully completed
+/// turn only, the last synchronous unphased agent message is the conservative
+/// fallback final answer. An explicit final-answer phase always wins.
+fn CodexTurn::fallback_final_answer_id(self : CodexTurn) -> String? {
+  if self.status != "completed" ||
+    self.items.iter().any(item => item.is_explicit_final_answer()) {
+    return None
+  }
+  for index = self.items.length() - 1; index >= 0; index = index - 1 {
+    let item = self.items[index]
+    if item.kind == "agentMessage" &&
+      item.value is Object(fields) &&
+      (fields.get("phase") is None || fields.get("phase") is Some(Null)) &&
+      @jsonx.json_text(fields, "delivery") != Some("async") {
+      return Some(item.id)
+    }
+  }
+  None
+}
+
+///|
+/// Project one Codex turn while retaining its native item identity and a
+/// deterministic model-step grouping. A reasoning item starts a step; tools
+/// remain with the prose/reasoning before them; prose after tool activity starts
+/// the next step. This matches Codex's ordered item stream without inventing an
+/// OpenSeek integer sequence.
+fn CodexTurn::transcript_rows(
+  self : CodexTurn,
+) -> Array[@transcript.TranscriptRow] {
+  let rows : Array[@transcript.TranscriptRow] = []
+  let fallback_final = self.fallback_final_answer_id()
+  let completion_ts = self.completed_at.map(seconds => {
+    seconds.to_double() * 1000.0
+  })
+  let mut step_number = 0
+  let mut current_step : String? = None
+  let mut step_has_tool = false
+  for item in self.items {
+    if item.kind == "userMessage" || item.kind == "contextCompaction" {
+      current_step = None
+      step_has_tool = false
+    } else if item.participates_in_step() {
+      let starts_step = current_step is None ||
+        item.kind == "reasoning" ||
+        ((item.kind == "agentMessage" || item.kind == "plan") && step_has_tool)
+      if starts_step {
+        step_number += 1
+        current_step = Some("turn\u{0}\{self.id}\u{0}step\u{0}\{step_number}")
+        step_has_tool = false
+      }
+    }
+    let final_answer = item.is_explicit_final_answer() ||
+      fallback_final == Some(item.id)
+    let transcript_item = if final_answer && completion_ts is Some(ts) {
+      item.transcript_item(final_answer~, fallback_ts=ts)
+    } else {
+      item.transcript_item(final_answer~)
+    }
+    // GPT can commit a reasoning item whose only payload is encrypted. Keep
+    // the semantic item in state so a later summary delta can reveal it, but
+    // avoid an empty Thought card in the display projection.
+    let blank_thought = transcript_item.kind
+      is @transcript.Assistant(
+        reasoning=Some(summary),
+        prose=None,
+        calls=[],
+        ..
+      ) &&
+      summary.is_blank()
+    if !blank_thought {
+      rows.push({
+        item: transcript_item,
+        identity: "turn\u{0}\{self.id}\u{0}item\u{0}\{item.id}",
+        step_identity: if item.participates_in_step() {
+          current_step
+        } else {
+          None
+        },
+      })
+    }
+    if item.is_tool_item() {
+      step_has_tool = true
+    }
+  }
+  rows
+}
+
+///|
+/// The root shell consumes these display-only rows with the same transcript
 /// view used for OpenSeek. Notices and per-turn failures become ordinary
 /// danger messages, so Codex does not need a parallel banner/message layout.
-pub fn State::transcript_items(
-  self : State,
-) -> Array[@transcript.TranscriptItem] {
-  let items : Array[@transcript.TranscriptItem] = []
+pub fn State::transcript_rows(self : State) -> Array[@transcript.TranscriptRow] {
+  let rows : Array[@transcript.TranscriptRow] = []
   if !self.notice.is_empty() {
-    items.push({
-      kind: @transcript.Failure(self.notice),
-      ts: None,
-      sequence: None,
+    rows.push({
+      item: {
+        kind: @transcript.Failure(self.notice),
+        ts: None,
+        sequence: None,
+      },
+      identity: "codex-notice",
+      step_identity: None,
     })
   }
   if self.waiting_for_first_user_item() &&
     self.submitted_first_prompt is Some(submitted) {
-    items.push({
-      kind: @transcript.User(submitted.prompt()),
-      ts: None,
-      sequence: None,
+    rows.push({
+      item: {
+        kind: @transcript.User(submitted.prompt()),
+        ts: None,
+        sequence: None,
+      },
+      identity: self.submitted_first_prompt_client_id
+      .map(client_id => "client\u{0}\{client_id}")
+      .unwrap_or("codex-first-prompt"),
+      step_identity: None,
     })
   }
   if self.active_thread() is Some(active) {
     for turn in active.turns {
-      for item in turn.items {
-        let transcript_item = item.transcript_item()
-        // GPT can commit a reasoning item whose only payload is encrypted:
-        // until app-server exposes summary text, there is nothing the
-        // transcript can display and an empty thought becomes a blank
-        // "Thought" card. Keep the semantic item in Codex state so a later
-        // summary delta can reveal it, but omit it from this display snapshot.
-        let blank_thought = transcript_item.kind
-          is @transcript.Assistant(reasoning=Some(summary), ..) &&
-          summary.is_blank()
-        if !blank_thought {
-          items.push(transcript_item)
-        }
+      for row in turn.transcript_rows() {
+        rows.push(row)
       }
       // A receipt belongs after the canonical items already observed in the
       // same turn. The app-server User item removes it before the next render,
       // so this projection never shows both representations of one steer.
       for receipt in self.pending_steers {
         if receipt.turn_id == turn.id {
-          items.push(receipt.transcript_item())
+          rows.push({
+            item: receipt.transcript_item(),
+            identity: receipt.client_user_message_id
+            .map(client_id => "client\u{0}\{client_id}")
+            .unwrap_or("steer\u{0}\{receipt.submission_id}"),
+            step_identity: None,
+          })
         }
       }
       if turn.error is Some(message) {
-        items.push({
-          kind: @transcript.Failure(message),
-          ts: None,
-          sequence: None,
+        rows.push({
+          item: {
+            kind: @transcript.Failure(message),
+            ts: None,
+            sequence: None,
+          },
+          identity: "turn\u{0}\{turn.id}\u{0}error",
+          step_identity: None,
         })
       }
     }
   }
-  items
+  rows
+}
+
+///|
+/// Compatibility projection for callers that need only semantic items. The
+/// shared component consumes `transcript_rows` so it can preserve row/step ids.
+pub fn State::transcript_items(
+  self : State,
+) -> Array[@transcript.TranscriptItem] {
+  self.transcript_rows().map(row => row.item)
 }
 
 ///|
@@ -3237,6 +3775,7 @@ test "Codex completed items replace streamed presentation state" {
     status: "inProgress",
     started_at: None,
     completed_at: None,
+    latest_usage_tokens: 0,
     items: [started],
     items_view: None,
     error: None,
@@ -3263,7 +3802,7 @@ test "Codex reasoning summaries render text instead of JSON syntax" {
       { "type": "summary_text", "text": "Second" },
     ],
   }).unwrap()
-  assert_eq(item.text(), "First\nSecond")
+  assert_eq(item.text(), "First\n\nSecond")
 }
 
 ///|

--- a/desktop/frontend/codex/model.mbt
+++ b/desktop/frontend/codex/model.mbt
@@ -164,6 +164,14 @@ priv struct CodexItem {
   id : String
   kind : String
   value : Json
+  // Items without their own status (web search and hook prompts, for example)
+  // still need the notification boundary to say whether their shared tool row
+  // is pending. Thread snapshots contain settled history by default; live
+  // `item/started` and `item/completed` notifications override it exactly.
+  completed : Bool
+  // Live lifecycle notifications stamp an item exactly. Thread snapshots do
+  // not carry that field, so reloaded history remains honestly undated.
+  ts : Double?
   // Deltas are presentation-only. `item/completed` replaces `value` and
   // clears this field because the completed item is authoritative.
   streamed : String
@@ -1247,13 +1255,17 @@ pub fn State::with_editor_comment(
 }
 
 ///|
-fn CodexItem::decode(value : Json) -> CodexItem? {
+fn CodexItem::decode(
+  value : Json,
+  completed? : Bool = true,
+  ts? : Double,
+) -> CodexItem? {
   guard value is Object(fields) &&
     @jsonx.json_text(fields, "id") is Some(id) &&
     @jsonx.json_text(fields, "type") is Some(kind) else {
     return None
   }
-  Some({ id, kind, value, streamed: "", })
+  Some({ id, kind, value, completed, ts, streamed: "", })
 }
 
 ///|
@@ -2183,6 +2195,69 @@ fn CodexThread::with_item(
 }
 
 ///|
+/// Convert app-server's structured standing-plan notification into the exact
+/// `{steps:[{title,status}]}` payload consumed by OpenSeek's shared plan card.
+/// The notification has no item id, so the client-local row is replaced and
+/// moved to the latest activity position on every update instead of inventing
+/// several durable calls. A malformed step rejects the whole update: showing a
+/// partial checklist would claim a plan Codex never reported.
+fn CodexThread::with_plan_update(
+  self : CodexThread,
+  turn_id : String,
+  fields : Map[String, Json],
+) -> CodexThread {
+  guard fields.get("plan") is Some(Array(entries)) else { return self }
+  let steps : Array[Json] = []
+  for entry in entries {
+    guard entry is Object(step) &&
+      @jsonx.json_text(step, "step") is Some(title) &&
+      @jsonx.json_text(step, "status") is Some(status) else {
+      return self
+    }
+    let status = if status == "inProgress" { "in_progress" } else { status }
+    steps.push({ "title": title, "status": status })
+  }
+  let id = "openseek-plan:\{turn_id}"
+  let value : Json = {
+    "id": id,
+    "type": "planUpdate",
+    "steps": Json::array(steps),
+    "explanation": fields.get("explanation").unwrap_or(Json::null()),
+  }
+  let item : CodexItem = {
+    id,
+    kind: "planUpdate",
+    value,
+    completed: true,
+    ts: None,
+    streamed: "",
+  }
+  let mut found = false
+  let turns = self.turns.map(turn => {
+    if turn.id == turn_id {
+      found = true
+      let items = turn.items.filter(existing => existing.kind != "planUpdate")
+      items.push(item)
+      { ..turn, items, }
+    } else {
+      turn
+    }
+  })
+  if !found {
+    turns.push({
+      id: turn_id,
+      status: "inProgress",
+      started_at: None,
+      completed_at: None,
+      items: [item],
+      items_view: None,
+      error: None,
+    })
+  }
+  { ..self, turns, }
+}
+
+///|
 fn CodexThread::with_delta(
   self : CodexThread,
   turn_id : String,
@@ -2194,6 +2269,41 @@ fn CodexThread::with_delta(
     turns: self.turns.map(turn => {
       if turn.id == turn_id {
         turn.with_delta(item_id, delta)
+      } else {
+        turn
+      }
+    }),
+  }
+}
+
+///|
+/// Adopt app-server's authoritative live patch for one file-change item. The
+/// item id and all lifecycle fields stay untouched; only the `changes` payload
+/// that the shared diff card reads is replaced.
+fn CodexThread::with_file_changes(
+  self : CodexThread,
+  turn_id : String,
+  item_id : String,
+  changes : Json,
+) -> CodexThread {
+  {
+    ..self,
+    turns: self.turns.map(turn => {
+      if turn.id == turn_id {
+        {
+          ..turn,
+          items: turn.items.map(item => {
+            if item.id == item_id &&
+              item.kind == "fileChange" &&
+              item.value is Object(fields) {
+              let fields = fields.copy()
+              fields["changes"] = changes
+              { ..item, value: Json::object(fields), }
+            } else {
+              item
+            }
+          }),
+        }
       } else {
         turn
       }
@@ -2265,19 +2375,33 @@ fn State::with_notification(
       } else {
         observed
       }
-    "item/started" | "item/completed" =>
-      if @jsonx.json_text(fields, "turnId") is Some(turn_id) &&
-        fields.get("item") is Some(value) &&
-        CodexItem::decode(value) is Some(item) {
+    "turn/plan/updated" =>
+      if @jsonx.json_text(fields, "turnId") is Some(turn_id) {
         {
           ..observed,
-          selection: CodexStoredTask(
-            active.with_item(
-              turn_id,
-              item,
-              completed=method_ == "item/completed",
+          selection: CodexStoredTask(active.with_plan_update(turn_id, fields)),
+        }
+      } else {
+        observed
+      }
+    "item/started" | "item/completed" =>
+      if @jsonx.json_text(fields, "turnId") is Some(turn_id) &&
+        fields.get("item") is Some(value) {
+        let completed = method_ == "item/completed"
+        let ts = match
+          fields.get(if completed { "completedAtMs" } else { "startedAtMs" }) {
+          Some(Number(value, ..)) => Some(value)
+          _ => None
+        }
+        if CodexItem::decode(value, completed~, ts?) is Some(item) {
+          {
+            ..observed,
+            selection: CodexStoredTask(
+              active.with_item(turn_id, item, completed~),
             ),
-          ),
+          }
+        } else {
+          observed
         }
       } else {
         observed
@@ -2286,13 +2410,40 @@ fn State::with_notification(
     | "item/plan/delta"
     | "item/reasoning/summaryTextDelta"
     | "item/reasoning/textDelta"
-    | "item/commandExecution/outputDelta" =>
+    | "item/commandExecution/outputDelta"
+    | "item/fileChange/outputDelta" =>
       if @jsonx.json_text(fields, "turnId") is Some(turn_id) &&
         @jsonx.json_text(fields, "itemId") is Some(item_id) &&
         @jsonx.json_text(fields, "delta") is Some(delta) {
         {
           ..observed,
           selection: CodexStoredTask(active.with_delta(turn_id, item_id, delta)),
+        }
+      } else {
+        observed
+      }
+    "item/mcpToolCall/progress" =>
+      if @jsonx.json_text(fields, "turnId") is Some(turn_id) &&
+        @jsonx.json_text(fields, "itemId") is Some(item_id) &&
+        @jsonx.json_text(fields, "message") is Some(message) {
+        {
+          ..observed,
+          selection: CodexStoredTask(
+            active.with_delta(turn_id, item_id, "\{message}\n"),
+          ),
+        }
+      } else {
+        observed
+      }
+    "item/fileChange/patchUpdated" =>
+      if @jsonx.json_text(fields, "turnId") is Some(turn_id) &&
+        @jsonx.json_text(fields, "itemId") is Some(item_id) &&
+        fields.get("changes") is Some(changes) {
+        {
+          ..observed,
+          selection: CodexStoredTask(
+            active.with_file_changes(turn_id, item_id, changes),
+          ),
         }
       } else {
         observed
@@ -2491,6 +2642,22 @@ fn CodexItem::text(self : CodexItem) -> String {
                 line=0,
               ),
             )
+          } else if value is Object(input) &&
+            @jsonx.json_text(input, "type") is Some("skill") &&
+            @jsonx.json_text(input, "name") is Some(name) {
+            // Skills already have a native shared mention kind, so they can
+            // retain the same chip the composer showed instead of disappearing
+            // from the historical user message.
+            mentions.push(@mention_context.Skill(name~))
+          } else if value is Object(input) &&
+            (
+              @jsonx.json_text(input, "type") is Some("localImage") ||
+              @jsonx.json_text(input, "type") is Some("localAudio")
+            ) &&
+            @jsonx.json_text(input, "path") is Some(path) {
+            // The shared transcript does not own a media attachment card yet,
+            // but it can preserve a local attachment as a navigable file chip.
+            mentions.push(@mention_context.File(path~))
           }
         }
       }
@@ -2607,9 +2774,10 @@ fn CodexItem::transcript_item(self : CodexItem) -> @transcript.TranscriptItem {
   }
   {
     kind,
-    // The current app-server item snapshot has no durable display timestamp.
-    // Leaving it absent is honest; the shared turn rule simply omits its clock.
-    ts: None,
+    // Live notifications carry exact item lifecycle stamps. Reloaded snapshots
+    // do not, so those items continue to omit the clock instead of borrowing a
+    // turn-level time that may belong to a different model step.
+    ts: self.ts,
     // App-server items have their own ids but no OpenSeek store sequence. The
     // transcript overview therefore derives a stable fallback turn key.
     sequence: None,
@@ -2617,12 +2785,59 @@ fn CodexItem::transcript_item(self : CodexItem) -> @transcript.TranscriptItem {
 }
 
 ///|
+/// The app-server classifies simple file reads inside a command execution. Only
+/// that exact single-action shape becomes OpenSeek's `read`; pipelines and
+/// mixed commands remain `shell` rather than being summarized as a file read.
+fn CodexItem::command_read_action(self : CodexItem) -> Map[String, Json]? {
+  guard self.kind == "commandExecution" && self.value is Object(fields) else {
+    return None
+  }
+  guard fields.get("commandActions") is Some(Array(actions)) &&
+    actions is [Object(action)] &&
+    @jsonx.json_text(action, "type") is Some("read") else {
+    return None
+  }
+  Some(action)
+}
+
+///|
 /// Normalize app-server tool-like item names to the categories already used
-/// by OpenSeek's activity summary (read/edit/shell) where the meaning matches.
+/// by OpenSeek's activity summary and semantic cards where the meaning and
+/// payload agree. Dynamic tools retain their advertised tool name, which lets
+/// a Codex `run_moonbit`, `read`, or `edit` call reach the same shared card.
 fn CodexItem::tool_name(self : CodexItem) -> String {
+  guard self.value is Object(fields) else { return self.kind }
   match self.kind {
-    "commandExecution" => "shell"
-    "fileChange" => "edit"
+    "commandExecution" =>
+      if self.command_read_action() is Some(_) {
+        "read"
+      } else {
+        "shell"
+      }
+    "fileChange" =>
+      if fields.get("changes") is Some(Array(changes)) && changes.length() > 1 {
+        "multi_edit"
+      } else {
+        "edit"
+      }
+    "mcpToolCall" => {
+      let server = @jsonx.json_text(fields, "server").unwrap_or("")
+      let tool = @jsonx.json_text(fields, "tool").unwrap_or("tool")
+      if server.is_blank() {
+        tool
+      } else {
+        "mcp__\{server}__\{tool}"
+      }
+    }
+    "dynamicToolCall" => @jsonx.json_text(fields, "tool").unwrap_or("tool")
+    "collabAgentToolCall" => @jsonx.json_text(fields, "tool").unwrap_or("agent")
+    "subAgentActivity" => "subagent"
+    "hookPrompt" => "hook_prompt"
+    "webSearch" => "web_search"
+    "imageView" => "image_view"
+    "imageGeneration" => "image_generation"
+    "enteredReviewMode" | "exitedReviewMode" => "review"
+    "planUpdate" => "plan"
     other => other
   }
 }
@@ -2636,22 +2851,66 @@ fn CodexItem::tool_arguments(self : CodexItem) -> String? {
   }
   match self.kind {
     "commandExecution" => {
-      let arguments : Json = {
-        "command": @jsonx.json_text(fields, "command").unwrap_or(""),
+      let arguments : Json = if self.command_read_action() is Some(action) {
+        {
+          "path": @jsonx.json_text(action, "path").unwrap_or(""),
+          "name": @jsonx.json_text(action, "name").unwrap_or(""),
+          "command": @jsonx.json_text(action, "command").unwrap_or(""),
+          "cwd": @jsonx.json_text(fields, "cwd").unwrap_or(""),
+        }
+      } else {
+        {
+          "command": @jsonx.json_text(fields, "command").unwrap_or(""),
+          "cwd": @jsonx.json_text(fields, "cwd").unwrap_or(""),
+        }
       }
       Some(arguments.stringify())
     }
     "fileChange" =>
-      match fields.get("changes") {
-        Some(changes) => {
-          let arguments : Json = { "changes": changes }
+      if fields.get("changes") is Some(Array(changes)) {
+        if changes.length() == 1 {
+          Some(changes[0].stringify())
+        } else {
+          let arguments : Json = { "edits": Json::array(changes) }
           Some(arguments.stringify())
         }
-        None => None
+      } else {
+        fields.get("changes").map(value => value.stringify())
       }
+    "mcpToolCall" | "dynamicToolCall" =>
+      fields.get("arguments").map(value => value.stringify())
+    "collabAgentToolCall" => {
+      let arguments : Json = {
+        "tool": @jsonx.json_text(fields, "tool").unwrap_or("agent"),
+        "prompt": fields.get("prompt").unwrap_or(Json::null()),
+        "model": fields.get("model").unwrap_or(Json::null()),
+        "reasoningEffort": fields.get("reasoningEffort").unwrap_or(Json::null()),
+        "senderThreadId": fields.get("senderThreadId").unwrap_or(Json::null()),
+        "receiverThreadIds": fields
+        .get("receiverThreadIds")
+        .unwrap_or(Json::array([])),
+      }
+      Some(arguments.stringify())
+    }
+    "subAgentActivity" => {
+      let arguments : Json = {
+        "agentPath": @jsonx.json_text(fields, "agentPath").unwrap_or(""),
+        "agentThreadId": @jsonx.json_text(fields, "agentThreadId").unwrap_or(""),
+        "kind": @jsonx.json_text(fields, "kind").unwrap_or(""),
+      }
+      Some(arguments.stringify())
+    }
+    "hookPrompt" =>
+      fields
+      .get("fragments")
+      .map(fragments => {
+        let arguments : Json = { "fragments": fragments }
+        arguments.stringify()
+      })
     "webSearch" => {
       let arguments : Json = {
         "query": @jsonx.json_text(fields, "query").unwrap_or(""),
+        "action": fields.get("action").unwrap_or(Json::null()),
       }
       Some(arguments.stringify())
     }
@@ -2661,6 +2920,35 @@ fn CodexItem::tool_arguments(self : CodexItem) -> String? {
       }
       Some(arguments.stringify())
     }
+    "sleep" =>
+      fields
+      .get("durationMs")
+      .map(duration => {
+        let arguments : Json = { "durationMs": duration }
+        arguments.stringify()
+      })
+    "imageGeneration" => {
+      let arguments : Json = {
+        "revisedPrompt": fields.get("revisedPrompt").unwrap_or(Json::null()),
+        "transparentBackground": fields
+        .get("transparentBackground")
+        .unwrap_or(Json::null()),
+      }
+      Some(arguments.stringify())
+    }
+    "enteredReviewMode" | "exitedReviewMode" => {
+      let arguments : Json = {
+        "review": @jsonx.json_text(fields, "review").unwrap_or(""),
+      }
+      Some(arguments.stringify())
+    }
+    "planUpdate" =>
+      fields
+      .get("steps")
+      .map(steps => {
+        let arguments : Json = { "steps": steps }
+        arguments.stringify()
+      })
     _ => Some(self.value.stringify())
   }
 }
@@ -2670,10 +2958,10 @@ fn CodexItem::tool_arguments(self : CodexItem) -> String? {
 /// progress the shared row remains a pending call with any streamed output it
 /// has already received.
 fn CodexItem::tool_has_result(self : CodexItem) -> Bool {
-  guard self.value is Object(fields) else { return true }
+  guard self.value is Object(fields) else { return self.completed }
   match @jsonx.json_text(fields, "status") {
     Some("inProgress") | Some("pending") => false
-    _ => true
+    _ => self.completed
   }
 }
 
@@ -2687,7 +2975,10 @@ fn CodexItem::tool_failed(self : CodexItem) -> Bool {
     _ => false
   }
   failed_status ||
-  @jsonx.json_int(fields, "exitCode").map(code => code != 0).unwrap_or(false)
+  @jsonx.json_int(fields, "exitCode").map(code => code != 0).unwrap_or(false) ||
+  fields.get("success") is Some(False) ||
+  (fields.get("error") is Some(error) && !(error is Null)) ||
+  (fields.get("failure") is Some(failure) && !(failure is Null))
 }
 
 ///|
@@ -2698,10 +2989,98 @@ fn CodexItem::tool_output(self : CodexItem) -> String {
   match self.kind {
     "commandExecution" =>
       @jsonx.json_text(fields, "aggregatedOutput").unwrap_or(self.streamed)
-    "fileChange" => @jsonx.json_text(fields, "status").unwrap_or("")
+    "fileChange" =>
+      if self.streamed.is_empty() {
+        @jsonx.json_text(fields, "status").unwrap_or("")
+      } else {
+        self.streamed
+      }
+    "mcpToolCall" => {
+      if fields.get("error") is Some(Object(error)) &&
+        @jsonx.json_text(error, "message") is Some(message) {
+        return message
+      }
+      if fields.get("result") is Some(Object(result)) &&
+        result.get("content") is Some(Array(blocks)) {
+        let text : Array[String] = []
+        let mut text_only = true
+        for block in blocks {
+          if block is Object(content) &&
+            @jsonx.json_text(content, "type") is Some("text") &&
+            @jsonx.json_text(content, "text") is Some(value) {
+            text.push(value)
+          } else {
+            text_only = false
+          }
+        }
+        if text_only && !text.is_empty() {
+          return text.join("\n")
+        }
+      }
+      match fields.get("result") {
+        Some(Null) | None => self.streamed
+        Some(result) => result.stringify(indent=2)
+      }
+    }
+    "dynamicToolCall" => {
+      if fields.get("contentItems") is Some(Array(items)) {
+        let text : Array[String] = []
+        let mut text_only = true
+        for item in items {
+          if item is Object(content) &&
+            @jsonx.json_text(content, "type") is Some("inputText") &&
+            @jsonx.json_text(content, "text") is Some(value) {
+            text.push(value)
+          } else {
+            text_only = false
+          }
+        }
+        if text_only && !text.is_empty() {
+          return text.join("\n")
+        }
+        return Json::array(items).stringify(indent=2)
+      }
+      ""
+    }
+    "collabAgentToolCall" =>
+      fields
+      .get("agentsStates")
+      .map(value => value.stringify(indent=2))
+      .unwrap_or(@jsonx.json_text(fields, "status").unwrap_or(""))
+    "webSearch" =>
+      match fields.get("results") {
+        Some(Null) | None => ""
+        Some(results) => results.stringify(indent=2)
+      }
+    "imageGeneration" =>
+      match fields.get("failure") {
+        Some(failure) if !(failure is Null) => failure.stringify(indent=2)
+        _ => @jsonx.json_text(fields, "result").unwrap_or("")
+      }
+    "hookPrompt" => {
+      let text : Array[String] = []
+      if fields.get("fragments") is Some(Array(fragments)) {
+        for fragment in fragments {
+          if fragment is Object(fragment) &&
+            @jsonx.json_text(fragment, "text") is Some(value) {
+            text.push(value)
+          }
+        }
+      }
+      text.join("\n")
+    }
     "enteredReviewMode" | "exitedReviewMode" =>
       @jsonx.json_text(fields, "review").unwrap_or("")
-    _ => ""
+    _ => {
+      for key in ["output", "result", "content"] {
+        match fields.get(key) {
+          Some(String(value)) => return value
+          Some(value) if !(value is Null) => return value.stringify(indent=2)
+          _ => ()
+        }
+      }
+      ""
+    }
   }
 }
 
@@ -2713,12 +3092,75 @@ fn CodexItem::tool_brief(self : CodexItem) -> String? {
   Some(
     match self.kind {
       "commandExecution" =>
-        @jsonx.json_text(fields, "command").unwrap_or("Command")
-      "fileChange" => "Changed files"
-      "webSearch" => "Searched the web"
-      "imageView" => "Viewed image"
+        if self.command_read_action() is Some(action) {
+          "read " + @jsonx.json_text(action, "path").unwrap_or("file")
+        } else {
+          @jsonx.json_text(fields, "command").unwrap_or("command")
+        }
+      "fileChange" =>
+        if fields.get("changes") is Some(Array(changes)) {
+          if changes is [Object(change)] &&
+            @jsonx.json_text(change, "path") is Some(path) {
+            "changed \{path}"
+          } else {
+            "changed \{changes.length()} files"
+          }
+        } else {
+          "changed files"
+        }
+      "mcpToolCall" => {
+        let server = @jsonx.json_text(fields, "server").unwrap_or("MCP")
+        let tool = @jsonx.json_text(fields, "tool").unwrap_or("tool")
+        "\{server} · \{tool}"
+      }
+      "dynamicToolCall" => {
+        let tool = @jsonx.json_text(fields, "tool").unwrap_or("tool")
+        match @jsonx.json_text(fields, "namespace") {
+          Some(namespace_) if !namespace_.is_blank() =>
+            "\{namespace_} · \{tool}"
+          _ => tool
+        }
+      }
+      "collabAgentToolCall" =>
+        @jsonx.json_text(fields, "tool").unwrap_or("agent")
+      "subAgentActivity" => {
+        let kind = @jsonx.json_text(fields, "kind").unwrap_or("activity")
+        let path = @jsonx.json_text(fields, "agentPath").unwrap_or("agent")
+        "\{kind} \{path}"
+      }
+      "hookPrompt" => "hook prompt"
+      "webSearch" =>
+        "searched " + @jsonx.json_text(fields, "query").unwrap_or("the web")
+      "imageView" =>
+        "viewed " + @jsonx.json_text(fields, "path").unwrap_or("image")
+      "sleep" =>
+        "slept \{@jsonx.json_int(fields, "durationMs").unwrap_or(0)} ms"
+      "imageGeneration" =>
+        match @jsonx.json_text(fields, "savedPath") {
+          Some(path) if !path.is_blank() => "generated \{path}"
+          _ => "generated image"
+        }
       "enteredReviewMode" => "Entered review mode"
       "exitedReviewMode" => "Exited review mode"
+      "planUpdate" => {
+        let mut completed = 0
+        let mut total = 0
+        let mut current : String? = None
+        if fields.get("steps") is Some(Array(steps)) {
+          total = steps.length()
+          for step in steps {
+            if step is Object(step) {
+              match @jsonx.json_text(step, "status") {
+                Some("completed") => completed = completed + 1
+                Some("in_progress") => current = @jsonx.json_text(step, "title")
+                _ => ()
+              }
+            }
+          }
+        }
+        let progress = "plan \{completed}/\{total}"
+        current.map(title => progress + " · " + title).unwrap_or(progress)
+      }
       other => other
     },
   )

--- a/desktop/frontend/codex/model.mbt
+++ b/desktop/frontend/codex/model.mbt
@@ -3037,17 +3037,11 @@ fn CodexItem::text(self : CodexItem) -> String {
           } else if value is Object(input) &&
             @jsonx.json_text(input, "type") is Some("mention") &&
             @jsonx.json_text(input, "path") is Some(path) {
-            // This envelope is presentation-only. Codex still sends and
-            // stores native `UserInput::Mention` values; adapting them here
-            // lets the shared transcript rebuild the same chips its composer
-            // showed without changing the app-server payload.
-            mentions.push(
-              @mention_context.Symbol(
-                name=@jsonx.json_text(input, "name").unwrap_or(path),
-                file=path,
-                line=0,
-              ),
-            )
+            // The composer sends a File as app-server's native path-only
+            // mention. Restore that same kind: the native envelope carries no
+            // source line, so it must not become an unplaced Symbol with a
+            // fabricated numeric line.
+            mentions.push(@mention_context.File(path~))
           } else if value is Object(input) &&
             @jsonx.json_text(input, "type") is Some("skill") &&
             @jsonx.json_text(input, "name") is Some(name) {
@@ -3567,7 +3561,9 @@ fn CodexItem::tool_brief(self : CodexItem) -> String? {
       "imageView" =>
         "viewed " + @jsonx.json_text(fields, "path").unwrap_or("image")
       "sleep" =>
-        "slept \{@jsonx.json_int(fields, "durationMs").unwrap_or(0)} ms"
+        @jsonx.json_int(fields, "durationMs")
+        .map(duration => "slept \{duration} ms")
+        .unwrap_or("slept")
       "imageGeneration" =>
         match @jsonx.json_text(fields, "savedPath") {
           Some(path) if !path.is_blank() => "generated \{path}"

--- a/desktop/frontend/codex/model.mbt
+++ b/desktop/frontend/codex/model.mbt
@@ -740,7 +740,7 @@ fn State::registry_turn_cwd(self : State) -> String? {
 /// Permission changes are frozen while an operation is being accepted or a
 /// turn is active, so the visible choice always describes the next request.
 fn State::can_choose_permission(self : State) -> Bool {
-  self.foreground is None && self.active_turn_id() is None
+  self.foreground is None && !self.is_running()
 }
 
 ///|
@@ -2068,8 +2068,12 @@ fn State::with_login(self : State, value : Json) -> State {
 }
 
 ///|
+/// Report whether the selected stored task is running from either ordered
+/// task-level activity or a loaded in-progress turn. Reconnect snapshots can
+/// expose the first fact before this page has received the turn body.
 fn State::is_running(self : State) -> Bool {
   guard self.active_thread() is Some(active) else { return false }
+  self.activity.is_running(active.id) ||
   active.turns.iter().any(turn => turn.is_running())
 }
 
@@ -3256,6 +3260,9 @@ fn CodexItem::tool_name(self : CodexItem) -> String {
 ///|
 /// Keep the operation input separate from its result so the shared expanded
 /// tool row can render Arguments before Output instead of one raw JSON blob.
+/// Optional app-server metadata stays absent from the projected object; an
+/// empty string, null, or empty collection can be a real supplied value and
+/// therefore must not be invented as a missing-field marker.
 fn CodexItem::tool_arguments(self : CodexItem) -> String? {
   guard self.value is Object(fields) else {
     return Some(self.value.stringify())
@@ -3297,25 +3304,28 @@ fn CodexItem::tool_arguments(self : CodexItem) -> String? {
     "mcpToolCall" | "dynamicToolCall" =>
       fields.get("arguments").map(value => value.stringify())
     "collabAgentToolCall" => {
-      let arguments : Json = {
-        "tool": @jsonx.json_text(fields, "tool").unwrap_or("agent"),
-        "prompt": fields.get("prompt").unwrap_or(Json::null()),
-        "model": fields.get("model").unwrap_or(Json::null()),
-        "reasoningEffort": fields.get("reasoningEffort").unwrap_or(Json::null()),
-        "senderThreadId": fields.get("senderThreadId").unwrap_or(Json::null()),
-        "receiverThreadIds": fields
-        .get("receiverThreadIds")
-        .unwrap_or(Json::array([])),
+      let arguments : Map[String, Json] = Map([])
+      if @jsonx.json_text(fields, "tool") is Some(tool) {
+        arguments["tool"] = Json(tool)
       }
-      Some(arguments.stringify())
+      for
+        key in [
+          "prompt", "model", "reasoningEffort", "senderThreadId", "receiverThreadIds",
+        ] {
+        if fields.get(key) is Some(value) {
+          arguments[key] = value
+        }
+      }
+      Some(Json::object(arguments).stringify())
     }
     "subAgentActivity" => {
-      let arguments : Json = {
-        "agentPath": @jsonx.json_text(fields, "agentPath").unwrap_or(""),
-        "agentThreadId": @jsonx.json_text(fields, "agentThreadId").unwrap_or(""),
-        "kind": @jsonx.json_text(fields, "kind").unwrap_or(""),
+      let arguments : Map[String, Json] = Map([])
+      for key in ["agentPath", "agentThreadId", "kind"] {
+        if @jsonx.json_text(fields, key) is Some(value) {
+          arguments[key] = Json(value)
+        }
       }
-      Some(arguments.stringify())
+      Some(Json::object(arguments).stringify())
     }
     "hookPrompt" =>
       fields
@@ -3325,17 +3335,21 @@ fn CodexItem::tool_arguments(self : CodexItem) -> String? {
         arguments.stringify()
       })
     "webSearch" => {
-      let arguments : Json = {
-        "query": @jsonx.json_text(fields, "query").unwrap_or(""),
-        "action": fields.get("action").unwrap_or(Json::null()),
+      let arguments : Map[String, Json] = Map([])
+      if @jsonx.json_text(fields, "query") is Some(query) {
+        arguments["query"] = Json(query)
       }
-      Some(arguments.stringify())
+      if fields.get("action") is Some(action) {
+        arguments["action"] = action
+      }
+      Some(Json::object(arguments).stringify())
     }
     "imageView" => {
-      let arguments : Json = {
-        "path": @jsonx.json_text(fields, "path").unwrap_or(""),
+      let arguments : Map[String, Json] = Map([])
+      if @jsonx.json_text(fields, "path") is Some(path) {
+        arguments["path"] = Json(path)
       }
-      Some(arguments.stringify())
+      Some(Json::object(arguments).stringify())
     }
     "sleep" =>
       fields
@@ -3345,19 +3359,20 @@ fn CodexItem::tool_arguments(self : CodexItem) -> String? {
         arguments.stringify()
       })
     "imageGeneration" => {
-      let arguments : Json = {
-        "revisedPrompt": fields.get("revisedPrompt").unwrap_or(Json::null()),
-        "transparentBackground": fields
-        .get("transparentBackground")
-        .unwrap_or(Json::null()),
+      let arguments : Map[String, Json] = Map([])
+      for key in ["revisedPrompt", "transparentBackground"] {
+        if fields.get(key) is Some(value) {
+          arguments[key] = value
+        }
       }
-      Some(arguments.stringify())
+      Some(Json::object(arguments).stringify())
     }
     "enteredReviewMode" | "exitedReviewMode" => {
-      let arguments : Json = {
-        "review": @jsonx.json_text(fields, "review").unwrap_or(""),
+      let arguments : Map[String, Json] = Map([])
+      if @jsonx.json_text(fields, "review") is Some(review) {
+        arguments["review"] = Json(review)
       }
-      Some(arguments.stringify())
+      Some(Json::object(arguments).stringify())
     }
     "planUpdate" =>
       fields

--- a/desktop/frontend/codex/pkg.generated.mbti
+++ b/desktop/frontend/codex/pkg.generated.mbti
@@ -75,7 +75,7 @@ pub(all) struct SidebarContext {
 }
 
 type State derive(Eq)
-pub fn State::State(loading? : Bool) -> Self
+pub fn State::State(loading? : Bool, client_namespace? : String) -> Self
 pub fn State::accepts_composer_identity(Self, @composer.Identity, @interop.ChannelId) -> Bool
 pub fn State::account_label(Self) -> String
 pub fn State::active_id(Self) -> String?
@@ -105,6 +105,7 @@ pub fn State::refresh(Self, @cmd.Emit[Msg], @interop.ChannelId) -> (@cmd.Cmd, Se
 pub fn State::sign_in_required(Self) -> Bool
 pub fn State::signed_in(Self) -> Bool
 pub fn State::transcript_items(Self) -> Array[@transcript.TranscriptItem]
+pub fn State::transcript_rows(Self) -> Array[@transcript.TranscriptRow]
 pub fn State::with_editor_comment(Self, String, @common.Range, String, String, side? : @mention_context.AnnotationSide) -> Self
 pub fn State::with_git_details_closed(Self) -> Self
 pub fn State::worktree_launch_workspace(Self, @interop.ChannelId) -> @common.Uri?

--- a/desktop/frontend/codex/steer_receipt.mbt
+++ b/desktop/frontend/codex/steer_receipt.mbt
@@ -37,12 +37,14 @@ fn CodexThread::has_item_id(
 ///|
 /// Create the receipt synchronously before the asynchronous steer command can
 /// emit either a reply or an item notification. `next_steer_submission_id` is
-/// local presentation identity only; it is never sent to app-server.
+/// local presentation identity; `client_user_message_id` is the exact value
+/// sent to app-server and later echoed by the canonical User item.
 fn State::with_pending_steer(self : State, turn_id : String) -> State {
   guard self.active_thread() is Some(active) else { return self }
   let pending_steers = self.pending_steers.copy()
   pending_steers.push({
     submission_id: self.next_steer_submission_id,
+    client_user_message_id: self.client_user_message_id(),
     turn_id,
     submitted: { task: self.draft, mentions: self.mentions.copy(), },
     known_user_item_ids: active.user_item_ids(turn_id),
@@ -100,26 +102,20 @@ fn State::without_sending_steer(self : State, thread_id : String) -> State {
 
 ///|
 /// Reconcile one previously unseen canonical User item with local receipts.
-///
-/// The protocol supplies `(threadId, turnId, item.id)`, but neither the steer
-/// reply nor the item identifies the other: there is no returned `itemId`,
-/// echoed client submission id, or `source: "steer"` marker. We therefore make
-/// one explicit integration assumption here: this Desktop is the single writer
-/// for the turn, its composer lock serializes steer RPCs, and app-server emits
-/// User items for that connection in submission FIFO order. Under that rule,
-/// the first previously unseen User item in the same turn consumes the oldest
-/// eligible receipt. We never compare message text, so identical consecutive
-/// messages remain distinct through their app-server item ids.
+/// A current item consumes only the receipt whose request id it echoes. When
+/// either side predates that protocol field, the older FIFO behavior remains
+/// available explicitly; message text is never used as identity.
 ///
 /// The first prompt has its own older receipt. If it has not produced a User
-/// item yet, FIFO assigns the next unseen item to that prompt rather than to a
-/// later steer. Duplicate started/completed notifications are ignored because
-/// the item id is already present in the pre-notification state.
+/// item yet, a later steer receipt cannot consume it. Duplicate started and
+/// completed notifications are ignored because the item id is already present
+/// in the pre-notification state.
 fn State::with_observed_user_item(
   self : State,
   thread_id : String,
   turn_id : String,
   item_id : String,
+  client_user_message_id : String?,
 ) -> State {
   guard self.active_thread() is Some(active) &&
     active.id == thread_id &&
@@ -132,7 +128,14 @@ fn State::with_observed_user_item(
   let mut consumed = false
   let pending_steers : Array[CodexSteerReceipt] = []
   for receipt in self.pending_steers {
+    let same_submission = match client_user_message_id {
+      Some(client_id) => receipt.client_user_message_id == Some(client_id)
+      // Older app-server items and tests have no echo, so retain serialized
+      // FIFO only for that explicit compatibility shape.
+      None => true
+    }
     if !consumed &&
+      same_submission &&
       receipt.turn_id == turn_id &&
       !receipt.known_user_item_ids.contains(item_id) {
       consumed = true
@@ -153,13 +156,26 @@ fn State::with_observed_steer_turn(self : State, turn : CodexTurn) -> State {
   let mut next = self
   for item in turn.items {
     if item.kind == "userMessage" && !observed_user_item_ids.contains(item.id) {
-      if next.waiting_for_first_user_item() {
+      let owns_first_prompt = match next.submitted_first_prompt_client_id {
+        Some(client_id) => item.client_id() == Some(client_id)
+        None => true
+      }
+      if next.waiting_for_first_user_item() && owns_first_prompt {
         // This decoded turn is installed immediately after reconciliation, so
         // its first new User item can authoritatively replace the older prompt
         // receipt. Notifications keep the old install-then-observe ordering.
-        next = { ..next, submitted_first_prompt: None, }
+        next = {
+          ..next,
+          submitted_first_prompt: None,
+          submitted_first_prompt_client_id: None,
+        }
       } else {
-        next = next.with_observed_user_item(active.id, turn.id, item.id)
+        next = next.with_observed_user_item(
+          active.id,
+          turn.id,
+          item.id,
+          item.client_id(),
+        )
       }
       observed_user_item_ids.push(item.id)
     }
@@ -186,7 +202,7 @@ fn State::with_observed_steer_item(
     item.kind == "userMessage" else {
     return self
   }
-  self.with_observed_user_item(thread_id, turn_id, item.id)
+  self.with_observed_user_item(thread_id, turn_id, item.id, item.client_id())
 }
 
 ///|

--- a/desktop/frontend/codex/transcript_test.mbt
+++ b/desktop/frontend/codex/transcript_test.mbt
@@ -50,13 +50,7 @@ test "Codex adapts app-server items to the shared transcript model" {
   assert_eq(user.task, "inspect this")
   assert_true(
     user.mentions
-    is [
-      @mention_context.Symbol(
-        name="model.mbt",
-        file="desktop/frontend/codex/model.mbt",
-        line=0
-      ),
-    ],
+    is [@mention_context.File(path="desktop/frontend/codex/model.mbt")],
   )
   assert_true(
     items[1].kind is @transcript.Assistant(reasoning=None, calls=[], ..),
@@ -104,6 +98,30 @@ test "Codex omits unavailable command metadata from shared arguments" {
     fail("expected read metadata in shared tool arguments")
   }
   assert_eq(arguments, "{\"path\":\"src/main.mbt\"}")
+}
+
+///|
+test "Codex sleep brief preserves an absent duration" {
+  let state = @codex.State::from_thread_snapshot({
+    "thread": {
+      "id": "thread-1",
+      "turns": [
+        {
+          "id": "turn-1",
+          "status": "completed",
+          "items": [{ "id": "sleep-1", "type": "sleep" }],
+        },
+      ],
+    },
+  })
+  let items = state.transcript_items()
+  assert_eq(items.length(), 1)
+  guard items[0].kind is @transcript.Assistant(calls=[call], ..) else {
+    fail("expected a sleep tool call")
+  }
+  assert_eq(call.name, "sleep")
+  assert_eq(call.arguments, None)
+  assert_true(call.outcome is Done(brief=Some("slept"), ..))
 }
 
 ///|

--- a/desktop/frontend/codex/transcript_test.mbt
+++ b/desktop/frontend/codex/transcript_test.mbt
@@ -107,6 +107,74 @@ test "Codex omits unavailable command metadata from shared arguments" {
 }
 
 ///|
+test "Codex omits unavailable metadata from other tool arguments" {
+  let state = @codex.State::from_thread_snapshot({
+    "thread": {
+      "id": "thread-1",
+      "turns": [
+        {
+          "id": "turn-1",
+          "status": "completed",
+          "items": [
+            { "id": "collab-1", "type": "collabAgentToolCall", "tool": "wait" },
+            {
+              "id": "subagent-1",
+              "type": "subAgentActivity",
+              "agentPath": "root/reviewer",
+            },
+            {
+              "id": "search-1",
+              "type": "webSearch",
+              "action": { "type": "search" },
+            },
+            { "id": "view-1", "type": "imageView" },
+            {
+              "id": "image-1",
+              "type": "imageGeneration",
+              "transparentBackground": false,
+            },
+            { "id": "review-1", "type": "enteredReviewMode" },
+          ],
+        },
+      ],
+    },
+  })
+  let items = state.transcript_items()
+  assert_eq(items.length(), 6)
+  guard items[0].kind is @transcript.Assistant(calls=[collab_call], ..) &&
+    collab_call.arguments is Some(collab) else {
+    fail("expected collaboration arguments")
+  }
+  assert_eq(collab, "{\"tool\":\"wait\"}")
+  guard items[1].kind is @transcript.Assistant(calls=[subagent_call], ..) &&
+    subagent_call.arguments is Some(subagent) else {
+    fail("expected subagent arguments")
+  }
+  assert_eq(subagent, "{\"agentPath\":\"root/reviewer\"}")
+  guard items[2].kind is @transcript.Assistant(calls=[search_call], ..) &&
+    search_call.arguments is Some(search) else {
+    fail("expected web-search arguments")
+  }
+  assert_true(search.contains("\"action\""))
+  assert_false(search.contains("\"query\""))
+  guard items[3].kind is @transcript.Assistant(calls=[view_call], ..) &&
+    view_call.arguments is Some(image_view) else {
+    fail("expected image-view arguments")
+  }
+  assert_eq(image_view, "{}")
+  guard items[4].kind is @transcript.Assistant(calls=[generation_call], ..) &&
+    generation_call.arguments is Some(generation) else {
+    fail("expected image-generation arguments")
+  }
+  assert_eq(generation, "{\"transparentBackground\":false}")
+  guard items[5].kind is @transcript.Assistant(calls=[review_call], ..) &&
+    review_call.arguments is Some(review) else {
+    fail("expected review arguments")
+  }
+  assert_eq(review, "{}")
+}
+
+///|
 test "Codex omits reasoning without visible summary text" {
   let state = @codex.State::from_thread_snapshot({
     "thread": {

--- a/desktop/frontend/codex/transcript_test.mbt
+++ b/desktop/frontend/codex/transcript_test.mbt
@@ -77,6 +77,36 @@ test "Codex adapts app-server items to the shared transcript model" {
 }
 
 ///|
+test "Codex omits unavailable command metadata from shared arguments" {
+  let state = @codex.State::from_thread_snapshot({
+    "thread": {
+      "id": "thread-1",
+      "turns": [
+        {
+          "id": "turn-1",
+          "status": "completed",
+          "items": [
+            {
+              "id": "read-1",
+              "type": "commandExecution",
+              "commandActions": [{ "type": "read", "path": "src/main.mbt" }],
+              "status": "completed",
+              "aggregatedOutput": "ok",
+            },
+          ],
+        },
+      ],
+    },
+  })
+  let items = state.transcript_items()
+  guard items[0].kind is @transcript.Assistant(calls=[call], ..) &&
+    call.arguments is Some(arguments) else {
+    fail("expected read metadata in shared tool arguments")
+  }
+  assert_eq(arguments, "{\"path\":\"src/main.mbt\"}")
+}
+
+///|
 test "Codex omits reasoning without visible summary text" {
   let state = @codex.State::from_thread_snapshot({
     "thread": {
@@ -104,7 +134,12 @@ test "Codex omits reasoning without visible summary text" {
                 { "type": "summary_text", "text": "Inspecting the fix" },
               ],
             },
-            { "id": "agent-1", "type": "agentMessage", "text": "Done." },
+            {
+              "id": "agent-1",
+              "type": "agentMessage",
+              "phase": Json::null(),
+              "text": "Done.",
+            },
           ],
         },
       ],
@@ -119,9 +154,196 @@ test "Codex omits reasoning without visible summary text" {
   assert_eq(thought, "Inspecting the fix")
   assert_true(items[0].text() is None)
   assert_true(
-    items[1].kind is @transcript.Assistant(reasoning=None, calls=[], ..),
+    items[1].kind
+    is @transcript.Assistant(
+      reasoning=None,
+      prose=Some("Done."),
+      calls=[],
+      finished=true,
+      ..
+    ),
   )
   assert_eq(items[1].text(), Some("Done."))
+}
+
+///|
+test "Codex preserves item ids, step groups, and explicit final answers" {
+  let state = @codex.State::from_thread_snapshot({
+    "thread": {
+      "id": "thread-1",
+      "turns": [
+        {
+          "id": "turn-1",
+          "status": "completed",
+          "completedAt": 123,
+          "items": [
+            {
+              "id": "user-1",
+              "type": "userMessage",
+              "clientId": "page-1-submission-1",
+              "content": [{ "type": "text", "text": "inspect" }],
+            },
+            {
+              "id": "reasoning-1",
+              "type": "reasoning",
+              "summary": [{ "text": "Checking" }],
+            },
+            {
+              "id": "command-1",
+              "type": "commandExecution",
+              "command": "moon check",
+              "status": "completed",
+              "aggregatedOutput": "ok",
+            },
+            {
+              "id": "agent-1",
+              "type": "agentMessage",
+              "phase": "final_answer",
+              "text": "Done.",
+            },
+          ],
+        },
+      ],
+    },
+  })
+  let rows = state.transcript_rows()
+  assert_eq(rows.length(), 4)
+  assert_eq(rows[0].identity, "turn\u{0}turn-1\u{0}item\u{0}user-1")
+  assert_eq(rows[0].step_identity, None)
+  assert_eq(rows[1].step_identity, rows[2].step_identity)
+  assert_true(rows[1].step_identity is Some(_))
+  assert_true(rows[3].step_identity is Some(_))
+  assert_true(rows[3].step_identity != rows[2].step_identity)
+  assert_true(
+    rows[3].item.kind
+    is @transcript.Assistant(prose=Some("Done."), finished=true, ..),
+  )
+  assert_eq(rows[3].item.ts, Some(123000.0))
+}
+
+///|
+test "Codex keeps async final-shaped delivery as ordinary assistant prose" {
+  let state = @codex.State::from_thread_snapshot({
+    "thread": {
+      "id": "thread-1",
+      "turns": [
+        {
+          "id": "turn-1",
+          "status": "completed",
+          "items": [
+            {
+              "id": "agent-1",
+              "type": "agentMessage",
+              "phase": "final_answer",
+              "delivery": "async",
+              "text": "Background result",
+            },
+          ],
+        },
+      ],
+    },
+  })
+  let items = state.transcript_items()
+  assert_eq(items.length(), 1)
+  assert_true(
+    items[0].kind
+    is @transcript.Assistant(
+      prose=Some("Background result"),
+      finished=false,
+      ..
+    ),
+  )
+}
+
+///|
+#warnings("-alert_unstable")
+test "Codex keeps indexed reasoning summary separate from raw content" {
+  let dispatch : @cmd.Emit[@codex.Msg] = @cmd.Emit(_ => @cmd.none)
+  let state = @codex.State::from_thread_snapshot({
+    "thread": {
+      "id": "thread-1",
+      "turns": [
+        {
+          "id": "turn-1",
+          "status": "inProgress",
+          "items": [{ "id": "reasoning-1", "type": "reasoning" }],
+        },
+      ],
+    },
+  })
+  let (_, first_part) = @codex.update(
+    dispatch,
+    @codex.Msg::notification(
+      "item/reasoning/summaryPartAdded",
+      {
+        "threadId": "thread-1",
+        "turnId": "turn-1",
+        "itemId": "reasoning-1",
+        "summaryIndex": 0,
+      },
+      0,
+    ),
+    state,
+    @interop.ChannelId::Local,
+    _ => @cmd.none,
+  )
+  let (_, first_text) = @codex.update(
+    dispatch,
+    @codex.Msg::notification(
+      "item/reasoning/summaryTextDelta",
+      {
+        "threadId": "thread-1",
+        "turnId": "turn-1",
+        "itemId": "reasoning-1",
+        "summaryIndex": 0,
+        "delta": "First",
+      },
+      0,
+    ),
+    first_part,
+    @interop.ChannelId::Local,
+    _ => @cmd.none,
+  )
+  let (_, second_text) = @codex.update(
+    dispatch,
+    @codex.Msg::notification(
+      "item/reasoning/summaryTextDelta",
+      {
+        "threadId": "thread-1",
+        "turnId": "turn-1",
+        "itemId": "reasoning-1",
+        "summaryIndex": 1,
+        "delta": "Second",
+      },
+      0,
+    ),
+    first_text,
+    @interop.ChannelId::Local,
+    _ => @cmd.none,
+  )
+  let (_, with_raw) = @codex.update(
+    dispatch,
+    @codex.Msg::notification(
+      "item/reasoning/textDelta",
+      {
+        "threadId": "thread-1",
+        "turnId": "turn-1",
+        "itemId": "reasoning-1",
+        "contentIndex": 0,
+        "delta": "raw details",
+      },
+      0,
+    ),
+    second_text,
+    @interop.ChannelId::Local,
+    _ => @cmd.none,
+  )
+  let items = with_raw.transcript_items()
+  assert_eq(items.length(), 1)
+  assert_true(
+    items[0].kind
+    is @transcript.Assistant(reasoning=Some("First\n\nSecond"), ..),
+  )
 }
 
 ///|
@@ -211,48 +433,46 @@ test "Codex normalizes semantic app-server tools for the shared transcript" {
   })
   let items = state.transcript_items()
   assert_eq(items.length(), 5)
-  guard items[0].kind
-    is @transcript.Tool(
-      name="read",
-      arguments=Some(read_arguments),
-      has_result=true,
-      is_error=false,
-      ..
-    ) else {
+  guard items[0].kind is @transcript.Assistant(calls=[read_call], ..) &&
+    read_call.name == "read" &&
+    read_call.arguments is Some(read_arguments) else {
     fail("expected a classified command read")
   }
   assert_true(read_arguments.contains("src/main.mbt"))
-  assert_eq(items[0].content, "fn main { }")
-  guard items[1].kind
-    is @transcript.Tool(name="edit", arguments=Some(edit_arguments), ..) else {
+  assert_true(
+    read_call.outcome is Done(content="fn main { }", is_error=false, ..),
+  )
+  guard items[1].kind is @transcript.Assistant(calls=[edit_call], ..) &&
+    edit_call.name == "edit" &&
+    edit_call.arguments is Some(edit_arguments) else {
     fail("expected one file change to become edit")
   }
   assert_true(edit_arguments.contains("@@ -1 +1 @@"))
   assert_true(edit_arguments.contains("src/main.mbt"))
-  guard items[2].kind
-    is @transcript.Tool(name="multi_edit", arguments=Some(multi_arguments), ..) else {
+  guard items[2].kind is @transcript.Assistant(calls=[multi_edit_call], ..) &&
+    multi_edit_call.name == "multi_edit" &&
+    multi_edit_call.arguments is Some(multi_arguments) else {
     fail("expected several file changes to become multi_edit")
   }
   assert_true(multi_arguments.contains("\"edits\""))
   assert_true(multi_arguments.contains("a.mbt"))
   assert_true(multi_arguments.contains("b.mbt"))
-  guard items[3].kind
-    is @transcript.Tool(name="mcp__docs__lookup", arguments=Some(mcp_args), ..) else {
+  guard items[3].kind is @transcript.Assistant(calls=[mcp_call], ..) &&
+    mcp_call.name == "mcp__docs__lookup" &&
+    mcp_call.arguments is Some(mcp_args) else {
     fail("expected an MCP registry-style tool name")
   }
   assert_true(mcp_args.contains("TranscriptItem"))
-  assert_eq(items[3].content, "MCP result")
-  guard items[4].kind
-    is @transcript.Tool(
-      name="run_moonbit",
-      arguments=Some(dynamic_args),
-      is_error=false,
-      ..
-    ) else {
+  assert_true(mcp_call.outcome is Done(content="MCP result", ..))
+  guard items[4].kind is @transcript.Assistant(calls=[dynamic_call], ..) &&
+    dynamic_call.name == "run_moonbit" &&
+    dynamic_call.arguments is Some(dynamic_args) else {
     fail("expected a dynamic tool to retain its semantic name")
   }
   assert_true(dynamic_args.contains("fn main"))
-  assert_eq(items[4].content, "program passed")
+  assert_true(
+    dynamic_call.outcome is Done(content="program passed", is_error=false, ..),
+  )
 }
 
 ///|
@@ -326,27 +546,59 @@ test "Codex gives every remaining app-server activity a shared semantic row" {
   })
   let items = state.transcript_items()
   assert_eq(items.length(), 10)
-  assert_true(items[0].kind is @transcript.Assistant(is_danger=false))
-  assert_eq(items[0].content, "Proposed approach")
-  assert_true(items[1].kind is @transcript.Tool(name="hook_prompt", ..))
-  assert_eq(items[1].content, "Check generated files")
   assert_true(
-    items[2].kind is @transcript.Tool(name="spawnAgent", is_error=false, ..),
+    items[0].kind
+    is @transcript.Assistant(prose=Some("Proposed approach"), calls=[], ..),
   )
-  assert_true(items[2].content.contains("thread-2"))
-  assert_true(items[3].kind is @transcript.Tool(name="subagent", ..))
-  assert_true(items[4].kind is @transcript.Tool(name="web_search", ..))
-  assert_true(items[4].content.contains("Result"))
-  assert_true(items[5].kind is @transcript.Tool(name="image_view", ..))
-  assert_true(items[6].kind is @transcript.Tool(name="sleep", ..))
+  guard items[1].kind is @transcript.Assistant(calls=[hook_call], ..) else {
+    fail("expected a hook prompt tool call")
+  }
+  assert_eq(hook_call.name, "hook_prompt")
+  assert_true(hook_call.outcome is Done(content="Check generated files", ..))
+  guard items[2].kind is @transcript.Assistant(calls=[spawn_call], ..) else {
+    fail("expected a spawnAgent tool call")
+  }
+  assert_eq(spawn_call.name, "spawnAgent")
+  guard spawn_call.outcome is Done(content=spawn_content, is_error=false, ..) else {
+    fail("expected completed spawnAgent output")
+  }
+  assert_true(spawn_content.contains("thread-2"))
+  guard items[3].kind is @transcript.Assistant(calls=[subagent_call], ..) else {
+    fail("expected a subagent tool call")
+  }
+  assert_eq(subagent_call.name, "subagent")
+  guard items[4].kind is @transcript.Assistant(calls=[search_call], ..) else {
+    fail("expected a web search tool call")
+  }
+  assert_eq(search_call.name, "web_search")
+  guard search_call.outcome is Done(content=search_content, ..) else {
+    fail("expected completed web search output")
+  }
+  assert_true(search_content.contains("Result"))
+  guard items[5].kind is @transcript.Assistant(calls=[view_call], ..) else {
+    fail("expected an image view tool call")
+  }
+  assert_eq(view_call.name, "image_view")
+  guard items[6].kind is @transcript.Assistant(calls=[sleep_call], ..) else {
+    fail("expected a sleep tool call")
+  }
+  assert_eq(sleep_call.name, "sleep")
+  guard items[7].kind is @transcript.Assistant(calls=[image_call], ..) else {
+    fail("expected an image generation tool call")
+  }
+  assert_eq(image_call.name, "image_generation")
   assert_true(
-    items[7].kind
-    is @transcript.Tool(name="image_generation", is_error=false, ..),
+    image_call.outcome
+    is Done(content="https://example.invalid/image.png", is_error=false, ..),
   )
-  assert_eq(items[7].content, "https://example.invalid/image.png")
-  assert_true(items[8].kind is @transcript.Tool(name="review", ..))
-  assert_eq(items[8].content, "Review the current changes")
-  assert_true(items[9].kind is @transcript.Summary)
+  guard items[8].kind is @transcript.Assistant(calls=[review_call], ..) else {
+    fail("expected a review tool call")
+  }
+  assert_eq(review_call.name, "review")
+  assert_true(
+    review_call.outcome is Done(content="Review the current changes", ..),
+  )
+  assert_true(items[9].kind is @transcript.Summary(_))
 }
 
 ///|
@@ -381,14 +633,14 @@ test "Codex structured plan notifications use the shared plan payload" {
   )
   let items = planned.transcript_items()
   assert_eq(items.length(), 1)
-  guard items[0].kind
-    is @transcript.Tool(
-      name="plan",
-      arguments=Some(arguments),
-      has_result=true,
+  guard items[0].kind is @transcript.Assistant(calls=[call], ..) &&
+    call.name == "plan" &&
+    call.arguments is Some(arguments) &&
+    call.outcome
+    is Done(
+      content="Starting with the adapter",
       is_error=false,
-      brief=Some(brief),
-      ..
+      brief=Some(brief)
     ) else {
     fail("expected a shared plan tool row")
   }
@@ -420,10 +672,12 @@ test "Codex item notifications preserve pending tool state" {
     @interop.ChannelId::Local,
     _ => @cmd.none,
   )
-  assert_true(
-    pending.transcript_items()[0].kind
-    is @transcript.Tool(name="web_search", has_result=false, ..),
-  )
+  guard pending.transcript_items()[0].kind
+    is @transcript.Assistant(calls=[pending_call], ..) else {
+    fail("expected a pending web search")
+  }
+  assert_eq(pending_call.name, "web_search")
+  assert_true(pending_call.outcome is Pending(_))
   assert_eq(pending.transcript_items()[0].ts, Some(1000.0))
   let completed_params : Json = {
     "threadId": "thread-1",
@@ -438,11 +692,80 @@ test "Codex item notifications preserve pending tool state" {
     @interop.ChannelId::Local,
     _ => @cmd.none,
   )
-  assert_true(
-    completed.transcript_items()[0].kind
-    is @transcript.Tool(name="web_search", has_result=true, ..),
-  )
+  guard completed.transcript_items()[0].kind
+    is @transcript.Assistant(calls=[completed_call], ..) else {
+    fail("expected a completed web search")
+  }
+  assert_eq(completed_call.name, "web_search")
+  assert_true(completed_call.outcome is Done(_))
   assert_eq(completed.transcript_items()[0].ts, Some(2000.0))
+}
+
+///|
+#warnings("-alert_unstable")
+test "Codex summary turns retain item lifecycle timestamps" {
+  let dispatch : @cmd.Emit[@codex.Msg] = @cmd.Emit(_ => @cmd.none)
+  let state = @codex.State::from_thread_snapshot({
+    "thread": {
+      "id": "thread-1",
+      "turns": [{ "id": "turn-1", "status": "inProgress", "items": [] }],
+    },
+  })
+  let (_, observed) = @codex.update(
+    dispatch,
+    @codex.Msg::notification(
+      "item/completed",
+      {
+        "threadId": "thread-1",
+        "turnId": "turn-1",
+        "completedAtMs": 1234,
+        "item": {
+          "id": "agent-1",
+          "type": "agentMessage",
+          "phase": "commentary",
+          "text": "Working",
+        },
+      },
+      0,
+    ),
+    state,
+    @interop.ChannelId::Local,
+    _ => @cmd.none,
+  )
+  let (_, settled) = @codex.update(
+    dispatch,
+    @codex.Msg::notification(
+      "turn/completed",
+      {
+        "threadId": "thread-1",
+        "turn": {
+          "id": "turn-1",
+          "status": "completed",
+          "completedAt": 2,
+          "itemsView": "summary",
+          "items": [
+            {
+              "id": "agent-1",
+              "type": "agentMessage",
+              "phase": "commentary",
+              "text": "Working",
+            },
+          ],
+        },
+      },
+      0,
+    ),
+    observed,
+    @interop.ChannelId::Local,
+    _ => @cmd.none,
+  )
+  let items = settled.transcript_items()
+  assert_eq(items.length(), 1)
+  assert_true(
+    items[0].kind
+    is @transcript.Assistant(prose=Some("Working"), finished=false, ..),
+  )
+  assert_eq(items[0].ts, Some(1234.0))
 }
 
 ///|
@@ -499,12 +822,10 @@ test "Codex live patch and MCP progress update their shared rows" {
     _ => @cmd.none,
   )
   guard patched.transcript_items()[0].kind
-    is @transcript.Tool(
-      name="edit",
-      arguments=Some(arguments),
-      has_result=false,
-      ..
-    ) else {
+    is @transcript.Assistant(calls=[edit_call], ..) &&
+    edit_call.name == "edit" &&
+    edit_call.arguments is Some(arguments) &&
+    edit_call.outcome is Pending(_) else {
     fail("expected a pending live edit")
   }
   assert_true(arguments.contains("-old\\n+new"))
@@ -549,9 +870,12 @@ test "Codex live patch and MCP progress update their shared rows" {
     @interop.ChannelId::Local,
     _ => @cmd.none,
   )
-  assert_eq(
-    progressed.transcript_items()[1].content,
-    "Searching documentation\n",
+  guard progressed.transcript_items()[1].kind
+    is @transcript.Assistant(calls=[mcp_call], ..) else {
+    fail("expected MCP progress in the shared tool call")
+  }
+  assert_true(
+    mcp_call.outcome is Pending(output=Some("Searching documentation\n")),
   )
 }
 
@@ -580,7 +904,8 @@ test "Codex keeps skill and local media inputs as shared mention chips" {
     },
   })
   let items = state.transcript_items()
-  guard @mention_context.parse(items[0].content) is Some(message) else {
+  guard items[0].kind is @transcript.User(content) &&
+    @mention_context.parse(content) is Some(message) else {
     fail("expected a shared mention envelope")
   }
   assert_eq(message.task, "Inspect these")

--- a/desktop/frontend/codex/transcript_test.mbt
+++ b/desktop/frontend/codex/transcript_test.mbt
@@ -123,3 +123,472 @@ test "Codex omits reasoning without visible summary text" {
   )
   assert_eq(items[1].text(), Some("Done."))
 }
+
+///|
+test "Codex normalizes semantic app-server tools for the shared transcript" {
+  let state = @codex.State::from_thread_snapshot({
+    "thread": {
+      "id": "thread-1",
+      "turns": [
+        {
+          "id": "turn-1",
+          "status": "completed",
+          "items": [
+            {
+              "id": "read-1",
+              "type": "commandExecution",
+              "command": "sed -n '1,20p' src/main.mbt",
+              "cwd": "/work/project",
+              "commandActions": [
+                {
+                  "type": "read",
+                  "command": "sed -n '1,20p' src/main.mbt",
+                  "name": "main.mbt",
+                  "path": "src/main.mbt",
+                },
+              ],
+              "status": "completed",
+              "exitCode": 0,
+              "aggregatedOutput": "fn main { }",
+            },
+            {
+              "id": "edit-1",
+              "type": "fileChange",
+              "status": "completed",
+              "changes": [
+                {
+                  "path": "src/main.mbt",
+                  "kind": { "type": "update", "move_path": Json::null() },
+                  "diff": "@@ -1 +1 @@\n-fn old { }\n+fn main { }",
+                },
+              ],
+            },
+            {
+              "id": "edit-2",
+              "type": "fileChange",
+              "status": "completed",
+              "changes": [
+                {
+                  "path": "a.mbt",
+                  "kind": { "type": "add" },
+                  "diff": "+let a = 1",
+                },
+                {
+                  "path": "b.mbt",
+                  "kind": { "type": "delete" },
+                  "diff": "-let b = 2",
+                },
+              ],
+            },
+            {
+              "id": "mcp-1",
+              "type": "mcpToolCall",
+              "server": "docs",
+              "tool": "lookup",
+              "arguments": { "query": "TranscriptItem" },
+              "status": "completed",
+              "result": {
+                "content": [{ "type": "text", "text": "MCP result" }],
+              },
+              "error": Json::null(),
+            },
+            {
+              "id": "dynamic-1",
+              "type": "dynamicToolCall",
+              "namespace": "workspace",
+              "tool": "run_moonbit",
+              "arguments": { "source": "fn main { println(\"hi\") }" },
+              "status": "completed",
+              "success": true,
+              "contentItems": [
+                { "type": "inputText", "text": "program passed" },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  })
+  let items = state.transcript_items()
+  assert_eq(items.length(), 5)
+  guard items[0].kind
+    is @transcript.Tool(
+      name="read",
+      arguments=Some(read_arguments),
+      has_result=true,
+      is_error=false,
+      ..
+    ) else {
+    fail("expected a classified command read")
+  }
+  assert_true(read_arguments.contains("src/main.mbt"))
+  assert_eq(items[0].content, "fn main { }")
+  guard items[1].kind
+    is @transcript.Tool(name="edit", arguments=Some(edit_arguments), ..) else {
+    fail("expected one file change to become edit")
+  }
+  assert_true(edit_arguments.contains("@@ -1 +1 @@"))
+  assert_true(edit_arguments.contains("src/main.mbt"))
+  guard items[2].kind
+    is @transcript.Tool(name="multi_edit", arguments=Some(multi_arguments), ..) else {
+    fail("expected several file changes to become multi_edit")
+  }
+  assert_true(multi_arguments.contains("\"edits\""))
+  assert_true(multi_arguments.contains("a.mbt"))
+  assert_true(multi_arguments.contains("b.mbt"))
+  guard items[3].kind
+    is @transcript.Tool(name="mcp__docs__lookup", arguments=Some(mcp_args), ..) else {
+    fail("expected an MCP registry-style tool name")
+  }
+  assert_true(mcp_args.contains("TranscriptItem"))
+  assert_eq(items[3].content, "MCP result")
+  guard items[4].kind
+    is @transcript.Tool(
+      name="run_moonbit",
+      arguments=Some(dynamic_args),
+      is_error=false,
+      ..
+    ) else {
+    fail("expected a dynamic tool to retain its semantic name")
+  }
+  assert_true(dynamic_args.contains("fn main"))
+  assert_eq(items[4].content, "program passed")
+}
+
+///|
+test "Codex gives every remaining app-server activity a shared semantic row" {
+  let state = @codex.State::from_thread_snapshot({
+    "thread": {
+      "id": "thread-1",
+      "turns": [
+        {
+          "id": "turn-1",
+          "status": "completed",
+          "items": [
+            { "id": "plan-1", "type": "plan", "text": "Proposed approach" },
+            {
+              "id": "hook-1",
+              "type": "hookPrompt",
+              "fragments": [
+                { "hookRunId": "hook-run-1", "text": "Check generated files" },
+              ],
+            },
+            {
+              "id": "collab-1",
+              "type": "collabAgentToolCall",
+              "tool": "spawnAgent",
+              "senderThreadId": "thread-1",
+              "receiverThreadIds": ["thread-2"],
+              "prompt": "Inspect the adapter",
+              "model": "gpt-5",
+              "reasoningEffort": "high",
+              "status": "completed",
+              "agentsStates": {
+                "thread-2": { "status": "completed", "message": "done" },
+              },
+            },
+            {
+              "id": "subagent-1",
+              "type": "subAgentActivity",
+              "agentPath": "adapter_review",
+              "agentThreadId": "thread-2",
+              "kind": "interacted",
+            },
+            {
+              "id": "search-1",
+              "type": "webSearch",
+              "query": "MoonBit adapter",
+              "action": { "type": "search", "query": "MoonBit adapter" },
+              "results": [{ "title": "Result" }],
+            },
+            { "id": "view-1", "type": "imageView", "path": "/work/a.png" },
+            { "id": "sleep-1", "type": "sleep", "durationMs": 250 },
+            {
+              "id": "image-1",
+              "type": "imageGeneration",
+              "status": "completed",
+              "result": "https://example.invalid/image.png",
+              "savedPath": "/work/generated.png",
+              "revisedPrompt": "A diagram",
+              "transparentBackground": false,
+              "failure": Json::null(),
+            },
+            {
+              "id": "review-1",
+              "type": "enteredReviewMode",
+              "review": "Review the current changes",
+            },
+            { "id": "compact-1", "type": "contextCompaction" },
+          ],
+        },
+      ],
+    },
+  })
+  let items = state.transcript_items()
+  assert_eq(items.length(), 10)
+  assert_true(items[0].kind is @transcript.Assistant(is_danger=false))
+  assert_eq(items[0].content, "Proposed approach")
+  assert_true(items[1].kind is @transcript.Tool(name="hook_prompt", ..))
+  assert_eq(items[1].content, "Check generated files")
+  assert_true(
+    items[2].kind is @transcript.Tool(name="spawnAgent", is_error=false, ..),
+  )
+  assert_true(items[2].content.contains("thread-2"))
+  assert_true(items[3].kind is @transcript.Tool(name="subagent", ..))
+  assert_true(items[4].kind is @transcript.Tool(name="web_search", ..))
+  assert_true(items[4].content.contains("Result"))
+  assert_true(items[5].kind is @transcript.Tool(name="image_view", ..))
+  assert_true(items[6].kind is @transcript.Tool(name="sleep", ..))
+  assert_true(
+    items[7].kind
+    is @transcript.Tool(name="image_generation", is_error=false, ..),
+  )
+  assert_eq(items[7].content, "https://example.invalid/image.png")
+  assert_true(items[8].kind is @transcript.Tool(name="review", ..))
+  assert_eq(items[8].content, "Review the current changes")
+  assert_true(items[9].kind is @transcript.Summary)
+}
+
+///|
+#warnings("-alert_unstable")
+test "Codex structured plan notifications use the shared plan payload" {
+  let dispatch : @cmd.Emit[@codex.Msg] = @cmd.Emit(_ => @cmd.none)
+  let state = @codex.State::from_thread_snapshot({
+    "thread": {
+      "id": "thread-1",
+      "turns": [{ "id": "turn-1", "status": "inProgress", "items": [] }],
+    },
+  })
+  let (_, planned) = @codex.update(
+    dispatch,
+    @codex.Msg::notification(
+      "turn/plan/updated",
+      {
+        "threadId": "thread-1",
+        "turnId": "turn-1",
+        "explanation": "Starting with the adapter",
+        "plan": [
+          { "step": "Map items", "status": "completed" },
+          { "step": "Run tests", "status": "inProgress" },
+          { "step": "Review diff", "status": "pending" },
+        ],
+      },
+      0,
+    ),
+    state,
+    @interop.ChannelId::Local,
+    _ => @cmd.none,
+  )
+  let items = planned.transcript_items()
+  assert_eq(items.length(), 1)
+  guard items[0].kind
+    is @transcript.Tool(
+      name="plan",
+      arguments=Some(arguments),
+      has_result=true,
+      is_error=false,
+      brief=Some(brief),
+      ..
+    ) else {
+    fail("expected a shared plan tool row")
+  }
+  assert_true(arguments.contains("\"title\":\"Run tests\""))
+  assert_true(arguments.contains("\"status\":\"in_progress\""))
+  assert_eq(brief, "plan 1/3 · Run tests")
+}
+
+///|
+#warnings("-alert_unstable")
+test "Codex item notifications preserve pending tool state" {
+  let dispatch : @cmd.Emit[@codex.Msg] = @cmd.Emit(_ => @cmd.none)
+  let state = @codex.State::from_thread_snapshot({
+    "thread": {
+      "id": "thread-1",
+      "turns": [{ "id": "turn-1", "status": "inProgress", "items": [] }],
+    },
+  })
+  let started : Json = {
+    "threadId": "thread-1",
+    "turnId": "turn-1",
+    "startedAtMs": 1000,
+    "item": { "id": "search-1", "type": "webSearch", "query": "MoonBit" },
+  }
+  let (_, pending) = @codex.update(
+    dispatch,
+    @codex.Msg::notification("item/started", started, 0),
+    state,
+    @interop.ChannelId::Local,
+    _ => @cmd.none,
+  )
+  assert_true(
+    pending.transcript_items()[0].kind
+    is @transcript.Tool(name="web_search", has_result=false, ..),
+  )
+  assert_eq(pending.transcript_items()[0].ts, Some(1000.0))
+  let completed_params : Json = {
+    "threadId": "thread-1",
+    "turnId": "turn-1",
+    "completedAtMs": 2000,
+    "item": { "id": "search-1", "type": "webSearch", "query": "MoonBit" },
+  }
+  let (_, completed) = @codex.update(
+    dispatch,
+    @codex.Msg::notification("item/completed", completed_params, 0),
+    pending,
+    @interop.ChannelId::Local,
+    _ => @cmd.none,
+  )
+  assert_true(
+    completed.transcript_items()[0].kind
+    is @transcript.Tool(name="web_search", has_result=true, ..),
+  )
+  assert_eq(completed.transcript_items()[0].ts, Some(2000.0))
+}
+
+///|
+#warnings("-alert_unstable")
+test "Codex live patch and MCP progress update their shared rows" {
+  let dispatch : @cmd.Emit[@codex.Msg] = @cmd.Emit(_ => @cmd.none)
+  let state = @codex.State::from_thread_snapshot({
+    "thread": {
+      "id": "thread-1",
+      "turns": [{ "id": "turn-1", "status": "inProgress", "items": [] }],
+    },
+  })
+  let (_, editing) = @codex.update(
+    dispatch,
+    @codex.Msg::notification(
+      "item/started",
+      {
+        "threadId": "thread-1",
+        "turnId": "turn-1",
+        "startedAtMs": 1000,
+        "item": {
+          "id": "edit-1",
+          "type": "fileChange",
+          "status": "inProgress",
+          "changes": [],
+        },
+      },
+      0,
+    ),
+    state,
+    @interop.ChannelId::Local,
+    _ => @cmd.none,
+  )
+  let (_, patched) = @codex.update(
+    dispatch,
+    @codex.Msg::notification(
+      "item/fileChange/patchUpdated",
+      {
+        "threadId": "thread-1",
+        "turnId": "turn-1",
+        "itemId": "edit-1",
+        "changes": [
+          {
+            "path": "main.mbt",
+            "kind": { "type": "update", "move_path": Json::null() },
+            "diff": "-old\n+new",
+          },
+        ],
+      },
+      0,
+    ),
+    editing,
+    @interop.ChannelId::Local,
+    _ => @cmd.none,
+  )
+  guard patched.transcript_items()[0].kind
+    is @transcript.Tool(
+      name="edit",
+      arguments=Some(arguments),
+      has_result=false,
+      ..
+    ) else {
+    fail("expected a pending live edit")
+  }
+  assert_true(arguments.contains("-old\\n+new"))
+  let (_, mcp_started) = @codex.update(
+    dispatch,
+    @codex.Msg::notification(
+      "item/started",
+      {
+        "threadId": "thread-1",
+        "turnId": "turn-1",
+        "startedAtMs": 1100,
+        "item": {
+          "id": "mcp-1",
+          "type": "mcpToolCall",
+          "server": "docs",
+          "tool": "lookup",
+          "arguments": { "query": "adapter" },
+          "status": "inProgress",
+          "result": Json::null(),
+          "error": Json::null(),
+        },
+      },
+      0,
+    ),
+    patched,
+    @interop.ChannelId::Local,
+    _ => @cmd.none,
+  )
+  let (_, progressed) = @codex.update(
+    dispatch,
+    @codex.Msg::notification(
+      "item/mcpToolCall/progress",
+      {
+        "threadId": "thread-1",
+        "turnId": "turn-1",
+        "itemId": "mcp-1",
+        "message": "Searching documentation",
+      },
+      0,
+    ),
+    mcp_started,
+    @interop.ChannelId::Local,
+    _ => @cmd.none,
+  )
+  assert_eq(
+    progressed.transcript_items()[1].content,
+    "Searching documentation\n",
+  )
+}
+
+///|
+test "Codex keeps skill and local media inputs as shared mention chips" {
+  let state = @codex.State::from_thread_snapshot({
+    "thread": {
+      "id": "thread-1",
+      "turns": [
+        {
+          "id": "turn-1",
+          "status": "completed",
+          "items": [
+            {
+              "id": "user-1",
+              "type": "userMessage",
+              "content": [
+                { "type": "text", "text": "Inspect these" },
+                { "type": "skill", "name": "moonbit", "path": "SKILL.md" },
+                { "type": "localImage", "path": "/work/screenshot.png" },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  })
+  let items = state.transcript_items()
+  guard @mention_context.parse(items[0].content) is Some(message) else {
+    fail("expected a shared mention envelope")
+  }
+  assert_eq(message.task, "Inspect these")
+  assert_true(
+    message.mentions
+    is [
+      @mention_context.Skill(name="moonbit"),
+      @mention_context.File(path="/work/screenshot.png"),
+    ],
+  )
+}

--- a/desktop/frontend/codex/update.mbt
+++ b/desktop/frontend/codex/update.mbt
@@ -150,6 +150,7 @@ pub fn update(
           draft: "",
           mentions: [],
           submitted_first_prompt: None,
+          submitted_first_prompt_client_id: None,
           pending_steers: [],
           placement: @composer.LocalCheckout,
           foreground: None,
@@ -189,6 +190,7 @@ pub fn update(
             draft: "",
             mentions: [],
             submitted_first_prompt: None,
+            submitted_first_prompt_client_id: None,
             pending_steers: [],
             notice: "",
           }.begin_foreground(CodexThreadReply(thread_id, activity_frontier)),
@@ -459,7 +461,11 @@ pub fn update(
           kind is CodexTurnStartReply(_) ||
           kind is CodexWorktreeTurnReply(_, _)
         ) {
-        { ..settled, submitted_first_prompt: None, }
+        {
+          ..settled,
+          submitted_first_prompt: None,
+          submitted_first_prompt_client_id: None,
+        }
       } else {
         settled
       }
@@ -1135,6 +1141,93 @@ test "Codex steer receipts reconcile duplicate text by item id and FIFO" {
   assert_eq(items.length(), 3)
   assert_true(items.iter().all(item => item.kind is @transcript.User(_)))
   assert_true(items.iter().all(item => item.text() == Some("same text")))
+}
+
+///|
+test "Codex steer receipt consumes only its echoed client user-message id" {
+  let dispatch : @cmd.Emit[Msg] = @cmd.Emit(_ => @cmd.none)
+  let open_external = (_ : String) => @cmd.none
+  let state = {
+    ..State::from_thread_snapshot({
+      "thread": {
+        "id": "thread-1",
+        "turns": [
+          {
+            "id": "turn-1",
+            "status": "inProgress",
+            "items": [
+              {
+                "id": "initial-user",
+                "type": "userMessage",
+                "clientId": "another-page-submission-1",
+                "content": [{ "type": "text", "text": "initial" }],
+              },
+            ],
+          },
+        ],
+      },
+    }),
+    client_namespace: Some("page-a"),
+    connection: CodexReady,
+  }
+  let (_, sending) = update(
+    dispatch,
+    ComposerAction(
+      @composer.DraftSubmitted(
+        identity=state.composer_identity(@interop.ChannelId::Local),
+        draft={ task: "same text", mentions: [], },
+      ),
+    ),
+    state,
+    @interop.ChannelId::Local,
+    open_external,
+  )
+  assert_eq(
+    sending.pending_steers[0].client_user_message_id,
+    Some("page-a-codex-submission-1"),
+  )
+  let (_, foreign) = update(
+    dispatch,
+    Notification(
+      method_="item/started",
+      params={
+        "threadId": "thread-1",
+        "turnId": "turn-1",
+        "item": {
+          "id": "foreign-user",
+          "type": "userMessage",
+          "clientId": "page-b-codex-submission-1",
+          "content": [{ "type": "text", "text": "same text" }],
+        },
+      },
+      generation=1,
+    ),
+    sending,
+    @interop.ChannelId::Local,
+    open_external,
+  )
+  assert_eq(foreign.pending_steers.length(), 1)
+  let (_, own) = update(
+    dispatch,
+    Notification(
+      method_="item/started",
+      params={
+        "threadId": "thread-1",
+        "turnId": "turn-1",
+        "item": {
+          "id": "own-user",
+          "type": "userMessage",
+          "clientId": "page-a-codex-submission-1",
+          "content": [{ "type": "text", "text": "same text" }],
+        },
+      },
+      generation=2,
+    ),
+    foreign,
+    @interop.ChannelId::Local,
+    open_external,
+  )
+  assert_true(own.pending_steers.is_empty())
 }
 
 ///|

--- a/desktop/frontend/codex/update.mbt
+++ b/desktop/frontend/codex/update.mbt
@@ -2085,6 +2085,30 @@ test "Codex observed running task steers without resume" {
 }
 
 ///|
+test "Codex status-only running task waits for its turn id" {
+  let dispatch : @cmd.Emit[Msg] = @cmd.Emit(_ => @cmd.none)
+  let observed = {
+    ..State::from_thread_snapshot({
+      "thread": {
+        "id": "thread-1",
+        "status": { "type": "active", "activeFlags": [] },
+        "turns": [],
+      },
+    }),
+    connection: CodexReady,
+    draft: "follow up",
+  }
+  assert_true(observed.is_running())
+  let (_, once) = observed.submit_composer(dispatch, @interop.ChannelId::Local)
+  let (_, twice) = observed.submit_composer(dispatch, @interop.ChannelId::Local)
+  assert_true(once == twice)
+  assert_false(once.owns_foreground(CodexResumeReply("thread-1")))
+  assert_false(once.owns_foreground(CodexTurnStartReply("thread-1")))
+  assert_false(once.owns_foreground(CodexTurnSteerReply("thread-1")))
+  assert_eq(once.draft, "follow up")
+}
+
+///|
 test "Codex idle stored task resumes before starting a turn" {
   let dispatch : @cmd.Emit[Msg] = @cmd.Emit(_ => @cmd.none)
   let idle = {

--- a/desktop/frontend/component_transcript.mbt
+++ b/desktop/frontend/component_transcript.mbt
@@ -15,9 +15,13 @@ fn Model::transcript_input(self : Model) -> @transcript_component.Input {
         active_session=self.codex.active_id().unwrap_or("none"),
         root=placement.bind(value => value.checkout_root()),
         submission_generation=0,
-        items=@transcript_component.VisibleRow::history(
-          self.codex.transcript_items(),
-        ),
+        items=self.codex
+          .transcript_rows()
+          .map(row => {
+            item: row.item,
+            identity: row.identity,
+            step_identity: row.step_identity,
+          }),
         streaming_response=None,
         streaming_identity="idle",
       )

--- a/desktop/frontend/composer/component_xxtest.mbt
+++ b/desktop/frontend/composer/component_xxtest.mbt
@@ -381,7 +381,7 @@ test "the heartbeat reports only the detail it actually has" {
   let full : RunHeartbeat = {
     stage: Thinking,
     started_ms: Some(clock_ms - 134_000.0),
-    tokens: 12_345,
+    tokens: Some(12_345),
   }
   assert_eq(full.label(clock_ms~), "Thinking… (2m 14s · 12.3k tokens)")
   // A run adopted from a reconnect has no start this page witnessed. Its age
@@ -391,10 +391,16 @@ test "the heartbeat reports only the detail it actually has" {
     "Thinking… (12.3k tokens)",
   )
   // Before the first usage event there is no count to report.
-  assert_eq({ ..full, tokens: 0, }.label(clock_ms~), "Thinking… (2m 14s)")
+  assert_eq({ ..full, tokens: None, }.label(clock_ms~), "Thinking… (2m 14s)")
+  // Zero is data when the engine explicitly reports it, not the sentinel for
+  // the absent branch above.
+  assert_eq(
+    { ..full, tokens: Some(0), }.label(clock_ms~),
+    "Thinking… (2m 14s · 0 tokens)",
+  )
   // Neither known: the bare stage is still the one thing worth saying.
   assert_eq(
-    { ..full, started_ms: None, tokens: 0, }.label(clock_ms~),
+    { ..full, started_ms: None, tokens: None, }.label(clock_ms~),
     "Thinking…",
   )
   // A clock that has not advanced past the start — the first render after a
@@ -404,7 +410,7 @@ test "the heartbeat reports only the detail it actually has" {
     "Thinking… (12.3k tokens)",
   )
   let bare = (stage : RunStage) => {
-    ({ stage, started_ms: None, tokens: 0, } : RunHeartbeat).label(clock_ms~)
+    ({ stage, started_ms: None, tokens: None, } : RunHeartbeat).label(clock_ms~)
   }
   assert_eq(bare(Starting), "Starting…")
   assert_eq(bare(AtStep(3)), "Working · step 3")
@@ -431,7 +437,7 @@ test "an idle tick changes nothing, a running one advances the clock" {
   assert_true(after_idle == mounted)
   let running = {
     ..idle,
-    run: Some({ stage: Thinking, started_ms: None, tokens: 0, }),
+    run: Some({ stage: Thinking, started_ms: None, tokens: None, }),
   }
   let stale = { ..mounted, clock_ms: 0.0, }
   let (after_running, _) = stale.update(

--- a/desktop/frontend/composer/contract.mbt
+++ b/desktop/frontend/composer/contract.mbt
@@ -193,10 +193,12 @@ pub(all) enum RunStage {
 /// `started_ms` is `None` whenever that moment is not the page's to know — a
 /// run adopted from a reconnect began before anyone here was watching, and
 /// dating it from the moment it was noticed always reports too short a wait.
+/// `tokens` is likewise `None` until the engine reports usage; `Some(0)` is an
+/// explicit zero-token report rather than another spelling of absence.
 pub(all) struct RunHeartbeat {
   stage : RunStage
   started_ms : Double?
-  tokens : Int
+  tokens : Int?
 } derive(Eq, @debug.Debug)
 
 ///|

--- a/desktop/frontend/composer/pkg.generated.mbti
+++ b/desktop/frontend/composer/pkg.generated.mbti
@@ -264,7 +264,7 @@ pub fn Replacement::to_repr(Self) -> @debug.Repr
 pub(all) struct RunHeartbeat {
   stage : RunStage
   started_ms : Double?
-  tokens : Int
+  tokens : Int?
 } derive(Eq, @debug.Debug)
 pub fn RunHeartbeat::equal(Self, Self) -> Bool
 pub fn RunHeartbeat::not_equal(Self, Self) -> Bool

--- a/desktop/frontend/composer/view.mbt
+++ b/desktop/frontend/composer/view.mbt
@@ -812,8 +812,8 @@ fn RunHeartbeat::label(self : RunHeartbeat, clock_ms~ : Double) -> String {
   if self.started_ms is Some(started) && clock_ms > started {
     detail.push(elapsed_label(clock_ms - started))
   }
-  if self.tokens > 0 {
-    detail.push("\{@labels.compact_count(self.tokens)} tokens")
+  if self.tokens is Some(tokens) {
+    detail.push("\{@labels.compact_count(tokens)} tokens")
   }
   if detail.is_empty() {
     stage

--- a/desktop/frontend/composer_contract_wbtest.mbt
+++ b/desktop/frontend/composer_contract_wbtest.mbt
@@ -23,7 +23,7 @@ test "the composer is handed the turn's facts, not a rendered row" {
   // to the component, so a span that changes every second costs one
   // component's render instead of reprojecting every component's input.
   guard running.composer_input().run
-    is Some({ stage: Thinking, started_ms: None, tokens: 0, }) else {
+    is Some({ stage: Thinking, started_ms: None, tokens: None, }) else {
     fail("expected the open turn's heartbeat facts")
   }
   let idle = running.replace_conversation({ ..conv, run: NoRun(ended=None), })

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -732,7 +732,9 @@ priv struct RunState {
   // nothing persists a sub-run's progress, so a reload mid-turn shows the
   // tool call pending with no lane under it.
   subruns : Array[@subrun.Lane]
-  usage_tokens : Int
+  // No Usage event means no count. Preserve an explicit zero separately so
+  // every renderer can distinguish a real report from absent metadata.
+  usage_tokens : Int?
 } derive(Eq)
 
 ///|
@@ -744,7 +746,7 @@ fn RunState::empty() -> RunState {
     live_reasoning: None,
     reasoning_frontier: 0,
     subruns: [],
-    usage_tokens: 0,
+    usage_tokens: None,
   }
 }
 

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -2551,6 +2551,7 @@ fn initial_model() -> Model {
     _ => None
   }
   let is_desktop = @interop.openseek_api() is Some(_)
+  let page_namespace = generated_session_id()
   {
     // The desktop window's one channel; a browser page starts empty and
     // fills `devices` from the fetched roster (`apply_roster`).
@@ -2603,7 +2604,7 @@ fn initial_model() -> Model {
     active_session: "",
     loading_conversation: None,
     transcript_request_generation: 0,
-    page_namespace: generated_session_id(),
+    page_namespace,
     submission_sequence: 0,
     conversations: [],
     project_picker: None,
@@ -2614,7 +2615,7 @@ fn initial_model() -> Model {
     selected_conversation: None,
     conversation_load_failure: None,
     screen: Chat,
-    codex: @codex.State(),
+    codex: @codex.State(client_namespace=page_namespace),
     skills: @skills.State::empty(),
     installed_skills: [],
     composer_context_generation: 0,

--- a/desktop/frontend/transcript/component/component.mbt
+++ b/desktop/frontend/transcript/component/component.mbt
@@ -16,11 +16,14 @@ fn Source::wire(self : Source) -> String {
 
 ///|
 /// One visible transcript item paired with the stable identity used by keyed
-/// reconciliation. The identity is opaque to the component's callers and is
-/// never emitted as a DOM id or attribute.
+/// reconciliation. `step_identity` groups Codex rows that belong to the same
+/// inferred model step; OpenSeek responses already carry one whole step in a
+/// single item and leave it absent. Neither identity is emitted as a DOM id or
+/// attribute.
 pub(all) struct VisibleRow {
   item : @transcript.TranscriptItem
   identity : String
+  step_identity : String?
 } derive(Eq)
 
 ///|
@@ -35,7 +38,7 @@ pub fn VisibleRow::history(
       Some(sequence) => "s\{sequence}"
       None => "l\{index}"
     }
-    rows.push({ item, identity, })
+    rows.push({ item, identity, step_identity: None, })
   }
   rows
 }
@@ -678,6 +681,7 @@ test "local pinned transitions are pure" {
         {
           item: { kind: User("new turn"), ts: None, sequence: None, },
           identity: "l0",
+          step_identity: None,
         },
       ],
     },

--- a/desktop/frontend/transcript/component/edit_diff.mbt
+++ b/desktop/frontend/transcript/component/edit_diff.mbt
@@ -1,18 +1,17 @@
 // The `edit` and `multi_edit` tools' arguments, read back out of the
 // transcript as the change they describe.
 //
-// Their payload states a replacement as two separate fields — `old_string` and
-// `new_string` — and the generic rendering prints both, JSON-escaped, one
-// after the other. What the model actually did is the difference between them,
-// and reading it out of two escaped blobs is work a reader should not be
-// doing. The card below synthesizes the diff, the way `viz` does for the same
-// two tools, and states the anchors (`path`/`file`, `start_line`) as chips.
+// OpenSeek tool calls state a replacement as two separate fields —
+// `old_string` and `new_string` — while Codex app-server file-change items
+// record a unified `diff`. The generic rendering leaves either form buried in
+// JSON. The card below synthesizes the first form, reads the second verbatim,
+// and states the anchors (`path`/`file`, `start_line`) as chips.
 //
-// The diff is *derived*, not recorded: it is these two strings compared, not
-// what the tool wrote to the file. Whether the edit applied at all is the
-// paired result — a rejected call still renders, because the change it asked
-// for is what a reader is trying to see. The recorded payload stays a click
-// away in the shared Original JSON tab.
+// For an OpenSeek tool call the diff is derived from its recorded request and
+// the paired result says whether it applied. For Codex the diff itself is the
+// recorded file-change payload. A rejected OpenSeek call still renders the
+// change it requested, and both forms keep their exact payload a click away in
+// the shared Original JSON tab.
 
 ///|
 /// One edit's rendering: the chips that anchor it and the diff it describes.
@@ -29,9 +28,9 @@ priv struct EditDiff {
 const MAX_RENDERED_EDITS = 50
 
 ///|
-/// The card body for an `edit` call: the change it asked for as a diff, under
-/// the chips that anchor it. `None` when the payload is not a readable edit —
-/// it then keeps the generic JSON rendering, which clamps before parsing.
+/// The card body for an `edit` row: the requested or recorded change as a diff,
+/// under the chips that anchor it. `None` when the payload is not readable — it
+/// then keeps the generic JSON rendering, which clamps before parsing.
 fn edit_card(arguments : String) -> @html.Html? {
   guard card_fields(arguments) is Some(fields) else { return None }
   guard decode_edit(fields, path_key="path") is Some(edit) else { return None }
@@ -98,38 +97,52 @@ fn multi_edit_card(arguments : String) -> @html.Html? {
 
 ///|
 /// Decode one edit-shaped object — `edit`'s own arguments, or one entry of a
-/// `multi_edit` batch — into the chips that anchor it and the diff between its
-/// two strings. `None` when it is not an edit this card can show: no string
-/// pair, or a pair with no difference (which the tools reject anyway, and
-/// which would render as an empty change).
+/// `multi_edit` batch — into the chips that anchor it and its diff. OpenSeek's
+/// tools describe the change as `old_string` plus `new_string`; Codex app-server
+/// records the applied unified `diff` directly. Both are exact recorded
+/// semantics, so the shared card accepts either without attempting to derive
+/// one protocol from the other.
 fn decode_edit(fields : Map[String, Json], path_key~ : String) -> EditDiff? {
-  guard fields.get("old_string") is Some(String(old)) &&
-    fields.get("new_string") is Some(String(new)) &&
-    old != new else {
-    return None
+  let diff = match (fields.get("old_string"), fields.get("new_string")) {
+    (Some(String(old)), Some(String(new))) if old != new =>
+      @edit_diff.generate(old, new)
+    _ =>
+      match fields.get("diff") {
+        Some(String(diff)) if !diff.is_blank() => diff
+        _ => return None
+      }
+  }
+  let anchor_key = if fields.get(path_key) is Some(_) {
+    path_key
+  } else if fields.get("path") is Some(_) {
+    // Codex uses `path` for every entry, including a multi-file patch;
+    // OpenSeek's `multi_edit` calls use `file`.
+    "path"
+  } else {
+    path_key
   }
   let chips = scalar_chips(
     fields,
     // The order the tools' schemas list them in: what file, then where in it.
     known=[
-      path_key, "start_line", "end_line", "replace_all_preview", "revert_on_parse_errors",
+      anchor_key, "start_line", "end_line", "replace_all_preview", "revert_on_parse_errors",
     ],
-    dramatized=["old_string", "new_string"],
+    dramatized=["old_string", "new_string", "diff"],
   )
-  Some({ chips, diff: @edit_diff.generate(old, new), })
+  Some({ chips, diff, })
 }
 
 ///|
-/// A synthesized diff as colored lines: `+ ` added, `- ` removed, anything
-/// else context — including the skip marker `truncate_output` leaves behind in
-/// a long change, which is context about the diff itself.
+/// A synthesized or recorded diff as colored lines. `+++` and `---` unified
+/// headers remain context; other leading `+`/`-` lines are additions/removals.
+/// The skip marker `truncate_output` leaves in a long change is context too.
 fn diff_block(text : String) -> @html.Html {
   let lines : Array[@html.Html] = [
     for raw in truncate_output(text, line_prefix_width=2).split("\n") => {
       let line = raw.to_owned()
-      let cls = if line.has_prefix("+ ") {
+      let cls = if line.has_prefix("+") && !line.has_prefix("+++") {
         "diff-add"
-      } else if line.has_prefix("- ") {
+      } else if line.has_prefix("-") && !line.has_prefix("---") {
         "diff-del"
       } else {
         "diff-ctx"

--- a/desktop/frontend/transcript/component/pkg.generated.mbti
+++ b/desktop/frontend/transcript/component/pkg.generated.mbti
@@ -24,7 +24,7 @@ pub(all) struct Actions {
 }
 
 type Input derive(Eq)
-pub fn Input::Input(source~ : Source, focused~ : @interop.ChannelId, active_session~ : String, root~ : @common.Uri?, submission_generation~ : Int, items~ : Array[VisibleRow], streaming_response~ : String?, streaming_reasoning? : String, reasoning_complete? : Bool, streaming_identity~ : String) -> Self
+pub fn Input::Input(source~ : Source, focused~ : @interop.ChannelId, active_session~ : String, root~ : @common.Uri?, submission_generation~ : Int, items~ : Array[@transcript.TranscriptRow], streaming_response~ : String?, streaming_reasoning? : String, reasoning_complete? : Bool, streaming_identity~ : String) -> Self
 pub fn Input::equal(Self, Self) -> Bool
 pub fn Input::not_equal(Self, Self) -> Bool
 
@@ -34,14 +34,6 @@ pub(all) enum Source {
 } derive(Eq)
 pub fn Source::equal(Self, Self) -> Bool
 pub fn Source::not_equal(Self, Self) -> Bool
-
-pub(all) struct VisibleRow {
-  item : @transcript.TranscriptItem
-  identity : String
-} derive(Eq)
-pub fn VisibleRow::equal(Self, Self) -> Bool
-pub fn VisibleRow::history(Array[@transcript.TranscriptItem]) -> Array[Self]
-pub fn VisibleRow::not_equal(Self, Self) -> Bool
 
 // Type aliases
 

--- a/desktop/frontend/transcript/component/rendering.mbt
+++ b/desktop/frontend/transcript/component/rendering.mbt
@@ -150,17 +150,29 @@ fn stream_blocks(input : Input) -> @vector.Vector[Block] {
   let assistant_name = input.source.assistant_name()
   let subrun_parent = input.subrun_parent()
   let blocks : Array[Block] = []
-  // OpenSeek numbers its model steps: every provider response that is not a
-  // checkpoint replay is one. Codex and legacy items carry no ordinal.
+  // OpenSeek already projects one provider response per model step. Codex
+  // projects its native items separately, so its adapter supplies a shared
+  // identity and only the first row in that inferred step carries the label.
   let mut steps = 0
+  let mut codex_step : String? = None
   for index, row in input.items {
     let item = row.item
-    let step_label = if input.source is OpenSeek &&
-      item.kind is Assistant(replay=false, ..) {
-      steps += 1
-      Some("#\{steps}")
-    } else {
-      None
+    let step_label = match input.source {
+      OpenSeek =>
+        if item.kind is Assistant(replay=false, ..) {
+          steps += 1
+          Some("#\{steps}")
+        } else {
+          None
+        }
+      Codex =>
+        if row.step_identity is Some(identity) && codex_step != Some(identity) {
+          codex_step = Some(identity)
+          steps += 1
+          Some("#\{steps}")
+        } else {
+          None
+        }
     }
     let anchor = if item.kind is User(_) {
       Some(@transcript_overview.TurnKey::of(item, index~).anchor())
@@ -194,11 +206,7 @@ fn stream_blocks(input : Input) -> @vector.Vector[Block] {
         prose=input.streaming_response,
         reasoning=input.streaming_reasoning,
         reasoning_complete=input.reasoning_complete,
-        step_label=if input.source is OpenSeek {
-          Some("#\{steps + 1}")
-        } else {
-          None
-        },
+        step_label=Some("#\{steps + 1}"),
         assistant_name~,
       ),
     })

--- a/desktop/frontend/transcript/component/view_tests.mbt
+++ b/desktop/frontend/transcript/component/view_tests.mbt
@@ -32,8 +32,9 @@ test "transcript stream children use stable typed keys in display order" {
       {
         item: { kind: User("question"), ts: None, sequence: Some(41), },
         identity: "s41",
+        step_identity: None,
       },
-      { item: response, identity: "s42", },
+      { item: response, identity: "s42", step_identity: None, },
     ],
     streaming_response=Some("partial answer"),
     streaming_identity="r7",
@@ -64,6 +65,7 @@ test "transcript stream children use stable typed keys in display order" {
           ),
         },
         identity: "s42",
+        step_identity: None,
       },
     ],
   }
@@ -71,10 +73,84 @@ test "transcript stream children use stable typed keys in display order" {
 }
 
 ///|
+test "Codex step identities label one row per step and the live successor" {
+  let input = Input(
+    source=Codex,
+    focused=@interop.ChannelId::Local,
+    active_session="thread-1",
+    root=None,
+    submission_generation=0,
+    items=[
+      {
+        item: {
+          kind: Assistant(
+            reasoning=Some("Inspecting"),
+            prose=None,
+            calls=[],
+            replay=false,
+            finished=false,
+          ),
+          ts: None,
+          sequence: None,
+        },
+        identity: "reasoning-1",
+        step_identity: Some("step-1"),
+      },
+      {
+        item: {
+          kind: Assistant(
+            reasoning=None,
+            prose=None,
+            calls=[
+              {
+                call_id: "command-1",
+                name: "shell",
+                arguments: Some("moon check"),
+                outcome: Done(content="ok", is_error=false, brief=None),
+              },
+            ],
+            replay=false,
+            finished=false,
+          ),
+          ts: None,
+          sequence: None,
+        },
+        identity: "command-1",
+        step_identity: Some("step-1"),
+      },
+      {
+        item: {
+          kind: Assistant(
+            reasoning=None,
+            prose=Some("Done"),
+            calls=[],
+            replay=false,
+            finished=true,
+          ),
+          ts: None,
+          sequence: None,
+        },
+        identity: "agent-1",
+        step_identity: Some("step-2"),
+      },
+    ],
+    streaming_response=Some("One more thing"),
+    streaming_identity="turn-2",
+  )
+  let blocks = stream_blocks(input).to_array()
+  assert_eq(blocks.length(), 4)
+  assert_true(blocks[0].content is Item(step_label=Some("#1"), ..))
+  assert_true(blocks[1].content is Item(step_label=None, ..))
+  assert_true(blocks[2].content is Item(step_label=Some("#2"), ..))
+  assert_true(blocks[3].content is Live(step_label=Some("#3"), ..))
+}
+
+///|
 test "the live response is one node, replaced by the durable one" {
   let user : VisibleRow = {
     item: { kind: User("question"), ts: None, sequence: Some(1), },
     identity: "s1",
+    step_identity: None,
   }
   let live_input = Input(
     source=OpenSeek,
@@ -110,6 +186,7 @@ test "the live response is one node, replaced by the durable one" {
           sequence: Some(2),
         },
         identity: "s2",
+        step_identity: None,
       },
     ],
     streaming_reasoning: None,
@@ -129,6 +206,7 @@ test "a streaming delta changes only the live block" {
       {
         item: { kind: User("question"), ts: Some(1.0e12), sequence: Some(1), },
         identity: "s1",
+        step_identity: None,
       },
       {
         item: {
@@ -143,6 +221,7 @@ test "a streaming delta changes only the live block" {
           sequence: Some(2),
         },
         identity: "s2",
+        step_identity: None,
       },
     ],
     streaming_response=Some("partial"),

--- a/desktop/frontend/transcript/pkg.generated.mbti
+++ b/desktop/frontend/transcript/pkg.generated.mbti
@@ -135,6 +135,14 @@ pub fn TranscriptItem::equal(Self, Self) -> Bool
 pub fn TranscriptItem::not_equal(Self, Self) -> Bool
 pub fn TranscriptItem::text(Self) -> String?
 
+pub(all) struct TranscriptRow {
+  item : TranscriptItem
+  identity : String
+  step_identity : String?
+} derive(Eq)
+pub fn TranscriptRow::equal(Self, Self) -> Bool
+pub fn TranscriptRow::not_equal(Self, Self) -> Bool
+
 // Type aliases
 
 // Traits

--- a/desktop/frontend/transcript/types.mbt
+++ b/desktop/frontend/transcript/types.mbt
@@ -96,6 +96,18 @@ pub fn TranscriptItem::text(self : TranscriptItem) -> String? {
 }
 
 ///|
+/// One display row with identities that survive transcript insertions and
+/// reloads. `identity` names this exact row; `step_identity` groups the prose,
+/// reasoning, and tool activity produced by one model step. Neither value is a
+/// DOM id or durable store sequence, so transcript sources can retain their
+/// native string ids without overloading `TranscriptItem::sequence`.
+pub(all) struct TranscriptRow {
+  item : TranscriptItem
+  identity : String
+  step_identity : String?
+} derive(Eq)
+
+///|
 /// One sidebar entry from the engine's durable session list: the session id
 /// and its display title (first user message, already truncated engine-side;
 /// blank or absent for a session with no user message yet). `workspace` is
@@ -128,3 +140,6 @@ pub extend SessionListItem with Eq::{equal, not_equal}
 
 ///|
 pub extend TranscriptItem with Eq::{equal, not_equal}
+
+///|
+pub extend TranscriptRow with Eq::{equal, not_equal}

--- a/desktop/frontend/transcript_rendering.mbt
+++ b/desktop/frontend/transcript_rendering.mbt
@@ -30,7 +30,7 @@ fn Conversation::visible_transcript_rows(
       Some(sequence) => DurableTranscriptRow(sequence)
       None => LegacyTranscriptRow(index)
     }
-    durable.push({ item, identity: identity.wire(), })
+    durable.push({ item, identity: identity.wire(), step_identity: None, })
   }
   durable
 }

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -77,7 +77,7 @@ fn focus_channel(
       // Codex is host-owned just like the other focused mirrors. Clear the
       // previous device's account and conversation list before its replies
       // can be mistaken for this device's sidebar section.
-      codex: @codex.State(loading=true),
+      codex: @codex.State(loading=true, client_namespace=model.page_namespace),
       // The old HostConnection is already parked. Preserve the remaining
       // owner/root state until the post-dispatch sync retires its file-index
       // cache and re-roots against the newly focused host.

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1221,7 +1221,7 @@ fn apply_engine_event(
           ..conv,
           turn: {
             ..conv.turn,
-            usage_tokens: prompt_tokens + completion_tokens,
+            usage_tokens: Some(prompt_tokens + completion_tokens),
           },
         },
       )
@@ -8846,11 +8846,11 @@ test "the run heartbeat carries only the facts the page actually has" {
   let full = {
     ..running_conversation(),
     run_started_ms: Some(1_000.0),
-    turn: { ..running_conversation().turn, usage_tokens: 12_345, },
+    turn: { ..running_conversation().turn, usage_tokens: Some(12_345), },
   }
   assert_eq(
     full.run_heartbeat(),
-    Some({ stage: Thinking, started_ms: Some(1_000.0), tokens: 12_345, }),
+    Some({ stage: Thinking, started_ms: Some(1_000.0), tokens: Some(12_345), }),
   )
   // A run adopted from a reconnect has no start this page witnessed. The
   // composer omits the span rather than dating it from when we noticed.
@@ -9181,7 +9181,7 @@ test "session rotation activates a fresh conversation, keeping the old one" {
   )
   inspect(next.active_session, content="desktop-fresh")
   inspect(next.active().messages.length(), content="0")
-  inspect(next.active().turn.usage_tokens, content="0")
+  assert_eq(next.active().turn.usage_tokens, None)
   assert_true(next.display_status() is Ready)
   // The previous conversation keeps running in the background.
   guard next.find_conversation(@interop.ChannelId::Local, "desktop-test")
@@ -10801,7 +10801,7 @@ test "session loaded swaps the active conversation onto the stored session" {
       messages: [{ kind: User("old chat"), ts: None, sequence: None, }],
       turn: {
         ..test_conversation().turn,
-        usage_tokens: 42,
+        usage_tokens: Some(42),
         streaming_response: Some("leftover"),
       },
     })
@@ -10866,7 +10866,7 @@ test "session loaded swaps the active conversation onto the stored session" {
   inspect(once.active().messages.length(), content="2")
   assert_eq(once.active().messages[0].text(), Some("stored question"))
   assert_eq(once.active().turn.streaming_response, None)
-  inspect(once.active().turn.usage_tokens, content="0")
+  assert_eq(once.active().turn.usage_tokens, None)
   assert_eq(
     once.active().workspace,
     Project(root=@interop.ChannelId::Local.test_project()),
@@ -11142,7 +11142,7 @@ test "a run boundary discards the previous turn's live state whole" {
       live_reasoning: None,
       reasoning_frontier: 0,
       subruns: [lane],
-      usage_tokens: 4200,
+      usage_tokens: Some(4200),
     },
   }
   let (_, next) = update_dev(
@@ -11164,7 +11164,7 @@ test "a run boundary discards the previous turn's live state whole" {
   }
   assert_eq(next.active().turn.streaming_response, None)
   inspect(next.active().turn.subruns.length(), content="0")
-  inspect(next.active().turn.usage_tokens, content="0")
+  assert_eq(next.active().turn.usage_tokens, None)
 }
 
 ///|

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -1359,8 +1359,8 @@ fn topbar_view(
     ]),
   )
   items.push(run_indicator(model, conv))
-  if conv.turn.usage_tokens > 0 {
-    items.push(@html.span(class="pill", token_label(conv.turn.usage_tokens)))
+  if conv.turn.usage_tokens is Some(tokens) {
+    items.push(@html.span(class="pill", token_label(tokens)))
   }
   // Export is a native-window operation and the visualizer consumes durable
   // OpenSeek JSONL. Remote-device conversations and fresh drafts therefore do

--- a/desktop/internal/api/payload.mbt
+++ b/desktop/internal/api/payload.mbt
@@ -119,6 +119,9 @@ fn @protocol.CodexTurnStartPayload::app_server_params(
   if self.cwd is Some(cwd) {
     fields["cwd"] = Json(cwd)
   }
+  if self.client_user_message_id is Some(client_id) {
+    fields["clientUserMessageId"] = Json(client_id)
+  }
   self.permission_mode.write_app_server_settings(fields)
   Json(fields)
 }
@@ -173,6 +176,7 @@ test "Codex resume and turn map full access without a reviewer" {
     "threadId": "thread-1",
     "cwd": "/work/project",
     "input": [{ "type": "text", "text": "hello" }],
+    "clientUserMessageId": "page-1-submission-1",
     "model": "gpt-test",
     "effort": "high",
     "permissionMode": "requestApproval",
@@ -183,6 +187,7 @@ test "Codex resume and turn map full access without a reviewer" {
     "threadId": "thread-1",
     "cwd": "/work/project",
     "input": [{ "type": "text", "text": "hello" }],
+    "clientUserMessageId": "page-1-submission-1",
     "model": "gpt-test",
     "effort": "high",
     "permissions": ":workspace",

--- a/desktop/internal/protocol/codex_commands.mbt
+++ b/desktop/internal/protocol/codex_commands.mbt
@@ -119,6 +119,7 @@ pub(all) struct CodexReviewStartPayload {
 pub(all) struct CodexTurnStartPayload {
   thread_id : String
   input : Array[Json]
+  client_user_message_id : String?
   model : String?
   effort : String?
   cwd : String?
@@ -129,6 +130,7 @@ pub(all) struct CodexTurnStartPayload {
 pub(all) struct CodexTurnSteerPayload {
   thread_id : String
   input : Array[Json]
+  client_user_message_id : String?
   expected_turn_id : String
 } derive(Debug, Eq)
 
@@ -528,6 +530,7 @@ pub impl FromJson for CodexTurnStartPayload with fn from_json(json, path) {
   {
     thread_id: object.required_string("threadId"),
     input: object.required_array("input"),
+    client_user_message_id: object.optional_string("clientUserMessageId"),
     model: object.optional_string("model"),
     effort: object.optional_string("effort"),
     cwd: object.optional_string("cwd"),
@@ -553,6 +556,9 @@ pub impl ToJson for CodexTurnStartPayload with fn to_json(self) {
   if self.cwd is Some(cwd) {
     fields["cwd"] = Json(cwd)
   }
+  if self.client_user_message_id is Some(client_id) {
+    fields["clientUserMessageId"] = Json(client_id)
+  }
   fields["permissionMode"] = ToJson::to_json(self.permission_mode)
   Json(fields)
 }
@@ -563,17 +569,22 @@ pub impl FromJson for CodexTurnSteerPayload with fn from_json(json, path) {
   {
     thread_id: object.required_string("threadId"),
     input: object.required_array("input"),
+    client_user_message_id: object.optional_string("clientUserMessageId"),
     expected_turn_id: object.required_string("expectedTurnId"),
   }
 }
 
 ///|
 pub impl ToJson for CodexTurnSteerPayload with fn to_json(self) {
-  {
+  let fields : Map[String, Json] = {
     "threadId": Json(self.thread_id),
     "input": Json(self.input),
     "expectedTurnId": Json(self.expected_turn_id),
   }
+  if self.client_user_message_id is Some(client_id) {
+    fields["clientUserMessageId"] = Json(client_id)
+  }
+  Json(fields)
 }
 
 ///|

--- a/desktop/internal/protocol/codex_commands_test.mbt
+++ b/desktop/internal/protocol/codex_commands_test.mbt
@@ -34,6 +34,7 @@ test "Codex permission modes and turn payloads keep Desktop field names" {
   let start : @protocol.CodexTurnStartPayload = {
     thread_id: "thread-1",
     input: [{ "type": "text", "text": "hello" }],
+    client_user_message_id: Some("page-1-submission-1"),
     model: Some("gpt-test"),
     effort: Some("high"),
     cwd: None,
@@ -42,6 +43,7 @@ test "Codex permission modes and turn payloads keep Desktop field names" {
   @debug.assert_eq(start.to_json(), {
     "threadId": "thread-1",
     "input": [{ "type": "text", "text": "hello" }],
+    "clientUserMessageId": "page-1-submission-1",
     "model": "gpt-test",
     "effort": "high",
     "permissionMode": "fullAccess",
@@ -49,11 +51,24 @@ test "Codex permission modes and turn payloads keep Desktop field names" {
   let steer : @protocol.CodexTurnSteerPayload = {
     thread_id: "thread-1",
     input: [{ "type": "text", "text": "more" }],
+    client_user_message_id: Some("page-1-submission-2"),
     expected_turn_id: "turn-1",
   }
   @debug.assert_eq(steer.to_json(), {
     "threadId": "thread-1",
     "input": [{ "type": "text", "text": "more" }],
+    "clientUserMessageId": "page-1-submission-2",
+    "expectedTurnId": "turn-1",
+  })
+  let legacy_steer : @protocol.CodexTurnSteerPayload = @json.from_json({
+    "threadId": "thread-1",
+    "input": [{ "type": "text", "text": "legacy" }],
+    "expectedTurnId": "turn-1",
+  })
+  assert_eq(legacy_steer.client_user_message_id, None)
+  @debug.assert_eq(legacy_steer.to_json(), {
+    "threadId": "thread-1",
+    "input": [{ "type": "text", "text": "legacy" }],
     "expectedTurnId": "turn-1",
   })
 }

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -694,6 +694,7 @@ pub impl @json.FromJson for CodexTurnReply
 pub(all) struct CodexTurnStartPayload {
   thread_id : String
   input : Array[Json]
+  client_user_message_id : String?
   model : String?
   effort : String?
   cwd : String?
@@ -710,6 +711,7 @@ pub impl @json.FromJson for CodexTurnStartPayload
 pub(all) struct CodexTurnSteerPayload {
   thread_id : String
   input : Array[Json]
+  client_user_message_id : String?
   expected_turn_id : String
 } derive(Eq, @debug.Debug)
 pub fn CodexTurnSteerPayload::equal(Self, Self) -> Bool


### PR DESCRIPTION
## Summary

- normalize Codex app-server thread items into the shared transcript item model
- preserve structured plans, tool lifecycle state, progress, timestamps, mentions, and protocol-specific payloads
- render Codex file-change unified diffs through the shared edit cards and cover the conversions with focused tests

## Testing

- moon -C desktop test frontend/codex --target js
- moon -C desktop test frontend/transcript/component --target js
- moon -C desktop check frontend --target js
- moon -C desktop fmt
- moon -C desktop info