### PR TITLE
refactor(desktop): mint terminal IDs with UUIDs

### DIFF
--- a/desktop/frontend/terminal/host.mbt
+++ b/desktop/frontend/terminal/host.mbt
@@ -35,15 +35,15 @@ priv struct TerminalStyle {
 /// `terminal_open` reply that names it); `Opened` flushes them into the
 /// claiming tab.
 priv struct TermHost {
-  entries : Map[Int, TermEntry]
+  entries : Map[String, TermEntry]
   /// Root-owned terminal state projected into the imperative output path.
   /// The projection is refreshed only after terminal lifecycle transitions;
   /// raw output reads it without publishing a Rabbita message.
-  mut owners : Map[(@interop.ChannelId, String), Int]
+  mut owners : Map[String, (@interop.ChannelId, String)]
   mut opening_channels : Array[@interop.ChannelId]
   /// Output that arrived before `terminal_open` identified its tab:
   /// `(sequence, base64_data)`.
-  pending : Map[(@interop.ChannelId, String), Array[(Int, String)]]
+  pending : Map[String, (@interop.ChannelId, Array[(Int, String)])]
   mut resize_wired : Bool
 }
 
@@ -131,7 +131,7 @@ fn no_args() -> Array[@js.Value] {
 /// Show `key`'s element, hide the rest, then re-fit and focus the shown one
 /// (its `onResize` keeps the PTY's grid in sync). Imperative display state:
 /// the elements are outside the virtual DOM.
-fn show_only(key : Int) -> Unit {
+fn show_only(key : String) -> Unit {
   for entry_key, entry in term_host.entries {
     let style : @js.Value = entry.element.get_with_string("style")
     style.set_with_string(
@@ -169,7 +169,7 @@ fn refit_visible() -> Unit {
 /// exists), make it the visible one, and report its grid size through
 /// `EmulatorReady`. Idempotent: the update loop decides whether a ready
 /// report should spawn a session, so re-reports are harmless.
-fn mount_tab(dispatch : @cmd.Emit[Msg], key : Int) -> @cmd.Cmd {
+fn mount_tab(dispatch : @cmd.Emit[Msg], key : String) -> @cmd.Cmd {
   @cmd.custom_cmd(
     scheduler => {
       guard xterm_module() is Some(module_) else { return }
@@ -288,9 +288,9 @@ fn hide_all() -> Unit {
 /// closed): show it, hide the rest, re-fit and focus. `sync` dispatches
 /// this whenever the tab that should be on screen changes — including
 /// conversation switches, which produce no terminal message of their own.
-fn apply_shown(key : Int?) -> @cmd.Cmd {
+fn apply_shown(key : String?) -> @cmd.Cmd {
   @cmd.custom_cmd(
-    _scheduler => {
+    _ => {
       match key {
         Some(key) => show_only(key)
         None => hide_all()
@@ -306,7 +306,7 @@ fn apply_shown(key : Int?) -> @cmd.Cmd {
 /// command covers tabs that survive a later light/dark switch.
 fn apply_theme() -> @cmd.Cmd {
   @cmd.custom_cmd(
-    _scheduler => {
+    _ => {
       let theme : @js.Value = terminal_style().get_with_string("theme")
       for _, entry in term_host.entries {
         let options : @js.Value = entry.term.get_with_string("options")
@@ -325,7 +325,7 @@ fn apply_theme() -> @cmd.Cmd {
 /// visible emulator updates both xterm's metrics and the PTY grid through the
 /// existing `onResize` callback.
 pub fn apply_font_family(font_family : String) -> @cmd.Cmd {
-  @cmd.custom_cmd(_scheduler => {
+  @cmd.custom_cmd(_ => {
     for _, entry in term_host.entries {
       let options : @js.Value = entry.term.get_with_string("options")
       options.set_with_string("fontFamily", @js.Value::cast_from(font_family))
@@ -339,7 +339,7 @@ pub fn apply_font_family(font_family : String) -> @cmd.Cmd {
 /// same size from the root CSS token when they mount. Re-fitting reports the
 /// resulting grid through xterm's existing `onResize` callback.
 pub fn apply_font_size(font_size : Double) -> @cmd.Cmd {
-  @cmd.custom_cmd(_scheduler => {
+  @cmd.custom_cmd(_ => {
     for _, entry in term_host.entries {
       let options : @js.Value = entry.term.get_with_string("options")
       options.set_with_string("fontSize", @js.Value::cast_from(font_size))
@@ -354,11 +354,11 @@ pub fn apply_font_size(font_size : Double) -> @cmd.Cmd {
 /// `opening_channels` always describe the same accepted State without making
 /// raw output enter the root update loop.
 fn State::sync_host_routes(self : State) -> @cmd.Cmd {
-  let owners : Map[(@interop.ChannelId, String), Int] = Map([])
+  let owners : Map[String, (@interop.ChannelId, String)] = Map([])
   let opening_channels : Array[@interop.ChannelId] = []
   for tab in self.tabs {
     match tab.id {
-      Some(id) => owners[(tab.workspace.channel(), id)] = tab.key
+      Some(id) => owners[id] = (tab.workspace.channel(), tab.key)
       None if tab.status is TabOpening => {
         let channel = tab.workspace.channel()
         if !opening_channels.contains(channel) {
@@ -368,7 +368,7 @@ fn State::sync_host_routes(self : State) -> @cmd.Cmd {
       None => ()
     }
   }
-  @cmd.custom_cmd(_scheduler => {
+  @cmd.custom_cmd(_ => {
     term_host.owners = owners
     term_host.opening_channels = opening_channels
   })
@@ -381,7 +381,7 @@ fn State::sync_host_routes(self : State) -> @cmd.Cmd {
 fn TermHost::write_to_tab(
   self : TermHost,
   channel : @interop.ChannelId,
-  key : Int,
+  key : String,
   id : String,
   sequence : Int,
   data : String,
@@ -415,15 +415,19 @@ pub fn output(
   data : String,
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
-    let owner = (channel, id)
-    match term_host.owners.get(owner) {
-      Some(key) =>
-        scheduler.add(term_host.write_to_tab(channel, key, id, sequence, data))
+    match term_host.owners.get(id) {
+      Some((owner_channel, key)) =>
+        scheduler.add(
+          term_host.write_to_tab(owner_channel, key, id, sequence, data),
+        )
       None =>
         if term_host.opening_channels.contains(channel) {
-          let chunks = term_host.pending.get(owner).unwrap_or([])
+          let (pending_channel, chunks) = match term_host.pending.get(id) {
+            Some(pending) => pending
+            None => (channel, [])
+          }
           chunks.push((sequence, data))
-          term_host.pending[owner] = chunks
+          term_host.pending[id] = (pending_channel, chunks)
         } else {
           scheduler.add(TerminalAck::{ channel, id, sequence, }.send())
         }
@@ -435,15 +439,10 @@ pub fn output(
 /// Flush chunks buffered for `id` into the tab that just claimed it. Every
 /// flushed chunk goes through the normal write path, so each one is
 /// acknowledged as it renders.
-fn flush_pending(
-  channel : @interop.ChannelId,
-  key : Int,
-  id : String,
-) -> @cmd.Cmd {
+fn flush_pending(key : String, id : String) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
-    let owner = (channel, id)
-    guard term_host.pending.get(owner) is Some(chunks) else { return }
-    term_host.pending.remove(owner)
+    guard term_host.pending.get(id) is Some((channel, chunks)) else { return }
+    term_host.pending.remove(id)
     for chunk in chunks {
       // The accepted Opened transition supplies the key directly; its route
       // projection is scheduled by reconciliation immediately afterward.
@@ -455,11 +454,10 @@ fn flush_pending(
 ///|
 /// Drop any buffer for a session that ended unclaimed, acknowledging the
 /// bytes so the host's window is released before the session's teardown.
-fn drop_pending(channel : @interop.ChannelId, id : String) -> @cmd.Cmd {
+fn drop_pending(id : String) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
-    let owner = (channel, id)
-    guard term_host.pending.get(owner) is Some(chunks) else { return }
-    term_host.pending.remove(owner)
+    guard term_host.pending.get(id) is Some((channel, chunks)) else { return }
+    term_host.pending.remove(id)
     for chunk in chunks {
       scheduler.add(TerminalAck::{ channel, id, sequence: chunk.0, }.send())
     }
@@ -474,37 +472,37 @@ fn TermHost::clear_pending(
   self : TermHost,
   channel : @interop.ChannelId,
 ) -> @cmd.Cmd {
-  @cmd.custom_cmd(_scheduler => {
-    let retained : Map[(@interop.ChannelId, String), Int] = Map([])
-    for owner, key in term_host.owners {
+  @cmd.custom_cmd(_ => {
+    let retained : Map[String, (@interop.ChannelId, String)] = Map([])
+    for id, owner in term_host.owners {
       if owner.0 != channel {
-        retained[owner] = key
+        retained[id] = owner
       }
     }
     term_host.owners = retained
     term_host.opening_channels = term_host.opening_channels.filter(existing => {
       existing != channel
     })
-    let owners : Array[(@interop.ChannelId, String)] = []
-    for owner, _ in self.pending {
-      if owner.0 == channel {
-        owners.push(owner)
+    let pending_ids : Array[String] = []
+    for id, pending in self.pending {
+      if pending.0 == channel {
+        pending_ids.push(id)
       }
     }
-    for owner in owners {
-      self.pending.remove(owner)
+    for id in pending_ids {
+      self.pending.remove(id)
     }
   })
 }
 
 ///|
 /// Dispose a closed tab's emulator and remove its element.
-fn dispose_tab(key : Int) -> @cmd.Cmd {
-  @cmd.custom_cmd(_scheduler => {
-    let retained : Map[(@interop.ChannelId, String), Int] = Map([])
-    for owner, owner_key in term_host.owners {
-      if owner_key != key {
-        retained[owner] = owner_key
+fn dispose_tab(key : String) -> @cmd.Cmd {
+  @cmd.custom_cmd(_ => {
+    let retained : Map[String, (@interop.ChannelId, String)] = Map([])
+    for id, owner in term_host.owners {
+      if owner.1 != key {
+        retained[id] = owner
       }
     }
     term_host.owners = retained

--- a/desktop/frontend/terminal/host.mbt
+++ b/desktop/frontend/terminal/host.mbt
@@ -39,11 +39,11 @@ priv struct TermHost {
   /// Root-owned terminal state projected into the imperative output path.
   /// The projection is refreshed only after terminal lifecycle transitions;
   /// raw output reads it without publishing a Rabbita message.
-  mut owners : Map[(@interop.ChannelId, Int), Int]
+  mut owners : Map[(@interop.ChannelId, String), Int]
   mut opening_channels : Array[@interop.ChannelId]
   /// Output that arrived before `terminal_open` identified its tab:
   /// `(sequence, base64_data)`.
-  pending : Map[(@interop.ChannelId, Int), Array[(Int, String)]]
+  pending : Map[(@interop.ChannelId, String), Array[(Int, String)]]
   mut resize_wired : Bool
 }
 
@@ -354,7 +354,7 @@ pub fn apply_font_size(font_size : Double) -> @cmd.Cmd {
 /// `opening_channels` always describe the same accepted State without making
 /// raw output enter the root update loop.
 fn State::sync_host_routes(self : State) -> @cmd.Cmd {
-  let owners : Map[(@interop.ChannelId, Int), Int] = Map([])
+  let owners : Map[(@interop.ChannelId, String), Int] = Map([])
   let opening_channels : Array[@interop.ChannelId] = []
   for tab in self.tabs {
     match tab.id {
@@ -382,7 +382,7 @@ fn TermHost::write_to_tab(
   self : TermHost,
   channel : @interop.ChannelId,
   key : Int,
-  id : Int,
+  id : String,
   sequence : Int,
   data : String,
 ) -> @cmd.Cmd {
@@ -410,7 +410,7 @@ fn TermHost::write_to_tab(
 /// dropped so it cannot consume the host's flow-control window.
 pub fn output(
   channel : @interop.ChannelId,
-  id : Int,
+  id : String,
   sequence : Int,
   data : String,
 ) -> @cmd.Cmd {
@@ -435,7 +435,11 @@ pub fn output(
 /// Flush chunks buffered for `id` into the tab that just claimed it. Every
 /// flushed chunk goes through the normal write path, so each one is
 /// acknowledged as it renders.
-fn flush_pending(channel : @interop.ChannelId, key : Int, id : Int) -> @cmd.Cmd {
+fn flush_pending(
+  channel : @interop.ChannelId,
+  key : Int,
+  id : String,
+) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     let owner = (channel, id)
     guard term_host.pending.get(owner) is Some(chunks) else { return }
@@ -451,7 +455,7 @@ fn flush_pending(channel : @interop.ChannelId, key : Int, id : Int) -> @cmd.Cmd 
 ///|
 /// Drop any buffer for a session that ended unclaimed, acknowledging the
 /// bytes so the host's window is released before the session's teardown.
-fn drop_pending(channel : @interop.ChannelId, id : Int) -> @cmd.Cmd {
+fn drop_pending(channel : @interop.ChannelId, id : String) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     let owner = (channel, id)
     guard term_host.pending.get(owner) is Some(chunks) else { return }
@@ -471,7 +475,7 @@ fn TermHost::clear_pending(
   channel : @interop.ChannelId,
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(_scheduler => {
-    let retained : Map[(@interop.ChannelId, Int), Int] = Map([])
+    let retained : Map[(@interop.ChannelId, String), Int] = Map([])
     for owner, key in term_host.owners {
       if owner.0 != channel {
         retained[owner] = key
@@ -481,7 +485,7 @@ fn TermHost::clear_pending(
     term_host.opening_channels = term_host.opening_channels.filter(existing => {
       existing != channel
     })
-    let owners : Array[(@interop.ChannelId, Int)] = []
+    let owners : Array[(@interop.ChannelId, String)] = []
     for owner, _ in self.pending {
       if owner.0 == channel {
         owners.push(owner)
@@ -497,7 +501,7 @@ fn TermHost::clear_pending(
 /// Dispose a closed tab's emulator and remove its element.
 fn dispose_tab(key : Int) -> @cmd.Cmd {
   @cmd.custom_cmd(_scheduler => {
-    let retained : Map[(@interop.ChannelId, Int), Int] = Map([])
+    let retained : Map[(@interop.ChannelId, String), Int] = Map([])
     for owner, owner_key in term_host.owners {
       if owner_key != key {
         retained[owner] = owner_key

--- a/desktop/frontend/terminal/moon.pkg
+++ b/desktop/frontend/terminal/moon.pkg
@@ -9,6 +9,7 @@ import {
   "openseek_desktop/frontend/internal/terminal_input",
   "openseek_desktop/internal/protocol",
   "openseek_desktop/internal/commands",
+  "openseek_desktop/internal/uuid/browser" @uuid,
   "openseek_desktop/frontend/interop",
   "openseek_desktop/frontend/resource",
 }

--- a/desktop/frontend/terminal/ops.mbt
+++ b/desktop/frontend/terminal/ops.mbt
@@ -50,7 +50,7 @@ fn open_session(
 fn send_input(
   dispatch : @cmd.Emit[Msg],
   channel : @interop.ChannelId,
-  id : Int,
+  id : String,
   data : String,
   binary : Bool,
 ) -> @cmd.Cmd {
@@ -85,7 +85,7 @@ fn send_input(
 ///|
 fn send_resize(
   channel : @interop.ChannelId,
-  id : Int,
+  id : String,
   cols : Int,
   rows : Int,
 ) -> @cmd.Cmd {
@@ -110,7 +110,7 @@ fn send_resize(
 /// outstanding sequence at most once.
 priv struct TerminalAck {
   channel : @interop.ChannelId
-  id : Int
+  id : String
   sequence : Int
 }
 
@@ -124,10 +124,10 @@ fn TerminalAck::send(self : TerminalAck) -> @cmd.Cmd {
           sequence: self.sequence,
         }) catch {
           _ => {
-            // The in-process bridge keeps one terminal-id namespace, so a lost
-            // reply is safe to retry there. A remote WebSocket failure ends the
-            // namespace together with all of its PTYs; replaying this id after
-            // reconnect could acknowledge an unrelated new terminal.
+            // UUIDs are never reassigned, so a retry cannot acknowledge a
+            // replacement terminal. Keep the existing retry only for the
+            // in-process bridge; a remote WebSocket failure tears down the
+            // connection and all PTYs it owned.
             if self.channel is @interop.ChannelId::Local {
               _scheduler.add(@cmd.delay(self.send(), AckRetryDelayMs))
             }
@@ -140,7 +140,7 @@ fn TerminalAck::send(self : TerminalAck) -> @cmd.Cmd {
 }
 
 ///|
-fn send_close(channel : @interop.ChannelId, id : Int) -> @cmd.Cmd {
+fn send_close(channel : @interop.ChannelId, id : String) -> @cmd.Cmd {
   @cmd.custom_cmd(_scheduler => {
     @js.async_run(() => {
       ignore(

--- a/desktop/frontend/terminal/ops.mbt
+++ b/desktop/frontend/terminal/ops.mbt
@@ -102,9 +102,10 @@ fn send_resize(
 }
 
 ///|
-/// One output acknowledgement, sent after xterm has rendered the chunk. A
-/// failed bridge no longer owns a PTY or flow-control window to release, so
-/// the acknowledgement is not retried.
+/// One output acknowledgement, sent after xterm has rendered the chunk. The
+/// host treats `sequence` cumulatively, so a later successful acknowledgement
+/// also covers this one if the request does not reach the host; no retry timer
+/// is needed.
 priv struct TerminalAck {
   channel : @interop.ChannelId
   id : String

--- a/desktop/frontend/terminal/ops.mbt
+++ b/desktop/frontend/terminal/ops.mbt
@@ -3,17 +3,14 @@
 // reply back into the update loop; the steady-state ops are fire-and-forget
 // — input failures surface as `InputFailed` (an error toast),
 // resize/close failures are dropped (their loss only degrades, and a dead
-// session reports itself through `terminal_exit`). Flow-control acks retry
-// until the host accepts their idempotent output sequence.
-
-///|
-const AckRetryDelayMs = 100
+// session reports itself through `terminal_exit`). Flow-control acks are sent
+// once after xterm renders their output sequence.
 
 ///|
 fn open_session(
   dispatch : @cmd.Emit[Msg],
   channel : @interop.ChannelId,
-  key : Int,
+  key : String,
   session : String,
   workspace : @common.Uri?,
   cols : Int,
@@ -89,7 +86,7 @@ fn send_resize(
   cols : Int,
   rows : Int,
 ) -> @cmd.Cmd {
-  @cmd.custom_cmd(_scheduler => {
+  @cmd.custom_cmd(_ => {
     @js.async_run(() => {
       ignore(
         @interop.bridge_request(channel, @commands.terminal_resize, {
@@ -105,9 +102,9 @@ fn send_resize(
 }
 
 ///|
-/// One output acknowledgement. Within its owning connection, retrying the
-/// same session/sequence pair is safe because the host removes each
-/// outstanding sequence at most once.
+/// One output acknowledgement, sent after xterm has rendered the chunk. A
+/// failed bridge no longer owns a PTY or flow-control window to release, so
+/// the acknowledgement is not retried.
 priv struct TerminalAck {
   channel : @interop.ChannelId
   id : String
@@ -116,23 +113,14 @@ priv struct TerminalAck {
 
 ///|
 fn TerminalAck::send(self : TerminalAck) -> @cmd.Cmd {
-  @cmd.custom_cmd(_scheduler => {
+  @cmd.custom_cmd(_ => {
     @js.async_run(() => {
       ignore(
         @interop.bridge_request(self.channel, @commands.terminal_ack, {
           id: self.id,
           sequence: self.sequence,
         }) catch {
-          _ => {
-            // UUIDs are never reassigned, so a retry cannot acknowledge a
-            // replacement terminal. Keep the existing retry only for the
-            // in-process bridge; a remote WebSocket failure tears down the
-            // connection and all PTYs it owned.
-            if self.channel is @interop.ChannelId::Local {
-              _scheduler.add(@cmd.delay(self.send(), AckRetryDelayMs))
-            }
-            return
-          }
+          _ => return
         },
       )
     })
@@ -141,7 +129,7 @@ fn TerminalAck::send(self : TerminalAck) -> @cmd.Cmd {
 
 ///|
 fn send_close(channel : @interop.ChannelId, id : String) -> @cmd.Cmd {
-  @cmd.custom_cmd(_scheduler => {
+  @cmd.custom_cmd(_ => {
     @js.async_run(() => {
       ignore(
         @interop.bridge_request(channel, @commands.terminal_close, { id, }) catch {

--- a/desktop/frontend/terminal/pkg.generated.mbti
+++ b/desktop/frontend/terminal/pkg.generated.mbti
@@ -40,16 +40,16 @@ pub(all) enum Msg {
   ToggleTerminal
   SessionExited(channel~ : @interop.ChannelId, id~ : String, code~ : Int)
   NewTerminal
-  TabSelected(key~ : Int)
-  TabClosed(key~ : Int)
-  EmulatorReady(key~ : Int, cols~ : Int, rows~ : Int)
-  Opened(channel~ : @interop.ChannelId, key~ : Int, id~ : String)
-  OpenFailed(key~ : Int, message~ : String)
-  UserInput(key~ : Int, data~ : String)
+  TabSelected(key~ : String)
+  TabClosed(key~ : String)
+  EmulatorReady(key~ : String, cols~ : Int, rows~ : Int)
+  Opened(channel~ : @interop.ChannelId, key~ : String, id~ : String)
+  OpenFailed(key~ : String, message~ : String)
+  UserInput(key~ : String, data~ : String)
   LinkActivated(url~ : String)
-  BinaryInput(key~ : Int, data~ : String)
+  BinaryInput(key~ : String, data~ : String)
   InputFailed(message~ : String)
-  ViewportResized(key~ : Int, cols~ : Int, rows~ : Int)
+  ViewportResized(key~ : String, cols~ : Int, rows~ : Int)
 }
 
 pub struct State {

--- a/desktop/frontend/terminal/pkg.generated.mbti
+++ b/desktop/frontend/terminal/pkg.generated.mbti
@@ -15,7 +15,7 @@ pub fn apply_font_size(Double) -> @cmd.Cmd
 
 pub fn component(@rabbita.Val[Input], @rabbita.Val[State], @cmd.Emit[Msg]) -> @rabbita.Val[@html.Html]
 
-pub fn output(@interop.ChannelId, Int, Int, String) -> @cmd.Cmd
+pub fn output(@interop.ChannelId, String, Int, String) -> @cmd.Cmd
 
 // Errors
 
@@ -38,12 +38,12 @@ pub fn Input::not_equal(Self, Self) -> Bool
 
 pub(all) enum Msg {
   ToggleTerminal
-  SessionExited(channel~ : @interop.ChannelId, id~ : Int, code~ : Int)
+  SessionExited(channel~ : @interop.ChannelId, id~ : String, code~ : Int)
   NewTerminal
   TabSelected(key~ : Int)
   TabClosed(key~ : Int)
   EmulatorReady(key~ : Int, cols~ : Int, rows~ : Int)
-  Opened(channel~ : @interop.ChannelId, key~ : Int, id~ : Int)
+  Opened(channel~ : @interop.ChannelId, key~ : Int, id~ : String)
   OpenFailed(key~ : Int, message~ : String)
   UserInput(key~ : Int, data~ : String)
   LinkActivated(url~ : String)

--- a/desktop/frontend/terminal/resize.mbt
+++ b/desktop/frontend/terminal/resize.mbt
@@ -41,7 +41,7 @@ let terminal_resizer : TerminalResizer = {
 /// that finds the stable handle performs the installation.
 fn TerminalResizer::mount(self : TerminalResizer) -> @cmd.Cmd {
   @cmd.custom_cmd(
-    _scheduler => {
+    _ => {
       if self.installed.val {
         return
       }

--- a/desktop/frontend/terminal/state.mbt
+++ b/desktop/frontend/terminal/state.mbt
@@ -5,9 +5,9 @@
 // stay alive while the user looks elsewhere.
 
 ///|
-/// Which device/workspace a tab belongs to. Host-assigned terminal ids are
-/// scoped to one bridge connection, so the channel is part of the identity:
-/// two devices can both name their first terminal `1` without sharing tabs.
+/// Which device/workspace a tab belongs to. A terminal UUID identifies the
+/// host session, while the channel retains the connection that owns and can
+/// operate that PTY.
 /// Main-checkout conversations in the same registered project directory on
 /// one device share a group. A worktree is a separate group keyed by its
 /// registered project and worktree name, while a scratch group is keyed by
@@ -44,7 +44,7 @@ priv enum TabStatus {
 /// restarts reuse them, so a tab never migrates between workspaces.
 priv struct Tab {
   key : Int
-  id : Int?
+  id : String?
   workspace : WorkspaceKey
   workspace_label : String
   session : String
@@ -69,7 +69,7 @@ pub struct State {
   /// The reply is the first event that identifies the opening tab, so it
   /// consumes the pair and retires that tab instead of reviving an
   /// already-dead session.
-  priv exited_before_open : Array[(@interop.ChannelId, Int)]
+  priv exited_before_open : Array[(@interop.ChannelId, String)]
   /// The color scheme last applied to every mounted emulator. Keeping this in
   /// model state lets `sync` refresh existing xterm instances exactly once
   /// when the application switches between light and dark mode.
@@ -188,7 +188,7 @@ fn State::tab_by_key(self : State, key : Int) -> Tab? {
 fn State::tab_by_id(
   self : State,
   channel : @interop.ChannelId,
-  id : Int,
+  id : String,
 ) -> Tab? {
   for tab in self.tabs {
     if tab.workspace.channel() == channel &&
@@ -232,7 +232,7 @@ pub(all) enum Msg {
   /// Show/hide the panel (every shell keeps running while hidden).
   ToggleTerminal
   /// `terminal_exit` event: the shell ended, so its tab retires.
-  SessionExited(channel~ : @interop.ChannelId, id~ : Int, code~ : Int)
+  SessionExited(channel~ : @interop.ChannelId, id~ : String, code~ : Int)
   /// Open one more terminal in the active conversation's workspace.
   NewTerminal
   TabSelected(key~ : Int)
@@ -242,7 +242,7 @@ pub(all) enum Msg {
   EmulatorReady(key~ : Int, cols~ : Int, rows~ : Int)
   /// `terminal_open` replied for the tab. The channel is retained because the
   /// tab may have been closed or the UI may have switched devices meanwhile.
-  Opened(channel~ : @interop.ChannelId, key~ : Int, id~ : Int)
+  Opened(channel~ : @interop.ChannelId, key~ : Int, id~ : String)
   OpenFailed(key~ : Int, message~ : String)
   /// Keystrokes from one tab's emulator.
   UserInput(key~ : Int, data~ : String)

--- a/desktop/frontend/terminal/state.mbt
+++ b/desktop/frontend/terminal/state.mbt
@@ -5,9 +5,9 @@
 // stay alive while the user looks elsewhere.
 
 ///|
-/// Which device/workspace a tab belongs to. A terminal UUID identifies the
-/// host session, while the channel retains the connection that owns and can
-/// operate that PTY.
+/// Which device/workspace a tab belongs to. The channel is part of the
+/// workspace grouping and selects the bridge used to drive that tab; terminal
+/// UUIDs themselves need no channel scope.
 /// Main-checkout conversations in the same registered project directory on
 /// one device share a group. A worktree is a separate group keyed by its
 /// registered project and worktree name, while a scratch group is keyed by
@@ -43,7 +43,7 @@ priv enum TabStatus {
 /// `session`/`workspace_path` are the binding the tab was opened with —
 /// restarts reuse them, so a tab never migrates between workspaces.
 priv struct Tab {
-  key : Int
+  key : String
   id : String?
   workspace : WorkspaceKey
   workspace_label : String
@@ -55,17 +55,17 @@ priv struct Tab {
 ///|
 pub struct State {
   priv open : Bool
-  priv next_key : Int
   priv tabs : Array[Tab]
   /// The remembered active tab per workspace group, as an association list
   /// (small; a workspace rarely has more than a handful of tabs).
-  priv active : Array[(WorkspaceKey, Int)]
+  priv active : Array[(WorkspaceKey, String)]
   /// The tab whose emulator element is currently displayed (`None` while
   /// the panel is closed). Mirrors imperative DOM state so `sync` can tell
   /// when a conversation switch must re-aim the display — the switch itself
   /// produces no terminal message.
-  priv shown : Int?
-  /// Channel/session ids whose exit event beat their `terminal_open` reply.
+  priv shown : String?
+  /// Session UUIDs whose exit event beat their `terminal_open` reply, paired
+  /// with the channel used to discard that channel's pending output on loss.
   /// The reply is the first event that identifies the opening tab, so it
   /// consumes the pair and retires that tab instead of reviving an
   /// already-dead session.
@@ -83,7 +83,6 @@ pub struct State {
 pub fn State::empty() -> State {
   {
     open: false,
-    next_key: 1,
     tabs: [],
     active: [],
     shown: None,
@@ -175,7 +174,7 @@ fn State::active_tab(self : State, ctx : Ctx) -> Tab? {
 }
 
 ///|
-fn State::tab_by_key(self : State, key : Int) -> Tab? {
+fn State::tab_by_key(self : State, key : String) -> Tab? {
   for tab in self.tabs {
     if tab.key == key {
       return Some(tab)
@@ -185,15 +184,9 @@ fn State::tab_by_key(self : State, key : Int) -> Tab? {
 }
 
 ///|
-fn State::tab_by_id(
-  self : State,
-  channel : @interop.ChannelId,
-  id : String,
-) -> Tab? {
+fn State::tab_by_id(self : State, id : String) -> Tab? {
   for tab in self.tabs {
-    if tab.workspace.channel() == channel &&
-      tab.id is Some(tab_id) &&
-      tab_id == id {
+    if tab.id is Some(tab_id) && tab_id == id {
       return Some(tab)
     }
   }
@@ -220,7 +213,7 @@ fn State::replace_tab(self : State, updated : Tab) -> State {
 fn State::remember_active(
   self : State,
   group : WorkspaceKey,
-  key : Int,
+  key : String,
 ) -> State {
   let active = self.active.filter(entry => entry.0 != group)
   active.push((group, key))
@@ -235,30 +228,30 @@ pub(all) enum Msg {
   SessionExited(channel~ : @interop.ChannelId, id~ : String, code~ : Int)
   /// Open one more terminal in the active conversation's workspace.
   NewTerminal
-  TabSelected(key~ : Int)
+  TabSelected(key~ : String)
   /// Close a tab: its shell is torn down, its emulator disposed.
-  TabClosed(key~ : Int)
+  TabClosed(key~ : String)
   /// The tab's emulator is mounted, fitted, and reports its grid size.
-  EmulatorReady(key~ : Int, cols~ : Int, rows~ : Int)
+  EmulatorReady(key~ : String, cols~ : Int, rows~ : Int)
   /// `terminal_open` replied for the tab. The channel is retained because the
   /// tab may have been closed or the UI may have switched devices meanwhile.
-  Opened(channel~ : @interop.ChannelId, key~ : Int, id~ : String)
-  OpenFailed(key~ : Int, message~ : String)
+  Opened(channel~ : @interop.ChannelId, key~ : String, id~ : String)
+  OpenFailed(key~ : String, message~ : String)
   /// Keystrokes from one tab's emulator.
-  UserInput(key~ : Int, data~ : String)
+  UserInput(key~ : String, data~ : String)
   /// A web URL activated through xterm's link addon. The main frontend routes
   /// it through the same dock/system-browser policy as conversation anchors.
   LinkActivated(url~ : String)
   /// xterm's `onBinary` payload, encoded as base64 so each JS character code
   /// reaches the PTY as exactly one byte instead of being UTF-8 re-encoded.
-  BinaryInput(key~ : Int, data~ : String)
+  BinaryInput(key~ : String, data~ : String)
   /// `terminal_input` failed for the tab: the keystrokes were lost. The
   /// main package surfaces the message as an error toast (the panel has no
   /// toast rail of its own); the tab's status is untouched — a lost
   /// keystroke does not make the session failed.
   InputFailed(message~ : String)
   /// One tab's emulator re-fit to a new grid size.
-  ViewportResized(key~ : Int, cols~ : Int, rows~ : Int)
+  ViewportResized(key~ : String, cols~ : Int, rows~ : Int)
 }
 
 ///|

--- a/desktop/frontend/terminal/terminal_xxtest.mbt
+++ b/desktop/frontend/terminal/terminal_xxtest.mbt
@@ -34,31 +34,27 @@ test "an exit before the open reply cannot revive a dead terminal" {
     connected: true,
   }
   let (_, opening) = update(emit, ToggleTerminal, State::empty(), ctx)
+  let key = opening.tabs[0].key
+  let terminal_id = "terminal-exit-race"
   let (_, exited) = update(
     emit,
-    SessionExited(
-      channel=@interop.ChannelId::Local,
-      id="terminal-exit-race",
-      code=0,
-    ),
+    SessionExited(channel=@interop.ChannelId::Local, id=terminal_id, code=0),
     opening,
     ctx,
   )
   assert_true(
-    exited.exited_before_open.contains(
-      (@interop.ChannelId::Local, "terminal-exit-race"),
-    ),
+    exited.exited_before_open.contains((@interop.ChannelId::Local, terminal_id)),
   )
   let (_, replied) = update(
     emit,
-    Opened(channel=@interop.ChannelId::Local, key=1, id="terminal-exit-race"),
+    Opened(channel=@interop.ChannelId::Local, key~, id=terminal_id),
     exited,
     ctx,
   )
   assert_true(replied.tabs.is_empty())
   assert_true(
     !replied.exited_before_open.contains(
-      (@interop.ChannelId::Local, "terminal-exit-race"),
+      (@interop.ChannelId::Local, terminal_id),
     ),
   )
   assert_true(!replied.open)
@@ -87,7 +83,7 @@ test "sync records color-scheme changes even when the shown tab is unchanged" {
 }
 
 ///|
-test "terminal routes retain their owning device" {
+test "terminal UUIDs route independently of the focused device" {
   let emit : @cmd.Emit[Msg] = @cmd.Emit(_ => @cmd.none)
   guard @resource.of_path(@interop.ChannelId::Local, "/work/project")
     is Some(local_workspace) else {
@@ -115,27 +111,27 @@ test "terminal routes retain their owning device" {
     State::empty(),
     local_ctx,
   )
+  let local_key = local_opening.tabs[0].key
+  let local_id = "terminal-local"
   let (_, local_running) = update(
     emit,
-    Opened(
-      channel=@interop.ChannelId::Local,
-      key=1,
-      id="shared-terminal-fixture",
-    ),
+    Opened(channel=@interop.ChannelId::Local, key=local_key, id=local_id),
     local_opening,
     local_ctx,
   )
   let (_, both_opening) = update(emit, NewTerminal, local_running, remote_ctx)
+  let remote_key = both_opening.tabs[1].key
+  let remote_id = "terminal-remote"
   let (_, both_running) = update(
     emit,
-    Opened(channel=remote, key=2, id="shared-terminal-fixture"),
+    Opened(channel=remote, key=remote_key, id=remote_id),
     both_opening,
     remote_ctx,
   )
   inspect(both_running.tabs.length(), content="2")
   let (_, remote_exited) = update(
     emit,
-    SessionExited(channel=remote, id="shared-terminal-fixture", code=0),
+    SessionExited(channel=remote, id=remote_id, code=0),
     both_running,
     remote_ctx,
   )
@@ -147,7 +143,7 @@ test "terminal routes retain their owning device" {
     tab.workspace is Project(@interop.ChannelId::Local, resource) &&
     resource.path == "/work/project",
   )
-  assert_true(tab.id is Some("shared-terminal-fixture"))
+  assert_true(tab.id == Some(local_id))
 }
 
 ///|
@@ -160,11 +156,10 @@ test "a disconnected channel retires only its terminal tabs" {
   }
   let state : State = {
     open: true,
-    next_key: 3,
     tabs: [
       {
-        key: 1,
-        id: Some("local-terminal"),
+        key: "tab-local",
+        id: Some("terminal-local"),
         workspace: Project(local_channel, local_workspace),
         workspace_label: "local",
         session: "local",
@@ -172,8 +167,8 @@ test "a disconnected channel retires only its terminal tabs" {
         status: TabRunning,
       },
       {
-        key: 2,
-        id: Some("remote-terminal"),
+        key: "tab-remote",
+        id: Some("terminal-remote"),
         workspace: Project(remote, remote_workspace),
         workspace_label: "remote",
         session: "remote",
@@ -182,13 +177,13 @@ test "a disconnected channel retires only its terminal tabs" {
       },
     ],
     active: [
-      (Project(local_channel, local_workspace), 1),
-      (Project(remote, remote_workspace), 2),
+      (Project(local_channel, local_workspace), "tab-local"),
+      (Project(remote, remote_workspace), "tab-remote"),
     ],
-    shown: Some(2),
+    shown: Some("tab-remote"),
     exited_before_open: [
-      (remote, "remote-opening-terminal"),
-      (local_channel, "local-opening-terminal"),
+      (remote, "exited-remote"),
+      (local_channel, "exited-local"),
     ],
     synced_dark_mode: Some(false),
     live_channels: [local_channel, remote],
@@ -202,8 +197,7 @@ test "a disconnected channel retires only its terminal tabs" {
   )
   assert_true(disconnected.shown is None)
   assert_true(
-    disconnected.exited_before_open ==
-    [(local_channel, "local-opening-terminal")],
+    disconnected.exited_before_open == [(local_channel, "exited-local")],
   )
 }
 
@@ -261,9 +255,14 @@ test "a missing checkout refuses new PTYs and retires only its conversation" {
     connected: true,
   }
   let (_, opening) = update(emit, ToggleTerminal, State::empty(), ctx)
+  let opening_key = opening.tabs[0].key
   let (_, running) = update(
     emit,
-    Opened(channel=@interop.ChannelId::Local, key=1, id="worktree-terminal"),
+    Opened(
+      channel=@interop.ChannelId::Local,
+      key=opening_key,
+      id="terminal-missing",
+    ),
     opening,
     ctx,
   )
@@ -273,9 +272,14 @@ test "a missing checkout refuses new PTYs and retires only its conversation" {
     placement: Some(@interop.WorkspaceRoot(root=workspace)),
   }
   let (_, other_opening) = update(emit, NewTerminal, running, other_ctx)
+  let other_key = other_opening.tabs[1].key
   let (_, both_running) = update(
     emit,
-    Opened(channel=@interop.ChannelId::Local, key=2, id="project-terminal"),
+    Opened(
+      channel=@interop.ChannelId::Local,
+      key=other_key,
+      id="terminal-other",
+    ),
     other_opening,
     other_ctx,
   )
@@ -289,15 +293,11 @@ test "a missing checkout refuses new PTYs and retires only its conversation" {
   assert_true(retired.shown is None)
   let (still_retired, _) = sync(emit, retired, missing_ctx)
   assert_true(still_retired == retired)
-  let (_, toggle_refused) = update(
-    emit,
-    ToggleTerminal,
-    State::empty(),
-    missing_ctx,
-  )
-  let (_, new_refused) = update(emit, NewTerminal, State::empty(), missing_ctx)
-  assert_true(toggle_refused == State::empty())
-  assert_true(new_refused == State::empty())
+  let empty = State::empty()
+  let (_, toggle_refused) = update(emit, ToggleTerminal, empty, missing_ctx)
+  let (_, new_refused) = update(emit, NewTerminal, empty, missing_ctx)
+  assert_true(toggle_refused == empty)
+  assert_true(new_refused == empty)
 }
 
 ///|
@@ -360,14 +360,10 @@ test "an unresolved placement cannot reveal or create a project terminal" {
   let (waiting, _) = sync(emit, project_opening, unresolved)
   assert_eq(waiting.tabs.length(), 1)
   assert_true(waiting.shown is None)
-  let (_, toggle_refused) = update(
-    emit,
-    ToggleTerminal,
-    State::empty(),
-    unresolved,
-  )
+  let empty = State::empty()
+  let (_, toggle_refused) = update(emit, ToggleTerminal, empty, unresolved)
   let (_, new_refused) = update(emit, NewTerminal, waiting, unresolved)
-  assert_true(toggle_refused == State::empty())
+  assert_true(toggle_refused == empty)
   assert_true(new_refused == waiting)
   // Once the list identifies the worktree, the already-open panel creates a
   // correctly isolated worktree tab instead of migrating the project tab.

--- a/desktop/frontend/terminal/terminal_xxtest.mbt
+++ b/desktop/frontend/terminal/terminal_xxtest.mbt
@@ -36,22 +36,30 @@ test "an exit before the open reply cannot revive a dead terminal" {
   let (_, opening) = update(emit, ToggleTerminal, State::empty(), ctx)
   let (_, exited) = update(
     emit,
-    SessionExited(channel=@interop.ChannelId::Local, id=42, code=0),
+    SessionExited(
+      channel=@interop.ChannelId::Local,
+      id="terminal-exit-race",
+      code=0,
+    ),
     opening,
     ctx,
   )
   assert_true(
-    exited.exited_before_open.contains((@interop.ChannelId::Local, 42)),
+    exited.exited_before_open.contains(
+      (@interop.ChannelId::Local, "terminal-exit-race"),
+    ),
   )
   let (_, replied) = update(
     emit,
-    Opened(channel=@interop.ChannelId::Local, key=1, id=42),
+    Opened(channel=@interop.ChannelId::Local, key=1, id="terminal-exit-race"),
     exited,
     ctx,
   )
   assert_true(replied.tabs.is_empty())
   assert_true(
-    !replied.exited_before_open.contains((@interop.ChannelId::Local, 42)),
+    !replied.exited_before_open.contains(
+      (@interop.ChannelId::Local, "terminal-exit-race"),
+    ),
   )
   assert_true(!replied.open)
 }
@@ -79,7 +87,7 @@ test "sync records color-scheme changes even when the shown tab is unchanged" {
 }
 
 ///|
-test "same-numbered terminal ids on different devices stay isolated" {
+test "terminal routes retain their owning device" {
   let emit : @cmd.Emit[Msg] = @cmd.Emit(_ => @cmd.none)
   guard @resource.of_path(@interop.ChannelId::Local, "/work/project")
     is Some(local_workspace) else {
@@ -109,21 +117,25 @@ test "same-numbered terminal ids on different devices stay isolated" {
   )
   let (_, local_running) = update(
     emit,
-    Opened(channel=@interop.ChannelId::Local, key=1, id=1),
+    Opened(
+      channel=@interop.ChannelId::Local,
+      key=1,
+      id="shared-terminal-fixture",
+    ),
     local_opening,
     local_ctx,
   )
   let (_, both_opening) = update(emit, NewTerminal, local_running, remote_ctx)
   let (_, both_running) = update(
     emit,
-    Opened(channel=remote, key=2, id=1),
+    Opened(channel=remote, key=2, id="shared-terminal-fixture"),
     both_opening,
     remote_ctx,
   )
   inspect(both_running.tabs.length(), content="2")
   let (_, remote_exited) = update(
     emit,
-    SessionExited(channel=remote, id=1, code=0),
+    SessionExited(channel=remote, id="shared-terminal-fixture", code=0),
     both_running,
     remote_ctx,
   )
@@ -135,7 +147,7 @@ test "same-numbered terminal ids on different devices stay isolated" {
     tab.workspace is Project(@interop.ChannelId::Local, resource) &&
     resource.path == "/work/project",
   )
-  assert_true(tab.id is Some(1))
+  assert_true(tab.id is Some("shared-terminal-fixture"))
 }
 
 ///|
@@ -152,7 +164,7 @@ test "a disconnected channel retires only its terminal tabs" {
     tabs: [
       {
         key: 1,
-        id: Some(1),
+        id: Some("local-terminal"),
         workspace: Project(local_channel, local_workspace),
         workspace_label: "local",
         session: "local",
@@ -161,7 +173,7 @@ test "a disconnected channel retires only its terminal tabs" {
       },
       {
         key: 2,
-        id: Some(1),
+        id: Some("remote-terminal"),
         workspace: Project(remote, remote_workspace),
         workspace_label: "remote",
         session: "remote",
@@ -174,7 +186,10 @@ test "a disconnected channel retires only its terminal tabs" {
       (Project(remote, remote_workspace), 2),
     ],
     shown: Some(2),
-    exited_before_open: [(remote, 9), (local_channel, 9)],
+    exited_before_open: [
+      (remote, "remote-opening-terminal"),
+      (local_channel, "local-opening-terminal"),
+    ],
     synced_dark_mode: Some(false),
     live_channels: [local_channel, remote],
   }
@@ -186,7 +201,10 @@ test "a disconnected channel retires only its terminal tabs" {
     resource.path == "/local",
   )
   assert_true(disconnected.shown is None)
-  assert_true(disconnected.exited_before_open == [(local_channel, 9)])
+  assert_true(
+    disconnected.exited_before_open ==
+    [(local_channel, "local-opening-terminal")],
+  )
 }
 
 ///|
@@ -245,7 +263,7 @@ test "a missing checkout refuses new PTYs and retires only its conversation" {
   let (_, opening) = update(emit, ToggleTerminal, State::empty(), ctx)
   let (_, running) = update(
     emit,
-    Opened(channel=@interop.ChannelId::Local, key=1, id=7),
+    Opened(channel=@interop.ChannelId::Local, key=1, id="worktree-terminal"),
     opening,
     ctx,
   )
@@ -257,7 +275,7 @@ test "a missing checkout refuses new PTYs and retires only its conversation" {
   let (_, other_opening) = update(emit, NewTerminal, running, other_ctx)
   let (_, both_running) = update(
     emit,
-    Opened(channel=@interop.ChannelId::Local, key=2, id=8),
+    Opened(channel=@interop.ChannelId::Local, key=2, id="project-terminal"),
     other_opening,
     other_ctx,
   )

--- a/desktop/frontend/terminal/update.mbt
+++ b/desktop/frontend/terminal/update.mbt
@@ -32,7 +32,7 @@ fn open_new_tab(
   ctx : Ctx,
 ) -> (@cmd.Cmd, State) {
   guard workspace_key(ctx) is Some(group) else { return (@cmd.none, state) }
-  let key = state.next_key
+  let key = @uuid.mint()
   let tab : Tab = {
     key,
     id: None,
@@ -42,12 +42,7 @@ fn open_new_tab(
     workspace_path: ctx.placement.bind(placement => placement.project_root()),
     status: TabOpening,
   }
-  let state = {
-    ..state,
-    next_key: key + 1,
-    tabs: state.tabs + [tab],
-    shown: Some(key),
-  }
+  let state = { ..state, tabs: state.tabs + [tab], shown: Some(key), }
   (
     @cmd.batch([terminal_resizer.mount(), mount_tab(dispatch, key)]),
     state.remember_active(group, key),
@@ -59,7 +54,7 @@ fn open_new_tab(
 /// the panel with it: an open panel over an empty group would immediately
 /// respawn a shell (see `sync`), which must not happen when the user
 /// deliberately ended the last one.
-fn drop_tab(state : State, ctx : Ctx, key : Int) -> (Array[@cmd.Cmd], State) {
+fn drop_tab(state : State, ctx : Ctx, key : String) -> (Array[@cmd.Cmd], State) {
   let cmds = [dispose_tab(key)]
   let state = {
     ..state,
@@ -83,7 +78,7 @@ fn State::retire_missing_session(
   self : State,
   ctx : Ctx,
 ) -> (Array[@cmd.Cmd], State) {
-  let retired : Array[Int] = []
+  let retired : Array[String] = []
   let commands : Array[@cmd.Cmd] = []
   for tab in self.tabs {
     if tab.workspace.channel() == ctx.channel && tab.session == ctx.session {
@@ -112,14 +107,8 @@ pub fn State::handle(
   msg : Msg,
   input : Input,
 ) -> (@cmd.Cmd, State) {
-  // Replies queued by a retired connection cannot attach to a later PTY that
-  // happens to reuse the same numeric id.
-  let owner_live = match msg {
-    Opened(channel~, key=_, id=_) | SessionExited(channel~, id=_, code=_) =>
-      input.live_channels.contains(channel)
-    _ => true
-  }
-  guard owner_live else { return (@cmd.none, self) }
+  // Tab keys and terminal ids are UUIDs, so a delayed reply from a retired
+  // connection cannot attach itself to a later tab or PTY.
   update(dispatch, msg, self, input.ctx)
 }
 
@@ -221,26 +210,23 @@ fn update(
           tab.workspace.channel() == channel &&
           tab.status is TabOpening {
           let (cmds, state) = drop_tab(state, ctx, key)
-          cmds.push(drop_pending(channel, id))
+          cmds.push(drop_pending(id))
           (@cmd.batch(cmds), state)
         } else {
-          (drop_pending(channel, id), state)
+          (drop_pending(id), state)
         }
       } else if state.tab_by_key(key) is Some(tab) &&
         tab.workspace.channel() == channel &&
         tab.status is TabOpening {
         (
-          flush_pending(channel, key, id),
+          flush_pending(key, id),
           state.replace_tab({ ..tab, id: Some(id), status: TabRunning, }),
         )
       } else {
         // The tab was closed while the open was in flight; the session
         // belongs to nobody, so retire it on the host connection that opened
         // it, even if another device is focused now.
-        (
-          @cmd.batch([send_close(channel, id), drop_pending(channel, id)]),
-          state,
-        )
+        (@cmd.batch([send_close(channel, id), drop_pending(id)]), state)
       }
     }
     OpenFailed(key~, message~) =>
@@ -285,7 +271,7 @@ fn update(
         (@cmd.none, state)
       }
     SessionExited(channel~, id~, code=_) =>
-      match state.tab_by_id(channel, id) {
+      match state.tab_by_id(id) {
         // The shell ended (Ctrl+D, `exit`, or a crash): its tab retires,
         // and the visible group's last tab takes the panel with it.
         Some(tab) => {
@@ -300,7 +286,7 @@ fn update(
             }) {
             let owner = (channel, id)
             (
-              drop_pending(channel, id),
+              drop_pending(id),
               if state.exited_before_open.contains(owner) {
                 state
               } else {
@@ -311,21 +297,19 @@ fn update(
               },
             )
           } else {
-            (drop_pending(channel, id), state)
+            (drop_pending(id), state)
           }
       }
   }
 }
 
 ///|
-/// Retire all tabs owned by one dead connection. Terminal ids cannot survive a
-/// WebSocket reconnect: the host tears down the old connection's PTYs before
-/// the browser dials again. UUIDs do not replace connection ownership: model
-/// lookup and the imperative pre-open buffer retain `(channel, id)` so only
-/// the disconnected channel's state is removed.
+/// Retire all tabs owned by one dead connection. The host tears down that
+/// connection's PTYs before the browser dials again; UUID identities make
+/// delayed lifecycle messages unable to match replacement tabs.
 fn disconnect(state : State, channel : @interop.ChannelId) -> (@cmd.Cmd, State) {
   let commands : Array[@cmd.Cmd] = [term_host.clear_pending(channel)]
-  let retired_keys : Array[Int] = []
+  let retired_keys : Array[String] = []
   for tab in state.tabs {
     if tab.workspace.channel() == channel {
       retired_keys.push(tab.key)

--- a/desktop/frontend/terminal/update.mbt
+++ b/desktop/frontend/terminal/update.mbt
@@ -320,9 +320,9 @@ fn update(
 ///|
 /// Retire all tabs owned by one dead connection. Terminal ids cannot survive a
 /// WebSocket reconnect: the host tears down the old connection's PTYs before
-/// the browser dials again. Keeping another channel's same-numbered tab is
-/// safe because both model lookup and the imperative pre-open buffer use the
-/// `(channel, id)` pair.
+/// the browser dials again. UUIDs do not replace connection ownership: model
+/// lookup and the imperative pre-open buffer retain `(channel, id)` so only
+/// the disconnected channel's state is removed.
 fn disconnect(state : State, channel : @interop.ChannelId) -> (@cmd.Cmd, State) {
   let commands : Array[@cmd.Cmd] = [term_host.clear_pending(channel)]
   let retired_keys : Array[Int] = []

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -18065,7 +18065,7 @@ fn desktop_model() -> Model {
   let model = { ..test_model(), is_desktop: true, }
   let (_, model) = update(
     test_dispatch(),
-    Terminal(@terminal.TabSelected(key=0)),
+    Terminal(@terminal.TabSelected(key="missing-tab")),
     model,
   )
   model

--- a/desktop/internal/host/terminal_ops.mbt
+++ b/desktop/internal/host/terminal_ops.mbt
@@ -1,7 +1,6 @@
 // The integrated terminal's transport-independent host ops. PTY output stays
 // byte-transparent across JSON by using base64; each emitted chunk also has a
-// per-session sequence so a client can retry an acknowledgement safely. The
-// host mints each session id as a UUID; ordering remains the sequence's job.
+// per-session sequence so a client can retry an acknowledgement safely.
 
 ///|
 type TerminalOpenPayload = @protocol.TerminalOpenPayload

--- a/desktop/internal/host/terminal_ops.mbt
+++ b/desktop/internal/host/terminal_ops.mbt
@@ -1,6 +1,7 @@
 // The integrated terminal's transport-independent host ops. PTY output stays
 // byte-transparent across JSON by using base64; each emitted chunk also has a
-// per-session sequence so a client can retry an acknowledgement safely.
+// per-session sequence so a client can retry an acknowledgement safely. The
+// host mints each session id as a UUID; ordering remains the sequence's job.
 
 ///|
 type TerminalOpenPayload = @protocol.TerminalOpenPayload
@@ -36,14 +37,14 @@ type TerminalClosePayload = @protocol.TerminalClosePayload
 
 ///|
 priv struct TerminalOutputPayload {
-  id : Int
+  id : String
   sequence : Int
   data : String
 }
 
 ///|
 priv struct TerminalExitPayload {
-  id : Int
+  id : String
   code : Int
 }
 

--- a/desktop/internal/host/terminal_ops.mbt
+++ b/desktop/internal/host/terminal_ops.mbt
@@ -1,6 +1,7 @@
 // The integrated terminal's transport-independent host ops. PTY output stays
 // byte-transparent across JSON by using base64; each emitted chunk also has a
-// per-session sequence so a client can retry an acknowledgement safely.
+// per-session sequence so a later acknowledgement can cumulatively cover an
+// earlier request that did not reach the host.
 
 ///|
 type TerminalOpenPayload = @protocol.TerminalOpenPayload

--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -590,6 +590,8 @@ pub(all) struct TerminalOpenPayload {
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
+/// Terminal input is a wire union: text carries `data`, byte-oriented input
+/// carries `data_base64`, and the inactive field is absent rather than null.
 pub(all) struct TerminalInputPayload {
   id : String
   data : String?
@@ -597,8 +599,6 @@ pub(all) struct TerminalInputPayload {
 } derive(Debug, Eq)
 
 ///|
-/// Terminal input is a wire union: text carries `data`, byte-oriented input
-/// carries `data_base64`, and the inactive field is omitted rather than null.
 pub impl FromJson for TerminalInputPayload with fn from_json(json, path) {
   let object = JsonObject::decode(json, path, "terminal input payload")
   let data = object.optional_string("data")

--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -591,28 +591,97 @@ pub(all) struct TerminalOpenPayload {
 
 ///|
 pub(all) struct TerminalInputPayload {
-  id : Int
+  id : String
   data : String?
   data_base64 : String?
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(Debug, Eq)
+
+///|
+/// Terminal input is a wire union: text carries `data`, byte-oriented input
+/// carries `data_base64`, and the inactive field is omitted rather than null.
+pub impl FromJson for TerminalInputPayload with fn from_json(json, path) {
+  let object = JsonObject::decode(json, path, "terminal input payload")
+  let data = object.optional_string("data")
+  let data_base64 = object.optional_string("data_base64")
+  match (data, data_base64) {
+    (Some(_), None) | (None, Some(_)) => ()
+    _ =>
+      raise JsonDecodeError(
+        (path, "exactly one of data and data_base64 must be present"),
+      )
+  }
+  { id: object.required_string("id"), data, data_base64, }
+}
+
+///|
+pub impl ToJson for TerminalInputPayload with fn to_json(self) {
+  let fields : Map[String, Json] = { "id": self.id.to_json() }
+  if self.data is Some(data) {
+    fields["data"] = data.to_json()
+  }
+  if self.data_base64 is Some(data_base64) {
+    fields["data_base64"] = data_base64.to_json()
+  }
+  Json::object(fields)
+}
 
 ///|
 pub(all) struct TerminalResizePayload {
-  id : Int
+  id : String
   cols : Int
   rows : Int
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(Debug, Eq)
+
+///|
+pub impl FromJson for TerminalResizePayload with fn from_json(json, path) {
+  let object = JsonObject::decode(json, path, "terminal resize payload")
+  {
+    id: object.required_string("id"),
+    cols: object.required_int("cols"),
+    rows: object.required_int("rows"),
+  }
+}
+
+///|
+pub impl ToJson for TerminalResizePayload with fn to_json(self) {
+  { "id": self.id, "cols": self.cols, "rows": self.rows }
+}
 
 ///|
 pub(all) struct TerminalAckPayload {
-  id : Int
+  id : String
   sequence : Int
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(Debug, Eq)
+
+///|
+pub impl FromJson for TerminalAckPayload with fn from_json(json, path) {
+  let object = JsonObject::decode(json, path, "terminal ack payload")
+  {
+    id: object.required_string("id"),
+    sequence: object.required_int("sequence"),
+  }
+}
+
+///|
+pub impl ToJson for TerminalAckPayload with fn to_json(self) {
+  { "id": self.id, "sequence": self.sequence }
+}
 
 ///|
 pub(all) struct TerminalClosePayload {
-  id : Int
-} derive(Debug, Eq, FromJson, ToJson)
+  id : String
+} derive(Debug, Eq)
+
+///|
+pub impl FromJson for TerminalClosePayload with fn from_json(json, path) {
+  let object = JsonObject::decode(json, path, "terminal close payload")
+  { id: object.required_string("id"), }
+}
+
+///|
+pub impl ToJson for TerminalClosePayload with fn to_json(self) {
+  { "id": self.id }
+}
 
 ///|
 pub(all) struct LspOpenPayload {
@@ -1149,16 +1218,42 @@ pub(all) struct FsWatchFailedPayload {
 
 ///|
 pub(all) struct TerminalOutputPayload {
-  id : Int
+  id : String
   sequence : Int
   data : String
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(Debug, Eq)
+
+///|
+pub impl FromJson for TerminalOutputPayload with fn from_json(json, path) {
+  let object = JsonObject::decode(json, path, "terminal output payload")
+  {
+    id: object.required_string("id"),
+    sequence: object.required_int("sequence"),
+    data: object.required_string("data"),
+  }
+}
+
+///|
+pub impl ToJson for TerminalOutputPayload with fn to_json(self) {
+  { "id": self.id, "sequence": self.sequence, "data": self.data }
+}
 
 ///|
 pub(all) struct TerminalExitPayload {
-  id : Int
+  id : String
   code : Int
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(Debug, Eq)
+
+///|
+pub impl FromJson for TerminalExitPayload with fn from_json(json, path) {
+  let object = JsonObject::decode(json, path, "terminal exit payload")
+  { id: object.required_string("id"), code: object.required_int("code"), }
+}
+
+///|
+pub impl ToJson for TerminalExitPayload with fn to_json(self) {
+  { "id": self.id, "code": self.code }
+}
 
 ///|
 pub extend AgentErrorPayload with Debug::{to_repr}

--- a/desktop/internal/protocol/desktop_replies.mbt
+++ b/desktop/internal/protocol/desktop_replies.mbt
@@ -1526,8 +1526,10 @@ pub(all) struct TerminalOpenReply {
 
 ///|
 pub impl FromJson for TerminalOpenReply with fn from_json(json, path) {
-  let object = JsonObject::decode(json, path, "terminal open reply")
-  { id: object.required_string("id"), }
+  guard json is Object(fields) && fields.get("id") is Some(String(id)) else {
+    raise JsonDecodeError((path, "expected terminal open reply"))
+  }
+  { id, }
 }
 
 ///|

--- a/desktop/internal/protocol/desktop_replies.mbt
+++ b/desktop/internal/protocol/desktop_replies.mbt
@@ -1521,8 +1521,19 @@ pub impl FromJson for BrowseDirectoryReply with fn from_json(json, path) {
 
 ///|
 pub(all) struct TerminalOpenReply {
-  id : Int
-} derive(Debug, Eq, FromJson, ToJson)
+  id : String
+} derive(Debug, Eq)
+
+///|
+pub impl FromJson for TerminalOpenReply with fn from_json(json, path) {
+  let object = JsonObject::decode(json, path, "terminal open reply")
+  { id: object.required_string("id"), }
+}
+
+///|
+pub impl ToJson for TerminalOpenReply with fn to_json(self) {
+  { "id": self.id }
+}
 
 ///|
 pub(all) struct MoonIdeLocation {

--- a/desktop/internal/protocol/desktop_replies_test.mbt
+++ b/desktop/internal/protocol/desktop_replies_test.mbt
@@ -1409,6 +1409,179 @@ test "a reconnect settlement is refused unless it names run, session and outcome
 }
 
 ///|
+test "terminal input encodes one data arm and rejects malformed identities" {
+  let text : @protocol.TerminalInputPayload = {
+    id: "terminal-text",
+    data: Some("ls\n"),
+    data_base64: None,
+  }
+  @debug.assert_eq(text.to_json(), { "id": "terminal-text", "data": "ls\n" })
+  let decoded_text : @protocol.TerminalInputPayload = @json.from_json(
+    text.to_json(),
+  )
+  assert_eq(decoded_text, text)
+  let binary : @protocol.TerminalInputPayload = {
+    id: "terminal-binary",
+    data: None,
+    data_base64: Some("AA=="),
+  }
+  @debug.assert_eq(binary.to_json(), {
+    "id": "terminal-binary",
+    "data_base64": "AA==",
+  })
+  let decoded_binary : @protocol.TerminalInputPayload = @json.from_json(
+    binary.to_json(),
+  )
+  assert_eq(decoded_binary, binary)
+  for
+    invalid in (
+      [
+        { "data": "x" },
+        { "id": null, "data": "x" },
+        { "id": 7, "data": "x" },
+        { "id": "terminal-empty" },
+        { "id": "terminal-empty", "data": null, "data_base64": null },
+        { "id": "terminal-both", "data": "x", "data_base64": "eA==" },
+      ] : Array[Json]) {
+    let rejected = try {
+      let _ : @protocol.TerminalInputPayload = @json.from_json(invalid)
+      false
+    } catch {
+      _ => true
+    }
+    assert_true(rejected)
+  }
+}
+
+///|
+test "terminal command payloads require a string id and integer arguments" {
+  let resize : @protocol.TerminalResizePayload = {
+    id: "terminal-resize",
+    cols: 120,
+    rows: 40,
+  }
+  let decoded_resize : @protocol.TerminalResizePayload = @json.from_json(
+    resize.to_json(),
+  )
+  assert_eq(decoded_resize, resize)
+  let ack : @protocol.TerminalAckPayload = { id: "terminal-ack", sequence: 3, }
+  let decoded_ack : @protocol.TerminalAckPayload = @json.from_json(
+    ack.to_json(),
+  )
+  assert_eq(decoded_ack, ack)
+  let close : @protocol.TerminalClosePayload = { id: "terminal-close", }
+  let decoded_close : @protocol.TerminalClosePayload = @json.from_json(
+    close.to_json(),
+  )
+  assert_eq(decoded_close, close)
+  for
+    invalid in (
+      [
+        { "id": 7, "cols": 120, "rows": 40 },
+        { "id": "terminal-resize", "rows": 40 },
+        { "id": "terminal-resize", "cols": "120", "rows": 40 },
+      ] : Array[Json]) {
+    let rejected = try {
+      let _ : @protocol.TerminalResizePayload = @json.from_json(invalid)
+      false
+    } catch {
+      _ => true
+    }
+    assert_true(rejected)
+  }
+  for
+    invalid in (
+      [
+        { "sequence": 3 },
+        { "id": null, "sequence": 3 },
+        { "id": "terminal-ack", "sequence": "3" },
+      ] : Array[Json]) {
+    let rejected = try {
+      let _ : @protocol.TerminalAckPayload = @json.from_json(invalid)
+      false
+    } catch {
+      _ => true
+    }
+    assert_true(rejected)
+  }
+  for
+    invalid in (
+      [Json::empty_object(), { "id": null }, { "id": 7 }] : Array[Json]) {
+    let rejected = try {
+      let _ : @protocol.TerminalClosePayload = @json.from_json(invalid)
+      false
+    } catch {
+      _ => true
+    }
+    assert_true(rejected)
+  }
+}
+
+///|
+test "terminal replies and notifications require their complete wire shape" {
+  let opened : @protocol.TerminalOpenReply = { id: "terminal-open", }
+  let decoded_opened : @protocol.TerminalOpenReply = @json.from_json(
+    opened.to_json(),
+  )
+  assert_eq(decoded_opened, opened)
+  let output : @protocol.TerminalOutputPayload = {
+    id: "terminal-output",
+    sequence: 4,
+    data: "cHR5",
+  }
+  let decoded_output : @protocol.TerminalOutputPayload = @json.from_json(
+    output.to_json(),
+  )
+  assert_eq(decoded_output, output)
+  let exited : @protocol.TerminalExitPayload = { id: "terminal-exit", code: 0, }
+  let decoded_exited : @protocol.TerminalExitPayload = @json.from_json(
+    exited.to_json(),
+  )
+  assert_eq(decoded_exited, exited)
+  for
+    invalid in (
+      [Json::empty_object(), { "id": null }, { "id": 7 }] : Array[Json]) {
+    let rejected = try {
+      let _ : @protocol.TerminalOpenReply = @json.from_json(invalid)
+      false
+    } catch {
+      _ => true
+    }
+    assert_true(rejected)
+  }
+  for
+    invalid in (
+      [
+        { "id": 7, "sequence": 4, "data": "cHR5" },
+        { "id": "terminal-output", "sequence": 4 },
+        { "id": "terminal-output", "sequence": null, "data": "cHR5" },
+      ] : Array[Json]) {
+    let rejected = try {
+      let _ : @protocol.TerminalOutputPayload = @json.from_json(invalid)
+      false
+    } catch {
+      _ => true
+    }
+    assert_true(rejected)
+  }
+  for
+    invalid in (
+      [
+        { "id": 7, "code": 0 },
+        { "id": "terminal-exit" },
+        { "id": "terminal-exit", "code": "0" },
+      ] : Array[Json]) {
+    let rejected = try {
+      let _ : @protocol.TerminalExitPayload = @json.from_json(invalid)
+      false
+    } catch {
+      _ => true
+    }
+    assert_true(rejected)
+  }
+}
+
+///|
 test "file stats keep missing, present, and failed distinct on the wire" {
   let reply : @protocol.StatFilesReply = {
     stats: [

--- a/desktop/internal/protocol/desktop_replies_test.mbt
+++ b/desktop/internal/protocol/desktop_replies_test.mbt
@@ -1409,24 +1409,24 @@ test "a reconnect settlement is refused unless it names run, session and outcome
 }
 
 ///|
-test "terminal input encodes one data arm and rejects malformed identities" {
+test "terminal input encodes and decodes exactly one data field" {
   let text : @protocol.TerminalInputPayload = {
-    id: "terminal-text",
+    id: "terminal-7",
     data: Some("ls\n"),
     data_base64: None,
   }
-  @debug.assert_eq(text.to_json(), { "id": "terminal-text", "data": "ls\n" })
+  @debug.assert_eq(text.to_json(), { "id": "terminal-7", "data": "ls\n" })
   let decoded_text : @protocol.TerminalInputPayload = @json.from_json(
     text.to_json(),
   )
   assert_eq(decoded_text, text)
   let binary : @protocol.TerminalInputPayload = {
-    id: "terminal-binary",
+    id: "terminal-8",
     data: None,
     data_base64: Some("AA=="),
   }
   @debug.assert_eq(binary.to_json(), {
-    "id": "terminal-binary",
+    "id": "terminal-8",
     "data_base64": "AA==",
   })
   let decoded_binary : @protocol.TerminalInputPayload = @json.from_json(
@@ -1436,146 +1436,16 @@ test "terminal input encodes one data arm and rejects malformed identities" {
   for
     invalid in (
       [
-        { "data": "x" },
-        { "id": null, "data": "x" },
-        { "id": 7, "data": "x" },
-        { "id": "terminal-empty" },
-        { "id": "terminal-empty", "data": null, "data_base64": null },
-        { "id": "terminal-both", "data": "x", "data_base64": "eA==" },
+        { "id": "terminal-9" },
+        { "id": "terminal-9", "data": null, "data_base64": null },
+        { "id": "terminal-9", "data": "x", "data_base64": "eA==" },
       ] : Array[Json]) {
     let rejected = try {
       let _ : @protocol.TerminalInputPayload = @json.from_json(invalid)
-      false
     } catch {
       _ => true
-    }
-    assert_true(rejected)
-  }
-}
-
-///|
-test "terminal command payloads require a string id and integer arguments" {
-  let resize : @protocol.TerminalResizePayload = {
-    id: "terminal-resize",
-    cols: 120,
-    rows: 40,
-  }
-  let decoded_resize : @protocol.TerminalResizePayload = @json.from_json(
-    resize.to_json(),
-  )
-  assert_eq(decoded_resize, resize)
-  let ack : @protocol.TerminalAckPayload = { id: "terminal-ack", sequence: 3, }
-  let decoded_ack : @protocol.TerminalAckPayload = @json.from_json(
-    ack.to_json(),
-  )
-  assert_eq(decoded_ack, ack)
-  let close : @protocol.TerminalClosePayload = { id: "terminal-close", }
-  let decoded_close : @protocol.TerminalClosePayload = @json.from_json(
-    close.to_json(),
-  )
-  assert_eq(decoded_close, close)
-  for
-    invalid in (
-      [
-        { "id": 7, "cols": 120, "rows": 40 },
-        { "id": "terminal-resize", "rows": 40 },
-        { "id": "terminal-resize", "cols": "120", "rows": 40 },
-      ] : Array[Json]) {
-    let rejected = try {
-      let _ : @protocol.TerminalResizePayload = @json.from_json(invalid)
-      false
-    } catch {
-      _ => true
-    }
-    assert_true(rejected)
-  }
-  for
-    invalid in (
-      [
-        { "sequence": 3 },
-        { "id": null, "sequence": 3 },
-        { "id": "terminal-ack", "sequence": "3" },
-      ] : Array[Json]) {
-    let rejected = try {
-      let _ : @protocol.TerminalAckPayload = @json.from_json(invalid)
-      false
-    } catch {
-      _ => true
-    }
-    assert_true(rejected)
-  }
-  for
-    invalid in (
-      [Json::empty_object(), { "id": null }, { "id": 7 }] : Array[Json]) {
-    let rejected = try {
-      let _ : @protocol.TerminalClosePayload = @json.from_json(invalid)
-      false
-    } catch {
-      _ => true
-    }
-    assert_true(rejected)
-  }
-}
-
-///|
-test "terminal replies and notifications require their complete wire shape" {
-  let opened : @protocol.TerminalOpenReply = { id: "terminal-open", }
-  let decoded_opened : @protocol.TerminalOpenReply = @json.from_json(
-    opened.to_json(),
-  )
-  assert_eq(decoded_opened, opened)
-  let output : @protocol.TerminalOutputPayload = {
-    id: "terminal-output",
-    sequence: 4,
-    data: "cHR5",
-  }
-  let decoded_output : @protocol.TerminalOutputPayload = @json.from_json(
-    output.to_json(),
-  )
-  assert_eq(decoded_output, output)
-  let exited : @protocol.TerminalExitPayload = { id: "terminal-exit", code: 0, }
-  let decoded_exited : @protocol.TerminalExitPayload = @json.from_json(
-    exited.to_json(),
-  )
-  assert_eq(decoded_exited, exited)
-  for
-    invalid in (
-      [Json::empty_object(), { "id": null }, { "id": 7 }] : Array[Json]) {
-    let rejected = try {
-      let _ : @protocol.TerminalOpenReply = @json.from_json(invalid)
-      false
-    } catch {
-      _ => true
-    }
-    assert_true(rejected)
-  }
-  for
-    invalid in (
-      [
-        { "id": 7, "sequence": 4, "data": "cHR5" },
-        { "id": "terminal-output", "sequence": 4 },
-        { "id": "terminal-output", "sequence": null, "data": "cHR5" },
-      ] : Array[Json]) {
-    let rejected = try {
-      let _ : @protocol.TerminalOutputPayload = @json.from_json(invalid)
-      false
-    } catch {
-      _ => true
-    }
-    assert_true(rejected)
-  }
-  for
-    invalid in (
-      [
-        { "id": 7, "code": 0 },
-        { "id": "terminal-exit" },
-        { "id": "terminal-exit", "code": "0" },
-      ] : Array[Json]) {
-    let rejected = try {
-      let _ : @protocol.TerminalExitPayload = @json.from_json(invalid)
-      false
-    } catch {
-      _ => true
+    } noraise {
+      _ => false
     }
     assert_true(rejected)
   }

--- a/desktop/internal/protocol/desktop_transport.mbt
+++ b/desktop/internal/protocol/desktop_transport.mbt
@@ -289,10 +289,13 @@ pub fn Notification::params(self : Notification) -> Json {
 
 ///|
 test "desktop notifications round-trip at the wire edge" {
-  let event = Notification::from_wire("terminal.exit", { "id": 1, "code": 0 })
+  let event = Notification::from_wire("terminal.exit", {
+    "id": "terminal-fixture",
+    "code": 0,
+  })
   guard event is Some(event) else { fail("known notification was rejected") }
   assert_eq(event.wire_name(), "terminal.exit")
-  assert_eq(event.params(), { "id": 1, "code": 0 })
+  assert_eq(event.params(), { "id": "terminal-fixture", "code": 0 })
   let settings = Notification::from_wire("workspace.settings_changed", {
     "workspace": "/home/u/proj",
     "worktree_mode": true,

--- a/desktop/internal/protocol/desktop_transport.mbt
+++ b/desktop/internal/protocol/desktop_transport.mbt
@@ -290,12 +290,12 @@ pub fn Notification::params(self : Notification) -> Json {
 ///|
 test "desktop notifications round-trip at the wire edge" {
   let event = Notification::from_wire("terminal.exit", {
-    "id": "terminal-fixture",
+    "id": "terminal-1",
     "code": 0,
   })
   guard event is Some(event) else { fail("known notification was rejected") }
   assert_eq(event.wire_name(), "terminal.exit")
-  assert_eq(event.params(), { "id": "terminal-fixture", "code": 0 })
+  assert_eq(event.params(), { "id": "terminal-1", "code": 0 })
   let settings = Notification::from_wire("workspace.settings_changed", {
     "workspace": "/home/u/proj",
     "worktree_mode": true,

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -2178,44 +2178,52 @@ pub fn SymbolRange::to_json(Self) -> Json
 pub fn SymbolRange::to_repr(Self) -> @debug.Repr
 
 pub(all) struct TerminalAckPayload {
-  id : Int
+  id : String
   sequence : Int
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+} derive(Eq, @debug.Debug)
 pub fn TerminalAckPayload::equal(Self, Self) -> Bool
 pub fn TerminalAckPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn TerminalAckPayload::not_equal(Self, Self) -> Bool
 pub fn TerminalAckPayload::to_json(Self) -> Json
 pub fn TerminalAckPayload::to_repr(Self) -> @debug.Repr
+pub impl ToJson for TerminalAckPayload
+pub impl @json.FromJson for TerminalAckPayload
 
 pub(all) struct TerminalClosePayload {
-  id : Int
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+  id : String
+} derive(Eq, @debug.Debug)
 pub fn TerminalClosePayload::equal(Self, Self) -> Bool
 pub fn TerminalClosePayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn TerminalClosePayload::not_equal(Self, Self) -> Bool
 pub fn TerminalClosePayload::to_json(Self) -> Json
 pub fn TerminalClosePayload::to_repr(Self) -> @debug.Repr
+pub impl ToJson for TerminalClosePayload
+pub impl @json.FromJson for TerminalClosePayload
 
 pub(all) struct TerminalExitPayload {
-  id : Int
+  id : String
   code : Int
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+} derive(Eq, @debug.Debug)
 pub fn TerminalExitPayload::equal(Self, Self) -> Bool
 pub fn TerminalExitPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn TerminalExitPayload::not_equal(Self, Self) -> Bool
 pub fn TerminalExitPayload::to_json(Self) -> Json
 pub fn TerminalExitPayload::to_repr(Self) -> @debug.Repr
+pub impl ToJson for TerminalExitPayload
+pub impl @json.FromJson for TerminalExitPayload
 
 pub(all) struct TerminalInputPayload {
-  id : Int
+  id : String
   data : String?
   data_base64 : String?
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+} derive(Eq, @debug.Debug)
 pub fn TerminalInputPayload::equal(Self, Self) -> Bool
 pub fn TerminalInputPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn TerminalInputPayload::not_equal(Self, Self) -> Bool
 pub fn TerminalInputPayload::to_json(Self) -> Json
 pub fn TerminalInputPayload::to_repr(Self) -> @debug.Repr
+pub impl ToJson for TerminalInputPayload
+pub impl @json.FromJson for TerminalInputPayload
 
 pub(all) struct TerminalOpenPayload {
   session : String
@@ -2230,35 +2238,41 @@ pub fn TerminalOpenPayload::to_json(Self) -> Json
 pub fn TerminalOpenPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct TerminalOpenReply {
-  id : Int
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+  id : String
+} derive(Eq, @debug.Debug)
 pub fn TerminalOpenReply::equal(Self, Self) -> Bool
 pub fn TerminalOpenReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn TerminalOpenReply::not_equal(Self, Self) -> Bool
 pub fn TerminalOpenReply::to_json(Self) -> Json
 pub fn TerminalOpenReply::to_repr(Self) -> @debug.Repr
+pub impl ToJson for TerminalOpenReply
+pub impl @json.FromJson for TerminalOpenReply
 
 pub(all) struct TerminalOutputPayload {
-  id : Int
+  id : String
   sequence : Int
   data : String
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+} derive(Eq, @debug.Debug)
 pub fn TerminalOutputPayload::equal(Self, Self) -> Bool
 pub fn TerminalOutputPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn TerminalOutputPayload::not_equal(Self, Self) -> Bool
 pub fn TerminalOutputPayload::to_json(Self) -> Json
 pub fn TerminalOutputPayload::to_repr(Self) -> @debug.Repr
+pub impl ToJson for TerminalOutputPayload
+pub impl @json.FromJson for TerminalOutputPayload
 
 pub(all) struct TerminalResizePayload {
-  id : Int
+  id : String
   cols : Int
   rows : Int
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+} derive(Eq, @debug.Debug)
 pub fn TerminalResizePayload::equal(Self, Self) -> Bool
 pub fn TerminalResizePayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn TerminalResizePayload::not_equal(Self, Self) -> Bool
 pub fn TerminalResizePayload::to_json(Self) -> Json
 pub fn TerminalResizePayload::to_repr(Self) -> @debug.Repr
+pub impl ToJson for TerminalResizePayload
+pub impl @json.FromJson for TerminalResizePayload
 
 pub(all) struct TextSearchError {
   code : String

--- a/desktop/internal/terminal/moon.pkg
+++ b/desktop/internal/terminal/moon.pkg
@@ -5,6 +5,7 @@ import {
   "moonbitlang/async/cond_var",
   "moonbitlang/core/debug",
   "openseek_desktop/internal/env",
+  "openseek_desktop/internal/uuid",
   "tonyfettes/xlog",
 }
 

--- a/desktop/internal/terminal/moon.pkg
+++ b/desktop/internal/terminal/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "moonbit-community/pty",
   "moonbitlang/core/encoding/utf8",
+  "moonbitlang/core/deque",
   "moonbitlang/async",
   "moonbitlang/async/cond_var",
   "moonbitlang/core/debug",

--- a/desktop/internal/terminal/pkg.generated.mbti
+++ b/desktop/internal/terminal/pkg.generated.mbti
@@ -2,21 +2,21 @@
 package "openseek_desktop/internal/terminal"
 
 // Values
-pub fn ack_terminal(TerminalState, id~ : Int, sequence~ : Int) -> Unit
+pub fn ack_terminal(TerminalState, id~ : String, sequence~ : Int) -> Unit
 
 pub fn close_all_terminals(TerminalState) -> Unit
 
-pub fn close_terminal(TerminalState, id~ : Int) -> Unit
+pub fn close_terminal(TerminalState, id~ : String) -> Unit
 
 pub fn new_terminal_state() -> TerminalState
 
-pub async fn open_terminal(TerminalState, cwd~ : String, cols~ : Int, rows~ : Int, command? : Array[String]) -> Int
+pub async fn open_terminal(TerminalState, cwd~ : String, cols~ : Int, rows~ : Int, command? : Array[String]) -> String
 
-pub fn resize_terminal(TerminalState, id~ : Int, cols~ : Int, rows~ : Int) -> Unit raise
+pub fn resize_terminal(TerminalState, id~ : String, cols~ : Int, rows~ : Int) -> Unit raise
 
 pub async fn run_terminal_pump(TerminalState, async (TerminalPush) -> Unit) -> Unit
 
-pub async fn write_terminal(TerminalState, id~ : Int, Bytes) -> Unit
+pub async fn write_terminal(TerminalState, id~ : String, Bytes) -> Unit
 
 // Errors
 pub suberror TerminalError {
@@ -25,8 +25,8 @@ pub suberror TerminalError {
 
 // Types and methods
 pub(all) enum TerminalPush {
-  Output(id~ : Int, sequence~ : Int, data~ : Bytes)
-  Exited(id~ : Int, code~ : Int)
+  Output(id~ : String, sequence~ : Int, data~ : Bytes)
+  Exited(id~ : String, code~ : Int)
 }
 
 type TerminalState

--- a/desktop/internal/terminal/pump.mbt
+++ b/desktop/internal/terminal/pump.mbt
@@ -105,8 +105,7 @@ async fn run_session(
     }
     let session : TerminalSession = {
       pty,
-      unacked: 0,
-      unacked_chunks: Map([]),
+      output: { unacked: 0, chunks: Map([]), },
       next_output_sequence: 1,
       cond: Cond(),
       close_requested: Queue(kind=Blocking(1)),
@@ -144,10 +143,9 @@ async fn run_session(
         session.next_output_sequence = sequence + 1
         // Record the debt before emitting: the webview can acknowledge as soon
         // as it receives the event, including before this task resumes.
-        session.unacked_chunks[sequence] = n
-        session.unacked += n
+        session.output.record(sequence, n)
         emit(Output(id=request.id, sequence~, data=Bytes::from_array(buf[:n])))
-        while session.unacked >= HighWatermark && !session.closing {
+        while session.output.unacked >= HighWatermark && !session.closing {
           session.cond.wait()
         }
       }

--- a/desktop/internal/terminal/pump.mbt
+++ b/desktop/internal/terminal/pump.mbt
@@ -105,8 +105,7 @@ async fn run_session(
     }
     let session : TerminalSession = {
       pty,
-      output: { unacked: 0, chunks: Map([]), },
-      next_output_sequence: 1,
+      output: { unacked: 0, chunks: Deque([]), next_sequence: 1, },
       cond: Cond(),
       close_requested: Queue(kind=Blocking(1)),
       closing: false,
@@ -139,11 +138,9 @@ async fn run_session(
         if n <= 0 {
           break
         }
-        let sequence = session.next_output_sequence
-        session.next_output_sequence = sequence + 1
         // Record the debt before emitting: the webview can acknowledge as soon
         // as it receives the event, including before this task resumes.
-        session.output.record(sequence, n)
+        let sequence = session.output.record(n)
         emit(Output(id=request.id, sequence~, data=Bytes::from_array(buf[:n])))
         while session.output.unacked >= HighWatermark && !session.closing {
           session.cond.wait()

--- a/desktop/internal/terminal/terminal.mbt
+++ b/desktop/internal/terminal/terminal.mbt
@@ -113,9 +113,6 @@ pub async fn open_terminal(
 ) -> String {
   guard !state.closed else { raise TerminalError("terminal service is closed") }
   let argv = session_argv(command?)
-  // Session ids cross the host/frontend boundary and may outlive a page
-  // connection in delayed messages, so mint a fresh identity instead of
-  // reusing a connection-local counter value.
   guard @uuid.mint() is Some(id) else {
     raise TerminalError("could not create a terminal id")
   }

--- a/desktop/internal/terminal/terminal.mbt
+++ b/desktop/internal/terminal/terminal.mbt
@@ -26,8 +26,8 @@ pub(all) enum TerminalPush {
   /// `sequence` identifies this output chunk within one session. The webview
   /// echoes it in `terminal_ack`, making retries safe when a bridge response
   /// is lost after the host already applied the acknowledgement.
-  Output(id~ : Int, sequence~ : Int, data~ : Bytes)
-  Exited(id~ : Int, code~ : Int)
+  Output(id~ : String, sequence~ : Int, data~ : Bytes)
+  Exited(id~ : String, code~ : Int)
 }
 
 ///|
@@ -60,7 +60,7 @@ priv struct TerminalSession {
 
 ///|
 priv struct OpenRequest {
-  id : Int
+  id : String
   /// The page connection that submitted this request. A later connect
   /// handshake invalidates it even if the pump has already dequeued it.
   connection_generation : Int
@@ -78,8 +78,7 @@ priv struct OpenRequest {
 /// spawns, the table of live sessions, and the current page connection.
 struct TerminalState {
   requests : @async.Queue[OpenRequest]
-  sessions : Map[Int, TerminalSession]
-  mut next_id : Int
+  sessions : Map[String, TerminalSession]
   /// Once closed, this state cannot serve another connection. Page reconnects
   /// use `close_all_terminals` instead and leave the pump available.
   mut closed : Bool
@@ -93,7 +92,6 @@ pub fn new_terminal_state() -> TerminalState {
   {
     requests: Queue(kind=Unbounded),
     sessions: Map([]),
-    next_id: 1,
     closed: false,
     connection_generation: 0,
   }
@@ -112,11 +110,15 @@ pub async fn open_terminal(
   cols~ : Int,
   rows~ : Int,
   command? : Array[String],
-) -> Int {
+) -> String {
   guard !state.closed else { raise TerminalError("terminal service is closed") }
   let argv = session_argv(command?)
-  let id = state.next_id
-  state.next_id = id + 1
+  // Session ids cross the host/frontend boundary and may outlive a page
+  // connection in delayed messages, so mint a fresh identity instead of
+  // reusing a connection-local counter value.
+  guard @uuid.mint() is Some(id) else {
+    raise TerminalError("could not create a terminal id")
+  }
   let reply : @async.Queue[Result[Unit, String]] = Queue(kind=Blocking(1))
   state.requests.put({
     id,
@@ -140,7 +142,7 @@ pub async fn open_terminal(
 /// Write user input (already encoded as terminal input bytes) to a session.
 pub async fn write_terminal(
   state : TerminalState,
-  id~ : Int,
+  id~ : String,
   data : Bytes,
 ) -> Unit {
   guard state.sessions.get(id) is Some(session) else {
@@ -156,7 +158,7 @@ pub async fn write_terminal(
 /// Propagate a webview-side viewport change to the PTY.
 pub fn resize_terminal(
   state : TerminalState,
-  id~ : Int,
+  id~ : String,
   cols~ : Int,
   rows~ : Int,
 ) -> Unit raise {
@@ -172,7 +174,11 @@ pub fn resize_terminal(
 /// Acknowledge one output chunk the webview has finished rendering. A sequence
 /// is removed at most once, so retrying after a lost bridge response cannot
 /// double-release the flow-control window.
-pub fn ack_terminal(state : TerminalState, id~ : Int, sequence~ : Int) -> Unit {
+pub fn ack_terminal(
+  state : TerminalState,
+  id~ : String,
+  sequence~ : Int,
+) -> Unit {
   guard state.sessions.get(id) is Some(session) else { return }
   guard session.unacked_chunks.get(sequence) is Some(bytes) else { return }
   session.unacked_chunks.remove(sequence)
@@ -190,7 +196,7 @@ pub fn ack_terminal(state : TerminalState, id~ : Int, sequence~ : Int) -> Unit {
 /// output tasks together; the PTY then closes its controlling handle, allows a
 /// bounded graceful exit, and releases its native resources before `Exited`.
 /// Unknown ids are a no-op (already exited).
-pub fn close_terminal(state : TerminalState, id~ : Int) -> Unit {
+pub fn close_terminal(state : TerminalState, id~ : String) -> Unit {
   guard state.sessions.get(id) is Some(session) else { return }
   guard !session.closing else { return }
   session.closing = true

--- a/desktop/internal/terminal/terminal.mbt
+++ b/desktop/internal/terminal/terminal.mbt
@@ -43,18 +43,24 @@ const HighWatermark = 262144
 /// the client has not demonstrated it received.
 priv struct TerminalOutputWindow {
   mut unacked : Int
-  chunks : Map[Int, Int]
+  // Byte counts in sequence order. The first outstanding sequence is
+  // `next_sequence - chunks.length()`, so no sequence-to-size map is needed.
+  chunks : @deque.Deque[Int]
+  mut next_sequence : Int
 }
 
 ///|
-/// Record one emitted chunk before it becomes visible to the client.
+/// Record one emitted chunk before it becomes visible to the client and
+/// return its monotonically increasing sequence.
 fn TerminalOutputWindow::record(
   self : TerminalOutputWindow,
-  sequence : Int,
   bytes : Int,
-) -> Unit {
-  self.chunks[sequence] = bytes
+) -> Int {
+  let sequence = self.next_sequence
+  self.next_sequence += 1
+  self.chunks.push_back(bytes)
   self.unacked += bytes
+  sequence
 }
 
 ///|
@@ -64,22 +70,26 @@ fn TerminalOutputWindow::acknowledge_through(
   self : TerminalOutputWindow,
   sequence : Int,
 ) -> Bool {
-  guard self.chunks.get(sequence) is Some(_) else { return false }
-  for chunk in self.chunks.to_array() {
-    let (chunk_sequence, bytes) = chunk
-    if chunk_sequence <= sequence {
-      self.chunks.remove(chunk_sequence)
-      self.unacked -= bytes
-    }
+  let first_sequence = self.next_sequence - self.chunks.length()
+  let acknowledged_chunks = sequence - first_sequence + 1
+  guard acknowledged_chunks > 0 && acknowledged_chunks <= self.chunks.length() else {
+    return false
+  }
+  for bytes in self.chunks.drain(start=0, len=acknowledged_chunks) {
+    self.unacked -= bytes
   }
   self.unacked < HighWatermark
 }
 
 ///|
 test "a later terminal acknowledgement advances the output window" {
-  let window : TerminalOutputWindow = { unacked: 0, chunks: Map([]), }
+  let window : TerminalOutputWindow = {
+    unacked: 0,
+    chunks: Deque([]),
+    next_sequence: 1,
+  }
   for sequence in 1..<=16 {
-    window.record(sequence, 16384)
+    assert_eq(window.record(16384), sequence)
   }
   assert_eq(window.unacked, HighWatermark)
   // A successful acknowledgement before four missing tail requests frees
@@ -88,13 +98,13 @@ test "a later terminal acknowledgement advances the output window" {
   assert_true(window.acknowledge_through(12))
   assert_eq(window.unacked, 65536)
   assert_eq(window.chunks.length(), 4)
-  window.record(17, 16384)
+  assert_eq(window.record(16384), 17)
   assert_true(window.acknowledge_through(17))
   assert_eq(window.unacked, 0)
   assert_true(window.chunks.is_empty())
   // Duplicate and invented future acknowledgements cannot release anything.
   assert_false(window.acknowledge_through(17))
-  window.record(18, 16384)
+  assert_eq(window.record(16384), 18)
   assert_false(window.acknowledge_through(19))
   assert_eq(window.unacked, 16384)
 }
@@ -103,7 +113,6 @@ test "a later terminal acknowledgement advances the output window" {
 priv struct TerminalSession {
   pty : @pty.Pty
   output : TerminalOutputWindow
-  mut next_output_sequence : Int
   /// Wakes the session's read loop when acknowledgements drain the debt or
   /// the session starts closing.
   cond : @cond_var.Cond

--- a/desktop/internal/terminal/terminal.mbt
+++ b/desktop/internal/terminal/terminal.mbt
@@ -24,8 +24,8 @@ priv suberror TerminalPumpClosed {
 /// the session drained.
 pub(all) enum TerminalPush {
   /// `sequence` identifies this output chunk within one session. The webview
-  /// echoes it in `terminal_ack`, making retries safe when a bridge response
-  /// is lost after the host already applied the acknowledgement.
+  /// echoes the latest rendered value in `terminal_ack`; acknowledging a
+  /// sequence also acknowledges every earlier outstanding chunk.
   Output(id~ : String, sequence~ : Int, data~ : Bytes)
   Exited(id~ : String, code~ : Int)
 }
@@ -37,17 +37,72 @@ pub(all) enum TerminalPush {
 const HighWatermark = 262144
 
 ///|
-/// Resume reading once acknowledgements bring the debt below this.
-const LowWatermark = 65536
+/// Outstanding output for one terminal. Acknowledgements are cumulative so a
+/// later successful request covers earlier requests that did not reach the
+/// host. An unknown future sequence remains a no-op instead of releasing data
+/// the client has not demonstrated it received.
+priv struct TerminalOutputWindow {
+  mut unacked : Int
+  chunks : Map[Int, Int]
+}
+
+///|
+/// Record one emitted chunk before it becomes visible to the client.
+fn TerminalOutputWindow::record(
+  self : TerminalOutputWindow,
+  sequence : Int,
+  bytes : Int,
+) -> Unit {
+  self.chunks[sequence] = bytes
+  self.unacked += bytes
+}
+
+///|
+/// Release `sequence` and every earlier outstanding chunk. The result tells
+/// the blocked reader whether the bounded window has capacity again.
+fn TerminalOutputWindow::acknowledge_through(
+  self : TerminalOutputWindow,
+  sequence : Int,
+) -> Bool {
+  guard self.chunks.get(sequence) is Some(_) else { return false }
+  for chunk in self.chunks.to_array() {
+    let (chunk_sequence, bytes) = chunk
+    if chunk_sequence <= sequence {
+      self.chunks.remove(chunk_sequence)
+      self.unacked -= bytes
+    }
+  }
+  self.unacked < HighWatermark
+}
+
+///|
+test "a later terminal acknowledgement advances the output window" {
+  let window : TerminalOutputWindow = { unacked: 0, chunks: Map([]), }
+  for sequence in 1..<=16 {
+    window.record(sequence, 16384)
+  }
+  assert_eq(window.unacked, HighWatermark)
+  // A successful acknowledgement before four missing tail requests frees
+  // capacity immediately; the reader can emit another chunk whose later
+  // cumulative acknowledgement retires the whole missing suffix.
+  assert_true(window.acknowledge_through(12))
+  assert_eq(window.unacked, 65536)
+  assert_eq(window.chunks.length(), 4)
+  window.record(17, 16384)
+  assert_true(window.acknowledge_through(17))
+  assert_eq(window.unacked, 0)
+  assert_true(window.chunks.is_empty())
+  // Duplicate and invented future acknowledgements cannot release anything.
+  assert_false(window.acknowledge_through(17))
+  window.record(18, 16384)
+  assert_false(window.acknowledge_through(19))
+  assert_eq(window.unacked, 16384)
+}
 
 ///|
 priv struct TerminalSession {
   pty : @pty.Pty
-  /// Bytes emitted to the webview but not yet acknowledged.
-  mut unacked : Int
-  /// Each sequence remains here until its acknowledgement is applied. Removing
-  /// it exactly once makes a retried acknowledgement idempotent.
-  unacked_chunks : Map[Int, Int]
+  output : TerminalOutputWindow
   mut next_output_sequence : Int
   /// Wakes the session's read loop when acknowledgements drain the debt or
   /// the session starts closing.
@@ -168,22 +223,16 @@ pub fn resize_terminal(
 }
 
 ///|
-/// Acknowledge one output chunk the webview has finished rendering. A sequence
-/// is removed at most once, so retrying after a lost bridge response cannot
-/// double-release the flow-control window.
+/// Acknowledge every output chunk through the latest sequence the webview has
+/// rendered. A later acknowledgement covers an earlier request that failed to
+/// reach the host; duplicates and out-of-order older requests remain no-ops.
 pub fn ack_terminal(
   state : TerminalState,
   id~ : String,
   sequence~ : Int,
 ) -> Unit {
   guard state.sessions.get(id) is Some(session) else { return }
-  guard session.unacked_chunks.get(sequence) is Some(bytes) else { return }
-  session.unacked_chunks.remove(sequence)
-  session.unacked -= bytes
-  if session.unacked < 0 {
-    session.unacked = 0
-  }
-  if session.unacked < LowWatermark {
+  if session.output.acknowledge_through(sequence) {
     session.cond.signal()
   }
 }

--- a/desktop/internal/terminal/terminal_test.mbt
+++ b/desktop/internal/terminal/terminal_test.mbt
@@ -185,8 +185,8 @@ async test "close_all_terminals retires every live session" {
         }
       }
     })
-    let expected = [first, second]
     exited.sort()
+    let expected = [first, second]
     expected.sort()
     assert_eq(exited, expected)
   })

--- a/desktop/internal/terminal/terminal_test.mbt
+++ b/desktop/internal/terminal/terminal_test.mbt
@@ -177,7 +177,7 @@ async test "close_all_terminals retires every live session" {
     let first = @terminal.open_terminal(state, cwd=".", cols=80, rows=24)
     let second = @terminal.open_terminal(state, cwd=".", cols=80, rows=24)
     @terminal.close_all_terminals(state)
-    let exited : Array[Int] = []
+    let exited : Array[String] = []
     @async.with_timeout(5000, () => {
       while exited.length() < 2 {
         if pushes.get() is Exited(id~, ..) {
@@ -185,8 +185,10 @@ async test "close_all_terminals retires every live session" {
         }
       }
     })
+    let expected = [first, second]
     exited.sort()
-    assert_eq(exited, [first, second])
+    expected.sort()
+    assert_eq(exited, expected)
   })
 }
 
@@ -300,10 +302,10 @@ async test "duplicate acknowledgements release an output chunk only once" {
 test "ops on unknown terminal ids degrade cleanly" {
   let state = @terminal.new_terminal_state()
   // ack and close are fire-and-forget: an id that already exited is fine.
-  @terminal.ack_terminal(state, id=99, sequence=1)
-  @terminal.close_terminal(state, id=99)
+  @terminal.ack_terminal(state, id="missing-terminal", sequence=1)
+  @terminal.close_terminal(state, id="missing-terminal")
   let failed = try {
-    @terminal.resize_terminal(state, id=99, cols=80, rows=24)
+    @terminal.resize_terminal(state, id="missing-terminal", cols=80, rows=24)
     false
   } catch {
     @terminal.TerminalError(_) => true

--- a/desktop/internal/terminal/terminal_test.mbt
+++ b/desktop/internal/terminal/terminal_test.mbt
@@ -226,9 +226,8 @@ async test "close_all_terminals cancels queued opens from an older page" {
 }
 
 ///|
-/// A bridge timeout can make the webview retry an acknowledgement whose first
-/// request already reached the host. Repeating that sequence must not release
-/// any other chunks or wake the paused reader prematurely.
+/// A later successful acknowledgement must cover earlier output requests that
+/// did not reach the host and wake a reader stopped at the bounded window.
 ///
 /// Skipped: this deadlocks on the Linux CI runners often enough to red-line
 /// unrelated pull requests — 8 of the 40 main runs before 2026-08-08, on both
@@ -252,7 +251,7 @@ async test "close_all_terminals cancels queued opens from an older page" {
 /// 0.3.2 upgrade in #692, so that is not the trigger.
 #skip("deadlocks intermittently on Linux CI; see the note above")
 #cfg(not(platform="windows"))
-async test "duplicate acknowledgements release an output chunk only once" {
+async test "a cumulative acknowledgement resumes terminal output" {
   @async.with_task_group(group => {
     let state = @terminal.new_terminal_state()
     defer state.shutdown()
@@ -266,7 +265,7 @@ async test "duplicate acknowledgements release an output chunk only once" {
     let chunks : Array[(Int, Int)] = []
     let mut received = 0
     // Match the host's high watermark. Once this much output has arrived, the
-    // reader is parked until unique acknowledgements drain below its low mark.
+    // reader is parked until an acknowledgement makes window capacity.
     while received < 262144 {
       match pushes.get() {
         Output(id=output_id, sequence~, data~) =>
@@ -280,17 +279,10 @@ async test "duplicate acknowledgements release an output chunk only once" {
           )
       }
     }
-    guard chunks.get(0) is Some(first) else {
+    guard chunks.last() is Some(last) else {
       fail("terminal produced no output chunks")
     }
-    for _ in 0..<32 {
-      @terminal.ack_terminal(state, id~, sequence=first.0)
-    }
-    let prematurely_resumed = @async.with_timeout_opt(500, () => pushes.get())
-    assert_true(prematurely_resumed is None)
-    for chunk in chunks {
-      @terminal.ack_terminal(state, id~, sequence=chunk.0)
-    }
+    @terminal.ack_terminal(state, id~, sequence=last.0)
     let resumed = @async.with_timeout_opt(5000, () => pushes.get())
     assert_true(resumed is Some(Output(id=output_id, ..)) && output_id == id)
     @terminal.close_terminal(state, id~)

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -531,19 +531,19 @@ solely for a detected development layout.
 
 ### terminal.* — connection-scoped PTYs
 
-Each terminal session receives a freshly minted UUID. A client connection owns
-the PTYs it opens: output returns only to that connection, and closing the
-desktop page or browser WebSocket tears down all of its PTYs. A reconnect
-therefore starts with no terminal sessions; clients must discard their old ids
-and open replacements after `BridgeReady` even though ids are never reused.
+Each client connection owns an independent set of PTYs. Terminal ids are
+unique only within that connection, output returns only to that connection,
+and closing the desktop page or browser WebSocket tears down all of its PTYs.
+A reconnect therefore starts with no terminal sessions; clients must discard
+their old ids and open replacements after `BridgeReady`.
 
 PTY bytes stay byte-transparent over JSON. Output is always base64. Text input
 uses `data`; byte-oriented xterm input uses `data_base64`, and exactly one of
 the two fields must be present. Each output chunk occupies the host's bounded
 flow-control window until the client acknowledges its `sequence`; retrying the
-same acknowledgement within that connection is safe. UUID identity prevents a
-delayed acknowledgement from naming an unrelated replacement session, while
-the owning connection still determines where the acknowledgement is routed.
+same acknowledgement within that connection is safe. An acknowledgement from
+a dead connection must not be replayed after reconnect because the new
+connection has an independent terminal-id namespace.
 
 | method | params | result |
 |---|---|---|

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -540,10 +540,13 @@ their old ids and open replacements after `BridgeReady`.
 PTY bytes stay byte-transparent over JSON. Output is always base64. Text input
 uses `data`; byte-oriented xterm input uses `data_base64`, and exactly one of
 the two fields must be present. Each output chunk occupies the host's bounded
-flow-control window until the client acknowledges its `sequence`; retrying the
-same acknowledgement within that connection is safe. An acknowledgement from
-a dead connection must not be replayed after reconnect because the new
-connection has an independent terminal-id namespace.
+flow-control window until the client acknowledges it. An acknowledgement for
+`sequence` also acknowledges every earlier outstanding sequence for that
+terminal, so a later acknowledgement covers an earlier request that did not
+reach the host. Duplicate acknowledgements and sequences older than the
+already-applied frontier are safe no-ops. An acknowledgement from a dead
+connection must not be replayed after reconnect because the new connection
+has an independent terminal-id namespace.
 
 | method | params | result |
 |---|---|---|

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -531,19 +531,19 @@ solely for a detected development layout.
 
 ### terminal.* — connection-scoped PTYs
 
-Each client connection owns an independent set of PTYs. Terminal ids are
-unique only within that connection, output returns only to that connection,
-and closing the desktop page or browser WebSocket tears down all of its PTYs.
-A reconnect therefore starts with no terminal sessions; clients must discard
-their old ids and open replacements after `BridgeReady`.
+Each terminal session receives a freshly minted UUID. A client connection owns
+the PTYs it opens: output returns only to that connection, and closing the
+desktop page or browser WebSocket tears down all of its PTYs. A reconnect
+therefore starts with no terminal sessions; clients must discard their old ids
+and open replacements after `BridgeReady` even though ids are never reused.
 
 PTY bytes stay byte-transparent over JSON. Output is always base64. Text input
 uses `data`; byte-oriented xterm input uses `data_base64`, and exactly one of
 the two fields must be present. Each output chunk occupies the host's bounded
 flow-control window until the client acknowledges its `sequence`; retrying the
-same acknowledgement within that connection is safe. An acknowledgement from
-a dead connection must not be replayed after reconnect because the new
-connection has an independent terminal-id namespace.
+same acknowledgement within that connection is safe. UUID identity prevents a
+delayed acknowledgement from naming an unrelated replacement session, while
+the owning connection still determines where the acknowledgement is routed.
 
 | method | params | result |
 |---|---|---|


### PR DESCRIPTION
## Summary

- mechanically extract the terminal UUID changes already reviewed in #1095
- mint host terminal IDs and frontend tab keys with the shared UUID package
- carry string identities through handwritten codecs, host routing, and frontend state, removing obsolete channel guards and acknowledgement retries
- keep ordered counters as integers: terminal output sequences, connection generations, and JSON-RPC request IDs

## Validation

- just check
- just test
- just build
- moon test desktop/internal/terminal --target native
- moon test desktop/internal/protocol --target native
- moon test desktop/frontend/terminal --target js