### PR TITLE
fix(viz): restore subrun navigation

### DIFF
--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -88,9 +88,11 @@ enum Msg {
   SessionsFetched(Result[String, Error])
   Select(String)
   SessionFetched(String, Result[String, Error])
-  // A subrun chip (or any in-page `#s=` anchor) changed the hash: resolve
-  // the value against the listing and select.
-  HashNavigated(String)
+  // Rabbita captured an anchor click. Only internal `#s=…` requests belong to
+  // this viewer; other anchors keep their existing handling.
+  UrlRequested(@url.UrlRequest)
+  // A URL pushed by the request handler, or restored through browser history.
+  UrlChanged(@url.Url)
   // One child (subagent) session fetched for the selected parent:
   // (parent key, child session id, response).
   SubrunFetched(String, String, Result[String, Error])
@@ -282,14 +284,29 @@ fn update(emit : @cmd.Emit[Msg], msg : Msg, model : Model) -> (@cmd.Cmd, Model) 
         },
       )
     }
-    HashNavigated(value) =>
-      // Resolve like the startup restore; an unknown value (an element
-      // anchor's hash, an unlisted id) is ignored rather than clearing the
-      // current session.
-      match resolve_session_key(model.sessions, value) {
-        Some(key) if model.selected != Some(key) =>
-          update(emit, Select(key), model)
-        _ => (@cmd.none, model)
+    UrlRequested(request) =>
+      match request {
+        Internal(url) =>
+          if url.fragment is Some(fragment) &&
+            HashSessionKey::from_fragment(fragment) is Some(_) {
+            (@nav.push_url(url.to_string()), model)
+          } else {
+            (@cmd.none, model)
+          }
+        External(_) => (@cmd.none, model)
+      }
+    UrlChanged(url) =>
+      if url.fragment is Some(fragment) &&
+        HashSessionKey::from_fragment(fragment) is Some(key) {
+        // Resolve like startup restoration; unknown anchors do not clear the
+        // current session.
+        match resolve_session_key(model.sessions, key.0) {
+          Some(key) if model.selected != Some(key) =>
+            update(emit, Select(key), model)
+          _ => (@cmd.none, model)
+        }
+      } else {
+        (@cmd.none, model)
       }
     SubrunFetched(parent_key, child_id, result) =>
       // A child transcript for a parent the user already left is stale;
@@ -972,29 +989,62 @@ fn subrun_child_refs(
 }
 
 ///|
-/// In-page session navigation: subrun chips are plain `#s=…` anchors, so a
-/// click only changes the hash — this listener turns that into a selection.
-/// App-initiated hash writes use replaceState, which never fires
-/// `hashchange`, so navigation cannot loop.
-fn install_hash_navigation(emit : @cmd.Emit[Msg]) -> @cmd.Cmd {
-  @cmd.custom_cmd(scheduler => {
-    install_hashchange_listener(key => scheduler.add(emit(HashNavigated(key))))
-  })
+/// The decoded session key carried by an `s=` hash parameter. Keeping the
+/// decoder on this type makes URL parsing a self-contained boundary instead of
+/// scattering percent-decoding rules through update branches.
+priv struct HashSessionKey(String)
+
+///|
+/// Read the first `s=` parameter from a URL fragment. Subrun links percent-
+/// encode UTF-8 bytes, and `+` follows URLSearchParams' spelling for a space.
+fn HashSessionKey::from_fragment(fragment : StringView) -> HashSessionKey? {
+  for parameter in fragment.split("&") {
+    if parameter is [.. "s=", .. encoded] {
+      return HashSessionKey::decode(encoded)
+    }
+  }
+  None
 }
 
 ///|
-extern "js" fn install_hashchange_listener(
-  on_session : (String) -> Unit,
-) -> Unit =
-  #|(cb) => {
-  #|  if (typeof window === 'undefined') return;
-  #|  window.addEventListener('hashchange', () => {
-  #|    try {
-  #|      const s = new URLSearchParams(location.hash.slice(1)).get('s') || '';
-  #|      if (s) cb(s);
-  #|    } catch (e) {}
-  #|  });
-  #|}
+fn HashSessionKey::decode(encoded : StringView) -> HashSessionKey? {
+  let bytes = Buffer(size_hint=encoded.length())
+  for remaining = encoded {
+    match remaining {
+      [] => {
+        let value = @utf8.decode(bytes.to_bytes()) catch { _ => break None }
+        break Some(HashSessionKey(value))
+      }
+      ['%', high, low, .. rest] => {
+        guard HashSessionKey::hex_value(high) is Some(high) &&
+          HashSessionKey::hex_value(low) is Some(low) else {
+          break None
+        }
+        bytes.write_byte((high * 16 + low).to_byte())
+        continue rest
+      }
+      ['%', ..] => break None
+      ['+', .. rest] => {
+        bytes.write_byte(b' ')
+        continue rest
+      }
+      [character, .. rest] => {
+        bytes.write_char_utf8(character)
+        continue rest
+      }
+    }
+  }
+}
+
+///|
+fn HashSessionKey::hex_value(character : Char) -> Int? {
+  match character {
+    '0'..='9' => Some(character.to_int() - 0x30)
+    'A'..='F' => Some(character.to_int() - 0x41 + 10)
+    'a'..='f' => Some(character.to_int() - 0x61 + 10)
+    _ => None
+  }
+}
 
 ///|
 fn session_label(model : Model, key : String) -> String {

--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -287,23 +287,43 @@ fn update(emit : @cmd.Emit[Msg], msg : Msg, model : Model) -> (@cmd.Cmd, Model) 
     UrlRequested(request) =>
       match request {
         Internal(url) =>
-          if url.fragment is Some(fragment) &&
-            HashSessionKey::from_fragment(fragment) is Some(_) {
-            (@nav.push_url(url.to_string()), model)
+          if url.fragment is Some(fragment) {
+            try HashSessionKey::from_fragment(fragment) catch {
+              MalformedHashSessionKey =>
+                (
+                  @cmd.none,
+                  {
+                    ..model,
+                    status: "invalid session link: malformed s= value",
+                  },
+                )
+            } noraise {
+              Some(_) => (@nav.push_url(url.to_string()), model)
+              None => (@cmd.none, model)
+            }
           } else {
             (@cmd.none, model)
           }
         External(_) => (@cmd.none, model)
       }
     UrlChanged(url) =>
-      if url.fragment is Some(fragment) &&
-        HashSessionKey::from_fragment(fragment) is Some(key) {
-        // Resolve like startup restoration; unknown anchors do not clear the
-        // current session.
-        match resolve_session_key(model.sessions, key.0) {
-          Some(key) if model.selected != Some(key) =>
-            update(emit, Select(key), model)
-          _ => (@cmd.none, model)
+      if url.fragment is Some(fragment) {
+        try HashSessionKey::from_fragment(fragment) catch {
+          MalformedHashSessionKey =>
+            (
+              @cmd.none,
+              { ..model, status: "invalid session link: malformed s= value", },
+            )
+        } noraise {
+          Some(key) =>
+            // Resolve like startup restoration; unknown anchors do not clear
+            // the current session.
+            match resolve_session_key(model.sessions, key.0) {
+              Some(key) if model.selected != Some(key) =>
+                update(emit, Select(key), model)
+              _ => (@cmd.none, model)
+            }
+          None => (@cmd.none, model)
         }
       } else {
         (@cmd.none, model)
@@ -995,35 +1015,46 @@ fn subrun_child_refs(
 priv struct HashSessionKey(String)
 
 ///|
+/// A present `s=` parameter whose percent escapes or decoded UTF-8 are invalid.
+/// Absence remains `None`; callers catch this error to report malformed links.
+priv suberror MalformedHashSessionKey
+
+///|
 /// Read the first `s=` parameter from a URL fragment. Subrun links percent-
 /// encode UTF-8 bytes, and `+` follows URLSearchParams' spelling for a space.
-fn HashSessionKey::from_fragment(fragment : StringView) -> HashSessionKey? {
+fn HashSessionKey::from_fragment(
+  fragment : StringView,
+) -> HashSessionKey? raise MalformedHashSessionKey {
   for parameter in fragment.split("&") {
     if parameter is [.. "s=", .. encoded] {
-      return HashSessionKey::decode(encoded)
+      return Some(HashSessionKey::decode(encoded))
     }
   }
   None
 }
 
 ///|
-fn HashSessionKey::decode(encoded : StringView) -> HashSessionKey? {
+fn HashSessionKey::decode(
+  encoded : StringView,
+) -> HashSessionKey raise MalformedHashSessionKey {
   let bytes = Buffer(size_hint=encoded.length())
   for remaining = encoded {
     match remaining {
       [] => {
-        let value = @utf8.decode(bytes.to_bytes()) catch { _ => break None }
-        break Some(HashSessionKey(value))
+        let value = @utf8.decode(bytes.to_bytes()) catch {
+          _ => raise MalformedHashSessionKey
+        }
+        break HashSessionKey(value)
       }
       ['%', high, low, .. rest] => {
         guard HashSessionKey::hex_value(high) is Some(high) &&
           HashSessionKey::hex_value(low) is Some(low) else {
-          break None
+          raise MalformedHashSessionKey
         }
         bytes.write_byte((high * 16 + low).to_byte())
         continue rest
       }
-      ['%', ..] => break None
+      ['%', ..] => raise MalformedHashSessionKey
       ['+', .. rest] => {
         bytes.write_byte(b' ')
         continue rest

--- a/cmd/viz_app/e2e/tests/support/viz_browser_harness.js
+++ b/cmd/viz_app/e2e/tests/support/viz_browser_harness.js
@@ -5,6 +5,9 @@ export class VizBrowserHarness {
     this.page = page;
     this.pageErrors = [];
     this.apiRequests = [];
+    this.sessionId = 'viz-1';
+    this.extraSessionRows = [];
+    this.childEvents = new Map();
     this.events = [
       JSON.stringify({
         version: 1,
@@ -114,13 +117,14 @@ export class VizBrowserHarness {
   sessionRows() {
     return [
       {
-        key: 'viz-1',
-        id: 'viz-1',
+        key: this.sessionId,
+        id: this.sessionId,
         root_label: '/workspace/.openseek',
         is_marker: true,
         last_active: 1,
         first_prompt: 'Inspect the session viewer',
       },
+      ...this.extraSessionRows,
     ];
   }
 
@@ -137,8 +141,12 @@ export class VizBrowserHarness {
     ].join('\n') + '\n';
   }
 
-  sessionEnvelope(id = 'viz-1') {
-    if (id !== 'viz-1') {
+  sessionEnvelope(id = this.sessionId) {
+    if (this.childEvents.has(id)) {
+      const events = this.childEvents.get(id);
+      return { found: true, events, events_bytes: events.length };
+    }
+    if (id !== this.sessionId) {
       return { found: false, events: '', events_bytes: 0 };
     }
     return {
@@ -160,7 +168,7 @@ export class VizBrowserHarness {
         window.__OPENSEEK_DATA__ = data;
       }, {
         '/api/sessions': JSON.stringify(this.sessionRows()),
-        '/api/sessions/viz-1': JSON.stringify(this.sessionEnvelope()),
+        [`/api/sessions/${this.sessionId}`]: JSON.stringify(this.sessionEnvelope()),
       });
     }
     await this.page.route('**/viz_app.js', route => route.fulfill({
@@ -198,6 +206,6 @@ export class VizBrowserHarness {
     await this.page.locator('.session-item', {
       hasText: 'Inspect the session viewer',
     }).click();
-    await this.page.locator('.header-id', { hasText: 'viz-1' }).waitFor();
+    await this.page.locator('.header-id', { hasText: this.sessionId }).waitFor();
   }
 }

--- a/cmd/viz_app/e2e/tests/viz_dom.spec.js
+++ b/cmd/viz_app/e2e/tests/viz_dom.spec.js
@@ -81,6 +81,79 @@ test('a dropped session file replaces the served selection without another fetch
   await dataTransfer.dispose();
 });
 
+test('a subrun link opens the child session', async ({ page }) => {
+  const viewer = new VizBrowserHarness(page);
+  viewer.sessionId = 'viz parent';
+  viewer.events = viewer.eventLog([
+    {
+      sequence: 1,
+      item: { kind: 'user', payload: { content: 'Delegate the investigation' } },
+    },
+    {
+      sequence: 2,
+      item: {
+        kind: 'assistant',
+        payload: {
+          content: '',
+          tool_calls: [{
+            id: 'explore-parent',
+            name: 'explore',
+            arguments: '{"query":"find the renderer"}',
+          }],
+        },
+      },
+    },
+    {
+      sequence: 3,
+      item: {
+        kind: 'tool_result',
+        payload: {
+          tool_call_id: 'explore-parent',
+          tool_name: 'explore',
+          content: 'Subagent completed.',
+          is_error: false,
+          brief: 'explore sr-2 (completed)',
+        },
+      },
+    },
+  ], { id: viewer.sessionId });
+  const childId = 'viz parent-sr-2';
+  viewer.extraSessionRows = [{
+    key: childId,
+    id: childId,
+    root_label: '/workspace/.openseek',
+    is_marker: true,
+    last_active: 1,
+    first_prompt: 'Child investigation',
+  }];
+  viewer.childEvents.set(childId, viewer.eventLog([
+    {
+      sequence: 1,
+      item: { kind: 'user', payload: { content: 'Child investigation' } },
+    },
+    {
+      sequence: 2,
+      item: {
+        kind: 'assistant',
+        payload: { content: 'The child session is open.', tool_calls: [] },
+      },
+    },
+  ], { id: childId }));
+  await viewer.install();
+  await viewer.goto();
+  await viewer.openSession();
+  await page.getByRole('button', { name: 'Raw log' }).click();
+
+  // Wait for the child prefetch to finish so its parent re-render cannot race
+  // the user click that this test exercises.
+  await page.locator('.subrun-transcript').waitFor({ state: 'attached' });
+  await page.getByRole('link', { name: '↳ subagent' }).click();
+  await expect(page.locator('.header-id')).toHaveText(childId);
+  await expect(page.getByText('The child session is open.', { exact: true }))
+    .toBeVisible();
+  expect(viewer.pageErrors).toEqual([]);
+});
+
 test('URL hash restores a session and scrolls to its requested event', async ({ page }) => {
   const viewer = new VizBrowserHarness(page);
   viewer.events = viewer.eventLog(Array.from({ length: 24 }, (_, index) => ({

--- a/cmd/viz_app/e2e/tests/viz_dom.spec.js
+++ b/cmd/viz_app/e2e/tests/viz_dom.spec.js
@@ -169,7 +169,8 @@ test('URL hash restores a session and scrolls to its requested event', async ({ 
   await viewer.install();
   await viewer.goto('#s=viz-1&v=raw&seq=24');
 
-  await expect(page).toHaveURL(/#s=viz-1&v=raw&seq=24$/);
+  await expect(page.locator('.header-id')).toHaveText(viewer.sessionId);
+  await expect(page.locator('.raw-log')).toBeVisible();
   await expect(page.getByText('Final hash target', { exact: true })).toBeInViewport();
   expect(viewer.pageErrors).toEqual([]);
 });

--- a/cmd/viz_app/main.mbt
+++ b/cmd/viz_app/main.mbt
@@ -13,9 +13,6 @@ fn main {
           @cmd.batch([
             fetch_text(emit, "/api/sessions", result => SessionsFetched(result)),
             install_shortcuts(emit),
-            // Subrun chips navigate by writing `#s=…`; turn those hash changes
-            // into selections.
-            install_hash_navigation(emit),
             // Keep `seq=` in the URL hash while scrolling and make scrubber
             // segments jump, so a refresh restores the position.
             @cmd.effect(() => install_position_tracker()),
@@ -25,6 +22,15 @@ fn main {
       update=(state, msg, emit) => {
         let (cmd, model) = update(emit, msg, state)
         (model, cmd)
+      },
+      // Rabbita owns clicks on its `<a>` nodes. Accept subrun URL requests,
+      // push them into browser history, then resolve the resulting URL change
+      // through the same selection path used by startup restoration.
+      subscriptions=(_, emit) => {
+        @sub.batch([
+          @sub.on_url_request(emit.map(request => UrlRequested(request))),
+          @sub.on_url_changed(emit.map(url => UrlChanged(url))),
+        ])
       },
     )
     state.view(state => view(emit, state))

--- a/cmd/viz_app/moon.pkg
+++ b/cmd/viz_app/moon.pkg
@@ -7,7 +7,11 @@ import {
   "moonbit-community/rabbita/html",
   "moonbit-community/rabbita/cmd",
   "moonbit-community/rabbita/http",
+  "moonbit-community/rabbita/nav",
+  "moonbit-community/rabbita/sub",
+  "moonbit-community/rabbita/url",
   "moonbitlang/core/debug",
+  "moonbitlang/core/encoding/utf8",
   "moonbitlang/core/json",
 }
 


### PR DESCRIPTION
## Summary

- route Rabbita-owned anchor clicks through `on_url_request` and `on_url_changed`
- replace the custom hashchange listener while preserving percent-encoded session ids
- cover a real subrun click that opens the child session and its content

## Context

Rabbita 0.15 captures `@html.a` clicks and prevents native hash navigation, so the previous hashchange listener never observed subrun clicks. #1171 has been squash merged; this branch is rebased directly onto `main`.

## Test

- `moon check --target js` in `cmd/viz_app`
- `just viz-test-browser`