### PR TITLE
fix(desktop): prevent blank screen when focusing tool tabs

### DIFF
--- a/desktop/e2e/tests/rabbita_dom.spec.js
+++ b/desktop/e2e/tests/rabbita_dom.spec.js
@@ -436,6 +436,82 @@ test('transcript overview previews failed turns and jumps among mounted messages
   expect(app.pageErrors).toEqual([]);
 });
 
+test('tool-call tabs keep focus-driven scrolling inside the transcript', async ({ page }) => {
+  const app = new DesktopBrowserHarness(page);
+  const events = [
+    {
+      sequence: 1,
+      item: {
+        kind: 'user',
+        payload: { content: 'Show the browser fixture with a long transcript' },
+      },
+    },
+  ];
+  let sequence = 2;
+  for (let row = 1; row <= 100; row += 1) {
+    events.push({
+      sequence,
+      item: {
+        kind: 'assistant',
+        payload: { content: `Transcript filler row ${row}` },
+      },
+    });
+    sequence += 1;
+  }
+  events.push({
+    sequence,
+    item: {
+      kind: 'assistant',
+      payload: {
+        content: '',
+        tool_calls: [
+          {
+            id: 'deep-tabbed-call',
+            name: 'mbtx',
+            arguments: JSON.stringify({
+              source: 'fn main { println("browser fixture") }',
+            }),
+          },
+        ],
+      },
+    },
+  });
+  app.sessionEvents = events;
+  await app.install();
+  await app.goto();
+  // Proton's current CEF does not use the size container as the absolute
+  // positioning root. Neutralize Chromium's newer behavior so this browser
+  // test exercises the same geometry as the shipping desktop host.
+  await page.addStyleTag({ content: '#transcript { container-type: normal; }' });
+  await app.openSession();
+
+  const transcript = page.locator('#transcript');
+  const tabs = transcript.locator('.tool-call-tabs');
+  const originalJson = tabs.getByText('Original JSON', { exact: true });
+  await transcript.locator('.tool-call-summary').click();
+  await transcript.evaluate(node => {
+    node.scrollTop = node.scrollHeight;
+  });
+  await expect(originalJson).toBeVisible();
+  expect(await transcript.evaluate(node => node.scrollTop)).toBeGreaterThan(0);
+  expect(await page.evaluate(() => document.scrollingElement.scrollTop)).toBe(0);
+
+  await originalJson.click();
+
+  const originalJsonInput = tabs.locator('.tool-call-tab-input').nth(1);
+  await expect(originalJsonInput).toBeChecked();
+  await originalJsonInput.focus();
+  await expect(originalJsonInput).toBeFocused();
+  expect(await transcript.evaluate(node => getComputedStyle(node).position))
+    .toBe('relative');
+  expect(await originalJsonInput.evaluate(node =>
+    Boolean(node.offsetParent?.closest('#transcript')))).toBe(true);
+  expect(await page.evaluate(() => document.scrollingElement.scrollTop)).toBe(0);
+  expect(await page.locator('.app').evaluate(node =>
+    node.getBoundingClientRect().top)).toBe(0);
+  expect(app.pageErrors).toEqual([]);
+});
+
 test('transcript Markdown keeps links safe and loads local raster bytes through the host', async ({ page }) => {
   const app = new DesktopBrowserHarness(page);
   app.binaryFiles['diagram.png'] = {

--- a/desktop/styles/transcript.css
+++ b/desktop/styles/transcript.css
@@ -1,6 +1,10 @@
 
 /* ---------- transcript ---------- */
 .transcript {
+  /* Keep clipped accessibility controls in this scroller's coordinate
+     space. Proton's CEF otherwise positions a focused tool-tab radio
+     against the document and scrolls the entire app out of the viewport. */
+  position: relative;
   min-height: 0;
   overflow: auto;
   /* Reserve both edges so the centered stream does not shift when overflow


### PR DESCRIPTION
## Summary

- keep hidden tool-tab controls positioned within the transcript scroller
- prevent focus-driven scrolling from moving the entire desktop app outside the viewport
- add a browser E2E regression covering a long transcript and focused Original JSON tab

## Root cause

In the Proton CEF host, the clipped radio input used by tool-call tabs could be positioned against the document. Focusing it near the bottom of a long transcript scrolled the root document instead of the transcript, moving the app out of the viewport and leaving a blank window.

## Testing

- targeted Playwright regression: 1 passed
- moon test --target js: 3169 passed
- moon build --target native: passed
- moon build --target js: passed
- moon fmt --check: passed
- git diff --check: passed
- full desktop E2E: 20 passed, 2 unrelated existing failures

## Environment notes

- moon test --target native reaches the existing desktop internal API executable but exits with Windows status 0xc0000135 because a runtime DLL is unavailable
- moon cram test tests/cram is blocked because this Windows environment cannot resolve a shell path
- moon check --target native --deny-warn is blocked by four existing unused-field warnings in agent_tool/bgjobs/bgjobs.mbt