### PR TITLE
feat(desktop): render MBTI files as UML diagrams

### DIFF
--- a/desktop/e2e/tests/rabbita_dom.spec.js
+++ b/desktop/e2e/tests/rabbita_dom.spec.js
@@ -172,6 +172,78 @@ test('Review routes Markdown source and keeps non-MoonBit comparisons on Line di
   expect(app.pageErrors).toEqual([]);
 });
 
+test('ordinary MBTI files render as UML and reviews keep source surfaces', async ({ page }) => {
+  const app = new DesktopBrowserHarness(page);
+  const path = 'api/pkg.generated.mbti';
+  const working = [
+    'package "fixture/api"',
+    '',
+    'pub struct Point {',
+    '  x : Double',
+    '  y : Double',
+    '}',
+    '',
+    'pub trait Shape {',
+    '  area(Self) -> Double',
+    '}',
+    '',
+    'impl Shape for Point',
+  ].join('\n');
+  const baseline = working.replace('  y : Double\n', '');
+  app.searchFiles = [path];
+  app.workingFiles[path] = working;
+  app.gitChanges = [{
+    path,
+    index_status: ' ',
+    worktree_status: 'M',
+    kind: 'modified',
+  }];
+  app.gitFilesByRevision[app.gitBaseline][path] = baseline;
+
+  await app.install();
+  await app.goto();
+  await app.openSession();
+  await app.openQuickOpen();
+  await page.getByRole('option', { name: /pkg\.generated\.mbti/ }).click();
+
+  const diagram = page.locator('#mbti-diagram-host');
+  await expect(diagram).toBeVisible();
+  await expect(diagram.locator('svg')).toBeVisible();
+  await expect(diagram.locator('svg')).toContainText('Point');
+  const view = page.getByRole('group', { name: 'MBTI view' });
+  await expect(view.getByRole('button')).toHaveText(['Diagram', 'Source']);
+  await expect(view.getByRole('button', { name: 'Diagram' })).toHaveAttribute(
+    'aria-pressed',
+    'true',
+  );
+
+  await view.getByRole('button', { name: 'Source' }).click();
+  await expect(diagram).toBeHidden();
+  await expect(page.locator('#viewer-host')).toBeVisible();
+  await expect(page.locator('#viewer-host')).toContainText('Point');
+  await expect(view.getByRole('button', { name: 'Source' })).toHaveAttribute(
+    'aria-pressed',
+    'true',
+  );
+  await view.getByRole('button', { name: 'Diagram' }).click();
+  await expect(diagram.locator('svg')).toBeVisible();
+
+  await app.openReview();
+  await page.getByRole('button', { name: /View diff: api\/pkg\.generated\.mbti/ }).click();
+  await expect(page.getByRole('group', { name: 'MBTI view' })).toHaveCount(0);
+  await expect(diagram).toBeHidden();
+  const review = page.getByRole('toolbar', { name: 'Review mode' });
+  await expect(review.getByRole('button', { name: 'Line diff' })).toHaveAttribute(
+    'aria-pressed',
+    'true',
+  );
+  await review.getByRole('button', { name: 'File view' }).click();
+  await expect(page.locator('#viewer-host')).toBeVisible();
+  await expect(page.locator('#viewer-host')).toContainText('Point');
+  await expect(diagram).toBeHidden();
+  expect(app.pageErrors).toEqual([]);
+});
+
 test('Git history expands commits and opens an immutable historical diff', async ({ page }) => {
   const app = new DesktopBrowserHarness(page);
   await app.install();

--- a/desktop/e2e/tests/support/desktop_browser_harness.js
+++ b/desktop/e2e/tests/support/desktop_browser_harness.js
@@ -92,6 +92,7 @@ export class DesktopBrowserHarness {
         '',
       ].join('\n'),
     };
+    this.searchFiles = ['src/main.mbt', 'README.md'];
     // Transcript images use the same fs.read_file RPC as text files, but the
     // real host returns bytes plus a verified media type. Tests opt into that
     // response per path instead of bypassing the product image loader.
@@ -773,7 +774,7 @@ export class DesktopBrowserHarness {
         };
       case 'fs.search_files':
         return {
-          files: ['src/main.mbt', 'README.md'],
+          files: [...this.searchFiles],
           from_cache: false,
           limit_hit: false,
           cancelled: false,

--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -18,6 +18,12 @@ const ViewerHostId = "viewer-host"
 const MarkdownViewerHostId = "markdown-viewer-host"
 
 ///|
+/// The stable sibling host for the UML rendering of an ordinary generated
+/// MoonBit interface. The code Viewer keeps the same source model mounted
+/// behind it so switching back to source is non-destructive.
+const MbtiDiagramHostId = "mbti-diagram-host"
+
+///|
 /// The stable sibling host reserved for the switchable DiffEditor.
 const DiffEditorHostId = "diff-editor-host"
 
@@ -70,6 +76,11 @@ priv struct ViewerHost {
   // inside the code Viewer. It shares product services but owns its own model
   // and view-state lifetime.
   mut markdown_viewer : @viewer.MarkdownViewer?
+  // The MBTI host is plain generated SVG rather than another editor widget.
+  // Cache the rendered input so unrelated app updates do not repeat UML
+  // layout while its stable host remains mounted.
+  mut mbti_resource : String?
+  mut mbti_source : String?
   // Desired full-comparison layout survives a pre-mount command in the same
   // way font settings do for the source Viewer.
   mut diff_options : @viewer.DiffEditorOptions
@@ -127,6 +138,8 @@ let viewer_state : ViewerHost = {
   viewer: None,
   diff_editor: None,
   markdown_viewer: None,
+  mbti_resource: None,
+  mbti_source: None,
   diff_options: @viewer.DiffEditorOptions(
     editor_options=@viewer.ViewerOptions(
       theme="light",
@@ -290,6 +303,11 @@ fn supports_moon_diff(path : String) -> Bool {
 ///|
 fn uses_markdown_presentation(name : String) -> Bool {
   name.to_lower().has_suffix(".md") || language_id(name) == "markdown"
+}
+
+///|
+fn uses_mbti_presentation(name : String) -> Bool {
+  name.to_lower().has_suffix(".mbti")
 }
 
 ///|
@@ -993,6 +1011,51 @@ fn dispose_source_model(model : @model.TextModel?) -> Unit {
 }
 
 ///|
+/// Render a generated interface into the stable MBTI host at most once per
+/// resource/content pair. The UML module returns generated SVG at this trusted
+/// insertion boundary; a malformed interface gets an explicit error surface
+/// with the source toggle still available in the breadcrumb.
+fn show_mbti_diagram(resource : @common.Uri, source : String) -> Unit {
+  let resource_key = resource.to_string()
+  if viewer_state.mbti_resource == Some(resource_key) &&
+    viewer_state.mbti_source == Some(source) {
+    return
+  }
+  guard @dom.document().get_element_by_id(MbtiDiagramHostId).to_option()
+    is Some(host) else {
+    return
+  }
+  viewer_state.mbti_resource = Some(resource_key)
+  viewer_state.mbti_source = Some(source)
+  match @viewer.render_mbti_diagram_svg(source) {
+    Some(svg) => host.set_inner_html(svg)
+    None => {
+      let message =
+        #|<div class="mbti-diagram-error" role="status">This interface could not be rendered as a UML diagram. View the source for details.</div>
+      host.set_inner_html(message)
+    }
+  }
+}
+
+///|
+fn clear_mbti_diagram() -> Unit {
+  viewer_state.mbti_resource = None
+  viewer_state.mbti_source = None
+  if @dom.document().get_element_by_id(MbtiDiagramHostId).to_option()
+    is Some(host) {
+    host.set_inner_html("")
+  }
+}
+
+///|
+/// Schedule an imperative editor effect for the render that exposes its stable
+/// host. Keeping the scheduler plumbing here also leaves large effect bodies in
+/// the formatter's compact single-closure form.
+fn after_render_effect(action : () -> Unit) -> @cmd.Cmd {
+  @cmd.custom_cmd(_scheduler => action(), kind=@cmd.after_render)
+}
+
+///|
 /// Show a file's contents in the viewer as a fresh read-only document. A
 /// symbol jump's `range`, when present, is revealed centered once the
 /// document is set. The caret stays collapsed at the range start while an
@@ -1026,10 +1089,11 @@ fn show_file_in_viewer(
   diff? : (String, String),
   search_highlights? : @grep_search.EditorHighlights,
 ) -> @cmd.Cmd {
-  let show = @cmd.custom_cmd(_scheduler => {
-    // Reads are always batched behind a mount request whose after-render tick
-    // runs before this async reply, so the viewer exists here (see
-    // `ViewerHost::viewer`); the guard only drops a pathological stray.
+  let show = after_render_effect(() => {
+    // A fast host (including the browser fixture) may settle `read_file`
+    // before the mount command from the open action reaches its after-render
+    // phase. Commit the document in that same phase so the stable hosts and
+    // their widgets exist before either the source model or MBTI SVG is set.
     guard viewer_state.viewer is Some(viewer) &&
       viewer_state.markdown_viewer is Some(markdown_viewer) else {
       return
@@ -1051,6 +1115,9 @@ fn show_file_in_viewer(
         ) catch {
           _ => return
         }
+    }
+    if uses_mbti_presentation(name) {
+      show_mbti_diagram(uri, content)
     }
     // Whether anything needs redrawing is decided here, against the document
     // the viewer really shows — the update loop only says "show this", it
@@ -1357,6 +1424,7 @@ fn clear_viewer() -> @cmd.Cmd {
     viewer_state.absolute = None
     viewer_state.relative = None
     viewer_state.navigation = None
+    clear_mbti_diagram()
     clear_diff_comparison()
     clear_semantic_review_editors()
   })
@@ -1394,6 +1462,7 @@ fn clear_document() -> @cmd.Cmd {
     viewer_state.absolute = None
     viewer_state.relative = None
     viewer_state.navigation = None
+    clear_mbti_diagram()
   })
 }
 

--- a/desktop/frontend/fileeditor/mbti_presentation_wbtest.mbt
+++ b/desktop/frontend/fileeditor/mbti_presentation_wbtest.mbt
@@ -1,0 +1,108 @@
+///|
+test "ordinary MBTI tabs default to diagram and toggle without replacing the document" {
+  let path = @pathx.Relative("api/pkg.generated.mbti")
+  let docs = owned_state().docs.copy()
+  docs[path] = loaded_doc(path.0)
+  let state = { ..owned_state(), docs, }
+  let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path), }
+
+  assert_true(mbti_view_available(state, ctx))
+  assert_true(uses_mbti_diagram_surface(state, ctx))
+  assert_true(state.mbti_view_mode(path) is MbtiDiagram)
+
+  let (_, source) = update(
+    test_emit(),
+    MbtiViewModeSelected(MbtiSource),
+    state,
+    ctx,
+  )
+  assert_true(source.mbti_view_mode(path) is MbtiSource)
+  assert_false(uses_mbti_diagram_surface(source, ctx))
+  assert_true(source.docs.get(path) == state.docs.get(path))
+
+  let (_, diagram) = update(
+    test_emit(),
+    MbtiViewModeSelected(MbtiDiagram),
+    source,
+    ctx,
+  )
+  assert_true(diagram.mbti_view_mode(path) is MbtiDiagram)
+  assert_true(uses_mbti_diagram_surface(diagram, ctx))
+}
+
+///|
+test "reviewed MBTI files keep source and reject the diagram toggle" {
+  let path = @pathx.Relative("api/pkg.generated.mbti")
+  let selected = test_modified_change(path)
+  let docs = owned_state().docs.copy()
+  docs[path] = {
+    ..loaded_doc(path.0),
+    review: Some({
+      generation: 1,
+      working_generation: 1,
+      baseline: ReviewContent("package \"old\""),
+      view_mode: ReviewSource,
+      selected,
+    }),
+  }
+  let state = { ..owned_state(), docs, }
+  let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path), }
+
+  assert_false(mbti_view_available(state, ctx))
+  assert_false(uses_mbti_diagram_surface(state, ctx))
+  let (_, after) = update(
+    test_emit(),
+    MbtiViewModeSelected(MbtiSource),
+    state,
+    ctx,
+  )
+  assert_true(after == state)
+}
+
+///|
+test "positioned MBTI opens use source and closing forgets the tab preference" {
+  let path = @pathx.Relative("api/pkg.generated.mbti")
+  let docs = owned_state().docs.copy()
+  docs[path] = loaded_doc(path.0)
+  let state = { ..owned_state(), docs, }
+  let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path), }
+
+  let (_, positioned) = open_document(
+    test_emit(),
+    state,
+    ctx,
+    path,
+    name="pkg.generated.mbti",
+    range=Some(@common.Range(3, 1, 3, 8)),
+    had_active=true,
+  )
+  assert_true(positioned.mbti_view_mode(path) is MbtiSource)
+
+  let (_, closed) = close_document(
+    test_emit(),
+    positioned,
+    { ..ctx, open_files: [], active_file: None, },
+    path,
+    next=None,
+    was_active=true,
+  )
+  assert_true(closed.mbti_view_modes.get(path) is None)
+  assert_true(closed.mbti_view_mode(path) is MbtiDiagram)
+}
+
+///|
+test "non-MBTI documents do not expose or accept MBTI presentation" {
+  let path = @pathx.Relative("src/main.mbt")
+  let docs = owned_state().docs.copy()
+  docs[path] = loaded_doc(path.0)
+  let state = { ..owned_state(), docs, }
+  let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path), }
+  assert_false(mbti_view_available(state, ctx))
+  let (_, after) = update(
+    test_emit(),
+    MbtiViewModeSelected(MbtiSource),
+    state,
+    ctx,
+  )
+  assert_true(after == state)
+}

--- a/desktop/frontend/fileeditor/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/pkg.generated.mbti
@@ -212,6 +212,13 @@ pub(all) enum HistoryDiffSide {
   HistoryModified
 } derive(Eq)
 
+pub(all) enum MbtiViewMode {
+  MbtiDiagram
+  MbtiSource
+} derive(Eq)
+pub fn MbtiViewMode::equal(Self, Self) -> Bool
+pub fn MbtiViewMode::not_equal(Self, Self) -> Bool
+
 pub struct ModelUri(String)
 pub fn ModelUri::of(@common.Uri) -> Self
 
@@ -257,6 +264,7 @@ pub(all) enum Msg {
   RevealNextReviewDiffChange
   RevealSemanticReviewSectionChange(String, Bool)
   ToggleReviewProgress
+  MbtiViewModeSelected(MbtiViewMode)
   GitOriginalLoaded(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, generation~ : Int, background~ : Bool, original~ : @protocol.GitOriginalFileReply)
   GitOriginalFailed(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, generation~ : Int, background~ : Bool, message~ : String)
   HistoryBlobLoaded(owner~ : @interop.ConversationKey, key~ : String, generation~ : Int, side~ : HistoryDiffSide, blob~ : @protocol.GitOriginalFileReply)
@@ -393,6 +401,7 @@ pub(all) struct State {
   loading : Array[@pathx.Relative]
   children : Map[@pathx.Relative, Array[FileEntry]]
   docs : Map[@pathx.Relative, Doc]
+  mbti_view_modes : Map[@pathx.Relative, MbtiViewMode]
   highlighted : @pathx.Relative?
   index : FileIndex
   error : String?

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -84,6 +84,15 @@ pub(all) enum ReviewViewMode {
 } derive(Eq)
 
 ///|
+/// The presentation selected for an ordinary generated MoonBit interface.
+/// Diff/review and positioned navigation ignore this preference and keep the
+/// source surface, but a normal `.mbti` tab starts in diagram mode.
+pub(all) enum MbtiViewMode {
+  MbtiDiagram
+  MbtiSource
+} derive(Eq)
+
+///|
 /// The layout shared by Line and sectioned semantic comparison. This
 /// panel-level preference is independent from `ReviewViewMode`: returning to
 /// source keeps it for the next review and the next changed file.
@@ -511,6 +520,10 @@ pub(all) struct State {
   // mirrors the dock strip's file tabs (`Ctx.open_files`): the root update
   // adds an entry when it opens a tab and drops it when the tab closes.
   docs : Map[@pathx.Relative, Doc]
+  // Per-tab MBTI presentation. Absence is the normal default (`MbtiDiagram`),
+  // so a closed and later reopened interface starts rendered again. Special
+  // source-bearing opens record `MbtiSource` while that tab remains open.
+  mbti_view_modes : Map[@pathx.Relative, MbtiViewMode]
   // The directory whose immediate children are open in the breadcrumb's
   // VS Code-style picker. The legacy field and message names remain so this
   // presentation change does not grow the package's public API.
@@ -571,10 +584,19 @@ pub fn State::empty() -> State {
     loading: [],
     children: Map([]),
     docs: Map([]),
+    mbti_view_modes: Map([]),
     highlighted: None,
     index: IndexEmpty,
     error: None,
   }
+}
+
+///|
+/// An open MBTI tab defaults to its rendered diagram without storing a map
+/// entry. Explicit source/diagram selections then live only for that tab's
+/// lifetime.
+fn State::mbti_view_mode(self : State, path : @pathx.Relative) -> MbtiViewMode {
+  self.mbti_view_modes.get(path).unwrap_or(MbtiDiagram)
 }
 
 ///|
@@ -852,6 +874,9 @@ pub(all) enum Msg {
   // Mark the active changed-file review as reviewed, or return it to the
   // unreviewed queue. Ordinary file tabs ignore the action.
   ToggleReviewProgress
+  // Select the ordinary `.mbti` tab's rendered diagram or source. Reviews,
+  // history comparisons, and non-MBTI documents ignore the action.
+  MbtiViewModeSelected(MbtiViewMode)
   // One `git.original_file` request settled. `path` is always the current
   // changed path (the dock/document key), even when the host read its rename
   // source from `original_path`.
@@ -1076,6 +1101,9 @@ pub extend ReconciledPlacement with Eq::{equal, not_equal}
 
 ///|
 pub extend ReviewBaseline with Eq::{equal, not_equal}
+
+///|
+pub extend MbtiViewMode with Eq::{equal, not_equal}
 
 ///|
 pub extend ReviewDiffLayout with Eq::{equal, not_equal}

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -414,6 +414,18 @@ pub fn open_document(
     }
     _ => state
   }
+  // A position-bearing open (Search, go-to-definition, or an annotation
+  // jump) needs a visible text model so its range can be revealed. Plain file
+  // and tab opens retain this tab's explicit selection, with Diagram as the
+  // default for a newly opened `.mbti`.
+  let state = if uses_mbti_presentation(name) &&
+    (range is Some(_) || annotation is Some(_)) {
+    let mbti_view_modes = state.mbti_view_modes.copy()
+    mbti_view_modes[path] = MbtiSource
+    { ..state, mbti_view_modes, }
+  } else {
+    state
+  }
   let clear_review = if ctx.active_file == Some(path) {
     // Always clear the displayed resource, even when this path has no cached
     // `Doc`: a reviewed tab can be closed while another dock kind is active,
@@ -1082,6 +1094,9 @@ pub fn close_document(
 ) -> (@cmd.Cmd, State) {
   let docs = state.docs.copy()
   docs.remove(path)
+  let mbti_view_modes = state.mbti_view_modes.copy()
+  mbti_view_modes.remove(path)
+  let state = { ..state, mbti_view_modes, }
   // Closing a tab is useful local state even while placement is parked, but
   // promoting its neighbor must not address the missing checkout. Recovery's
   // sync pass restores whichever surviving tab the dock made active.
@@ -2248,6 +2263,27 @@ pub fn update(
       // cannot see a CSS change on its own.
       let opening = !state.tree_open
       (request_viewer_remeasure(), { ..state, tree_open: opening, })
+    }
+    MbtiViewModeSelected(mode) => {
+      guard ctx.active_history_diff is None &&
+        ctx.active_file is Some(path) &&
+        state.docs.get(path)
+        is Some({ name, state: TabLoaded(..), review: None, .. }) &&
+        uses_mbti_presentation(name) else {
+        return (@cmd.none, state)
+      }
+      if state.mbti_view_mode(path) == mode {
+        return (@cmd.none, state)
+      }
+      let mbti_view_modes = state.mbti_view_modes.copy()
+      mbti_view_modes[path] = mode
+      (
+        // A Viewer measured while hidden reports its minimum box. Switching
+        // back to Source must remeasure after the host becomes visible;
+        // Diagram is static SVG, so the same no-op-safe command is sufficient.
+        request_viewer_remeasure(),
+        { ..state, mbti_view_modes, },
+      )
     }
     DiffLoadingDue(owner~, path~, generation~) =>
       if state.owner == Some(owner) &&

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -297,8 +297,8 @@ pub fn resize_handle_view() -> @html.Html {
 /// viewer with its notice overlay, and the workspace tree (expandable and
 /// always rooted at the workspace root) as a toggleable pane on
 /// the viewer's right. Always rendered so the viewer's host element
-/// (`viewer-host`, `markdown-viewer-host`, `diff-editor-host`, and
-/// `semantic-review-host`) stay put
+/// (`viewer-host`, `markdown-viewer-host`, `mbti-diagram-host`,
+/// `diff-editor-host`, and `semantic-review-host`) stay put
 /// across renders and screen
 /// switches; CSS hides the inactive surface and the tree pane when toggled off,
 /// and collapses the whole panel to zero width when it is closed. The children's
@@ -339,6 +339,9 @@ pub fn body_view(
         )
       None => false
     })
+  let use_mbti_surface = !use_diff_surface &&
+    !use_markdown_surface &&
+    uses_mbti_diagram_surface(state, ctx)
   let use_semantic_surface = use_diff_surface &&
     state.review_diff_mode != ReviewDiffLine &&
     (match ctx.active_history_diff {
@@ -350,7 +353,7 @@ pub fn body_view(
     attrs=@html.Attrs::build()
       .id(ViewerHostId)
       .class(
-        if use_diff_surface || use_markdown_surface {
+        if use_diff_surface || use_markdown_surface || use_mbti_surface {
           "viewer-host editor-shell moonbit-viewer-surface-hidden"
         } else {
           "viewer-host editor-shell"
@@ -367,6 +370,19 @@ pub fn body_view(
           "viewer-host editor-shell"
         } else {
           "viewer-host editor-shell moonbit-viewer-surface-hidden"
+        },
+      )
+      .data_set("theme", if ctx.dark_mode { "dark" } else { "light" }),
+    ([] : Array[@html.Html]),
+  )
+  let mbti_diagram_host = @html.div(
+    attrs=@html.Attrs::build()
+      .id(MbtiDiagramHostId)
+      .class(
+        if use_mbti_surface {
+          "viewer-host editor-shell mbti-diagram-host"
+        } else {
+          "viewer-host editor-shell mbti-diagram-host moonbit-viewer-surface-hidden"
         },
       )
       .data_set("theme", if ctx.dark_mode { "dark" } else { "light" }),
@@ -409,6 +425,7 @@ pub fn body_view(
     @html.div(class="viewer-stack", [
       viewer_host,
       markdown_viewer_host,
+      mbti_diagram_host,
       diff_editor_host,
       semantic_review_host,
       viewer_notice(state, ctx),
@@ -1806,6 +1823,9 @@ pub fn breadcrumb_view(
     path_row.push(review_badge(dispatch, state, ctx))
     path_row.push(review_progress(dispatch, state, ctx))
   }
+  if mbti_view_available(state, ctx) {
+    path_row.push(mbti_view_toolbar(dispatch, state, ctx))
+  }
   path_row.push(
     @html.button(
       class="panel-toggle",
@@ -1847,6 +1867,68 @@ pub fn breadcrumb_view(
       path_row,
     )
   }
+}
+
+///|
+/// Only an ordinary, loaded generated interface owns the diagram/source
+/// presentation. Review and historical paths retain their code surfaces.
+fn mbti_view_available(state : State, ctx : Ctx) -> Bool {
+  guard ctx.active_history_diff is None && ctx.active_file is Some(path) else {
+    return false
+  }
+  state.docs.get(path) is Some({ name, state: TabLoaded(..), review: None, .. }) &&
+  uses_mbti_presentation(name)
+}
+
+///|
+fn uses_mbti_diagram_surface(state : State, ctx : Ctx) -> Bool {
+  guard mbti_view_available(state, ctx) && ctx.active_file is Some(path) else {
+    return false
+  }
+  state.mbti_view_mode(path) == MbtiDiagram
+}
+
+///|
+fn mbti_view_button(
+  dispatch : @cmd.Emit[Msg],
+  selected : MbtiViewMode,
+  mode : MbtiViewMode,
+  label : String,
+) -> @html.Html {
+  let active = selected == mode
+  @html.button(
+    type_="button",
+    class=if active {
+      "review-mode-button active"
+    } else {
+      "review-mode-button"
+    },
+    on_click=if active {
+      @cmd.none
+    } else {
+      dispatch(MbtiViewModeSelected(mode))
+    },
+    attrs=@html.Attrs::build().aria_pressed(active.to_string()),
+    label,
+  )
+}
+
+///|
+fn mbti_view_toolbar(
+  dispatch : @cmd.Emit[Msg],
+  state : State,
+  ctx : Ctx,
+) -> @html.Html {
+  guard ctx.active_file is Some(path) else { return @html.nothing }
+  let selected = state.mbti_view_mode(path)
+  @html.div(
+    class="review-mode-toolbar mbti-view-toolbar",
+    attrs=@html.Attrs::build().role("group").aria_label("MBTI view"),
+    [
+      mbti_view_button(dispatch, selected, MbtiDiagram, "Diagram"),
+      mbti_view_button(dispatch, selected, MbtiSource, "Source"),
+    ],
+  )
 }
 
 ///|

--- a/desktop/styles/file_panel.css
+++ b/desktop/styles/file_panel.css
@@ -160,6 +160,31 @@ button.panel-toggle:not(:disabled):hover {
 .viewer-stack > .viewer-host {
   flex: 1 1 auto;
 }
+.viewer-host.mbti-diagram-host {
+  box-sizing: border-box;
+  align-items: safe center;
+  justify-content: safe center;
+  padding: 24px;
+  overflow: auto;
+  color: var(--vscode-editor-foreground, var(--color-text-primary));
+  background: var(--vscode-editor-background, var(--color-bg-surface));
+  overscroll-behavior: contain;
+}
+.mbti-diagram-host:not(.moonbit-viewer-surface-hidden) {
+  display: flex;
+}
+.mbti-diagram-host > svg {
+  display: block;
+  flex: 0 0 auto;
+  margin: auto;
+}
+.mbti-diagram-error {
+  max-width: 420px;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-md);
+  line-height: var(--line-height-relaxed);
+  text-align: center;
+}
 .viewer-notice {
   position: absolute;
   inset: 0;

--- a/editor/internal/viewer/markdown/diagram_code_block.mbt
+++ b/editor/internal/viewer/markdown/diagram_code_block.mbt
@@ -74,7 +74,7 @@ fn viewer_uml_color_scheme() -> @uml_style.ColorScheme {
   let muted = "var(--vscode-descriptionForeground, #6e7781)"
   let surface = "var(--vscode-editorWidget-background, var(--vscode-editor-background, #ffffff))"
   let note_surface = "var(--vscode-editorHoverWidget-background, var(--vscode-editorWidget-background, #fff8c5))"
-  @uml_style.ColorScheme(
+  ColorScheme(
     foreground,
     foreground,
     canvas="none",

--- a/editor/internal/viewer/markdown/diagram_code_block.mbt
+++ b/editor/internal/viewer/markdown/diagram_code_block.mbt
@@ -48,11 +48,33 @@ fn render_diago_svg(source : String) -> String? {
 /// Uses CSS-backed paint values so one synchronous UML SVG follows the host's
 /// current foreground and surface colors without a theme-time rerender.
 pub fn render_uml_diagram_svg(source : String) -> String? {
+  let color_scheme = viewer_uml_color_scheme()
+  Some(@uml.render_svg(source, color_scheme~)) catch {
+    _ => None
+  }
+}
+
+///|
+/// Compile one generated MoonBit interface body directly to the UML
+/// renderer's MBTI diagram family. The source is the `.mbti` file itself, not
+/// a PlantUML wrapper; malformed interfaces stay on the caller's fallback
+/// path.
+pub fn render_mbti_diagram_svg(source : String) -> String? {
+  let color_scheme = viewer_uml_color_scheme()
+  Some(@uml.render_mbti_svg(source, color_scheme~)) catch {
+    _ => None
+  }
+}
+
+///|
+/// Keep every synchronous UML surface on the same CSS-backed palette. SVGs
+/// can then follow a host theme change without recompiling their source.
+fn viewer_uml_color_scheme() -> @uml_style.ColorScheme {
   let foreground = "var(--vscode-editor-foreground, #1f2328)"
   let muted = "var(--vscode-descriptionForeground, #6e7781)"
   let surface = "var(--vscode-editorWidget-background, var(--vscode-editor-background, #ffffff))"
   let note_surface = "var(--vscode-editorHoverWidget-background, var(--vscode-editorWidget-background, #fff8c5))"
-  let color_scheme = @uml_style.ColorScheme(
+  @uml_style.ColorScheme(
     foreground,
     foreground,
     canvas="none",
@@ -69,9 +91,6 @@ pub fn render_uml_diagram_svg(source : String) -> String? {
     page_break=muted,
     transparent="none",
   )
-  Some(@uml.render_svg(source, color_scheme~)) catch {
-    _ => None
-  }
 }
 
 ///|

--- a/editor/internal/viewer/markdown/pkg.generated.mbti
+++ b/editor/internal/viewer/markdown/pkg.generated.mbti
@@ -19,6 +19,8 @@ pub fn markdown_table_of_contents(MarkdownDocumentProjection) -> Array[MarkdownT
 
 pub fn render_markdown(String, language_id? : String, code_block_renderer? : (MarkdownCodeBlock, String?) -> String) -> MarkdownRenderFact
 
+pub fn render_mbti_diagram_svg(String) -> String?
+
 pub fn render_tokenized_code_block(MarkdownCodeBlock, String?) -> String
 
 pub fn render_uml_diagram_svg(String) -> String?

--- a/editor/moon.mod
+++ b/editor/moon.mod
@@ -25,7 +25,7 @@ import {
   "moonbit-community/rabbita@0.15.4",
   "Milky2018/diago@0.3.0",
   "moonbitlang/x@0.4.50",
-  "kokic/uml@0.1.10",
+  "kokic/uml@0.2.2",
 }
 
 options(

--- a/editor/viewer/markdown_diagrams.mbt
+++ b/editor/viewer/markdown_diagrams.mbt
@@ -7,3 +7,11 @@
 pub fn render_uml_diagram_svg(source : String) -> String? {
   @markdown_core.render_uml_diagram_svg(source)
 }
+
+///|
+/// Compile a generated `.mbti` interface body to a theme-aware SVG. Invalid
+/// or unsupported interface source returns `None` so hosts can keep a source
+/// fallback available.
+pub fn render_mbti_diagram_svg(source : String) -> String? {
+  @markdown_core.render_mbti_diagram_svg(source)
+}

--- a/editor/viewer/markdown_diagrams_test.mbt
+++ b/editor/viewer/markdown_diagrams_test.mbt
@@ -12,3 +12,27 @@ test "public Viewer UML renderer returns SVG only for valid diagrams" {
   assert_true(svg.contains("--vscode-editor-foreground"))
   assert_true(render_uml_diagram_svg("@startuml\n@enduml") is None)
 }
+
+///|
+test "public Viewer MBTI renderer accepts a bare generated interface" {
+  let source =
+    #|package "example/geometry"
+    #|
+    #|pub struct Point {
+    #|  x : Double
+    #|  y : Double
+    #|}
+    #|
+    #|pub trait Shape {
+    #|  area(Self) -> Double
+    #|}
+    #|
+    #|impl Shape for Point
+  guard render_mbti_diagram_svg(source) is Some(svg) else {
+    fail("expected MBTI SVG")
+  }
+  assert_true(svg.contains("<svg"))
+  assert_true(svg.contains("Point"))
+  assert_true(svg.contains("--vscode-editor-foreground"))
+  assert_true(render_mbti_diagram_svg("pub struct MissingPackage") is None)
+}

--- a/editor/viewer/pkg.generated.mbti
+++ b/editor/viewer/pkg.generated.mbti
@@ -23,6 +23,8 @@ import {
 // Values
 pub fn overlay_widget(String, @dom.Element) -> @browser.OverlayWidget
 
+pub fn render_mbti_diagram_svg(String) -> String?
+
 pub fn render_uml_diagram_svg(String) -> String?
 
 pub fn view_zone(Int, @dom.Element, after_column? : Int, after_column_affinity? : @model.PositionAffinity, show_in_hidden_areas? : Bool, ignore_hidden_area_source? : String, ordinal? : Int, suppress_mouse_down? : Bool, height_in_lines? : Double, height_in_px? : Double, min_width_in_px? : Double, margin_dom_node? : @dom.Element, on_dom_node_top? : (Double) -> Unit raise, on_dom_node_layout? : (Bool, Double) -> Unit raise, on_computed_height? : (Double) -> Unit raise) -> @browser.ViewZone


### PR DESCRIPTION
## Summary

- Upgrade `kokic/uml` to `0.2.2` and expose its MBTI SVG renderer through the editor viewer API with the existing theme-aware UML palette.
- Render ordinary `.mbti` files as UML diagrams by default, with a per-tab `Diagram` / `Source` toggle.
- Keep `.mbti` source visible in review, diff, history, and position-targeted navigation flows.
- Commit file presentation after render so fast file reads cannot race the stable viewer hosts, and add renderer, state, and browser E2E coverage.

## Testing

- `just check`
- `just test` (3,439 native tests, 3,176 JS tests, 28 cram tests)
- `just editor-test` (4,156 tests)
- `just editor-test-browser` (111 tests)
- `moon -C editor test viewer --target js` (3 tests)
- `moon -C desktop test frontend/fileeditor --target js` (147 tests)
- `OPENSEEK_DESKTOP_BROWSER_BASE_URL=http://127.0.0.1:5187 npm --prefix desktop/e2e test -- --grep "ordinary MBTI files render as UML"` (1 passed)
- `moon -C desktop run --target native package/macos -- --release --target app --no-open`
- `codesign --verify --deep --strict desktop/dist/SeekMoon.app`
- Manually verified the packaged app's MBTI Diagram/Source toggle and source-only review Line Diff/File View; no page errors or console warnings.
