### PR TITLE
feat(viz): give the user's own prompts a visual clue

### DIFF
--- a/agent_session/goal.mbt
+++ b/agent_session/goal.mbt
@@ -37,6 +37,19 @@ pub const GoalReminderPrefix : String = "[goal reminder]"
 pub const GoalCheckPrefix : String = "[goal check]"
 
 ///|
+/// Exact text of the prompt the serve engine submits to open an
+/// auto-continuation turn on a standing goal.
+///
+/// It is durably appended as a `User` message like any other prompt — the
+/// model has to read it as one — but no human typed it. Readers that tell
+/// the user's own words apart from engine-injected input (the visualizer)
+/// need the exact text, so it lives here with the goal vocabulary where the
+/// producer (`cmd/openseek` serve) and its readers cannot drift.
+pub const GoalContinuePrompt : String =
+  #|Continue working toward the standing goal. When it is fully met, record
+  #|that by calling the goal tool with status "met".
+
+///|
 /// A standing goal derived from the durable event log.
 pub struct StandingGoal {
   priv text : String

--- a/agent_session/pkg.generated.mbti
+++ b/agent_session/pkg.generated.mbti
@@ -17,6 +17,8 @@ pub const GoalCheckPrefix : String = "[goal check]"
 
 pub const GoalClearedNotice : String = "[goal cleared]"
 
+pub const GoalContinuePrompt : String = "Continue working toward the standing goal. When it is fully met, record\nthat by calling the goal tool with status \"met\"."
+
 pub const GoalPrefix : String = "[goal]"
 
 pub const GoalReminderPrefix : String = "[goal reminder]"

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -35,9 +35,11 @@ priv enum GoalAction {
 const GoalAutoContinueMaxTurns : Int = 20
 
 ///|
-const GoalContinuePrompt : String =
-  #|Continue working toward the standing goal. When it is fully met, record
-  #|that by calling the goal tool with status "met".
+/// The prompt that opens an auto-continuation turn. Defined with the goal
+/// vocabulary in `agent_session` because the visualizer has to recognize the
+/// resulting `User` event as engine-injected rather than something the user
+/// said, and a second copy of the text here would let the two drift.
+const GoalContinuePrompt : String = @agent_session.GoalContinuePrompt
 
 ///|
 /// Whether a pending auto intent may be promoted to armed: the persisted

--- a/cmd/viz_app/e2e/tests/viz_dom.spec.js
+++ b/cmd/viz_app/e2e/tests/viz_dom.spec.js
@@ -313,3 +313,77 @@ test('theme controls change the rendered palette and follow the system theme', a
   expect(systemBackground).toBe(darkBackground);
   expect(viewer.pageErrors).toEqual([]);
 });
+
+test('the user bubble marks only the prompts a person typed', async ({ page }) => {
+  const continuePrompt = 'Continue working toward the standing goal. When it is fully met, record\n'
+    + 'that by calling the goal tool with status "met".';
+  const viewer = new VizBrowserHarness(page);
+  viewer.events = viewer.eventLog([
+    { sequence: 1, item: { kind: 'user', payload: { content: 'Ship the viewer change' } } },
+    {
+      sequence: 2,
+      item: { kind: 'assistant', payload: { content: 'On it.', tool_calls: [] } },
+    },
+    { sequence: 3, item: { kind: 'user', payload: { content: 'Also update the docs' } } },
+    { sequence: 4, item: { kind: 'terminal', payload: { kind: 'finished', message: 'Done.' } } },
+    { sequence: 5, item: { kind: 'user', payload: { content: continuePrompt } } },
+    {
+      sequence: 6,
+      item: { kind: 'terminal', payload: { kind: 'finished', message: 'Done again.' } },
+    },
+  ]);
+  await viewer.install();
+  await viewer.goto();
+  await viewer.openSession();
+  await page.getByRole('button', { name: 'Raw log' }).click();
+
+  // The opening prompt and the mid-turn steer are the user's; the engine's
+  // relaunch prompt is not, and must not wear the same bubble.
+  await expect(page.locator('.card.user.typed')).toHaveCount(2);
+  await expect(page.locator('.card.user.typed').first()).toContainText('You');
+  await expect(page.locator('.card.user.auto-continue')).toHaveCount(1);
+  await expect(page.locator('.card.user.auto-continue')).toContainText('Auto-continue');
+
+  // The bubble is a fill and an offset, not only a caption: that is what a
+  // reader skimming a long log actually sees. Both cards are measured in one
+  // evaluate so a re-render between two measurements cannot split the pair.
+  const layout = await page.evaluate(() => {
+    const box = selector => document.querySelector(selector).getBoundingClientRect();
+    const fill = selector =>
+      getComputedStyle(document.querySelector(selector)).backgroundColor;
+    return {
+      bubbleLeft: box('.card.user.typed').left,
+      plainLeft: box('.card.user.auto-continue').left,
+      bubbleFill: fill('.card.user.typed'),
+      plainFill: fill('.card.user.auto-continue'),
+    };
+  });
+  expect(layout.bubbleLeft).toBeGreaterThan(layout.plainLeft);
+  expect(layout.bubbleFill).not.toBe(layout.plainFill);
+
+  // A collapsed turn still reports the steer it hides.
+  await expect(page.locator('.turn-steer-badge')).toHaveCount(1);
+  await expect(page.locator('.turn-steer-badge')).toContainText('1 steer');
+  expect(viewer.pageErrors).toEqual([]);
+});
+
+test("a subagent transcript's task is not captioned as the user's", async ({ page }) => {
+  const viewer = new VizBrowserHarness(page);
+  viewer.sessionId = 'viz-1-sr-1';
+  viewer.events = viewer.eventLog([
+    { sequence: 1, item: { kind: 'user', payload: { content: 'Question: which version?' } } },
+    {
+      sequence: 2,
+      item: { kind: 'assistant', payload: { content: 'Looking it up.', tool_calls: [] } },
+    },
+  ], { id: viewer.sessionId });
+  await viewer.install();
+  await viewer.goto();
+  await viewer.openSession();
+  await page.getByRole('button', { name: 'Raw log' }).click();
+
+  await expect(page.locator('.card.user.delegated')).toHaveCount(1);
+  await expect(page.locator('.card.user.delegated')).toContainText('Task from parent');
+  await expect(page.locator('.card.user.typed')).toHaveCount(0);
+  expect(viewer.pageErrors).toEqual([]);
+});

--- a/viz/README.mbt.md
+++ b/viz/README.mbt.md
@@ -17,6 +17,27 @@ either view remains available from the toggle.
 A Light / Dark / System theme toggle sits in the sidebar (default Light;
 System follows the OS via `prefers-color-scheme`).
 
+## Who said it
+
+Both views give a prompt a person actually typed the desktop transcript's
+treatment — a filled bubble pushed to the right edge, captioned **You** — so
+the human side of a long conversation is findable at a glance. A turn header
+also counts the mid-turn steers it hides while collapsed (`✋ 2 steers`).
+
+Not every user-role message is the user's, and the viewer says so rather than
+lending them the bubble:
+
+| Message | Caption |
+|---|---|
+| A prompt or steer someone typed | **You** (bubble) |
+| `@agent_session.GoalContinuePrompt`, which serve submits to relaunch a turn on a standing goal | **Auto-continue** |
+| The opening task of a sub-run child session (`<parent>-sr-N`), written by the agent that spawned it | **Task from parent** |
+| A runtime notice or compaction summary, which `chat_messages` replays as a user-role message | **Runtime notice** / **Summary**, as in the raw log |
+
+The auto-continue text is matched against the constant the engine submits, so
+rewording that prompt stops the match instead of quietly captioning engine
+text as the user's.
+
 ## Pieces
 
 | Package          | Target | Role                                                                 |

--- a/viz/pkg.generated.mbti
+++ b/viz/pkg.generated.mbti
@@ -35,6 +35,7 @@ pub fn subrun_child_ids(@agent_session.Session, String) -> Array[String]
 pub struct SubrunView {
   parent : String
   children : Map[String, @agent_session.Session]
+  delegated : Bool
 }
 
 pub(all) enum ViewMode {

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -1873,6 +1873,57 @@ test "model-view user cards keep the caption of the event behind them" {
 }
 
 ///|
+/// The origins array is only useful if it stays index-for-index with
+/// `chat_messages()`, and one extra or missing entry silently shifts every
+/// later caption instead of failing loudly. The projection's own invariant
+/// pins that down: `User`, `Runtime` and `Summary` are exactly the items that
+/// become user-role messages, so an origin from one of them must land on a
+/// user-role message and nothing else may. Exercised against the cases the
+/// walker special-cases — a summary projecting at the start of its covered
+/// range, a dangling call healed with a synthetic result, a terminal
+/// repeating the assistant's final answer, and a context-yield terminal that
+/// projects no message at all.
+test "message origins stay aligned with the projection" {
+  let session = @agent_session.Session(
+      SessionId("aligned"),
+      system_prompt="sys",
+    )
+    .append(Runtime(RuntimeNotice("\{@agent_session.GoalPrefix}\nobjective")))
+    .append(User(UserMessage("first")))
+    .append(
+      Assistant(
+        AssistantMessage("calling", tool_calls=[
+          ToolCall(id="dangling", name="shell", arguments="{}"),
+        ]),
+      ),
+    )
+    // No result for `dangling`: the projection heals it with a synthetic tool
+    // message that no durable event backs.
+    .append(Terminal(Finished("first answer")))
+    .append(User(UserMessage("second")))
+    .append(Assistant(AssistantMessage("answer")))
+    // Repeats the assistant final, so it projects no extra message.
+    .append(Terminal(Finished("answer")))
+    .append(User(UserMessage("third")))
+    .append(
+      Summary(SessionSummary(content="covered", from_sequence=8, to_sequence=8)),
+    )
+    .append(
+      Terminal(Finished("\{@agent_session.ContextYieldAnswerPrefix} continued")),
+    )
+  let messages = session.chat_messages()
+  let origins = model_message_origins(session)
+  assert_eq(origins.length(), messages.length())
+  for index, message in messages {
+    let from_user_item = match origins[index] {
+      FromUser | FromRuntime | FromSummary(..) => true
+      Other => false
+    }
+    assert_eq(from_user_item, message.role is User)
+  }
+}
+
+///|
 test "model metadata omits an assistant final's duplicate terminal" {
   let session = @agent_session.Session(SessionId("labels"), system_prompt="")
     .append(User(UserMessage("first")))

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -411,7 +411,7 @@ fn user_role_card_style(
 ) -> (String, String) {
   match origin {
     FromRuntime => ("runtime", "Runtime notice")
-    FromSummary => ("summary", "Summary")
+    FromSummary(from~, to~) => ("summary", summary_label(from~, to~))
     // `Other` cannot reach a user-role card: the projection only synthesizes
     // assistant and tool messages. Classifying it as input is the honest
     // fallback if that ever changes — it says no more than the role does.
@@ -1414,8 +1414,18 @@ fn summary_card(
   time : String,
   summary : @agent_session.SessionSummary,
 ) -> @html.Html {
-  let label = "Summary · covers events \{summary.from_sequence()}..\{summary.to_sequence()}"
+  let label = summary_label(
+    from=summary.from_sequence(),
+    to=summary.to_sequence(),
+  )
   card("summary", label, seq, time~, [text_block(summary.content())])
+}
+
+///|
+/// Caption for a compaction summary, shared by the raw log's card and the
+/// model view's projection of the same event so the two cannot drift.
+fn summary_label(from~ : Int, to~ : Int) -> String {
+  "Summary · covers events \{from}..\{to}"
 }
 
 ///|
@@ -1691,7 +1701,9 @@ fn model_message_step_labels(session : @agent_session.Session) -> Array[String] 
 priv enum MessageOrigin {
   FromUser
   FromRuntime
-  FromSummary
+  /// A compaction summary, carrying the range it covers so the model view can
+  /// caption it exactly as the raw log's own card does.
+  FromSummary(from~ : Int, to~ : Int)
   /// An assistant/tool/terminal event, or a message with no durable event at
   /// all: the system prompt and the projection's synthesized tool repairs.
   Other
@@ -1707,7 +1719,8 @@ fn model_message_origins(
     match event.item() {
       User(_) => FromUser
       Runtime(_) => FromRuntime
-      Summary(_) => FromSummary
+      Summary(summary) =>
+        FromSummary(from=summary.from_sequence(), to=summary.to_sequence())
       Assistant(_) | Tool(_) | Terminal(_) => Other
     }
   }
@@ -1844,9 +1857,18 @@ test "model-view user cards keep the caption of the event behind them" {
     )
     captions.push(label)
   }
+  // The summary keeps the caption the raw log's own card gives it, range and
+  // all, so the same event reads the same way in both views.
   debug_inspect(
     captions,
-    content="[\"Summary\", \"Auto-continue\", \"Runtime notice\", \"You\"]",
+    content=(
+      #|[
+      #|  "Summary · covers events 1..3",
+      #|  "Auto-continue",
+      #|  "Runtime notice",
+      #|  "You",
+      #|]
+    ),
   )
 }
 

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -18,6 +18,9 @@ pub fn render_session(
   let subrun = SubrunView::{
     parent: session.id().value(),
     children: subrun_children,
+    // A child opened on its own (from the sidebar, or a `#s=` link) is only
+    // recognizable by the id shape the sub-run runner mints.
+    delegated: is_subrun_session_id(session.id().value()),
   }
   match mode {
     RawLog => render_raw(session, subrun)
@@ -209,6 +212,14 @@ fn turn_block(
   // Surface failed tools in the turn header so a turn carrying errors is
   // scannable even while its cards are folded or the turn itself is collapsed.
   let summary : Array[@html.Html] = [@html.text(label)]
+  // Same reason for steering: a mid-turn interjection can redirect the whole
+  // turn, and it is the one thing in the turn the user wrote themselves.
+  let steers = if subrun.delegated { 0 } else { count_turn_steers(turn) }
+  if steers > 0 {
+    summary.push(
+      @html.span(class="turn-steer-badge") <| " · ✋ \{steers} steer\{plural(steers)}",
+    )
+  }
   let errors = count_turn_tool_errors(turn)
   if errors > 0 {
     summary.push(
@@ -283,13 +294,156 @@ fn format_span_total_seconds(span_ms : Int64) -> String {
 }
 
 ///|
+/// The turn header's one-line preview: what opened the turn. A turn the
+/// engine relaunched on a standing goal always opens with the same boilerplate
+/// prompt, so it is named for what it is instead of spending the header on 80
+/// characters every such turn repeats.
 fn turn_preview(turn : Array[@agent_session.SessionEvent]) -> String {
   for event in turn {
     if event.item() is User(message) {
-      return truncate(one_line(message.content()), 80)
+      return if message.content() == @agent_session.GoalContinuePrompt {
+        "↻ auto-continue"
+      } else {
+        truncate(one_line(message.content()), 80)
+      }
     }
   }
   "\{turn.length()} events"
+}
+
+///|
+test "an auto-continued turn is named rather than previewed" {
+  let session = @agent_session.Session(SessionId("t"), system_prompt="")
+    .append(User(UserMessage(@agent_session.GoalContinuePrompt)))
+    .append(Terminal(Finished("done")))
+    .append(User(UserMessage("now do the other thing")))
+    .append(Terminal(Finished("done again")))
+  let turns = group_turns(session.events())
+  inspect(turn_preview(turns[0]), content="↻ auto-continue")
+  inspect(turn_preview(turns[1]), content="now do the other thing")
+}
+
+///|
+test "the turn header counts only the steers a person typed" {
+  let session = @agent_session.Session(SessionId("t"), system_prompt="")
+    .append(User(UserMessage("start")))
+    .append(Assistant(AssistantMessage("working")))
+    .append(User(UserMessage("actually, also this")))
+    .append(User(UserMessage(@agent_session.GoalContinuePrompt)))
+    .append(Terminal(Finished("done")))
+  let turns = group_turns(session.events())
+  // The opening prompt is not a steer, and the engine's prompt never is.
+  inspect(count_turn_steers(turns[0]), content="1")
+}
+
+///|
+/// Mid-turn steering: `User` events after the one that opened the turn that a
+/// person actually typed. A collapsed turn hides its cards, so the header
+/// carries a count — without it, an interjection that redirected a whole turn
+/// is invisible until the turn is expanded.
+fn count_turn_steers(turn : Array[@agent_session.SessionEvent]) -> Int {
+  let mut steers = 0
+  let mut seen_first = false
+  for event in turn {
+    guard event.item() is User(message) else { continue }
+    if !seen_first {
+      seen_first = true
+      continue
+    }
+    if user_input(message.content(), delegated=false) is Typed {
+      steers += 1
+    }
+  }
+  steers
+}
+
+///|
+/// Who actually wrote a user-role message.
+///
+/// Everything the engine replays to the model as a user turn lands in the log
+/// as a `User` event, but only some of it is a person's own words: a standing
+/// goal relaunches turns with `GoalContinuePrompt`, and a sub-run child's
+/// opening task is written by the agent that spawned it. Captioning all three
+/// "You" would put words in the reader's mouth — in a goal-driven session most
+/// `User` events are auto-continuations.
+priv enum UserInput {
+  /// A prompt or mid-turn steer a person typed.
+  Typed
+  /// The exact prompt serve submits to open an auto-continuation turn.
+  AutoContinue
+  /// The task a parent agent handed a sub-run child.
+  Delegated
+}
+
+///|
+/// Classify one user-role message. `delegated` is a property of the session
+/// being rendered, not of the text, so it decides first.
+fn user_input(content : String, delegated~ : Bool) -> UserInput {
+  if delegated {
+    Delegated
+  } else if content == @agent_session.GoalContinuePrompt {
+    AutoContinue
+  } else {
+    Typed
+  }
+}
+
+///|
+/// Card class and caption for a user-role message. Only `Typed` gets the
+/// `typed` bubble the stylesheet fills and pushes right.
+fn UserInput::card_style(self : UserInput) -> (String, String) {
+  match self {
+    Typed => ("user typed", "You")
+    AutoContinue => ("user auto-continue", "Auto-continue")
+    Delegated => ("user delegated", "Task from parent")
+  }
+}
+
+///|
+/// Card class and caption for a model-view user-role message, which the
+/// projection feeds from three different durable items. A runtime notice or a
+/// summary keeps the class the raw log gives it, so the same event reads the
+/// same way in both views.
+fn user_role_card_style(
+  content : String,
+  origin~ : MessageOrigin,
+  delegated~ : Bool,
+) -> (String, String) {
+  match origin {
+    FromRuntime => ("runtime", "Runtime notice")
+    FromSummary => ("summary", "Summary")
+    // `Other` cannot reach a user-role card: the projection only synthesizes
+    // assistant and tool messages. Classifying it as input is the honest
+    // fallback if that ever changes — it says no more than the role does.
+    FromUser | Other => user_input(content, delegated~).card_style()
+  }
+}
+
+///|
+/// The engine's auto-continuation prompt is matched against the exact constant
+/// serve submits, so rewording it stops the match instead of silently
+/// captioning engine text as the user's.
+test "user cards name who actually wrote the message" {
+  fn caption(content : String, delegated : Bool) -> String {
+    let (kind, label) = user_input(content, delegated~).card_style()
+    "\{kind} · \{label}"
+  }
+
+  inspect(caption("ship the feature", false), content="user typed · You")
+  inspect(
+    caption(@agent_session.GoalContinuePrompt, false),
+    content="user auto-continue · Auto-continue",
+  )
+  // Text that only resembles the engine's prompt is still the user's own.
+  inspect(
+    caption("Continue working toward the standing goal.", false),
+    content="user typed · You",
+  )
+  // A sub-run child's prompt is its parent agent's task, whatever it says.
+  inspect(
+    caption("survey the parser", true),
+    content="user delegated · Task from parent",
+  )
 }
 
 ///|
@@ -306,8 +460,13 @@ fn event_card(
 ) -> @html.Html {
   let seq = event.sequence()
   match event.item() {
-    User(message) =>
-      card("user", "User", seq, time~, [text_block(message.content())])
+    User(message) => {
+      let (kind, label) = user_input(
+        message.content(),
+        delegated=subrun.delegated,
+      ).card_style()
+      card(kind, label, seq, time~, [text_block(message.content())])
+    }
     Assistant(message) =>
       assistant_card(
         seq,
@@ -1364,6 +1523,9 @@ fn render_model(
   let escalated = model_escalated_result_ids(messages, tags)
   let plans = model_plan_baselines(messages, failed)
   let anchor_seqs = model_message_anchor_seqs(session)
+  // The projection replays runtime notices and summaries as user-role
+  // messages, so a card's caption comes from the durable item behind it.
+  let origins = model_message_origins(session)
   let cards : Array[@html.Html] = [
     for index, message in messages => {
       let time = time_labels.get(index).unwrap_or("")
@@ -1384,6 +1546,7 @@ fn render_model(
         time~,
         step_label~,
         anchor~,
+        origin=origins.get(index).unwrap_or(Other),
       )
     }
   ]
@@ -1447,14 +1610,15 @@ fn remove_pending_tool_id(
 }
 
 ///|
-fn flush_pending_tool_labels(
+fn[T] flush_pending_tool_labels(
   pending : Array[String],
-  labels : Array[String],
+  labels : Array[T],
+  unbacked~ : T,
 ) -> Unit {
   for _ in pending {
     // Synthetic repair messages are not backed by a durable event, so they do
     // not get a timestamp/step label.
-    labels.push("")
+    labels.push(unbacked)
   }
   pending.clear()
 }
@@ -1500,7 +1664,7 @@ fn model_message_time_labels(session : @agent_session.Session) -> Array[String] 
   let label_of = (event : @agent_session.SessionEvent) => {
     event_label(labels, event)
   }
-  model_message_labels(session, label_of~, tool_label_of=label_of)
+  model_message_labels(session, label_of~, tool_label_of=label_of, unbacked="")
 }
 
 ///|
@@ -1509,9 +1673,50 @@ fn model_message_time_labels(session : @agent_session.Session) -> Array[String] 
 /// results may project as model messages, but they are not agent-loop steps.
 fn model_message_step_labels(session : @agent_session.Session) -> Array[String] {
   let steps = agent_step_labels(session)
-  model_message_labels(session, label_of=event => event_label(steps, event), tool_label_of=_ => {
-    ""
-  })
+  model_message_labels(
+    session,
+    label_of=event => event_label(steps, event),
+    tool_label_of=_ => "",
+    unbacked="",
+  )
+}
+
+///|
+/// The durable item a projected model message came from.
+///
+/// The projection replays `User`, `Runtime` and `Summary` events alike as
+/// user-role messages, so the model view cannot read "a person wrote this" off
+/// a message's role — it asks here instead, and a goal marker or a compaction
+/// summary keeps the caption the raw log gives it.
+priv enum MessageOrigin {
+  FromUser
+  FromRuntime
+  FromSummary
+  /// An assistant/tool/terminal event, or a message with no durable event at
+  /// all: the system prompt and the projection's synthesized tool repairs.
+  Other
+}
+
+///|
+/// One origin per projected model message, parallel to
+/// `Session::chat_messages()`.
+fn model_message_origins(
+  session : @agent_session.Session,
+) -> Array[MessageOrigin] {
+  let origin_of = (event : @agent_session.SessionEvent) => {
+    match event.item() {
+      User(_) => FromUser
+      Runtime(_) => FromRuntime
+      Summary(_) => FromSummary
+      Assistant(_) | Tool(_) | Terminal(_) => Other
+    }
+  }
+  model_message_labels(
+    session,
+    label_of=origin_of,
+    tool_label_of=origin_of,
+    unbacked=Other,
+  )
 }
 
 ///|
@@ -1521,7 +1726,12 @@ fn model_message_step_labels(session : @agent_session.Session) -> Array[String] 
 /// to anchor at) get `""`.
 fn model_message_anchor_seqs(session : @agent_session.Session) -> Array[String] {
   let seq_of = (event : @agent_session.SessionEvent) => "\{event.sequence()}"
-  model_message_labels(session, label_of=seq_of, tool_label_of=seq_of)
+  model_message_labels(
+    session,
+    label_of=seq_of,
+    tool_label_of=seq_of,
+    unbacked="",
+  )
 }
 
 ///|
@@ -1532,12 +1742,13 @@ fn model_message_anchor_seqs(session : @agent_session.Session) -> Array[String] 
 /// `""` (see `flush_pending_tool_labels`). This walker must mirror the
 /// projection's message order exactly; one extra or missing label shifts every
 /// later chip.
-fn model_message_labels(
+fn[T] model_message_labels(
   session : @agent_session.Session,
-  label_of~ : (@agent_session.SessionEvent) -> String,
-  tool_label_of~ : (@agent_session.SessionEvent) -> String,
-) -> Array[String] {
-  let out : Array[String] = [""]
+  label_of~ : (@agent_session.SessionEvent) -> T,
+  tool_label_of~ : (@agent_session.SessionEvent) -> T,
+  unbacked~ : T,
+) -> Array[T] {
+  let out : Array[T] = [unbacked]
   let pending_tool_calls : Array[String] = []
   let mut previous_assistant_answer : String? = None
   let events = session.events()
@@ -1548,7 +1759,7 @@ fn model_message_labels(
       if candidate.item() is Summary(summary) &&
         summary.from_sequence() == event.sequence() &&
         !model_event_covered_by_later_summary(candidate, events) {
-        flush_pending_tool_labels(pending_tool_calls, out)
+        flush_pending_tool_labels(pending_tool_calls, out, unbacked~)
         out.push(label_of(candidate))
         previous_assistant_answer = None
       }
@@ -1560,7 +1771,7 @@ fn model_message_labels(
       // Labeled above at the start of its covered range.
       Summary(_) => ()
       Assistant(message) => {
-        flush_pending_tool_labels(pending_tool_calls, out)
+        flush_pending_tool_labels(pending_tool_calls, out, unbacked~)
         out.push(label_of(event))
         previous_assistant_answer = Some(message.content())
         for call in message.tool_calls() {
@@ -1574,7 +1785,7 @@ fn model_message_labels(
         }
       Terminal(terminal) => {
         if !pending_tool_calls.is_empty() {
-          flush_pending_tool_labels(pending_tool_calls, out)
+          flush_pending_tool_labels(pending_tool_calls, out, unbacked~)
           previous_assistant_answer = None
         }
         let repeated_assistant_final = terminal is Finished(answer) &&
@@ -1587,7 +1798,7 @@ fn model_message_labels(
         previous_assistant_answer = None
       }
       item => {
-        flush_pending_tool_labels(pending_tool_calls, out)
+        flush_pending_tool_labels(pending_tool_calls, out, unbacked~)
         previous_assistant_answer = None
         if item_projects_model_message(item) {
           out.push(label_of(event))
@@ -1595,8 +1806,48 @@ fn model_message_labels(
       }
     }
   }
-  flush_pending_tool_labels(pending_tool_calls, out)
+  flush_pending_tool_labels(pending_tool_calls, out, unbacked~)
   out
+}
+
+///|
+/// Everything the projection feeds the model as a user turn arrives with role
+/// `User`, so captioning off the role alone would file a goal marker and a
+/// compaction summary under the user's own words.
+test "model-view user cards keep the caption of the event behind them" {
+  let session = @agent_session.Session(
+      SessionId("origins"),
+      system_prompt="sys",
+    )
+    .append(Runtime(RuntimeNotice("\{@agent_session.GoalPrefix}\nship it")))
+    .append(User(UserMessage("do the thing")))
+    .append(Assistant(AssistantMessage("on it")))
+    .append(
+      Summary(SessionSummary(content="covered", from_sequence=1, to_sequence=3)),
+    )
+    .append(User(UserMessage(@agent_session.GoalContinuePrompt)))
+    .append(
+      Runtime(RuntimeNotice("\{@agent_session.GoalReminderPrefix}\nship it")),
+    )
+    .append(User(UserMessage("one more thing")))
+    .append(Terminal(Finished("done")))
+  let messages = session.chat_messages()
+  let origins = model_message_origins(session)
+  assert_eq(origins.length(), messages.length())
+  let captions : Array[String] = []
+  for index, message in messages {
+    guard message.role is User else { continue }
+    let (_, label) = user_role_card_style(
+      message.content,
+      origin=origins[index],
+      delegated=false,
+    )
+    captions.push(label)
+  }
+  debug_inspect(
+    captions,
+    content="[\"Summary\", \"Auto-continue\", \"Runtime notice\", \"You\"]",
+  )
 }
 
 ///|
@@ -1924,6 +2175,7 @@ fn message_card(
   time~ : String,
   step_label~ : String,
   anchor~ : String?,
+  origin~ : MessageOrigin,
   subrun~ : SubrunView,
 ) -> @html.Html {
   match message.role {
@@ -1937,10 +2189,15 @@ fn message_card(
           text_block(message.content),
         ],
       ]
-    User =>
+    User => {
+      let (kind, label) = user_role_card_style(
+        message.content,
+        origin~,
+        delegated=subrun.delegated,
+      )
       model_card(
-        "user",
-        "User",
+        kind,
+        label,
         message,
         briefs,
         failed,
@@ -1950,6 +2207,7 @@ fn message_card(
         step_label~,
         anchor~,
       )
+    }
     Assistant =>
       model_card(
         "assistant",
@@ -2379,6 +2637,32 @@ test "truncate caps by character without splitting surrogate pairs" {
 pub struct SubrunView {
   parent : String
   children : Map[String, @agent_session.Session]
+  /// Whether the session being rendered is itself a sub-run child. Its
+  /// `User` events are the task its parent agent handed it, so the view must
+  /// not caption them as the person's own words.
+  delegated : Bool
+}
+
+///|
+/// Whether a session id is one the sub-run runner minted for a child
+/// (`<parent>-sr-N`, the shape `subrun_child_id` builds). Parent ids are
+/// user-chosen, so a hand-named session can wear the shape; it only decides
+/// how a `User` card is captioned, never what is shown.
+fn is_subrun_session_id(id : String) -> Bool {
+  lexmatch id {
+    re"^(.|\n)*" + re"-sr-[0-9]+$" => true
+    _ => false
+  }
+}
+
+///|
+test "sub-run child ids are the ones ending in -sr-<n>" {
+  inspect(is_subrun_session_id("run7-sr-1"), content="true")
+  inspect(is_subrun_session_id("run7-sr-12"), content="true")
+  // A parent id may itself contain dashes and digits without being a child.
+  inspect(is_subrun_session_id("run7"), content="false")
+  inspect(is_subrun_session_id("run-sr-x"), content="false")
+  inspect(is_subrun_session_id("run7-sr-1-more"), content="false")
 }
 
 ///|
@@ -2493,6 +2777,9 @@ fn subrun_transcript(child : @agent_session.Session) -> @html.Html {
   let body = render_raw(child, {
     parent: child.id().value(),
     children: Map([]),
+    // Known for certain here, whatever the child's id looks like: this
+    // transcript is nested inside the parent's own tool result.
+    delegated: true,
   })
   anchor_namespace.val = saved
   @html.details(class="subrun-transcript") <| [

--- a/web/index.html
+++ b/web/index.html
@@ -20,6 +20,8 @@
       --accent: #2563eb;
       --on-accent: #ffffff;
       --user: #2f5bd6;
+      --user-bubble: #e7edfd;
+      --user-bubble-border: #b6c7f2;
       --assistant: #1a8f63;
       --tool: #8a6d10;
       --error: #c2334a;
@@ -53,6 +55,8 @@
       --accent: #6ea8fe;
       --on-accent: #0b0d12;
       --user: #6f93ff;
+      --user-bubble: #1a2340;
+      --user-bubble-border: #33436f;
       --assistant: #36c08a;
       --tool: #c9a227;
       --error: #e0556b;
@@ -87,6 +91,8 @@
         --accent: #6ea8fe;
         --on-accent: #0b0d12;
         --user: #6f93ff;
+        --user-bubble: #1a2340;
+        --user-bubble-border: #33436f;
         --assistant: #36c08a;
         --tool: #c9a227;
         --error: #e0556b;
@@ -354,6 +360,7 @@
     .error-toggle:hover, .error-jump:hover { border-color: var(--error); }
     .error-toggle.active { background: var(--error); color: #fff; border-color: var(--error); }
     .turn-error-badge { color: var(--error); }
+    .turn-steer-badge { color: var(--user); }
     .errors-only-empty { color: var(--muted); margin-top: 24px; }
     /* errors-only: keep failed tool-result cards AND the assistant card holding the
        failing call (so the call and its result stay as two cells), plus the turns
@@ -433,6 +440,28 @@
       margin: 8px 0;
     }
     .card.user { border-left-color: var(--user); }
+    /* The user's own words are the one thing in a log nobody generated, and a
+       left rail three pixels wide did not say so. A typed prompt — or a steer
+       dropped mid-turn — gets the desktop transcript's bubble: filled, its own
+       border, pushed to the right edge, so the human side of the conversation
+       is findable at a glance in a wall of tool cards. The engine's
+       auto-continue prompt and a sub-run child's task from its parent are
+       user-role messages too, so they keep the plain card on the agent's side
+       of the column, muted, and say who wrote them. */
+    .card.user.typed {
+      margin-left: auto;
+      max-width: 88%;
+      background: var(--user-bubble);
+      border-color: var(--user-bubble-border);
+      border-left-color: var(--user);
+    }
+    .card.user.typed > .card-label { color: var(--user); }
+    .card.user.auto-continue, .card.user.delegated {
+      border-left-color: var(--muted);
+    }
+    .card.user.auto-continue > .card-body, .card.user.delegated > .card-body {
+      color: var(--muted);
+    }
     .card.assistant { border-left-color: var(--assistant); }
     .card.tool { border-left-color: var(--tool); }
     .card.tool.error { border-left-color: var(--error); background: var(--notice-error-bg); }


### PR DESCRIPTION
## Why

Every event in the viewer renders as the same card, separated only by a 3px left rail — so a prompt, the one thing in a session log a person actually wrote, is as easy to miss as a tool result. The desktop transcript already solves this with a bubble; the viewer now does too.

## What changed

A prompt or a mid-turn steer gets a **filled bubble pushed to the right edge, captioned "You"**, in both the raw log and the model view. A turn header also counts the steers it hides while collapsed (`✋ 2 steers`).

That caption has to be earned, because a user-role message is not always the user's. In `ccomp-run9`, **four of six `User` events were the engine's**, and captioning them "You" would have been worse than the flat styling it replaces:

| Message | Caption |
|---|---|
| A prompt or steer someone typed | **You** (bubble) |
| `GoalContinuePrompt` — what serve submits to relaunch a turn on a standing goal | **Auto-continue**, muted |
| The opening task of a sub-run child (`<parent>-sr-N`), written by the agent that spawned it | **Task from parent**, muted |
| A runtime notice / compaction summary, which `chat_messages` also replays as a user-role message | **Runtime notice** / **Summary · covers events N..M**, exactly as the raw log captions them |

An auto-continued turn is also named `↻ auto-continue` in its header instead of repeating the same 80 characters of boilerplate in every relaunched turn.

The model-view captions come from the durable item behind each projected message (`model_message_origins`, built by the same order-mirroring walker the timestamp and step chips use, now generic over its label type) rather than from a message's role — the projection feeds `User`, `Runtime` and `Summary` into user-role messages alike.

`GoalContinuePrompt` moves from `cmd/openseek/serve.mbt` to `agent_session` beside the goal markers, so the producer and the reader share one copy of the text. Rewording it stops the match instead of silently captioning engine text as the user's.

## Before / after

Before — `#2`, `#5` (typed) and `#8` (engine auto-continue) are indistinguishable:

```
#2 USER   Read viz/view.mbt and tell me how user cards render today.
#5 USER   Also check web/index.html while you are in there.
#8 USER   Continue working toward the standing goal. When it is fully met, …
```

After:

```
TURN 1 · READ VIZ/VIEW.MBT AND … · 5.5S · ✋ 1 STEER
                              ┌──────────────────────────────────────────┐
                              │ #2 YOU  Read viz/view.mbt and tell me …  │  ← filled, right-shifted
                              └──────────────────────────────────────────┘
TURN 2 · ↻ AUTO-CONTINUE · 2.0S
  #8 AUTO-CONTINUE  Continue working toward the standing goal. …            ← muted, left, plain
```

## Verification

- `moon check --deny-warn`, `moon fmt --check`, `moon info` — clean.
- `moon test`: viz 17, `agent_session` 38, `cmd/openseek` 84, `cmd/viz_app` 31 — green.
- `just viz-test-browser` — 12/12, including two new cases asserting the rendered fill and horizontal offset, and that a subagent transcript's task is never captioned as the user's.
- Eyeballed light and dark, raw and model views, plus a real subagent session (`ccomp-run11-sr-1`) and a parent whose nested child transcript renders `card user delegated` inside the parent's `card user typed`.

**Negative controls** — each new test was confirmed to fail when the behaviour it guards is removed:

| Sabotage | Test that caught it |
|---|---|
| auto-continue match disabled | unit `user cards name who actually wrote the message`, browser `the user bubble marks only…` |
| `delegated` forced false | browser `a subagent transcript's task is not captioned as the user's` |
| bubble CSS reduced to a rail | browser fill/offset assertions |
| unbacked origin ≠ `Other` | unit `message origins stay aligned with the projection` |

**No cross-model review.** subal is out of credits until Sep 7 and Kimi's provider returned HTTP 500 on three consecutive attempts, so the usual per-commit reviewer pass did not happen on this branch. Worth a closer human read than usual, particularly `model_message_origins` staying index-parallel with `chat_messages()` — the third commit pins that with the projection's own invariant, but it is the place where a mistake would be silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NbnfwnhKH1Z7LGfFccFDmh
