### PR TITLE
feat(desktop): add more font size choices

### DIFF
--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -388,43 +388,43 @@ fn AppFont::css_family(self : AppFont) -> String {
 ///|
 /// The base text size selected in Settings. The CSS token scale derives the
 /// surrounding app sizes from this choice; the editor and terminal receive
-/// the pixel value directly because their layout engines measure glyphs.
-priv enum AppFontSize {
-  Small
-  Medium
-  Large
-} derive(Eq)
+/// the adjacent smaller pixel value because their glyphs look larger.
+priv struct AppFontSize(Int) derive(Eq, Debug)
 
 ///|
-/// Unknown or absent stored values retain the current choice, so older builds
-/// and corrupt localStorage values preserve the readable default.
+const AppFontSizeMinPixels : Int = 12
+
+///|
+const AppFontSizeMaxPixels : Int = 18
+
+///|
+/// Invalid ephemeral localStorage values retain the current readable choice.
 fn AppFontSize::parse(value : String, fallback : AppFontSize) -> AppFontSize {
-  match value {
-    "small" => Small
-    "medium" => Medium
-    "large" => Large
-    _ => fallback
+  let pixels = @string.parse_int(value) catch { _ => return fallback }
+  if pixels >= AppFontSizeMinPixels && pixels <= AppFontSizeMaxPixels {
+    AppFontSize(pixels)
+  } else {
+    fallback
   }
 }
 
 ///|
 fn AppFontSize::wire(self : AppFontSize) -> String {
-  match self {
-    Small => "small"
-    Medium => "medium"
-    Large => "large"
-  }
+  let AppFontSize(pixels) = self
+  pixels.to_string()
+}
+
+///|
+fn AppFontSize::base_pixels(self : AppFontSize) -> Int {
+  let AppFontSize(pixels) = self
+  pixels
 }
 
 ///|
 /// Measured monospace surfaces use one pixel less than the selected app base.
 /// Their larger-looking glyphs then align with surrounding system-sans text.
 fn AppFontSize::pixels(self : AppFontSize) -> Double {
-  match self {
-    Small => 12.0
-    Medium => 13.0
-    Large => 14.0
-  }
+  (self.base_pixels() - 1).to_double()
 }
 
 ///|
@@ -2478,7 +2478,7 @@ fn initial_model() -> Model {
     system_dark: host_prefers_dark(),
     theme: System,
     app_font: SystemMono,
-    app_font_size: Medium,
+    app_font_size: AppFontSize(14),
     narrow,
     sidebar_open: !narrow,
     right_panel_open: false,

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -12084,7 +12084,7 @@ test "loaded UI preferences parse their wire names" {
       tree_layout="",
       theme="dark",
       font="menlo",
-      font_size="large",
+      font_size="15",
       model="deepseek-v4-flash",
       conversation_models="[{\"key\":\"local/desktop-test\",\"model\":\"deepseek-v4-pro\"}]",
       agent="codex",
@@ -12098,7 +12098,7 @@ test "loaded UI preferences parse their wire names" {
   assert_true(restored.notification_corner is TopLeft)
   assert_true(restored.theme is Dark)
   assert_true(restored.app_font is Menlo)
-  assert_true(restored.app_font_size is Large)
+  assert_eq(restored.app_font_size, AppFontSize(15))
   assert_true(restored.default_model is Low)
   assert_true(restored.default_agent is CodexAgent)
   assert_true(restored.openseek_reasoning is ReasoningHigh)
@@ -12127,7 +12127,7 @@ test "loaded UI preferences parse their wire names" {
   assert_true(unknown.notification_corner is BottomRight)
   assert_true(unknown.theme is System)
   assert_true(unknown.app_font is SystemMono)
-  assert_true(unknown.app_font_size is Medium)
+  assert_eq(unknown.app_font_size, AppFontSize(14))
   assert_true(unknown.default_model is High)
   assert_true(unknown.openseek_reasoning is ReasoningMax)
   assert_true(unknown.glm_reasoning is ReasoningOff)
@@ -15302,24 +15302,21 @@ test "monospace settings switch code surfaces and are idempotent" {
 
 ///|
 test "font-size settings switch every text surface and are idempotent" {
-  assert_eq(Small.pixels(), 12.0)
-  assert_eq(Medium.pixels(), 13.0)
-  assert_eq(Large.pixels(), 14.0)
+  assert_eq(AppFontSize(12).pixels(), 11.0)
+  assert_eq(AppFontSize(14).pixels(), 13.0)
+  assert_eq(AppFontSize(18).pixels(), 17.0)
   let dispatch = test_dispatch()
   let model = test_model()
-  let (_, first) = update(dispatch, FontSizeChanged("small"), model)
-  let (_, second) = update(dispatch, FontSizeChanged("small"), model)
-  assert_true(first.app_font_size is Small)
-  assert_true(second.app_font_size is Small)
-  assert_eq(first.app_font_size.pixels(), 12.0)
-  let (_, large) = update(dispatch, FontSizeChanged("large"), first)
-  assert_true(large.app_font_size is Large)
-  assert_eq(large.app_font_size.pixels(), 14.0)
-  let (_, medium) = update(dispatch, FontSizeChanged("medium"), large)
-  assert_true(medium.app_font_size is Medium)
-  assert_eq(medium.app_font_size.pixels(), 13.0)
+  let (_, first) = update(dispatch, FontSizeChanged("15"), model)
+  let (_, second) = update(dispatch, FontSizeChanged("15"), first)
+  assert_eq(first.app_font_size, AppFontSize(15))
+  assert_eq(second.app_font_size, AppFontSize(15))
+  assert_eq(first.app_font_size.pixels(), 14.0)
+  let (_, largest) = update(dispatch, FontSizeChanged("18"), first)
+  assert_eq(largest.app_font_size, AppFontSize(18))
+  assert_eq(largest.app_font_size.pixels(), 17.0)
   let (_, unchanged) = update(dispatch, FontSizeChanged("unknown"), model)
-  assert_true(unchanged.app_font_size is Medium)
+  assert_eq(unchanged.app_font_size, AppFontSize(14))
 }
 
 ///|

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -1203,9 +1203,13 @@ fn settings_page(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
             model,
             id="font-size-select",
             options=[
-              { value: "small", label: "Small (13px)", },
-              { value: "medium", label: "Medium (14px)", },
-              { value: "large", label: "Large (15px)", },
+              { value: "12", label: "12px", },
+              { value: "13", label: "13px", },
+              { value: "14", label: "14px", },
+              { value: "15", label: "15px", },
+              { value: "16", label: "16px", },
+              { value: "17", label: "17px", },
+              { value: "18", label: "18px", },
             ],
             selected=model.app_font_size.wire(),
             aria_label="Font size",
@@ -1416,7 +1420,12 @@ fn workspace_settings_page(
 test "settings and the browser address bar declare form focus ownership" {
   let dispatch = test_dispatch()
   let settings_markup = @rabbita.render_to_string(() => {
-    @rabbita.Val::constant(settings_page(dispatch, test_model()))
+    @rabbita.Val::constant(
+      settings_page(dispatch, {
+        ..test_model(),
+        select_menu: Some(FontSizeMenu),
+      }),
+    )
   })
   // Settings use the same app-owned button/listbox control as the composer;
   // no platform select may reintroduce a native popup on one page only.
@@ -1425,6 +1434,9 @@ test "settings and the browser address bar declare form focus ownership" {
     settings_markup.contains("class=\"custom-select setting-select\""),
   )
   assert_true(settings_markup.contains("aria-haspopup=\"listbox\""))
+  assert_true(settings_markup.contains("id=\"font-size-select\""))
+  assert_true(settings_markup.contains("12px"))
+  assert_true(settings_markup.contains("18px"))
   // Settings fields own their existing borders directly; there is no nested
   // target that could draw a second frame.
   assert_true(settings_markup.contains("data-focus-owner=\"\""))

--- a/desktop/styles/tokens.css
+++ b/desktop/styles/tokens.css
@@ -11,10 +11,11 @@
     "Liberation Mono", "Courier New", monospace;
   --font-family-sans: ui-sans-serif, system-ui, -apple-system,
     BlinkMacSystemFont, "Segoe UI", sans-serif;
-  --font-size-xs: 12px;
-  --font-size-sm: 13px;
-  --font-size-md: 14px;
-  --font-size-lg: 17px;
+  --font-size-base: 14px;
+  --font-size-xs: calc(var(--font-size-base) - 2px);
+  --font-size-sm: calc(var(--font-size-base) - 1px);
+  --font-size-md: var(--font-size-base);
+  --font-size-lg: calc(var(--font-size-base) + 3px);
   --font-weight-regular: 450;
   --line-height-tight: 1;
   --line-height-normal: 1.5;
@@ -149,21 +150,34 @@
     monospace;
 }
 
-/* Medium is the token scale declared on :root. Small and Large shift the four
-   shared steps together, preserving the hierarchy between labels and body
-   text while the selected base size remains exactly 13px or 15px. */
-:root[data-font-size="small"] {
-  --font-size-xs: 11px;
-  --font-size-sm: 12px;
-  --font-size-md: 13px;
-  --font-size-lg: 16px;
+/* Settings moves the base from 12px through 18px. The derived tokens shift as
+   one scale, preserving the hierarchy between labels, body text, and headings. */
+:root[data-font-size="12"] {
+  --font-size-base: 12px;
 }
 
-:root[data-font-size="large"] {
-  --font-size-xs: 13px;
-  --font-size-sm: 14px;
-  --font-size-md: 15px;
-  --font-size-lg: 18px;
+:root[data-font-size="13"] {
+  --font-size-base: 13px;
+}
+
+:root[data-font-size="14"] {
+  --font-size-base: 14px;
+}
+
+:root[data-font-size="15"] {
+  --font-size-base: 15px;
+}
+
+:root[data-font-size="16"] {
+  --font-size-base: 16px;
+}
+
+:root[data-font-size="17"] {
+  --font-size-base: 17px;
+}
+
+:root[data-font-size="18"] {
+  --font-size-base: 18px;
 }
 
 /* The app stylesheet loads after the Viewer theme. Monospace glyphs look


### PR DESCRIPTION
## Summary

- replace the three-level font size setting with numeric values from 12px through 18px
- scale the shared application typography tokens from the selected base size
- keep editor and terminal monospace text visually matched at one pixel smaller

## Testing

- `just check`
- `moon -C desktop test frontend --target js`
- `moon -C desktop build frontend/desktop --target js`