### PR TITLE
fix(viz): restore tool pairing navigation

### DIFF
--- a/cmd/viz_app/e2e/tests/viz_dom.spec.js
+++ b/cmd/viz_app/e2e/tests/viz_dom.spec.js
@@ -118,6 +118,57 @@ test('keyboard shortcuts navigate between failures', async ({ page }) => {
   expect(viewer.pageErrors).toEqual([]);
 });
 
+test('a tool pairing link brings its distant result into view', async ({ page }) => {
+  const viewer = new VizBrowserHarness(page);
+  viewer.events = viewer.eventLog([
+    {
+      sequence: 1,
+      item: {
+        kind: 'assistant',
+        payload: {
+          content: '',
+          tool_calls: [{
+            id: 'long-call',
+            name: 'shell',
+            arguments: '{"cmd":"moon test"}',
+          }],
+        },
+      },
+    },
+    ...Array.from({ length: 36 }, (_, index) => ({
+      sequence: index + 2,
+      item: {
+        kind: 'runtime_notice',
+        payload: { content: `Progress update ${index + 1}` },
+      },
+    })),
+    {
+      sequence: 38,
+      item: {
+        kind: 'tool_result',
+        payload: {
+          tool_call_id: 'long-call',
+          tool_name: 'shell',
+          content: 'done',
+          is_error: false,
+        },
+      },
+    },
+  ]);
+  await viewer.install();
+  await viewer.goto();
+  await viewer.openSession();
+  await page.getByRole('button', { name: 'Raw log' }).click();
+
+  const pairingLinks = page.getByRole('link', { name: 'call 1' });
+  await expect(pairingLinks).toHaveCount(2);
+  await expect(pairingLinks.first()).toBeInViewport();
+  await expect(pairingLinks.last()).not.toBeInViewport();
+  await pairingLinks.first().click();
+  await expect(pairingLinks.last()).toBeInViewport({ ratio: 1 });
+  expect(viewer.pageErrors).toEqual([]);
+});
+
 test('keyboard shortcut unfolds the nearest card', async ({ page }) => {
   await page.setViewportSize({ width: 900, height: 900 });
   const viewer = new VizBrowserHarness(page);

--- a/web/index.html
+++ b/web/index.html
@@ -703,10 +703,13 @@
     // viewer's s/v/seq position state, which a bare `#tool-result-N` assignment
     // would wipe (the scrollspy re-records seq= right after the jump scrolls).
     // Delegated on document, so it survives the app's virtual-DOM re-renders.
-    // Missing targets fall through to native navigation.
+    // Rabbita captures ordinary links and prevents their browser default before
+    // the event reaches document. This handler therefore identifies its own
+    // `.tool-link` first instead of treating `defaultPrevented` as a veto.
+    // Missing targets fall through to Rabbita's link handling.
     document.addEventListener("click", function (e) {
       // Leave modified / non-primary clicks to the browser (open-in-new-tab etc.).
-      if (e.defaultPrevented || e.button !== 0) return;
+      if (e.button !== 0) return;
       if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
       if (!(e.target instanceof Element)) return;
       var link = e.target.closest("a.tool-link");


### PR DESCRIPTION
## Summary

- let the Viz pairing-link handler run after Rabbita captures the anchor click
- preserve the existing session hash while scrolling to the paired card
- cover a real click that brings an off-screen result fully into the viewport

## Context

Rabbita 0.15 prevents the browser default for ordinary links before the event reaches the document-level pairing handler, so the old `defaultPrevented` guard skipped the product-owned scroll behavior. #1171 has been squash merged; this branch is rebased directly onto `main`.

## Test

- `just viz-test-browser`