### PR TITLE
feat(desktop): add UUID minting packages

### DIFF
--- a/desktop/internal/uuid/browser/moon.pkg
+++ b/desktop/internal/uuid/browser/moon.pkg
@@ -1,0 +1,3 @@
+warnings = "+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"
+
+supported_targets = "js"

--- a/desktop/internal/uuid/browser/pkg.generated.mbti
+++ b/desktop/internal/uuid/browser/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "openseek_desktop/internal/uuid/browser"
+
+// Values
+pub fn mint() -> String
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits

--- a/desktop/internal/uuid/browser/uuid.mbt
+++ b/desktop/internal/uuid/browser/uuid.mbt
@@ -1,0 +1,12 @@
+///|
+/// Mint a lowercase RFC 9562 UUID version 4 in Desktop's browser process.
+/// The packaged WebView contract includes Web Crypto, which also lets
+/// synchronous UI callbacks keep their existing non-optional return types.
+pub extern "js" fn mint() -> String =
+  #| () => {
+  #|   const crypto = globalThis.crypto;
+  #|   if (!crypto || typeof crypto.randomUUID !== "function") {
+  #|     throw new Error("Web Crypto randomUUID is unavailable");
+  #|   }
+  #|   return crypto.randomUUID();
+  #| }

--- a/desktop/internal/uuid/moon.pkg
+++ b/desktop/internal/uuid/moon.pkg
@@ -1,0 +1,8 @@
+import {
+  "moonbitlang/core/encoding/utf8",
+  "moonbitlang/core/env",
+}
+
+warnings = "+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"
+
+supported_targets = "js+native"

--- a/desktop/internal/uuid/pkg.generated.mbti
+++ b/desktop/internal/uuid/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "openseek_desktop/internal/uuid"
+
+// Values
+pub fn mint() -> String?
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits

--- a/desktop/internal/uuid/uuid.mbt
+++ b/desktop/internal/uuid/uuid.mbt
@@ -1,0 +1,27 @@
+///|
+/// Mint a lowercase RFC 9562 UUID version 4 from 128 bits supplied by the
+/// platform entropy source. `None` means the current runtime cannot provide
+/// cryptographically secure randomness; callers decide how their boundary
+/// reports that failure.
+pub fn mint() -> String? {
+  guard @env.rand(16) is Some(bytes) else { return None }
+  let text = StringBuilder()
+  for index, byte in bytes {
+    if index == 4 || index == 6 || index == 8 || index == 10 {
+      text.write_char('-')
+    }
+    let raw = byte.to_int()
+    let value = if index == 6 {
+      (raw & 0x0f) | 0x40
+    } else if index == 8 {
+      (raw & 0x3f) | 0x80
+    } else {
+      raw
+    }
+    if value < 0x10 {
+      text.write_char('0')
+    }
+    text.write_string(value.to_string(radix=16))
+  }
+  Some(text.to_string())
+}

--- a/desktop/internal/uuid/uuid_test.mbt
+++ b/desktop/internal/uuid/uuid_test.mbt
@@ -1,0 +1,15 @@
+///|
+test "mint returns distinct RFC 9562 version 4 UUIDs" {
+  guard @uuid.mint() is Some(first) else { fail("OS entropy unavailable") }
+  guard @uuid.mint() is Some(second) else { fail("OS entropy unavailable") }
+  assert_not_eq(first, second)
+  assert_eq(first.length(), 36)
+  assert_eq(first[8], '-')
+  assert_eq(first[13], '-')
+  assert_eq(first[18], '-')
+  assert_eq(first[23], '-')
+  assert_eq(first[14], '4')
+  assert_true(
+    first[19] == '8' || first[19] == '9' || first[19] == 'a' || first[19] == 'b',
+  )
+}


### PR DESCRIPTION
## Summary

- add a native/shared UUID v4 package backed by the platform entropy source
- add a synchronous browser package backed by Web Crypto randomUUID
- generate both package interfaces and test UUID shape, version, variant, and uniqueness

This PR only introduces the UUID packages. It does not migrate any existing IDs or change wire payloads.

## Validation

- moon check --target native --deny-warn
- moon check --target js --deny-warn
- moon test desktop/internal/uuid --target native
- moon test desktop/internal/uuid --target js
- moon info
- moon fmt
- git diff --check