### PR TITLE
fix(desktop): settle stale cancelling runs from cancel replies

### DIFF
--- a/desktop/frontend/bridge.mbt
+++ b/desktop/frontend/bridge.mbt
@@ -1395,11 +1395,11 @@ async fn request_agent_goal(
 }
 
 ///|
-/// Ask the host to cancel `run_id`. Only a failure is worth reporting: the
-/// host raises when the cancellation could not be delivered, and answers
-/// normally otherwise — including for a turn that ended on its own just
-/// before the request landed, which is a race the user cannot see and does
-/// not need to. The run itself ends through its `agent.finished`.
+/// Ask the host to cancel `run_id`. A matching reply leaves the run in
+/// Cancelling until its `agent.finished`. An empty reply means the turn had
+/// already ended; report that boundary explicitly because the Finished push
+/// may be the very notification this page missed. Failures are likewise tied
+/// to the exact run so the optimistic Cancelling phase can be made retryable.
 fn cancel_openseek(
   dispatch : @cmd.Emit[Msg],
   channel : @interop.ChannelId,
@@ -1407,7 +1407,7 @@ fn cancel_openseek(
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let _ : @protocol.CancelReply = @interop.bridge_request(
+      let reply : @protocol.CancelReply = @interop.bridge_request(
         channel,
         @commands.agent_cancel,
         { run_id: Some(run_id), },
@@ -1415,13 +1415,21 @@ fn cancel_openseek(
         error => {
           scheduler.add(
             dispatch(
-              HostActionFailed(
-                "Failed to cancel the run: " + @interop.bridge_error_text(error),
+              FromDevice(
+                channel,
+                CancelFailed(
+                  run_id~,
+                  message="Failed to cancel the run: " +
+                    @interop.bridge_error_text(error),
+                ),
               ),
             ),
           )
           return
         }
+      }
+      if reply.run_id is None {
+        scheduler.add(dispatch(FromDevice(channel, CancelNotOpen(run_id~))))
       }
     })
   })

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -2039,6 +2039,14 @@ priv enum DeviceMsg {
   // this client did not send it and must not put another client's text in
   // this composer.
   SteerRejected(session~ : String, submission_id~ : String, run_id~ : String)
+  // The addressed run was already absent when Stop reached the host. This is
+  // success for the user's intent, but no future Finished notification can
+  // retire a stale local Cancelling phase, so the reply itself must do it.
+  CancelNotOpen(run_id~ : String)
+  // A cancellation that could not be delivered must put the exact run back
+  // into a stoppable phase. A lifecycle resync follows in case the response
+  // failed after the run independently ended.
+  CancelFailed(run_id~ : String, message~ : String)
   SessionsLoaded(
     Array[@transcript.SessionListItem],
     connection_generation~ : Int,

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -5367,6 +5367,64 @@ fn update_device_msg(
       } else {
         (@cmd.none, model)
       }
+    CancelNotOpen(run_id~) => {
+      guard model.conversation_by_run(channel, run_id) is Some(conv) else {
+        return (@cmd.none, model)
+      }
+      // The id-addressed reply is authoritative: this exact run is no longer
+      // open at the host. Close the optimistic Cancelling phase immediately,
+      // then ask for the saved settlement so the ordinary Finished path can
+      // recover its outcome and refresh the transcript. A successor that won
+      // the race has another id and is left untouched by the guard above.
+      let closed = conv.clear_streams().forget_steers_for_run(run_id)
+      let closed = if closed.pending_approval
+        is Some({ run_id: Some(owner), .. }) &&
+        owner == run_id {
+        { ..closed, pending_approval: None, }
+      } else {
+        closed
+      }
+      let updated = model.replace_conversation({
+        ..closed,
+        run: NoRun(ended=None),
+        last_run_id: Some(run_id),
+      })
+      (
+        fetch_runs(
+          dispatch,
+          channel,
+          updated.run_snapshot_frontier(channel),
+          dev.connection_generation,
+        ),
+        updated,
+      )
+    }
+    CancelFailed(run_id~, message~) => {
+      guard model.conversation_by_run(channel, run_id) is Some(conv) &&
+        conv.run is Open(run_id=current, stage=Cancelling) &&
+        current == run_id else {
+        return (@cmd.none, model)
+      }
+      // Stop was optimistic. If delivery failed, hand the control back while
+      // a runs snapshot determines whether the engine is in fact still live.
+      let retryable = model.replace_conversation({
+        ..conv,
+        run: Open(run_id~, stage=AtStep(None)),
+      })
+      let (notice, notified) = retryable.notify_error(dispatch, message)
+      (
+        @cmd.batch([
+          notice,
+          fetch_runs(
+            dispatch,
+            channel,
+            notified.run_snapshot_frontier(channel),
+            dev.connection_generation,
+          ),
+        ]),
+        notified,
+      )
+    }
     SessionsLoaded(items, connection_generation~, request_generation~) => {
       guard connection_generation == dev.connection_generation &&
         request_generation == dev.sessions_request_generation else {
@@ -11544,6 +11602,49 @@ test "a cancelling turn cannot be steered; the text stays in the composer" {
   let (_, next) = update(dispatch, Send, model)
   inspect(next.active().task, content="too late")
   inspect(next.active().pending_steers.length(), content="0")
+}
+
+///|
+test "a Stop reply for an already-ended run retires Stopping" {
+  let dispatch = test_dispatch()
+  let model = running_model().replace_conversation({
+    ..running_conversation(),
+    run: Open(run_id="r7", stage=Cancelling),
+  })
+  let (_, next) = update_dev(dispatch, CancelNotOpen(run_id="r7"), model)
+  assert_true(next.active().run is NoRun(ended=None))
+  assert_eq(next.active().last_run_id, Some("r7"))
+}
+
+///|
+test "a failed Stop becomes retryable instead of staying Stopping" {
+  let dispatch = test_dispatch()
+  let model = running_model().replace_conversation({
+    ..running_conversation(),
+    run: Open(run_id="r7", stage=Cancelling),
+  })
+  let (_, next) = update_dev(
+    dispatch,
+    CancelFailed(run_id="r7", message="cancel transport failed"),
+    model,
+  )
+  assert_true(next.active().run is Open(run_id="r7", stage=AtStep(None)))
+  assert_true(
+    next.notifications
+    .iter()
+    .any(item => item.message.contains("cancel transport failed")),
+  )
+}
+
+///|
+test "an old empty cancel reply cannot close a successor" {
+  let dispatch = test_dispatch()
+  let model = running_model().replace_conversation({
+    ..running_conversation(),
+    run: Open(run_id="r8", stage=Opened),
+  })
+  let (_, next) = update_dev(dispatch, CancelNotOpen(run_id="r7"), model)
+  assert_true(next.active().run is Open(run_id="r8", stage=Opened))
 }
 
 ///|


### PR DESCRIPTION
## Problem

Stop moves an open run to the optimistic Cancelling phase. The frontend previously ignored a successful cancel reply and reported transport failure only as a generic toast. If the host replied that the addressed run had already ended, no future agent.finished was guaranteed to arrive, so the GUI could remain Stopping indefinitely. A failed cancel likewise left Stop non-retryable.

## Fix

- Observe CancelReply instead of discarding it.
- Treat an empty run_id reply as authoritative evidence that the exact addressed run is no longer open, close only that run, and request agent.runs settlement recovery.
- Tie cancel failures to the exact run, roll Cancelling back to a stoppable phase, report the error, and resync lifecycle state.
- Guard late replies by run id so they cannot close a successor run.

## Reproduction and verification

Regression tests cover an already-ended run stuck in Stopping, a failed Stop becoming retryable, and a stale empty reply racing a successor.

- moon test desktop/frontend/update.mbt --target js: 302/302
- just check
- just test: native 3383/3383, JS 3158/3158, cram 28/28
- just build
- moon info && moon fmt
- git diff --check

No public MoonBit interface changed.