### PR TITLE
feat(viz): navigate a log by its prompts, Codex-style

### DIFF
--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -701,6 +701,27 @@ extern "js" fn install_position_tracker() -> Unit =
   #|    history.replaceState(null, '', '#' + params.toString());
   #|    el.scrollIntoView({ block: 'start' });
   #|  });
+  #|  // Prompt-rail ticks are `<a>` nodes, and Rabbita owns those clicks: it
+  #|  // prevents the default jump and dispatches a UrlRequest the app drops
+  #|  // for fragment-only links. The jump is delegated here instead, like the
+  #|  // scrubber's, so it keeps the `#s=…` state hash intact and records the
+  #|  // new position in `seq=` without a history entry.
+  #|  document.addEventListener('click', (event) => {
+  #|    if (!(event.target instanceof Element)) return;
+  #|    const mark = event.target.closest('a.rail-mark');
+  #|    if (!mark) return;
+  #|    event.preventDefault();
+  #|    const href = mark.getAttribute('href') || '';
+  #|    const id = href.startsWith('#') ? href.slice(1) : '';
+  #|    const el = id ? document.getElementById(id) : null;
+  #|    if (!el) return;
+  #|    if (id.startsWith('seq-')) {
+  #|      const params = new URLSearchParams(location.hash.slice(1));
+  #|      params.set('seq', id.slice(4));
+  #|      history.replaceState(null, '', '#' + params.toString());
+  #|    }
+  #|    el.scrollIntoView({ block: 'start' });
+  #|  });
   #|  // Instant scrubber tooltip: shows each segment's data-label ("Step
   #|  // N/M[ · has failures]") the moment the pointer touches it — a native
   #|  // title tooltip would lag behind the OS hover delay while sweeping.

--- a/cmd/viz_app/e2e/tests/viz_dom.spec.js
+++ b/cmd/viz_app/e2e/tests/viz_dom.spec.js
@@ -8,7 +8,9 @@ test('session filters and argument modes change what the reader can see', async 
   await viewer.openSession();
   await page.getByRole('button', { name: 'Raw log' }).click();
 
-  const userMessage = page.locator('.session-view')
+  // Scoped to the card: the prompt rail's hover preview repeats the prompt
+  // text, and this test is about the card the filters show and hide.
+  const userMessage = page.locator('.session-view .card')
     .getByText('Inspect the session viewer', { exact: true });
   const shellCall = page.locator('details.tool-call').filter({ hasText: 'moon test' });
   const shellFailure = page.locator('details.card').filter({ hasText: 'fixture failure' });
@@ -75,7 +77,8 @@ test('a dropped session file replaces the served selection without another fetch
   await page.locator('.app').dispatchEvent('drop', { dataTransfer });
 
   await expect(page.getByText(/dropped file: dropped-session\.jsonl/)).toBeVisible();
-  await expect(page.getByText('Running the browser fixture.', { exact: true })).toBeVisible();
+  await expect(page.locator('.card').getByText('Running the browser fixture.', { exact: true }))
+    .toBeVisible();
   expect(viewer.apiRequests).toHaveLength(requestsBeforeDrop);
   expect(viewer.pageErrors).toEqual([]);
   await dataTransfer.dispose();
@@ -284,7 +287,8 @@ test('standalone export reads embedded data without session requests', async ({ 
   await viewer.install({ standalone: true });
   await viewer.goto();
 
-  await expect(page.getByText('Running the browser fixture.', { exact: true })).toBeVisible();
+  await expect(page.locator('.card').getByText('Running the browser fixture.', { exact: true }))
+    .toBeVisible();
   expect(viewer.apiRequests).toEqual([]);
   expect(viewer.pageErrors).toEqual([]);
 });
@@ -314,7 +318,7 @@ test('theme controls change the rendered palette and follow the system theme', a
   expect(viewer.pageErrors).toEqual([]);
 });
 
-test('the user bubble marks only the prompts a person typed', async ({ page }) => {
+test('the raised user card marks only the prompts a person typed', async ({ page }) => {
   const continuePrompt = 'Continue working toward the standing goal. When it is fully met, record\n'
     + 'that by calling the goal tool with status "met".';
   const viewer = new VizBrowserHarness(page);
@@ -338,32 +342,101 @@ test('the user bubble marks only the prompts a person typed', async ({ page }) =
   await page.getByRole('button', { name: 'Raw log' }).click();
 
   // The opening prompt and the mid-turn steer are the user's; the engine's
-  // relaunch prompt is not, and must not wear the same bubble.
+  // relaunch prompt is not, and must not wear the same raised card.
   await expect(page.locator('.card.user.typed')).toHaveCount(2);
   await expect(page.locator('.card.user.typed').first()).toContainText('You');
   await expect(page.locator('.card.user.auto-continue')).toHaveCount(1);
   await expect(page.locator('.card.user.auto-continue')).toContainText('Auto-continue');
 
-  // The bubble is a fill and an offset, not only a caption: that is what a
-  // reader skimming a long log actually sees. Both cards are measured in one
-  // evaluate so a re-render between two measurements cannot split the pair.
+  // The raised card is elevation, fill, and bold type, not only a caption:
+  // that is what a reader skimming a long log actually sees. Both cards are
+  // measured in one evaluate so a re-render between two measurements cannot
+  // split the pair.
   const layout = await page.evaluate(() => {
-    const box = selector => document.querySelector(selector).getBoundingClientRect();
-    const fill = selector =>
-      getComputedStyle(document.querySelector(selector)).backgroundColor;
+    const style = selector => getComputedStyle(document.querySelector(selector));
     return {
-      bubbleLeft: box('.card.user.typed').left,
-      plainLeft: box('.card.user.auto-continue').left,
-      bubbleFill: fill('.card.user.typed'),
-      plainFill: fill('.card.user.auto-continue'),
+      typedFill: style('.card.user.typed').backgroundColor,
+      plainFill: style('.card.user.auto-continue').backgroundColor,
+      typedShadow: style('.card.user.typed').boxShadow,
+      plainShadow: style('.card.user.auto-continue').boxShadow,
+      typedWeight: style('.card.user.typed .content').fontWeight,
+      plainWeight: style('.card.user.auto-continue .content').fontWeight,
     };
   });
-  expect(layout.bubbleLeft).toBeGreaterThan(layout.plainLeft);
-  expect(layout.bubbleFill).not.toBe(layout.plainFill);
+  expect(layout.typedFill).not.toBe(layout.plainFill);
+  expect(layout.typedShadow).not.toBe('none');
+  expect(layout.plainShadow).toBe('none');
+  expect(Number(layout.typedWeight)).toBeGreaterThan(Number(layout.plainWeight));
 
   // A collapsed turn still reports the steer it hides.
   await expect(page.locator('.turn-steer-badge')).toHaveCount(1);
   await expect(page.locator('.turn-steer-badge')).toContainText('1 steer');
+  expect(viewer.pageErrors).toEqual([]);
+});
+
+test('the prompt rail previews typed prompts and jumps to them', async ({ page }) => {
+  const viewer = new VizBrowserHarness(page);
+  viewer.events = viewer.eventLog([
+    {
+      sequence: 1,
+      ts: 1788316865000,
+      item: { kind: 'user', payload: { content: 'Ship the viewer change' } },
+    },
+    {
+      sequence: 2,
+      item: { kind: 'assistant', payload: { content: 'On it.', tool_calls: [] } },
+    },
+    ...Array.from({ length: 30 }, (_, index) => ({
+      sequence: index + 3,
+      item: {
+        kind: 'runtime_notice',
+        payload: { content: `Progress update ${index + 1}` },
+      },
+    })),
+    { sequence: 33, item: { kind: 'user', payload: { content: 'Also update the docs' } } },
+    {
+      sequence: 34,
+      item: {
+        kind: 'tool_result',
+        payload: {
+          tool_call_id: 'late-call',
+          tool_name: 'shell',
+          content: 'boom',
+          is_error: true,
+        },
+      },
+    },
+    { sequence: 35, item: { kind: 'terminal', payload: { kind: 'finished', message: 'Done.' } } },
+  ]);
+  await viewer.install();
+  await viewer.goto();
+  await viewer.openSession();
+  await page.getByRole('button', { name: 'Raw log' }).click();
+
+  // One tick per typed prompt; the engine wrote nothing here, so two.
+  const marks = page.locator('.rail-mark');
+  await expect(marks).toHaveCount(2);
+
+  // Hovering a tick raises the Codex-style preview: the prompt in bold, its
+  // wall-clock stamp, and the opening of the reply it drew.
+  await marks.first().hover();
+  const firstPreview = marks.first().locator('.rail-preview');
+  await expect(firstPreview).toBeVisible();
+  await expect(firstPreview).toContainText('Ship the viewer change');
+  await expect(firstPreview).toContainText('2026-09-02 02:41 UTC');
+  await expect(firstPreview).toContainText('On it.');
+
+  // The steer's span contains the failed tool call, and its preview says so.
+  await marks.last().hover();
+  const lastPreview = marks.last().locator('.rail-preview');
+  await expect(lastPreview).toBeVisible();
+  await expect(lastPreview).toContainText('had error');
+
+  // Clicking the steer's tick crosses thirty notice cards in one jump.
+  const steer = page.locator('.card.user.typed').filter({ hasText: 'Also update the docs' });
+  await expect(steer).not.toBeInViewport();
+  await marks.last().click();
+  await expect(steer).toBeInViewport();
   expect(viewer.pageErrors).toEqual([]);
 });
 

--- a/viz/README.mbt.md
+++ b/viz/README.mbt.md
@@ -19,17 +19,18 @@ System follows the OS via `prefers-color-scheme`).
 
 ## Who said it
 
-Both views give a prompt a person actually typed the desktop transcript's
-treatment — a filled bubble pushed to the right edge, captioned **You** — so
-the human side of a long conversation is findable at a glance. A turn header
-also counts the mid-turn steers it hides while collapsed (`✋ 2 steers`).
+Both views give a prompt a person actually typed a Codex-style treatment — a
+raised card with a shadow, the prompt in bold headline type, captioned **You**
+beneath it — so the human side of a long conversation is findable at a glance.
+A turn header also counts the mid-turn steers it hides while collapsed
+(`✋ 2 steers`).
 
 Not every user-role message is the user's, and the viewer says so rather than
-lending them the bubble:
+lending them the raised card:
 
 | Message | Caption |
 |---|---|
-| A prompt or steer someone typed | **You** (bubble) |
+| A prompt or steer someone typed | **You** (raised card) |
 | `@agent_session.GoalContinuePrompt`, which serve submits to relaunch a turn on a standing goal | **Auto-continue** |
 | The opening task of a sub-run child session (`<parent>-sr-N`), written by the agent that spawned it | **Task from parent** |
 | A runtime notice or compaction summary, which `chat_messages` replays as a user-role message | **Runtime notice** / **Summary**, as in the raw log |
@@ -37,6 +38,13 @@ lending them the bubble:
 The auto-continue text is matched against the constant the engine submits, so
 rewording that prompt stops the match instead of quietly captioning engine
 text as the user's.
+
+A Codex-style prompt navigator rides the log's left gutter in both views: one
+tick mark per typed prompt, in a column that stays put while the log scrolls.
+Hovering a tick raises the same card the prompt wears — its text, wall-clock
+stamp, a `had errors` flag when the span it started hit failed tools, and the
+opening of the reply it drew — and clicking jumps to the prompt's card
+(recording the position in the hash's `seq=`, like the step scrubber).
 
 ## Pieces
 

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -1582,7 +1582,8 @@ fn prompt_rail(
     for mark in marks => {
       let preview : Array[@html.Html] = [
         @html.div(class="rail-preview-text") <| truncate(
-          one_line(mark.text), 220,
+          one_line(mark.text),
+          220,
         ),
       ]
       if !mark.time.is_empty() {
@@ -1596,7 +1597,8 @@ fn prompt_rail(
       if !mark.reply.is_blank() {
         preview.push(
           @html.blockquote(class="rail-preview-reply") <| truncate(
-            one_line(mark.reply), 180,
+            one_line(mark.reply),
+            180,
           ),
         )
       }
@@ -1609,7 +1611,9 @@ fn prompt_rail(
   @html.nav(
     class="prompt-rail",
     attrs=@html.Attrs::build().aria_label("User prompts"),
-  ) <| [@html.div(class="rail-marks") <| items]
+  ) <| [
+    @html.div(class="rail-marks") <| items,
+  ]
 }
 
 ///|

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -76,8 +76,12 @@ fn render_raw(
   let plans = raw_plan_baselines(session, failed)
   let step_labels = agent_step_labels(session)
   let turns = group_turns(session.events())
-  let blocks : Array[@html.Html] = [
-    for index, turn in turns => {
+  if turns.is_empty() {
+    return empty_state("This session has no events yet.")
+  }
+  let blocks : Array[@html.Html] = [prompt_rail(session, subrun)]
+  for index, turn in turns {
+    blocks.push(
       turn_block(
         index + 1,
         turn,
@@ -88,11 +92,8 @@ fn render_raw(
         plans,
         step_labels,
         subrun,
-      )
-    }
-  ]
-  if blocks.is_empty() {
-    return empty_state("This session has no events yet.")
+      ),
+    )
   }
   @html.div(class="log raw-log") <| blocks
 }
@@ -390,7 +391,7 @@ fn user_input(content : String, delegated~ : Bool) -> UserInput {
 
 ///|
 /// Card class and caption for a user-role message. Only `Typed` gets the
-/// `typed` bubble the stylesheet fills and pushes right.
+/// `typed` raised card the stylesheet elevates and sets in bold type.
 fn UserInput::card_style(self : UserInput) -> (String, String) {
   match self {
     Typed => ("user typed", "You")
@@ -1509,6 +1510,185 @@ fn steps_with_errors(
   flagged
 }
 
+// ---- prompt rail -----------------------------------------------------------
+
+///|
+/// One entry in the prompt navigator: a prompt the person actually typed,
+/// with what a reader needs to decide whether to jump — when it was sent,
+/// whether the work it started hit tool errors, and how the model's reply
+/// opened.
+priv struct PromptMark {
+  seq : Int
+  time : String
+  text : String
+  mut errors : Int
+  mut reply : String
+}
+
+///|
+/// The typed prompts of a session, in log order. Each mark's error count and
+/// reply preview cover the span from its prompt up to the next typed prompt,
+/// so a mid-turn steer owns the errors that followed it, not the whole
+/// turn's. Replayed assistant events are skipped: the reply shown is the one
+/// this prompt actually drew.
+fn prompt_marks(
+  session : @agent_session.Session,
+  delegated~ : Bool,
+) -> Array[PromptMark] {
+  let marks : Array[PromptMark] = []
+  for event in session.events() {
+    match event.item() {
+      User(message) =>
+        if user_input(message.content(), delegated~) is Typed {
+          marks.push({
+            seq: event.sequence(),
+            time: wall_clock_label(event.unix_ms()),
+            text: message.content(),
+            errors: 0,
+            reply: "",
+          })
+        }
+      Assistant(message) =>
+        if !message.is_replay() &&
+          !message.content().is_blank() &&
+          marks.last() is Some(mark) &&
+          mark.reply.is_empty() {
+          mark.reply = message.content()
+        }
+      Tool(result) =>
+        if result.is_error() && marks.last() is Some(mark) {
+          mark.errors += 1
+        }
+      _ => ()
+    }
+  }
+  marks
+}
+
+///|
+/// A Codex-style prompt navigator: a slim column of tick marks riding the
+/// log's left gutter, one per typed prompt. Hovering a tick raises the same
+/// card the prompt itself wears — bold text, wall-clock stamp, an error
+/// flag, the reply's opening — and clicking jumps to the prompt's card via
+/// its `seq-` anchor, which both views share. Renders nothing when the
+/// session has no typed prompts (a sub-run child's task is its parent's).
+fn prompt_rail(
+  session : @agent_session.Session,
+  subrun : SubrunView,
+) -> @html.Html {
+  let marks = prompt_marks(session, delegated=subrun.delegated)
+  guard !marks.is_empty() else { return @html.nothing }
+  let items : Array[@html.Html] = [
+    for mark in marks => {
+      let preview : Array[@html.Html] = [
+        @html.div(class="rail-preview-text") <| truncate(
+          one_line(mark.text), 220,
+        ),
+      ]
+      if !mark.time.is_empty() {
+        preview.push(@html.div(class="rail-preview-time") <| mark.time)
+      }
+      if mark.errors > 0 {
+        preview.push(
+          @html.div(class="rail-preview-errors") <| "had error\{plural(mark.errors)}",
+        )
+      }
+      if !mark.reply.is_blank() {
+        preview.push(
+          @html.blockquote(class="rail-preview-reply") <| truncate(
+            one_line(mark.reply), 180,
+          ),
+        )
+      }
+      @html.a(class="rail-mark", href="#\{seq_anchor(mark.seq)}", [
+        @html.span(class="rail-tick") <| "",
+        @html.div(class="rail-preview") <| preview,
+      ])
+    }
+  ]
+  @html.nav(
+    class="prompt-rail",
+    attrs=@html.Attrs::build().aria_label("User prompts"),
+  ) <| [@html.div(class="rail-marks") <| items]
+}
+
+///|
+/// A unix-ms stamp as `YYYY-MM-DD HH:MM UTC` (the app header's spelling), or
+/// `""` for the 0 sentinel of an event appended without a clock. Pure civil-
+/// from-days arithmetic so the label is identical on every target and in
+/// every test environment.
+fn wall_clock_label(unix_ms : Int64) -> String {
+  guard unix_ms > 0 else { return "" }
+  let seconds = unix_ms / 1000
+  let days = (seconds / 86400).to_int()
+  let day_seconds = (seconds % 86400).to_int()
+  let z = days + 719468
+  let era = z / 146097
+  let doe = z % 146097
+  let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365
+  let doy = doe - (365 * yoe + yoe / 4 - yoe / 100)
+  let mp = (5 * doy + 2) / 153
+  let day = doy - (153 * mp + 2) / 5 + 1
+  let month = if mp < 10 { mp + 3 } else { mp - 9 }
+  let year = yoe + era * 400 + (if month <= 2 { 1 } else { 0 })
+  let hour = day_seconds / 3600
+  let minute = day_seconds % 3600 / 60
+  "\{year}-\{pad2(month)}-\{pad2(day)} \{pad2(hour)}:\{pad2(minute)} UTC"
+}
+
+///|
+fn pad2(n : Int) -> String {
+  if n < 10 {
+    "0\{n}"
+  } else {
+    "\{n}"
+  }
+}
+
+///|
+test "wall_clock_label converts unix ms to a civil UTC stamp" {
+  // 2026-09-02 02:41:05 UTC
+  inspect(wall_clock_label(1788316865000), content="2026-09-02 02:41 UTC")
+  // The unix epoch itself, exercising the year/month arithmetic at a boundary.
+  inspect(wall_clock_label(31536000000), content="1971-01-01 00:00 UTC")
+  // Events appended without a clock keep the 0 sentinel and get no stamp.
+  inspect(wall_clock_label(0), content="")
+}
+
+///|
+/// Marks segment the log by typed prompts: a steer's mark owns the errors
+/// and the reply that followed it, and engine-authored user messages (the
+/// auto-continue prompt) contribute no mark at all.
+test "prompt_marks segments errors and replies by typed prompt" {
+  let s = @agent_session.Session(SessionId("rail"), system_prompt="")
+    .append(User(UserMessage("ship the feature")))
+    .append(Assistant(AssistantMessage("Starting on it.")))
+    .append(
+      Tool(
+        ToolResult(
+          tool_call_id="c1",
+          tool_name="shell",
+          content="boom",
+          is_error=true,
+        ),
+      ),
+    )
+    .append(User(UserMessage("also fix the docs")))
+    .append(Assistant(AssistantMessage("Docs updated.")))
+    .append(Terminal(Finished("done")))
+    .append(User(UserMessage(@agent_session.GoalContinuePrompt)))
+    .append(Terminal(Finished("done again")))
+  let marks = prompt_marks(s, delegated=false)
+  inspect(marks.length(), content="2")
+  inspect(marks[0].text, content="ship the feature")
+  inspect(marks[0].errors, content="1")
+  inspect(marks[0].reply, content="Starting on it.")
+  inspect(marks[1].errors, content="0")
+  inspect(marks[1].reply, content="Docs updated.")
+  // A sub-run child's user messages are its parent's task: no marks at all.
+  inspect(prompt_marks(s, delegated=true).length(), content="0")
+}
+
 // ---- model projection view -------------------------------------------------
 
 ///|
@@ -1563,7 +1743,9 @@ fn render_model(
   if cards.is_empty() {
     return empty_state("The model projection is empty.")
   }
-  @html.div(class="log model-log") <| cards
+  let blocks : Array[@html.Html] = [prompt_rail(session, subrun)]
+  blocks.append(cards)
+  @html.div(class="log model-log") <| blocks
 }
 
 ///|

--- a/web/index.html
+++ b/web/index.html
@@ -20,8 +20,9 @@
       --accent: #2563eb;
       --on-accent: #ffffff;
       --user: #2f5bd6;
-      --user-bubble: #e7edfd;
-      --user-bubble-border: #b6c7f2;
+      --user-card: #f1f3f7;
+      --user-card-border: #dfe3ea;
+      --user-card-shadow: 0 1px 3px rgba(28, 32, 39, .07), 0 10px 24px rgba(28, 32, 39, .1);
       --assistant: #1a8f63;
       --tool: #8a6d10;
       --error: #c2334a;
@@ -55,8 +56,9 @@
       --accent: #6ea8fe;
       --on-accent: #0b0d12;
       --user: #6f93ff;
-      --user-bubble: #1a2340;
-      --user-bubble-border: #33436f;
+      --user-card: #21252f;
+      --user-card-border: #353b49;
+      --user-card-shadow: 0 1px 3px rgba(0, 0, 0, .3), 0 12px 28px rgba(0, 0, 0, .35);
       --assistant: #36c08a;
       --tool: #c9a227;
       --error: #e0556b;
@@ -91,8 +93,9 @@
         --accent: #6ea8fe;
         --on-accent: #0b0d12;
         --user: #6f93ff;
-        --user-bubble: #1a2340;
-        --user-bubble-border: #33436f;
+        --user-card: #21252f;
+        --user-card-border: #353b49;
+        --user-card-shadow: 0 1px 3px rgba(0, 0, 0, .3), 0 12px 28px rgba(0, 0, 0, .35);
         --assistant: #36c08a;
         --tool: #c9a227;
         --error: #e0556b;
@@ -442,20 +445,70 @@
     .card.user { border-left-color: var(--user); }
     /* The user's own words are the one thing in a log nobody generated, and a
        left rail three pixels wide did not say so. A typed prompt — or a steer
-       dropped mid-turn — gets the desktop transcript's bubble: filled, its own
-       border, pushed to the right edge, so the human side of the conversation
-       is findable at a glance in a wall of tool cards. The engine's
-       auto-continue prompt and a sub-run child's task from its parent are
-       user-role messages too, so they keep the plain card on the agent's side
-       of the column, muted, and say who wrote them. */
+       dropped mid-turn — gets a Codex-style card: a raised surface with a
+       shadow, the prompt set in bold headline type, and the caption tucked
+       underneath it, so the human side of the conversation is findable at a
+       glance in a wall of tool cards. The engine's auto-continue prompt and
+       a sub-run child's task from its parent are user-role messages too, so
+       they keep the plain flat card, muted, and say who wrote them. */
     .card.user.typed {
-      margin-left: auto;
-      max-width: 88%;
-      background: var(--user-bubble);
-      border-color: var(--user-bubble-border);
-      border-left-color: var(--user);
+      display: flex; flex-direction: column;
+      max-width: 92%;
+      background: var(--user-card);
+      border-color: var(--user-card-border);
+      border-left-width: 1px;
+      border-radius: 14px;
+      padding: 14px 18px;
+      box-shadow: var(--user-card-shadow);
     }
-    .card.user.typed > .card-label { color: var(--user); }
+    .card.user.typed > .card-label { order: 1; margin: 8px 0 0; }
+    .card.user.typed .content {
+      font-family: inherit; font-size: 15px; font-weight: 600; line-height: 1.5;
+    }
+    /* Codex-style prompt navigator: a sticky column of tick marks in the
+       log's left gutter, one per typed prompt. Hovering a tick raises the
+       same card the prompt itself wears; clicking jumps to the prompt's
+       seq- anchor. The nav is height 0 so it never displaces the cards. */
+    .log { position: relative; }
+    .prompt-rail { position: sticky; top: 130px; height: 0; z-index: 45; }
+    .rail-marks {
+      position: absolute; left: -24px; top: 0;
+      display: flex; flex-direction: column; gap: 8px;
+    }
+    .rail-mark {
+      position: relative; display: block; width: 22px; padding: 2px 0;
+      text-decoration: none;
+    }
+    .rail-tick {
+      display: block; width: 15px; height: 3px; border-radius: 2px;
+      background: var(--user); opacity: .5;
+    }
+    .rail-mark:hover .rail-tick, .rail-mark:focus-visible .rail-tick { opacity: 1; }
+    .rail-preview {
+      display: none; position: absolute; left: 22px; top: -10px;
+      width: min(520px, 60vw);
+      background: var(--user-card);
+      border: 1px solid var(--user-card-border);
+      border-radius: 14px;
+      box-shadow: var(--user-card-shadow);
+      padding: 14px 18px;
+    }
+    .rail-mark:hover .rail-preview, .rail-mark:focus-visible .rail-preview {
+      display: block;
+    }
+    .rail-preview-text { font-weight: 600; font-size: 14px; color: var(--text); }
+    .rail-preview-time {
+      margin-top: 6px; font-size: 11.5px; color: var(--muted);
+      font-family: ui-monospace, monospace;
+    }
+    .rail-preview-errors {
+      margin-top: 6px; font-size: 12px; font-weight: 600; color: var(--error);
+    }
+    .rail-preview-reply {
+      margin: 8px 0 0; padding: 0 0 0 10px;
+      border-left: 2px solid var(--border);
+      color: var(--muted); font-size: 12.5px; line-height: 1.45;
+    }
     .card.user.auto-continue, .card.user.delegated {
       border-left-color: var(--muted);
     }


### PR DESCRIPTION
## What

Follow-up to #1200. That PR made a typed prompt findable once on screen; this one makes it findable from anywhere in the log, with the two-part Codex treatment:

**Raised prompt cards** — the typed-prompt card drops the chat bubble (right offset, blue fill) for a Codex-style raised surface: left-aligned, rounded, shadowed, the prompt in bold headline type, caption and timestamp tucked underneath. Engine-authored user messages (auto-continue, a sub-run's task from its parent) keep the plain flat card.

**A prompt navigator rail** — one tick per typed prompt in the log's left gutter, sticky while the log scrolls, in both the raw log and the model view. Hovering a tick raises the same card the prompt wears: its text, wall-clock stamp, a `had errors` flag, and the opening of the reply it drew. Clicking jumps to the prompt's `seq-` anchor. Marks segment the log per prompt, so a mid-turn steer owns the errors that followed *it*, not the whole turn's.

## How

- Rabbita owns `<a>` clicks and the shell drops fragment-only URL requests, so a tick's jump is a delegated click handler beside the step scrubber's: `scrollIntoView` plus a `replaceState` recording the position in the hash's `seq=` while keeping `#s=…` intact.
- The rail's wall-clock stamps come from pure civil-from-days arithmetic (viz stays extern-free), so labels are identical on every target and in every test environment.
- A sub-run child renders no rail: its user messages are delegated, which yields no typed marks by the same classification the cards use.

## Tests

- Unit tests on the mark walker (segmentation, delegated sessions) and the clock formatter.
- A Playwright case pinning the tick count, the hover preview's contents, and a click crossing thirty cards into viewport.
- The prior bubble test now pins elevation, fill, and bold type instead of the right offset; three older tests scope text locators to `.card` because the preview legitimately repeats prompt text in the DOM.
- All 13 e2e cases and all viz unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017XVytqJnGjoSJrW3DtQVTN