### PR TITLE
chore(agent_session): hide and deprecate manual trait-method overrides

### DIFF
--- a/agent_session/log/log_test.mbt
+++ b/agent_session/log/log_test.mbt
@@ -33,7 +33,7 @@ fn sample_session() -> @agent_session.Session {
 fn events_jsonl(session : @agent_session.Session) -> String {
   let out = StringBuilder()
   for event in session.events() {
-    out.write_string(event.to_json().stringify())
+    out.write_string(ToJson::to_json(event).stringify())
     out.write_char('\n')
   }
   out.to_string()

--- a/agent_session/pkg.generated.mbti
+++ b/agent_session/pkg.generated.mbti
@@ -39,13 +39,8 @@ pub struct AssistantMessage {
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn AssistantMessage::AssistantMessage(String, tool_calls? : Array[@deepseek.ToolCall], reasoning_content? : String, is_replay? : Bool) -> Self
 pub fn AssistantMessage::content(Self) -> String
-pub fn AssistantMessage::equal(Self, Self) -> Bool
-pub fn AssistantMessage::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn AssistantMessage::is_replay(Self) -> Bool
-pub fn AssistantMessage::not_equal(Self, Self) -> Bool
 pub fn AssistantMessage::reasoning_content(Self) -> String?
-pub fn AssistantMessage::to_json(Self) -> Json
-pub fn AssistantMessage::to_repr(Self) -> @debug.Repr
 pub fn AssistantMessage::tool_calls(Self) -> Array[@deepseek.ToolCall]
 
 pub(all) struct GoalBaseline {
@@ -69,11 +64,6 @@ pub struct RuntimeNotice {
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn RuntimeNotice::RuntimeNotice(String) -> Self
 pub fn RuntimeNotice::content(Self) -> String
-pub fn RuntimeNotice::equal(Self, Self) -> Bool
-pub fn RuntimeNotice::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
-pub fn RuntimeNotice::not_equal(Self, Self) -> Bool
-pub fn RuntimeNotice::to_json(Self) -> Json
-pub fn RuntimeNotice::to_repr(Self) -> @debug.Repr
 
 pub struct Session {
   // private fields
@@ -85,41 +75,30 @@ pub fn Session::chat_messages(Self) -> Array[@deepseek.ChatMessage]
 pub fn Session::compact(Self, content~ : String, from_sequence~ : Int, to_sequence~ : Int, unix_ms? : Int64) -> Self raise
 pub fn Session::current_goal(Self) -> StandingGoal?
 pub fn Session::current_goal_baseline(Self) -> GoalBaseline?
-pub fn Session::equal(Self, Self) -> Bool
 pub fn Session::events(Self) -> @vector.Vector[SessionEvent]
 pub fn Session::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn Session::id(Self) -> SessionId
 pub fn Session::last_sequence(Self) -> Int
-pub fn Session::not_equal(Self, Self) -> Bool
 pub fn Session::summary_item(Self, content~ : String, from_sequence~ : Int, to_sequence~ : Int) -> SessionItem raise
 pub fn Session::system_prompt(Self) -> String
 pub fn Session::to_json(Self) -> Json
-pub fn Session::to_repr(Self) -> @debug.Repr
 pub impl ToJson for Session
 pub impl @json.FromJson for Session
 
 pub struct SessionEvent {
   // private fields
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
-pub fn SessionEvent::equal(Self, Self) -> Bool
-pub fn SessionEvent::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SessionEvent::is_agent_step(Self) -> Bool
 pub fn SessionEvent::item(Self) -> SessionItem
-pub fn SessionEvent::not_equal(Self, Self) -> Bool
 pub fn SessionEvent::sequence(Self) -> Int
-pub fn SessionEvent::to_json(Self) -> Json
-pub fn SessionEvent::to_repr(Self) -> @debug.Repr
 pub fn SessionEvent::unix_ms(Self) -> Int64
 
 pub struct SessionId {
   // private fields
 } derive(Eq, @debug.Debug)
 pub fn SessionId::SessionId(String) -> Self
-pub fn SessionId::equal(Self, Self) -> Bool
 pub fn SessionId::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SessionId::generated(prefix~ : String, now_ms~ : Int64, salt? : String) -> Self
-pub fn SessionId::not_equal(Self, Self) -> Bool
-pub fn SessionId::to_repr(Self) -> @debug.Repr
 pub fn SessionId::value(Self) -> String
 pub impl @json.FromJson for SessionId
 
@@ -131,10 +110,7 @@ pub(all) enum SessionItem {
   Summary(SessionSummary)
   Terminal(TurnTerminal)
 } derive(Eq, @debug.Debug)
-pub fn SessionItem::equal(Self, Self) -> Bool
 pub fn SessionItem::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
-pub fn SessionItem::not_equal(Self, Self) -> Bool
-pub fn SessionItem::to_repr(Self) -> @debug.Repr
 pub impl @json.FromJson for SessionItem
 
 pub struct SessionSummary {
@@ -142,12 +118,7 @@ pub struct SessionSummary {
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn SessionSummary::SessionSummary(content~ : String, from_sequence~ : Int, to_sequence~ : Int) -> Self
 pub fn SessionSummary::content(Self) -> String
-pub fn SessionSummary::equal(Self, Self) -> Bool
-pub fn SessionSummary::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SessionSummary::from_sequence(Self) -> Int
-pub fn SessionSummary::not_equal(Self, Self) -> Bool
-pub fn SessionSummary::to_json(Self) -> Json
-pub fn SessionSummary::to_repr(Self) -> @debug.Repr
 pub fn SessionSummary::to_sequence(Self) -> Int
 
 pub struct StandingGoal {
@@ -165,12 +136,7 @@ pub struct ToolResult {
 pub fn ToolResult::ToolResult(tool_call_id~ : String, tool_name~ : String, content~ : String, is_error? : Bool, brief? : String) -> Self
 pub fn ToolResult::brief(Self) -> String?
 pub fn ToolResult::content(Self) -> String
-pub fn ToolResult::equal(Self, Self) -> Bool
-pub fn ToolResult::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn ToolResult::is_error(Self) -> Bool
-pub fn ToolResult::not_equal(Self, Self) -> Bool
-pub fn ToolResult::to_json(Self) -> Json
-pub fn ToolResult::to_repr(Self) -> @debug.Repr
 pub fn ToolResult::tool_call_id(Self) -> String
 pub fn ToolResult::tool_name(Self) -> String
 
@@ -180,10 +146,7 @@ pub(all) enum TurnTerminal {
   Interrupted(String)
   Failed(String)
 } derive(Eq, @debug.Debug)
-pub fn TurnTerminal::equal(Self, Self) -> Bool
 pub fn TurnTerminal::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
-pub fn TurnTerminal::not_equal(Self, Self) -> Bool
-pub fn TurnTerminal::to_repr(Self) -> @debug.Repr
 pub impl @json.FromJson for TurnTerminal
 
 pub struct UserMessage {
@@ -191,12 +154,7 @@ pub struct UserMessage {
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn UserMessage::UserMessage(String, submission_id? : String) -> Self
 pub fn UserMessage::content(Self) -> String
-pub fn UserMessage::equal(Self, Self) -> Bool
-pub fn UserMessage::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
-pub fn UserMessage::not_equal(Self, Self) -> Bool
 pub fn UserMessage::submission_id(Self) -> String?
-pub fn UserMessage::to_json(Self) -> Json
-pub fn UserMessage::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/agent_session/session_test.mbt
+++ b/agent_session/session_test.mbt
@@ -34,7 +34,7 @@ test "event timestamps round trip through JSON" {
     User(UserMessage("hello")),
     unix_ms=1781144351123L,
   )
-  let line = stamped.events()[0].to_json().stringify()
+  let line = ToJson::to_json(stamped.events()[0]).stringify()
   assert_eq(
     line,
     (
@@ -55,7 +55,7 @@ test "event timestamps round trip through JSON" {
 test "assistant checkpoint replay provenance is durable and sparse" {
   let ordinary = @agent_session.AssistantMessage("answer")
   assert_false(ordinary.is_replay())
-  assert_false(ordinary.to_json().stringify().contains("is_replay"))
+  assert_false(ToJson::to_json(ordinary).stringify().contains("is_replay"))
   let replay = @agent_session.AssistantMessage(
     "answer",
     reasoning_content="thought",
@@ -63,7 +63,7 @@ test "assistant checkpoint replay provenance is durable and sparse" {
   )
   assert_true(replay.is_replay())
   let decoded : @agent_session.AssistantMessage = @json.from_json(
-    replay.to_json(),
+    ToJson::to_json(replay),
   )
   assert_true(decoded.is_replay())
   assert_eq(decoded.reasoning_content(), Some("thought"))
@@ -78,7 +78,7 @@ test "ToolResult brief round-trips when present" {
     brief="ran ls → 2 files",
   )
   let decoded : @agent_session.ToolResult = @json.from_json(
-    with_brief.to_json(),
+    ToJson::to_json(with_brief),
   )
   guard decoded.brief() is Some(text) else { fail("brief should round-trip") }
   assert_eq(text, "ran ls → 2 files")

--- a/agent_session/store/store.mbt
+++ b/agent_session/store/store.mbt
@@ -129,7 +129,8 @@ fn header_line(session : @agent_session.Session) -> String {
 fn events_jsonl(events : @vector.Vector[@agent_session.SessionEvent]) -> String {
   let builder = StringBuilder()
   for event in events {
-    builder <+ "\{event.to_json().stringify()}\n"
+    let line = ToJson::to_json(event).stringify()
+    builder <+ "\{line}\n"
   }
   builder.to_string()
 }
@@ -354,7 +355,7 @@ async fn persist_event(
     // does not silently follow an upstream default change.
     @fs.write_file(
       path,
-      "\{event.to_json().stringify()}\n",
+      ToJson::to_json(event).stringify() + "\n",
       create_mode=OpenOrCreate,
       append=true,
       sync=Data,

--- a/agent_session/store/store_test.mbt
+++ b/agent_session/store/store_test.mbt
@@ -495,7 +495,7 @@ async test "store rejects a session file without a header record" {
   // lost — must fail loudly rather than load with a fabricated identity.
   @fs.write_file(
     session_file(store, "s1"),
-    "\{event.to_json().stringify()}\n",
+    ToJson::to_json(event).stringify() + "\n",
     create_mode=CreateOrTruncate,
   )
   try store.load(SessionId("s1")) catch {
@@ -575,7 +575,7 @@ async test "load keeps a complete final record that lost only its newline" {
   // The append was torn exactly at the newline boundary: the record is whole.
   @fs.write_file(
     session_file(store, "s1"),
-    event.to_json().stringify(),
+    ToJson::to_json(event).stringify(),
     create_mode=OpenOrCreate,
     append=true,
   )
@@ -623,7 +623,7 @@ async test "append repairs and keeps a complete unterminated final event" {
   store.create(session)
   @fs.write_file(
     session_file(store, "s1"),
-    event.to_json().stringify(),
+    ToJson::to_json(event).stringify(),
     create_mode=OpenOrCreate,
     append=true,
   )
@@ -653,7 +653,7 @@ async test "append rejects a stale snapshot against an unterminated durable even
   // path that discards that writer's data.
   @fs.write_file(
     session_file(store, "s1"),
-    event.to_json().stringify(),
+    ToJson::to_json(event).stringify(),
     create_mode=OpenOrCreate,
     append=true,
   )
@@ -804,7 +804,7 @@ async test "load still fails on corruption that is not a torn tail" {
       let (_, event) = session.append_event(Runtime(RuntimeNotice("later")))
       @fs.write_file(
         session_file(store, "s1"),
-        "\{event.to_json().stringify()}\n",
+        ToJson::to_json(event).stringify() + "\n",
         create_mode=OpenOrCreate,
         append=true,
       )

--- a/agent_session/types.mbt
+++ b/agent_session/types.mbt
@@ -653,97 +653,161 @@ pub fn Session::compact(
 }
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend AssistantMessage with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend AssistantMessage with FromJson::{from_json}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend AssistantMessage with Eq::{equal, not_equal}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend AssistantMessage with ToJson::{to_json}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend RuntimeNotice with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend RuntimeNotice with FromJson::{from_json}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend RuntimeNotice with Eq::{equal, not_equal}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend RuntimeNotice with ToJson::{to_json}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend Session with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend Session with Eq::{equal, not_equal}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend SessionEvent with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend SessionEvent with FromJson::{from_json}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend SessionEvent with Eq::{equal, not_equal}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend SessionEvent with ToJson::{to_json}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend SessionId with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend SessionId with Eq::{equal, not_equal}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend SessionItem with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend SessionItem with Eq::{equal, not_equal}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend SessionSummary with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend SessionSummary with FromJson::{from_json}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend SessionSummary with Eq::{equal, not_equal}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend SessionSummary with ToJson::{to_json}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend ToolResult with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend ToolResult with FromJson::{from_json}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend ToolResult with Eq::{equal, not_equal}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend ToolResult with ToJson::{to_json}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend TurnTerminal with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend TurnTerminal with Eq::{equal, not_equal}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend UserMessage with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend UserMessage with FromJson::{from_json}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend UserMessage with Eq::{equal, not_equal}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend UserMessage with ToJson::{to_json}

--- a/eval/prompt_task/harness/analyzer_wbtest.mbt
+++ b/eval/prompt_task/harness/analyzer_wbtest.mbt
@@ -2,7 +2,7 @@
 fn session_events(session : @agent_session.Session) -> String {
   let out = StringBuilder()
   for event in session.events() {
-    out.write_string(event.to_json().stringify())
+    out.write_string(ToJson::to_json(event).stringify())
     out.write_char('\n')
   }
   out.to_string()

--- a/viz/viz_test.mbt
+++ b/viz/viz_test.mbt
@@ -48,7 +48,8 @@ fn sample_session() -> @agent_session.Session {
 fn events_jsonl(session : @agent_session.Session) -> String {
   let out = StringBuilder()
   for event in session.events() {
-    out <+ "\{event.to_json().stringify()}\n"
+    let line = ToJson::to_json(event).stringify()
+    out <+ "\{line}\n"
   }
   out.to_string()
 }


### PR DESCRIPTION
## What
The session types in `agent_session` already `derive(Eq, Debug, ToJson, FromJson)`.
The manual `extend ... with ...` blocks in [agent_session/types.mbt](https://github.com/moonbitlang/openseek/blob/main/agent_session/types.mbt) override a few of the derived methods.
All of those override blocks are now marked `#doc(hidden)` + `#deprecated`:
- `#doc(hidden)` drops them from the generated docs and the public interface (the 32 methods leave `agent_session/pkg.generated.mbti`).
- `#deprecated` steers remaining callers to the trait-qualified forms, so any future removal breaks loudly only where a caller still uses the override.
## Call-site migration
Internal call sites that used the deprecated method syntax (`event.to_json()`) now use the trait-qualified call (`ToJson::to_json(event)`) — same dispatch, same serialization, no behavior change:
- `agent_session/store/store.mbt` (durable JSONL serialization)
- `agent_session/{log,session,store}` tests
- `eval/prompt_task/harness/analyzer_wbtest.mbt`
- `viz/viz_test.mbt` (js-target test)
## Verification
- `moon fmt --check` — clean
- `moon check --target native --deny-warn` — 0 warnings
- `moon check --target js --deny-warn` — 0 warnings (caught the `viz` site, which native skips)
- `moon info` then `git diff -- '*.mbti'` — only the intended regeneration, committed
- `moon test --target native agent_session eval/prompt_task` — 38/38 passed
- The full native suite fails 2 unrelated `agent_tool/shell` tests locally, but only on this machine: with `desktop/dist/` present the macOS `sandbox-exec` profile scan exceeds its 64KB limit (`sandbox-exec: data object length 74063 exceeds maximum (65535)`). The same committed tree in a fresh worktree (no `desktop/dist/`) passes all three, and Linux CI has no `sandbox-exec`, so these cannot fail there.
Generated with SeekMoon