### PR TITLE
workflow/viz: journal visualizer CLI (live watch, derived dataflow, outputs) + deep-research example

### DIFF
--- a/workflow/examples/deep-research.mbtx
+++ b/workflow/examples/deep-research.mbtx
@@ -1,0 +1,141 @@
+import {
+  "moonbitlang/async@0.21.1",
+  "bobzhang/workflow@0.1.2",
+  "bobzhang/workflow@0.1.2/spawn",
+}
+
+///|
+/// DEEP RESEARCH, watched live: three survey scouts fan out in
+/// parallel, a follow-up probe targets what the survey left open, and a
+/// synthesis agent — whose prompt embeds every prior answer — writes a
+/// design proposal. Each completion lands in the journal as it happens,
+/// so a concurrent `viz --watch` renders the run in real time, and the
+/// synthesis edges appear in the derived dataflow graph.
+///
+///   moon run workflow/viz -- deep-research.jsonl live.html --watch &
+///   moon run workflow/examples/deep-research.mbtx      (repo root)
+///
+/// Needs `openseek` on PATH and a provider key in the environment.
+async fn main {
+  research() catch {
+    error => println("workflow failed: \{error}")
+  }
+}
+
+///|
+let question : String = "How should the bobzhang/workflow library support human-in-the-loop waits (Golem-style promises: suspend until external input, at zero cost)?"
+
+///|
+async fn research() -> Unit {
+  let wf = @workflow.Workflow(
+    runner=@spawn.contract_runner(launch=call => {
+      // The step ceiling must ride ARGV: the envelope carries max_steps
+      // as data, but the engine child takes its enforced ceiling from
+      // the command line (a gap this example discovered the hard way —
+      // its first run's scouts sailed past their intended budgets).
+      let argv = ["subrun", call.kind]
+      if call.max_steps is Some(steps) {
+        argv.push("--max-steps")
+        argv.push("\{steps}")
+      }
+      { command: "openseek", args: argv, cwd: None, extra_env: None, deadline_ms: None }
+    }),
+    journal=@workflow.Journal::load("deep-research.jsonl"),
+    max_concurrent=3,
+    on_event=event => match event {
+      @workflow.PhaseStarted(title) => println("━━ phase: \{title}")
+      @workflow.AgentStarted(label~, ..) => println("  ▶ \{label}")
+      @workflow.AgentReplayed(label~, ..) => println("  ↺ \{label} (replayed)")
+      _ => ()
+    },
+  )
+
+  // ---- Phase 1: survey, in parallel ----
+  wf.phase("Survey")
+  let surveys = [
+    (
+      "journal",
+      "For \{question} — what would a PENDING wait look like as a journal entry? Study how outcomes/failures are recorded and replayed, and what a wait-entry must satisfy. Short paragraph + citations.",
+      "workflow/journal.mbt workflow/types.mbt",
+    ),
+    (
+      "events",
+      "For \{question} — how would a suspended wait surface in the event stream and the balanced start/finish brackets? Short paragraph + citations.",
+      "workflow/workflow.mbt",
+    ),
+    (
+      "contract",
+      "For \{question} — does the child contract need changes, or do waits live entirely above the Runner seam? Short paragraph + citations.",
+      "workflow/spawn/contract.mbt workflow/runner.mbt",
+    ),
+  ]
+  let found = @workflow.collect_ok(
+    @workflow.fan_out(surveys, survey => {
+      let (name, prompt, hints) = survey
+      wf.try_agent(prompt, kind="explore", hints~, label="survey:\{name}", max_steps=14)
+    }),
+    min_ok=2,
+  ) catch {
+    error => {
+      println("survey failed: \{error}")
+      return
+    }
+  }
+  let notes = found.map(report => clip(answer_of(report), 550))
+
+  // ---- Phase 2: probe the open question the survey exposes ----
+  wf.phase("Probe")
+  let probe = wf.try_agent(
+    "Given these findings on \{question} — \{notes.join(" ||| ")} — identify the SINGLE hardest unresolved design problem and investigate it in the code. Short paragraph + citations.",
+    kind="explore",
+    hints="workflow/",
+    label="probe:hardest",
+    max_steps=14,
+  )
+  let probe_note = match probe {
+    Ok(report) => clip(answer_of(report), 550)
+    Err(error) => {
+      println("  probe failed (\{error}) — synthesizing from the survey alone")
+      ""
+    }
+  }
+
+  // ---- Phase 3: synthesis embeds everything above ----
+  wf.phase("Synthesize")
+  match
+    wf.try_agent(
+      "Write a concrete design proposal for \{question} Base it ONLY on this research: \{notes.join(" ||| ")} ||| HARDEST: \{probe_note}. Give: the new API surface, the journal representation of a pending wait, and resume semantics. Be specific; cite files to change.",
+      kind="explore",
+      hints="workflow/",
+      label="synthesis",
+      max_steps=14,
+    ) {
+    Ok(report) => println("\n━━ PROPOSAL ━━\n\{answer_of(report)}")
+    Err(error) => println("synthesis failed: \{error}")
+  }
+  println(
+    "\n\{wf.calls_made()} live, \{wf.calls_replayed()} replayed, \{wf.tokens_spent()} fresh tokens",
+  )
+}
+
+///|
+fn answer_of(report : Json) -> String {
+  match report {
+    { "answer": String(text), .. } => text
+    other => other.stringify()
+  }
+}
+
+///|
+fn clip(text : String, limit : Int) -> String {
+  let out = StringBuilder()
+  let mut count = 0
+  for ch in text {
+    if count >= limit {
+      break
+    }
+    out.write_char(ch)
+    count += 1
+  }
+  out.to_string()
+}

--- a/workflow/examples/deep-research.mbtx
+++ b/workflow/examples/deep-research.mbtx
@@ -108,7 +108,7 @@ async fn research() -> Unit {
       kind="explore",
       hints="workflow/",
       label="synthesis",
-      max_steps=14,
+      max_steps=28,
     ) {
     Ok(report) => println("\n━━ PROPOSAL ━━\n\{answer_of(report)}")
     Err(error) => println("synthesis failed: \{error}")

--- a/workflow/moon.mod
+++ b/workflow/moon.mod
@@ -1,6 +1,6 @@
 name = "bobzhang/workflow"
 
-version = "0.1.1"
+version = "0.1.2"
 
 import {
   "moonbitlang/async@0.21.1",

--- a/workflow/viz/main.mbt
+++ b/workflow/viz/main.mbt
@@ -1,0 +1,301 @@
+///|
+/// Journal → HTML: render any workflow journal as a self-contained
+/// report — the attempt ledger (status, steps, token costs) plus a
+/// DERIVED dataflow graph: an edge exists where one agent's recorded
+/// output appears verbatim inside a later agent's input. Dynamic
+/// workflows declare no graph, so none is stored; content recovers it.
+///
+///   moon run workflow/viz -- <journal.jsonl> [out.html] [--watch]
+///   moonx bobzhang/workflow/viz <journal.jsonl> [out.html] [--watch]
+///
+/// `--watch` re-renders every 2 seconds and the page auto-refreshes —
+/// a live view of a RUNNING workflow's completions.
+async fn main {
+  run() catch {
+    error => println("viz failed: \{error}")
+  }
+}
+
+///|
+async fn run() -> Unit {
+  let args = @env.args()
+  let positional : Array[String] = []
+  let mut watch = false
+  for index, arg in args {
+    if index == 0 {
+      continue
+    }
+    if arg == "--watch" {
+      watch = true
+    } else {
+      positional.push(arg)
+    }
+  }
+  guard positional.length() >= 1 else {
+    println("usage: viz <journal.jsonl> [out.html] [--watch]")
+    return
+  }
+  let path = positional[0]
+  let out = if positional.length() >= 2 {
+    positional[1]
+  } else {
+    "\{path}.html"
+  }
+  for ;; {
+    render(path, out, watch) catch {
+      error =>
+        if watch {
+          println("(\{error} — retrying)")
+        } else {
+          raise error
+        }
+    }
+    guard watch else { break }
+    @async.sleep(2_000)
+  }
+}
+
+///|
+/// READ-ONLY journal parse. Deliberately not `Journal::load`: load
+/// REPAIRS torn tails on disk, and a watcher must never rewrite a file
+/// a running workflow is appending to. Unparsable lines (the live
+/// writer's torn tail) are simply skipped for this tick.
+async fn read_entries(path : String) -> Array[@workflow.JournalEntry] {
+  let entries : Array[@workflow.JournalEntry] = []
+  guard @fs.exists(path) else { return entries }
+  let text = @fs.read_file(path).text() catch { _ => return entries }
+  for line in text.split("\n") {
+    let line = line.trim()
+    if line.is_empty() {
+      continue
+    }
+    let parsed : @workflow.JournalEntry? = try {
+      match @json.parse(line.to_owned()) {
+        { "v": Number(1, ..), "e": entry, .. } => Some(@json.from_json(entry))
+        _ => None
+      }
+    } catch {
+      _ => None
+    }
+    if parsed is Some(entry) {
+      entries.push(entry)
+    }
+  }
+  entries
+}
+
+///|
+async fn render(path : String, out : String, watch : Bool) -> Unit {
+  let entries = read_entries(path)
+  guard entries.length() > 0 else {
+    println("journal \{path} holds no entries yet")
+    return
+  }
+
+  // Derive dataflow: output-of(i) embedded in input-of(j), i < j. The
+  // probe is JSON-escaped through the encoder itself, so it matches how
+  // the text actually appears inside a stringified input.
+  let values : Array[String] = entries.map(entry => answer_of(entry.outcome))
+  let inputs : Array[String] = entries.map(entry => entry.call.input.stringify())
+  let edges : Array[(Int, Int)] = []
+  for j, input in inputs {
+    for i in 0..<j {
+      let value = values[i]
+      if value.length() > 60 {
+        let quoted = Json::string(clip(value, 50)).stringify()
+        let probe = quoted[1:quoted.length() - 1]
+        if input.contains(probe.to_owned()) {
+          edges.push((i, j))
+        }
+      }
+    }
+  }
+
+  // ---- the ledger rows and graph geometry ----
+  let mut max_tokens = 1
+  for entry in entries {
+    max_tokens = max_tokens.max(tokens_of(entry.outcome))
+  }
+  let rows = StringBuilder()
+  for index, entry in entries {
+    let finished = entry.outcome is Finished(..)
+    let pill = if finished {
+      "<span class=\"pill ok\">Finished</span>"
+    } else {
+      "<span class=\"pill bad\">DidNotFinish</span>"
+    }
+    let tokens = tokens_of(entry.outcome)
+    let width = 100 * tokens / max_tokens
+    let detail = escape(
+      match entry.outcome {
+        Finished(value~, ..) => clip(answer_of_value(value), 180)
+        DidNotFinish(failure~, ..) => "\{failure}"
+      },
+    )
+    rows.write_string(
+      "<tr title=\"\{detail}\"><td class=\"num\">\{index + 1}</td><td class=\"lbl\">\{escape(entry.call.label)}</td><td>\{pill}</td><td class=\"num\">\{steps_of(entry.outcome)}</td><td class=\"barcell\"><div class=\"bar\"><div class=\"track\"><div class=\"fill\" style=\"width:\{width.max(if tokens > 0 { 2 } else { 0 })}%\"></div></div><span class=\"val\">\{tokens}</span></div></td></tr>",
+    )
+  }
+  let graph = StringBuilder()
+  let row_h = 40
+  let height = entries.length() * row_h + 16
+  graph.write_string(
+    "<svg viewBox=\"0 0 460 \{height}\" role=\"img\" aria-label=\"Derived dataflow: an edge means a later agent's input embeds an earlier agent's output\"><defs><marker id=\"af\" viewBox=\"0 0 8 8\" refX=\"7\" refY=\"4\" markerWidth=\"6.5\" markerHeight=\"6.5\" orient=\"auto\"><path d=\"M0,0 L8,4 L0,8 z\" fill=\"var(--accent)\"/></marker></defs>",
+  )
+  for edge in edges {
+    let (a, b) = edge
+    let y1 = 22 + a * row_h
+    let y2 = 22 + b * row_h
+    let spread = 40 + (b - a) * 26
+    graph.write_string(
+      "<path d=\"M 212 \{y1} C \{212 + spread} \{y1}, \{212 + spread} \{y2}, 218 \{y2}\" fill=\"none\" stroke=\"var(--accent)\" stroke-width=\"1.4\" opacity=\"0.75\" marker-end=\"url(#af)\"/>",
+    )
+  }
+  for index, entry in entries {
+    let y = 22 + index * row_h
+    let color = if entry.outcome is Finished(..) {
+      "var(--replay)"
+    } else {
+      "var(--fail)"
+    }
+    graph.write_string(
+      "<circle cx=\"200\" cy=\"\{y}\" r=\"7\" fill=\"\{color}\" fill-opacity=\"0.18\" stroke=\"\{color}\" stroke-width=\"1.6\"/><text x=\"188\" y=\"\{y + 4}\" text-anchor=\"end\" font-size=\"12\" font-family=\"ui-monospace,Menlo,monospace\" fill=\"var(--ink)\">\{escape(entry.call.label)}</text>",
+    )
+  }
+  graph.write_string("</svg>")
+  let refresh = if watch {
+    "<meta http-equiv=\"refresh\" content=\"2\">"
+  } else {
+    ""
+  }
+  let outputs = StringBuilder()
+  for index, entry in entries {
+    let finished = entry.outcome is Finished(..)
+    let body = escape(
+      match entry.outcome {
+        Finished(value~, ..) => answer_of_value(value)
+        DidNotFinish(failure~, ..) => "\{failure}"
+      },
+    )
+    let mark = if finished { "ok" } else { "bad" }
+    outputs.write_string(
+      "<details\{if index == entries.length() - 1 { " open" } else { "" }}><summary><span class=\"num\">\{index + 1}</span> <span class=\"lbl\">\{escape(entry.call.label)}</span> <span class=\"pill \{mark}\">\{if finished { "Finished" } else { "DidNotFinish" }}</span></summary><div class=\"out\">\{body}</div></details>",
+    )
+  }
+  let page = "<!doctype html><meta charset=\"utf-8\">" +
+    refresh +
+    "<title>journal: \{escape(path)}</title>" +
+    style +
+    "<div class=\"wrap\"><h1>\{escape(path)}</h1><p class=\"dek\">\{entries.length()} recorded attempt(s) · \{edges.length()} dataflow edge(s) derived from content. A journal records LIVE outcomes only — repeated labels are re-attempts or cascade generations; replays are served, never re-appended.</p><div class=\"grid\"><div class=\"panel\"><h2>Ledger</h2><div style=\"overflow-x:auto\"><table><tr><th>#</th><th>agent</th><th>outcome</th><th style=\"text-align:right\">steps</th><th>tokens</th></tr>" +
+    rows.to_string() +
+    "</table></div></div><div class=\"panel\"><h2>Derived dataflow</h2><div style=\"overflow-x:auto\">" +
+    graph.to_string() +
+    "</div></div></div><div class=\"panel\" style=\"margin-top:1.3rem\"><h2>Outputs</h2>" +
+    outputs.to_string() +
+    "</div></div>"
+  @fs.write_file(out, page)
+  println(
+    "wrote \{out}: \{entries.length()} entries, \{edges.length()} derived edge(s)",
+  )
+}
+
+///|
+fn tokens_of(outcome : @workflow.AgentOutcome) -> Int {
+  let attempt = match outcome {
+    Finished(attempt~, ..) => Some(attempt)
+    DidNotFinish(attempt~, ..) => attempt
+  }
+  match attempt {
+    Some(attempt) => attempt.prompt_tokens + attempt.completion_tokens
+    None => 0
+  }
+}
+
+///|
+fn steps_of(outcome : @workflow.AgentOutcome) -> Int {
+  match outcome {
+    Finished(attempt~, ..) => attempt.steps_used
+    DidNotFinish(attempt=Some(attempt), ..) => attempt.steps_used
+    DidNotFinish(attempt=None, ..) => 0
+  }
+}
+
+///|
+fn answer_of(outcome : @workflow.AgentOutcome) -> String {
+  match outcome {
+    Finished(value~, ..) => answer_of_value(value)
+    DidNotFinish(..) => ""
+  }
+}
+
+///|
+fn answer_of_value(value : Json) -> String {
+  match value {
+    { "answer": String(text), .. } => text
+    other => other.stringify()
+  }
+}
+
+///|
+fn clip(text : String, limit : Int) -> String {
+  let out = StringBuilder()
+  let mut count = 0
+  for ch in text {
+    if count >= limit {
+      break
+    }
+    out.write_char(ch)
+    count += 1
+  }
+  out.to_string()
+}
+
+///|
+fn escape(text : String) -> String {
+  let out = StringBuilder()
+  for ch in text {
+    match ch {
+      '&' => out.write_string("&amp;")
+      '<' => out.write_string("&lt;")
+      '>' => out.write_string("&gt;")
+      '"' => out.write_string("&quot;")
+      _ => out.write_char(ch)
+    }
+  }
+  out.to_string()
+}
+
+///|
+let style : String =
+  #|<style>
+  #|:root{--paper:#FAFAF7;--ink:#23272E;--soft:#5A6069;--line:#DDDCD4;--card:#F1F0EA;--replay:#1C8A5B;--spend:#A96F24;--fail:#B04A3E;--accent:#2F5FA8}
+  #|@media (prefers-color-scheme: dark){:root{--paper:#14161A;--ink:#D8DCE2;--soft:#99A1AC;--line:#2C3038;--card:#1B1E24;--replay:#3FBF8A;--spend:#D9A05B;--fail:#D97D6F;--accent:#7CA5DE}}
+  #|body{margin:0;color:var(--ink);background:var(--paper);font:15px/1.55 "Avenir Next",Seravek,"Segoe UI",system-ui,sans-serif}
+  #|.wrap{max-width:62rem;margin:0 auto;padding:2.2rem 1.25rem 3rem}
+  #|h1{font-size:1.3rem;font-weight:700;margin:0 0 .3rem;font-family:ui-monospace,Menlo,monospace}
+  #|.dek{color:var(--soft);margin:0 0 1.3rem;max-width:75ch}
+  #|.grid{display:grid;grid-template-columns:minmax(0,1fr);gap:1.3rem}
+  #|@media(min-width:880px){.grid{grid-template-columns:minmax(0,3fr) minmax(0,2fr)}}
+  #|.panel{border:1px solid var(--line);border-radius:10px;background:var(--card);padding:1rem 1.1rem;min-width:0}
+  #|.panel h2{font-size:.78rem;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--soft);margin:0 0 .8rem}
+  #|table{border-collapse:collapse;width:100%;font-size:13px}
+  #|th{text-align:left;color:var(--soft);font-weight:600;padding:4px 10px 6px 0;border-bottom:1px solid var(--line)}
+  #|td{padding:7px 10px 7px 0;border-bottom:1px solid var(--line);vertical-align:middle}
+  #|tr:last-child td{border-bottom:none}
+  #|.num{font-variant-numeric:tabular-nums;text-align:right;padding-right:0;color:var(--soft)}
+  #|.lbl{font-family:ui-monospace,Menlo,monospace;font-size:12px;white-space:nowrap}
+  #|.pill{display:inline-block;font-weight:600;font-size:10.5px;letter-spacing:.04em;padding:3px 8px;border-radius:999px;border:1px solid;white-space:nowrap}
+  #|.pill.ok{color:var(--replay);border-color:var(--replay)}
+  #|.pill.bad{color:var(--fail);border-color:var(--fail)}
+  #|.barcell{width:34%;min-width:120px}
+  #|.bar{display:flex;align-items:center;gap:8px}
+  #|.bar .track{flex:1;height:10px;position:relative}
+  #|.bar .fill{position:absolute;inset:0 auto 0 0;border-radius:0 4px 4px 0;background:var(--spend);min-width:2px}
+  #|.bar .val{font-variant-numeric:tabular-nums;font-size:12px;color:var(--soft);white-space:nowrap}
+  #|svg{max-width:100%;height:auto;display:block}
+  #|details{border-bottom:1px solid var(--line);padding:6px 0}
+  #|details:last-child{border-bottom:none}
+  #|summary{cursor:pointer;display:flex;gap:10px;align-items:center}
+  #|summary::marker{color:var(--soft)}
+  #|.out{white-space:pre-wrap;font-size:13.5px;line-height:1.6;color:var(--ink);padding:10px 4px 8px 22px;max-width:75ch}
+  #|</style>

--- a/workflow/viz/moon.pkg
+++ b/workflow/viz/moon.pkg
@@ -1,0 +1,11 @@
+import {
+  "bobzhang/workflow",
+  "moonbitlang/async",
+  "moonbitlang/async/fs",
+  "moonbitlang/core/env",
+  "moonbitlang/core/json",
+}
+
+supported_targets = "native+wasm"
+
+pkgtype(kind: "executable")

--- a/workflow/viz/pkg.generated.mbti
+++ b/workflow/viz/pkg.generated.mbti
@@ -1,0 +1,12 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/workflow/viz"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits


### PR DESCRIPTION
Answers "can we visualize a dynamic workflow — including in real time?" with a shipped component and a live-verified example.

**`workflow/viz`** — a moonx-invokable CLI (`moonx --target native bobzhang/workflow/viz@latest journal.jsonl`, verified cold against the published 0.1.2):
- **Ledger**: every recorded attempt with status, steps, and token-cost bars.
- **Derived dataflow**: dynamic workflows declare no DAG, so none is stored — an edge is recovered wherever one agent's recorded output appears verbatim inside a later agent's input (the probe is escaped through the JSON encoder so it matches stringified inputs). On real journals this recovers the debate's advocates→judge fan-in and cascade, the hunt loop's triangular seed structure, fixit's scout→worker handoff, and correctly draws zero edges for a pure parallel map.
- **Outputs**: every agent's complete answer, expandable per agent.
- **`--watch`**: re-renders every 2s with page auto-refresh — a live view of a running workflow, verified by watching a run's ledger grow generation by generation. A safety property worth calling out: watch mode deliberately avoids `Journal::load`, whose torn-tail *repair* would rewrite a file the running workflow is mid-append on; viz uses its own read-only parser and skips the writer's torn tail for a tick.

**`workflow/examples/deep-research.mbtx`** — the showcase for both: three survey scouts in parallel, a probe whose prompt embeds their findings, a synthesis embedding everything — a research funnel whose edges appear in the visualizer as the run progresses. Its first live run (watched in real time in a browser) also exposed a genuine integration gap, now documented in the example: the request envelope *carries* `max_steps`, but the engine child *enforces* its ceiling from argv — so the launch seam must place the limit on the command line, and the engine honoring the envelope's value is follow-up work.

Also records the published 0.1.2 version in `moon.mod` (the #1208 squash predated the viz pushes; this PR restores that package as one coherent unit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013t7W9RHYTLx5vcNyftZxeY