### PR TITLE
refactor(tui): remove engine environment bindings

### DIFF
--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -36,8 +36,8 @@ async fn dispatch() -> Unit {
     // argparse rejects unknown subcommands during parse, so this is unreachable.
     Some((name, _)) => fail("unhandled subcommand: \{name}")
     // Bare `openseek` IS `openseek tui`: re-parse through the `tui` subcommand so
-    // its own options and env bindings (OPENSEEK_ENGINE, OPENSEEK_ENGINE_MODE)
-    // apply to the default UI, not only to an explicit `tui`. The first parse
+    // its own options apply to the default UI, not only to an explicit `tui`.
+    // The first parse
     // already accepted `argv` at the root, and `tui` inherits the root globals,
     // so this re-parse cannot newly fail.
     None => {

--- a/cmd/tui/README.md
+++ b/cmd/tui/README.md
@@ -9,7 +9,7 @@ explicit `openseek tui` subcommand. There is no separate `tui` executable.
 The UI runs no agent code itself. It spawns the `openseek` engine — by default
 this same binary, re-launched in `serve` mode (so the UI and engine can never
 drift out of sync), resolved from `argv[0]` when invoked by path and otherwise
-from `PATH`; override with `--engine` or `OPENSEEK_ENGINE` — **once per session**
+from `PATH`; override with `--engine` — **once per session**
 and drives it over stdin commands, rendering the engine's JSONL event stream:
 streamed thinking and answer text move live on the activity line, each turn's
 reasoning is kept as a dim `✻` transcript aside above its answer, and tool
@@ -18,8 +18,8 @@ Ctrl-C cancels the turn (a second Ctrl-C kills the engine, and the next prompt
 respawns it on the same session).
 
 A custom or recorded-stream engine that only speaks the original
-one-process-per-prompt protocol works with `--engine-mode oneshot` (env
-`OPENSEEK_ENGINE_MODE`); it spawns `<engine> run --session=<id>
+one-process-per-prompt protocol works with `--engine-mode oneshot`; it spawns
+`<engine> run --session=<id>
 --session-root=<root> -- <task>` per prompt, steering is unavailable, and it
 requires an explicit `--engine` (re-launching this binary in oneshot would only
 lose steering for no gain).

--- a/cmd/tui/main.mbt
+++ b/cmd/tui/main.mbt
@@ -99,13 +99,11 @@ pub fn tui_ui_options() -> Array[@argparse.OptionArg] {
     OptionArg(
       "engine",
       long="engine",
-      env="OPENSEEK_ENGINE",
       about="Agent engine to spawn (default: this openseek binary); reads its JSONL event stream from stdout.",
     ),
     OptionArg(
       "engine-mode",
       long="engine-mode",
-      env="OPENSEEK_ENGINE_MODE",
       default_values=["serve"],
       about="Engine protocol: serve (one persistent, steerable process) or oneshot (spawn per prompt, for replay engines).",
     ),
@@ -245,10 +243,10 @@ fn parse_config(matches : @argparse.Matches) -> AppConfig raise {
       root
     }
   }
-  // An explicit --engine / OPENSEEK_ENGINE wins; otherwise re-launch this
-  // command as the engine (see `default_engine`). Presence of a non-blank value,
-  // not a magic default string, decides — which also gates oneshot below. A
-  // blank `--engine ""` counts as unset rather than an empty command.
+  // An explicit --engine wins; otherwise re-launch this command as the engine
+  // (see `default_engine`). Presence of a non-blank value, not a magic default
+  // string, decides — which also gates oneshot below. A blank `--engine ""`
+  // counts as unset rather than an empty command.
   let explicit_engine : String? = if engine_input.trim().is_empty() {
     None
   } else {
@@ -262,7 +260,7 @@ fn parse_config(matches : @argparse.Matches) -> AppConfig raise {
   // and loses steering/compaction, so require an explicit engine.
   if engine_mode is OneShot && explicit_engine is None {
     fail(
-      "--engine-mode oneshot requires an explicit --engine / OPENSEEK_ENGINE (it is for replay/custom engines)",
+      "--engine-mode oneshot requires an explicit --engine (it is for replay/custom engines)",
     )
   }
   // Enforced here rather than via argparse `required`: see `tui_shared_options`.
@@ -302,8 +300,8 @@ fn parse_config(matches : @argparse.Matches) -> AppConfig raise {
 }
 
 ///|
-/// The engine command when `--engine`/`OPENSEEK_ENGINE` is unset. A normal
-/// binary argv0 is re-execed directly; a bare argv0 falls back to PATH lookup.
+/// The engine command when `--engine` is unset. A normal binary argv0 is
+/// re-execed directly; a bare argv0 falls back to PATH lookup.
 /// Moon's debug native `tcc -run` path is different: argv0 is the generated C
 /// source and no sibling `.exe` is produced, so re-enter through the generated
 /// TCC response file; it carries the include paths, defines, linked dylibs, and
@@ -442,9 +440,7 @@ pub async fn run(matches : @argparse.Matches) -> Unit {
     println(
       "error: engine '\{config.engine_display()}' is not usable: it must be on PATH, executable, and accept `--help` (exit 0) the way openseek does.",
     )
-    println(
-      "Pass --engine <path>, set OPENSEEK_ENGINE, or install the openseek binary.",
-    )
+    println("Pass --engine <path> or install the openseek binary.")
     @sys.exit(1)
   }
   // The UI takes over the terminal, so refuse when stdin/stdout is not a TTY (a
@@ -682,23 +678,14 @@ test "default_engine re-launches a path argv0 and falls back to PATH otherwise" 
 }
 
 ///|
-async test "engine defaults to this binary; --engine/OPENSEEK_ENGINE override it" {
-  // No --engine and no env: fall through to re-launching this binary.
+async test "engine defaults to this binary; --engine overrides it" {
+  // No --engine: fall through to re-launching this binary.
   let default_cfg = parse_config(
     cli_command().parse(argv=[], env={ "DEEPSEEK": "k" }),
   )
   let (expected_engine, expected_prefix) = default_engine(@env.args())
   assert_eq(default_cfg.engine, expected_engine)
   @debug.assert_eq(default_cfg.engine_args_prefix, expected_prefix)
-  // OPENSEEK_ENGINE is treated as an explicit engine.
-  let env_cfg = parse_config(
-    cli_command().parse(argv=[], env={
-      "DEEPSEEK": "k",
-      "OPENSEEK_ENGINE": "./fake-engine",
-    }),
-  )
-  assert_eq(env_cfg.engine, "./fake-engine")
-  @debug.assert_eq(env_cfg.engine_args_prefix, [])
 }
 
 ///|
@@ -717,7 +704,7 @@ async test "oneshot engine mode requires an explicit engine" {
 }
 
 ///|
-async test "oneshot with an explicit engine (flag or env) is accepted" {
+async test "oneshot with an explicit engine is accepted" {
   let flag_cfg = parse_config(
     cli_command().parse(
       argv=["--engine-mode", "oneshot", "--engine", "./fake-engine"],
@@ -727,14 +714,6 @@ async test "oneshot with an explicit engine (flag or env) is accepted" {
   assert_true(flag_cfg.engine_mode is OneShot)
   assert_eq(flag_cfg.engine, "./fake-engine")
   @debug.assert_eq(flag_cfg.engine_args_prefix, [])
-  let env_cfg = parse_config(
-    cli_command().parse(argv=[], env={
-      "DEEPSEEK": "k",
-      "OPENSEEK_ENGINE": "./fake-engine",
-      "OPENSEEK_ENGINE_MODE": "oneshot",
-    }),
-  )
-  assert_true(env_cfg.engine_mode is OneShot)
 }
 
 ///|

--- a/cmd/tui/state.mbt
+++ b/cmd/tui/state.mbt
@@ -16,8 +16,7 @@ priv struct AppConfig {
   // The agent engine the TUI spawns and reads JSONL events from. Defaults to
   // this running `openseek` binary re-launched as the engine (see
   // `default_engine`), so it never spawns a stale, separately-built engine;
-  // override (e.g. to a recorded-stream replayer) with `--engine` or
-  // `OPENSEEK_ENGINE`.
+  // override (e.g. to a recorded-stream replayer) with `--engine`.
   engine : String
   // Extra arguments inserted before the engine subcommand. Usually empty; when
   // the TUI itself was launched through Moon's debug native `tcc -run` path, the

--- a/tests/cram/cli.md
+++ b/tests/cram/cli.md
@@ -101,16 +101,13 @@ error: unexpected value 'something' found; no more were expected
 
 ## Bare `openseek` Is The Interactive UI
 
-With no subcommand, `openseek` launches the UI — it behaves as `openseek tui`, so
-the UI's environment config (`OPENSEEK_ENGINE`, `OPENSEEK_ENGINE_MODE`) still
-applies to the default entrypoint. Here a bogus `OPENSEEK_ENGINE` makes the
-engine pre-flight fail deterministically, proving the env var is honored for a
-bare launch.
+With no subcommand, `openseek` launches the UI — it behaves as `openseek tui`.
+Here the default engine reaches the non-TTY guard, proving the bare entrypoint
+was dispatched through the UI without needing a custom engine.
 
 ```mooncram
-$ env DEEPSEEK=test-key OPENSEEK_ENGINE=does-not-exist openseek.exe 2>&1
-error: engine 'does-not-exist' is not usable: it must be on PATH, executable, and accept `--help` (exit 0) the way openseek does.
-Pass --engine <path>, set OPENSEEK_ENGINE, or install the openseek binary.
+$ env DEEPSEEK=test-key openseek.exe 2>&1
+error: the interactive UI needs a terminal; run a headless task with `openseek run "…"` (or `openseek serve` for the JSONL protocol).
 [1]
 ```
 

--- a/tests/cram/cli.md
+++ b/tests/cram/cli.md
@@ -102,13 +102,20 @@ error: unexpected value 'something' found; no more were expected
 ## Bare `openseek` Is The Interactive UI
 
 With no subcommand, `openseek` launches the UI — it behaves as `openseek tui`.
-Here the default engine reaches the non-TTY guard, proving the bare entrypoint
-was dispatched through the UI without needing a custom engine.
+The cram sandbox exposes the binary only as `openseek.exe`, while the default
+engine re-launches the canonical name `openseek`; symlinking it into a scratch
+dir on `PATH` simulates a real install where that name resolves. The default
+engine's pre-flight succeeds and the bare entrypoint reaches the non-TTY guard,
+proving it was dispatched through the UI.
 
 ```mooncram
-$ env DEEPSEEK=test-key openseek.exe 2>&1
+$ sh <<'EOF'
+> bin=$(mktemp -d)
+> ln -s "$(command -v openseek.exe)" "$bin/openseek"
+> PATH="$bin:$PATH" env DEEPSEEK=test-key openseek.exe 2>&1
+> rm -rf "$bin"
+> EOF
 error: the interactive UI needs a terminal; run a headless task with `openseek run "…"` (or `openseek serve` for the JSONL protocol).
-[1]
 ```
 
 ## `openseek run` Runs One Task Headlessly

--- a/tests/cram/tui.md
+++ b/tests/cram/tui.md
@@ -31,8 +31,8 @@ Options:
   --session <session>            Create or resume this durable session id.
   --session-root <session-root>  Directory containing durable OpenSeek sessions. [default: .openseek]
   --continue                     Resume the most recently active session in --session-root.
-  --engine <engine>              Agent engine to spawn (default: this openseek binary); reads its JSONL event stream from stdout. [env: OPENSEEK_ENGINE]
-  --engine-mode <engine-mode>    Engine protocol: serve (one persistent, steerable process) or oneshot (spawn per prompt, for replay engines). [env: OPENSEEK_ENGINE_MODE] [default: serve]
+  --engine <engine>              Agent engine to spawn (default: this openseek binary); reads its JSONL event stream from stdout.
+  --engine-mode <engine-mode>    Engine protocol: serve (one persistent, steerable process) or oneshot (spawn per prompt, for replay engines). [default: serve]
   --prompt <prompt>              Initial prompt to send once the UI opens.
 ```
 
@@ -80,13 +80,13 @@ stdout-empty
 ## The Engine Is Probed Before The UI Starts
 
 The UI spawns the `openseek` engine (by default this same binary, in `serve`
-mode; override with `--engine`/`OPENSEEK_ENGINE`) and probes it with `--help`
+mode; override with `--engine`) and probes it with `--help`
 first. A missing engine fails fast, before the UI takes over the terminal.
 
 ```mooncram
 $ env DEEPSEEK=test-key openseek.exe tui --engine openseek-not-a-real-binary
 error: engine 'openseek-not-a-real-binary' is not usable: it must be on PATH, executable, and accept `--help` (exit 0) the way openseek does.
-Pass --engine <path>, set OPENSEEK_ENGINE, or install the openseek binary.
+Pass --engine <path> or install the openseek binary.
 [1]
 ```
 
@@ -99,6 +99,6 @@ prompt path is wired — there is no free-form positional.
 ```mooncram
 $ env DEEPSEEK=test-key openseek.exe tui --engine does-not-exist --prompt "inspect project"
 error: engine 'does-not-exist' is not usable: it must be on PATH, executable, and accept `--help` (exit 0) the way openseek does.
-Pass --engine <path>, set OPENSEEK_ENGINE, or install the openseek binary.
+Pass --engine <path> or install the openseek binary.
 [1]
 ```


### PR DESCRIPTION
Remove the `OPENSEEK_ENGINE` and `OPENSEEK_ENGINE_MODE` environment
bindings from the TUI's `--engine` / `--engine-mode` options, so an engine
is chosen only by an explicit `--engine` flag or by re-launching this
binary (the documented default). Splitting out of #1197 so this lands
independently of the prompt-guidance docs change.

- `cmd/tui`: drop `env=` from the engine options; keep `--engine-mode
  oneshot` requiring an explicit `--engine`; update help/docs/tests.
- `cmd/openseek`: drop the env-binding note in the bare-`openseek`
  re-dispatch comment.
- `tests/cram`: the bare-`openseek` test now reaches the non-TTY guard by
  symlinking the sandbox binary as `openseek` on `PATH` (the default
  engine re-launches that canonical name), and the TUI help/engine-probe
  transcripts no longer advertise the env vars.

Verified: `moon check --target native/js --deny-warn`, `moon fmt --check`,
`moon info` (no `.mbti` drift), and `moon test cmd/openseek cmd/tui`
(170 tests) all pass; cram tests run in CI (28/28).

Generated with SeekMoon