### PR TITLE
docs(prompt): document Json::number vs Json(x) for non-finite doubles

### DIFF
--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -907,6 +907,11 @@ test {
   `Json::empty_object()` for an empty object. Do not create JSON with
   `Json::Object(...)`, `Json::String(...)`, or `Json::True`; use variants
   mainly for pattern matching.
+- `Json::number(x)` keeps `NaN` and `Infinity` as numeric JSON tokens, while
+  `Json(x)` for a `Double` goes through `Double::to_json` and encodes them as
+  the strings `"NaN"`/`"Infinity"`. Keep `Json::number(x)` for an unguarded
+  `Double`; use `Json(x)` only when the value is known to be finite or is not
+  a `Double`.
 - For integer JSON numbers, use `Json::number(n.to_double(), repr=text.to_owned())`
   when you need output to preserve integer spelling.
 - For JSON CLI stdout and tests, use `json.stringify()` or inspect

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -912,6 +912,11 @@ fn default_prompt() -> String {
     #|  `Json::empty_object()` for an empty object. Do not create JSON with
     #|  `Json::Object(...)`, `Json::String(...)`, or `Json::True`; use variants
     #|  mainly for pattern matching.
+    #|- `Json::number(x)` keeps `NaN` and `Infinity` as numeric JSON tokens, while
+    #|  `Json(x)` for a `Double` goes through `Double::to_json` and encodes them as
+    #|  the strings `"NaN"`/`"Infinity"`. Keep `Json::number(x)` for an unguarded
+    #|  `Double`; use `Json(x)` only when the value is known to be finite or is not
+    #|  a `Double`.
     #|- For integer JSON numbers, use `Json::number(n.to_double(), repr=text.to_owned())`
     #|  when you need output to preserve integer spelling.
     #|- For JSON CLI stdout and tests, use `json.stringify()` or inspect


### PR DESCRIPTION
Document the `Json::number(x)` vs `Json(x)` distinction for non-finite
doubles in the built-in prompt's JSON guidance.

`Json(x)` for a `Double` routes through `Double::to_json`, which encodes
`NaN`/`Infinity` as the strings `"NaN"`/`"Infinity"` instead of numeric
tokens, so call sites with unguarded `Double`s must keep `Json::number`.
The guidance now records that exception explicitly; the generated prompt
(`prompt/generated_default_prompt.mbt`) is regenerated from
`prompt/default_prompt.mbt.md` by the `md_to_mbt_string` dev rule.

The `OPENSEEK_ENGINE` / `OPENSEEK_ENGINE_MODE` removal that previously rode
along on this branch is now its own PR: #1209.

Generated with SeekMoon