### PR TITLE
Salt desktop-minted worktree branches against cross-machine name collisions

### DIFF
--- a/desktop/internal/engine/archive_submodule_wbtest.mbt
+++ b/desktop/internal/engine/archive_submodule_wbtest.mbt
@@ -90,18 +90,21 @@ async test "archive deletes a submodule checkout that git worktree remove refuse
   assert_false(@fsx.exists(clean_checkout.to_path()))
   // Branches and placements survive, and git's worktree bookkeeping is
   // pruned rather than left stale.
+  guard @worktree.list(repo.to_string()).worktrees is [first, second] else {
+    fail("both worktree placements must survive archive")
+  }
   assert_true(
     @gitx.probe(repo, [
-      "show-ref", "--verify", "--quiet", "refs/heads/openseek/wt-1",
+      "show-ref",
+      "--verify",
+      "--quiet",
+      "refs/heads/\{first.branch}",
     ])
     is Some(_),
   )
   assert_false(
     @gitx.run(repo, ["worktree", "list", "--porcelain"]).contains(".worktrees/"),
   )
-  guard @worktree.list(repo.to_string()).worktrees is [first, second] else {
-    fail("both worktree placements must survive archive")
-  }
   assert_false(first.present)
   assert_false(second.present)
   @fs.rmdir(root.to_string(), recursive=true)

--- a/desktop/internal/engine/worktree_seam_wbtest.mbt
+++ b/desktop/internal/engine/worktree_seam_wbtest.mbt
@@ -469,8 +469,8 @@ async test "a checkout deleted outside the app refuses runs and is repairable" {
   guard created.worktrees is [created_info] else {
     fail("create must publish the one worktree it made")
   }
-  // The minted branch is salted past the bare `openseek/wt`, and the repair
-  // restores that same branch — never a lookalike.
+  // The repair restores the very branch create minted (`openseek/wt-<salt>`),
+  // never a lookalike.
   assert_true(created_info.branch.has_prefix("openseek/wt-"))
   assert_eq(
     @gitx.run(checkout, ["rev-parse", "--abbrev-ref", "HEAD"]),

--- a/desktop/internal/engine/worktree_seam_wbtest.mbt
+++ b/desktop/internal/engine/worktree_seam_wbtest.mbt
@@ -466,9 +466,15 @@ async test "a checkout deleted outside the app refuses runs and is repairable" {
     @fsx.read_text(checkout.join("kept.txt").to_path()),
     "committed work",
   )
+  guard created.worktrees is [created_info] else {
+    fail("create must publish the one worktree it made")
+  }
+  // The minted branch is salted past the bare `openseek/wt`, and the repair
+  // restores that same branch — never a lookalike.
+  assert_true(created_info.branch.has_prefix("openseek/wt-"))
   assert_eq(
     @gitx.run(checkout, ["rev-parse", "--abbrev-ref", "HEAD"]),
-    "openseek/wt",
+    created_info.branch,
   )
   assert_eq(
     @worktree.run_dir(repo, "s-vanish").to_string(),
@@ -568,7 +574,10 @@ async test "archive keeps worktree placement for explicit repair after unarchive
   assert_false(@fsx.exists(repo.join(".worktrees/wt-1").to_path()))
   assert_true(
     @gitx.probe(repo, [
-      "show-ref", "--verify", "--quiet", "refs/heads/openseek/wt-1",
+      "show-ref",
+      "--verify",
+      "--quiet",
+      "refs/heads/\{archived_worktree.branch}",
     ])
     is Some(_),
   )

--- a/desktop/internal/worktree/moon.pkg
+++ b/desktop/internal/worktree/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "moonbitlang/core/env" @sys,
+  "openseek_desktop/internal/entropy",
   "openseek_desktop/internal/fsx",
   "openseek_desktop/internal/gitx",
   "openseek_desktop/internal/pathx",

--- a/desktop/internal/worktree/worktree.mbt
+++ b/desktop/internal/worktree/worktree.mbt
@@ -682,6 +682,27 @@ pub async fn list_codex_worktree_bindings() -> Array[CodexWorktreeBinding] {
 }
 
 ///|
+/// A fresh 16-hex-char salt from OS entropy (`@sys.rand`: the native
+/// runtime's source, WASI `random_get` on wasm). Every minted branch is
+/// salted so that two machines' independent `wt-N` counters can never mint
+/// the same branch name and collide on a shared remote; a missing entropy
+/// source refuses rather than minting a guessable name.
+fn fresh_branch_salt() -> String raise WorktreeError {
+  guard @sys.rand(8) is Some(bytes) else {
+    raise WorktreeError("no OS entropy available to mint a worktree branch")
+  }
+  let salt = StringBuilder()
+  for byte in bytes {
+    let value = byte.to_int()
+    if value < 0x10 {
+      salt.write_char('0')
+    }
+    salt.write_string(value.to_string(radix=16))
+  }
+  salt.to_string()
+}
+
+///|
 /// The smallest `wt-N` nobody holds: free in the registry, on disk, and as
 /// a branch. Branches survive removal, so the counter naturally skips past
 /// history instead of resurrecting an old branch.
@@ -701,13 +722,15 @@ async fn fresh_worktree_name(
     if occupied {
       continue
     }
+    // Salted branches survive removal as `openseek/<name>-<salt>`, so a
+    // name's history is a prefix match, not an exact ref.
     if @gitx.probe(dir, [
-        "show-ref",
-        "--verify",
-        "--quiet",
-        "refs/heads/\{WorktreeBranchPrefix}\{name}",
+        "for-each-ref",
+        "--format=%(refname)",
+        "refs/heads/\{WorktreeBranchPrefix}\{name}-*",
       ])
-      is Some(_) {
+      is Some(listing) &&
+      !listing.is_empty() {
       continue
     }
     return name
@@ -716,8 +739,9 @@ async fn fresh_worktree_name(
 }
 
 ///|
-/// Create a worktree `<workspace>/.worktrees/<name>` on a fresh branch
-/// `openseek/<name>` at the workspace's current HEAD, bound from birth to
+/// Create a worktree `<workspace>/.worktrees/<name>` on a fresh salted
+/// branch `openseek/<name>-<salt>` at the workspace's current HEAD, bound
+/// from birth to
 /// `owner` — creation IS the binding, so the start path never mutates the
 /// registry and a refused start cannot re-route a conversation. The owner id
 /// is the idempotency key: an owner that already holds a worktree gets that
@@ -870,7 +894,7 @@ pub async fn create(
       "\{target} already exists on disk; another tool may own it",
     )
   }
-  let branch = WorktreeBranchPrefix + name
+  let branch = WorktreeBranchPrefix + name + "-" + fresh_branch_salt()
   if @gitx.probe(dir, [
       "show-ref",
       "--verify",

--- a/desktop/internal/worktree/worktree.mbt
+++ b/desktop/internal/worktree/worktree.mbt
@@ -682,31 +682,9 @@ pub async fn list_codex_worktree_bindings() -> Array[CodexWorktreeBinding] {
 }
 
 ///|
-/// A fresh 8-hex-char salt from OS entropy (`@sys.rand`). Every minted
-/// branch is salted so that two machines' independent `wt-N` counters can
-/// never mint the same branch name and collide on a shared remote; 32 bits
-/// is plenty for that, and anything longer only clutters the branch chip
-/// and pull-request heads. A missing entropy source refuses rather than
-/// minting a guessable name.
-fn fresh_branch_salt() -> String raise WorktreeError {
-  guard @sys.rand(4) is Some(bytes) else {
-    raise WorktreeError("no OS entropy available to mint a worktree branch")
-  }
-  let salt = StringBuilder()
-  for byte in bytes {
-    let value = byte.to_int()
-    if value < 0x10 {
-      salt.write_char('0')
-    }
-    salt.write_string(value.to_string(radix=16))
-  }
-  salt.to_string()
-}
-
-///|
 /// The smallest `wt-N` nobody holds: free in the registry, on disk, and as
-/// a branch. Branches survive removal, so the counter naturally skips past
-/// history instead of resurrecting an old branch.
+/// a branch. Branches survive removal, so the counter moves past history
+/// instead of pairing a reused name with a lookalike of an old branch.
 async fn fresh_worktree_name(
   dir : @pathx.Absolute,
   entries : Array[WorktreeEntry],
@@ -744,12 +722,11 @@ async fn fresh_worktree_name(
 ///|
 /// Create a worktree `<workspace>/.worktrees/<name>` on a fresh salted
 /// branch `openseek/<name>-<salt>` at the workspace's current HEAD, bound
-/// from birth to
-/// `owner` — creation IS the binding, so the start path never mutates the
-/// registry and a refused start cannot re-route a conversation. The owner id
-/// is the idempotency key: an owner that already holds a worktree gets that
-/// binding back instead of a second checkout, which is what
-/// makes a lost create reply safe to retry. The name is host-generated
+/// from birth to `owner` — creation IS the binding, so the start path never
+/// mutates the registry and a refused start cannot re-route a conversation.
+/// The owner id is the idempotency key: an owner that already holds a
+/// worktree gets that binding back instead of a second checkout, which is
+/// what makes a lost create reply safe to retry. The name is host-generated
 /// (`wt-N`); the wire op takes none — `name?` exists for tests, which need
 /// deterministic fixtures and keep the holder-naming refusals covered.
 /// The whole op runs under `workspace_lifecycle_lock` (like removal), so
@@ -897,7 +874,15 @@ pub async fn create(
       "\{target} already exists on disk; another tool may own it",
     )
   }
-  let branch = WorktreeBranchPrefix + name + "-" + fresh_branch_salt()
+  // Salted so that two machines' independent `wt-N` counters can never mint
+  // the same branch name and collide on a shared remote; 32 bits is plenty
+  // for that, and anything longer only clutters the branch chip and
+  // pull-request heads. No OS entropy is a hard failure, never weak
+  // randomness.
+  guard @entropy.random_hex(4) is Some(salt) else {
+    raise WorktreeError("no OS entropy available to mint a worktree branch")
+  }
+  let branch = "\{WorktreeBranchPrefix}\{name}-\{salt}"
   @workspaces.exclude_from_git(dir, WorktreesDirName)
   let base = @gitx.run(dir, ["rev-parse", "HEAD"])
   // The branch comes first, on its own: our locks are in-process only, so
@@ -1409,8 +1394,7 @@ async test "worktree create provisions checkout, branch, registry, exclusion" {
   assert_eq(reply.name, "fix-auth")
   guard reply.worktrees is [info] else { fail("expected one worktree") }
   assert_eq(info.name, "fix-auth")
-  // The branch is minted salted past the bare name (`openseek/<name>-<salt>`)
-  // so machine-local counters can never collide on a shared remote.
+  // The minted branch is `openseek/<name>-<8 hex chars of salt>`.
   assert_true(info.branch.has_prefix("openseek/fix-auth-"))
   assert_eq(info.branch.length(), "openseek/fix-auth-".length() + 8)
   assert_eq(info.base, @gitx.run(repo, ["rev-parse", "HEAD"]))

--- a/desktop/internal/worktree/worktree.mbt
+++ b/desktop/internal/worktree/worktree.mbt
@@ -682,13 +682,14 @@ pub async fn list_codex_worktree_bindings() -> Array[CodexWorktreeBinding] {
 }
 
 ///|
-/// A fresh 16-hex-char salt from OS entropy (`@sys.rand`: the native
-/// runtime's source, WASI `random_get` on wasm). Every minted branch is
-/// salted so that two machines' independent `wt-N` counters can never mint
-/// the same branch name and collide on a shared remote; a missing entropy
-/// source refuses rather than minting a guessable name.
+/// A fresh 8-hex-char salt from OS entropy (`@sys.rand`). Every minted
+/// branch is salted so that two machines' independent `wt-N` counters can
+/// never mint the same branch name and collide on a shared remote; 32 bits
+/// is plenty for that, and anything longer only clutters the branch chip
+/// and pull-request heads. A missing entropy source refuses rather than
+/// minting a guessable name.
 fn fresh_branch_salt() -> String raise WorktreeError {
-  guard @sys.rand(8) is Some(bytes) else {
+  guard @sys.rand(4) is Some(bytes) else {
     raise WorktreeError("no OS entropy available to mint a worktree branch")
   }
   let salt = StringBuilder()
@@ -722,11 +723,13 @@ async fn fresh_worktree_name(
     if occupied {
       continue
     }
-    // Salted branches survive removal as `openseek/<name>-<salt>`, so a
-    // name's history is a prefix match, not an exact ref.
+    // Salted branches survive removal as `openseek/<name>-<salt>`, and
+    // branches minted before salting as the bare `openseek/<name>`, so a
+    // name's history is the exact ref plus the prefix match.
     if @gitx.probe(dir, [
         "for-each-ref",
         "--format=%(refname)",
+        "refs/heads/\{WorktreeBranchPrefix}\{name}",
         "refs/heads/\{WorktreeBranchPrefix}\{name}-*",
       ])
       is Some(listing) &&
@@ -878,9 +881,9 @@ pub async fn create(
     Some(name) => name
     None => fresh_worktree_name(dir, entries)
   }
-  // Refusals name the holder: the registry entry, the directory (a subtask
-  // slice can own `.worktrees/<name>` without any registry entry), or the
-  // branch.
+  // Refusals name the holder: the registry entry or the directory (a subtask
+  // slice can own `.worktrees/<name>` without any registry entry). The branch
+  // is freshly salted, so nothing can hold it ahead of us.
   if entries.iter().any(entry => entry.name == name) {
     raise WorktreeError("worktree \{name} already exists in this workspace")
   }
@@ -895,17 +898,6 @@ pub async fn create(
     )
   }
   let branch = WorktreeBranchPrefix + name + "-" + fresh_branch_salt()
-  if @gitx.probe(dir, [
-      "show-ref",
-      "--verify",
-      "--quiet",
-      "refs/heads/\{branch}",
-    ])
-    is Some(_) {
-    raise WorktreeError(
-      "branch \{branch} already exists; delete it or pick another name",
-    )
-  }
   @workspaces.exclude_from_git(dir, WorktreesDirName)
   let base = @gitx.run(dir, ["rev-parse", "HEAD"])
   // The branch comes first, on its own: our locks are in-process only, so
@@ -1420,7 +1412,7 @@ async test "worktree create provisions checkout, branch, registry, exclusion" {
   // The branch is minted salted past the bare name (`openseek/<name>-<salt>`)
   // so machine-local counters can never collide on a shared remote.
   assert_true(info.branch.has_prefix("openseek/fix-auth-"))
-  assert_eq(info.branch.length(), "openseek/fix-auth-".length() + 16)
+  assert_eq(info.branch.length(), "openseek/fix-auth-".length() + 8)
   assert_eq(info.base, @gitx.run(repo, ["rev-parse", "HEAD"]))
   // Creation IS the binding: the entry carries its conversation from birth.
   assert_eq(info.session, Some("s-fix-auth"))
@@ -1537,6 +1529,10 @@ async test "worktree names are host-generated and skip surviving branches" {
   }
   assert_eq(a.name, "wt-2")
   assert_eq(b.name, "wt-3")
+  // A bare `openseek/wt-4` left behind by a build that minted unsalted
+  // branches is history too: the counter moves past it instead of pairing
+  // the directory with a lookalike salted branch.
+  ignore(@gitx.run(repo, ["branch", "openseek/wt-4"]))
   // Codex uses the same registry, name allocator, and idempotency contract,
   // but its owner remains in a distinct field from OpenSeek sessions.
   let codex = create(host, repo.to_string(), WorktreeOwner::codex("thread-1"), fn(
@@ -1544,15 +1540,15 @@ async test "worktree names are host-generated and skip surviving branches" {
   ) {
 
   })
-  assert_eq(codex.name, "wt-4")
+  assert_eq(codex.name, "wt-5")
   let codex_replay = create(
     host,
     repo.to_string(),
     WorktreeOwner::codex("thread-1"),
     fn(_) {  },
   )
-  assert_eq(codex_replay.name, "wt-4")
-  guard codex_replay.worktrees.iter().find_first(info => info.name == "wt-4")
+  assert_eq(codex_replay.name, "wt-5")
+  guard codex_replay.worktrees.iter().find_first(info => info.name == "wt-5")
     is Some(codex_info) else {
     fail("expected Codex-owned worktree row")
   }

--- a/desktop/internal/worktree/worktree.mbt
+++ b/desktop/internal/worktree/worktree.mbt
@@ -1417,7 +1417,10 @@ async test "worktree create provisions checkout, branch, registry, exclusion" {
   assert_eq(reply.name, "fix-auth")
   guard reply.worktrees is [info] else { fail("expected one worktree") }
   assert_eq(info.name, "fix-auth")
-  assert_eq(info.branch, "openseek/fix-auth")
+  // The branch is minted salted past the bare name (`openseek/<name>-<salt>`)
+  // so machine-local counters can never collide on a shared remote.
+  assert_true(info.branch.has_prefix("openseek/fix-auth-"))
+  assert_eq(info.branch.length(), "openseek/fix-auth-".length() + 16)
   assert_eq(info.base, @gitx.run(repo, ["rev-parse", "HEAD"]))
   // Creation IS the binding: the entry carries its conversation from birth.
   assert_eq(info.session, Some("s-fix-auth"))
@@ -1428,7 +1431,10 @@ async test "worktree create provisions checkout, branch, registry, exclusion" {
   assert_true(@fsx.is_dir(repo.join(".worktrees/fix-auth").to_path()))
   assert_true(
     @gitx.probe(repo, [
-      "show-ref", "--verify", "--quiet", "refs/heads/openseek/fix-auth",
+      "show-ref",
+      "--verify",
+      "--quiet",
+      "refs/heads/\{info.branch}",
     ])
     is Some(_),
   )
@@ -1437,7 +1443,7 @@ async test "worktree create provisions checkout, branch, registry, exclusion" {
     @gitx.run(repo.join(".worktrees/fix-auth"), [
       "rev-parse", "--abbrev-ref", "HEAD",
     ]),
-    "openseek/fix-auth",
+    info.branch,
   )
   let exclude = @fsx.read_text(repo.join(".git/info/exclude").to_path())
   assert_true(exclude.contains(".worktrees/"))
@@ -1673,12 +1679,6 @@ async test "worktree create names the holder in every refusal" {
       "already exists on disk",
     ),
   )
-  ignore(@gitx.run(repo, ["branch", "openseek/task"]))
-  assert_true(
-    create_refusal(host, repo.to_string(), "s-4", "task").contains(
-      "branch openseek/task already exists",
-    ),
-  )
   // A workspace that is not a git repository cannot host worktrees; a linked
   // worktree registered before the attach guard existed is refused too.
   let plain = root.join("plain")
@@ -1738,14 +1738,12 @@ async test "worktree remove enforces the dirty check and keeps the branch" {
       "no worktree named",
     ),
   )
-  ignore(
-    create(
-      host,
-      repo.to_string(),
-      WorktreeOwner::openseek("s-w1"),
-      fn(_) {  },
-      name="w1",
-    ),
+  let w1 = create(
+    host,
+    repo.to_string(),
+    WorktreeOwner::openseek("s-w1"),
+    fn(_) {  },
+    name="w1",
   )
   @fs.write_file(
     repo.join(".worktrees/w1/junk.txt").to_string(),
@@ -1765,27 +1763,33 @@ async test "worktree remove enforces the dirty check and keeps the branch" {
   assert_eq(committed.val, 0)
   assert_eq(forced.worktrees.length(), 0)
   assert_false(@fsx.exists(repo.join(".worktrees/w1").to_path()))
+  guard w1.worktrees is [w1_info] else { fail("expected one worktree") }
   // Committed work is never lost: the branch survives every removal.
   assert_true(
     @gitx.probe(repo, [
-      "show-ref", "--verify", "--quiet", "refs/heads/openseek/w1",
+      "show-ref",
+      "--verify",
+      "--quiet",
+      "refs/heads/\{w1_info.branch}",
     ])
     is Some(_),
   )
-  ignore(
-    create(
-      host,
-      repo.to_string(),
-      WorktreeOwner::openseek("s-w2"),
-      fn(_) {  },
-      name="w2",
-    ),
+  let w2 = create(
+    host,
+    repo.to_string(),
+    WorktreeOwner::openseek("s-w2"),
+    fn(_) {  },
+    name="w2",
   )
   ignore(remove(host, repo.to_string(), "w2", false, fn(_) {  }))
   assert_eq(list(repo.to_string()).worktrees.length(), 0)
+  guard w2.worktrees is [w2_info] else { fail("expected one worktree") }
   assert_true(
     @gitx.probe(repo, [
-      "show-ref", "--verify", "--quiet", "refs/heads/openseek/w2",
+      "show-ref",
+      "--verify",
+      "--quiet",
+      "refs/heads/\{w2_info.branch}",
     ])
     is Some(_),
   )


### PR DESCRIPTION
## Problem

The desktop host minted every conversation worktree branch as
`openseek/wt-N` from a machine-local counter. Two machines both mint
`openseek/wt-3`; when both land on the shared remote, the names collide.

## Fix

- Mint the branch as `openseek/<name>-<salt>`: 8 hex chars of OS entropy
  via `@env.rand` (the native runtime's source; WASI `random_get` on wasm).
  A missing entropy source raises instead of minting a guessable name. The
  `wt-N` directory name stays machine-local.
- The `wt-N` counter's skip-past-history probe becomes a prefix match over
  the salted refs (`for-each-ref` with a `-*` pattern).
- Worktree tests assert against the minted branch (from the placement row
  or create reply) instead of the bare `openseek/wt-N` name, and lock in
  the salted shape.

## Verification

- `moon check --target native --deny-warn` (workspace): clean
- `moon fmt --check`: clean
- `moon info` + no `.mbti` drift
- `moon test internal/engine` (full suite): passed

Not verified locally: the `desktop-e2e` Playwright workflow and the
JS-target check row — CI covers those.

Generated with SeekMoon