### PR TITLE
workflow: support the wasm target (published as 0.1.1)

### DIFF
--- a/workflow/examples/scout/moon.pkg
+++ b/workflow/examples/scout/moon.pkg
@@ -5,6 +5,6 @@ import {
   "moonbitlang/core/env",
 }
 
-supported_targets = "+native"
+supported_targets = "native+wasm"
 
 pkgtype(kind: "executable")

--- a/workflow/moon.mod
+++ b/workflow/moon.mod
@@ -1,6 +1,6 @@
 name = "bobzhang/workflow"
 
-version = "0.1.0"
+version = "0.1.1"
 
 import {
   "moonbitlang/async@0.21.1",

--- a/workflow/moon.pkg
+++ b/workflow/moon.pkg
@@ -11,4 +11,4 @@ import {
   "moonbitlang/core/json",
 } for "test"
 
-supported_targets = "+native"
+supported_targets = "native+wasm"

--- a/workflow/spawn/moon.pkg
+++ b/workflow/spawn/moon.pkg
@@ -13,4 +13,4 @@ import {
   "moonbitlang/async/process",
 } for "test"
 
-supported_targets = "+native"
+supported_targets = "native+wasm"


### PR DESCRIPTION
Widens `supported_targets` to `native+wasm` for the workflow module (core, `spawn`, example) and bumps to 0.1.1 — nothing in the dependency graph required native-only; the declaration was just conservative scaffolding.

Verified on wasm, empirically:
- all 43 module tests pass under moonrun, including file-backed journal I/O and real child-process spawning (`sh` contract children);
- the scout example runs end to end — a **wasm-compiled orchestrator spawning native openseek children**, generation 2 replayed from the journal for 0 spawns / 0 tokens;
- a standalone `.mbtx` script resolves `bobzhang/workflow@0.1.1` cold from mooncakes and runs with `--target wasm` or `--target native`.

(One diagnostic dead-end worth recording: an apparent wasm spawn failure turned out to be `moon`'s target switch pruning the previously built release binary — not a sandbox restriction. moonrun spawns processes and touches the filesystem fine.)

`bobzhang/workflow@0.1.1` is published. js support would additionally need the file-backed journal extracted from core (the architecture review's portability item); `spawn` stays native/wasm by nature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013t7W9RHYTLx5vcNyftZxeY