### PR TITLE
bobzhang/workflow: engine-agnostic workflow orchestration module

### DIFF
--- a/moon.work
+++ b/moon.work
@@ -6,4 +6,5 @@ members = [
   "./editor",
   "./editor/server",
   "./desktop",
+  "./workflow",
 ]

--- a/workflow/README.mbt.md
+++ b/workflow/README.mbt.md
@@ -1,0 +1,215 @@
+# bobzhang/workflow
+
+Engine-agnostic multi-agent workflow orchestration with journaled
+replay/resume — a MoonBit take on the workflow-as-code model: a workflow
+is an ordinary async program, the "graph" unfolds as it runs, and
+durability comes from replaying a journal of typed outcomes rather than
+from a static DAG.
+
+The core package never spawns anything. Its one seam is `Runner`: a
+single async function from `AgentCall` to `AgentOutcome`. Engines plug
+in from the outside — through the `spawn` sub-package's child-contract
+implementation for out-of-process engines, or any in-process function;
+tests plug in fakes, which is why everything below runs hermetically.
+
+## The failure model
+
+Everything else follows from three decisions:
+
+- **Failure is data, in a typed channel.** An agent that produced no
+  usable report raises `WorkflowError::AgentFailed` with a typed
+  `AgentFailure` cause; `try_agent` folds it into a `Result` for fan-out
+  sites. Forgetting to choose a failure policy is a compile error, never
+  a silent `null`.
+- **Cost is never lost.** `AgentOutcome` carries the attempt's spend on
+  BOTH arms — a timed-out child's tokens land in `tokens_spent()` just
+  like a success's. `attempt=None` means no launch was ever tried.
+- **Cancellation is not failure.** Engine bugs and cancellation `raise`
+  through and cancel the task group; the launch allowance only counts
+  agents that actually launched — a call cancelled while queued costs
+  nothing.
+
+## A workflow, end to end
+
+One phase fans three verifiers out over a finding, a quorum policy
+requires at least 2 of the 3 CALLS to succeed (agreement between the
+returned verdicts is then the script's own judgment, as the filter below
+shows), and every launch is capped by the shared semaphore:
+
+```mbt check
+///|
+async fn verdict_runner(call : @workflow.AgentCall) -> @workflow.AgentOutcome {
+  @async.pause()
+  let verdict : Json = if call.input is { "query": String(q), .. } &&
+    q.contains("lens=repro") {
+    { "confirmed": false }
+  } else {
+    { "confirmed": true }
+  }
+  Finished(value=verdict, attempt={
+    attempt_id: "sr-\{call.label}",
+    steps_used: 3,
+    prompt_tokens: 70,
+    completion_tokens: 30,
+  })
+}
+
+///|
+async test "fan out three lenses, gate on a 2-of-3 quorum" {
+  let wf = @workflow.Workflow(
+    runner=@workflow.Runner(verdict_runner),
+    max_concurrent=4,
+    max_calls=16,
+  )
+  wf.phase("Verify")
+  let results = @workflow.fan_out(["correctness", "security", "repro"], lens => {
+    wf.try_agent(
+      kind="judge",
+      "Judge the finding through lens=\{lens}: real?",
+      label="verify:\{lens}",
+    )
+  })
+  let confirmed = @workflow.quorum(results, need=2)
+    .filter(v => v is { "confirmed": True, .. })
+    .length()
+  assert_eq(confirmed, 2)
+  assert_eq(wf.calls_made(), 3)
+  assert_eq(wf.tokens_spent(), 300)
+}
+```
+
+`fan_out` gives every item its own `Result` slot — one lost verifier
+never poisons its siblings, and the tokens they spent stay spent. When
+later work is worthless without ALL of a stage, use `parallel_all`
+instead: the first failure cancels every sibling still in flight. The
+policies are one identifier each: `all_ok`, `collect_ok(min_ok~)`,
+`quorum(need~)`.
+
+Multi-stage pipelines are just function composition inside the fan-out —
+stages need no barrier between them, so composing them per-item IS the
+pipeline:
+
+```mbt check
+///|
+async test "find then verify, with no barrier between the stages" {
+  let wf = @workflow.Workflow(runner=@workflow.Runner(verdict_runner))
+  let verified = @workflow.fan_out(["pkg/a", "pkg/b"], target => {
+    let finding = wf.try_agent("Find the worst bug in \{target}", kind="judge")
+    match finding {
+      // Each finding proceeds to verification the moment ITS finder
+      // returns — b's finder may still be running while a verifies.
+      Ok(_) =>
+        wf.try_agent(
+          "Adversarially verify the finding in \{target}",
+          kind="judge",
+        )
+      Err(error) => Err(error)
+    }
+  })
+  assert_eq(@workflow.all_ok(verified).length(), 2)
+}
+```
+
+## Replay: crash, resume, and pay only for new work
+
+Every live outcome is appended to the `Journal` — the call's WORK
+identity (kind, input, max_steps — never the display label) plus the
+lossless outcome. Re-running the same program against the same journal
+replays successes for free, keeps a human's `Skipped` refusal standing,
+and re-attempts other failures — getting past those is what resume is
+for:
+
+```mbt check
+///|
+async test "the second generation replays instead of re-paying" {
+  let journal = @workflow.Journal::in_memory()
+  let wf1 = @workflow.Workflow(
+    runner=@workflow.Runner(verdict_runner),
+    journal~,
+  )
+  let first = wf1.agent(
+    "Judge the finding through lens=security: real?",
+    kind="judge",
+  )
+  assert_eq(wf1.tokens_spent(), 100)
+
+  // Same program, next generation: served from the journal — no launch,
+  // no slot, no fresh spend.
+  let wf2 = @workflow.Workflow(
+    runner=@workflow.Runner(verdict_runner),
+    journal=@workflow.Journal::in_memory(prior=journal.recorded()),
+  )
+  assert_eq(
+    wf2.agent("Judge the finding through lens=security: real?", kind="judge"),
+    first,
+  )
+  assert_eq(wf2.calls_made(), 0)
+  assert_eq(wf2.calls_replayed(), 1)
+  assert_eq(wf2.tokens_spent(), 0)
+}
+```
+
+File-backed journals (`@workflow.Journal::load(path)`) are append-only JSONL,
+accumulated across generations. A torn final line — the signature of
+crashing mid-append — is dropped AND repaired on disk; corruption
+anywhere else raises `JournalCorrupted`. Identical concurrent calls are
+intentional samples (three identical verifiers) and consume entries as a
+multiset.
+
+## Observability
+
+`@workflow.Workflow(on_event=...)` narrates the run: `PhaseStarted`, `Log`, and an
+`AgentStarted`/`AgentFinished` bracket that balances on EVERY path —
+success, typed failure, cancellation (`Interrupted`), and infrastructure
+error (`Errored`) — plus `AgentReplayed` for journal hits. Purely
+observational: no control flow rides on events.
+
+## Plugging in an engine
+
+Any process that speaks the CHILD CONTRACT is already an engine: one
+JSON line on stdin — the VERSIONED request envelope
+`{"workflow_contract": 1, id, kind, max_steps?, input}`, with the pipe
+held open (EOF is graceful cancel) — JSONL events on stdout
+(`usage`/`agent_step` are accounted exactly), and one final
+`{"subrun_report": ...}` line. The `spawn` sub-package is the contract's
+one implementation:
+
+```moonbit nocheck
+///|
+let runner = @spawn.contract_runner(launch=_ => {
+  command: "my-engine",
+  args: [],
+  cwd: None,
+  extra_env: None,
+  deadline_ms: None,
+})
+```
+
+For an engine whose reports are pure values, that is the whole adapter —
+a shim around a Rust CLI needs only to translate framing, and gets
+journal replay, budgets, and cancellation for free. An engine whose
+reports name stateful resources should also pass `validate_replay`.
+
+For in-process engines (and tests), implement one async function and
+wrap it:
+
+```moonbit nocheck
+///|
+let runner = @workflow.Runner(call => {
+  // spawn something, await it, and account honestly:
+  Finished(value=report_json, attempt={
+    subrun_id,
+    steps_used,
+    prompt_tokens,
+    completion_tokens,
+  })
+})
+```
+
+openseek's production adapter (`agent_workflow` in the openseek module)
+maps `explore`/`review`/`echo` kinds onto `openseek subrun` child
+processes and adds write-capable `worker` slices — confined git
+worktrees whose outcomes are captured from git evidence, replayed by
+their LOGICAL identity, and re-validated against the live registry at
+replay time (a stale outcome runs live instead of lying). The dependency points engine → framework: this
+module never learns openseek exists.

--- a/workflow/combinators.mbt
+++ b/workflow/combinators.mbt
@@ -1,0 +1,98 @@
+///|
+/// Run thunks concurrently, each already carrying its failure policy in
+/// its type: a thunk resolves to `Result[T, WorkflowError]` (build them
+/// from `try_agent`), so one agent's failure lands in its own slot without
+/// disturbing siblings — tokens already spent on the others stay spent.
+/// Anything a thunk RAISES is deliberately not caught: engine bugs and
+/// cancellation fail the task group and cancel every peer, never demoted
+/// to a slot a policy could quietly discard. Pair with `all_ok` /
+/// `collect_ok` / `quorum` to choose the policy in one identifier.
+pub async fn[T] parallel(
+  thunks : Array[async () -> Result[T, WorkflowError]],
+) -> Array[Result[T, WorkflowError]] {
+  let results : Array[Result[T, WorkflowError]?] = Array::make(
+    thunks.length(),
+    None,
+  )
+  @async.with_task_group(group => {
+    for index, thunk in thunks {
+      group.spawn_bg(() => results[index] = Some(thunk()))
+    }
+  })
+  results.map(slot => slot.unwrap())
+}
+
+///|
+/// Fail-fast fan-out: the first thunk to RAISE (an `agent` call
+/// propagating its `AgentFailed`, an engine bug, cancellation) cancels
+/// every sibling still in flight and propagates. The right shape when
+/// later work is worthless without ALL of this stage — otherwise prefer
+/// `parallel`, which keeps what succeeded.
+pub async fn[T] parallel_all(thunks : Array[async () -> T]) -> Array[T] {
+  let results : Array[T?] = Array::make(thunks.length(), None)
+  @async.with_task_group(group => {
+    for index, thunk in thunks {
+      group.spawn_bg(() => results[index] = Some(thunk()))
+    }
+  })
+  results.map(slot => slot.unwrap())
+}
+
+///|
+/// Fan items out through one async stage, one `Result` slot per item.
+/// Multi-stage pipelines are function composition inside `run` — stages
+/// need no barrier between them, so composing them per-item IS the
+/// pipeline.
+pub async fn[A, B] fan_out(
+  items : Array[A],
+  run : async (A) -> Result[B, WorkflowError],
+) -> Array[Result[B, WorkflowError]] {
+  parallel(items.map(item => () => run(item)))
+}
+
+///|
+/// Policy: every slot must have succeeded; re-raise the first failure
+/// otherwise. Post-hoc fail-fast — siblings have already run to
+/// completion; use `parallel_all` when failure should cancel them instead.
+pub fn[T] all_ok(
+  results : Array[Result[T, WorkflowError]],
+) -> Array[T] raise WorkflowError {
+  let ok = []
+  for result in results {
+    match result {
+      Ok(value) => ok.push(value)
+      Err(error) => raise error
+    }
+  }
+  ok
+}
+
+///|
+/// Policy: keep the successes, requiring at least `min_ok` of them
+/// (`QuorumNotReached` otherwise). `min_ok=0` is pure best-effort
+/// collection; a negative `min_ok` is treated as 0.
+pub fn[T] collect_ok(
+  results : Array[Result[T, WorkflowError]],
+  min_ok? : Int = 0,
+) -> Array[T] raise WorkflowError {
+  let ok = []
+  for result in results {
+    if result is Ok(value) {
+      ok.push(value)
+    }
+  }
+  if ok.length() < min_ok {
+    raise QuorumNotReached(need=min_ok, ok=ok.length(), of=results.length())
+  }
+  ok
+}
+
+///|
+/// Policy: k-of-n agreement gates (adversarial verification, vote panels):
+/// at least `need` slots must have succeeded.
+pub fn[T] quorum(
+  results : Array[Result[T, WorkflowError]],
+  need~ : Int,
+) -> Array[T] raise WorkflowError {
+  collect_ok(results, min_ok=need)
+}

--- a/workflow/examples/scout/main.mbt
+++ b/workflow/examples/scout/main.mbt
@@ -1,0 +1,93 @@
+///|
+/// A WORKFLOW SCRIPT: the shape a generated or hand-written orchestration
+/// takes. Its whole dependency closure is `bobzhang/workflow` (plus its
+/// `spawn` sub-package) — the engine is just a binary path in argv[1]
+/// that speaks the child contract.
+///
+///   moon run workflow/examples/scout -- <engine> [journal.jsonl] [kind] [model]
+///
+/// With no kind, three `subrun echo` probes run keylessly. With
+/// `explore` (and optionally a model name), one real read-only scout
+/// answers a question about the repository — the provider key rides the
+/// inherited environment, exactly as the contract prescribes. Run twice
+/// with a journal path to watch the second generation replay from the
+/// journal instead of spawning any children.
+async fn main {
+  let args = @env.args()
+  guard args.length() >= 2 else {
+    println("usage: scout <engine-binary> [journal.jsonl] [kind] [model]")
+    return
+  }
+  let exe = args[1]
+  let journal = if args.length() >= 3 && args[2] != "-" {
+    @workflow.Journal::load(args[2])
+  } else {
+    @workflow.Journal::in_memory()
+  }
+  let kind = if args.length() >= 4 { args[3] } else { "echo" }
+  let model : String? = if args.length() >= 5 { Some(args[4]) } else { None }
+  let wf = @workflow.Workflow(
+    runner=@spawn.contract_runner(launch=call => {
+      // The script owns its launch: the request ENVELOPE already carries
+      // kind and the step ceiling, so argv holds only engine settings.
+      // The API key is NEVER here — it rides the inherited environment.
+      let argv = ["subrun", call.kind]
+      if call.max_steps is Some(steps) {
+        argv.push("--max-steps")
+        argv.push("\{steps}")
+      }
+      if model is Some(model) {
+        argv.push("--model")
+        argv.push(model)
+      }
+      {
+        command: exe,
+        args: argv,
+        cwd: None,
+        extra_env: None,
+        deadline_ms: None,
+      }
+    }),
+    max_concurrent=4,
+    max_calls=16,
+    journal~,
+    on_event=event => {
+      match event {
+        @workflow.AgentStarted(label~, ..) => println("  ▶ \{label}")
+        @workflow.AgentReplayed(label~, ..) =>
+          println("  ↺ \{label} (replayed)")
+        _ => ()
+      }
+    },
+  )
+  wf.phase("Scout")
+  let results = if kind == "echo" {
+    // Three keyless probes; each is one child process of the engine.
+    @workflow.fan_out(["alpha", "beta", "gamma"], probe => {
+      wf.try_agent("probe \{probe}", kind="echo", label="scout:\{probe}")
+    })
+  } else {
+    // One REAL scout: a model-driven read-only agent over this
+    // repository, bounded by a small step ceiling.
+    [
+      wf.try_agent(
+        "What kinds does `openseek subrun` dispatch, and where is the dispatch? Answer in one sentence.",
+        kind~,
+        hints="cmd/openseek/subrun.mbt",
+        label="scout:subrun-kinds",
+        max_steps=24,
+      ),
+    ]
+  }
+  // Report per slot: a failed agent is a printed line, not a crash —
+  // the typed error channel makes the choice explicit.
+  for result in results {
+    match result {
+      Ok(answer) => println("  report: \{answer.stringify()}")
+      Err(error) => println("  FAILED: \{error}")
+    }
+  }
+  println(
+    "launched \{wf.calls_made()} children, replayed \{wf.calls_replayed()}, spent \{wf.tokens_spent()} tokens",
+  )
+}

--- a/workflow/examples/scout/moon.pkg
+++ b/workflow/examples/scout/moon.pkg
@@ -1,0 +1,10 @@
+import {
+  "bobzhang/workflow",
+  "moonbitlang/async",
+  "bobzhang/workflow/spawn",
+  "moonbitlang/core/env",
+}
+
+supported_targets = "+native"
+
+pkgtype(kind: "executable")

--- a/workflow/examples/scout/pkg.generated.mbti
+++ b/workflow/examples/scout/pkg.generated.mbti
@@ -1,0 +1,12 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/workflow/examples/scout"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits

--- a/workflow/journal.mbt
+++ b/workflow/journal.mbt
@@ -1,0 +1,252 @@
+///|
+/// One journal record: an agent call's work identity and what it resolved
+/// to. The journal is the workflow's durability seam — everything a resumed
+/// run needs to skip re-paying for work already done rides these entries,
+/// so the entry must lose nothing the live run knew (hence `AgentOutcome`,
+/// the lossless envelope, and not just the value).
+pub(all) struct JournalEntry {
+  call : AgentCall
+  outcome : AgentOutcome
+} derive(Eq, ToJson, FromJson)
+
+///|
+pub extend JournalEntry with Eq::{equal, not_equal}
+
+///|
+pub extend JournalEntry with ToJson::{to_json}
+
+///|
+pub extend JournalEntry with FromJson::{from_json}
+
+///|
+/// The journal file is damaged somewhere other than its final line. A torn
+/// TAIL is expected crash damage and is repaired on load; mid-file
+/// corruption means the append-only contract was broken by something else
+/// and must not be silently dropped.
+pub suberror JournalCorrupted {
+  JournalCorrupted(path~ : String, line~ : Int)
+}
+
+///|
+pub extend JournalCorrupted with Show::{to_string, output}
+
+///|
+pub impl Show for JournalCorrupted with fn output(self, logger) {
+  let JournalCorrupted(path~, line~) = self
+  logger.write_string("journal \{path} is corrupt at line \{line}")
+}
+
+///|
+/// The replay journal: prior-run entries consumed by WORK-IDENTITY match
+/// as this run re-executes, plus an append-only record of this run's live
+/// outcomes. Replay rules:
+///
+/// - a matching `Finished` entry replays its value — the work is not
+///   re-paid, and neither the launch allowance nor `tokens_spent` is
+///   charged (historical spend lives here, not in the fresh account);
+/// - a matching `Skipped` entry replays as the same refusal — a human
+///   declined this call once, and resume must not override that decision;
+/// - any other failure does NOT replay: getting past it is what resume is
+///   FOR, so the call runs live again (and consumes fresh launch
+///   allowance — size `max_calls` with re-attempts in mind).
+///
+/// Identity is the call's work content — kind, input, max_steps, and
+/// the workflow's replay scope — never the display label. Duplicate identical calls are intentional samples
+/// (three identical verifiers), so matching consumes entries as a
+/// multiset: each replay consumes one entry, in file order, and only LIVE
+/// outcomes are recorded — replays are never re-appended, so entry counts
+/// stay honest across any number of resume generations.
+///
+/// A file-backed journal assumes ONE writing workflow process per path:
+/// appends are serialized within the process, not across processes.
+pub struct Journal {
+  priv prior : Array[JournalEntry]
+  priv consumed : Array[Bool]
+  priv path : String?
+  priv recorded : Array[JournalEntry]
+  priv write_lock : @async.Mutex
+}
+
+///|
+/// A journal with no backing file: `prior` seeds replay (empty by
+/// default, copied — later mutation of the argument cannot skew the
+/// consumption bookkeeping), live outcomes accumulate in `recorded`. The
+/// test-and-embed constructor.
+pub fn Journal::in_memory(prior? : Array[JournalEntry] = []) -> Journal {
+  let prior = prior.copy()
+  {
+    prior,
+    consumed: Array::make(prior.length(), false),
+    path: None,
+    recorded: [],
+    write_lock: Mutex(),
+  }
+}
+
+///|
+/// Open (or start) a file-backed journal: an append-only JSONL file, one
+/// entry per line, accumulated across every generation of the run. A
+/// missing file is an empty journal.
+///
+/// Crash honesty: a torn TAIL — an unparsable or undecodable final line,
+/// or a final line missing its newline — is the signature of dying
+/// mid-append. The damaged suffix is dropped from replay AND repaired on
+/// disk (atomic rewrite-and-rename), so the next generation's appends
+/// land on a clean boundary instead of concatenating onto torn bytes.
+/// Damage anywhere else raises `JournalCorrupted`. Lines are split at the
+/// byte level before UTF-8 decoding, so a tail torn mid-codepoint cannot
+/// poison the healthy prefix.
+pub async fn Journal::load(path : String) -> Journal {
+  let prior : Array[JournalEntry] = []
+  if @fs.exists(path) {
+    let bytes = @fs.read_file(path).binary()
+    let segments : Array[(Int, Int)] = []
+    let mut start = 0
+    for index in 0..<bytes.length() {
+      if bytes[index] == b'\n' {
+        segments.push((start, index))
+        start = index + 1
+      }
+    }
+    let terminated = start == bytes.length()
+    if !terminated {
+      segments.push((start, bytes.length()))
+    }
+    // An unterminated final line needs the on-disk repair even when its
+    // content parses: the next append would otherwise fuse two entries.
+    let mut needs_repair = !terminated
+    for index, segment in segments {
+      let (from, to) = segment
+      let parsed : Result[JournalEntry?, Error] = Ok(parse_line(bytes[from:to])) catch {
+        error => Err(error)
+      }
+      match parsed {
+        Ok(Some(entry)) => prior.push(entry)
+        Ok(None) => ()
+        Err(_) if index == segments.length() - 1 => needs_repair = true
+        Err(_) => raise JournalCorrupted(path~, line=index + 1)
+      }
+    }
+    if needs_repair {
+      let out = StringBuilder()
+      for entry in prior {
+        out.write_string(({ "v": 1, "e": entry.to_json() } : Json).stringify())
+        out.write_char('\n')
+      }
+      let tmp = path + ".repair"
+      @fs.write_file(tmp, out.to_string())
+      @fs.rename(tmp, path, replace=true)
+    }
+  }
+  {
+    prior,
+    consumed: Array::make(prior.length(), false),
+    path: Some(path),
+    recorded: [],
+    write_lock: Mutex(),
+  }
+}
+
+///|
+/// One line's entry, `None` for a blank line (also covers the `\r` a CRLF
+/// writer leaves behind). Raises on undecodable bytes or unparsable JSON —
+/// the caller decides whether that is a torn tail or corruption.
+fn parse_line(segment : BytesView) -> JournalEntry? raise {
+  let text = @utf8.decode(segment).trim()
+  if text.is_empty() {
+    return None
+  }
+  // Schema-versioned envelope: the storage format is an evolvable
+  // contract of its own, never derived codec output blessed by accident.
+  guard @json.parse(text.to_owned()) is { "v": Number(1, ..), "e": entry, .. } else {
+    fail("journal line is not a v1 entry")
+  }
+  Some(@json.from_json(entry))
+}
+
+///|
+/// This run's live outcomes, in completion order (a copy — the journal's
+/// own bookkeeping cannot be skewed through it).
+pub fn Journal::recorded(self : Journal) -> Array[JournalEntry] {
+  self.recorded.copy()
+}
+
+///|
+/// The prior-run entries replay draws from, in file order (a copy).
+pub fn Journal::prior(self : Journal) -> Array[JournalEntry] {
+  self.prior.copy()
+}
+
+///|
+/// Two calls describe the same WORK: everything but the display label.
+fn same_work(a : AgentCall, b : AgentCall) -> Bool {
+  a.kind == b.kind &&
+  a.input == b.input &&
+  a.max_steps == b.max_steps &&
+  a.scope == b.scope
+}
+
+///|
+/// CLAIM the next replay candidate for one call, consuming it. Purely
+/// synchronous — no suspension separates lookup from consumption, so
+/// concurrent identical calls each claim a distinct entry. Selection
+/// prefers successes (in file order); only when no unconsumed success
+/// remains does the EARLIEST recorded skip stand in. The caller walks
+/// candidates: a candidate its validator vetoes stays consumed, and the
+/// next claim gets the next candidate — a stale generation must never
+/// mask the valid one recorded after it. `release` rolls a claim back
+/// when validation UNWINDS (cancellation, registry error): the entry was
+/// neither served nor rejected, so it stays available.
+fn Journal::claim(self : Journal, call : AgentCall) -> (Int, AgentOutcome)? {
+  let mut skip_slot : Int? = None
+  for index, entry in self.prior {
+    if self.consumed[index] || !same_work(entry.call, call) {
+      continue
+    }
+    match entry.outcome {
+      Finished(..) => {
+        self.consumed[index] = true
+        return Some((index, entry.outcome))
+      }
+      DidNotFinish(failure=Skipped, ..) =>
+        if skip_slot is None {
+          skip_slot = Some(index)
+        }
+      DidNotFinish(..) => ()
+    }
+  }
+  // No success to replay: a recorded human refusal still stands; any
+  // other failure yields a live re-attempt.
+  if skip_slot is Some(index) {
+    self.consumed[index] = true
+    return Some((index, self.prior[index].outcome))
+  }
+  None
+}
+
+///|
+/// Roll back a claim whose validation unwound before deciding.
+fn Journal::release(self : Journal, slot : Int) -> Unit {
+  self.consumed[slot] = false
+}
+
+///|
+/// Append one live outcome — to memory always, and through to the backing
+/// file when there is one. Appends are serialized behind a mutex: one
+/// entry's line may take several syscalls to write, and concurrent agent
+/// completions must interleave at line granularity, never byte.
+async fn Journal::record(self : Journal, entry : JournalEntry) -> Unit {
+  self.recorded.push(entry)
+  if self.path is Some(path) {
+    self.write_lock.acquire()
+    defer self.write_lock.release()
+    // OpenOrCreate, not the default CreateOrTruncate: append must never
+    // wipe the generations already on disk.
+    @fs.write_file(
+      path,
+      ({ "v": 1, "e": entry.to_json() } : Json).stringify() + "\n",
+      append=true,
+      create_mode=OpenOrCreate,
+    )
+  }
+}

--- a/workflow/journal_test.mbt
+++ b/workflow/journal_test.mbt
@@ -1,0 +1,466 @@
+///|
+/// Replay/resume tests. The runners tell the story: `must_not_run` fails
+/// the test if a call that should have replayed launches; `recovered`
+/// succeeds where a prior generation failed, playing the "resume gets past
+/// the failure" role.
+async fn must_not_run(_call : @workflow.AgentCall) -> @workflow.AgentOutcome {
+  @async.pause()
+  fail("this call must have been served from the journal")
+}
+
+///|
+async fn recovered(call : @workflow.AgentCall) -> @workflow.AgentOutcome {
+  @async.pause()
+  guard call.input is { "query": String(prompt), .. } else {
+    fail("the recovered runner expects the explore-style input")
+  }
+  Finished(value={ "recovered": prompt }, attempt=attempt_for(call))
+}
+
+///|
+fn call_for(prompt : String, label? : String) -> @workflow.AgentCall {
+  {
+    kind: "scout",
+    input: { "query": prompt },
+    label: label.unwrap_or(prompt),
+    max_steps: None,
+    scope: "",
+  }
+}
+
+///|
+fn success_entry(
+  prompt : String,
+  value : Json,
+  label? : String,
+) -> @workflow.JournalEntry {
+  {
+    call: call_for(prompt, label?),
+    outcome: Finished(value~, attempt=attempt_for(call_for(prompt))),
+  }
+}
+
+///|
+fn failure_entry(
+  prompt : String,
+  failure : @workflow.AgentFailure,
+) -> @workflow.JournalEntry {
+  { call: call_for(prompt), outcome: DidNotFinish(failure~, attempt=None), }
+}
+
+///|
+async test "a journalled success replays without launching or charging" {
+  let journal = @workflow.Journal::in_memory()
+  let wf1 = @workflow.Workflow(runner=@workflow.Runner(scripted), journal~)
+  let first = wf1.agent("hello", kind="scout")
+  assert_eq(wf1.calls_made(), 1)
+  assert_eq(journal.recorded().length(), 1)
+  let events : Array[String] = []
+  let wf2 = @workflow.Workflow(
+    runner=@workflow.Runner(must_not_run),
+    journal=@workflow.Journal::in_memory(prior=journal.recorded()),
+    on_event=event => events.push(render(event)),
+  )
+  let second = wf2.agent("hello", kind="scout")
+  assert_eq(second, first)
+  assert_eq(wf2.calls_made(), 0)
+  assert_eq(wf2.calls_replayed(), 1)
+  assert_eq(wf2.tokens_spent(), 0)
+  assert_eq(events, ["replay hello ok"])
+}
+
+///|
+async test "a journalled failure is re-attempted live" {
+  let journal = @workflow.Journal::in_memory()
+  let wf1 = @workflow.Workflow(runner=@workflow.Runner(scripted), journal~)
+  guard wf1.try_agent("fail:x", kind="scout") is Err(_) else {
+    fail("expected the first attempt to fail")
+  }
+  guard journal.recorded() is [{ outcome: DidNotFinish(..), .. }] else {
+    fail("expected the failure to be journalled losslessly")
+  }
+  let wf2 = @workflow.Workflow(
+    runner=@workflow.Runner(recovered),
+    journal=@workflow.Journal::in_memory(prior=journal.recorded()),
+  )
+  let value = wf2.agent("fail:x", kind="scout")
+  assert_eq(value, { "recovered": "fail:x" })
+  assert_eq(wf2.calls_made(), 1)
+  assert_eq(wf2.calls_replayed(), 0)
+}
+
+///|
+async test "a journalled skip replays as the same refusal" {
+  let wf = @workflow.Workflow(
+    runner=@workflow.Runner(must_not_run),
+    journal=@workflow.Journal::in_memory(prior=[
+      failure_entry("risky", @workflow.AgentFailure::Skipped),
+    ]),
+  )
+  guard wf.try_agent("risky", kind="scout")
+    is Err(@workflow.AgentFailed(failure=Skipped, ..)) else {
+    fail("expected the recorded refusal to stand")
+  }
+  assert_eq(wf.calls_replayed(), 1)
+  assert_eq(wf.tokens_spent(), 0)
+}
+
+///|
+async test "replay prefers a newer success over an older failure" {
+  let wf = @workflow.Workflow(
+    runner=@workflow.Runner(must_not_run),
+    journal=@workflow.Journal::in_memory(prior=[
+      failure_entry("x", @workflow.AgentFailure::TimedOut),
+      success_entry("x", { "answer": 42 }),
+    ]),
+  )
+  assert_eq(wf.agent("x", kind="scout"), { "answer": 42 })
+}
+
+///|
+async test "identical calls consume journal entries as a multiset" {
+  let wf = @workflow.Workflow(
+    runner=@workflow.Runner(recovered),
+    journal=@workflow.Journal::in_memory(prior=[
+      success_entry("vote", { "sample": 1 }),
+      success_entry("vote", { "sample": 2 }),
+    ]),
+  )
+  assert_eq(wf.agent("vote", kind="scout"), { "sample": 1 })
+  assert_eq(wf.agent("vote", kind="scout"), { "sample": 2 })
+  // A third identical call outruns the journal: it runs live.
+  assert_eq(wf.agent("vote", kind="scout"), { "recovered": "vote" })
+  assert_eq(wf.calls_replayed(), 2)
+  assert_eq(wf.calls_made(), 1)
+}
+
+///|
+async test "the display label is not part of the work identity" {
+  let wf = @workflow.Workflow(
+    runner=@workflow.Runner(must_not_run),
+    journal=@workflow.Journal::in_memory(prior=[
+      success_entry("q", { "a": 1 }, label="scout-one"),
+    ]),
+  )
+  assert_eq(wf.agent("q", kind="scout", label="scout-two"), { "a": 1 })
+}
+
+///|
+async test "a file-backed journal resumes across generations" {
+  let dir = @fs.tmpdir(prefix="workflow-journal-")
+  let path = "\{dir}/journal.jsonl"
+  // Generation 1: one success, one failure, appended as they complete.
+  let wf1 = @workflow.Workflow(
+    runner=@workflow.Runner(scripted),
+    journal=@workflow.Journal::load(path),
+  )
+  let first = wf1.agent("hello", kind="scout")
+  guard wf1.try_agent("fail:x", kind="scout") is Err(_) else {
+    fail("expected the first attempt to fail")
+  }
+  // Generation 2: the success replays, the failure re-attempts and
+  // recovers — and the recovery is appended for the next generation.
+  let journal2 = @workflow.Journal::load(path)
+  assert_eq(journal2.prior().length(), 2)
+  let wf2 = @workflow.Workflow(
+    runner=@workflow.Runner(recovered),
+    journal=journal2,
+  )
+  assert_eq(wf2.agent("hello", kind="scout"), first)
+  assert_eq(wf2.agent("fail:x", kind="scout"), { "recovered": "fail:x" })
+  assert_eq(wf2.calls_replayed(), 1)
+  assert_eq(wf2.calls_made(), 1)
+  // Generation 3: everything replays; nothing may launch.
+  let journal3 = @workflow.Journal::load(path)
+  assert_eq(journal3.prior().length(), 3)
+  let wf3 = @workflow.Workflow(
+    runner=@workflow.Runner(must_not_run),
+    journal=journal3,
+  )
+  assert_eq(wf3.agent("hello", kind="scout"), first)
+  assert_eq(wf3.agent("fail:x", kind="scout"), { "recovered": "fail:x" })
+  @fs.rmdir(dir, recursive=true) catch {
+    _ => ()
+  }
+}
+
+///|
+async test "replay prefers a success over a recorded skip" {
+  let wf = @workflow.Workflow(
+    runner=@workflow.Runner(must_not_run),
+    journal=@workflow.Journal::in_memory(prior=[
+      failure_entry("x", @workflow.AgentFailure::Skipped),
+      success_entry("x", { "answer": 1 }),
+    ]),
+  )
+  assert_eq(wf.agent("x", kind="scout"), { "answer": 1 })
+}
+
+///|
+async test "re-attempting a journalled failure consumes fresh allowance" {
+  // Documented semantics: failures never replay, so every generation's
+  // re-attempt is a real launch — max_calls must be sized with that in
+  // mind. This pins the behavior so changing it is a decision, not drift.
+  let wf = @workflow.Workflow(
+    runner=@workflow.Runner(recovered),
+    journal=@workflow.Journal::in_memory(prior=[
+      failure_entry("x", @workflow.AgentFailure::TimedOut),
+    ]),
+    max_calls=1,
+  )
+  assert_eq(wf.agent("x", kind="scout"), { "recovered": "x" })
+  guard wf.try_agent("y", kind="scout")
+    is Err(@workflow.CallBudgetExhausted(..)) else {
+    fail("expected the re-attempt to have spent the allowance")
+  }
+}
+
+///|
+async test "concurrent identical calls consume distinct journal entries" {
+  let wf = @workflow.Workflow(
+    runner=@workflow.Runner(must_not_run),
+    journal=@workflow.Journal::in_memory(prior=[
+      success_entry("vote", { "sample": 1 }),
+      success_entry("vote", { "sample": 2 }),
+    ]),
+  )
+  let results = @workflow.parallel([
+    () => wf.try_agent("vote", kind="scout"),
+    () => wf.try_agent("vote", kind="scout"),
+  ])
+  let values = @workflow.all_ok(results)
+  // Completion order is scheduling-dependent; the multiset is not.
+  assert_true(values.contains({ "sample": 1 }))
+  assert_true(values.contains({ "sample": 2 }))
+  assert_eq(wf.calls_replayed(), 2)
+}
+
+///|
+async test "concurrent live agents append whole lines" {
+  let dir = @fs.tmpdir(prefix="workflow-journal-parallel-")
+  let path = "\{dir}/journal.jsonl"
+  let wf = @workflow.Workflow(
+    runner=@workflow.Runner(scripted),
+    journal=@workflow.Journal::load(path),
+  )
+  let results = @workflow.parallel([
+    () => wf.try_agent("a", kind="scout"),
+    () => wf.try_agent("b", kind="scout"),
+    () => wf.try_agent("c", kind="scout"),
+  ])
+  assert_eq(@workflow.all_ok(results).length(), 3)
+  // Every line survives a reload: no interleaved bytes, no torn entries.
+  assert_eq(@workflow.Journal::load(path).prior().length(), 3)
+  @fs.rmdir(dir, recursive=true) catch {
+    _ => ()
+  }
+}
+
+///|
+async test "label-only differences replay through a file round trip" {
+  let dir = @fs.tmpdir(prefix="workflow-journal-label-")
+  let path = "\{dir}/journal.jsonl"
+  let wf1 = @workflow.Workflow(
+    runner=@workflow.Runner(scripted),
+    journal=@workflow.Journal::load(path),
+  )
+  let first = wf1.agent("q", kind="scout", label="scout-one")
+  let wf2 = @workflow.Workflow(
+    runner=@workflow.Runner(must_not_run),
+    journal=@workflow.Journal::load(path),
+  )
+  assert_eq(wf2.agent("q", kind="scout", label="scout-two"), first)
+  @fs.rmdir(dir, recursive=true) catch {
+    _ => ()
+  }
+}
+
+///|
+async test "a failed journal append surfaces as one errored bracket" {
+  let dir = @fs.tmpdir(prefix="workflow-journal-gone-")
+  let path = "\{dir}/journal.jsonl"
+  let journal = @workflow.Journal::load(path)
+  // Yank the directory out from under the journal: the outcome resolves,
+  // then persistence fails.
+  @fs.rmdir(dir, recursive=true)
+  let events : Array[String] = []
+  let wf = @workflow.Workflow(runner=@workflow.Runner(scripted), journal~, on_event=event => {
+    events.push(render(event))
+  })
+  let mut raised = false
+  let _ = wf.agent("q", kind="scout") catch {
+    _ => {
+      raised = true
+      Json::null()
+    }
+  }
+  assert_true(raised)
+  // Exactly one bracket close, as infrastructure failure — and the
+  // attempt's tokens were charged before persistence was tried.
+  assert_eq(events, ["start q scout -", "finish q errored"])
+  assert_eq(wf.tokens_spent(), 10)
+}
+
+///|
+async test "a torn final line is dropped AND repaired on disk" {
+  let dir = @fs.tmpdir(prefix="workflow-journal-torn-")
+  let entry_line = (
+      { "v": 1, "e": Json(success_entry("hello", { "a": 1 })) } : Json).stringify() +
+    "\n"
+  // Torn tail: the signature of a crash mid-append.
+  let torn = "\{dir}/torn.jsonl"
+  @fs.write_file(torn, entry_line + "{\"call\": {\"kind")
+  let journal = @workflow.Journal::load(torn)
+  assert_eq(journal.prior().length(), 1)
+  // The load repaired the physical tail: a new append must land on a
+  // clean line boundary, and the next generation must see both entries —
+  // the regression for append-after-torn-tail corrupting the file.
+  let wf = @workflow.Workflow(runner=@workflow.Runner(scripted), journal~)
+  let _ = wf.agent("world", kind="scout")
+  assert_eq(@workflow.Journal::load(torn).prior().length(), 2)
+  @fs.rmdir(dir, recursive=true) catch {
+    _ => ()
+  }
+}
+
+///|
+async test "a valid final line missing its newline is kept and normalized" {
+  let dir = @fs.tmpdir(prefix="workflow-journal-noeol-")
+  let entry_line = (
+      { "v": 1, "e": Json(success_entry("hello", { "a": 1 })) } : Json).stringify() +
+    "\n"
+  let unterminated = (
+    { "v": 1, "e": Json(success_entry("tail", { "b": 2 })) } : Json).stringify()
+  let path = "\{dir}/journal.jsonl"
+  @fs.write_file(path, entry_line + unterminated)
+  let journal = @workflow.Journal::load(path)
+  assert_eq(journal.prior().length(), 2)
+  // Repair added the missing newline: an append cannot fuse two entries.
+  let wf = @workflow.Workflow(runner=@workflow.Runner(scripted), journal~)
+  let _ = wf.agent("world", kind="scout")
+  assert_eq(@workflow.Journal::load(path).prior().length(), 3)
+  @fs.rmdir(dir, recursive=true) catch {
+    _ => ()
+  }
+}
+
+///|
+async test "a tail torn mid-codepoint cannot poison the healthy prefix" {
+  let dir = @fs.tmpdir(prefix="workflow-journal-codepoint-")
+  let entry_line = (
+      { "v": 1, "e": Json(success_entry("hello", { "a": 1 })) } : Json).stringify() +
+    "\n"
+  let path = "\{dir}/journal.jsonl"
+  @fs.write_file(path, entry_line + "{\"call\": \"")
+  // One leading byte of a two-byte UTF-8 sequence: strict whole-file
+  // decoding would refuse the entire journal.
+  @fs.write_file(path, b"\xc3", append=true, create_mode=OpenOrCreate)
+  let journal = @workflow.Journal::load(path)
+  assert_eq(journal.prior().length(), 1)
+  @fs.rmdir(dir, recursive=true) catch {
+    _ => ()
+  }
+}
+
+///|
+async test "corruption before the final line raises JournalCorrupted" {
+  let dir = @fs.tmpdir(prefix="workflow-journal-corrupt-")
+  let entry_line = (
+      { "v": 1, "e": Json(success_entry("hello", { "a": 1 })) } : Json).stringify() +
+    "\n"
+  let corrupt = "\{dir}/corrupt.jsonl"
+  @fs.write_file(corrupt, entry_line + "{\"call\": {\"kind\n" + entry_line)
+  let mut raised = false
+  let _ = @workflow.Journal::load(corrupt) catch {
+    @workflow.JournalCorrupted(line=2, ..) => {
+      raised = true
+      @workflow.Journal::in_memory()
+    }
+    _ => fail("expected JournalCorrupted at line 2")
+  }
+  assert_true(raised)
+  @fs.rmdir(dir, recursive=true) catch {
+    _ => ()
+  }
+}
+
+///|
+async test "a vetoed replay runs live and the stale entry stays consumed" {
+  let vetoes : Ref[Int] = { val: 0, }
+  let wf = @workflow.Workflow(
+    runner=@workflow.Runner(recovered, validate_replay=(_, _) => {
+      vetoes.val += 1
+      Rerun
+    }),
+    journal=@workflow.Journal::in_memory(prior=[
+      success_entry("x", { "stale": true }),
+    ]),
+  )
+  // The journal has a hit, but the engine vetoes it: live run.
+  assert_eq(wf.agent("x", kind="scout"), { "recovered": "x" })
+  assert_eq(wf.calls_replayed(), 0)
+  assert_eq(wf.calls_made(), 1)
+  assert_eq(vetoes.val, 1)
+  // The vetoed entry was consumed: the next identical call never even
+  // reaches the validator.
+  assert_eq(wf.agent("x", kind="scout"), { "recovered": "x" })
+  assert_eq(vetoes.val, 1)
+}
+
+///|
+async test "a stale candidate does not mask the newer valid one" {
+  // Two journalled successes for the same call; the engine's validator
+  // rejects the first (stale) and accepts the second — replay must WALK
+  // to the valid candidate, not fall back to a live run.
+  let wf = @workflow.Workflow(
+    runner=@workflow.Runner(recovered, validate_replay=(_, outcome) => {
+      if outcome is Finished(value={ "sample": 2, .. }, ..) {
+        Serve(outcome)
+      } else {
+        Rerun
+      }
+    }),
+    journal=@workflow.Journal::in_memory(prior=[
+      success_entry("x", { "sample": 1 }),
+      success_entry("x", { "sample": 2 }),
+    ]),
+  )
+  assert_eq(wf.agent("x", kind="scout"), { "sample": 2 })
+  assert_eq(wf.calls_replayed(), 1)
+  assert_eq(wf.calls_made(), 0)
+  // Both candidates are now consumed (one vetoed, one served): the next
+  // identical call runs live.
+  assert_eq(wf.agent("x", kind="scout"), { "recovered": "x" })
+  assert_eq(wf.calls_made(), 1)
+}
+
+///|
+async test "a validator unwind rolls the claim back" {
+  let attempts : Ref[Int] = { val: 0, }
+  let wf = @workflow.Workflow(
+    runner=@workflow.Runner(must_not_run, validate_replay=(_, outcome) => {
+      attempts.val += 1
+      if attempts.val == 1 {
+        // The registry check blew up mid-validation: the claim must be
+        // rolled back, not burned.
+        fail("registry unavailable")
+      }
+      Serve(outcome)
+    }),
+    journal=@workflow.Journal::in_memory(prior=[
+      success_entry("x", { "answer": 42 }),
+    ]),
+  )
+  let mut unwound = false
+  let _ = wf.agent("x", kind="scout") catch {
+    _ => {
+      unwound = true
+      Json::null()
+    }
+  }
+  assert_true(unwound)
+  // Same entry, second chance: validation now passes and the entry is
+  // still there to serve.
+  assert_eq(wf.agent("x", kind="scout"), { "answer": 42 })
+  assert_eq(wf.calls_replayed(), 1)
+}

--- a/workflow/moon.mod
+++ b/workflow/moon.mod
@@ -1,0 +1,19 @@
+name = "bobzhang/workflow"
+
+version = "0.1.0"
+
+import {
+  "moonbitlang/async@0.21.1",
+}
+
+readme = "README.mbt.md"
+
+repository = "https://github.com/bobzhang/openseek"
+
+license = "Apache-2.0"
+
+description = "Engine-agnostic multi-agent workflow orchestration with journaled replay/resume"
+
+preferred_target = "native"
+
+warnings = "+missing_doc+unnecessary_view_op+test_unqualified_package+unused_default_value+implicit_impl_as_method"

--- a/workflow/moon.pkg
+++ b/workflow/moon.pkg
@@ -1,0 +1,14 @@
+import {
+  "moonbitlang/async",
+  "moonbitlang/async/fs",
+  "moonbitlang/core/encoding/utf8",
+  "moonbitlang/core/json",
+}
+
+import {
+  "moonbitlang/async",
+  "moonbitlang/async/fs",
+  "moonbitlang/core/json",
+} for "test"
+
+supported_targets = "+native"

--- a/workflow/pkg.generated.mbti
+++ b/workflow/pkg.generated.mbti
@@ -1,0 +1,158 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/workflow"
+
+import {
+  "moonbitlang/async/semaphore",
+  "moonbitlang/core/json",
+}
+
+// Values
+pub fn[T] all_ok(Array[Result[T, WorkflowError]]) -> Array[T] raise WorkflowError
+
+pub fn[T] collect_ok(Array[Result[T, WorkflowError]], min_ok? : Int) -> Array[T] raise WorkflowError
+
+pub async fn[A, B] fan_out(Array[A], async (A) -> Result[B, WorkflowError]) -> Array[Result[B, WorkflowError]]
+
+pub async fn[T] parallel(Array[async () -> Result[T, WorkflowError]]) -> Array[Result[T, WorkflowError]]
+
+pub async fn[T] parallel_all(Array[async () -> T]) -> Array[T]
+
+pub fn[T] quorum(Array[Result[T, WorkflowError]], need~ : Int) -> Array[T] raise WorkflowError
+
+// Errors
+pub suberror JournalCorrupted {
+  JournalCorrupted(path~ : String, line~ : Int)
+}
+pub fn JournalCorrupted::output(Self, &Logger) -> Unit
+pub fn JournalCorrupted::to_string(Self) -> String
+pub impl Show for JournalCorrupted
+
+pub suberror WorkflowError {
+  AgentFailed(label~ : String, failure~ : AgentFailure)
+  CallBudgetExhausted(label~ : String)
+  QuorumNotReached(need~ : Int, ok~ : Int, of~ : Int)
+}
+pub fn WorkflowError::output(Self, &Logger) -> Unit
+pub fn WorkflowError::to_string(Self) -> String
+pub impl Show for WorkflowError
+
+// Types and methods
+pub(all) struct AgentAttempt {
+  attempt_id : String
+  steps_used : Int
+  prompt_tokens : Int
+  completion_tokens : Int
+} derive(Eq, ToJson, @json.FromJson)
+pub fn AgentAttempt::equal(Self, Self) -> Bool
+pub fn AgentAttempt::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn AgentAttempt::not_equal(Self, Self) -> Bool
+pub fn AgentAttempt::to_json(Self) -> Json
+
+pub(all) struct AgentCall {
+  kind : String
+  input : Json
+  label : String
+  max_steps : Int?
+  scope : String
+} derive(Eq, ToJson, @json.FromJson)
+pub fn AgentCall::equal(Self, Self) -> Bool
+pub fn AgentCall::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn AgentCall::not_equal(Self, Self) -> Bool
+pub fn AgentCall::to_json(Self) -> Json
+
+pub(all) enum AgentDisposition {
+  Succeeded
+  FailedAgent
+  Interrupted
+  Errored
+} derive(Eq)
+pub fn AgentDisposition::equal(Self, Self) -> Bool
+pub fn AgentDisposition::not_equal(Self, Self) -> Bool
+
+pub(all) enum AgentFailure {
+  TimedOut
+  NoReport
+  MaxSteps
+  ContextYield
+  Skipped
+  Failed(String)
+} derive(Eq, ToJson, @json.FromJson)
+pub fn AgentFailure::equal(Self, Self) -> Bool
+pub fn AgentFailure::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn AgentFailure::not_equal(Self, Self) -> Bool
+pub fn AgentFailure::output(Self, &Logger) -> Unit
+pub fn AgentFailure::to_json(Self) -> Json
+pub fn AgentFailure::to_string(Self) -> String
+pub impl Show for AgentFailure
+
+pub(all) enum AgentOutcome {
+  Finished(value~ : Json, attempt~ : AgentAttempt)
+  DidNotFinish(failure~ : AgentFailure, attempt~ : AgentAttempt?)
+} derive(Eq, ToJson, @json.FromJson)
+pub fn AgentOutcome::equal(Self, Self) -> Bool
+pub fn AgentOutcome::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn AgentOutcome::not_equal(Self, Self) -> Bool
+pub fn AgentOutcome::to_json(Self) -> Json
+
+pub struct Journal {
+  // private fields
+}
+pub fn Journal::in_memory(prior? : Array[JournalEntry]) -> Self
+pub async fn Journal::load(String) -> Self
+pub fn Journal::prior(Self) -> Array[JournalEntry]
+pub fn Journal::recorded(Self) -> Array[JournalEntry]
+
+pub(all) struct JournalEntry {
+  call : AgentCall
+  outcome : AgentOutcome
+} derive(Eq, ToJson, @json.FromJson)
+pub fn JournalEntry::equal(Self, Self) -> Bool
+pub fn JournalEntry::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn JournalEntry::not_equal(Self, Self) -> Bool
+pub fn JournalEntry::to_json(Self) -> Json
+
+pub(all) enum ReplayDecision {
+  Serve(AgentOutcome)
+  Rerun
+}
+
+pub struct Runner {
+  // private fields
+}
+pub fn Runner::Runner(async (AgentCall) -> AgentOutcome, validate_replay? : async (AgentCall, AgentOutcome) -> ReplayDecision) -> Self
+pub async fn Runner::invoke(Self, AgentCall) -> AgentOutcome
+
+pub struct Workflow {
+  runner : Runner
+  slots : @semaphore.Semaphore
+  on_event : (WorkflowEvent) -> Unit
+  journal : Journal?
+  replay_scope : String
+  max_calls : Int?
+  mut calls_made : Int
+  mut replays : Int
+  mut prompt_tokens : Int
+  mut completion_tokens : Int
+  mut current_phase : String?
+}
+pub fn Workflow::Workflow(runner~ : Runner, max_concurrent? : Int, max_calls? : Int, journal? : Journal, replay_scope? : String, on_event? : (WorkflowEvent) -> Unit) -> Self raise
+pub async fn Workflow::agent(Self, String, kind~ : String, hints? : String, label? : String, max_steps? : Int) -> Json
+pub async fn Workflow::agent_call(Self, kind~ : String, input~ : Json, label~ : String, max_steps? : Int) -> Json
+pub fn Workflow::calls_made(Self) -> Int
+pub fn Workflow::calls_replayed(Self) -> Int
+pub fn Workflow::log(Self, String) -> Unit
+pub fn Workflow::phase(Self, String) -> Unit
+pub fn Workflow::tokens_spent(Self) -> Int
+pub async fn Workflow::try_agent(Self, String, kind~ : String, hints? : String, label? : String, max_steps? : Int) -> Result[Json, WorkflowError]
+
+pub(all) enum WorkflowEvent {
+  PhaseStarted(String)
+  Log(String)
+  AgentStarted(label~ : String, kind~ : String, phase~ : String?)
+  AgentFinished(label~ : String, disposition~ : AgentDisposition)
+  AgentReplayed(label~ : String, disposition~ : AgentDisposition)
+}
+
+// Type aliases
+
+// Traits

--- a/workflow/runner.mbt
+++ b/workflow/runner.mbt
@@ -1,0 +1,57 @@
+///|
+/// What the engine decided about a journal candidate at replay time:
+/// serve it (possibly REHYDRATED — the validator may substitute an
+/// outcome whose physical handles it refreshed), or veto it and run
+/// live. Raising out of the validator means validation itself failed —
+/// the claim rolls back and stays available.
+pub(all) enum ReplayDecision {
+  Serve(AgentOutcome)
+  Rerun
+}
+
+///|
+/// The engine seam: HOW one agent call actually runs. The real runner
+/// spawns child processes; unit tests inject a fake that never leaves the
+/// process. Everything the run resolved to — success or failure, WITH its
+/// cost — rides the returned `AgentOutcome`; `raise` carries only what
+/// the workflow must not absorb: cancellation and engine bugs.
+///
+/// `validate_replay` guards STATEFUL outcomes at resume time: when a
+/// journal hit is about to be served, the engine may inspect it against
+/// live state (does the branch this outcome names still exist?) and
+/// decide. Engines whose outcomes are pure values need no validator:
+/// replay of a plain report can never lie.
+pub struct Runner {
+  priv run : async (AgentCall) -> AgentOutcome
+  priv validate_replay : (async (AgentCall, AgentOutcome) -> ReplayDecision)?
+}
+
+///|
+/// Wrap a run function (and optionally a replay validator) as a `Runner`.
+pub fn Runner::Runner(
+  run : async (AgentCall) -> AgentOutcome,
+  validate_replay? : async (AgentCall, AgentOutcome) -> ReplayDecision,
+) -> Runner {
+  { run, validate_replay, }
+}
+
+///|
+/// Run one call through this runner. Composing runners (a dispatcher
+/// delegating by kind) goes through here, never through the fields.
+pub async fn Runner::invoke(self : Runner, call : AgentCall) -> AgentOutcome {
+  (self.run)(call)
+}
+
+///|
+/// The replay decision for one journal candidate: the validator's, or
+/// `Serve` unchanged when the engine registered none.
+async fn Runner::decide_replay(
+  self : Runner,
+  call : AgentCall,
+  outcome : AgentOutcome,
+) -> ReplayDecision {
+  match self.validate_replay {
+    Some(validate) => validate(call, outcome)
+    None => Serve(outcome)
+  }
+}

--- a/workflow/spawn/contract.mbt
+++ b/workflow/spawn/contract.mbt
@@ -1,0 +1,419 @@
+///|
+/// THE CHILD CONTRACT, and its one implementation.
+///
+/// A workflow agent can be any process that speaks this wire contract:
+///
+/// - the runner writes ONE JSON line on the child's stdin and holds the
+///   pipe open — closing it is the graceful-cancel signal, not the end
+///   of input. The line is the VERSIONED request envelope
+///   `{"workflow_contract": 1, "id": ..., "kind": ..., "max_steps"?: ...,
+///   "input": ...}` — self-contained, so the request never depends on
+///   engine-specific argv (argv remains deployment configuration);
+/// - the child emits JSONL on stdout: event lines (an object with an
+///   `event` tag — `usage` and `agent_step` are summed/maxed for exact
+///   cost accounting; `max_steps_exhausted`, `context_yield`,
+///   `turn_failed`, `agent_setup_failed`, `command_error`, and
+///   `agent_aborted` classify how a run degraded) and, last, ONE
+///   distinguished `{"subrun_report": ...}` line carrying the result;
+/// - non-JSON stdout lines are skipped (a leaky tool subprocess must not
+///   poison the run);
+/// - after `wall_deadline_ms` the runner closes stdin and grants
+///   `cancel_grace_ms` to flush and exit — a report landing in the grace
+///   window still counts — then terminates the child.
+///
+/// `openseek subrun <kind>` speaks this contract natively; a shim around
+/// any other engine (a Rust CLI, a shell script) needs only to translate
+/// framing. External cancellation of the CALLER is never folded into a
+/// terminal: it re-raises after teardown, per structured concurrency.
+let default_cancel_grace_ms : Int = 5_000
+
+///|
+/// How a contract run ended. `Captured` means a report line arrived —
+/// whether its CONTENT is acceptable is the caller's judgment, at the
+/// layer that knows the report schema.
+pub enum ContractTerminal {
+  Captured
+  NoReport
+  MaxSteps
+  ContextYield
+  TimedOut
+  Failed(String)
+} derive(Eq)
+
+///|
+pub extend ContractTerminal with Eq::{equal, not_equal}
+
+///|
+/// One contract run's outcome: the RAW report (when one arrived) plus the
+/// cost observed from the child's own event stream.
+pub struct ContractResult {
+  report : Json?
+  terminal : ContractTerminal
+  steps_used : Int
+  prompt_tokens : Int
+  completion_tokens : Int
+}
+
+///|
+/// Live cost counters, updated AS the child streams. Pass one in to keep
+/// visibility into a run that ends by cancellation — the raise unwinds
+/// past the return value, but not past this.
+pub struct ContractProgress {
+  mut steps : Int
+  mut prompt_tokens : Int
+  mut completion_tokens : Int
+}
+
+///|
+/// Fresh zeroed counters.
+pub fn ContractProgress::ContractProgress() -> ContractProgress {
+  { steps: 0, prompt_tokens: 0, completion_tokens: 0, }
+}
+
+///|
+priv struct Observations {
+  progress : ContractProgress
+  observe_line : ((Json) -> Unit)?
+  mut max_steps_exhausted : Bool
+  mut context_yield : Bool
+  mut failure : String?
+  mut report : Json?
+}
+
+///|
+/// Classify one child stdout line, structurally — the tags are the wire
+/// contract, not any engine's type vocabulary.
+fn Observations::observe(self : Observations, line : String) -> Unit {
+  let trimmed = line.trim(chars="\r\n")
+  if trimmed == "" {
+    return
+  }
+  guard (Some(@json.parse(trimmed.to_owned())) catch { _ => None })
+    is Some(json) else {
+    return
+  }
+  if self.observe_line is Some(hook) {
+    hook(json)
+  }
+  if json is { "subrun_report": report, .. } {
+    self.report = Some(report)
+    return
+  }
+  match json {
+    { "event": "agent_step", "step": Number(step, ..), .. } =>
+      if integral(step) is Some(step) {
+        self.progress.steps = self.progress.steps.max(step)
+      }
+    {
+      "event": "usage",
+      "usage": {
+        "prompt_tokens": Number(prompt, ..),
+        "completion_tokens": Number(completion, ..),
+        "total_tokens": Number(total, ..),
+        "prompt_cache_hit_tokens": Number(cache_hit, ..),
+        "prompt_cache_miss_tokens": Number(cache_miss, ..),
+        ..
+      },
+      ..
+    } =>
+      // Integral-only and whole-object, exactly as the engine's typed
+      // decoder: a counter of 1.5 is not a token count, and a malformed
+      // usage line is ignored WHOLE — never partially charged.
+      if integral(prompt) is Some(prompt) &&
+        integral(completion) is Some(completion) &&
+        integral(total) is Some(_) &&
+        integral(cache_hit) is Some(_) &&
+        integral(cache_miss) is Some(_) {
+        self.progress.prompt_tokens += prompt
+        self.progress.completion_tokens += completion
+      }
+    { "event": "max_steps_exhausted", .. } => self.max_steps_exhausted = true
+    {
+      "event": "context_yield",
+      "to_sequence": Number(to_sequence, ..),
+      "answer": String(_),
+      ..
+    } => if integral(to_sequence) is Some(_) { self.context_yield = true }
+    { "event": "turn_failed", "error": String(error), .. }
+    | { "event": "agent_setup_failed", "error": String(error), .. }
+    | { "event": "command_error", "error": String(error), .. } =>
+      self.failure = Some(error)
+    { "event": "agent_aborted", "reason": String(reason), .. } =>
+      self.failure = Some(reason)
+    _ => ()
+  }
+}
+
+///|
+/// JSON has one number type, so an `Int` field arrives as a `Number`;
+/// reject a fractional value rather than silently truncating it.
+fn integral(value : Double) -> Int? {
+  let rounded = value.to_int()
+  if rounded.to_double() == value {
+    Some(rounded)
+  } else {
+    None
+  }
+}
+
+///|
+/// Run one child over the contract: spawn, feed the input line, drain and
+/// account the event stream, enforce the wall deadline with its grace
+/// window, and tear the child down on every path. Crash isolation is
+/// structural: a dead or unspawnable child is a `Failed` terminal, never
+/// a dead caller. External cancellation re-raises after teardown.
+pub async fn contract_run(
+  command~ : String,
+  args~ : Array[String],
+  input~ : Json,
+  kind~ : String,
+  id~ : String,
+  max_steps? : Int,
+  wall_deadline_ms~ : Int,
+  cancel_grace_ms? : Int = default_cancel_grace_ms,
+  cwd? : String,
+  extra_env? : Map[String, String],
+  progress? : ContractProgress,
+  observe_line? : (Json) -> Unit,
+) -> ContractResult {
+  let progress = match progress {
+    Some(progress) => progress
+    None => ContractProgress()
+  }
+  let observations : Observations = {
+    progress,
+    observe_line,
+    max_steps_exhausted: false,
+    context_yield: false,
+    failure: None,
+    report: None,
+  }
+  let mut timed_out = false
+  // The group call is itself fold-guarded: a spawn failure can surface
+  // ASYNCHRONOUSLY (the spawn's internal reaper task raising at group
+  // exit, e.g. EAGAIN under fork pressure), bypassing the per-call
+  // catches inside. Cancellation still re-raises; anything else becomes
+  // a Failed terminal — a loaded machine must degrade the run, never
+  // crash the caller.
+  try
+    @async.with_task_group() <| group => {
+      let (child_stdin, stdin_writer) = @process.write_to_process() catch {
+        error if @async.is_being_cancelled() => raise error
+        error => {
+          observations.failure = Some("subrun pipes unavailable: \{error}")
+          return
+        }
+      }
+      let (stdout_reader, child_stdout) = @process.read_from_process() catch {
+        error if @async.is_being_cancelled() => {
+          stdin_writer.close()
+          raise error
+        }
+        error => {
+          stdin_writer.close()
+          observations.failure = Some("subrun pipes unavailable: \{error}")
+          return
+        }
+      }
+      // `no_wait`: the group terminates the child at teardown rather than
+      // waiting for an exit that may only come once its stdin is closed.
+      let process = @process.spawn(
+        group,
+        command,
+        args,
+        inherit_env=true,
+        // Credentials that only exist in the caller's memory ride this
+        // overlay into the child's environment — argv would be visible
+        // in `ps`, the environment is not.
+        extra_env?,
+        stdin=child_stdin,
+        stdout=child_stdout,
+        cwd?=cwd.map(dir => dir.view()),
+        no_wait=true,
+      ) catch {
+        error if @async.is_being_cancelled() => {
+          stdout_reader.close()
+          stdin_writer.close()
+          raise error
+        }
+        error => {
+          stdout_reader.close()
+          stdin_writer.close()
+          observations.failure = Some("subrun spawn failed: \{error}")
+          return
+        }
+      }
+      async fn drain() -> Unit {
+        while stdout_reader.read_until("\n") is Some(line) {
+          observations.observe(line)
+        }
+      }
+      async fn feed_and_drain() -> Unit {
+        // One input line — the v1 request envelope; the pipe stays open,
+        // EOF is the cancel signal, not the end of input. The write sits
+        // INSIDE the deadline scope: an input larger than the pipe
+        // capacity against a child that never reads must hit the wall
+        // deadline, not block forever.
+        let request : Json = match max_steps {
+          Some(steps) =>
+            {
+              "workflow_contract": 1,
+              "id": id,
+              "kind": kind,
+              "max_steps": steps,
+              "input": input,
+            }
+          None =>
+            { "workflow_contract": 1, "id": id, "kind": kind, "input": input }
+        }
+        stdin_writer.write("\{request.stringify()}\n")
+        drain()
+      }
+      try {
+        match @async.with_timeout_opt(wall_deadline_ms, feed_and_drain) {
+          Some(_) =>
+            // Clean EOF: the child closed stdout. Read its exit status — a
+            // crash-class failure (panic, signal, nonzero exit) emits no
+            // failure event, and without this the runner is structurally
+            // blind to it and would misclassify the run as NoReport.
+            // Bounded: a child that closed stdout but lingers falls
+            // through to the cancel below.
+            match @async.with_timeout_opt(2_000, () => process.wait()) {
+              Some(code) if code != 0 &&
+                observations.report is None &&
+                observations.failure is None =>
+                observations.failure = Some("subrun exited \{code}")
+              _ => ()
+            }
+          None => {
+            // Deadline: graceful cancel first — close stdin, let the child
+            // flush; a report arriving in the grace window still counts.
+            timed_out = true
+            stdin_writer.close()
+            let _ = @async.with_timeout_opt(cancel_grace_ms, drain)
+          }
+        }
+      } catch {
+        error => {
+          // External cancellation (or a pipe failure): tear the child down
+          // and re-raise cancellation; fold anything else into the
+          // terminal.
+          @async.protect_from_cancel(() => {
+            stdout_reader.close()
+            stdin_writer.close()
+            process.cancel()
+          })
+          if @async.is_being_cancelled() {
+            raise error
+          }
+          if observations.failure is None {
+            observations.failure = Some("subrun stream failed: \{error}")
+          }
+          return
+        }
+      }
+      stdout_reader.close()
+      stdin_writer.close()
+      process.cancel()
+    }
+  catch {
+    error if @async.is_being_cancelled() || @async.is_cancellation_error(error) =>
+      raise error
+    error =>
+      if observations.failure is None {
+        observations.failure = Some("subrun runner failed: \{error}")
+      }
+  }
+  let terminal = match observations.report {
+    Some(_) => Captured
+    None =>
+      match observations.failure {
+        Some(error) => Failed(error)
+        None if timed_out => TimedOut
+        None if observations.max_steps_exhausted => MaxSteps
+        None if observations.context_yield => ContextYield
+        None => NoReport
+      }
+  }
+  {
+    report: observations.report,
+    terminal,
+    steps_used: progress.steps,
+    prompt_tokens: progress.prompt_tokens,
+    completion_tokens: progress.completion_tokens,
+  }
+}
+
+///|
+/// HOW one call becomes a process: the executable, its argv, and the
+/// per-launch execution envelope. Everything a sandbox wrapper or a
+/// deployment would want to rewrite lives HERE, in one immutable value —
+/// never scattered across positional tuples.
+pub(all) struct LaunchSpec {
+  command : String
+  args : Array[String]
+  cwd : String?
+  extra_env : Map[String, String]?
+  deadline_ms : Int?
+} derive(Eq)
+
+///|
+pub extend LaunchSpec with Eq::{equal, not_equal}
+
+///|
+/// A `Runner` for ANY engine speaking the child contract: `launch` turns
+/// each call into a `LaunchSpec`, the request envelope carries the
+/// call's kind/limits/input, and every terminal maps into the lossless
+/// `AgentOutcome` envelope. For engines whose reports are pure values
+/// this is the whole adapter — an openseek-independent codex shim plugs
+/// in right here. An engine whose reports name STATEFUL resources must
+/// also pass `validate_replay`, or resumed journals can serve outcomes
+/// whose referents no longer exist.
+pub fn contract_runner(
+  launch~ : (@workflow.AgentCall) -> LaunchSpec,
+  deadline_ms? : Int = 600_000,
+  validate_replay? : async (@workflow.AgentCall, @workflow.AgentOutcome) -> @workflow.ReplayDecision,
+) -> @workflow.Runner {
+  let ids : Ref[Int] = { val: 0, }
+  @workflow.Runner(validate_replay?, call => {
+    let spec = launch(call)
+    ids.val += 1
+    let id = "cr-\{ids.val}"
+    let cwd = spec.cwd
+    let extra_env = spec.extra_env
+    let result = contract_run(
+      command=spec.command,
+      args=spec.args,
+      input=call.input,
+      kind=call.kind,
+      id~,
+      max_steps?=call.max_steps,
+      wall_deadline_ms=spec.deadline_ms.unwrap_or(deadline_ms),
+      cwd?,
+      extra_env?,
+    )
+    let attempt : @workflow.AgentAttempt = {
+      attempt_id: id,
+      steps_used: result.steps_used,
+      prompt_tokens: result.prompt_tokens,
+      completion_tokens: result.completion_tokens,
+    }
+    match result.terminal {
+      Captured =>
+        match result.report {
+          Some(value) => Finished(value~, attempt~)
+          None =>
+            DidNotFinish(
+              failure=Failed("captured terminal without a report"),
+              attempt=Some(attempt),
+            )
+        }
+      NoReport => DidNotFinish(failure=NoReport, attempt=Some(attempt))
+      MaxSteps => DidNotFinish(failure=MaxSteps, attempt=Some(attempt))
+      ContextYield => DidNotFinish(failure=ContextYield, attempt=Some(attempt))
+      TimedOut => DidNotFinish(failure=TimedOut, attempt=Some(attempt))
+      Failed(reason) =>
+        DidNotFinish(failure=Failed(reason), attempt=Some(attempt))
+    }
+  })
+}

--- a/workflow/spawn/moon.pkg
+++ b/workflow/spawn/moon.pkg
@@ -1,0 +1,16 @@
+import {
+  "bobzhang/workflow",
+  "moonbitlang/async",
+  "moonbitlang/async/io",
+  "moonbitlang/async/process",
+  "moonbitlang/core/json",
+}
+
+import {
+  "bobzhang/workflow",
+  "moonbitlang/async",
+  "moonbitlang/async/fs",
+  "moonbitlang/async/process",
+} for "test"
+
+supported_targets = "+native"

--- a/workflow/spawn/pkg.generated.mbti
+++ b/workflow/spawn/pkg.generated.mbti
@@ -1,0 +1,54 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/workflow/spawn"
+
+import {
+  "bobzhang/workflow",
+}
+
+// Values
+pub async fn contract_run(command~ : String, args~ : Array[String], input~ : Json, kind~ : String, id~ : String, max_steps? : Int, wall_deadline_ms~ : Int, cancel_grace_ms? : Int, cwd? : String, extra_env? : Map[String, String], progress? : ContractProgress, observe_line? : (Json) -> Unit) -> ContractResult
+
+pub fn contract_runner(launch~ : (@workflow.AgentCall) -> LaunchSpec, deadline_ms? : Int, validate_replay? : async (@workflow.AgentCall, @workflow.AgentOutcome) -> @workflow.ReplayDecision) -> @workflow.Runner
+
+// Errors
+
+// Types and methods
+pub struct ContractProgress {
+  mut steps : Int
+  mut prompt_tokens : Int
+  mut completion_tokens : Int
+}
+pub fn ContractProgress::ContractProgress() -> Self
+
+pub struct ContractResult {
+  report : Json?
+  terminal : ContractTerminal
+  steps_used : Int
+  prompt_tokens : Int
+  completion_tokens : Int
+}
+
+pub enum ContractTerminal {
+  Captured
+  NoReport
+  MaxSteps
+  ContextYield
+  TimedOut
+  Failed(String)
+} derive(Eq)
+pub fn ContractTerminal::equal(Self, Self) -> Bool
+pub fn ContractTerminal::not_equal(Self, Self) -> Bool
+
+pub(all) struct LaunchSpec {
+  command : String
+  args : Array[String]
+  cwd : String?
+  extra_env : Map[String, String]?
+  deadline_ms : Int?
+} derive(Eq)
+pub fn LaunchSpec::equal(Self, Self) -> Bool
+pub fn LaunchSpec::not_equal(Self, Self) -> Bool
+
+// Type aliases
+
+// Traits

--- a/workflow/spawn/spawn_test.mbt
+++ b/workflow/spawn/spawn_test.mbt
@@ -1,0 +1,186 @@
+///|
+/// Contract tests over SCRIPTED children: any process that speaks the
+/// child contract exercises this package end to end — `sh` plays every
+/// engine. The spawnability probe uses the low-level process API so only
+/// a genuinely spawn-hostile sandbox can skip these.
+async fn can_spawn_sh() -> Bool {
+  let code = @process.run("sh", ["-c", "exit 0"]) catch { _ => return false }
+  code == 0
+}
+
+///|
+async fn run_script(script : String) -> @spawn.ContractResult {
+  @spawn.contract_run(
+    command="sh",
+    args=["-c", script],
+    input={ "query": "q" },
+    kind="probe",
+    id="test-1",
+    wall_deadline_ms=10_000,
+  )
+}
+
+///|
+async test "events and the report line are drained and accounted" {
+  guard can_spawn_sh() else {
+    println("skipped: cannot spawn sh")
+    return
+  }
+  let script =
+    #|read line
+    #|printf '{"timestamp":"t","level":"INFO","source":"s","event":"agent_step","step":1}\n'
+    #|printf 'not json at all\n'
+    #|printf '{"timestamp":"t","level":"INFO","source":"s","event":"usage","usage":{"prompt_tokens":90,"completion_tokens":10,"total_tokens":100,"prompt_cache_hit_tokens":0,"prompt_cache_miss_tokens":90}}\n'
+    #|printf '{"timestamp":"t","level":"INFO","source":"s","event":"agent_step","step":2}\n'
+    #|printf '{"subrun_report": {"answer": "forty-two"}}\n'
+  let result = run_script(script)
+  guard result.terminal is Captured else { fail("expected Captured") }
+  assert_eq(result.report, Some(({ "answer": "forty-two" } : Json)))
+  assert_eq(result.steps_used, 2)
+  assert_eq(result.prompt_tokens, 90)
+  assert_eq(result.completion_tokens, 10)
+}
+
+///|
+async test "a clean exit without a report is NoReport" {
+  guard can_spawn_sh() else {
+    println("skipped: cannot spawn sh")
+    return
+  }
+  let script =
+    #|read line
+    #|printf '{"timestamp":"t","level":"INFO","source":"s","event":"agent_step","step":1}\n'
+  let result = run_script(script)
+  guard result.terminal is NoReport else { fail("expected NoReport") }
+  assert_eq(result.report, None)
+}
+
+///|
+async test "an observed step exhaustion is MaxSteps" {
+  guard can_spawn_sh() else {
+    println("skipped: cannot spawn sh")
+    return
+  }
+  let script =
+    #|read line
+    #|printf '{"timestamp":"t","level":"INFO","source":"s","event":"max_steps_exhausted"}\n'
+  guard run_script(script).terminal is MaxSteps else {
+    fail("expected MaxSteps")
+  }
+}
+
+///|
+async test "a reported turn failure classifies as Failed" {
+  guard can_spawn_sh() else {
+    println("skipped: cannot spawn sh")
+    return
+  }
+  let script =
+    #|read line
+    #|printf '{"timestamp":"t","level":"ERROR","source":"s","event":"turn_failed","error":"the model refused"}\n'
+  guard run_script(script).terminal is Failed(reason) else {
+    fail("expected Failed")
+  }
+  assert_true(reason.contains("refused"))
+}
+
+///|
+async test "a spawn failure folds into Failed, never a crash" {
+  let result = @spawn.contract_run(
+    command="/nonexistent/engine-not-here",
+    args=[],
+    input={ "query": "q" },
+    kind="probe",
+    id="test-2",
+    wall_deadline_ms=2_000,
+  )
+  match result.terminal {
+    Failed(_) => ()
+    // Some sandboxes surface spawn refusal as an immediate empty exit.
+    NoReport => ()
+    _ => fail("expected the missing binary to degrade, not crash")
+  }
+}
+
+///|
+/// The point of the whole package: a FOREIGN engine — here, `sh` itself —
+/// plugs into the workflow with no openseek anywhere, and gets journal
+/// replay for free.
+async test "a foreign contract engine gets workflows and replay for free" {
+  guard can_spawn_sh() else {
+    println("skipped: cannot spawn sh")
+    return
+  }
+  let dir = @fs.tmpdir(prefix="workflow-contract-journal-")
+  let path = "\{dir}/journal.jsonl"
+  let live =
+    #|read line
+    #|printf '{"timestamp":"t","level":"INFO","source":"s","event":"usage","usage":{"prompt_tokens":7,"completion_tokens":3,"total_tokens":10,"prompt_cache_hit_tokens":0,"prompt_cache_miss_tokens":7}}\n'
+    #|printf '{"subrun_report": %s}\n' "$line"
+  let wf1 = @workflow.Workflow(
+    runner=@spawn.contract_runner(launch=_ => {
+      command: "sh",
+      args: ["-c", live],
+      cwd: None,
+      extra_env: None,
+      deadline_ms: None,
+    }),
+    journal=@workflow.Journal::load(path),
+  )
+  // The report echoes the input line: the v1 request envelope carrying
+  // the call's kind and exact input — self-contained, no argv needed.
+  let first = wf1.agent("hello", kind="probe", hints="from a foreign engine")
+  assert_eq(first, {
+    "workflow_contract": 1,
+    "id": "cr-1",
+    "kind": "probe",
+    "input": { "query": "hello", "hints": "from a foreign engine" },
+  })
+  assert_eq(wf1.tokens_spent(), 10)
+  // Resume: served from the journal, no process spawned.
+  let poisoned =
+    #|read line
+    #|printf '{"subrun_report": {"wrong": true}}\n'
+  let wf2 = @workflow.Workflow(
+    runner=@spawn.contract_runner(launch=_ => {
+      command: "sh",
+      args: ["-c", poisoned],
+      cwd: None,
+      extra_env: None,
+      deadline_ms: None,
+    }),
+    journal=@workflow.Journal::load(path),
+  )
+  assert_eq(
+    wf2.agent("hello", kind="probe", hints="from a foreign engine"),
+    first,
+  )
+  assert_eq(wf2.calls_made(), 0)
+  assert_eq(wf2.calls_replayed(), 1)
+  @fs.rmdir(dir, recursive=true) catch {
+    _ => ()
+  }
+}
+
+///|
+async test "malformed numeric events are ignored whole, never truncated" {
+  guard can_spawn_sh() else {
+    println("skipped: cannot spawn sh")
+    return
+  }
+  // A fractional step, a fractional token count, and a usage object
+  // missing its total: each ignored WHOLE — then one valid pair counts.
+  let script =
+    #|read line
+    #|printf '{"event":"agent_step","step":2.9}\n'
+    #|printf '{"event":"usage","usage":{"prompt_tokens":90.5,"completion_tokens":10,"total_tokens":100,"prompt_cache_hit_tokens":0,"prompt_cache_miss_tokens":90}}\n'
+    #|printf '{"event":"usage","usage":{"prompt_tokens":50,"completion_tokens":5}}\n'
+    #|printf '{"event":"agent_step","step":1}\n'
+    #|printf '{"event":"usage","usage":{"prompt_tokens":7,"completion_tokens":3,"total_tokens":10,"prompt_cache_hit_tokens":0,"prompt_cache_miss_tokens":7}}\n'
+    #|printf '{"subrun_report": {"ok": true}}\n'
+  let result = run_script(script)
+  guard result.terminal is Captured else { fail("expected Captured") }
+  assert_eq(result.steps_used, 1)
+  assert_eq(result.prompt_tokens, 7)
+  assert_eq(result.completion_tokens, 3)
+}

--- a/workflow/types.mbt
+++ b/workflow/types.mbt
@@ -1,0 +1,142 @@
+///|
+/// One request to run a sub-agent: the workflow-side view of a call before
+/// any engine specifics (binary path, model, endpoint) attach to it.
+/// `kind` names the child mode the engine dispatches on (`explore`,
+/// `echo`, later `worker`); `input` is the EXACT JSON the child receives
+/// as its input line — the persisted replay identity IS the child input,
+/// so an encoder change is an identity change and can never replay stale
+/// work. `label` is display metadata: journal replay matches on (kind,
+/// input, max_steps), never on the label.
+pub(all) struct AgentCall {
+  kind : String
+  input : Json
+  label : String
+  max_steps : Int?
+  /// Replay namespace: everything OUTSIDE the input that makes two
+  /// otherwise-identical calls non-interchangeable — model, prompt
+  /// revision, tenant, workspace. Empty means "unscoped".
+  scope : String
+} derive(Eq, ToJson, FromJson)
+
+///|
+/// The cost accounting of one attempt to run an agent, captured whether or
+/// not the attempt produced a report: a timed-out child spent real tokens,
+/// and losing that spend would understate every budget built on top.
+pub(all) struct AgentAttempt {
+  attempt_id : String
+  steps_used : Int
+  prompt_tokens : Int
+  completion_tokens : Int
+} derive(Eq, ToJson, FromJson)
+
+///|
+/// Why an agent produced no usable report — the workflow-facing vocabulary
+/// a script can meaningfully react to. Transient transport errors never
+/// appear here: retrying those is the engine's job, below this seam.
+/// Mirrors `@agent_subrun.SubrunTerminal` minus `Captured` (that one is the
+/// success path), plus `Skipped` (a human declined the call — replay keeps
+/// it declined rather than overriding the decision).
+pub(all) enum AgentFailure {
+  TimedOut
+  NoReport
+  MaxSteps
+  ContextYield
+  Skipped
+  Failed(String)
+} derive(Eq, ToJson, FromJson)
+
+///|
+/// The lossless envelope one agent run resolves to: either a report value
+/// with its attempt accounting, or a failure that STILL carries the
+/// attempt's cost. `attempt=None` means no launch was ever TRIED — a
+/// `Skipped` call, or a refusal before spawn; a child that failed to
+/// spawn or died early is an attempt that observed zero cost, not an
+/// absent one. This is the unit the journal persists: replaying it must
+/// lose nothing the live run knew.
+pub(all) enum AgentOutcome {
+  Finished(value~ : Json, attempt~ : AgentAttempt)
+  DidNotFinish(failure~ : AgentFailure, attempt~ : AgentAttempt?)
+} derive(Eq, ToJson, FromJson)
+
+///|
+/// The typed error channel of the workflow layer. Every call site must
+/// either propagate one of these or catch it into a `Result` — forgetting
+/// to choose a failure policy is a compile error, not a silent `null`.
+pub suberror WorkflowError {
+  /// The named agent call produced no usable report, and why.
+  AgentFailed(label~ : String, failure~ : AgentFailure)
+  /// The workflow's launch allowance was already spent when this call was
+  /// about to launch — the runaway backstop. Only LAUNCHED agents consume
+  /// allowance; a call cancelled while queued never counts.
+  CallBudgetExhausted(label~ : String)
+  /// A quorum/collect policy over a fan-out did not reach its threshold:
+  /// `ok` of `of` succeeded, `need` were required.
+  QuorumNotReached(need~ : Int, ok~ : Int, of~ : Int)
+}
+
+///|
+pub extend AgentCall with Eq::{equal, not_equal}
+
+///|
+pub extend AgentCall with ToJson::{to_json}
+
+///|
+pub extend AgentCall with FromJson::{from_json}
+
+///|
+pub extend AgentAttempt with Eq::{equal, not_equal}
+
+///|
+pub extend AgentAttempt with ToJson::{to_json}
+
+///|
+pub extend AgentAttempt with FromJson::{from_json}
+
+///|
+pub extend AgentFailure with Eq::{equal, not_equal}
+
+///|
+pub extend AgentFailure with ToJson::{to_json}
+
+///|
+pub extend AgentFailure with FromJson::{from_json}
+
+///|
+pub extend AgentOutcome with Eq::{equal, not_equal}
+
+///|
+pub extend AgentOutcome with ToJson::{to_json}
+
+///|
+pub extend AgentOutcome with FromJson::{from_json}
+
+///|
+pub extend AgentFailure with Show::{to_string, output}
+
+///|
+pub extend WorkflowError with Show::{to_string, output}
+
+///|
+pub impl Show for AgentFailure with fn output(self, logger) {
+  let text = match self {
+    TimedOut => "timed out"
+    NoReport => "finished without a report"
+    MaxSteps => "exhausted its step ceiling"
+    ContextYield => "yielded at the context ceiling"
+    Skipped => "was skipped by the user"
+    Failed(reason) => "failed: \{reason}"
+  }
+  logger.write_string(text)
+}
+
+///|
+pub impl Show for WorkflowError with fn output(self, logger) {
+  let text = match self {
+    AgentFailed(label~, failure~) => "agent '\{label}' \{failure}"
+    CallBudgetExhausted(label~) =>
+      "launch allowance exhausted before agent '\{label}' could launch"
+    QuorumNotReached(need~, ok~, of~) =>
+      "quorum not reached: \{ok} of \{of} succeeded, \{need} required"
+  }
+  logger.write_string(text)
+}

--- a/workflow/workflow.mbt
+++ b/workflow/workflow.mbt
@@ -1,0 +1,304 @@
+///|
+/// How one agent's lifetime ended, from the event stream's point of view.
+/// `Interrupted` is cancellation tearing the call down; `Errored` is an
+/// infrastructure failure escaping the call — an engine bug in the
+/// runner, or the journal append failing after the outcome resolved —
+/// both re-raise after the event fires, so `AgentStarted`/`AgentFinished`
+/// brackets always balance.
+pub(all) enum AgentDisposition {
+  Succeeded
+  FailedAgent
+  Interrupted
+  Errored
+} derive(Eq)
+
+///|
+pub extend AgentDisposition with Eq::{equal, not_equal}
+
+///|
+/// Progress the workflow narrates as it runs: phases group agents in a
+/// display, logs are one-line narrator messages, and the started/finished
+/// pair brackets each agent's lifetime — on every path, including
+/// cancellation. Purely observational: no control flow rides on these.
+pub(all) enum WorkflowEvent {
+  PhaseStarted(String)
+  Log(String)
+  AgentStarted(label~ : String, kind~ : String, phase~ : String?)
+  AgentFinished(label~ : String, disposition~ : AgentDisposition)
+  /// A journal hit: the result was served from a prior run — no launch,
+  /// no slot, no fresh spend. `Succeeded` replays a report, `FailedAgent`
+  /// replays a recorded human refusal.
+  AgentReplayed(label~ : String, disposition~ : AgentDisposition)
+}
+
+///|
+/// One workflow run: the runner seam, the concurrency gate every agent
+/// launch passes through, the launch allowance, and the running token
+/// account. Combinators (`parallel`, `fan_out`, policies) are free
+/// functions — this context only owns what must be shared state.
+pub struct Workflow {
+  runner : Runner
+  slots : @async.Semaphore
+  on_event : (WorkflowEvent) -> Unit
+  journal : Journal?
+  replay_scope : String
+  max_calls : Int?
+  mut calls_made : Int
+  mut replays : Int
+  mut prompt_tokens : Int
+  mut completion_tokens : Int
+  mut current_phase : String?
+}
+
+///|
+/// A workflow over `runner`, running at most `max_concurrent` agents at
+/// once and LAUNCHING at most `max_calls` agents over its lifetime (no cap
+/// when omitted — the caller's loop is trusted to terminate).
+pub fn Workflow::Workflow(
+  runner~ : Runner,
+  max_concurrent? : Int = 8,
+  max_calls? : Int,
+  journal? : Journal,
+  replay_scope? : String = "",
+  on_event? : (WorkflowEvent) -> Unit = _ => (),
+) -> Workflow raise {
+  guard max_concurrent >= 1 else {
+    fail("Workflow: max_concurrent must be at least 1")
+  }
+  guard !(max_calls is Some(max) && max < 0) else {
+    fail("Workflow: max_calls must not be negative")
+  }
+  {
+    runner,
+    slots: Semaphore(max_concurrent),
+    on_event,
+    journal,
+    replay_scope,
+    max_calls,
+    calls_made: 0,
+    replays: 0,
+    prompt_tokens: 0,
+    completion_tokens: 0,
+    current_phase: None,
+  }
+}
+
+///|
+/// Run ONE sub-agent and return its report value, from the standard
+/// scout input shape ({query, hints?} — contract v1). Raises `AgentFailed` when the child
+/// produced no usable report and `CallBudgetExhausted` when the launch
+/// allowance was spent — catch into a `Result` at fan-out sites
+/// (`try_agent` is the shorthand), propagate at load-bearing ones.
+pub async fn Workflow::agent(
+  self : Workflow,
+  prompt : String,
+  kind~ : String,
+  hints? : String,
+  label? : String,
+  max_steps? : Int,
+) -> Json {
+  // The explore/echo input contract: one self-contained question plus
+  // optional pointers. Kinds with their own input shape (worker slices)
+  // enter through `agent_call` directly.
+  let input : Json = match hints {
+    Some(hints) => { "query": prompt, "hints": hints }
+    None => { "query": prompt }
+  }
+  self.agent_call(
+    kind~,
+    input~,
+    label=label.unwrap_or(brief(prompt)),
+    max_steps?,
+  )
+}
+
+///|
+/// The kind-agnostic core `agent` wraps: run one sub-agent from its exact
+/// child input. `input` doubles as the journal's replay identity, so
+/// callers encoding their own kinds get replay for free.
+pub async fn Workflow::agent_call(
+  self : Workflow,
+  kind~ : String,
+  input~ : Json,
+  label~ : String,
+  max_steps? : Int,
+) -> Json {
+  // Phase attribution is invocation-time, not launch-time: a call issued
+  // under phase A that waits out the queue into phase B still belongs to A.
+  let phase = self.current_phase
+  let call : AgentCall = {
+    kind,
+    input,
+    label,
+    max_steps,
+    scope: self.replay_scope,
+  }
+  // Replay is checked before the slot queue and the allowance: a replayed
+  // result is not a launch — it holds no slot, debits no allowance, and
+  // re-charges no tokens (historical spend lives in the journal). The
+  // runner's validator vets every candidate IN TURN: a vetoed (stale)
+  // entry stays consumed and the NEXT matching entry gets its chance — a
+  // discarded generation must never mask the valid one behind it. Only
+  // when validation UNWINDS (cancellation, a registry error) is the
+  // claim rolled back: that entry was neither served nor rejected.
+  if self.journal is Some(journal) {
+    while journal.claim(call) is Some((slot, outcome)) {
+      let decision = {
+        errdefer journal.release(slot)
+        self.runner.decide_replay(call, outcome)
+      }
+      guard decision is Serve(outcome) else { continue }
+      self.replays += 1
+      match outcome {
+        Finished(value~, ..) => {
+          (self.on_event)(AgentReplayed(label~, disposition=Succeeded))
+          return value
+        }
+        DidNotFinish(failure~, ..) => {
+          (self.on_event)(AgentReplayed(label~, disposition=FailedAgent))
+          raise AgentFailed(label~, failure~)
+        }
+      }
+    }
+  }
+  self.slots.acquire()
+  defer self.slots.release()
+  // The semaphore deliberately swallows cancellation for a waiter it has
+  // already woken, so the slot is never lost — which means a call
+  // cancelled while queued arrives HERE holding a slot. Re-check before
+  // launching: `pause` raises `Cancelled` when the flag is set, and the
+  // defer above hands the slot back.
+  if @async.is_being_cancelled() {
+    @async.pause()
+  }
+  // The allowance counts LAUNCHED agents, so it is checked and debited
+  // AFTER the slot wait: a call cancelled while queued never consumes it.
+  // No suspension separates this check from the runner call.
+  if self.max_calls is Some(max) && self.calls_made >= max {
+    raise CallBudgetExhausted(label~)
+  }
+  self.calls_made += 1
+  (self.on_event)(AgentStarted(label~, kind~, phase~))
+  // ONE emission point closes the bracket on every unwind path:
+  // `FailedAgent` when the agent failed and its typed error is raised,
+  // `Interrupted`/`Errored` when the runner or the journal append unwound
+  // before resolution. The success path returns normally and emits its own
+  // `Succeeded`. (`errdefer`, not `catch` — catch will stop capturing
+  // async cancellation.)
+  let mut resolved : AgentDisposition? = None
+  errdefer (self.on_event)(
+    AgentFinished(
+      label~,
+      disposition=resolved.unwrap_or(
+        if @async.is_being_cancelled() {
+          Interrupted
+        } else {
+          Errored
+        },
+      ),
+    ),
+  )
+  let outcome = (self.runner.run)(call)
+  self.account(outcome)
+  if self.journal is Some(journal) {
+    journal.record({ call, outcome, })
+  }
+  match outcome {
+    Finished(value~, ..) => {
+      (self.on_event)(AgentFinished(label~, disposition=Succeeded))
+      value
+    }
+    DidNotFinish(failure~, ..) => {
+      resolved = Some(FailedAgent)
+      raise AgentFailed(label~, failure~)
+    }
+  }
+}
+
+///|
+/// `agent` with the typed error channel folded into the return value:
+/// workflow-level failures land in `Err`, cancellation and engine errors
+/// still propagate. The right shape at fan-out call sites, where one lost
+/// agent must not poison its siblings.
+pub async fn Workflow::try_agent(
+  self : Workflow,
+  prompt : String,
+  kind~ : String,
+  hints? : String,
+  label? : String,
+  max_steps? : Int,
+) -> Result[Json, WorkflowError] {
+  Ok(self.agent(prompt, kind~, hints?, label?, max_steps?)) catch {
+    AgentFailed(..) as err => Err(err)
+    CallBudgetExhausted(..) as err => Err(err)
+    QuorumNotReached(..) as err => Err(err)
+    error => raise error
+  }
+}
+
+///|
+/// Fold one outcome's attempt into the token account — on BOTH arms: a
+/// timed-out or truncated child spent real tokens, and a budget that
+/// missed them would systematically understate cost.
+fn Workflow::account(self : Workflow, outcome : AgentOutcome) -> Unit {
+  let attempt = match outcome {
+    Finished(attempt~, ..) => Some(attempt)
+    DidNotFinish(attempt~, ..) => attempt
+  }
+  if attempt is Some(attempt) {
+    self.prompt_tokens += attempt.prompt_tokens
+    self.completion_tokens += attempt.completion_tokens
+  }
+}
+
+///|
+/// Start a new phase: agent calls ISSUED from now on carry this title in
+/// their `AgentStarted` events until the next `phase` call.
+pub fn Workflow::phase(self : Workflow, title : String) -> Unit {
+  self.current_phase = Some(title)
+  (self.on_event)(PhaseStarted(title))
+}
+
+///|
+/// Emit one narrator line.
+pub fn Workflow::log(self : Workflow, message : String) -> Unit {
+  (self.on_event)(Log(message))
+}
+
+///|
+/// Agents actually launched so far (including ones still running); calls
+/// cancelled while queued and journal replays are not in this count.
+pub fn Workflow::calls_made(self : Workflow) -> Int {
+  self.calls_made
+}
+
+///|
+/// Calls served from the journal instead of launching.
+pub fn Workflow::calls_replayed(self : Workflow) -> Int {
+  self.replays
+}
+
+///|
+/// Total tokens spent by finished attempts this run — successes AND
+/// failures that ran a child. Replayed results will not re-charge here:
+/// historical spend lives in the journal, this counts fresh execution.
+pub fn Workflow::tokens_spent(self : Workflow) -> Int {
+  self.prompt_tokens + self.completion_tokens
+}
+
+///|
+/// The one-line display label a call gets when the caller gave none: the
+/// prompt's first line, capped at 48 chars.
+fn brief(text : String) -> String {
+  let out = StringBuilder()
+  let mut count = 0
+  for c in text {
+    if c == '\n' || count >= 48 {
+      out.write_string("…")
+      break
+    }
+    out.write_char(c)
+    count += 1
+  }
+  out.to_string()
+}

--- a/workflow/workflow_test.mbt
+++ b/workflow/workflow_test.mbt
@@ -1,0 +1,321 @@
+///|
+/// Combinator and context tests over FAKE runners: nothing here leaves the
+/// process — the engine seam is exactly one async function, so the fakes
+/// exercise accounting, policies, concurrency, cancellation, and events
+/// hermetically. The scripted runner dispatches on the prompt's prefix:
+/// `fail:` is an agent failure THAT STILL SPENT TOKENS, `skip:` a human
+/// refusal that never spawned a child, `boom:` an engine bug escaping the
+/// seam, `slow:` a long child for cancellation tests, anything else a
+/// success echoing its prompt.
+priv suberror EngineBoom {
+  EngineBoom
+}
+
+///|
+fn attempt_for(call : @workflow.AgentCall) -> @workflow.AgentAttempt {
+  {
+    attempt_id: "sr-\{call.label}",
+    steps_used: 1,
+    prompt_tokens: 7,
+    completion_tokens: 3,
+  }
+}
+
+///|
+async fn scripted(call : @workflow.AgentCall) -> @workflow.AgentOutcome {
+  @async.pause()
+  guard call.input is { "query": String(prompt), .. } else {
+    fail("the scripted runner expects the explore-style input")
+  }
+  if prompt.strip_prefix("fail:") is Some(_) {
+    return DidNotFinish(
+      failure=@workflow.AgentFailure::Failed("boom"),
+      attempt=Some(attempt_for(call)),
+    )
+  }
+  if prompt.strip_prefix("skip:") is Some(_) {
+    return DidNotFinish(failure=@workflow.AgentFailure::Skipped, attempt=None)
+  }
+  if prompt.strip_prefix("boom:") is Some(_) {
+    raise EngineBoom
+  }
+  if prompt.strip_prefix("slow:") is Some(_) {
+    @async.sleep(2_000)
+  }
+  Finished(value={ "echo": prompt }, attempt=attempt_for(call))
+}
+
+///|
+fn scripted_workflow(
+  max_concurrent? : Int = 8,
+  max_calls? : Int,
+  on_event? : (@workflow.WorkflowEvent) -> Unit,
+) -> @workflow.Workflow raise {
+  @workflow.Workflow(
+    runner=@workflow.Runner(scripted),
+    max_concurrent~,
+    max_calls?,
+    on_event?,
+  )
+}
+
+///|
+async test "agent returns the report value and accounts tokens" {
+  let wf = scripted_workflow()
+  let value = wf.agent("hello", kind="scout")
+  assert_eq(value, { "echo": "hello" })
+  assert_eq(wf.tokens_spent(), 10)
+  assert_eq(wf.calls_made(), 1)
+}
+
+///|
+async test "a failed agent still charges its attempt's tokens" {
+  let wf = scripted_workflow()
+  guard wf.try_agent("fail:a", kind="scout")
+    is Err(@workflow.AgentFailed(label="fail:a", failure=Failed("boom"))) else {
+    fail("expected AgentFailed with the runner's reason")
+  }
+  assert_eq(wf.tokens_spent(), 10)
+}
+
+///|
+async test "a skipped call spends nothing and replays as a refusal" {
+  let wf = scripted_workflow()
+  guard wf.try_agent("skip:a", kind="scout")
+    is Err(@workflow.AgentFailed(failure=Skipped, ..)) else {
+    fail("expected the skip to surface as AgentFailed(Skipped)")
+  }
+  assert_eq(wf.tokens_spent(), 0)
+}
+
+///|
+async test "the launch allowance ignores calls cancelled while queued" {
+  let wf = scripted_workflow(max_concurrent=1, max_calls=3)
+  // One slot: `slow:a` launches and holds it while `ok-b`/`ok-c` queue.
+  // Cancelling the fan-out WHILE they are queued must leave them undebited
+  // — only the launched agent counts, and the fallback below still fits.
+  @async.with_task_group(group => {
+    let work = group.spawn(() => {
+      @workflow.parallel_all([
+        () => wf.agent("slow:a", kind="scout"),
+        () => wf.agent("ok-b", kind="scout"),
+        () => wf.agent("ok-c", kind="scout"),
+      ])
+    })
+    group.spawn_bg(no_wait=true) <| () => {
+      // Handshake, not a timer: cancel only once the first agent has
+      // launched and the siblings have had scheduler turns to reach the
+      // semaphore queue.
+      while wf.calls_made() < 1 {
+        @async.pause()
+      }
+      for _ in 0..<10 {
+        @async.pause()
+      }
+      work.cancel()
+    }
+    let _ : Array[Json] = work.wait() catch {
+      error if @async.is_cancellation_error(error) => []
+      error => raise error
+    }
+  })
+  assert_eq(wf.calls_made(), 1)
+  let _ = wf.agent("ok-fallback", kind="scout")
+  assert_eq(wf.calls_made(), 2)
+}
+
+///|
+async test "the launch allowance refuses the call after the cap" {
+  let wf = scripted_workflow(max_calls=2)
+  let _ = wf.agent("one", kind="scout")
+  let _ = wf.agent("two", kind="scout")
+  guard wf.try_agent("three", kind="scout")
+    is Err(@workflow.CallBudgetExhausted(..)) else {
+    fail("expected the third launch to be refused")
+  }
+  assert_eq(wf.calls_made(), 2)
+}
+
+///|
+async test "parallel keeps sibling successes when one agent fails" {
+  let wf = scripted_workflow()
+  let results = @workflow.parallel([
+    () => wf.try_agent("a", kind="scout"),
+    () => wf.try_agent("fail:b", kind="scout"),
+    () => wf.try_agent("c", kind="scout"),
+  ])
+  guard results is [Ok(_), Err(@workflow.AgentFailed(..)), Ok(_)] else {
+    fail("expected exactly the middle slot to fail")
+  }
+  assert_eq(@workflow.collect_ok(results).length(), 2)
+  assert_eq(@workflow.quorum(results, need=2).length(), 2)
+  let short : Array[Json] = @workflow.quorum(results, need=3) catch {
+    @workflow.QuorumNotReached(need=3, ok=2, of=3) => []
+    _ => fail("expected QuorumNotReached(need=3, ok=2, of=3)")
+  }
+  assert_eq(short.length(), 0)
+  let mut reraised = false
+  let _ = @workflow.all_ok(results) catch {
+    @workflow.AgentFailed(label="fail:b", ..) => {
+      reraised = true
+      []
+    }
+    _ => fail("expected all_ok to re-raise the agent failure")
+  }
+  assert_true(reraised)
+}
+
+///|
+async test "an engine error is never demoted to a policy slot" {
+  let wf = scripted_workflow()
+  let mut engine_error = false
+  let _ : Array[Result[Json, @workflow.WorkflowError]] = @workflow.parallel([
+    () => wf.try_agent("a", kind="scout"),
+    () => wf.try_agent("boom:b", kind="scout"),
+  ]) catch {
+    EngineBoom => {
+      engine_error = true
+      []
+    }
+    _ => fail("expected the engine bug to propagate as itself")
+  }
+  assert_true(engine_error)
+}
+
+///|
+async test "parallel_all cancels a slow sibling and the workflow survives" {
+  let slow_completed : Ref[Bool] = { val: false, }
+  let events : Array[String] = []
+  let wf = scripted_workflow(on_event=event => events.push(render(event)))
+  let _ : Array[Json] = @workflow.parallel_all([
+    () => wf.agent("fail:a", kind="scout"),
+    () => {
+      let value = wf.agent("slow:b", kind="scout")
+      slow_completed.val = true
+      value
+    },
+  ]) catch {
+    @workflow.AgentFailed(label="fail:a", ..) => []
+    _ => fail("expected the failure to propagate")
+  }
+  assert_false(slow_completed.val)
+  // The cancelled sibling still closed its event bracket.
+  assert_true(events.contains("finish slow:b interrupted"))
+  // The semaphore and allowance are intact: the workflow keeps working.
+  let value = wf.agent("ok-after", kind="scout")
+  assert_eq(value, { "echo": "ok-after" })
+}
+
+///|
+async test "fan_out gives every item its own result slot" {
+  let wf = scripted_workflow()
+  let results = @workflow.fan_out(["p", "q", "r"], item => {
+    wf.try_agent(item, kind="scout")
+  })
+  assert_eq(@workflow.all_ok(results).length(), 3)
+  assert_eq(wf.calls_made(), 3)
+}
+
+///|
+async test "max_concurrent bounds in-flight agents" {
+  let in_flight : Ref[Int] = { val: 0, }
+  let peak : Ref[Int] = { val: 0, }
+  let runner = @workflow.Runner(call => {
+    in_flight.val += 1
+    if in_flight.val > peak.val {
+      peak.val = in_flight.val
+    }
+    @async.sleep(5)
+    in_flight.val -= 1
+    Finished(value=Json::null(), attempt=attempt_for(call))
+  })
+  let wf = @workflow.Workflow(runner~, max_concurrent=1)
+  let _ = @workflow.parallel_all([
+    () => wf.agent("a", kind="scout"),
+    () => wf.agent("b", kind="scout"),
+    () => wf.agent("c", kind="scout"),
+  ])
+  assert_eq(peak.val, 1)
+}
+
+///|
+async test "event brackets balance on success, failure, and engine error" {
+  let events : Array[String] = []
+  let wf = scripted_workflow(on_event=event => events.push(render(event)))
+  wf.phase("Scan")
+  wf.log("starting")
+  let _ = wf.agent("q", kind="scout", label="scout")
+  let _ = wf.try_agent("fail:x", kind="scout")
+  let _ = wf.agent("boom:y", kind="scout") catch { _ => Json::null() }
+  assert_eq(events, [
+    "phase Scan", "log starting", "start scout scout Scan", "finish scout ok", "start fail:x scout Scan",
+    "finish fail:x failed", "start boom:y scout Scan", "finish boom:y errored",
+  ])
+}
+
+///|
+async test "outcomes and failures survive the JSON round trip" {
+  let attempt : @workflow.AgentAttempt = {
+    attempt_id: "sr-1",
+    steps_used: 4,
+    prompt_tokens: 11,
+    completion_tokens: 5,
+  }
+  let outcomes : Array[@workflow.AgentOutcome] = [
+    Finished(value={ "answer": 42 }, attempt~),
+    DidNotFinish(
+      failure=@workflow.AgentFailure::TimedOut,
+      attempt=Some(attempt),
+    ),
+    DidNotFinish(
+      failure=@workflow.AgentFailure::NoReport,
+      attempt=Some(attempt),
+    ),
+    DidNotFinish(
+      failure=@workflow.AgentFailure::MaxSteps,
+      attempt=Some(attempt),
+    ),
+    DidNotFinish(
+      failure=@workflow.AgentFailure::ContextYield,
+      attempt=Some(attempt),
+    ),
+    DidNotFinish(failure=@workflow.AgentFailure::Skipped, attempt=None),
+    DidNotFinish(failure=@workflow.AgentFailure::Failed("reason"), attempt=None),
+  ]
+  for outcome in outcomes {
+    let back : @workflow.AgentOutcome = @json.from_json(outcome.to_json())
+    assert_true(back == outcome)
+  }
+}
+
+///|
+async test "quorum boundaries: zero and negative thresholds collect" {
+  let wf = scripted_workflow()
+  let results = @workflow.parallel([() => wf.try_agent("fail:a", kind="scout")])
+  assert_eq(@workflow.quorum(results, need=0).length(), 0)
+  assert_eq(@workflow.collect_ok(results, min_ok=-1).length(), 0)
+}
+
+///|
+fn render(event : @workflow.WorkflowEvent) -> String {
+  match event {
+    @workflow.PhaseStarted(title) => "phase \{title}"
+    @workflow.Log(message) => "log \{message}"
+    @workflow.AgentStarted(label~, kind~, phase~) =>
+      "start \{label} \{kind} \{phase.unwrap_or("-")}"
+    @workflow.AgentFinished(label~, disposition~) =>
+      "finish \{label} \{disposition_word(disposition)}"
+    @workflow.AgentReplayed(label~, disposition~) =>
+      "replay \{label} \{disposition_word(disposition)}"
+  }
+}
+
+///|
+fn disposition_word(disposition : @workflow.AgentDisposition) -> String {
+  match disposition {
+    @workflow.Succeeded => "ok"
+    @workflow.FailedAgent => "failed"
+    @workflow.Interrupted => "interrupted"
+    @workflow.Errored => "errored"
+  }
+}


### PR DESCRIPTION
Part 1 of 2 (the openseek adoption follows in #1180, stacked on this).

A new `bobzhang/workflow` module (wired via `moon.work`): multi-agent workflow orchestration in the workflow-as-code style — workflows are ordinary async programs, and durability comes from replaying a journal of typed outcomes rather than a static DAG. Depends only on `moonbitlang/async`; no openseek imports anywhere.

- **Typed failure model**: `WorkflowError`/`AgentFailure`; choosing a fan-out policy (`all_ok`/`collect_ok`/`quorum`) is compile-enforced. Engine errors and cancellation always propagate. Cost is never lost — failed attempts still charge the budget.
- **Journal replay**: append-only schema-versioned JSONL; scoped content identity with multiset consumption; candidate walk with a typed `ReplayDecision` veto and transactional claims; torn tails repaired on disk.
- **`workflow/spawn` — the child contract**: one versioned request envelope on stdin (`{"workflow_contract": 1, id, kind, max_steps?, input}`, EOF = graceful cancel), JSONL events + a final `subrun_report` line on stdout. `contract_runner(launch~)` turns any binary speaking it — in any language — into an engine with replay, budgets, and cancellation for free.
- **Runnable example**: `workflow/examples/scout` — a script depending only on this module that drives a contract-speaking binary; verified live against openseek (real DeepSeek scout, cited answer, replayed free next generation).

Tested README (`mbt check` blocks compile and run), 43 package tests, developed under adversarial xhigh review rounds with explicit sign-off; an architecture-review round shaped the final API (envelope, `LaunchSpec`, `ReplayDecision`, replay scope, neutral naming).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013t7W9RHYTLx5vcNyftZxeY