### PR TITLE
fix(desktop): restore the sidebar's right inset under overlay scrollbars

### DIFF
--- a/desktop/frontend/dom_helpers.mbt
+++ b/desktop/frontend/dom_helpers.mbt
@@ -123,3 +123,56 @@ fn watch_color_scheme(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
     })
   })
 }
+
+///|
+/// Write a custom property on the document element, where the stylesheets read
+/// it. Going through CSSOM rather than the `style` attribute preserves the
+/// properties other writers own (the sidebar's dragged width, the editor's).
+fn set_root_custom_property(name : String, value : String) -> Unit {
+  guard @dom.document().get_document_element() is Some(root) else { return }
+  let style : @js.Value = @js.Value::cast_from(root).get_with_string("style")
+  let _ : @js.Value = style.apply_with_string("setProperty", [
+    @js.Value::cast_from(name),
+    @js.Value::cast_from(value),
+  ])
+}
+
+///|
+/// The property `styles/sidebar.css` subtracts from its right inset.
+const ScrollbarLaneProperty = "--scrollbar-lane"
+
+///|
+/// Side of the throwaway scroller the lane is measured with. Arbitrary — only
+/// its difference from the client width is read.
+const ScrollbarProbeSide = 100
+
+///|
+/// Measure how much width a scrolling pane loses to its scrollbar and publish
+/// it as `--scrollbar-lane`. macOS draws overlay scrollbars, which float above
+/// the content and reserve nothing — `scrollbar-gutter: stable` leaves such a
+/// pane's edge flush; Windows and Linux draw classic ones, which take a lane
+/// out of the box. Nothing in CSS tells the two apart, and neither does the
+/// platform: macOS switches to classic bars under System Settings › Appearance
+/// › "Show scroll bars: Always". So measure a throwaway scroller and hand CSS
+/// the number. Read once at startup, which is also when a change to that
+/// system preference is picked up.
+fn measure_scrollbar_lane() -> @cmd.Cmd {
+  @cmd.custom_cmd(_ => {
+    guard @dom.document().get_body() is Some(body) else { return }
+    let probe = @dom.document().create_element("div")
+    // Inline styles, so no stylesheet can reshape the probe. `overflow-y:
+    // scroll` rather than `auto` puts a classic bar there even though the
+    // probe has nothing to scroll; the scrollbar's own styling is inherited
+    // from the document, so the probe sees whatever the real panes see.
+    probe.set_attribute(
+      "style",
+      "position:absolute;top:-9999px;left:-9999px;border:0;padding:0;" +
+      "width:\{ScrollbarProbeSide}px;height:\{ScrollbarProbeSide}px;overflow-y:scroll",
+    )
+    let node = probe.as_node()
+    body.append_child(node)
+    let lane = (ScrollbarProbeSide.to_double() - probe.get_client_width()).to_int()
+    body.remove_child(node)
+    set_root_custom_property(ScrollbarLaneProperty, "\{lane}px")
+  })
+}

--- a/desktop/frontend/sidebar_resize.mbt
+++ b/desktop/frontend/sidebar_resize.mbt
@@ -137,16 +137,9 @@ fn end_sidebar_resize() -> Unit {
 
 ///|
 /// Write the dragged width as a custom property on the document element,
-/// where the CSS `clamp(...)` reads it. Updating the property through CSSOM
-/// preserves the sizes owned by other panels (the editor width, the tree,
-/// the terminal height).
+/// where the CSS `clamp(...)` reads it.
 fn set_sidebar_width(width : Int) -> Unit {
-  guard document_element() is Some(root) else { return }
-  let style : @js.Value = @js.Value::cast_from(root).get_with_string("style")
-  let _ : @js.Value = style.apply_with_string("setProperty", [
-    @js.Value::cast_from("--sidebar-width"),
-    @js.Value::cast_from("\{width}px"),
-  ])
+  set_root_custom_property("--sidebar-width", "\{width}px")
 }
 
 ///|

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1791,6 +1791,7 @@ fn update_msg(
               clear_legacy_engine_settings(),
               watch_color_scheme(dispatch),
               request_sidebar_resize_mount(),
+              measure_scrollbar_lane(),
             ]),
             model,
           )
@@ -1801,6 +1802,7 @@ fn update_msg(
               watch_color_scheme(dispatch),
               rotate_session(dispatch, model.focused),
               request_sidebar_resize_mount(),
+              measure_scrollbar_lane(),
             ]),
             model,
           )

--- a/desktop/styles/base.css
+++ b/desktop/styles/base.css
@@ -179,34 +179,18 @@ samp,
   background: var(--color-text-selection);
 }
 
-/* Shared native scrollbar geometry and visible-thumb inset. */
+/* The app's one say over native scrollbars: the thumb color. Everything else
+   — the bar's width, and whether it overlays the content or takes a lane out
+   of it — belongs to the platform. Panes that need to know which of those
+   they got read `--scrollbar-lane`, measured at startup by
+   frontend/dom_helpers.mbt.
+
+   Do not reach for `::-webkit-scrollbar` to take any of that back: Chromium
+   drops those rules for any element with a non-initial `scrollbar-color`, and
+   this declaration inherits to every element in the page. Rules written there
+   would apply nowhere and quietly mislead whoever reads them next. */
 html {
   scrollbar-color: var(--color-scrollbar-thumb) transparent;
-}
-
-::-webkit-scrollbar {
-  width: var(--scrollbar-size);
-  height: var(--scrollbar-size);
-}
-::-webkit-scrollbar-thumb {
-  background: var(--color-scrollbar-thumb);
-  border-radius: var(--radius-pill);
-  border: 1px solid transparent;
-  background-clip: padding-box;
-}
-::-webkit-scrollbar-thumb:hover {
-  background: var(--color-scrollbar-thumb-hover);
-  background-clip: padding-box;
-}
-::-webkit-scrollbar-thumb:active {
-  background: var(--color-scrollbar-thumb-active);
-  background-clip: padding-box;
-}
-::-webkit-scrollbar-track {
-  background: transparent;
-}
-::-webkit-scrollbar-corner {
-  background: transparent;
 }
 
 /* Inline SVG icons (vscode-codicons). They take the surrounding control's

--- a/desktop/styles/sidebar.css
+++ b/desktop/styles/sidebar.css
@@ -5,6 +5,9 @@
    run its scrollbar at the sidebar's true edge instead of trapping it
    inside a shared padding box. */
 aside {
+  /* How far in from the aside's edges the sessions list and the footer sit.
+     The header keeps its own, wider inset for the icon buttons. */
+  --sidebar-inset: 12px;
   display: grid;
   grid-template-rows: auto minmax(0, 1fr) auto;
   gap: 14px;
@@ -66,9 +69,13 @@ html.is-resizing .sidebar-resize-handle {
   min-height: 0;
   overflow-y: auto;
   overflow-x: hidden;
-  /* The scroll box spans to the sidebar's edge. Its stable 12px gutter matches
-     the sections' left inset whether or not the bar shows. */
-  padding-right: 0;
+  /* The scroll box spans to the sidebar's edge, and the rows inside it stop
+     `--sidebar-inset` short of it however the platform draws its scrollbar. A
+     classic bar (Windows, Linux) fills the stable gutter and holds the rows
+     off the edge on its own; an overlay bar (macOS) floats above the content
+     and reserves nothing, so there the whole inset has to be real padding.
+     `--scrollbar-lane` is the measured width of the gutter the bar claims. */
+  padding-right: max(0px, var(--sidebar-inset) - var(--scrollbar-lane));
   scrollbar-gutter: stable;
 }
 
@@ -76,10 +83,10 @@ html.is-resizing .sidebar-resize-handle {
   display: grid;
   gap: 4px;
   min-width: 0;
-  /* The outer scroll lane already reserves the 12px right inset through its
-     stable scrollbar gutter. Keep only the matching left inset here so nested
-     sections do not double the empty space on the right. */
-  padding: 0 0 0 12px;
+  /* The outer scroll lane owns the right inset — its gutter and padding add
+     up to `--sidebar-inset` between them. Keep only the matching left inset
+     here so nested sections do not double the empty space on the right. */
+  padding: 0 0 0 var(--sidebar-inset);
 }
 
 .sidebar-heading {
@@ -1088,7 +1095,7 @@ button.row-twisty:hover {
   display: grid;
   gap: 8px;
   min-width: 0;
-  padding: 0 12px;
+  padding: 0 var(--sidebar-inset);
 }
 
 .sidebar-button {

--- a/desktop/styles/tokens.css
+++ b/desktop/styles/tokens.css
@@ -95,6 +95,14 @@
   /* Native overflow panes use a 12px hit lane; a 1px inset leaves a 10px
      visible thumb. */
   --scrollbar-size: 12px;
+
+  /* How much width a scrolling pane actually loses to its scrollbar,
+     measured once at startup by the frontend (dom_helpers.mbt) and rewritten
+     here. `0px` is the overlay case — macOS floats the bar above the content,
+     where `scrollbar-gutter` reserves nothing — and is the right fallback for
+     a page whose measurement never ran. Panels that want a fixed inset either
+     way subtract this from their own padding. */
+  --scrollbar-lane: 0px;
   --color-scrollbar-thumb: color-mix(
     in srgb,
     var(--color-text-primary) 32%,

--- a/desktop/styles/tokens.css
+++ b/desktop/styles/tokens.css
@@ -92,10 +92,6 @@
     transparent
   );
 
-  /* Native overflow panes use a 12px hit lane; a 1px inset leaves a 10px
-     visible thumb. */
-  --scrollbar-size: 12px;
-
   /* How much width a scrolling pane actually loses to its scrollbar,
      measured once at startup by the frontend (dom_helpers.mbt) and rewritten
      here. `0px` is the overlay case — macOS floats the bar above the content,
@@ -103,19 +99,12 @@
      a page whose measurement never ran. Panels that want a fixed inset either
      way subtract this from their own padding. */
   --scrollbar-lane: 0px;
+
+  /* The thumb color `scrollbar-color` sets. It has no hover or active
+     variant — the platform owns those. */
   --color-scrollbar-thumb: color-mix(
     in srgb,
     var(--color-text-primary) 32%,
-    transparent
-  );
-  --color-scrollbar-thumb-hover: color-mix(
-    in srgb,
-    var(--color-text-primary) 48%,
-    transparent
-  );
-  --color-scrollbar-thumb-active: color-mix(
-    in srgb,
-    var(--color-text-primary) 64%,
     transparent
   );
 


### PR DESCRIPTION
The sessions list lost the 12px of white it used to keep between its rows and the sidebar's border — the active row's rounded highlight and the branch/status icons now run straight into the seam, while the footer below still holds its 12px.

### Why

The inset was never padding. Before #1157 it was `scrollbar-gutter: stable` reserving the 9px custom scrollbar plus 3px of clearance. #1157 restated that as a 12px gutter and no padding:

```css
.sidebar-main { padding-right: 0; scrollbar-gutter: stable; }
```

and, in the same change, put `scrollbar-color` on `html`. `scrollbar-color` is inherited, so every scroll container in the app got a non-initial value — and Chromium gives the standard scrollbar properties precedence over `::-webkit-scrollbar`, which means `::-webkit-scrollbar { width: var(--scrollbar-size) }` no longer applies anywhere. Panes fall back to the platform's native scrollbar, macOS's is an overlay bar, and `scrollbar-gutter` reserves nothing for an overlay bar. 12px + 0 padding became 0.

(Same reason the `scrollbar-gutter: stable both-edges` that #1157 added to `.transcript` is inert on macOS — harmless there, since overlay bars never shift content in the first place. Only the sidebar was using the gutter as a design inset rather than as anti-shift.)

### Fix

Keep native scrollbars; move the inset back onto real padding, minus whatever the scrollbar already claims:

```css
aside { --sidebar-inset: 12px; }
.sidebar-main {
  padding-right: max(0px, var(--sidebar-inset) - var(--scrollbar-lane));
  scrollbar-gutter: stable;
}
```

`--scrollbar-lane` is measured once at startup (`measure_scrollbar_lane` in `frontend/dom_helpers.mbt`): a throwaway `overflow-y: scroll` probe is appended to `body`, `100 - clientWidth` is the lane, and the result is written to the document element. `tokens.css` declares `0px` as the fallback, which is the overlay answer.

| | lane | gutter | padding | right inset |
|---|---|---|---|---|
| macOS, overlay bars | 0 | 0 | 12 | **12px** |
| Windows / Linux, classic bars | ~15 | 15 | 0 | 15px, filled by the bar |
| macOS, "Show scroll bars: Always" | ~15 | 15 | 0 | 15px, filled by the bar |

A probe rather than a platform check because of that last row: macOS draws classic bars too, and nothing in CSS or `navigator.platform` distinguishes the two. The value is read once, so changing that system preference needs a restart to take effect here — noted in the function's doc comment.

Worth saying: this is self-correcting rather than a bet on the diagnosis above. If `::-webkit-scrollbar` were in fact still applying and the lane really were 12px, the padding would compute to 0 and the layout would be exactly what it is today.

Two smaller things carried along:

- `--sidebar-inset` replaces the three separate literal `12px`s (`.sidebar-main`, `.sidebar-section`, `.sidebar-footer`). Those had already drifted — the footer's was the only one still doing anything.
- `set_sidebar_width` now goes through a shared `set_root_custom_property` instead of repeating the CSSOM incantation.

### Second commit: the rules that misled us

`base.css`'s global `::-webkit-scrollbar*` block reaches nothing in the desktop app, for the same reason the gutter stopped reserving: the inherited `scrollbar-color` disables it everywhere. Those are the rules that made `--scrollbar-size: 12px` read like the real lane width. `--scrollbar-size` and the `-hover` / `-active` thumb tokens go with them; `scrollbar-color` has no hover or active variant, so the only thing the app still gets to set is the thumb color, and the comment above it now says that — and says why `::-webkit-scrollbar` is not a way back.

One honest caveat, since I first called this block simply dead: it is not literally unreachable. An engine without `scrollbar-color` support — Safari before 18.2 — still honors it, and the browser console page can run in one. There it trades a styled 12px always-on bar for the platform's own, which is what every other engine now draws and what #1157 set out to unify. Cosmetic either way, but worth a reviewer's eye rather than a silent deletion.

Split into its own commit; drop it if you would rather keep the fallback.

### Verification

`moon check --target js`, `moon fmt`, and `moon test frontend --target js` (448 passed) are clean. The visual result and the Windows column want a human: rows inset and aligned with the footer, the overlay bar floating over that gap rather than over the row icons, and drag-to-resize still working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WZayoFTPL7gjnJgasHy6Rd

