### PR TITLE
refactor(cli): remove OPENSEEK_CONCURRENCY environment binding

### DIFF
--- a/cmd/openseek/README.md
+++ b/cmd/openseek/README.md
@@ -152,8 +152,7 @@ original repo. Each run's session lives under its run directory.
 moon run cmd/openseek -- run --concurrency 3 --dir myproject "fix the failing test"
 ```
 
-`run --concurrency` (env `OPENSEEK_CONCURRENCY`, default `1`) cannot be combined
-with `--session` or `--no-session`.
+`run --concurrency` cannot be combined with `--session` or `--no-session`.
 
 ## Package Boundary
 

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -690,7 +690,6 @@ fn root_command() -> @argparse.Command {
           OptionArg(
             "concurrency",
             long="concurrency",
-            env="OPENSEEK_CONCURRENCY",
             default_values=["1"],
             about="Run the task in N sibling copies of --dir concurrently (best-of-N). Any explicit value, including 1, copies --dir into <dir>_run_<i> and never writes to --dir itself; omit the flag for a single in-place run.",
           ),
@@ -819,10 +818,10 @@ fn fleet_mode(matches : @argparse.Matches, concurrency : Int) -> Bool {
 }
 
 ///|
-/// Whether the user supplied `name` on the command line or via its
-/// environment variable, rather than the built-in default filling it in.
+/// Whether the user supplied `name` on the command line rather than the
+/// built-in default filling it in.
 fn explicitly_provided(matches : @argparse.Matches, name : String) -> Bool {
-  matches.sources.get(name) is (Some(Argv) | Some(Env))
+  matches.sources.get(name) is Some(Argv)
 }
 
 ///|
@@ -1458,9 +1457,6 @@ test "explicit --concurrency selects fleet mode even at 1" {
     env=Map([]),
   )
   assert_true(fleet_mode(explicit_one, 1))
-  // The env var counts as explicit too.
-  let via_env = run_matches(argv=["task"], env={ "OPENSEEK_CONCURRENCY": "1" })
-  assert_true(fleet_mode(via_env, 1))
   // Only the flagless default runs in place.
   let default_run = run_matches(argv=["task"], env=Map([]))
   assert_false(fleet_mode(default_run, 1))

--- a/tests/cram/cli.md
+++ b/tests/cram/cli.md
@@ -146,7 +146,7 @@ Options:
   --mcp-config <mcp-config>                                    Path to a JSON file of MCP servers ({"mcpServers": {"<name>": {"command", "args", "env"} | {"url", "headers"}}}); each server's tools (stdio subprocess or Streamable HTTP) are exposed to the agent, namespaced mcp__<server>__<tool>. Empty disables MCP. [env: OPENSEEK_MCP_CONFIG] [default: ]
   --review-deadline <review-deadline>                          Wall-clock deadline in milliseconds for one review audit (the review tool or --review-gate); default 900000 (15 minutes).
   --approval <approval>                                        What happens when a tool asks permission to run without its sandbox: never (default; refuse without asking, and do not offer the argument to the model), ask (prompt the controller over the command stream and wait), always (grant without asking). [env: OPENSEEK_APPROVAL] [default: never]
-  --concurrency <concurrency>                                  Run the task in N sibling copies of --dir concurrently (best-of-N). Any explicit value, including 1, copies --dir into <dir>_run_<i> and never writes to --dir itself; omit the flag for a single in-place run. [env: OPENSEEK_CONCURRENCY] [default: 1]
+  --concurrency <concurrency>                                  Run the task in N sibling copies of --dir concurrently (best-of-N). Any explicit value, including 1, copies --dir into <dir>_run_<i> and never writes to --dir itself; omit the flag for a single in-place run. [default: 1]
 ```
 
 `--approval ask` is refused here rather than accepted and then never honoured:


### PR DESCRIPTION
## Summary

- stop binding `run --concurrency` to `OPENSEEK_CONCURRENCY`
- keep fleet mode explicit on argv, including the copy-preserving `--concurrency 1` behavior
- update CLI docs and cram help snapshots

Follow-up to #1057.

## Rationale

Concurrency changes workspace placement: any explicit value, including `1`, runs in a copied sibling workspace. An inherited environment variable should not silently select that behavior. `--concurrency` remains the explicit interface.

## Compatibility

`OPENSEEK_CONCURRENCY` is no longer recognized. Use `openseek run --concurrency N`.

## Validation

- `git grep -w OPENSEEK_CONCURRENCY` returns no matches
- `moon check --warn-list +73` (36 existing warnings, 0 errors)
- `moon test cmd/openseek` (84/84)
- `moon cram test tests/cram` (28/28)
- `just check`
- `just build`
- `moon info && moon fmt` (no interface changes)

## Known unrelated test failures

`just test` ran 3,383 native tests: 3,359 passed and 24 failed. All failures are in unchanged shell/sandbox harness packages. Isolated reruns reproduce them: `agent_tool/shell` 116/137, `agent_tool/internal/sandbox` 19/20, and `eval/tool_harness` 2/4.