### PR TITLE
fix(desktop): track unread finishes by window visibility

### DIFF
--- a/desktop/frontend/boot.mbt
+++ b/desktop/frontend/boot.mbt
@@ -414,6 +414,11 @@ pub fn boot() -> Unit {
           )
         }
         if model.is_desktop {
+          subs.push(
+            window_focus_subscription(
+              emit.map(focused => WindowFocusChanged(focused)),
+            ),
+          )
           // Only overlay titlebars turn the page's top chrome into native
           // window chrome; Linux keeps its separate system titlebar.
           if window_titlebar_overlay_supported() {

--- a/desktop/frontend/interop/interop.mbt
+++ b/desktop/frontend/interop/interop.mbt
@@ -44,6 +44,25 @@ pub fn viewport_width() -> Int? {
 }
 
 ///|
+/// Whether this page's native/browser window currently owns focus. A headless
+/// runtime has no document and defaults to focused so model tests retain the
+/// ordinary foreground behavior.
+pub fn page_has_focus() -> Bool {
+  guard js_prop(@js.globalThis, "document") is Some(document) &&
+    js_prop(document, "hasFocus") is Some(_) else {
+    return true
+  }
+  let focused : Bool = document.apply_with_string(
+    "hasFocus",
+    ([] : Array[@js.Value]),
+  )
+  let hidden : Bool = js_prop(document, "hidden")
+    .map(value => value.cast())
+    .unwrap_or(false)
+  focused && !hidden
+}
+
+///|
 /// `Date.now()` in milliseconds. Only ever used for elapsed spans between two
 /// readings taken by this page, so the clock's absolute correctness — and its
 /// agreement with the host's — does not matter.

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -1359,6 +1359,10 @@ priv struct Model {
   // close path — from a browser tab, `window.close()` exits nothing, and the
   // update would yank the app out from under whoever is at the machine.
   is_desktop : Bool
+  // Whether the native window is currently focused. Conversation navigation
+  // has its own `focused` channel; both facts, together with `screen`, decide
+  // whether a completed turn was actually visible to the reader.
+  window_focused : Bool
   // Installed package version supplied by the native host's `app.info` op.
   app_version : String
   // A browser page's account layer: the relay session and the device
@@ -1765,6 +1769,9 @@ priv enum Msg {
   FontSizeChanged(String)
   // The window was resized; `width` decides the narrow (phone) layout.
   ViewportResized(width~ : Int)
+  // The native window gained or lost OS focus. This is deliberately distinct
+  // from the selected device channel stored in `Model.focused`.
+  WindowFocusChanged(Bool)
   SaveApiKey
   OpenSkills
   // Everything the Skills page does with itself once it is open.
@@ -2470,6 +2477,7 @@ fn initial_model() -> Model {
     deferred_host_settings: None,
     legacy_cleanup_pending: false,
     is_desktop,
+    window_focused: !is_desktop || @interop.page_has_focus(),
     app_version: "development",
     // Every browser page is the console: it signs in against the relay and
     // verifies its required query-selected device before that channel opens.
@@ -3295,6 +3303,50 @@ fn Model::conversation_by_pending_steer(
 }
 
 ///|
+/// Whether this conversation is the transcript the reader can currently see.
+/// Keeping this predicate separate from the unread bit makes window focus a
+/// read-state input, not a second encoding of read state.
+fn Model::conversation_is_visible(
+  self : Model,
+  channel : @interop.ChannelId,
+  session_id : String,
+) -> Bool {
+  self.window_focused &&
+  self.screen is Chat &&
+  channel == self.focused &&
+  session_id == self.active_session
+}
+
+///|
+/// Mark one conversation's completed turn as read. Badge synchronization is
+/// derived from the resulting model transition by `update`.
+fn Model::mark_conversation_read(
+  self : Model,
+  channel : @interop.ChannelId,
+  session_id : String,
+) -> Model {
+  let conversations = self.conversations.map(conv => {
+    if conv.device == channel && conv.session_id == session_id {
+      { ..conv, unseen_finish: false, }
+    } else {
+      conv
+    }
+  })
+  { ..self, conversations, }
+}
+
+///|
+/// A foreground chat reads the currently selected conversation through its
+/// latest completion. Other screens retain the unread state until the reader
+/// returns to the transcript.
+fn Model::mark_visible_conversation_read(self : Model) -> Model {
+  guard self.conversation_is_visible(self.focused, self.active_session) else {
+    return self
+  }
+  self.mark_conversation_read(self.focused, self.active_session)
+}
+
+///|
 /// Make `session_id` the on-screen conversation, creating its entry in
 /// `project` when it has none, and drop conversations with nothing worth
 /// keeping. Exact input ownership is retained even after lifecycle recovery
@@ -3316,8 +3368,7 @@ fn Model::activate(
   for conv in self.conversations {
     if conv.device == channel && conv.session_id == session_id {
       found = true
-      // Opening the conversation is what "seen" means.
-      conversations.push({ ..conv, unseen_finish: false, })
+      conversations.push(conv)
     } else if conv.worth_keeping() {
       conversations.push(conv)
     }
@@ -3336,7 +3387,20 @@ fn Model::activate(
   }
   // Activating a conversation is also what moves the UI's focus to its
   // device — a no-op while the app runs a single channel.
-  { ..self, focused: channel, active_session: session_id, conversations, }
+  let activated = {
+    ..self,
+    focused: channel,
+    active_session: session_id,
+    conversations,
+  }
+  // `activate` is the explicit navigation path into this transcript. A
+  // background programmatic activation does not claim that the reader saw it;
+  // the later window-focus event will mark it read once it is visible.
+  if self.window_focused {
+    activated.mark_conversation_read(channel, session_id)
+  } else {
+    activated
+  }
 }
 
 ///|

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -98,7 +98,7 @@ fn open_session_on(
 ) -> (@cmd.Cmd, Model) {
   let owner : @interop.ConversationKey = { channel, session: session_id, }
   if session_id == model.active_session {
-    let base = { ..model, screen: Chat, }
+    let base = { ..model, screen: Chat, }.mark_visible_conversation_read()
     // Re-selecting is an explicit catch-up point for writes made by an
     // idle CLI or another client. It also restarts an exhausted retry
     // round; an existing request stays single-flight. A fresh chat has no
@@ -3231,6 +3231,13 @@ fn update_msg(
     }
     ToggleSidebar =>
       (@cmd.none, { ..model, sidebar_open: !model.sidebar_open, })
+    WindowFocusChanged(focused) => {
+      // Returning to a visible transcript marks its completed turn read.
+      // Permission questions remain actionable until answered and therefore
+      // continue to contribute to the independently derived badge count.
+      let model = { ..model, window_focused: focused, }
+      (@cmd.none, model.mark_visible_conversation_read())
+    }
     ViewportResized(width~) => {
       let narrow = width <= NarrowBreakpoint
       // The embedded viewer only learns its host's size through layout(),
@@ -7394,10 +7401,12 @@ fn update_device_msg(
           ..settled_inputs,
           run: NoRun(ended=Some(RunFinished(RunOutcome::parse(status)))),
           last_run_id: Some(run_id),
-          // A finish the user watched happen needs no reminder; one landing
-          // in a background conversation leaves a dot until they visit.
-          unseen_finish: conv.device != model.focused ||
-          conv.session_id != model.active_session,
+          // A finish the user watched happen needs no reminder. Every other
+          // completion is unread until its transcript is actually visible.
+          unseen_finish: !model.conversation_is_visible(
+            conv.device,
+            conv.session_id,
+          ),
         }
         // The finished run just appended to the durable store, so the
         // sidebar list (and this conversation's title) may have changed —
@@ -8609,6 +8618,44 @@ test "a finish the user watched leaves no unseen dot" {
     running_model(),
   )
   inspect(next.active().unseen_finish, content="false")
+}
+
+///|
+test "a finish in an unfocused window still needs attention" {
+  let dispatch = test_dispatch()
+  let model = { ..running_model(), window_focused: false, }
+  let (_, next) = update_dev(
+    dispatch,
+    Finished(run_id="r7", status="finished", answer=Some("done")),
+    model,
+  )
+  inspect(next.active().unseen_finish, content="true")
+  inspect(next.notification_badge_count(), content="1")
+  let (_, focused) = update(dispatch, WindowFocusChanged(true), next)
+  inspect(focused.active().unseen_finish, content="false")
+  inspect(focused.notification_badge_count(), content="0")
+}
+
+///|
+test "a finish behind settings stays unread until the chat is reopened" {
+  let dispatch = test_dispatch()
+  let model = { ..running_model(), screen: Settings, }
+  let (_, next) = update_dev(
+    dispatch,
+    Finished(run_id="r7", status="finished", answer=Some("done")),
+    model,
+  )
+  inspect(next.active().unseen_finish, content="true")
+  inspect(next.notification_badge_count(), content="1")
+  let (_, opened) = open_session_on(
+    dispatch,
+    @interop.ChannelId::Local,
+    next,
+    "desktop-test",
+  )
+  assert_true(opened.screen is Chat)
+  inspect(opened.active().unseen_finish, content="false")
+  inspect(opened.notification_badge_count(), content="0")
 }
 
 ///|

--- a/desktop/frontend/window_focus.mbt
+++ b/desktop/frontend/window_focus.mbt
@@ -1,0 +1,54 @@
+// The selected device (`Model.focused`) and the operating-system window focus
+// answer different questions. This subscription owns the latter without
+// letting browser state leak into the pure update path.
+
+///|
+priv suberror WindowFocusSubscription {
+  WindowFocusSubscription(@cmd.Emit[Bool])
+}
+
+///|
+fn window_focus_sub_loader(
+  payload : Error,
+  scheduler : &Scheduler,
+) -> @sub.RunningSub? {
+  match payload {
+    WindowFocusSubscription(emit) => {
+      let mut emit = emit
+      let window = @dom.window().as_event_target()
+      let document = @dom.document().as_event_target()
+      let focus_listener : @dom.Listener = _ => scheduler.add(emit(true))
+      let blur_listener : @dom.Listener = _ => scheduler.add(emit(false))
+      let visibility_listener : @dom.Listener = _ => {
+        scheduler.add(emit(@interop.page_has_focus()))
+      }
+      window.add_event_listener("focus", focus_listener)
+      window.add_event_listener("blur", blur_listener)
+      document.add_event_listener("visibilitychange", visibility_listener)
+      Some({
+        unload: _ => {
+          window.remove_event_listener("focus", focus_listener)
+          window.remove_event_listener("blur", blur_listener)
+          document.remove_event_listener(
+            "visibilitychange", visibility_listener,
+          )
+        },
+        update_tagger: payload => {
+          guard payload is WindowFocusSubscription(next) else { return }
+          emit = next
+        },
+      })
+    }
+    _ => None
+  }
+}
+
+///|
+fn window_focus_subscription(emit : @cmd.Emit[Bool]) -> @sub.Sub {
+  @sub.custom_sub(
+    "window-focus",
+    Global,
+    WindowFocusSubscription(emit),
+    window_focus_sub_loader,
+  )
+}


### PR DESCRIPTION
## Summary

- track native window focus and document visibility separately from the selected conversation
- mark a finished turn unread unless its transcript is actually visible
- clear the active conversation read state when the user returns to its visible chat
- keep the native badge derived from absolute per-conversation attention state

## Tests

- moon -C desktop test frontend --target js
- just check