### PR TITLE
feat(desktop): badge conversations needing attention

### DIFF
--- a/desktop/frontend/approval_wbtest.mbt
+++ b/desktop/frontend/approval_wbtest.mbt
@@ -36,6 +36,10 @@ test "a permission question becomes the conversation's pending approval" {
   // It belongs to the run it was asked in, so a slow decision cannot settle a
   // question in a later one.
   assert_eq(pending.run_id, Some("r-test"))
+  assert_eq(
+    test_model().replace_conversation(conv).notification_badge_count(),
+    1,
+  )
 }
 
 ///|
@@ -109,6 +113,7 @@ test "answering is recorded once and does not retire the card" {
     fail("the card must stand until the engine settles it")
   }
   assert_true(pending.answered)
+  assert_eq(answered.notification_badge_count(), 0)
   // The second click is refused: the guard sees `answered` and returns before
   // building a command, so the opposite decision cannot follow the first one
   // out to the engine.
@@ -121,6 +126,69 @@ test "answering is recorded once and does not retire the card" {
     fail("expected the conversation")
   }
   assert_true(conv.pending_approval is Some({ answered: true, .. }))
+}
+
+///|
+test "notification badge counts local conversations needing attention" {
+  let pending : PendingApproval = {
+    id: "ap-local",
+    run_id: Some("r-local"),
+    tool_name: "mbtx",
+    detail: "escalate",
+    body: None,
+    answered: false,
+  }
+  let active = { ..running_conversation(), pending_approval: Some(pending), }
+  let background = {
+    ..empty_conversation(
+      @interop.ChannelId::Local,
+      "desktop-background",
+      @interop.ChannelId::Local.test_project(),
+    ),
+    run: Open(run_id="r-background", stage=Opened),
+    pending_approval: Some({
+      ..pending,
+      id: "ap-background",
+      run_id: Some("r-background"),
+    }),
+  }
+  let answered = {
+    ..empty_conversation(
+      @interop.ChannelId::Local,
+      "desktop-answered",
+      @interop.ChannelId::Local.test_project(),
+    ),
+    pending_approval: Some({ ..pending, id: "ap-answered", answered: true, }),
+  }
+  let finished = {
+    ..empty_conversation(
+      @interop.ChannelId::Local,
+      "desktop-finished",
+      @interop.ChannelId::Local.test_project(),
+    ),
+    unseen_finish: true,
+  }
+  let remote_channel = @interop.ChannelId::Remote("device-1")
+  let remote = {
+    ..empty_conversation(
+      remote_channel,
+      "desktop-remote",
+      remote_channel.test_project(),
+    ),
+    pending_approval: Some({ ..pending, id: "ap-remote", }),
+    unseen_finish: true,
+  }
+  let model = {
+    ..test_model(),
+    conversations: [active, background, answered, finished, remote],
+  }
+  assert_eq(model.notification_badge_count(), 3)
+  let seen = model.activate(
+    @interop.ChannelId::Local,
+    "desktop-finished",
+    @interop.ChannelId::Local.test_project(),
+  )
+  assert_eq(seen.notification_badge_count(), 2)
 }
 
 ///|
@@ -165,6 +233,7 @@ test "a rejoining page is handed the question it lost" {
   assert_eq(pending.id, "ap-1")
   assert_eq(pending.body, Some("fn main { println(1) }"))
   assert_false(pending.answered)
+  assert_eq(resynced.notification_badge_count(), 1)
 }
 
 ///|
@@ -273,6 +342,7 @@ test "a decision that never left the page restores the card" {
     fail("expected the conversation")
   }
   assert_true(sending.pending_approval is Some({ answered: true, .. }))
+  assert_eq(answered.notification_badge_count(), 0)
   let (_, restored) = update(
     test_dispatch(),
     ApprovalAnswerFailed(
@@ -289,6 +359,7 @@ test "a decision that never left the page restores the card" {
     fail("the card must survive a failed send")
   }
   assert_false(pending.answered)
+  assert_eq(restored.notification_badge_count(), 1)
   // And it is answerable again, for real: the guard that refuses a second
   // decision keys on the same flag.
   let (_, again) = update(
@@ -300,6 +371,7 @@ test "a decision that never left the page restores the card" {
     fail("expected the conversation")
   }
   assert_true(conv.pending_approval is Some({ answered: true, .. }))
+  assert_eq(again.notification_badge_count(), 0)
 }
 
 ///|
@@ -636,6 +708,7 @@ test "a finished run takes its unanswered question with it" {
     fail("expected the conversation")
   }
   assert_true(after.pending_approval is None)
+  assert_eq(ended.notification_badge_count(), 0)
 }
 
 ///|
@@ -664,4 +737,5 @@ test "a finished run leaves a question belonging to another run" {
     fail("expected the conversation")
   }
   assert_true(after.pending_approval is Some(_))
+  assert_eq(ended.notification_badge_count(), 1)
 }

--- a/desktop/frontend/system_notification.mbt
+++ b/desktop/frontend/system_notification.mbt
@@ -96,6 +96,68 @@ fn show_system_notification(
 }
 
 ///|
+/// The application badge is the number of local conversations that still need
+/// attention: either a permission decision or a background result the user has
+/// not opened. It is derived from replicated conversation state rather than
+/// incremented by events, so replay and reconnect converge to one value.
+fn Model::notification_badge_count(self : Model) -> Int {
+  let mut count = 0
+  for conv in self.conversations {
+    if conv.device is Local &&
+      (
+        conv.pending_approval is Some({ answered: false, .. }) ||
+        conv.unseen_finish
+      ) {
+      count += 1
+    }
+  }
+  count
+}
+
+///|
+/// Set the absolute native application badge count. Ordinary browsers do not
+/// expose the notification extension; unsupported platforms and rejected
+/// commands stay silent because the conversation cards remain authoritative.
+fn set_notification_badge_count(count : Int) -> @cmd.Cmd {
+  @cmd.custom_cmd(_scheduler => {
+    guard @interop.moonbit_bridge_root() is Some(root) &&
+      @interop.js_prop(root, "notification") is Some(notification) &&
+      @interop.js_prop(notification, "setBadge") is Some(_) else {
+      return
+    }
+    let payload = @js.Object::new()
+    payload["count"] = count
+    @js.async_run(() => {
+      let _ : @js.Value = @interop.js_method_promise(
+        notification,
+        "setBadge",
+        payload.to_value(),
+      ).wait() catch {
+        _ => return
+      }
+    })
+  })
+}
+
+///|
+/// Synchronize only transitions. `Init` clears any process-external badge
+/// left by an unclean shutdown before the first host snapshot restores the
+/// current absolute count.
+fn notification_badge_command(
+  previous : Model,
+  next : Model,
+  initialize : Bool,
+) -> @cmd.Cmd {
+  let previous_count = previous.notification_badge_count()
+  let next_count = next.notification_badge_count()
+  if initialize || previous_count != next_count {
+    set_notification_badge_count(next_count)
+  } else {
+    @cmd.none
+  }
+}
+
+///|
 fn FinishedSystemNotification::command(
   self : FinishedSystemNotification,
 ) -> @cmd.Cmd {

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1616,6 +1616,11 @@ fn update(
 ) -> (@cmd.Cmd, Model) {
   let previous = model
   let (cmd, model) = update_msg(dispatch, msg, model)
+  let notification_badge_cmd = notification_badge_command(
+    previous,
+    model,
+    msg is Init,
+  )
   let composer_context_changed = model.active_session != previous.active_session ||
     model.focused != previous.focused ||
     model.screen != previous.screen
@@ -1739,7 +1744,8 @@ fn update(
   let (model, browser_cmd) = sync_browser_view(dispatch, model)
   (
     @cmd.batch([
-      cmd, quick_open_cmd, panel_visibility_cmd, panel_cmd, terminal_cmd, browser_cmd,
+      cmd, notification_badge_cmd, quick_open_cmd, panel_visibility_cmd, panel_cmd,
+      terminal_cmd, browser_cmd,
     ]),
     model,
   )


### PR DESCRIPTION
## Summary

- derive the application badge count from local conversations that need attention
- count unanswered permission requests and background run finishes that have not been opened, once per conversation
- clear completed-run attention when the user opens the conversation and synchronize the absolute Proton badge after state transitions
- ignore remote conversations and degrade gracefully when the notification extension is unavailable

## Testing

- moon -C desktop test frontend/approval_wbtest.mbt --target js --filter "notification badge*"
- moon -C desktop test frontend --target js (458 passed)
- just check
- packaged a release macOS app with Proton 0.2.5 and verified its arm64 bundle with codesign --verify --deep --strict
- verified the packaged renderer can set and clear the native Proton badge