### PR TITLE
feat(desktop): add hunk-level review progress

### DIFF
--- a/desktop/e2e/tests/rabbita_dom.spec.js
+++ b/desktop/e2e/tests/rabbita_dom.spec.js
@@ -2255,11 +2255,21 @@ for (const layout of ['Split', 'Unified']) {
       const [button, line] = await Promise.all([action.boundingBox(), deleted.boundingBox()]);
       return Math.abs(button.y - line.y);
     }).toBeLessThan(3);
+    // The marker has its own gutter, before even the original line numbers.
+    // Check actual rendered boxes: moving an overlay left would fail this.
+    await expect.poll(() => action.evaluate(button => {
+      const panes = button.closest('.moonbit-diff-editor').querySelector('.moonbit-diff-editor-panes');
+      return button.getBoundingClientRect().right <= panes.getBoundingClientRect().left;
+    })).toBe(true);
     await action.click();
+    await expect(action).toHaveText('✓');
+    const panelBox = await page.locator('.editor').boundingBox();
+    const clip = { ...panelBox, height: Math.min(panelBox.height, 320) };
+    await page.screenshot({ path: `/tmp/hunk-gutter-${layout.toLowerCase()}-viewed.png`, clip });
     await expect(page.getByRole('button', { name: 'Mark file unreviewed', exact: true })).toHaveAttribute('aria-pressed', 'true');
     await action.click();
     await expect(page.getByRole('button', { name: 'Mark file reviewed', exact: true })).toHaveAttribute('aria-pressed', 'false');
-    await page.screenshot({ path: `/tmp/hunk-ux-${layout.toLowerCase()}.png` });
+    await page.screenshot({ path: `/tmp/hunk-gutter-${layout.toLowerCase()}.png`, clip });
     expect(app.pageErrors).toEqual([]);
   });
 }

--- a/desktop/e2e/tests/rabbita_dom.spec.js
+++ b/desktop/e2e/tests/rabbita_dom.spec.js
@@ -2194,3 +2194,72 @@ test('pending job waits show descriptions from earlier tool rows', async ({ page
   await expect(wait.first()).toContainText('"job_ids"');
   expect(app.pageErrors).toEqual([]);
 });
+
+for (const mode of ['Line', 'Token', 'Tree']) {
+  test(`${mode} hunk actions and navigation follow manual scrolling`, async ({ page }) => {
+    const app = new DesktopBrowserHarness(page);
+    const block = (name) => [`fn ${name} {`, ...Array.from({ length: 70 }, (_, i) => `  println("${name} ${i}")`), '}', ''];
+    const baseline = [...block('first'), ...block('second')].join('\n');
+    app.gitFilesByRevision[app.gitBaseline]['src/main.mbt'] = baseline;
+    app.workingFiles['src/main.mbt'] = baseline.replace('first 5', 'first changed').replace('second 60', 'second changed');
+    await app.install();
+    await app.goto();
+    await app.openSession();
+    await app.openReview();
+    await page.locator('#review-changes-body').getByRole('button', { name: /View diff: src\/main\.mbt/ }).click();
+    const toolbar = page.getByRole('toolbar', { name: 'Review mode' });
+    await toolbar.getByRole('button', { name: `${mode} diff` }).click();
+    const position = page.locator('.review-hunk-position');
+    await expect(position).toHaveText('1 of 2');
+    // Wheel input must update the counter without moving the cursor or marking
+    // coverage. The last hunk's action must then affect exactly that hunk.
+    const visibleEditor = page.locator('.moonbit-diff-editor:visible').last();
+    await visibleEditor.hover();
+    await page.mouse.wheel(0, 10000);
+    await expect(position).toHaveText('2 of 2');
+    await expect(page.getByRole('button', { name: 'Mark hunk viewed', exact: true })).toHaveAttribute('aria-pressed', 'false');
+    const localAction = page.locator('.moonbit-diff-hunk-action:visible button').last();
+    await localAction.click();
+    await expect(localAction).toBeFocused();
+    await expect(page.getByRole('button', { name: 'Unmark hunk viewed', exact: true })).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.getByRole('button', { name: 'Mark file reviewed', exact: true })).toHaveAttribute('aria-pressed', 'mixed');
+    await page.mouse.wheel(0, -10000);
+    await expect(position).toHaveText('1 of 2');
+    await expect(page.getByRole('button', { name: 'Mark hunk viewed', exact: true })).toHaveAttribute('aria-pressed', 'false');
+    await page.getByRole('button', { name: 'Next change', exact: true }).click();
+    await expect(position).toHaveText('2 of 2');
+    await expect(page.getByRole('button', { name: 'Unmark hunk viewed', exact: true })).toHaveAttribute('aria-pressed', 'true');
+    await page.locator('.moonbit-diff-hunk-action:visible button').last().click();
+    await expect(page.getByRole('button', { name: 'Mark file reviewed', exact: true })).toHaveAttribute('aria-pressed', 'false');
+    expect(app.pageErrors).toEqual([]);
+  });
+}
+
+for (const layout of ['Split', 'Unified']) {
+  test(`${layout} pure deletion has a local hunk action at its deleted line`, async ({ page }) => {
+    const app = new DesktopBrowserHarness(page);
+    const before = ['fn main {', '  println("keep")', '  println("delete me")', '  println("keep too")', '}', ''].join('\n');
+    app.gitFilesByRevision[app.gitBaseline]['src/main.mbt'] = before;
+    app.workingFiles['src/main.mbt'] = before.replace('  println("delete me")\n', '');
+    await app.install();
+    await app.goto();
+    await app.openSession();
+    await app.openReview();
+    await page.locator('#review-changes-body').getByRole('button', { name: /View diff: src\/main\.mbt/ }).click();
+    await page.getByRole('button', { name: `${layout} diff layout`, exact: true }).click();
+    const action = page.locator('.moonbit-diff-hunk-action:visible button');
+    await expect(action).toBeVisible();
+    const deleted = page.locator(layout === 'Split' ? '.moonbit-diff-editor-original .view-line' : '.diff-editor-inline-deleted-line').filter({ hasText: 'delete me' });
+    await expect(deleted).toHaveCount(1);
+    await expect.poll(async () => {
+      const [button, line] = await Promise.all([action.boundingBox(), deleted.boundingBox()]);
+      return Math.abs(button.y - line.y);
+    }).toBeLessThan(3);
+    await action.click();
+    await expect(page.getByRole('button', { name: 'Mark file unreviewed', exact: true })).toHaveAttribute('aria-pressed', 'true');
+    await action.click();
+    await expect(page.getByRole('button', { name: 'Mark file reviewed', exact: true })).toHaveAttribute('aria-pressed', 'false');
+    await page.screenshot({ path: `/tmp/hunk-ux-${layout.toLowerCase()}.png` });
+    expect(app.pageErrors).toEqual([]);
+  });
+}

--- a/desktop/e2e/tests/rabbita_dom.spec.js
+++ b/desktop/e2e/tests/rabbita_dom.spec.js
@@ -206,7 +206,8 @@ test('Review loads changed files and preserves its interactive diff workflow', a
 
   const progress = page.getByRole('button', { name: 'Mark file reviewed' });
   await progress.click();
-  await expect(progress).toHaveAttribute('aria-pressed', 'true');
+  await expect(page.getByRole('button', { name: 'Mark file unreviewed' }))
+    .toHaveAttribute('aria-pressed', 'true');
   await expect(changes.locator('.review-progress-summary')).toHaveText(
     '1 of 2 reviewable files reviewed',
   );
@@ -218,6 +219,104 @@ test('Review loads changed files and preserves its interactive diff workflow', a
     request.params?.path === 'src/lib.mbt' &&
     request.params?.revision === app.gitBaseline))
     .toBeTruthy();
+  expect(app.pageErrors).toEqual([]);
+});
+
+test('Review links hunk and file progress and reports the active hunk', async ({ page }) => {
+  const app = new DesktopBrowserHarness(page);
+  app.gitFilesByRevision[app.gitBaseline]['src/main.mbt'] = [
+    'fn main {',
+    '  println("baseline")',
+    '}',
+    '',
+    'fn spacer_one {',
+    '  println("same one")',
+    '}',
+    '',
+    'fn spacer_two {',
+    '  println("same two")',
+    '}',
+    '',
+    'fn tail {',
+    '  println("baseline tail")',
+    '}',
+    '',
+  ].join('\n');
+  app.workingFiles['src/main.mbt'] = [
+    'fn main {',
+    '  println("working tree")',
+    '}',
+    '',
+    'fn spacer_one {',
+    '  println("same one")',
+    '}',
+    '',
+    'fn spacer_two {',
+    '  println("same two")',
+    '}',
+    '',
+    'fn tail {',
+    '  println("working tail")',
+    '}',
+    '',
+  ].join('\n');
+
+  await app.install();
+  await app.goto();
+  await app.openSession();
+  await app.openReview();
+  const changes = page.locator('#review-changes-body');
+  await changes.getByRole('button', { name: /View diff: src\/main\.mbt/ }).click();
+
+  const navigation = page.getByRole('group', { name: 'Diff change navigation' });
+  const position = navigation.locator('.review-hunk-position');
+  await expect(position).toHaveText('1 of 2');
+  await expect(page.getByRole('button', { name: 'Mark hunk viewed' }))
+    .toHaveAttribute('aria-pressed', 'false');
+
+  await page.getByRole('button', { name: 'Mark hunk viewed' }).click();
+  await expect(page.getByRole('button', { name: 'Mark file reviewed' }))
+    .toHaveAttribute('aria-pressed', 'mixed');
+  await navigation.getByRole('button', { name: 'Next change' }).click();
+  await expect(position).toHaveText('2 of 2');
+  await page.getByRole('button', { name: 'Mark hunk viewed' }).click();
+  await expect(page.getByRole('button', { name: 'Mark file unreviewed' }))
+    .toHaveAttribute('aria-pressed', 'true');
+  await expect(changes.locator('.review-progress-summary')).toHaveText(
+    '1 of 2 reviewable files reviewed',
+  );
+
+  // Clearing the file clears every hunk; marking it again projects Viewed back
+  // onto every hunk without depending on the currently selected group.
+  await page.getByRole('button', { name: 'Mark file unreviewed' }).click();
+  await expect(page.getByRole('button', { name: 'Mark hunk viewed' }))
+    .toHaveAttribute('aria-pressed', 'false');
+  await navigation.getByRole('button', { name: 'Previous change' }).click();
+  await expect(position).toHaveText('1 of 2');
+  await expect(page.getByRole('button', { name: 'Mark hunk viewed' }))
+    .toHaveAttribute('aria-pressed', 'false');
+  await page.getByRole('button', { name: 'Mark file reviewed' }).click();
+  await expect(page.getByRole('button', { name: 'Unmark hunk viewed' }))
+    .toHaveAttribute('aria-pressed', 'true');
+  await navigation.getByRole('button', { name: 'Next change' }).click();
+  await expect(position).toHaveText('2 of 2');
+  await expect(page.getByRole('button', { name: 'Unmark hunk viewed' }))
+    .toHaveAttribute('aria-pressed', 'true');
+
+  // Semantic review is a MultiDiff surface. Its counter is global across the
+  // section-local editors, while file completion still projects into each
+  // section's current hunk.
+  const reviewToolbar = page.getByRole('toolbar', { name: 'Review mode' });
+  await reviewToolbar.getByRole('button', { name: 'Token diff' }).click();
+  await expect(reviewToolbar.getByRole('button', { name: 'Token diff' }))
+    .toHaveAttribute('aria-pressed', 'true');
+  await expect(position).toHaveText('1 of 2');
+  await expect(page.getByRole('button', { name: 'Unmark hunk viewed' }))
+    .toHaveAttribute('aria-pressed', 'true');
+  await navigation.getByRole('button', { name: 'Next change' }).click();
+  await expect(position).toHaveText('2 of 2');
+  await expect(page.getByRole('button', { name: 'Unmark hunk viewed' }))
+    .toHaveAttribute('aria-pressed', 'true');
   expect(app.pageErrors).toEqual([]);
 });
 

--- a/desktop/e2e/tests/rabbita_dom.spec.js
+++ b/desktop/e2e/tests/rabbita_dom.spec.js
@@ -2235,6 +2235,46 @@ for (const mode of ['Line', 'Token', 'Tree']) {
   });
 }
 
+for (const mode of ['Token', 'Tree']) {
+  test(`${mode} navigation enters the boundary after every section is collapsed`, async ({ page }) => {
+    const app = new DesktopBrowserHarness(page);
+    const baseline = ['fn first() -> Int { 1 }', '', 'fn second() -> Int { 2 }', ''].join('\n');
+    app.gitFilesByRevision[app.gitBaseline]['src/main.mbt'] = baseline;
+    app.workingFiles['src/main.mbt'] = baseline.replace('{ 1 }', '{ 10 }').replace('{ 2 }', '{ 20 }');
+    await app.install();
+    await app.goto();
+    await app.openSession();
+    await app.openReview();
+    await page.locator('#review-changes-body').getByRole('button', { name: /View diff: src\/main\.mbt/ }).click();
+    await page.getByRole('toolbar', { name: 'Review mode' }).getByRole('button', { name: `${mode} diff` }).click();
+    const sections = page.locator('.semantic-diff-entry');
+    const headers = sections.locator('.semantic-entry-header-content');
+    await expect(sections).toHaveCount(2);
+    for (const header of await headers.all()) {
+      await header.click();
+      await expect(header).toHaveAttribute('aria-expanded', 'false');
+    }
+    const position = page.locator('.review-hunk-position');
+    for (const next of ['button', 'F7']) {
+      if (next === 'button') {
+        await page.getByRole('button', { name: 'Next change', exact: true }).click();
+      } else {
+        await page.keyboard.press('F7');
+      }
+      await expect(headers.nth(0)).toHaveAttribute('aria-expanded', 'true');
+      await expect(headers.nth(1)).toHaveAttribute('aria-expanded', 'false');
+      await expect(position).toHaveText('1 of 2');
+      await headers.nth(0).click();
+      await expect(headers.nth(0)).toHaveAttribute('aria-expanded', 'false');
+    }
+    await page.keyboard.press('Shift+F7');
+    await expect(headers.nth(0)).toHaveAttribute('aria-expanded', 'false');
+    await expect(headers.nth(1)).toHaveAttribute('aria-expanded', 'true');
+    await expect(position).toHaveText('2 of 2');
+    expect(app.pageErrors).toEqual([]);
+  });
+}
+
 for (const layout of ['Split', 'Unified']) {
   test(`${layout} pure deletion has a local hunk action at its deleted line`, async ({ page }) => {
     const app = new DesktopBrowserHarness(page);
@@ -2250,11 +2290,15 @@ for (const layout of ['Split', 'Unified']) {
     const action = page.locator('.moonbit-diff-hunk-action:visible button');
     await expect(action).toBeVisible();
     const deleted = page.locator(layout === 'Split' ? '.moonbit-diff-editor-original .view-line' : '.diff-editor-inline-deleted-line').filter({ hasText: 'delete me' });
-    await expect(deleted).toHaveCount(1);
-    await expect.poll(async () => {
+    // Layout switching can leave the original pane mounted but hidden for a
+    // frame. Retry the complete geometry assertion until both boxes exist.
+    await expect(deleted).toBeVisible();
+    await expect(async () => {
       const [button, line] = await Promise.all([action.boundingBox(), deleted.boundingBox()]);
-      return Math.abs(button.y - line.y);
-    }).toBeLessThan(3);
+      expect(button).not.toBeNull();
+      expect(line).not.toBeNull();
+      expect(Math.abs(button.y - line.y)).toBeLessThan(3);
+    }).toPass({ timeout: 5_000 });
     // The marker has its own gutter, before even the original line numbers.
     // Check actual rendered boxes: moving an overlay left would fail this.
     await expect.poll(() => action.evaluate(button => {

--- a/desktop/e2e/tests/rabbita_dom.spec.js
+++ b/desktop/e2e/tests/rabbita_dom.spec.js
@@ -320,6 +320,36 @@ test('Review links hunk and file progress and reports the active hunk', async ({
   expect(app.pageErrors).toEqual([]);
 });
 
+for (const mode of ['Token', 'Tree']) {
+  test(`${mode} review links file progress after opening another file`, async ({ page }) => {
+    const app = new DesktopBrowserHarness(page);
+    await app.install();
+    await app.goto();
+    await app.openSession();
+    await app.openReview();
+    const changes = page.locator('#review-changes-body');
+    await changes.getByRole('button', { name: /View diff: src\/main\.mbt/ }).click();
+    const modeButton = page.getByRole('button', { name: `${mode} diff`, exact: true });
+    await modeButton.click();
+    await changes.getByRole('button', { name: /View diff: src\/lib\.mbt/ }).click();
+    await expect(modeButton).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.locator('.review-hunk-position')).toHaveText('1 of 1');
+
+    await page.getByRole('button', { name: 'Mark hunk viewed', exact: true }).click();
+    await expect(page.getByRole('button', { name: 'Mark file unreviewed' }))
+      .toHaveAttribute('aria-pressed', 'true');
+
+    await page.getByRole('button', { name: 'Mark file unreviewed' }).click();
+    await page.getByRole('button', { name: 'Mark file reviewed', exact: true }).click();
+    const unmarkHunk = page.getByRole('button', { name: 'Unmark hunk viewed' });
+    await expect(unmarkHunk).toBeEnabled();
+    await unmarkHunk.click();
+    await expect(page.getByRole('button', { name: 'Mark file reviewed', exact: true }))
+      .toHaveAttribute('aria-pressed', 'false');
+    expect(app.pageErrors).toEqual([]);
+  });
+}
+
 test('Review routes Markdown source and keeps non-MoonBit comparisons on Line diff', async ({ page }) => {
   const app = new DesktopBrowserHarness(page);
   const path = 'docs/Guide.MD';

--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -539,6 +539,10 @@ fn request_viewer_mount(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
           )
         })
         |> ignore
+        diff_editor.on_did_change_active_hunk(active_index => {
+          publish_line_review_active_hunk(diff_editor, active_index)
+        })
+        |> ignore
         viewer_state.diff_editor = Some(diff_editor)
       }
     },

--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -537,10 +537,11 @@ fn request_viewer_mount(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
               ReviewDiffNavigationAvailabilityChanged(navigation_available),
             ),
           )
+          publish_line_review_hunk_context(diff_editor)
         })
         |> ignore
-        diff_editor.on_did_change_active_hunk(active_index => {
-          publish_line_review_active_hunk(diff_editor, active_index)
+        diff_editor.on_did_change_active_hunk(_active_index => {
+          publish_line_review_hunk_context(diff_editor)
         })
         |> ignore
         viewer_state.diff_editor = Some(diff_editor)

--- a/desktop/frontend/fileeditor/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/pkg.generated.mbti
@@ -281,7 +281,7 @@ pub(all) enum Msg {
   MoonModViewModeSelected(MoonModViewMode)
   PackageGraphRequestLoaded(owner~ : @interop.ConversationKey, epoch~ : Int, path~ : @pathx.Relative, generation~ : Int, source~ : String)
   PackageGraphRequestFailed(owner~ : @interop.ConversationKey, epoch~ : Int, path~ : @pathx.Relative, generation~ : Int, message~ : String)
-  ReviewActiveHunkChanged(change~ : ChangedFile, review_generation~ : Int, hunk~ : ReviewHunk?)
+  ReviewActiveHunkChanged(change~ : ChangedFile, review_generation~ : Int, hunk~ : ReviewHunk?, file_changes~ : ReviewHunk?, position~ : ReviewHunkPosition?)
   ToggleActiveReviewHunk
   GitOriginalLoaded(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, generation~ : Int, background~ : Bool, original~ : @protocol.GitOriginalFileReply)
   GitOriginalFailed(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, generation~ : Int, background~ : Bool, message~ : String)
@@ -363,6 +363,12 @@ pub(all) struct ReviewHunk {
 } derive(Eq)
 pub fn ReviewHunk::equal(Self, Self) -> Bool
 pub fn ReviewHunk::not_equal(Self, Self) -> Bool
+
+pub(all) struct ReviewHunkPosition {
+  // private fields
+} derive(Eq)
+pub fn ReviewHunkPosition::equal(Self, Self) -> Bool
+pub fn ReviewHunkPosition::not_equal(Self, Self) -> Bool
 
 pub(all) struct ReviewState {
   generation : Int

--- a/desktop/frontend/fileeditor/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/pkg.generated.mbti
@@ -283,6 +283,7 @@ pub(all) enum Msg {
   PackageGraphRequestFailed(owner~ : @interop.ConversationKey, epoch~ : Int, path~ : @pathx.Relative, generation~ : Int, message~ : String)
   ReviewActiveHunkChanged(change~ : ChangedFile, review_generation~ : Int, surface_generation~ : Int, hunk~ : ReviewHunk?, file_changes~ : ReviewHunk?, position~ : ReviewHunkPosition?)
   ToggleActiveReviewHunk
+  ToggleReviewHunk(change~ : ChangedFile, review_generation~ : Int, surface_generation~ : Int, hunk~ : ReviewHunk, file_changes~ : ReviewHunk?, position~ : ReviewHunkPosition?)
   GitOriginalLoaded(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, generation~ : Int, background~ : Bool, original~ : @protocol.GitOriginalFileReply)
   GitOriginalFailed(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, generation~ : Int, background~ : Bool, message~ : String)
   HistoryBlobLoaded(owner~ : @interop.ConversationKey, key~ : String, generation~ : Int, side~ : HistoryDiffSide, blob~ : @protocol.GitOriginalFileReply)

--- a/desktop/frontend/fileeditor/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/pkg.generated.mbti
@@ -281,7 +281,7 @@ pub(all) enum Msg {
   MoonModViewModeSelected(MoonModViewMode)
   PackageGraphRequestLoaded(owner~ : @interop.ConversationKey, epoch~ : Int, path~ : @pathx.Relative, generation~ : Int, source~ : String)
   PackageGraphRequestFailed(owner~ : @interop.ConversationKey, epoch~ : Int, path~ : @pathx.Relative, generation~ : Int, message~ : String)
-  ReviewActiveHunkChanged(change~ : ChangedFile, review_generation~ : Int, hunk~ : ReviewHunk?, file_changes~ : ReviewHunk?, position~ : ReviewHunkPosition?)
+  ReviewActiveHunkChanged(change~ : ChangedFile, review_generation~ : Int, surface_generation~ : Int, hunk~ : ReviewHunk?, file_changes~ : ReviewHunk?, position~ : ReviewHunkPosition?)
   ToggleActiveReviewHunk
   GitOriginalLoaded(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, generation~ : Int, background~ : Bool, original~ : @protocol.GitOriginalFileReply)
   GitOriginalFailed(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, generation~ : Int, background~ : Bool, message~ : String)
@@ -435,6 +435,7 @@ pub(all) struct State {
   history_docs : Map[String, HistoryDiffDoc]
   history_generation : Int
   review_progress : Array[ChangedFileReview]
+  review_hunk_surface_generation : Int
   review_active_hunk : ReviewActiveHunk?
   changes_generation : Int
   request_epoch : Int

--- a/desktop/frontend/fileeditor/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/pkg.generated.mbti
@@ -102,6 +102,12 @@ pub(all) struct ChangedFile {
 pub fn ChangedFile::equal(Self, Self) -> Bool
 pub fn ChangedFile::not_equal(Self, Self) -> Bool
 
+pub(all) struct ChangedFileReview {
+  // private fields
+} derive(Eq)
+pub fn ChangedFileReview::equal(Self, Self) -> Bool
+pub fn ChangedFileReview::not_equal(Self, Self) -> Bool
+
 pub(all) struct Ctx {
   owner : @interop.ConversationKey
   request_epoch : Int
@@ -275,6 +281,8 @@ pub(all) enum Msg {
   MoonModViewModeSelected(MoonModViewMode)
   PackageGraphRequestLoaded(owner~ : @interop.ConversationKey, epoch~ : Int, path~ : @pathx.Relative, generation~ : Int, source~ : String)
   PackageGraphRequestFailed(owner~ : @interop.ConversationKey, epoch~ : Int, path~ : @pathx.Relative, generation~ : Int, message~ : String)
+  ReviewActiveHunkChanged(change~ : ChangedFile, review_generation~ : Int, hunk~ : ReviewHunk?)
+  ToggleActiveReviewHunk
   GitOriginalLoaded(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, generation~ : Int, background~ : Bool, original~ : @protocol.GitOriginalFileReply)
   GitOriginalFailed(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, generation~ : Int, background~ : Bool, message~ : String)
   HistoryBlobLoaded(owner~ : @interop.ConversationKey, key~ : String, generation~ : Int, side~ : HistoryDiffSide, blob~ : @protocol.GitOriginalFileReply)
@@ -313,6 +321,12 @@ pub fn ReconciledPlacement::is_parked(Self) -> Bool
 pub fn ReconciledPlacement::not_equal(Self, Self) -> Bool
 pub fn ReconciledPlacement::reconcile(Self, @interop.CheckoutPlacement?) -> Self
 
+pub(all) struct ReviewActiveHunk {
+  // private fields
+} derive(Eq)
+pub fn ReviewActiveHunk::equal(Self, Self) -> Bool
+pub fn ReviewActiveHunk::not_equal(Self, Self) -> Bool
+
 pub(all) enum ReviewBaseline {
   ReviewLoading
   ReviewContent(String)
@@ -336,6 +350,19 @@ pub(all) enum ReviewDiffMode {
   ReviewDiffToken
   ReviewDiffTree
 } derive(Eq, @debug.Debug)
+
+pub(all) enum ReviewFileProgress {
+  ReviewFileInProgress(ReviewHunk)
+  ReviewFileComplete
+} derive(Eq)
+pub fn ReviewFileProgress::equal(Self, Self) -> Bool
+pub fn ReviewFileProgress::not_equal(Self, Self) -> Bool
+
+pub(all) struct ReviewHunk {
+  // private fields
+} derive(Eq)
+pub fn ReviewHunk::equal(Self, Self) -> Bool
+pub fn ReviewHunk::not_equal(Self, Self) -> Bool
 
 pub(all) struct ReviewState {
   generation : Int
@@ -401,7 +428,8 @@ pub(all) struct State {
   git_graph_collapsed : Bool
   history_docs : Map[String, HistoryDiffDoc]
   history_generation : Int
-  reviewed_changes : Array[ChangedFile]
+  review_progress : Array[ChangedFileReview]
+  review_active_hunk : ReviewActiveHunk?
   changes_generation : Int
   request_epoch : Int
   file_link_generation : Int

--- a/desktop/frontend/fileeditor/review_hunk_bridge.mbt
+++ b/desktop/frontend/fileeditor/review_hunk_bridge.mbt
@@ -1,0 +1,143 @@
+///|
+priv enum ReviewHunkBridgeSurface {
+  ReviewLineSurface
+  ReviewSemanticSurface
+} derive(Eq)
+
+///|
+/// The active review identity is shared by the permanent Line editor and the
+/// currently visible semantic editors. Keeping only the visible surface here
+/// prevents the parked Line editor from replacing a Token/Tree selection.
+priv struct ReviewHunkBridgeTarget {
+  change : ChangedFile
+  review_generation : Int
+  surface : ReviewHunkBridgeSurface
+  semantic_input : SemanticReviewInput?
+  active_hunk : ReviewHunk?
+  dispatch : (Msg) -> Unit
+}
+
+///|
+let review_hunk_bridge_target : Ref[ReviewHunkBridgeTarget?] = Ref(None)
+
+///|
+fn current_review_hunk_bridge_target(
+  state : State,
+  active_file : @pathx.Relative?,
+  dispatch : (Msg) -> Unit,
+) -> ReviewHunkBridgeTarget? {
+  guard active_file is Some(path) &&
+    state.docs.get(path) is Some({ review: Some(review), .. }) &&
+    state.current_review_generation(review.selected, active_file)
+    is Some(review_generation) else {
+    return None
+  }
+  let active_hunk = state
+    .active_review_hunk(active_file)
+    .map(active => active.hunk)
+  Some({
+    change: review.selected,
+    review_generation,
+    surface: if state.semantic_review_input is Some(_) {
+      ReviewSemanticSurface
+    } else {
+      ReviewLineSurface
+    },
+    semantic_input: state.semantic_review_input,
+    active_hunk,
+    dispatch,
+  })
+}
+
+///|
+fn sync_review_hunk_bridge_target(
+  state : State,
+  active_file : @pathx.Relative?,
+  dispatch : (Msg) -> Unit,
+) -> Unit {
+  review_hunk_bridge_target.val = current_review_hunk_bridge_target(
+    state, active_file, dispatch,
+  )
+  if review_hunk_bridge_target.val is Some({ surface: ReviewLineSurface, .. }) &&
+    mounted_diff_editor() is Some(editor) {
+    publish_line_review_active_hunk(editor, editor.get_active_hunk_index())
+  }
+}
+
+///|
+fn projected_review_hunk(
+  editor : @viewer.DiffEditor,
+  active_index : Int?,
+  old_offset : Int?,
+  new_offset : Int?,
+) -> ReviewHunk? {
+  guard active_index is Some(index) else { return None }
+  let hunks = editor.get_hunks()
+  guard index >= 0 && index < hunks.length() else { return None }
+  let hunk = ReviewHunk::from_diff_hunk(hunks[index], old_offset, new_offset)
+  if hunk.is_empty() {
+    None
+  } else {
+    Some(hunk)
+  }
+}
+
+///|
+fn publish_review_active_hunk(
+  surface : ReviewHunkBridgeSurface,
+  hunk : ReviewHunk?,
+) -> Unit {
+  guard review_hunk_bridge_target.val is Some(target) &&
+    target.surface == surface &&
+    target.active_hunk != hunk else {
+    return
+  }
+  review_hunk_bridge_target.val = Some({ ..target, active_hunk: hunk, })
+  (target.dispatch)(
+    ReviewActiveHunkChanged(
+      change=target.change,
+      review_generation=target.review_generation,
+      hunk~,
+    ),
+  )
+}
+
+///|
+fn publish_line_review_active_hunk(
+  editor : @viewer.DiffEditor,
+  active_index : Int?,
+) -> Unit {
+  guard review_hunk_bridge_target.val
+    is Some({ surface: ReviewLineSurface, .. }) else {
+    return
+  }
+  publish_review_active_hunk(
+    ReviewLineSurface,
+    projected_review_hunk(editor, active_index, Some(0), Some(0)),
+  )
+}
+
+///|
+fn publish_semantic_review_active_hunk(
+  input : SemanticReviewInput,
+  key : String,
+  editor : @viewer.DiffEditor,
+  section : @moon_diff_provider.SemanticReviewSection,
+  active_index : Int?,
+) -> Unit {
+  guard review_hunk_bridge_target.val is Some(target) &&
+    target.surface == ReviewSemanticSurface &&
+    target.semantic_input == Some(input) &&
+    semantic_review_active_key.val == Some(key) else {
+    return
+  }
+  publish_review_active_hunk(
+    ReviewSemanticSurface,
+    projected_review_hunk(
+      editor,
+      active_index,
+      semantic_feedback_line_offset(section, SemanticReviewOriginal),
+      semantic_feedback_line_offset(section, SemanticReviewModified),
+    ),
+  )
+}

--- a/desktop/frontend/fileeditor/review_hunk_bridge.mbt
+++ b/desktop/frontend/fileeditor/review_hunk_bridge.mbt
@@ -11,6 +11,7 @@ priv enum ReviewHunkBridgeSurface {
 priv struct ReviewHunkBridgeTarget {
   change : ChangedFile
   review_generation : Int
+  surface_generation : Int
   surface : ReviewHunkBridgeSurface
   semantic_input : SemanticReviewInput?
   active_hunk : ReviewHunk?
@@ -42,6 +43,7 @@ fn current_review_hunk_bridge_target(
   Some({
     change: review.selected,
     review_generation,
+    surface_generation: state.review_hunk_surface_generation,
     surface: if state.semantic_review_input is Some(_) {
       ReviewSemanticSurface
     } else {
@@ -131,6 +133,7 @@ fn publish_review_active_hunk(
     ReviewActiveHunkChanged(
       change=target.change,
       review_generation=target.review_generation,
+      surface_generation=target.surface_generation,
       hunk~,
       file_changes~,
       position~,

--- a/desktop/frontend/fileeditor/review_hunk_bridge.mbt
+++ b/desktop/frontend/fileeditor/review_hunk_bridge.mbt
@@ -14,6 +14,8 @@ priv struct ReviewHunkBridgeTarget {
   surface : ReviewHunkBridgeSurface
   semantic_input : SemanticReviewInput?
   active_hunk : ReviewHunk?
+  file_changes : ReviewHunk?
+  position : ReviewHunkPosition?
   dispatch : (Msg) -> Unit
 }
 
@@ -32,9 +34,11 @@ fn current_review_hunk_bridge_target(
     is Some(review_generation) else {
     return None
   }
-  let active_hunk = state
-    .active_review_hunk(active_file)
-    .map(active => active.hunk)
+  let (active_hunk, file_changes, position) = match
+    state.active_review_hunk(active_file) {
+    Some(active) => (Some(active.hunk), active.file_changes, active.position)
+    None => (None, None, None)
+  }
   Some({
     change: review.selected,
     review_generation,
@@ -45,6 +49,8 @@ fn current_review_hunk_bridge_target(
     },
     semantic_input: state.semantic_review_input,
     active_hunk,
+    file_changes,
+    position,
     dispatch,
   })
 }
@@ -58,21 +64,19 @@ fn sync_review_hunk_bridge_target(
   review_hunk_bridge_target.val = current_review_hunk_bridge_target(
     state, active_file, dispatch,
   )
-  if review_hunk_bridge_target.val is Some({ surface: ReviewLineSurface, .. }) &&
-    mounted_diff_editor() is Some(editor) {
-    publish_line_review_active_hunk(editor, editor.get_active_hunk_index())
+  if mounted_diff_editor() is Some(editor) {
+    publish_line_review_hunk_context(editor)
   }
 }
 
 ///|
 fn projected_review_hunk(
-  editor : @viewer.DiffEditor,
+  hunks : Array[@viewer.DiffHunk],
   active_index : Int?,
   old_offset : Int?,
   new_offset : Int?,
 ) -> ReviewHunk? {
   guard active_index is Some(index) else { return None }
-  let hunks = editor.get_hunks()
   guard index >= 0 && index < hunks.length() else { return None }
   let hunk = ReviewHunk::from_diff_hunk(hunks[index], old_offset, new_offset)
   if hunk.is_empty() {
@@ -83,38 +87,80 @@ fn projected_review_hunk(
 }
 
 ///|
+fn projected_review_file_changes(
+  hunks : Array[@viewer.DiffHunk],
+) -> ReviewHunk? {
+  let mut file_changes = ReviewHunk(old_ranges=[], new_ranges=[])
+  for hunk in hunks {
+    file_changes = file_changes.union(
+      ReviewHunk::from_diff_hunk(hunk, Some(0), Some(0)),
+    )
+  }
+  if file_changes.is_empty() {
+    None
+  } else {
+    Some(file_changes)
+  }
+}
+
+///|
 fn publish_review_active_hunk(
   surface : ReviewHunkBridgeSurface,
   hunk : ReviewHunk?,
+  file_changes : ReviewHunk?,
+  position : ReviewHunkPosition?,
 ) -> Unit {
   guard review_hunk_bridge_target.val is Some(target) &&
     target.surface == surface &&
-    target.active_hunk != hunk else {
+    (
+      target.active_hunk != hunk ||
+      (
+        hunk is Some(_) &&
+        (target.file_changes != file_changes || target.position != position)
+      )
+    ) else {
     return
   }
-  review_hunk_bridge_target.val = Some({ ..target, active_hunk: hunk, })
+  review_hunk_bridge_target.val = Some({
+    ..target,
+    active_hunk: hunk,
+    file_changes,
+    position,
+  })
   (target.dispatch)(
     ReviewActiveHunkChanged(
       change=target.change,
       review_generation=target.review_generation,
       hunk~,
+      file_changes~,
+      position~,
     ),
   )
 }
 
 ///|
-fn publish_line_review_active_hunk(
-  editor : @viewer.DiffEditor,
-  active_index : Int?,
-) -> Unit {
-  guard review_hunk_bridge_target.val
-    is Some({ surface: ReviewLineSurface, .. }) else {
-    return
+fn publish_line_review_hunk_context(editor : @viewer.DiffEditor) -> Unit {
+  guard review_hunk_bridge_target.val is Some(target) else { return }
+  let hunks = editor.get_hunks()
+  let file_changes = projected_review_file_changes(hunks)
+  match target.surface {
+    ReviewLineSurface => {
+      let active_index = editor.get_active_hunk_index()
+      publish_review_active_hunk(
+        ReviewLineSurface,
+        projected_review_hunk(hunks, active_index, Some(0), Some(0)),
+        file_changes,
+        ReviewHunkPosition::from_zero_based(active_index, hunks.length()),
+      )
+    }
+    ReviewSemanticSurface =>
+      publish_review_active_hunk(
+        ReviewSemanticSurface,
+        target.active_hunk,
+        file_changes,
+        target.position,
+      )
   }
-  publish_review_active_hunk(
-    ReviewLineSurface,
-    projected_review_hunk(editor, active_index, Some(0), Some(0)),
-  )
 }
 
 ///|
@@ -131,13 +177,19 @@ fn publish_semantic_review_active_hunk(
     semantic_review_active_key.val == Some(key) else {
     return
   }
+  let hunks = editor.get_hunks()
+  let file_changes = mounted_diff_editor().bind(line_editor => {
+    projected_review_file_changes(line_editor.get_hunks())
+  })
   publish_review_active_hunk(
     ReviewSemanticSurface,
     projected_review_hunk(
-      editor,
+      hunks,
       active_index,
       semantic_feedback_line_offset(section, SemanticReviewOriginal),
       semantic_feedback_line_offset(section, SemanticReviewModified),
     ),
+    file_changes,
+    semantic_review_hunk_position(key, active_index),
   )
 }

--- a/desktop/frontend/fileeditor/review_hunk_bridge.mbt
+++ b/desktop/frontend/fileeditor/review_hunk_bridge.mbt
@@ -257,14 +257,7 @@ fn install_review_hunk_actions(
         mounted_diff_editor().bind(projected_review_file_changes) is None {
         button.set_attribute("disabled", "")
       }
-      button.set_attribute(
-        "class",
-        if viewed {
-          "review-badge review-progress reviewed"
-        } else {
-          "review-badge review-progress"
-        },
-      )
+      button.set_attribute("class", "review-hunk-marker")
       button.set_attribute(
         "aria-label",
         if viewed {
@@ -293,9 +286,9 @@ fn install_review_hunk_actions(
         @dom.document()
         .create_text_node(
           match status {
-            ReviewHunkViewed => "✓ Viewed"
-            ReviewHunkPartial => "◐ Mark viewed"
-            ReviewHunkUnviewed => "Mark viewed"
+            ReviewHunkViewed => "✓"
+            ReviewHunkPartial => "−"
+            ReviewHunkUnviewed => ""
           },
         )
         .as_node(),

--- a/desktop/frontend/fileeditor/review_hunk_bridge.mbt
+++ b/desktop/frontend/fileeditor/review_hunk_bridge.mbt
@@ -200,3 +200,190 @@ fn publish_semantic_review_active_hunk(
     semantic_review_hunk_position(key, active_index),
   )
 }
+
+///|
+fn sync_review_hunk_actions(state : State) -> Unit {
+  let target = review_hunk_bridge_target.val
+  if mounted_diff_editor() is Some(editor) {
+    if target is Some(target) && target.surface is ReviewLineSurface {
+      install_review_hunk_actions(state, target, editor, None)
+    } else {
+      editor.set_hunk_action_renderer(None)
+    }
+  }
+  if target is Some(target) && target.surface is ReviewSemanticSurface {
+    for key, entry in semantic_review_editors {
+      install_review_hunk_actions(
+        state,
+        target,
+        entry.editor,
+        Some((key, entry.section)),
+      )
+    }
+  }
+}
+
+///|
+fn install_review_hunk_actions(
+  state : State,
+  target : ReviewHunkBridgeTarget,
+  editor : @viewer.DiffEditor,
+  section : (String, @moon_diff_provider.SemanticReviewSection)?,
+) -> Unit {
+  editor.set_hunk_action_renderer(
+    Some(index => {
+      let (old_offset, new_offset) = match section {
+        None => (Some(0), Some(0))
+        Some((_, section)) =>
+          (
+            semantic_feedback_line_offset(section, SemanticReviewOriginal),
+            semantic_feedback_line_offset(section, SemanticReviewModified),
+          )
+      }
+      guard projected_review_hunk(
+          editor.get_hunks(),
+          Some(index),
+          old_offset,
+          new_offset,
+        )
+        is Some(hunk) else {
+        return None
+      }
+      let status = state.review_hunk_state(target.change, hunk)
+      let viewed = status is ReviewHunkViewed
+      let button = @dom.document().create_element("button")
+      button.set_attribute("type", "button")
+      if state.is_change_reviewed(target.change) &&
+        mounted_diff_editor().bind(projected_review_file_changes) is None {
+        button.set_attribute("disabled", "")
+      }
+      button.set_attribute(
+        "class",
+        if viewed {
+          "review-badge review-progress reviewed"
+        } else {
+          "review-badge review-progress"
+        },
+      )
+      button.set_attribute(
+        "aria-label",
+        if viewed {
+          "Unmark hunk \{index + 1} viewed"
+        } else {
+          "Mark hunk \{index + 1} viewed"
+        },
+      )
+      button.set_attribute(
+        "aria-pressed",
+        match status {
+          ReviewHunkViewed => "true"
+          ReviewHunkPartial => "mixed"
+          ReviewHunkUnviewed => "false"
+        },
+      )
+      button.set_attribute(
+        "title",
+        if viewed {
+          "Mark this hunk unviewed"
+        } else {
+          "Mark this hunk viewed"
+        },
+      )
+      button.append_child(
+        @dom.document()
+        .create_text_node(
+          match status {
+            ReviewHunkViewed => "✓ Viewed"
+            ReviewHunkPartial => "◐ Mark viewed"
+            ReviewHunkUnviewed => "Mark viewed"
+          },
+        )
+        .as_node(),
+      )
+      // Restoring a button's focus after a state refresh must not let the
+      // section's editor-focus bridge replace the outer scroll selection.
+      button.add_event_listener("focusin", event => event.stop_propagation())
+      button.add_event_listener("click", event => {
+        event.stop_propagation()
+        guard review_hunk_bridge_target.val is Some(current) &&
+          current.change == target.change &&
+          current.review_generation == target.review_generation &&
+          current.surface_generation == target.surface_generation else {
+          return
+        }
+        if section is Some((key, _)) {
+          semantic_review_active_key.val = Some(key)
+        }
+        editor.select_hunk(index)
+        let position = match section {
+          None =>
+            ReviewHunkPosition::from_zero_based(
+              Some(index),
+              editor.get_hunks().length(),
+            )
+          Some((key, _)) => semantic_review_hunk_position(key, Some(index))
+        }
+        (current.dispatch)(
+          ToggleReviewHunk(
+            change=current.change,
+            review_generation=current.review_generation,
+            surface_generation=current.surface_generation,
+            hunk~,
+            file_changes=mounted_diff_editor().bind(
+              projected_review_file_changes,
+            ),
+            position~,
+          ),
+        )
+      })
+      Some(button)
+    }),
+  )
+}
+
+///|
+/// Semantic editors expand to their full height; the outer scroll plane owns
+/// reading position. Pick one global hunk using its actual rendered geometry.
+fn track_semantic_review_scroll(host : @dom.Element) -> Unit {
+  guard review_hunk_bridge_target.val is Some(target) &&
+    target.surface is ReviewSemanticSurface else {
+    return
+  }
+  let offset = host.get_bounding_client_rect().get_top() +
+    host.get_client_height() * 0.5
+  let mut nearest : (String, Int, Double)? = None
+  for key in semantic_review_order {
+    guard semantic_review_editors.get(key) is Some(entry) &&
+      entry.host.get_client_height() > 0.0 else {
+      continue
+    }
+    let origin = entry.host.get_bounding_client_rect().get_top()
+    for index, _ in entry.editor.get_hunks() {
+      if entry.editor.get_hunk_viewport_bounds(index) is Some((top, bottom)) {
+        let distance = if offset < origin + top {
+          origin + top - offset
+        } else {
+          (offset - origin - bottom).max(0.0)
+        }
+        if nearest is None ||
+          (nearest is Some((_, _, previous)) && distance < previous) {
+          nearest = Some((key, index, distance))
+        }
+      }
+    }
+  }
+  if nearest is Some((key, index, _)) &&
+    semantic_review_editors.get(key) is Some(entry) {
+    semantic_review_active_key.val = Some(key)
+    entry.editor.select_hunk(index)
+    if target.semantic_input is Some(input) {
+      publish_semantic_review_active_hunk(
+        input,
+        key,
+        entry.editor,
+        entry.section,
+        Some(index),
+      )
+    }
+  }
+}

--- a/desktop/frontend/fileeditor/review_hunk_bridge.mbt
+++ b/desktop/frontend/fileeditor/review_hunk_bridge.mbt
@@ -89,15 +89,21 @@ fn projected_review_hunk(
 }
 
 ///|
-fn projected_review_file_changes(
-  hunks : Array[@viewer.DiffHunk],
-) -> ReviewHunk? {
-  let mut file_changes = ReviewHunk(old_ranges=[], new_ranges=[])
-  for hunk in hunks {
-    file_changes = file_changes.union(
-      ReviewHunk::from_diff_hunk(hunk, Some(0), Some(0)),
-    )
+fn projected_review_file_changes(editor : @viewer.DiffEditor) -> ReviewHunk? {
+  // The parked Line editor may never have been laid out for this file, so its
+  // visual hunks can be empty even after the logical diff is ready. Only use
+  // the current model pair's changes, excluding geometry-only alignments.
+  guard editor.is_diff_up_to_date() && editor.get_diff() is Some(diff) else {
+    return None
   }
+  let old_ranges : Array[@common.LineRange] = []
+  let new_ranges : Array[@common.LineRange] = []
+  for change in diff.changes {
+    guard change.kind is Visible else { continue }
+    old_ranges.push(change.mapping.original)
+    new_ranges.push(change.mapping.modified)
+  }
+  let file_changes = ReviewHunk(old_ranges~, new_ranges~)
   if file_changes.is_empty() {
     None
   } else {
@@ -145,7 +151,7 @@ fn publish_review_active_hunk(
 fn publish_line_review_hunk_context(editor : @viewer.DiffEditor) -> Unit {
   guard review_hunk_bridge_target.val is Some(target) else { return }
   let hunks = editor.get_hunks()
-  let file_changes = projected_review_file_changes(hunks)
+  let file_changes = projected_review_file_changes(editor)
   match target.surface {
     ReviewLineSurface => {
       let active_index = editor.get_active_hunk_index()
@@ -181,9 +187,7 @@ fn publish_semantic_review_active_hunk(
     return
   }
   let hunks = editor.get_hunks()
-  let file_changes = mounted_diff_editor().bind(line_editor => {
-    projected_review_file_changes(line_editor.get_hunks())
-  })
+  let file_changes = mounted_diff_editor().bind(projected_review_file_changes)
   publish_review_active_hunk(
     ReviewSemanticSurface,
     projected_review_hunk(

--- a/desktop/frontend/fileeditor/review_hunks.mbt
+++ b/desktop/frontend/fileeditor/review_hunks.mbt
@@ -114,7 +114,26 @@ pub(all) struct ReviewActiveHunk {
   priv change : ChangedFile
   priv review_generation : Int
   priv hunk : ReviewHunk
+  // The complete Line diff is the file-level review universe. Semantic hunks
+  // project into it, but never redefine it when filters or grouping change.
+  priv file_changes : ReviewHunk?
+  priv position : ReviewHunkPosition?
 } derive(Eq)
+
+///|
+pub(all) struct ReviewHunkPosition {
+  priv current : Int
+  priv total : Int
+} derive(Eq)
+
+///|
+fn ReviewHunkPosition::from_zero_based(
+  index : Int?,
+  total : Int,
+) -> ReviewHunkPosition? {
+  guard index is Some(index) && index >= 0 && index < total else { return None }
+  Some({ current: index + 1, total, })
+}
 
 ///|
 fn normalize_review_line_ranges(
@@ -331,6 +350,8 @@ fn State::accept_active_review_hunk(
   change : ChangedFile,
   review_generation : Int,
   hunk : ReviewHunk?,
+  file_changes : ReviewHunk?,
+  position : ReviewHunkPosition?,
   active_file : @pathx.Relative?,
 ) -> State {
   guard self.current_review_generation(change, active_file) ==
@@ -339,7 +360,13 @@ fn State::accept_active_review_hunk(
   }
   {
     ..self,
-    review_active_hunk: hunk.map(hunk => { change, review_generation, hunk, }),
+    review_active_hunk: hunk.map(hunk => {
+      change,
+      review_generation,
+      hunk,
+      file_changes,
+      position,
+    }),
   }
 }
 
@@ -366,9 +393,21 @@ fn State::toggle_active_review_hunk(
     return self
   }
   match self.review_file_progress(active.change) {
-    // Complete belongs to the explicit file-level control. Without the full
-    // hunk universe, a single-hunk action cannot reconstruct its complement.
-    Some(ReviewFileComplete) => self
+    Some(ReviewFileComplete) => {
+      // File completion projects to every hunk. Once the full Line universe is
+      // known, unmarking one hunk keeps every other hunk viewed and naturally
+      // returns the file to partial progress.
+      guard active.file_changes is Some(file_changes) else { return self }
+      let next = file_changes.subtract(active.hunk)
+      self.set_review_file_progress(
+        active.change,
+        if next.is_empty() {
+          None
+        } else {
+          Some(ReviewFileInProgress(next))
+        },
+      )
+    }
     Some(ReviewFileInProgress(coverage)) => {
       let next = if coverage.contains(active.hunk) {
         coverage.subtract(active.hunk)
@@ -379,6 +418,9 @@ fn State::toggle_active_review_hunk(
         active.change,
         if next.is_empty() {
           None
+        } else if active.file_changes is Some(file_changes) &&
+          next.contains(file_changes) {
+          Some(ReviewFileComplete)
         } else {
           Some(ReviewFileInProgress(next))
         },
@@ -387,7 +429,12 @@ fn State::toggle_active_review_hunk(
     None =>
       self.set_review_file_progress(
         active.change,
-        Some(ReviewFileInProgress(active.hunk)),
+        if active.file_changes is Some(file_changes) &&
+          active.hunk.contains(file_changes) {
+          Some(ReviewFileComplete)
+        } else {
+          Some(ReviewFileInProgress(active.hunk))
+        },
       )
   }
 }
@@ -412,3 +459,6 @@ pub extend ChangedFileReview with Eq::{equal, not_equal}
 
 ///|
 pub extend ReviewActiveHunk with Eq::{equal, not_equal}
+
+///|
+pub extend ReviewHunkPosition with Eq::{equal, not_equal}

--- a/desktop/frontend/fileeditor/review_hunks.mbt
+++ b/desktop/frontend/fileeditor/review_hunks.mbt
@@ -1,0 +1,414 @@
+///|
+/// One hunk's true changed lines in full-file coordinates. The same normalized
+/// value also stores accumulated Line/Token/Tree review coverage.
+pub(all) struct ReviewHunk {
+  priv old_ranges : Array[@common.LineRange]
+  priv new_ranges : Array[@common.LineRange]
+} derive(Eq)
+
+///|
+fn ReviewHunk::ReviewHunk(
+  old_ranges~ : Array[@common.LineRange],
+  new_ranges~ : Array[@common.LineRange],
+) -> ReviewHunk {
+  {
+    old_ranges: normalize_review_line_ranges(old_ranges),
+    new_ranges: normalize_review_line_ranges(new_ranges),
+  }
+}
+
+///|
+fn ReviewHunk::is_empty(self : ReviewHunk) -> Bool {
+  self.old_ranges.is_empty() && self.new_ranges.is_empty()
+}
+
+///|
+fn ReviewHunk::union(self : ReviewHunk, other : ReviewHunk) -> ReviewHunk {
+  let old_ranges = self.old_ranges.copy()
+  old_ranges.append(other.old_ranges)
+  let new_ranges = self.new_ranges.copy()
+  new_ranges.append(other.new_ranges)
+  ReviewHunk(old_ranges~, new_ranges~)
+}
+
+///|
+fn ReviewHunk::subtract(self : ReviewHunk, other : ReviewHunk) -> ReviewHunk {
+  ReviewHunk(
+    old_ranges=review_line_ranges_subtract(self.old_ranges, other.old_ranges),
+    new_ranges=review_line_ranges_subtract(self.new_ranges, other.new_ranges),
+  )
+}
+
+///|
+fn ReviewHunk::contains(self : ReviewHunk, other : ReviewHunk) -> Bool {
+  review_line_ranges_subset(other.old_ranges, self.old_ranges) &&
+  review_line_ranges_subset(other.new_ranges, self.new_ranges)
+}
+
+///|
+fn ReviewHunk::intersects(self : ReviewHunk, other : ReviewHunk) -> Bool {
+  review_line_ranges_intersect(self.old_ranges, other.old_ranges) ||
+  review_line_ranges_intersect(self.new_ranges, other.new_ranges)
+}
+
+///|
+/// Only DiffEditor's real mapping members participate. Joined reveal context
+/// is navigation geometry, not review coverage. `None` drops an empty side's
+/// artificial TextModel anchor.
+fn ReviewHunk::from_diff_hunk(
+  hunk : @viewer.DiffHunk,
+  old_offset : Int?,
+  new_offset : Int?,
+) -> ReviewHunk {
+  let old_ranges : Array[@common.LineRange] = []
+  let new_ranges : Array[@common.LineRange] = []
+  for mapping in hunk.members {
+    if old_offset is Some(offset) && !mapping.original.is_empty() {
+      old_ranges.push(
+        @common.LineRange(
+          mapping.original.start_line_number + offset,
+          mapping.original.end_line_number_exclusive + offset,
+        ),
+      )
+    }
+    if new_offset is Some(offset) && !mapping.modified.is_empty() {
+      new_ranges.push(
+        @common.LineRange(
+          mapping.modified.start_line_number + offset,
+          mapping.modified.end_line_number_exclusive + offset,
+        ),
+      )
+    }
+  }
+  ReviewHunk(old_ranges~, new_ranges~)
+}
+
+///|
+priv enum ReviewHunkState {
+  ReviewHunkUnviewed
+  ReviewHunkPartial
+  ReviewHunkViewed
+}
+
+///|
+pub(all) enum ReviewFileProgress {
+  ReviewFileInProgress(ReviewHunk)
+  ReviewFileComplete
+} derive(Eq)
+
+///|
+pub(all) struct ChangedFileReview {
+  priv change : ChangedFile
+  priv progress : ReviewFileProgress
+} derive(Eq)
+
+///|
+priv enum ReviewCompletionState {
+  ReviewUnviewed
+  ReviewInProgress
+  ReviewComplete
+}
+
+///|
+pub(all) struct ReviewActiveHunk {
+  priv change : ChangedFile
+  priv review_generation : Int
+  priv hunk : ReviewHunk
+} derive(Eq)
+
+///|
+fn normalize_review_line_ranges(
+  ranges : Array[@common.LineRange],
+) -> Array[@common.LineRange] {
+  let sorted = ranges.filter(range => {
+    range.start_line_number >= 1 &&
+    range.end_line_number_exclusive > range.start_line_number
+  })
+  sorted.sort_by((left, right) => {
+    let starts = left.start_line_number - right.start_line_number
+    if starts != 0 {
+      starts
+    } else {
+      left.end_line_number_exclusive - right.end_line_number_exclusive
+    }
+  })
+  let result : Array[@common.LineRange] = []
+  for range in sorted {
+    if result.is_empty() {
+      result.push(range)
+      continue
+    }
+    let last_index = result.length() - 1
+    let last = result[last_index]
+    if range.start_line_number <= last.end_line_number_exclusive {
+      result[last_index] = @common.LineRange(
+        last.start_line_number,
+        last.end_line_number_exclusive.max(range.end_line_number_exclusive),
+      )
+    } else {
+      result.push(range)
+    }
+  }
+  result
+}
+
+///|
+fn review_line_ranges_subtract(
+  source : Array[@common.LineRange],
+  removed : Array[@common.LineRange],
+) -> Array[@common.LineRange] {
+  let source = normalize_review_line_ranges(source)
+  let removed = normalize_review_line_ranges(removed)
+  let result : Array[@common.LineRange] = []
+  for range in source {
+    let mut cursor = range.start_line_number
+    for cut in removed {
+      if cut.end_line_number_exclusive <= cursor {
+        continue
+      }
+      if cut.start_line_number >= range.end_line_number_exclusive {
+        break
+      }
+      if cut.start_line_number > cursor {
+        result.push(
+          @common.LineRange(
+            cursor,
+            cut.start_line_number.min(range.end_line_number_exclusive),
+          ),
+        )
+      }
+      cursor = cursor.max(cut.end_line_number_exclusive)
+      if cursor >= range.end_line_number_exclusive {
+        break
+      }
+    }
+    if cursor < range.end_line_number_exclusive {
+      result.push(@common.LineRange(cursor, range.end_line_number_exclusive))
+    }
+  }
+  result
+}
+
+///|
+fn review_line_ranges_subset(
+  requested : Array[@common.LineRange],
+  available : Array[@common.LineRange],
+) -> Bool {
+  let requested = normalize_review_line_ranges(requested)
+  let available = normalize_review_line_ranges(available)
+  let mut available_index = 0
+  for range in requested {
+    while available_index < available.length() &&
+          available[available_index].end_line_number_exclusive <=
+          range.start_line_number {
+      available_index += 1
+    }
+    if available_index >= available.length() {
+      return false
+    }
+    let cover = available[available_index]
+    if cover.start_line_number > range.start_line_number ||
+      cover.end_line_number_exclusive < range.end_line_number_exclusive {
+      return false
+    }
+  }
+  true
+}
+
+///|
+fn review_line_ranges_intersect(
+  left : Array[@common.LineRange],
+  right : Array[@common.LineRange],
+) -> Bool {
+  let left = normalize_review_line_ranges(left)
+  let right = normalize_review_line_ranges(right)
+  let mut left_index = 0
+  let mut right_index = 0
+  while left_index < left.length() && right_index < right.length() {
+    let left_range = left[left_index]
+    let right_range = right[right_index]
+    if left_range.start_line_number < right_range.end_line_number_exclusive &&
+      right_range.start_line_number < left_range.end_line_number_exclusive {
+      return true
+    }
+    if left_range.end_line_number_exclusive <
+      right_range.end_line_number_exclusive {
+      left_index += 1
+    } else {
+      right_index += 1
+    }
+  }
+  false
+}
+
+///|
+fn State::review_file_progress(
+  self : State,
+  change : ChangedFile,
+) -> ReviewFileProgress? {
+  for entry in self.review_progress {
+    if entry.change == change {
+      return Some(entry.progress)
+    }
+  }
+  None
+}
+
+///|
+fn State::changed_file_review_state(
+  self : State,
+  change : ChangedFile,
+) -> ReviewCompletionState {
+  match self.review_file_progress(change) {
+    None => ReviewUnviewed
+    Some(ReviewFileInProgress(_)) => ReviewInProgress
+    Some(ReviewFileComplete) => ReviewComplete
+  }
+}
+
+///|
+fn State::is_change_reviewed(self : State, change : ChangedFile) -> Bool {
+  self.changed_file_review_state(change) is ReviewComplete
+}
+
+///|
+fn State::review_hunk_state(
+  self : State,
+  change : ChangedFile,
+  hunk : ReviewHunk,
+) -> ReviewHunkState {
+  if hunk.is_empty() {
+    return ReviewHunkUnviewed
+  }
+  match self.review_file_progress(change) {
+    Some(ReviewFileComplete) => ReviewHunkViewed
+    Some(ReviewFileInProgress(coverage)) =>
+      if coverage.contains(hunk) {
+        ReviewHunkViewed
+      } else if coverage.intersects(hunk) {
+        ReviewHunkPartial
+      } else {
+        ReviewHunkUnviewed
+      }
+    None => ReviewHunkUnviewed
+  }
+}
+
+///|
+fn State::set_review_file_progress(
+  self : State,
+  change : ChangedFile,
+  progress : ReviewFileProgress?,
+) -> State {
+  let entries = self.review_progress.filter(entry => entry.change != change)
+  if progress is Some(progress) {
+    entries.push({ change, progress, })
+  }
+  { ..self, review_progress: entries, }
+}
+
+///|
+fn State::current_review_generation(
+  self : State,
+  change : ChangedFile,
+  active_file : @pathx.Relative?,
+) -> Int? {
+  guard active_file == Some(change.path) &&
+    self.changes is ChangeListReady(files~, ..) &&
+    files.contains(change) &&
+    self.docs.get(change.path) is Some({ review: Some(review), .. }) &&
+    review.selected == change &&
+    review.view_mode is ReviewDiff &&
+    self.review_view_mode is ReviewDiff else {
+    return None
+  }
+  Some(review.diff_loading_generation())
+}
+
+///|
+fn State::accept_active_review_hunk(
+  self : State,
+  change : ChangedFile,
+  review_generation : Int,
+  hunk : ReviewHunk?,
+  active_file : @pathx.Relative?,
+) -> State {
+  guard self.current_review_generation(change, active_file) ==
+    Some(review_generation) else {
+    return self
+  }
+  {
+    ..self,
+    review_active_hunk: hunk.map(hunk => { change, review_generation, hunk, }),
+  }
+}
+
+///|
+fn State::active_review_hunk(
+  self : State,
+  active_file : @pathx.Relative?,
+) -> ReviewActiveHunk? {
+  guard self.review_active_hunk is Some(active) &&
+    self.current_review_generation(active.change, active_file) ==
+    Some(active.review_generation) else {
+    return None
+  }
+  Some(active)
+}
+
+///|
+fn State::toggle_active_review_hunk(
+  self : State,
+  active_file : @pathx.Relative?,
+) -> State {
+  guard self.active_review_hunk(active_file) is Some(active) &&
+    !active.hunk.is_empty() else {
+    return self
+  }
+  match self.review_file_progress(active.change) {
+    // Complete belongs to the explicit file-level control. Without the full
+    // hunk universe, a single-hunk action cannot reconstruct its complement.
+    Some(ReviewFileComplete) => self
+    Some(ReviewFileInProgress(coverage)) => {
+      let next = if coverage.contains(active.hunk) {
+        coverage.subtract(active.hunk)
+      } else {
+        coverage.union(active.hunk)
+      }
+      self.set_review_file_progress(
+        active.change,
+        if next.is_empty() {
+          None
+        } else {
+          Some(ReviewFileInProgress(next))
+        },
+      )
+    }
+    None =>
+      self.set_review_file_progress(
+        active.change,
+        Some(ReviewFileInProgress(active.hunk)),
+      )
+  }
+}
+
+///|
+fn State::clear_review_active_hunk(self : State) -> State {
+  if self.review_active_hunk is None {
+    self
+  } else {
+    { ..self, review_active_hunk: None, }
+  }
+}
+
+///|
+pub extend ReviewHunk with Eq::{equal, not_equal}
+
+///|
+pub extend ReviewFileProgress with Eq::{equal, not_equal}
+
+///|
+pub extend ChangedFileReview with Eq::{equal, not_equal}
+
+///|
+pub extend ReviewActiveHunk with Eq::{equal, not_equal}

--- a/desktop/frontend/fileeditor/review_hunks.mbt
+++ b/desktop/frontend/fileeditor/review_hunks.mbt
@@ -113,6 +113,7 @@ priv enum ReviewCompletionState {
 pub(all) struct ReviewActiveHunk {
   priv change : ChangedFile
   priv review_generation : Int
+  priv surface_generation : Int
   priv hunk : ReviewHunk
   // The complete Line diff is the file-level review universe. Semantic hunks
   // project into it, but never redefine it when filters or grouping change.
@@ -349,13 +350,15 @@ fn State::accept_active_review_hunk(
   self : State,
   change : ChangedFile,
   review_generation : Int,
+  surface_generation : Int,
   hunk : ReviewHunk?,
   file_changes : ReviewHunk?,
   position : ReviewHunkPosition?,
   active_file : @pathx.Relative?,
 ) -> State {
   guard self.current_review_generation(change, active_file) ==
-    Some(review_generation) else {
+    Some(review_generation) &&
+    self.review_hunk_surface_generation == surface_generation else {
     return self
   }
   {
@@ -363,6 +366,7 @@ fn State::accept_active_review_hunk(
     review_active_hunk: hunk.map(hunk => {
       change,
       review_generation,
+      surface_generation,
       hunk,
       file_changes,
       position,
@@ -377,7 +381,8 @@ fn State::active_review_hunk(
 ) -> ReviewActiveHunk? {
   guard self.review_active_hunk is Some(active) &&
     self.current_review_generation(active.change, active_file) ==
-    Some(active.review_generation) else {
+    Some(active.review_generation) &&
+    self.review_hunk_surface_generation == active.surface_generation else {
     return None
   }
   Some(active)
@@ -444,7 +449,16 @@ fn State::clear_review_active_hunk(self : State) -> State {
   if self.review_active_hunk is None {
     self
   } else {
-    { ..self, review_active_hunk: None, }
+    self.invalidate_review_hunk_surface()
+  }
+}
+
+///|
+fn State::invalidate_review_hunk_surface(self : State) -> State {
+  {
+    ..self,
+    review_hunk_surface_generation: self.review_hunk_surface_generation + 1,
+    review_active_hunk: None,
   }
 }
 

--- a/desktop/frontend/fileeditor/review_progress_wbtest.mbt
+++ b/desktop/frontend/fileeditor/review_progress_wbtest.mbt
@@ -20,111 +20,156 @@ fn review_progress_state() -> (State, Ctx, ChangedFile) raise {
 }
 
 ///|
-test "review progress toggles only the active exact change" {
-  let (state, ctx, selected) = review_progress_state()
-  let (_, reviewed) = update(test_emit(), ToggleReviewProgress, state, ctx)
-  assert_true(reviewed.reviewed_changes == [selected])
-  let (_, unreviewed) = update(test_emit(), ToggleReviewProgress, reviewed, ctx)
-  assert_true(unreviewed.reviewed_changes.is_empty())
-
-  let ordinary_docs = state.docs.copy()
-  ordinary_docs[selected.path] = {
-    ..ordinary_docs.get(selected.path).unwrap(),
-    review: None,
-  }
-  let ordinary = { ..state, docs: ordinary_docs, }
-  let (_, unchanged) = update(test_emit(), ToggleReviewProgress, ordinary, ctx)
-  assert_true(unchanged == ordinary)
+fn review_test_hunk(
+  old_start : Int,
+  old_end : Int,
+  new_start : Int,
+  new_end : Int,
+) -> ReviewHunk {
+  ReviewHunk(
+    old_ranges=if old_start < old_end {
+      [@common.LineRange(old_start, old_end)]
+    } else {
+      []
+    },
+    new_ranges=if new_start < new_end {
+      [@common.LineRange(new_start, new_end)]
+    } else {
+      []
+    },
+  )
 }
 
 ///|
-test "a final changes refresh invalidates progress when the row changes" {
-  let (state, ctx, selected) = review_progress_state()
-  let (_, reviewed) = update(test_emit(), ToggleReviewProgress, state, ctx)
-  let changed_again = { ..selected, index_status: "M", worktree_status: " ", }
-  let refreshing = {
-    ..reviewed,
-    changes: ChangeListReady(
-      repository=true,
-      files=[selected],
-      refreshing=true,
-      refresh_again=false,
-    ),
-  }
-  let (_, settled) = update(
+fn activate_review_hunk(
+  state : State,
+  ctx : Ctx,
+  selected : ChangedFile,
+  hunk : ReviewHunk,
+) -> State {
+  update(
     test_emit(),
-    ChangesLoaded(
-      owner=ctx.owner,
-      generation=refreshing.changes_generation,
-      repository=true,
-      head=None,
-      files=[changed_again],
+    ReviewActiveHunkChanged(
+      change=selected,
+      review_generation=1,
+      hunk=Some(hunk),
     ),
-    refreshing,
+    state,
     ctx,
-  )
-  assert_true(settled.reviewed_changes.is_empty())
-
-  let same_row_refresh = {
-    ..reviewed,
-    changes: ChangeListReady(
-      repository=true,
-      files=[selected],
-      refreshing=true,
-      refresh_again=false,
-    ),
-    changes_head: Some("old-head"),
-    changes_head_known: true,
-  }
-  let (_, moved_head) = update(
-    test_emit(),
-    ChangesLoaded(
-      owner=ctx.owner,
-      generation=same_row_refresh.changes_generation,
-      repository=true,
-      head=Some("new-head"),
-      files=[selected],
-    ),
-    same_row_refresh,
-    ctx,
-  )
-  assert_true(moved_head.reviewed_changes.is_empty())
+  ).1
 }
 
 ///|
-test "file events and run completion invalidate stale review progress" {
+test "review hunk normalizes unions and subtraction" {
+  let coverage = ReviewHunk(
+    old_ranges=[
+      @common.LineRange(4, 7),
+      @common.LineRange(1, 3),
+      @common.LineRange(3, 5),
+      @common.LineRange(8, 8),
+    ],
+    new_ranges=[@common.LineRange(10, 13)],
+  )
+  assert_eq(coverage.old_ranges, [@common.LineRange(1, 7)])
+  let removed = ReviewHunk(old_ranges=[@common.LineRange(2, 4)], new_ranges=[
+    @common.LineRange(11, 12),
+  ])
+  let retained = coverage.subtract(removed)
+  assert_eq(retained.old_ranges, [
+    @common.LineRange(1, 2),
+    @common.LineRange(4, 7),
+  ])
+  assert_eq(retained.new_ranges, [
+    @common.LineRange(10, 11),
+    @common.LineRange(12, 13),
+  ])
+  assert_true(retained.union(removed) == coverage)
+}
+
+///|
+test "hunk toggles keep partial and one-sided coverage without completing file" {
   let (state, ctx, selected) = review_progress_state()
-  let (_, reviewed) = update(test_emit(), ToggleReviewProgress, state, ctx)
-  let (_, unrelated) = update(
+  let inserted = review_test_hunk(1, 1, 3, 5)
+  let deleted = review_test_hunk(8, 10, 1, 1)
+  let inserted_active = activate_review_hunk(state, ctx, selected, inserted)
+  let (_, inserted_viewed) = update(
     test_emit(),
-    FsChanged(
-      root=ctx.test_root(),
-      generation=ctx.watch_identity(state.watch_generation),
-      changes=Some([Modified(@pathx.Relative("README.md"))]),
-    ),
-    reviewed,
+    ToggleActiveReviewHunk,
+    inserted_active,
     ctx,
   )
-  assert_true(unrelated.reviewed_changes == [selected])
+  assert_true(
+    inserted_viewed.review_hunk_state(selected, inserted) is ReviewHunkViewed,
+  )
+  let deleted_active = activate_review_hunk(
+    inserted_viewed, ctx, selected, deleted,
+  )
+  let (_, both_viewed) = update(
+    test_emit(),
+    ToggleActiveReviewHunk,
+    deleted_active,
+    ctx,
+  )
+  assert_true(
+    both_viewed.review_hunk_state(selected, deleted) is ReviewHunkViewed,
+  )
+  assert_true(
+    both_viewed.changed_file_review_state(selected) is ReviewInProgress,
+  )
+  let overlapping = ReviewHunk(old_ranges=[@common.LineRange(9, 12)], new_ranges=[])
+  assert_true(
+    both_viewed.review_hunk_state(selected, overlapping) is ReviewHunkPartial,
+  )
 
-  let (_, touched) = update(
+  let (_, complete) = update(
     test_emit(),
-    FsChanged(
-      root=ctx.test_root(),
-      generation=ctx.watch_identity(state.watch_generation),
-      changes=Some([Modified(selected.path)]),
-    ),
-    unrelated,
+    ToggleReviewProgress,
+    both_viewed,
     ctx,
   )
-  assert_true(touched.reviewed_changes.is_empty())
+  let (_, unchanged) = update(
+    test_emit(),
+    ToggleActiveReviewHunk,
+    complete,
+    ctx,
+  )
+  assert_true(unchanged == complete)
+}
 
-  let (_, remarked) = update(test_emit(), ToggleReviewProgress, touched, ctx)
-  let (_, settled) = update(
+///|
+test "active hunk requires the exact changed row and review generation" {
+  let (state, ctx, selected) = review_progress_state()
+  let hunk = review_test_hunk(2, 4, 2, 4)
+  let (_, stale_generation) = update(
     test_emit(),
-    RunSettled(owner=ctx.owner),
-    remarked,
+    ReviewActiveHunkChanged(
+      change=selected,
+      review_generation=0,
+      hunk=Some(hunk),
+    ),
+    state,
     ctx,
   )
-  assert_true(settled.reviewed_changes.is_empty())
+  assert_true(stale_generation.review_active_hunk is None)
+  let other = { ..selected, index_status: "M", worktree_status: " ", }
+  let (_, stale_row) = update(
+    test_emit(),
+    ReviewActiveHunkChanged(change=other, review_generation=1, hunk=Some(hunk)),
+    state,
+    ctx,
+  )
+  assert_true(stale_row.review_active_hunk is None)
+  let inactive_ctx = {
+    ..ctx,
+    active_file: Some(@pathx.Relative("src/other.mbt")),
+  }
+  let inactive = activate_review_hunk(state, inactive_ctx, selected, hunk)
+  assert_true(inactive.review_active_hunk is None)
+  let current = activate_review_hunk(state, ctx, selected, hunk)
+  assert_true(
+    current.active_review_hunk(ctx.active_file)
+    is Some({ change, review_generation: 1, hunk: current_hunk, }) &&
+    change == selected &&
+    current_hunk == hunk,
+  )
 }

--- a/desktop/frontend/fileeditor/review_progress_wbtest.mbt
+++ b/desktop/frontend/fileeditor/review_progress_wbtest.mbt
@@ -46,6 +46,9 @@ fn activate_review_hunk(
   ctx : Ctx,
   selected : ChangedFile,
   hunk : ReviewHunk,
+  file_changes : ReviewHunk,
+  index : Int,
+  total : Int,
 ) -> State {
   update(
     test_emit(),
@@ -53,6 +56,8 @@ fn activate_review_hunk(
       change=selected,
       review_generation=1,
       hunk=Some(hunk),
+      file_changes=Some(file_changes),
+      position=ReviewHunkPosition::from_zero_based(Some(index), total),
     ),
     state,
     ctx,
@@ -87,11 +92,14 @@ test "review hunk normalizes unions and subtraction" {
 }
 
 ///|
-test "hunk toggles keep partial and one-sided coverage without completing file" {
+test "hunk and file review progress stay linked in both directions" {
   let (state, ctx, selected) = review_progress_state()
   let inserted = review_test_hunk(1, 1, 3, 5)
   let deleted = review_test_hunk(8, 10, 1, 1)
-  let inserted_active = activate_review_hunk(state, ctx, selected, inserted)
+  let file_changes = inserted.union(deleted)
+  let inserted_active = activate_review_hunk(
+    state, ctx, selected, inserted, file_changes, 0, 2,
+  )
   let (_, inserted_viewed) = update(
     test_emit(),
     ToggleActiveReviewHunk,
@@ -102,7 +110,7 @@ test "hunk toggles keep partial and one-sided coverage without completing file" 
     inserted_viewed.review_hunk_state(selected, inserted) is ReviewHunkViewed,
   )
   let deleted_active = activate_review_hunk(
-    inserted_viewed, ctx, selected, deleted,
+    inserted_viewed, ctx, selected, deleted, file_changes, 1, 2,
   )
   let (_, both_viewed) = update(
     test_emit(),
@@ -113,39 +121,76 @@ test "hunk toggles keep partial and one-sided coverage without completing file" 
   assert_true(
     both_viewed.review_hunk_state(selected, deleted) is ReviewHunkViewed,
   )
+  assert_true(both_viewed.changed_file_review_state(selected) is ReviewComplete)
   assert_true(
-    both_viewed.changed_file_review_state(selected) is ReviewInProgress,
+    both_viewed.review_hunk_state(selected, inserted) is ReviewHunkViewed,
+  )
+
+  let inserted_active = activate_review_hunk(
+    both_viewed, ctx, selected, inserted, file_changes, 0, 2,
+  )
+  let (_, one_unviewed) = update(
+    test_emit(),
+    ToggleActiveReviewHunk,
+    inserted_active,
+    ctx,
+  )
+  assert_true(
+    one_unviewed.changed_file_review_state(selected) is ReviewInProgress,
+  )
+  assert_true(
+    one_unviewed.review_hunk_state(selected, inserted) is ReviewHunkUnviewed,
+  )
+  assert_true(
+    one_unviewed.review_hunk_state(selected, deleted) is ReviewHunkViewed,
   )
   let overlapping = ReviewHunk(old_ranges=[@common.LineRange(9, 12)], new_ranges=[])
   assert_true(
-    both_viewed.review_hunk_state(selected, overlapping) is ReviewHunkPartial,
+    one_unviewed.review_hunk_state(selected, overlapping) is ReviewHunkPartial,
   )
 
-  let (_, complete) = update(
+  let (_, file_complete) = update(
     test_emit(),
     ToggleReviewProgress,
-    both_viewed,
+    one_unviewed,
     ctx,
   )
-  let (_, unchanged) = update(
+  assert_true(
+    file_complete.review_hunk_state(selected, inserted) is ReviewHunkViewed,
+  )
+  assert_true(
+    file_complete.review_hunk_state(selected, deleted) is ReviewHunkViewed,
+  )
+  let (_, file_unviewed) = update(
     test_emit(),
-    ToggleActiveReviewHunk,
-    complete,
+    ToggleReviewProgress,
+    file_complete,
     ctx,
   )
-  assert_true(unchanged == complete)
+  assert_true(
+    file_unviewed.changed_file_review_state(selected) is ReviewUnviewed,
+  )
+  assert_true(
+    file_unviewed.review_hunk_state(selected, inserted) is ReviewHunkUnviewed,
+  )
+  assert_true(
+    file_unviewed.review_hunk_state(selected, deleted) is ReviewHunkUnviewed,
+  )
 }
 
 ///|
 test "active hunk requires the exact changed row and review generation" {
   let (state, ctx, selected) = review_progress_state()
   let hunk = review_test_hunk(2, 4, 2, 4)
+  let position = ReviewHunkPosition::from_zero_based(Some(0), 1)
   let (_, stale_generation) = update(
     test_emit(),
     ReviewActiveHunkChanged(
       change=selected,
       review_generation=0,
       hunk=Some(hunk),
+      file_changes=Some(hunk),
+      position~,
     ),
     state,
     ctx,
@@ -154,7 +199,13 @@ test "active hunk requires the exact changed row and review generation" {
   let other = { ..selected, index_status: "M", worktree_status: " ", }
   let (_, stale_row) = update(
     test_emit(),
-    ReviewActiveHunkChanged(change=other, review_generation=1, hunk=Some(hunk)),
+    ReviewActiveHunkChanged(
+      change=other,
+      review_generation=1,
+      hunk=Some(hunk),
+      file_changes=Some(hunk),
+      position~,
+    ),
     state,
     ctx,
   )
@@ -163,13 +214,26 @@ test "active hunk requires the exact changed row and review generation" {
     ..ctx,
     active_file: Some(@pathx.Relative("src/other.mbt")),
   }
-  let inactive = activate_review_hunk(state, inactive_ctx, selected, hunk)
+  let inactive = activate_review_hunk(
+    state, inactive_ctx, selected, hunk, hunk, 0, 1,
+  )
   assert_true(inactive.review_active_hunk is None)
-  let current = activate_review_hunk(state, ctx, selected, hunk)
+  let current = activate_review_hunk(state, ctx, selected, hunk, hunk, 0, 1)
   assert_true(
     current.active_review_hunk(ctx.active_file)
-    is Some({ change, review_generation: 1, hunk: current_hunk, }) &&
+    is Some(
+      {
+        change,
+        review_generation: 1,
+        hunk: current_hunk,
+        file_changes: Some(current_file_changes),
+        position: Some(current_position),
+      }
+    ) &&
     change == selected &&
-    current_hunk == hunk,
+    current_hunk == hunk &&
+    current_file_changes == hunk &&
+    current_position.current == 1 &&
+    current_position.total == 1,
   )
 }

--- a/desktop/frontend/fileeditor/review_progress_wbtest.mbt
+++ b/desktop/frontend/fileeditor/review_progress_wbtest.mbt
@@ -55,6 +55,7 @@ fn activate_review_hunk(
     ReviewActiveHunkChanged(
       change=selected,
       review_generation=1,
+      surface_generation=state.review_hunk_surface_generation,
       hunk=Some(hunk),
       file_changes=Some(file_changes),
       position=ReviewHunkPosition::from_zero_based(Some(index), total),
@@ -179,7 +180,7 @@ test "hunk and file review progress stay linked in both directions" {
 }
 
 ///|
-test "active hunk requires the exact changed row and review generation" {
+test "active hunk requires exact row, diff generation, and surface generation" {
   let (state, ctx, selected) = review_progress_state()
   let hunk = review_test_hunk(2, 4, 2, 4)
   let position = ReviewHunkPosition::from_zero_based(Some(0), 1)
@@ -188,6 +189,7 @@ test "active hunk requires the exact changed row and review generation" {
     ReviewActiveHunkChanged(
       change=selected,
       review_generation=0,
+      surface_generation=state.review_hunk_surface_generation,
       hunk=Some(hunk),
       file_changes=Some(hunk),
       position~,
@@ -202,6 +204,7 @@ test "active hunk requires the exact changed row and review generation" {
     ReviewActiveHunkChanged(
       change=other,
       review_generation=1,
+      surface_generation=state.review_hunk_surface_generation,
       hunk=Some(hunk),
       file_changes=Some(hunk),
       position~,
@@ -219,21 +222,51 @@ test "active hunk requires the exact changed row and review generation" {
   )
   assert_true(inactive.review_active_hunk is None)
   let current = activate_review_hunk(state, ctx, selected, hunk, hunk, 0, 1)
+  let surface_generation = state.review_hunk_surface_generation
   assert_true(
     current.active_review_hunk(ctx.active_file)
     is Some(
       {
         change,
         review_generation: 1,
+        surface_generation: active_surface_generation,
         hunk: current_hunk,
         file_changes: Some(current_file_changes),
         position: Some(current_position),
       }
     ) &&
     change == selected &&
+    active_surface_generation == surface_generation &&
     current_hunk == hunk &&
     current_file_changes == hunk &&
     current_position.current == 1 &&
     current_position.total == 1,
   )
+  let (_, token_surface) = update(
+    test_emit(),
+    ReviewDiffModeSelected(ReviewDiffToken),
+    current,
+    ctx,
+  )
+  let (_, line_surface) = update(
+    test_emit(),
+    ReviewDiffModeSelected(ReviewDiffLine),
+    token_surface,
+    ctx,
+  )
+  assert_eq(line_surface.review_hunk_surface_generation, surface_generation + 2)
+  let (_, late_surface) = update(
+    test_emit(),
+    ReviewActiveHunkChanged(
+      change=selected,
+      review_generation=1,
+      surface_generation~,
+      hunk=Some(hunk),
+      file_changes=Some(hunk),
+      position~,
+    ),
+    line_surface,
+    ctx,
+  )
+  assert_true(late_surface.review_active_hunk is None)
 }

--- a/desktop/frontend/fileeditor/semantic_review_view.mbt
+++ b/desktop/frontend/fileeditor/semantic_review_view.mbt
@@ -106,6 +106,7 @@ fn State::sync_semantic_review(self : State, ctx : Ctx) -> State {
   if input == self.semantic_review_input {
     return self
   }
+  let self = self.invalidate_review_hunk_surface()
   let plan = input.bind(input => {
     @moon_diff_provider.compute_sectioned_semantic_review_plan(
       input.old_source,

--- a/desktop/frontend/fileeditor/semantic_review_view.mbt
+++ b/desktop/frontend/fileeditor/semantic_review_view.mbt
@@ -1527,6 +1527,7 @@ fn sync_semantic_review_editors(
       })
       guard state.semantic_review_input is Some(input) else {
         clear_semantic_review_editors()
+        sync_review_hunk_actions(state)
         return
       }
       let desired = semantic_sections(state.semantic_review_plan)
@@ -1608,6 +1609,7 @@ fn sync_semantic_review_editors(
           entry.editor.get_active_hunk_index(),
         )
       }
+      sync_review_hunk_actions(state)
       update_semantic_review_scroll_width()
       schedule_semantic_review_scroll_width_update()
     },

--- a/desktop/frontend/fileeditor/semantic_review_view.mbt
+++ b/desktop/frontend/fileeditor/semantic_review_view.mbt
@@ -496,12 +496,13 @@ fn semantic_review_navigation_sub_loader(
           @dom.document().get_element_by_id(SemanticReviewHostId).to_option()
           is Some(host) &&
           @base_browser.event_target_has_matching_ancestor(
-            event, host, ".semantic-diff-editor-host",
+            event, host, ".semantic-diff-entry",
           ) else {
           return
         }
-        // Capture runs before the child DiffEditor performs its own cyclic F7
-        // command, so exactly one aggregate MultiDiff navigation is emitted.
+        // Include section headers so F7 still works after collapsing the last
+        // editor. Capture precedes the child's cyclic F7 command, so exactly
+        // one aggregate MultiDiff navigation is emitted.
         event.prevent_default()
         event.stop_propagation()
         scheduler.add(
@@ -1384,10 +1385,9 @@ fn clear_semantic_review_editors() -> Unit {
 }
 
 ///|
-fn semantic_review_navigation_index(current : String?) -> Int {
-  guard current is Some(current) else { return 0 }
-  let index = semantic_review_order.search(current)
-  index.unwrap_or(0)
+fn semantic_review_navigation_index(current : String?) -> Int? {
+  guard current is Some(current) else { return None }
+  semantic_review_order.search(current)
 }
 
 ///|
@@ -1448,7 +1448,24 @@ fn navigate_semantic_review_change(
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     guard !semantic_review_order.is_empty() else { return }
-    let index = semantic_review_navigation_index(semantic_review_active_key.val)
+    guard semantic_review_navigation_index(semantic_review_active_key.val)
+      is Some(index) else {
+      // With every section collapsed there is no active editor. Enter at the
+      // boundary instead of treating the first section as already visited.
+      let target_index = match direction {
+        SemanticReviewPrevious => semantic_review_order.length() - 1
+        SemanticReviewNext => 0
+      }
+      scheduler.add(
+        dispatch(
+          RevealSemanticReviewSectionChange(
+            semantic_review_order[target_index],
+            direction is SemanticReviewPrevious,
+          ),
+        ),
+      )
+      return
+    }
     let current = semantic_review_order[index]
     if !collapsed.contains(current) &&
       semantic_review_editors.get(current) is Some(entry) {

--- a/desktop/frontend/fileeditor/semantic_review_view.mbt
+++ b/desktop/frontend/fileeditor/semantic_review_view.mbt
@@ -1251,6 +1251,7 @@ fn create_semantic_review_editor(
   // below and do not wait for these compatibility layout frames.
   let diff_subscription = editor.on_did_update_diff(() => {
     schedule_semantic_review_scroll_width_update()
+    publish_current_semantic_review_active_hunk(input)
   })
   let active_hunk_subscription = editor.on_did_change_active_hunk(active_index => {
     publish_semantic_review_active_hunk(
@@ -1386,6 +1387,44 @@ fn semantic_review_navigation_index(current : String?) -> Int {
   guard current is Some(current) else { return 0 }
   let index = semantic_review_order.search(current)
   index.unwrap_or(0)
+}
+
+///|
+fn semantic_review_hunk_position(
+  key : String,
+  active_index : Int?,
+) -> ReviewHunkPosition? {
+  guard active_index is Some(active_index) else { return None }
+  let mut current : Int? = None
+  let mut total = 0
+  for section_key in semantic_review_order {
+    let count = semantic_review_editors
+      .get(section_key)
+      .map(entry => entry.editor.get_hunks().length())
+      .unwrap_or(0)
+    if section_key == key && active_index >= 0 && active_index < count {
+      current = Some(total + active_index)
+    }
+    total += count
+  }
+  ReviewHunkPosition::from_zero_based(current, total)
+}
+
+///|
+fn publish_current_semantic_review_active_hunk(
+  input : SemanticReviewInput,
+) -> Unit {
+  guard semantic_review_active_key.val is Some(key) &&
+    semantic_review_editors.get(key) is Some(entry) else {
+    return
+  }
+  publish_semantic_review_active_hunk(
+    input,
+    key,
+    entry.editor,
+    entry.section,
+    entry.editor.get_active_hunk_index(),
+  )
 }
 
 ///|

--- a/desktop/frontend/fileeditor/semantic_review_view.mbt
+++ b/desktop/frontend/fileeditor/semantic_review_view.mbt
@@ -448,6 +448,7 @@ priv struct SemanticReviewEditorHost {
   editor : @viewer.DiffEditor
   provider : @moon_diff_provider.MoonFragmentDiffProvider?
   diff_subscription : @common.Disposable
+  active_hunk_subscription : @common.Disposable
   content_height_subscription : @common.Disposable
   navigation_reveal_subscription : @common.Disposable
   pending_navigation_reveal_generation : Ref[Int?]
@@ -1154,6 +1155,7 @@ fn schedule_semantic_review_scroll_width_update() -> Unit {
 fn dispose_semantic_review_editor(entry : SemanticReviewEditorHost) -> Unit {
   semantic_review_navigation_generation.val += 1
   entry.diff_subscription.dispose()
+  entry.active_hunk_subscription.dispose()
   entry.content_height_subscription.dispose()
   entry.pending_navigation_reveal_generation.val = None
   entry.navigation_reveal_subscription.dispose()
@@ -1250,6 +1252,11 @@ fn create_semantic_review_editor(
   let diff_subscription = editor.on_did_update_diff(() => {
     schedule_semantic_review_scroll_width_update()
   })
+  let active_hunk_subscription = editor.on_did_change_active_hunk(active_index => {
+    publish_semantic_review_active_hunk(
+      input, key, editor, section, active_index,
+    )
+  })
   // DiffEditor publishes only after the comment ViewZone and both panes'
   // derived alignment zones have committed. Resize synchronously in that same
   // geometry batch; a delayed retry would only hide a missing notification and
@@ -1268,6 +1275,13 @@ fn create_semantic_review_editor(
   })
   let focus_listener : @dom.Listener = _ => {
     semantic_review_active_key.val = Some(key)
+    publish_semantic_review_active_hunk(
+      input,
+      key,
+      editor,
+      section,
+      editor.get_active_hunk_index(),
+    )
   }
   host.add_event_listener("focusin", focus_listener)
   let focus_subscription = @common.Disposable::from(() => {
@@ -1301,6 +1315,7 @@ fn create_semantic_review_editor(
     editor,
     provider,
     diff_subscription,
+    active_hunk_subscription,
     content_height_subscription,
     navigation_reveal_subscription,
     pending_navigation_reveal_generation,
@@ -1460,20 +1475,33 @@ fn reveal_semantic_review_section_change(
 ///|
 /// Reconcile section widgets after Rabbita has committed their keyed hosts.
 /// Unchanged sections retain their editor models, selection, and scroll state.
-fn sync_semantic_review_editors(state : State) -> @cmd.Cmd {
+fn sync_semantic_review_editors(
+  dispatch : @cmd.Emit[Msg],
+  state : State,
+  active_file : @pathx.Relative?,
+) -> @cmd.Cmd {
   @cmd.custom_cmd(
-    _scheduler => {
+    scheduler => {
+      sync_review_hunk_bridge_target(state, active_file, msg => {
+        scheduler.add(dispatch(msg))
+      })
       guard state.semantic_review_input is Some(input) else {
         clear_semantic_review_editors()
         return
       }
       let desired = semantic_sections(state.semantic_review_plan)
       let desired_keys = desired.map(section => section.key)
+      let visible_keys = desired_keys.filter(key => {
+        !state.semantic_review_collapsed.contains(key)
+      })
       semantic_review_order.clear()
       semantic_review_order.append(desired_keys)
       if semantic_review_active_key.val is Some(key) &&
-        !desired_keys.contains(key) {
+        !visible_keys.contains(key) {
         semantic_review_active_key.val = None
+      }
+      if semantic_review_active_key.val is None && !visible_keys.is_empty() {
+        semantic_review_active_key.val = Some(visible_keys[0])
       }
       let stale = semantic_review_editors
         .to_array()
@@ -1529,6 +1557,16 @@ fn sync_semantic_review_editors(state : State) -> @cmd.Cmd {
           is Some(entry) {
           semantic_review_editors[key] = entry
         }
+      }
+      if semantic_review_active_key.val is Some(key) &&
+        semantic_review_editors.get(key) is Some(entry) {
+        publish_semantic_review_active_hunk(
+          input,
+          key,
+          entry.editor,
+          entry.section,
+          entry.editor.get_active_hunk_index(),
+        )
       }
       update_semantic_review_scroll_width()
       schedule_semantic_review_scroll_width_update()

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -956,6 +956,14 @@ pub(all) enum Msg {
     position~ : ReviewHunkPosition?
   )
   ToggleActiveReviewHunk
+  ToggleReviewHunk(
+    change~ : ChangedFile,
+    review_generation~ : Int,
+    surface_generation~ : Int,
+    hunk~ : ReviewHunk,
+    file_changes~ : ReviewHunk?,
+    position~ : ReviewHunkPosition?
+  )
   // One `git.original_file` request settled. `path` is always the current
   // changed path (the dock/document key), even when the host read its rename
   // source from `original_path`.

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -472,8 +472,13 @@ pub(all) struct State {
   // Exact changed rows and their shared Line/Token/Tree review coverage.
   // Complete may come from the file control or full hunk coverage.
   review_progress : Array[ChangedFileReview]
+  // Monotonic identity of the visible hunk surface. Mode, filter, collapse,
+  // source/diff, and document transitions advance it so a callback queued by
+  // an older surface cannot restore its active hunk after the transition.
+  review_hunk_surface_generation : Int
   // Only the currently focused or navigated hunk is retained for the toolbar.
-  // Its exact row and review generation fence callbacks from older inputs.
+  // Its exact row, diff generation, and surface generation fence callbacks
+  // from older inputs.
   review_active_hunk : ReviewActiveHunk?
   // Monotonic request token retained across conversation re-roots and advanced
   // across same-owner placement changes. Owner plus this generation rejects an
@@ -595,6 +600,7 @@ pub fn State::empty() -> State {
     history_docs: Map([]),
     history_generation: 0,
     review_progress: [],
+    review_hunk_surface_generation: 0,
     review_active_hunk: None,
     changes_generation: 0,
     request_epoch: 0,
@@ -940,10 +946,11 @@ pub(all) enum Msg {
     message~ : String
   )
   // The visible DiffEditor publishes only its current projected hunk. The
-  // reducer validates both exact row identity and review generation.
+  // reducer validates exact row, diff generation, and surface generation.
   ReviewActiveHunkChanged(
     change~ : ChangedFile,
     review_generation~ : Int,
+    surface_generation~ : Int,
     hunk~ : ReviewHunk?,
     file_changes~ : ReviewHunk?,
     position~ : ReviewHunkPosition?

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -469,10 +469,12 @@ pub(all) struct State {
   // watcher/LSP projections. Keys combine commit and current path.
   history_docs : Map[String, HistoryDiffDoc]
   history_generation : Int
-  // Exact changed rows the user has marked reviewed in the current checkout.
-  // Watcher events and run boundaries invalidate affected progress; a final
-  // Git refresh also drops rows whose status or rename identity changed.
-  reviewed_changes : Array[ChangedFile]
+  // Exact changed rows and their shared Line/Token/Tree review coverage.
+  // Complete is an explicit file-level decision; hunk toggles stay partial.
+  review_progress : Array[ChangedFileReview]
+  // Only the currently focused or navigated hunk is retained for the toolbar.
+  // Its exact row and review generation fence callbacks from older inputs.
+  review_active_hunk : ReviewActiveHunk?
   // Monotonic request token retained across conversation re-roots and advanced
   // across same-owner placement changes. Owner plus this generation rejects an
   // old A→B→A reply or one from an earlier checkout incarnation.
@@ -592,7 +594,8 @@ pub fn State::empty() -> State {
     git_graph_collapsed: false,
     history_docs: Map([]),
     history_generation: 0,
-    reviewed_changes: [],
+    review_progress: [],
+    review_active_hunk: None,
     changes_generation: 0,
     request_epoch: 0,
     file_link_generation: 0,
@@ -936,6 +939,14 @@ pub(all) enum Msg {
     generation~ : Int,
     message~ : String
   )
+  // The visible DiffEditor publishes only its current projected hunk. The
+  // reducer validates both exact row identity and review generation.
+  ReviewActiveHunkChanged(
+    change~ : ChangedFile,
+    review_generation~ : Int,
+    hunk~ : ReviewHunk?
+  )
+  ToggleActiveReviewHunk
   // One `git.original_file` request settled. `path` is always the current
   // changed path (the dock/document key), even when the host read its rename
   // source from `original_path`.

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -470,7 +470,7 @@ pub(all) struct State {
   history_docs : Map[String, HistoryDiffDoc]
   history_generation : Int
   // Exact changed rows and their shared Line/Token/Tree review coverage.
-  // Complete is an explicit file-level decision; hunk toggles stay partial.
+  // Complete may come from the file control or full hunk coverage.
   review_progress : Array[ChangedFileReview]
   // Only the currently focused or navigated hunk is retained for the toolbar.
   // Its exact row and review generation fence callbacks from older inputs.
@@ -944,7 +944,9 @@ pub(all) enum Msg {
   ReviewActiveHunkChanged(
     change~ : ChangedFile,
     review_generation~ : Int,
-    hunk~ : ReviewHunk?
+    hunk~ : ReviewHunk?,
+    file_changes~ : ReviewHunk?,
+    position~ : ReviewHunkPosition?
   )
   ToggleActiveReviewHunk
   // One `git.original_file` request settled. `path` is always the current

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -2638,6 +2638,30 @@ pub fn update(
           ctx.active_file,
         ),
       )
+    ToggleReviewHunk(
+      change~,
+      review_generation~,
+      surface_generation~,
+      hunk~,
+      file_changes~,
+      position~
+    ) => {
+      guard state.current_review_generation(change, ctx.active_file) ==
+        Some(review_generation) &&
+        state.review_hunk_surface_generation == surface_generation else {
+        return (@cmd.none, state)
+      }
+      let next = state.accept_active_review_hunk(
+        change,
+        review_generation,
+        surface_generation,
+        Some(hunk),
+        file_changes,
+        position,
+        ctx.active_file,
+      )
+      (@cmd.none, next.toggle_active_review_hunk(ctx.active_file))
+    }
     ToggleActiveReviewHunk =>
       (@cmd.none, state.toggle_active_review_hunk(ctx.active_file))
     Search(msg) => {

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -2607,13 +2607,21 @@ pub fn update(
       }
       (@cmd.none, next)
     }
-    ReviewActiveHunkChanged(change~, review_generation~, hunk~) =>
+    ReviewActiveHunkChanged(
+      change~,
+      review_generation~,
+      hunk~,
+      file_changes~,
+      position~
+    ) =>
       (
         @cmd.none,
         state.accept_active_review_hunk(
           change,
           review_generation,
           hunk,
+          file_changes,
+          position,
           ctx.active_file,
         ),
       )

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -401,7 +401,7 @@ pub fn open_document(
   had_active~ : Bool,
 ) -> (@cmd.Cmd, State) {
   guard ctx.placement_ready() else { return (@cmd.none, state) }
-  let state = { ..state.clear_review_active_hunk(), highlighted: None, }
+  let state = { ..state.invalidate_review_hunk_surface(), highlighted: None, }
   // Opening the path from Files, Quick Open, navigation, or a mention leaves
   // review mode. If the same Viewer model stays attached, the show below
   // clears its resource-keyed quick-diff baseline without replacing content.
@@ -538,8 +538,19 @@ pub fn open_changed_document(
   guard ctx.placement_ready() && change.selectable() else {
     return (@cmd.none, state)
   }
-  let state = { ..state.clear_review_active_hunk(), highlighted: None, }
   let path = change.path
+  let reusing_exact_review = state.docs
+    .get(path)
+    .map(doc => doc.review is Some({ selected, .. }) && selected == change)
+    .unwrap_or(false)
+  let state = {
+    ..(if reusing_exact_review {
+      state.clear_review_active_hunk()
+    } else {
+      state.invalidate_review_hunk_surface()
+    }),
+    highlighted: None,
+  }
   // Selecting a Changes row is activation, not a manual reload. Reuse the
   // exact cached review (including one whose paired reads are still pending)
   // so repeated clicks cannot replace its generation, clear its DiffEditor
@@ -1057,7 +1068,7 @@ pub fn activate(
   guard ctx.placement_ready() && state.docs.get(path) is Some(doc) else {
     return (@cmd.none, state)
   }
-  let state = { ..state.clear_review_active_hunk(), highlighted: None, }
+  let state = { ..state.invalidate_review_hunk_surface(), highlighted: None, }
   let (show, doc, review_generation) = show_activated_tab(
     dispatch,
     ctx,
@@ -2326,7 +2337,7 @@ fn select_review_view_mode(
   }
   (
     command,
-    { ..state, docs, review_view_mode: view_mode, }.clear_review_active_hunk(),
+    { ..state, docs, review_view_mode: view_mode, }.invalidate_review_hunk_surface(),
   )
 }
 
@@ -2474,7 +2485,7 @@ pub fn update(
     ReviewDiffModeSelected(mode) => {
       guard moon_diff_available(state, ctx) else { return (@cmd.none, state) }
       let selected = {
-        ..state.clear_review_active_hunk(),
+        ..state.invalidate_review_hunk_surface(),
         review_diff_mode: mode,
       }
       if ctx.active_file is Some(path) &&
@@ -2500,7 +2511,7 @@ pub fn update(
       (
         @cmd.none,
         {
-          ..state.clear_review_active_hunk(),
+          ..state.invalidate_review_hunk_surface(),
           review_diff_ignore_comments: ignore_comments,
         },
       )
@@ -2514,7 +2525,7 @@ pub fn update(
       (
         @cmd.none,
         {
-          ..state.clear_review_active_hunk(),
+          ..state.invalidate_review_hunk_surface(),
           review_diff_ignore_tests: ignore_tests,
         },
       )
@@ -2536,7 +2547,7 @@ pub fn update(
       }
       (
         @cmd.none,
-        { ..state.clear_review_active_hunk(), semantic_review_collapsed, },
+        { ..state.invalidate_review_hunk_surface(), semantic_review_collapsed, },
       )
     }
     ReviewDiffNavigationAvailabilityChanged(available) =>
@@ -2610,6 +2621,7 @@ pub fn update(
     ReviewActiveHunkChanged(
       change~,
       review_generation~,
+      surface_generation~,
       hunk~,
       file_changes~,
       position~
@@ -2619,6 +2631,7 @@ pub fn update(
         state.accept_active_review_hunk(
           change,
           review_generation,
+          surface_generation,
           hunk,
           file_changes,
           position,

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -401,7 +401,7 @@ pub fn open_document(
   had_active~ : Bool,
 ) -> (@cmd.Cmd, State) {
   guard ctx.placement_ready() else { return (@cmd.none, state) }
-  let state = { ..state, highlighted: None, }
+  let state = { ..state.clear_review_active_hunk(), highlighted: None, }
   // Opening the path from Files, Quick Open, navigation, or a mention leaves
   // review mode. If the same Viewer model stays attached, the show below
   // clears its resource-keyed quick-diff baseline without replacing content.
@@ -538,7 +538,7 @@ pub fn open_changed_document(
   guard ctx.placement_ready() && change.selectable() else {
     return (@cmd.none, state)
   }
-  let state = { ..state, highlighted: None, }
+  let state = { ..state.clear_review_active_hunk(), highlighted: None, }
   let path = change.path
   // Selecting a Changes row is activation, not a manual reload. Reuse the
   // exact cached review (including one whose paired reads are still pending)
@@ -1057,7 +1057,7 @@ pub fn activate(
   guard ctx.placement_ready() && state.docs.get(path) is Some(doc) else {
     return (@cmd.none, state)
   }
-  let state = { ..state, highlighted: None, }
+  let state = { ..state.clear_review_active_hunk(), highlighted: None, }
   let (show, doc, review_generation) = show_activated_tab(
     dispatch,
     ctx,
@@ -2247,7 +2247,7 @@ pub fn sync(
     graph_cmd,
     history_cmd,
     package_graph_cmd,
-    sync_semantic_review_editors(state),
+    sync_semantic_review_editors(dispatch, state, ctx.active_file),
   ])
   // A closed panel re-roots (above) and keeps the watcher placed, but the tree
   // itself can wait for the reopen. Unresolved placement takes the same early
@@ -2324,7 +2324,10 @@ fn select_review_view_mode(
     ReviewSource => @cmd.batch([show, request_viewer_remeasure()])
     ReviewDiff => show
   }
-  (command, { ..state, docs, review_view_mode: view_mode, })
+  (
+    command,
+    { ..state, docs, review_view_mode: view_mode, }.clear_review_active_hunk(),
+  )
 }
 
 ///|
@@ -2470,7 +2473,10 @@ pub fn update(
     }
     ReviewDiffModeSelected(mode) => {
       guard moon_diff_available(state, ctx) else { return (@cmd.none, state) }
-      let selected = { ..state, review_diff_mode: mode, }
+      let selected = {
+        ..state.clear_review_active_hunk(),
+        review_diff_mode: mode,
+      }
       if ctx.active_file is Some(path) &&
         state.docs.get(path)
         is Some({ review: Some({ view_mode: ReviewSource, .. }), .. }) {
@@ -2491,7 +2497,13 @@ pub fn update(
         return (@cmd.none, state)
       }
       let ignore_comments = !state.review_diff_ignore_comments
-      (@cmd.none, { ..state, review_diff_ignore_comments: ignore_comments, })
+      (
+        @cmd.none,
+        {
+          ..state.clear_review_active_hunk(),
+          review_diff_ignore_comments: ignore_comments,
+        },
+      )
     }
     ToggleReviewDiffIgnoreTests => {
       guard moon_diff_ready(state, ctx) &&
@@ -2499,7 +2511,13 @@ pub fn update(
         return (@cmd.none, state)
       }
       let ignore_tests = !state.review_diff_ignore_tests
-      (@cmd.none, { ..state, review_diff_ignore_tests: ignore_tests, })
+      (
+        @cmd.none,
+        {
+          ..state.clear_review_active_hunk(),
+          review_diff_ignore_tests: ignore_tests,
+        },
+      )
     }
     SemanticReviewSectionToggled(key) => {
       guard semantic_sections(state.semantic_review_plan).any(section => {
@@ -2516,7 +2534,10 @@ pub fn update(
         collapsed.push(key)
         collapsed
       }
-      (@cmd.none, { ..state, semantic_review_collapsed, })
+      (
+        @cmd.none,
+        { ..state.clear_review_active_hunk(), semantic_review_collapsed, },
+      )
     }
     ReviewDiffNavigationAvailabilityChanged(available) =>
       (@cmd.none, { ..state, review_diff_navigation_available: available, })
@@ -2576,15 +2597,28 @@ pub fn update(
         files.contains(review.selected) else {
         return (@cmd.none, state)
       }
-      let reviewed_changes = if state.reviewed_changes.contains(review.selected) {
-        state.reviewed_changes.filter(change => change != review.selected)
+      let next = if state.is_change_reviewed(review.selected) {
+        state.set_review_file_progress(review.selected, None)
       } else {
-        let reviewed_changes = state.reviewed_changes.copy()
-        reviewed_changes.push(review.selected)
-        reviewed_changes
+        state.set_review_file_progress(
+          review.selected,
+          Some(ReviewFileComplete),
+        )
       }
-      (@cmd.none, { ..state, reviewed_changes, })
+      (@cmd.none, next)
     }
+    ReviewActiveHunkChanged(change~, review_generation~, hunk~) =>
+      (
+        @cmd.none,
+        state.accept_active_review_hunk(
+          change,
+          review_generation,
+          hunk,
+          ctx.active_file,
+        ),
+      )
+    ToggleActiveReviewHunk =>
+      (@cmd.none, state.toggle_active_review_hunk(ctx.active_file))
     Search(msg) => {
       let search = state.search.handle(msg, ctx.search_input())
       let next = { ..state, search, }
@@ -3014,12 +3048,22 @@ pub fn update(
           @cmd.none
         }
         review_cmds.push(settle)
-        let reviewed_changes = if follow_up {
-          state.reviewed_changes
+        let review_progress = if follow_up {
+          state.review_progress
         } else if head_changed {
           []
         } else {
-          state.reviewed_changes.filter(change => files.contains(change))
+          state.review_progress.filter(entry => files.contains(entry.change))
+        }
+        let review_active_hunk = if follow_up {
+          state.review_active_hunk
+        } else if head_changed {
+          None
+        } else {
+          match state.review_active_hunk {
+            Some(active) if files.contains(active.change) => Some(active)
+            _ => None
+          }
         }
         (
           @cmd.batch(review_cmds),
@@ -3038,7 +3082,8 @@ pub fn update(
             },
             changes_generation: next_generation,
             review_generation,
-            reviewed_changes,
+            review_progress,
+            review_active_hunk,
             background_review_requests,
             review_recovery_pending: if follow_up {
               state.review_recovery_pending
@@ -3433,7 +3478,8 @@ pub fn update(
         }
         let state = {
           ..state,
-          reviewed_changes: [],
+          review_progress: [],
+          review_active_hunk: None,
           index,
           watching,
           // Agent runs can alter unopened package manifests outside the
@@ -3490,10 +3536,17 @@ pub fn update(
         ctx.root() is Some(ctx_root) &&
         ctx_root == root &&
         generation == ctx.watch_identity(state.watch_generation) {
-        let reviewed_changes = match changes {
+        let review_progress = match changes {
           Some(changes) =>
-            state.reviewed_changes.filter(change => !change.touched_by(changes))
-          None => state.reviewed_changes
+            state.review_progress.filter(entry => {
+              !entry.change.touched_by(changes)
+            })
+          None => state.review_progress
+        }
+        let review_active_hunk = match (state.review_active_hunk, changes) {
+          (Some(active), Some(changes)) if active.change.touched_by(changes) =>
+            None
+          (active, _) => active
         }
         // A baseline checks the whole selection after watcher replacement.
         // Concrete batches stat only affected open files (the dock strip's
@@ -3630,7 +3683,8 @@ pub fn update(
         let next = {
           ..state,
           loading,
-          reviewed_changes,
+          review_progress,
+          review_active_hunk,
           index,
           package_graphs,
         }

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -1475,7 +1475,7 @@ fn change_inventory(
       } else {
         let reviewable = files.filter(change => change.selectable())
         let reviewed = reviewable
-          .filter(change => state.reviewed_changes.contains(change))
+          .filter(change => state.is_change_reviewed(change))
           .length()
         let rows = [
           @html.div(
@@ -1522,9 +1522,9 @@ fn changed_file_row(
   index : Int,
 ) -> @html.Html {
   let selected = change.is_selected(state, ctx)
-  let reviewed = state.reviewed_changes.contains(change)
+  let progress = state.changed_file_review_state(change)
   let mut class = if selected { "change-row selected" } else { "change-row" }
-  if reviewed {
+  if progress is ReviewComplete {
     class += " reviewed"
   }
   if !change.selectable() {
@@ -1543,10 +1543,10 @@ fn changed_file_row(
         "change-action unavailable"
       },
       if change.selectable() {
-        if reviewed {
-          "✓ Reviewed"
-        } else {
-          "View diff"
+        match progress {
+          ReviewComplete => "✓ Reviewed"
+          ReviewInProgress => "◐ In progress"
+          ReviewUnviewed => "View diff"
         }
       } else {
         "Unavailable"
@@ -1877,6 +1877,7 @@ pub fn breadcrumb_view(
         review_comments_control(dispatch, state, ctx),
         review_tests_control(dispatch, state, ctx),
         review_diff_navigation(dispatch, state, ctx),
+        review_hunk_toggle(dispatch, state, ctx),
       ]),
     ]
     if state.highlighted is Some(directory) {
@@ -2370,6 +2371,71 @@ fn review_diff_navigation(
 }
 
 ///|
+fn review_hunk_toggle_button(
+  dispatch : @cmd.Emit[Msg],
+  hunk_state : ReviewHunkState,
+  file_complete : Bool,
+) -> @html.Html {
+  let viewed = hunk_state is ReviewHunkViewed
+  @html.button(
+    type_="button",
+    class=if viewed {
+      "review-badge review-progress reviewed"
+    } else {
+      "review-badge review-progress"
+    },
+    title=if file_complete {
+      "File is marked reviewed"
+    } else if viewed {
+      "Mark this hunk unviewed"
+    } else {
+      "Mark this hunk viewed"
+    },
+    disabled=file_complete,
+    on_click=dispatch(ToggleActiveReviewHunk),
+    attrs=@html.Attrs::build()
+      .aria_label(
+        if file_complete {
+          "Hunk viewed"
+        } else if viewed {
+          "Unmark hunk viewed"
+        } else {
+          "Mark hunk viewed"
+        },
+      )
+      .aria_pressed(
+        match hunk_state {
+          ReviewHunkUnviewed => "false"
+          ReviewHunkPartial => "mixed"
+          ReviewHunkViewed => "true"
+        },
+      ),
+    match hunk_state {
+      ReviewHunkUnviewed => "Mark viewed"
+      ReviewHunkPartial => "◐ Mark viewed"
+      ReviewHunkViewed => "✓ Viewed"
+    },
+  )
+}
+
+///|
+fn review_hunk_toggle(
+  dispatch : @cmd.Emit[Msg],
+  state : State,
+  ctx : Ctx,
+) -> @html.Html {
+  guard state.active_review_hunk(ctx.active_file) is Some(active) else {
+    return @html.nothing
+  }
+  let hunk_state = state.review_hunk_state(active.change, active.hunk)
+  review_hunk_toggle_button(
+    dispatch,
+    hunk_state,
+    state.is_change_reviewed(active.change),
+  )
+}
+
+///|
 /// Line keeps its two models mounted while Token/Tree reuse one section plan;
 /// this explicit pair changes either presentation. File mode preserves the
 /// preference but disables both choices until the next review reveal.
@@ -2666,13 +2732,14 @@ fn review_progress(
     files.contains(review.selected) else {
     return @html.span(class="review-badge hidden", "")
   }
-  let reviewed = state.reviewed_changes.contains(review.selected)
+  let progress = state.changed_file_review_state(review.selected)
+  let reviewed = progress is ReviewComplete
   @html.button(
     type_="button",
-    class=if reviewed {
-      "review-badge review-progress reviewed"
-    } else {
-      "review-badge review-progress"
+    class=match progress {
+      ReviewComplete => "review-badge review-progress reviewed"
+      ReviewInProgress => "review-badge review-progress"
+      ReviewUnviewed => "review-badge review-progress"
     },
     title=if reviewed {
       "Return this changed file to the review queue"
@@ -2681,12 +2748,24 @@ fn review_progress(
     },
     on_click=dispatch(ToggleReviewProgress),
     attrs=@html.Attrs::build()
-      .aria_label("Mark file reviewed")
-      .aria_pressed(reviewed.to_string()),
-    if reviewed {
-      "✓ Reviewed"
-    } else {
-      "Mark reviewed"
+      .aria_label(
+        if reviewed {
+          "Mark file unreviewed"
+        } else {
+          "Mark file reviewed"
+        },
+      )
+      .aria_pressed(
+        match progress {
+          ReviewComplete => "true"
+          ReviewInProgress => "mixed"
+          ReviewUnviewed => "false"
+        },
+      ),
+    match progress {
+      ReviewComplete => "✓ Reviewed"
+      ReviewInProgress => "◐ In progress"
+      ReviewUnviewed => "Mark reviewed"
     },
   )
 }

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -2336,37 +2336,54 @@ fn review_diff_navigation(
   }
   let enabled = full_diff_ready(state, ctx) &&
     review_diff_navigation_enabled(state, ctx)
+  let position = state
+    .active_review_hunk(ctx.active_file)
+    .bind(active => active.position)
+  let controls : Array[@html.Html] = [
+    @html.button(
+      type_="button",
+      class="review-nav-button",
+      title="Previous change (Shift+F7)",
+      disabled=!enabled,
+      on_click=dispatch(RevealPreviousReviewDiffChange),
+      attrs=@html.Attrs::build()
+        .data_set("action", "previous-diff-change")
+        .aria_label("Previous change")
+        .aria_keyshortcuts("Shift+F7"),
+      @icons.icon(@icons.icon_arrow_up),
+    ),
+  ]
+  if position is Some(position) {
+    controls.push(
+      @html.span(
+        class="review-hunk-position",
+        attrs=@html.Attrs::build()
+          .aria_label("Hunk \{position.current} of \{position.total}")
+          .aria_live("polite"),
+        "\{position.current} of \{position.total}",
+      ),
+    )
+  }
+  controls.push(
+    @html.button(
+      type_="button",
+      class="review-nav-button",
+      title="Next change (F7)",
+      disabled=!enabled,
+      on_click=dispatch(RevealNextReviewDiffChange),
+      attrs=@html.Attrs::build()
+        .data_set("action", "next-diff-change")
+        .aria_label("Next change")
+        .aria_keyshortcuts("F7"),
+      @icons.icon(@icons.icon_arrow_down),
+    ),
+  )
   @html.div(
     class="review-diff-navigation",
     attrs=@html.Attrs::build()
       .role("group")
       .aria_label("Diff change navigation"),
-    [
-      @html.button(
-        type_="button",
-        class="review-nav-button",
-        title="Previous change (Shift+F7)",
-        disabled=!enabled,
-        on_click=dispatch(RevealPreviousReviewDiffChange),
-        attrs=@html.Attrs::build()
-          .data_set("action", "previous-diff-change")
-          .aria_label("Previous change")
-          .aria_keyshortcuts("Shift+F7"),
-        @icons.icon(@icons.icon_arrow_up),
-      ),
-      @html.button(
-        type_="button",
-        class="review-nav-button",
-        title="Next change (F7)",
-        disabled=!enabled,
-        on_click=dispatch(RevealNextReviewDiffChange),
-        attrs=@html.Attrs::build()
-          .data_set("action", "next-diff-change")
-          .aria_label("Next change")
-          .aria_keyshortcuts("F7"),
-        @icons.icon(@icons.icon_arrow_down),
-      ),
-    ],
+    controls,
   )
 }
 
@@ -2374,7 +2391,7 @@ fn review_diff_navigation(
 fn review_hunk_toggle_button(
   dispatch : @cmd.Emit[Msg],
   hunk_state : ReviewHunkState,
-  file_complete : Bool,
+  disabled : Bool,
 ) -> @html.Html {
   let viewed = hunk_state is ReviewHunkViewed
   @html.button(
@@ -2384,18 +2401,18 @@ fn review_hunk_toggle_button(
     } else {
       "review-badge review-progress"
     },
-    title=if file_complete {
+    title=if disabled {
       "File is marked reviewed"
     } else if viewed {
       "Mark this hunk unviewed"
     } else {
       "Mark this hunk viewed"
     },
-    disabled=file_complete,
+    disabled~,
     on_click=dispatch(ToggleActiveReviewHunk),
     attrs=@html.Attrs::build()
       .aria_label(
-        if file_complete {
+        if disabled {
           "Hunk viewed"
         } else if viewed {
           "Unmark hunk viewed"
@@ -2431,7 +2448,7 @@ fn review_hunk_toggle(
   review_hunk_toggle_button(
     dispatch,
     hunk_state,
-    state.is_change_reviewed(active.change),
+    state.is_change_reviewed(active.change) && active.file_changes is None,
   )
 }
 

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -437,6 +437,7 @@ pub fn body_view(
           return @cmd.none
         }
         sync_semantic_review_scroll_left(element.get_scroll_left())
+        track_semantic_review_scroll(element)
         @cmd.none
       }),
     semantic_review,

--- a/desktop/styles/file_panel.css
+++ b/desktop/styles/file_panel.css
@@ -2836,3 +2836,10 @@ button.git-history-file.selected {
 .workflow-row-detail:empty {
   display: none;
 }
+
+.moonbit-diff-hunk-action .review-progress {
+  font-family: var(--font-family-sans);
+  font-size: var(--font-size-xs);
+  line-height: 16px;
+  padding: 1px 6px;
+}

--- a/desktop/styles/file_panel.css
+++ b/desktop/styles/file_panel.css
@@ -2837,9 +2837,28 @@ button.git-history-file.selected {
   display: none;
 }
 
-.moonbit-diff-hunk-action .review-progress {
+.moonbit-diff-hunk-action .review-hunk-marker {
   font-family: var(--font-family-sans);
-  font-size: var(--font-size-xs);
+  font-size: 13px;
   line-height: 16px;
-  padding: 1px 6px;
+  color: var(--color-text-muted);
+  border-color: var(--color-text-muted);
+}
+
+.moonbit-diff-hunk-action .review-hunk-marker:hover {
+  color: var(--color-text-primary);
+  border-color: var(--color-text-primary);
+  background: var(--color-control-surface);
+}
+
+.moonbit-diff-hunk-action .review-hunk-marker[aria-pressed="true"],
+.moonbit-diff-hunk-action .review-hunk-marker[aria-pressed="mixed"] {
+  color: var(--color-success);
+  border-color: var(--color-success);
+  background: color-mix(in srgb, var(--color-success) 10%, var(--color-bg-surface));
+}
+
+.moonbit-diff-hunk-action .review-hunk-marker:disabled {
+  cursor: default;
+  opacity: 0.5;
 }

--- a/desktop/styles/file_panel.css
+++ b/desktop/styles/file_panel.css
@@ -2291,7 +2291,8 @@ button.git-history-file.selected {
   cursor: default;
   opacity: 0.45;
 }
-.review-nav-position {
+.review-nav-position,
+.review-hunk-position {
   min-width: 38px;
   color: var(--color-text-faint);
   font-size: var(--font-size-xs);

--- a/editor/internal/shell/examples/embedded_viewer/main.mbt
+++ b/editor/internal/shell/examples/embedded_viewer/main.mbt
@@ -651,7 +651,9 @@ fn embed_diff_editor() -> @viewer.DiffEditor {
         Some(index => {
           let button = @rdom.document().create_element("button")
           button.set_attribute("type", "button")
-          button.set_inner_html("Hunk \{index + 1}")
+          button.set_inner_html("✓")
+          button.set_attribute("title", "Select hunk \{index + 1}")
+          button.set_attribute("aria-label", "Select hunk \{index + 1}")
           button.add_event_listener("click", _ => view.select_hunk(index))
           Some(button)
         }),

--- a/editor/internal/shell/examples/embedded_viewer/main.mbt
+++ b/editor/internal/shell/examples/embedded_viewer/main.mbt
@@ -647,6 +647,15 @@ fn embed_diff_editor() -> @viewer.DiffEditor {
         .to_option()
         .unwrap()
       let view = @viewer.DiffEditor::create(host)
+      view.set_hunk_action_renderer(
+        Some(index => {
+          let button = @rdom.document().create_element("button")
+          button.set_attribute("type", "button")
+          button.set_inner_html("Hunk \{index + 1}")
+          button.add_event_listener("click", _ => view.select_hunk(index))
+          Some(button)
+        }),
+      )
       embed_diff_editor_cell.val = Some(view)
       view
     }

--- a/editor/internal/viewer/diff_editor/diff_state.mbt
+++ b/editor/internal/viewer/diff_editor/diff_state.mbt
@@ -53,6 +53,14 @@ priv struct DiffNavigationTarget {
 }
 
 ///|
+/// One product-visible hunk. `members` retains only the provider's real changed
+/// mappings; `reveal_mapping` is the joined range used by F7/Shift+F7.
+pub(all) struct DiffHunk {
+  members : Array[@diff.DetailedLineRangeMapping]
+  priv reveal_mapping : @diff.DetailedLineRangeMapping
+}
+
+///|
 // Pinned behavior oracle: vscode@07c20d96cf3f2cbc8142ac7079ba9048cf7f6134,
 // `accessibleDiffViewer.ts::computeViewElementGroups`. Its three context lines
 // on each side merge adjacent mappings while the gap is strictly less than
@@ -60,31 +68,41 @@ priv struct DiffNavigationTarget {
 const DiffNavigationGroupLineMargin = 3
 
 ///|
-fn DiffState::navigation_changes(
-  self : DiffState,
-) -> Array[@diff.DetailedLineRangeMapping] {
-  let result : Array[@diff.DetailedLineRangeMapping] = []
+fn DiffState::hunks(self : DiffState) -> Array[DiffHunk] {
+  let result : Array[DiffHunk] = []
   for mapping in self.visible_mappings() {
     let change = mapping.line_range_mapping
     if result.is_empty() {
-      result.push(change)
+      result.push({ members: [change], reveal_mapping: change, })
       continue
     }
     let last_index = result.length() - 1
     let previous = result[last_index]
     if change.modified.start_line_number -
-      previous.modified.end_line_number_exclusive <
+      previous.reveal_mapping.modified.end_line_number_exclusive <
       2 * DiffNavigationGroupLineMargin {
-      result[last_index] = DetailedLineRangeMapping(
-        previous.original.join(change.original),
-        previous.modified.join(change.modified),
-        None,
-      )
+      let members = previous.members.copy()
+      members.push(change)
+      result[last_index] = {
+        members,
+        reveal_mapping: DetailedLineRangeMapping(
+          previous.reveal_mapping.original.join(change.original),
+          previous.reveal_mapping.modified.join(change.modified),
+          None,
+        ),
+      }
     } else {
-      result.push(change)
+      result.push({ members: [change], reveal_mapping: change, })
     }
   }
   result
+}
+
+///|
+fn DiffState::navigation_changes(
+  self : DiffState,
+) -> Array[@diff.DetailedLineRangeMapping] {
+  self.hunks().map(hunk => hunk.reveal_mapping)
 }
 
 ///|

--- a/editor/internal/viewer/diff_editor/diff_state_wbtest.mbt
+++ b/editor/internal/viewer/diff_editor/diff_state_wbtest.mbt
@@ -44,6 +44,16 @@ test "Accessible F7 groups mappings whose three-line contexts overlap" {
 }
 
 ///|
+test "product hunk members exclude unchanged joined gaps" {
+  let first = diff_state_test_change(2, 3, 2, 3)
+  let second = diff_state_test_change(7, 8, 7, 8)
+  let hunk = DiffState::from_diff_result({
+      changes: [DocumentDiffChange(first), DocumentDiffChange(second)],
+    }).hunks()[0]
+  assert_eq(hunk.members, [first, second])
+}
+
+///|
 test "Accessible F7 keeps mappings separate at an exact six-line gap" {
   let state = DiffState::from_diff_result({
     changes: [

--- a/editor/internal/viewer/diff_editor/editors.mbt
+++ b/editor/internal/viewer/diff_editor/editors.mbt
@@ -22,15 +22,16 @@ struct DiffEditorModelPairCommitBarrier {
 }
 
 ///|
-let diff_control_lane_reserved_px : Int = 16
+let diff_markdown_comment_lane_reserved_px : Int = 16
 
 ///|
-/// Diff panes never install the folding contribution, but Markdown-comment
-/// and feedback controls still need the ordinary editor's 16px control lane.
-/// Add that lane explicitly so caller folding settings cannot remove it.
+/// Diff panes never install the folding contribution. Reserve its 16px lane
+/// only for rich Markdown-comment controls; source-only panes need no reserve.
+/// Feedback independently adds its own lane when enabled.
 fn diff_pane_options(
   editor_options : @code_widget.CodeEditorOptions,
   diff_word_wrap : DiffWordWrap,
+  render_markdown_comments : Bool,
   handle_mouse_wheel : Bool,
 ) -> @code_widget.CodeEditorOptions {
   (match diff_word_wrap {
@@ -38,7 +39,13 @@ fn diff_pane_options(
     Off => editor_options.with_soft_wrap(false)
   })
   .with_folding(false)
-  .with_additional_line_decorations_width(diff_control_lane_reserved_px)
+  .with_additional_line_decorations_width(
+    if render_markdown_comments {
+      diff_markdown_comment_lane_reserved_px
+    } else {
+      0
+    },
+  )
   .with_handle_mouse_wheel(handle_mouse_wheel)
 }
 
@@ -66,7 +73,7 @@ fn DiffEditorEditors::create(
     }
   }
   let pane_options = diff_pane_options(
-    editor_options, diff_word_wrap, handle_mouse_wheel,
+    editor_options, diff_word_wrap, render_markdown_comments, handle_mouse_wheel,
   )
   let editors : DiffEditorEditors = {
     original: @code_widget.CodeEditorWidget::create(
@@ -188,13 +195,14 @@ fn DiffEditorEditors::update_options(
   editor_options : @code_widget.CodeEditorOptions,
   diff_word_wrap : DiffWordWrap,
   layout : DiffEditorLayout,
+  render_markdown_comments : Bool,
   handle_mouse_wheel : Bool,
 ) -> Unit {
   if self.disposed {
     return
   }
   let pane_options = diff_pane_options(
-    editor_options, diff_word_wrap, handle_mouse_wheel,
+    editor_options, diff_word_wrap, render_markdown_comments, handle_mouse_wheel,
   )
   // Pinned DiffEditorEditors always updates both kernels. Inline's clipped
   // original must never wrap: deleted text wraps with the modified editor and

--- a/editor/internal/viewer/diff_editor/editors_wbtest.mbt
+++ b/editor/internal/viewer/diff_editor/editors_wbtest.mbt
@@ -1,13 +1,14 @@
 ///|
 test "diff panes reserve controls independently of folding options" {
   assert_eq(
-    diff_pane_options(CodeEditorOptions(folding=false), Inherit, true),
+    diff_pane_options(CodeEditorOptions(folding=false), Inherit, true, true),
     CodeEditorOptions(folding=false, line_decorations_width=26),
   )
   assert_eq(
     diff_pane_options(
       CodeEditorOptions(show_folding_controls=Never),
       Inherit,
+      true,
       true,
     ),
     CodeEditorOptions(
@@ -24,6 +25,7 @@ test "diff panes reserve controls independently of folding options" {
         line_decorations_width=14,
       ),
       Off,
+      true,
       false,
     ),
     CodeEditorOptions(

--- a/editor/internal/viewer/diff_editor/hunk_actions.mbt
+++ b/editor/internal/viewer/diff_editor/hunk_actions.mbt
@@ -1,0 +1,164 @@
+///|
+/// Host-owned actions share the hunk's rendered position, including deletion
+/// space. The widget owns their attachment and lifetime, but not their policy.
+pub fn DiffEditorWidget::set_hunk_action_renderer(
+  self : DiffEditorWidget,
+  renderer : ((Int) -> @rdom.Element?)?,
+) -> Unit {
+  self.hunk_action_renderer = renderer
+  self.render_hunk_actions()
+}
+
+///|
+fn DiffEditorWidget::clear_hunk_actions(self : DiffEditorWidget) -> Unit {
+  for (_, node) in self.hunk_actions {
+    self.root.remove_child(node.as_node())
+  }
+  self.hunk_actions.clear()
+}
+
+///|
+fn DiffEditorWidget::render_hunk_actions(self : DiffEditorWidget) -> Unit {
+  let mut focused : Int? = None
+  for (index, node) in self.hunk_actions {
+    if @base_browser.element_contains_active_element(node) {
+      focused = Some(index)
+    }
+  }
+  self.clear_hunk_actions()
+  guard self.hunk_action_renderer is Some(render) else { return }
+  for index, _ in self.get_hunks() {
+    if render(index) is Some(content) {
+      let wrapper = @rdom.document().create_element("div")
+      wrapper.set_attribute("class", "moonbit-diff-hunk-action")
+      wrapper.add_event_listener("wheel", event => {
+        if self.options.handle_mouse_wheel {
+          self.editors.modified.delegate_scroll_from_mouse_wheel_event(event)
+          |> ignore
+        }
+      })
+      wrapper.append_child(content.as_node())
+      self.root.append_child(wrapper.as_node())
+      self.hunk_actions.push((index, wrapper))
+      if focused == Some(index) {
+        @base_browser.focus_prevent_scroll(content)
+      }
+    }
+  }
+  self.layout_hunk_actions()
+}
+
+///|
+/// Pixel bounds relative to the widget viewport, also usable by outer-scroll
+/// hosts. Original lines retain deletion geometry in both Split and Inline.
+pub fn DiffEditorWidget::get_hunk_viewport_bounds(
+  self : DiffEditorWidget,
+  index : Int,
+) -> (Double, Double)? {
+  let hunks = self.get_hunks()
+  guard index >= 0 && index < hunks.length() else { return None }
+  let mapping = hunks[index].reveal_mapping
+  let mut bounds : (Double, Double)? = None
+  for
+    (pane, range) in [
+      (self.editors.original, mapping.original),
+      (self.editors.modified, mapping.modified),
+    ] {
+    guard !range.is_empty() && pane.get_model() is Some(model) else { continue }
+    let start = range.start_line_number.clamp(min=1, max=model.get_line_count())
+    let end = (range.end_line_number_exclusive - 1).clamp(
+      min=start,
+      max=model.get_line_count(),
+    )
+    if pane.get_vertical_reveal_bounds(
+        Range(start, 1, end, model.get_line_max_column(end)),
+      )
+      is Some((top, bottom)) {
+      let top = top - self.editors.modified.get_scroll_top()
+      let bottom = bottom - self.editors.modified.get_scroll_top()
+      bounds = Some(
+        match bounds {
+          None => (top, bottom)
+          Some((previous_top, previous_bottom)) =>
+            (previous_top.min(top), previous_bottom.max(bottom))
+        },
+      )
+    }
+  }
+  bounds
+}
+
+///|
+fn DiffEditorWidget::layout_hunk_actions(self : DiffEditorWidget) -> Unit {
+  let height = self.root.get_client_height()
+  for (index, node) in self.hunk_actions {
+    match self.get_hunk_viewport_bounds(index) {
+      Some((top, bottom)) if bottom > 0.0 && top < height => {
+        node.remove_attribute("hidden")
+        @base_browser.set_style_property(node, "top", "\{top.max(0.0)}px")
+      }
+      _ => node.set_attribute("hidden", "")
+    }
+  }
+}
+
+///|
+/// Select without moving the cursor or scrolling. Subsequent navigation starts
+/// at this hunk, so manual reading and toolbar navigation share one position.
+pub fn DiffEditorWidget::select_hunk(
+  self : DiffEditorWidget,
+  index : Int,
+) -> Unit {
+  guard index >= 0 && index < self.get_hunks().length() else { return }
+  self.navigate_from_active_hunk = true
+  self.set_active_hunk_index(Some(index))
+}
+
+///|
+fn hunk_distance(top : Double, bottom : Double, offset : Double) -> Double {
+  if offset < top {
+    top - offset
+  } else {
+    (offset - bottom).max(0.0)
+  }
+}
+
+///|
+fn DiffEditorWidget::track_hunk_at_viewport_offset(
+  self : DiffEditorWidget,
+  offset : Double,
+) -> Unit {
+  let mut nearest : (Int, Double)? = None
+  for index, _ in self.get_hunks() {
+    if self.get_hunk_viewport_bounds(index) is Some((top, bottom)) {
+      let distance = hunk_distance(top, bottom, offset)
+      if nearest is None ||
+        (nearest is Some((_, previous)) && distance < previous) {
+        nearest = Some((index, distance))
+      }
+    }
+  }
+  if nearest is Some((index, _)) {
+    self.select_hunk(index)
+  }
+}
+
+///|
+fn DiffEditorWidget::navigate_active_hunk(
+  self : DiffEditorWidget,
+  direction : Int,
+  wrap : Bool,
+) -> Bool {
+  let hunks = self.get_hunks()
+  guard self.active_hunk_index is Some(current) && !hunks.is_empty() else {
+    return false
+  }
+  let next = current + direction
+  guard wrap || (next >= 0 && next < hunks.length()) else { return false }
+  let index = (next + hunks.length()) % hunks.length()
+  self.reveal_navigation_target({
+    change_index: index,
+    change_count: hunks.length(),
+    change: hunks[index].reveal_mapping,
+  })
+}

--- a/editor/internal/viewer/diff_editor/hunk_actions.mbt
+++ b/editor/internal/viewer/diff_editor/hunk_actions.mbt
@@ -1,11 +1,35 @@
 ///|
+const DiffHunkActionGutterWidth = 24.0
+
+///|
+fn DiffEditorWidget::hunk_action_gutter_width(
+  self : DiffEditorWidget,
+) -> Double {
+  if self.hunk_action_renderer is Some(_) {
+    DiffHunkActionGutterWidth
+  } else {
+    0.0
+  }
+}
+
+///|
 /// Host-owned actions share the hunk's rendered position, including deletion
 /// space. The widget owns their attachment and lifetime, but not their policy.
 pub fn DiffEditorWidget::set_hunk_action_renderer(
   self : DiffEditorWidget,
   renderer : ((Int) -> @rdom.Element?)?,
 ) -> Unit {
+  let previous_width = self.hunk_action_gutter_width()
   self.hunk_action_renderer = renderer
+  let width = self.hunk_action_gutter_width()
+  @base_browser.set_style_property(
+    self.root,
+    "--diff-hunk-action-gutter-width",
+    "\{width}px",
+  )
+  if width != previous_width {
+    self.layout()
+  }
   self.render_hunk_actions()
 }
 

--- a/editor/internal/viewer/diff_editor/pkg.generated.mbti
+++ b/editor/internal/viewer/diff_editor/pkg.generated.mbti
@@ -163,6 +163,7 @@ pub fn DiffEditorWidget::focus(Self) -> Unit
 pub fn DiffEditorWidget::get_active_hunk_index(Self) -> Int?
 pub fn DiffEditorWidget::get_content_height(Self) -> Double
 pub fn DiffEditorWidget::get_diff(Self) -> @diff.DocumentDiff?
+pub fn DiffEditorWidget::get_hunk_viewport_bounds(Self, Int) -> (Double, Double)?
 pub fn DiffEditorWidget::get_hunks(Self) -> Array[DiffHunk]
 pub fn DiffEditorWidget::get_layout(Self) -> DiffEditorLayout
 pub fn DiffEditorWidget::get_max_scroll_left(Self) -> Double
@@ -180,7 +181,9 @@ pub fn DiffEditorWidget::reveal_next_change(Self) -> Bool
 pub fn DiffEditorWidget::reveal_next_change_without_wrap(Self) -> Bool
 pub fn DiffEditorWidget::reveal_previous_change(Self) -> Bool
 pub fn DiffEditorWidget::reveal_previous_change_without_wrap(Self) -> Bool
+pub fn DiffEditorWidget::select_hunk(Self, Int) -> Unit
 pub fn DiffEditorWidget::set_diff_provider(Self, &@diff.DocumentDiffProvider) -> Unit
+pub fn DiffEditorWidget::set_hunk_action_renderer(Self, ((Int) -> @dom.Element?)?) -> Unit
 pub fn DiffEditorWidget::set_model(Self, DiffEditorModelData?) -> DiffEditorModelData?
 pub fn DiffEditorWidget::set_scroll_left(Self, Double) -> Unit
 pub fn DiffEditorWidget::update_options(Self, @code_editor_widget.CodeEditorOptions, DiffEditorOptions) -> Unit

--- a/editor/internal/viewer/diff_editor/pkg.generated.mbti
+++ b/editor/internal/viewer/diff_editor/pkg.generated.mbti
@@ -155,18 +155,22 @@ pub struct DiffEditorWidget {
   mut pending_modified_scroll_top_echo : Double?
   mut pending_modified_scroll_left_echo : Double?
   mut disposed : Bool
+  // private fields
 }
 pub fn DiffEditorWidget::create(@dom.Element, services? : @code_editor_widget.CodeEditorServices, editor_options? : @code_editor_widget.CodeEditorOptions, options? : DiffEditorOptions, &@diff.DocumentDiffProvider) -> Self
 pub fn DiffEditorWidget::dispose(Self) -> Unit
 pub fn DiffEditorWidget::focus(Self) -> Unit
+pub fn DiffEditorWidget::get_active_hunk_index(Self) -> Int?
 pub fn DiffEditorWidget::get_content_height(Self) -> Double
 pub fn DiffEditorWidget::get_diff(Self) -> @diff.DocumentDiff?
+pub fn DiffEditorWidget::get_hunks(Self) -> Array[DiffHunk]
 pub fn DiffEditorWidget::get_layout(Self) -> DiffEditorLayout
 pub fn DiffEditorWidget::get_max_scroll_left(Self) -> Double
 pub fn DiffEditorWidget::get_model(Self) -> DiffEditorModelData?
 pub fn DiffEditorWidget::get_modified_vertical_reveal_bounds(Self, @common.Range) -> (Double, Double)?
 pub fn DiffEditorWidget::is_diff_up_to_date(Self) -> Bool
 pub fn DiffEditorWidget::layout(Self) -> Unit
+pub fn DiffEditorWidget::on_did_change_active_hunk(Self, (Int?) -> Unit) -> @common.Disposable
 pub fn DiffEditorWidget::on_did_change_content_height(Self, (Double) -> Unit) -> @common.Disposable
 pub fn DiffEditorWidget::on_did_reveal_change(Self, (DiffEditorRevealEvent) -> Unit) -> @common.Disposable
 pub fn DiffEditorWidget::on_did_update_diff(Self, () -> Unit) -> @common.Disposable
@@ -180,6 +184,11 @@ pub fn DiffEditorWidget::set_diff_provider(Self, &@diff.DocumentDiffProvider) ->
 pub fn DiffEditorWidget::set_model(Self, DiffEditorModelData?) -> DiffEditorModelData?
 pub fn DiffEditorWidget::set_scroll_left(Self, Double) -> Unit
 pub fn DiffEditorWidget::update_options(Self, @code_editor_widget.CodeEditorOptions, DiffEditorOptions) -> Unit
+
+pub(all) struct DiffHunk {
+  members : Array[@diff.DetailedLineRangeMapping]
+  // private fields
+}
 
 pub struct DiffMapping {
   kind : @diff.DocumentDiffChangeKind

--- a/editor/internal/viewer/diff_editor/widget.mbt
+++ b/editor/internal/viewer/diff_editor/widget.mbt
@@ -52,6 +52,8 @@ pub struct DiffEditorWidget {
   mut original_alignment_geometry : PaneGeometrySnapshot?
   mut modified_alignment_geometry : PaneGeometrySnapshot?
   mut diff_state : DiffState?
+  priv mut active_hunk_index : Int?
+  priv did_change_active_hunk : @base_common.Emitter[Int?]
   /// The section-host contract is published only after one complete geometry
   /// reconcile has committed both panes' owned alignment zones. Retaining the
   /// last value prevents a host height write followed by `layout()` from
@@ -227,6 +229,8 @@ pub fn DiffEditorWidget::create(
     original_alignment_geometry: None,
     modified_alignment_geometry: None,
     diff_state: None,
+    active_hunk_index: None,
+    did_change_active_hunk: Emitter(),
     did_change_content_height: Emitter(),
     did_reveal_change: Emitter(),
     last_published_content_height: None,
@@ -356,7 +360,19 @@ fn DiffEditorWidget::install_event_bridges(self : DiffEditorWidget) -> Unit {
     }),
   )
   self.lifetime.push(
-    self.view_model.on_did_update_diff(() => self.reconcile_view_model()),
+    self.view_model.on_did_update_diff(() => {
+      // Diff computation may settle while geometry reconciliation is blocked
+      // on a render. Invalidate the logical navigation state immediately so a
+      // retained index can never identify a hunk from the next result.
+      match self.view_model.get_state() {
+        Ready => ()
+        NoModel | Pending | Failed => {
+          self.diff_state = None
+          self.set_active_hunk_index(None)
+        }
+      }
+      self.reconcile_view_model()
+    }),
   )
   // A stable layout anchor is valid across presentation/geometry churn, but
   // not across edits to the model it names. Content changes retain the model
@@ -1122,6 +1138,7 @@ fn DiffEditorWidget::commit_empty_diff_features(
   self.original_alignment_geometry = None
   self.modified_alignment_geometry = None
   self.diff_state = None
+  self.set_active_hunk_index(None)
   self.sync_failure_diagnostic()
 }
 
@@ -1328,6 +1345,7 @@ pub fn DiffEditorWidget::set_model(
   self.pending_reveal_first_diff_generation = None
   self.pending_reveal_last_diff_generation = None
   self.pending_layout_modified_viewport = None
+  self.set_active_hunk_index(None)
   self.clear_pending_scroll_echoes()
   self.clear_diff_features_for_transition()
   self.layout_editors_after_render()
@@ -1528,6 +1546,38 @@ pub fn DiffEditorWidget::on_did_update_diff(
 }
 
 ///|
+pub fn DiffEditorWidget::get_hunks(self : DiffEditorWidget) -> Array[DiffHunk] {
+  match self.diff_state {
+    Some(diff_state) => diff_state.hunks()
+    None => []
+  }
+}
+
+///|
+pub fn DiffEditorWidget::get_active_hunk_index(self : DiffEditorWidget) -> Int? {
+  self.active_hunk_index
+}
+
+///|
+pub fn DiffEditorWidget::on_did_change_active_hunk(
+  self : DiffEditorWidget,
+  listener : (Int?) -> Unit,
+) -> @base_common.Disposable {
+  self.did_change_active_hunk.event(listener)
+}
+
+///|
+fn DiffEditorWidget::set_active_hunk_index(
+  self : DiffEditorWidget,
+  index : Int?,
+) -> Unit {
+  if self.active_hunk_index != index {
+    self.active_hunk_index = index
+    self.did_change_active_hunk.fire(index)
+  }
+}
+
+///|
 priv enum DiffNavigationPane {
   ModifiedNavigationPane
 }
@@ -1616,6 +1666,7 @@ fn DiffEditorWidget::reveal_navigation_target(
   ) else {
     return false
   }
+  self.set_active_hunk_index(Some(target.change_index))
   self.announce_navigation_target(target)
   true
 }
@@ -1681,11 +1732,12 @@ fn DiffEditorWidget::try_reveal_first_diff(self : DiffEditorWidget) -> Unit {
   self.pending_reveal_first_diff_generation = None
   let visible = diff_state.visible_mappings()
   if !visible.is_empty() {
-    self.reveal_change(
-      visible[0].line_range_mapping,
-      source="diffEditor.revealFirstDiff",
-    )
-    |> ignore
+    if self.reveal_change(
+        visible[0].line_range_mapping,
+        source="diffEditor.revealFirstDiff",
+      ) {
+      self.set_active_hunk_index(Some(0))
+    }
   }
 }
 
@@ -1734,11 +1786,13 @@ fn DiffEditorWidget::try_reveal_last_diff(self : DiffEditorWidget) -> Unit {
   self.pending_reveal_last_diff_generation = None
   let visible = diff_state.visible_mappings()
   guard !visible.is_empty() else { return }
-  self.reveal_change(
-    visible[visible.length() - 1].line_range_mapping,
-    source="diffEditor.revealLastDiff",
-  )
-  |> ignore
+  let hunks = diff_state.hunks()
+  if self.reveal_change(
+      visible[visible.length() - 1].line_range_mapping,
+      source="diffEditor.revealLastDiff",
+    ) {
+    self.set_active_hunk_index(Some(hunks.length() - 1))
+  }
 }
 
 ///|
@@ -1966,6 +2020,7 @@ pub fn DiffEditorWidget::dispose(self : DiffEditorWidget) -> Unit {
   self.has_valid_layout_box = false
   self.inline_original_strip_width = -1.0
   self.clear_pending_scroll_echoes()
+  self.did_change_active_hunk.dispose()
   self.did_change_content_height.dispose()
   self.did_reveal_change.dispose()
   self.host.remove_child(self.root.as_node())

--- a/editor/internal/viewer/diff_editor/widget.mbt
+++ b/editor/internal/viewer/diff_editor/widget.mbt
@@ -52,6 +52,9 @@ pub struct DiffEditorWidget {
   mut original_alignment_geometry : PaneGeometrySnapshot?
   mut modified_alignment_geometry : PaneGeometrySnapshot?
   mut diff_state : DiffState?
+  priv mut hunk_action_renderer : ((Int) -> @rdom.Element?)?
+  priv hunk_actions : Array[(Int, @rdom.Element)]
+  priv mut navigate_from_active_hunk : Bool
   priv mut active_hunk_index : Int?
   priv did_change_active_hunk : @base_common.Emitter[Int?]
   /// The section-host contract is published only after one complete geometry
@@ -229,6 +232,9 @@ pub fn DiffEditorWidget::create(
     original_alignment_geometry: None,
     modified_alignment_geometry: None,
     diff_state: None,
+    hunk_action_renderer: None,
+    hunk_actions: [],
+    navigate_from_active_hunk: false,
     active_hunk_index: None,
     did_change_active_hunk: Emitter(),
     did_change_content_height: Emitter(),
@@ -354,6 +360,15 @@ fn DiffEditorWidget::layout_editors_after_render(
 
 ///|
 fn DiffEditorWidget::install_event_bridges(self : DiffEditorWidget) -> Unit {
+  // Explicit cursor movement restores cursor-relative navigation after a
+  // viewport selection; hunk reveals retain their own selected group.
+  self.lifetime.push(
+    self.editors.modified.on_did_change_cursor_position(event => {
+      if event.source == "mouse" || event.source == "keyboard" {
+        self.navigate_from_active_hunk = false
+      }
+    }),
+  )
   self.lifetime.push(
     self.view_model.on_did_change_model(() => {
       self.editors.set_model(self.view_model.get_model())
@@ -431,6 +446,7 @@ fn DiffEditorWidget::install_event_bridges(self : DiffEditorWidget) -> Unit {
   self.lifetime.push(
     self.editors.modified.on_did_scroll_change(event => {
       self.refresh_overview_viewport()
+      self.layout_hunk_actions()
       let scroll_top_echo = self.consume_scroll_top_echo(
         ModifiedScrollPane,
         event.scroll_top,
@@ -447,6 +463,11 @@ fn DiffEditorWidget::install_event_bridges(self : DiffEditorWidget) -> Unit {
         if !scroll_top_echo {
           self.pending_layout_modified_viewport = None
           self.sync_scroll_top_to(OriginalScrollPane, event.scroll_top)
+        }
+        if self.options.handle_mouse_wheel {
+          self.track_hunk_at_viewport_offset(
+            self.editors.modified.get_layout_info().height * 0.5,
+          )
         }
       }
       if event.scroll_left_changed {
@@ -1293,6 +1314,7 @@ fn DiffEditorWidget::reconcile_view_model(self : DiffEditorWidget) -> Unit {
     // `commit_diff_state` has now replaced both sides' alignment zones. A
     // section host can synchronously adopt this height without observing the
     // one-pane Markdown/ViewZone intermediate state.
+    self.render_hunk_actions()
     self.publish_content_height_if_changed()
   }
   self.reconciling_generation += 1
@@ -1346,6 +1368,8 @@ pub fn DiffEditorWidget::set_model(
   self.pending_reveal_last_diff_generation = None
   self.pending_layout_modified_viewport = None
   self.set_active_hunk_index(None)
+  self.navigate_from_active_hunk = false
+  self.clear_hunk_actions()
   self.clear_pending_scroll_echoes()
   self.clear_diff_features_for_transition()
   self.layout_editors_after_render()
@@ -1812,6 +1836,9 @@ pub fn DiffEditorWidget::reveal_last_diff(self : DiffEditorWidget) -> Unit {
 ///|
 pub fn DiffEditorWidget::reveal_next_change(self : DiffEditorWidget) -> Bool {
   guard self.view_model.get_model() is Some(model) else { return false }
+  if self.navigate_from_active_hunk {
+    return self.navigate_active_hunk(1, true)
+  }
   let current_line = self.editors.modified
     .get_position()
     .map_or(1, position => position.line_number)
@@ -1832,6 +1859,9 @@ pub fn DiffEditorWidget::reveal_next_change(self : DiffEditorWidget) -> Bool {
 pub fn DiffEditorWidget::reveal_next_change_without_wrap(
   self : DiffEditorWidget,
 ) -> Bool {
+  if self.navigate_from_active_hunk {
+    return self.navigate_active_hunk(1, false)
+  }
   let current_line = self.editors.modified
     .get_position()
     .map_or(1, position => position.line_number)
@@ -1847,6 +1877,9 @@ pub fn DiffEditorWidget::reveal_next_change_without_wrap(
 pub fn DiffEditorWidget::reveal_previous_change(
   self : DiffEditorWidget,
 ) -> Bool {
+  if self.navigate_from_active_hunk {
+    return self.navigate_active_hunk(-1, true)
+  }
   let current_line = self.editors.modified
     .get_position()
     .map_or(1, position => position.line_number)
@@ -1862,6 +1895,9 @@ pub fn DiffEditorWidget::reveal_previous_change(
 pub fn DiffEditorWidget::reveal_previous_change_without_wrap(
   self : DiffEditorWidget,
 ) -> Bool {
+  if self.navigate_from_active_hunk {
+    return self.navigate_active_hunk(-1, false)
+  }
   let current_line = self.editors.modified
     .get_position()
     .map_or(1, position => position.line_number)
@@ -2020,6 +2056,8 @@ pub fn DiffEditorWidget::dispose(self : DiffEditorWidget) -> Unit {
   self.has_valid_layout_box = false
   self.inline_original_strip_width = -1.0
   self.clear_pending_scroll_echoes()
+  self.clear_hunk_actions()
+  self.hunk_action_renderer = None
   self.did_change_active_hunk.dispose()
   self.did_change_content_height.dispose()
   self.did_reveal_change.dispose()

--- a/editor/internal/viewer/diff_editor/widget.mbt
+++ b/editor/internal/viewer/diff_editor/widget.mbt
@@ -1451,6 +1451,7 @@ pub fn DiffEditorWidget::update_options(
       editor_options,
       options.diff_word_wrap,
       self.layout_state.actual_layout,
+      options.render_markdown_comments,
       options.handle_mouse_wheel,
     )
     self.apply_layout_dom()
@@ -2001,6 +2002,7 @@ pub fn DiffEditorWidget::layout(self : DiffEditorWidget) -> Unit {
     self.editor_options,
     self.options.diff_word_wrap,
     self.layout_state.actual_layout,
+    self.options.render_markdown_comments,
     self.options.handle_mouse_wheel,
   )
   self.apply_layout_dom()

--- a/editor/internal/viewer/diff_editor/widget.mbt
+++ b/editor/internal/viewer/diff_editor/widget.mbt
@@ -746,7 +746,9 @@ fn DiffEditorWidget::inline_original_width(
   decorations_left : Double,
 ) -> Double {
   let overview_width = if self.options.overview_ruler { 30.0 } else { 0.0 }
-  let panes_width = (self.layout_state.width - overview_width).max(0.0)
+  let panes_width = (self.layout_state.width -
+  overview_width -
+  self.hunk_action_gutter_width()).max(0.0)
   decorations_left.max(5.0).min(panes_width)
 }
 
@@ -1954,7 +1956,9 @@ fn DiffEditorWidget::apply_layout_dom(self : DiffEditorWidget) -> Unit {
       self.sash.remove_attribute("tabindex")
       self.modified_host.set_attribute("aria-label", "Modified file")
       let overview_width = if self.options.overview_ruler { 30.0 } else { 0.0 }
-      let panes_width = (self.layout_state.width - overview_width).max(0.0)
+      let panes_width = (self.layout_state.width -
+      overview_width -
+      self.hunk_action_gutter_width()).max(0.0)
       let original_width = self.inline_original_width(
         self.editors.original.get_layout_info().decorations_left,
       )

--- a/editor/tests/browser/component/diff_markdown_comments.spec.js
+++ b/editor/tests/browser/component/diff_markdown_comments.spec.js
@@ -210,6 +210,59 @@ test('keeps diff controls independent of host folding settings', async ({ page }
   await expectDecorationsLane(modified, 44);
 });
 
+test('reclaims the Markdown gutter in source mode while keeping feedback usable', async ({ page }) => {
+  const root = await openFixture(page);
+  const original = root.locator('.moonbit-diff-editor-original');
+  const modified = root.locator('.moonbit-diff-editor-modified');
+  const expectSourceLane = async (pane, width) => {
+    await expect(pane.locator(commentSelector)).toHaveCount(0);
+    await expect.poll(() => pane.evaluate((node) => {
+      const margin = node.querySelector('.margin');
+      const lineNumber = node.querySelector('.line-numbers');
+      return margin && lineNumber
+        ? margin.getBoundingClientRect().right - lineNumber.getBoundingClientRect().right
+        : null;
+    })).toBe(width);
+  };
+
+  await control(page, 'set_render_markdown_comments', false);
+  await expectSourceLane(modified, 10);
+  await control(page, 'set_feedback_enabled', true);
+  await expectSourceLane(modified, 28);
+
+  // Layout and host-option replay must not restore the obsolete 16px reserve
+  // or lose the live feedback reservation.
+  await control(page, 'resize', 620);
+  await control(page, 'set_folding_mode', 'disabled');
+  await control(page, 'set_layout', 'split');
+  await expectSourceLane(original, 28);
+  await expectSourceLane(modified, 28);
+  await control(page, 'set_layout', 'inline');
+  await expectSourceLane(modified, 28);
+
+  await modified.locator('.view-line', { hasText: 'let before = 1' }).hover();
+  const glyph = modified.locator('.margin-view-overlays .cldr.agent-feedback-glyph.line-hover');
+  await expect(glyph).toBeVisible();
+  const geometry = await glyph.evaluate((element) => {
+    const margin = element.closest('.margin').getBoundingClientRect();
+    const rect = element.getBoundingClientRect();
+    const before = getComputedStyle(element, '::before');
+    const left = rect.left + Number.parseFloat(before.left);
+    return { left, right: left + Number.parseFloat(before.width), marginLeft: margin.left, marginRight: margin.right };
+  });
+  expect(geometry.left).toBeGreaterThanOrEqual(geometry.marginLeft);
+  expect(geometry.right).toBeLessThanOrEqual(geometry.marginRight);
+  await glyph.click();
+  await expect(modified.locator('.agent-feedback-input-widget textarea')).toBeVisible();
+  await page.keyboard.press('Escape');
+
+  await control(page, 'set_render_markdown_comments', true);
+  await expectDecorationsLane(modified, 44);
+  await control(page, 'set_render_markdown_comments', false);
+  await control(page, 'set_feedback_enabled', false);
+  await expectSourceLane(modified, 10);
+});
+
 test('keeps rich comments in both split panes and only the modified inline pane', async ({ page }) => {
   const root = await openFixture(page);
   const original = root.locator('.moonbit-diff-editor-original');

--- a/editor/tests/browser/moonbit/component/diff_markdown_comments_scenario.mbt
+++ b/editor/tests/browser/moonbit/component/diff_markdown_comments_scenario.mbt
@@ -194,12 +194,14 @@ pub fn run_diff_markdown_comments_test() -> Unit {
   )
   let editor_options = Ref(diff_markdown_comment_editor_options("default"))
   let layout : Ref[@viewer.DiffEditorLayout] = Ref(Inline)
+  let render_markdown_comments = Ref(true)
   let diff_editor = @viewer.DiffEditor::create(
     host,
     services~,
     options=DiffEditorOptions(
       editor_options=editor_options.val,
       layout=layout.val,
+      render_markdown_comments=render_markdown_comments.val,
       automatic_inline=false,
     ),
   )
@@ -270,6 +272,7 @@ pub fn run_diff_markdown_comments_test() -> Unit {
         DiffEditorOptions(
           editor_options=editor_options.val,
           layout=layout.val,
+          render_markdown_comments=render_markdown_comments.val,
           automatic_inline=false,
         ),
       )
@@ -288,6 +291,18 @@ pub fn run_diff_markdown_comments_test() -> Unit {
         DiffEditorOptions(
           editor_options=editor_options.val,
           layout=layout.val,
+          render_markdown_comments=render_markdown_comments.val,
+          automatic_inline=false,
+        ),
+      )
+    },
+    enabled => {
+      render_markdown_comments.val = enabled
+      diff_editor.update_options(
+        DiffEditorOptions(
+          editor_options=editor_options.val,
+          layout=layout.val,
+          render_markdown_comments=enabled,
           automatic_inline=false,
         ),
       )
@@ -308,17 +323,19 @@ extern "js" fn install_diff_markdown_comments_controls(
   resize : (Int) -> Unit,
   set_feedback_enabled : (Bool) -> Unit,
   set_folding_mode : (String) -> Unit,
+  set_render_markdown_comments : (Bool) -> Unit,
   enable_auto_height : () -> Unit,
   content_height_event_count : () -> Int,
   content_height : () -> Double,
 ) -> Unit =
-  #| (setFixture, setLayout, resize, setFeedbackEnabled, setFoldingMode, enableAutoHeight, contentHeightEventCount, contentHeight) => {
+  #| (setFixture, setLayout, resize, setFeedbackEnabled, setFoldingMode, setRenderMarkdownComments, enableAutoHeight, contentHeightEventCount, contentHeight) => {
   #|   globalThis.__diffMarkdownCommentsControls = Object.freeze({
   #|     set_fixture: setFixture,
   #|     set_layout: setLayout,
   #|     resize,
   #|     set_feedback_enabled: setFeedbackEnabled,
   #|     set_folding_mode: setFoldingMode,
+  #|     set_render_markdown_comments: setRenderMarkdownComments,
   #|     enable_auto_height: enableAutoHeight,
   #|     content_height_event_count: contentHeightEventCount,
   #|     content_height: contentHeight,

--- a/editor/viewer/README.mbt.md
+++ b/editor/viewer/README.mbt.md
@@ -189,7 +189,8 @@ state, update event, paired content-height event, and next/previous change
 navigation. The height event is published only after both panes' alignment
 zones commit, so a stacked host never consumes a one-pane intermediate height.
 Hunk actions are host-owned DOM elements installed with
-`set_hunk_action_renderer`; the widget positions them using both panes' changed
+`set_hunk_action_renderer`; the widget reserves a 24px gutter before both panes'
+line numbers and positions compact actions using both panes' changed
 ranges, including pure deletions, and forwards wheel input to the scroll owner.
 The renderer returns a focusable action root and must tolerate being called
 again after diff or layout changes. Review coverage remains host policy.

--- a/editor/viewer/README.mbt.md
+++ b/editor/viewer/README.mbt.md
@@ -198,6 +198,9 @@ Manual scrolling selects the hunk nearest the viewport center without moving
 the cursor. Outer-scroll hosts use `get_hunk_viewport_bounds` and `select_hunk`
 to maintain one global selection. Navigation continues from that selection;
 explicit cursor movement restores cursor-relative navigation.
+Pane gutters reserve 16px for Markdown-comment folding only when
+`render_markdown_comments` is enabled. Source-only diff panes reclaim that
+space; enabled Feedback independently reserves its own control lane.
 
 It is readonly; moves, hide-unchanged, revert, editing, and the full accessible
 diff viewer are outside the current scope.

--- a/editor/viewer/README.mbt.md
+++ b/editor/viewer/README.mbt.md
@@ -188,6 +188,16 @@ the widget.
 state, update event, paired content-height event, and next/previous change
 navigation. The height event is published only after both panes' alignment
 zones commit, so a stacked host never consumes a one-pane intermediate height.
+Hunk actions are host-owned DOM elements installed with
+`set_hunk_action_renderer`; the widget positions them using both panes' changed
+ranges, including pure deletions, and forwards wheel input to the scroll owner.
+The renderer returns a focusable action root and must tolerate being called
+again after diff or layout changes. Review coverage remains host policy.
+Manual scrolling selects the hunk nearest the viewport center without moving
+the cursor. Outer-scroll hosts use `get_hunk_viewport_bounds` and `select_hunk`
+to maintain one global selection. Navigation continues from that selection;
+explicit cursor movement restores cursor-relative navigation.
+
 It is readonly; moves, hide-unchanged, revert, editing, and the full accessible
 diff viewer are outside the current scope.
 

--- a/editor/viewer/browser/diff_editor/diff_editor.css
+++ b/editor/viewer/browser/diff_editor/diff_editor.css
@@ -1,4 +1,6 @@
 .moonbit-diff-editor {
+  box-sizing: border-box;
+  padding-inline-start: var(--diff-hunk-action-gutter-width, 0px);
   position: absolute;
   inset: 0;
   display: flex;
@@ -440,12 +442,30 @@
 
 .moonbit-diff-hunk-action {
   position: absolute;
-  right: 34px;
+  left: 2px;
+  width: 20px;
+  display: flex;
+  justify-content: center;
   z-index: 15;
-  border-radius: 12px;
-  background: var(--vscode-editor-background);
 }
 
 .moonbit-diff-hunk-action[hidden] {
   display: none;
+}
+
+.moonbit-diff-hunk-action > button {
+  box-sizing: border-box;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: 1px solid var(--vscode-editorLineNumber-foreground);
+  border-radius: 3px;
+  color: var(--vscode-editor-foreground);
+  background: var(--vscode-editor-background);
+  cursor: pointer;
+}
+
+.moonbit-diff-hunk-action > button:focus-visible {
+  outline: 2px solid var(--vscode-focusBorder);
+  outline-offset: 1px;
 }

--- a/editor/viewer/browser/diff_editor/diff_editor.css
+++ b/editor/viewer/browser/diff_editor/diff_editor.css
@@ -437,3 +437,15 @@
   align-items: center;
   justify-content: center;
 }
+
+.moonbit-diff-hunk-action {
+  position: absolute;
+  right: 34px;
+  z-index: 15;
+  border-radius: 12px;
+  background: var(--vscode-editor-background);
+}
+
+.moonbit-diff-hunk-action[hidden] {
+  display: none;
+}

--- a/editor/viewer/diff_editor_facade.mbt
+++ b/editor/viewer/diff_editor_facade.mbt
@@ -21,6 +21,18 @@ pub(all) struct DiffEditorRevealEvent {
 } derive(Eq, Debug)
 
 ///|
+/// One F7/Shift+F7 hunk, retaining only its real changed mappings. Joined
+/// unchanged context remains an internal navigation detail.
+pub(all) struct DiffHunk {
+  members : Array[@diff.DetailedLineRangeMapping]
+}
+
+///|
+fn DiffHunk::from_internal(hunk : @diff_editor.DiffHunk) -> DiffHunk {
+  { members: hunk.members.copy(), }
+}
+
+///|
 pub(all) enum DiffEditorLayout {
   SideBySide
   Inline
@@ -306,6 +318,24 @@ pub fn DiffEditor::on_did_update_diff(
   listener : () -> Unit,
 ) -> @base_common.Disposable {
   self.widget.on_did_update_diff(listener)
+}
+
+///|
+pub fn DiffEditor::get_hunks(self : DiffEditor) -> Array[DiffHunk] {
+  self.widget.get_hunks().map(DiffHunk::from_internal)
+}
+
+///|
+pub fn DiffEditor::get_active_hunk_index(self : DiffEditor) -> Int? {
+  self.widget.get_active_hunk_index()
+}
+
+///|
+pub fn DiffEditor::on_did_change_active_hunk(
+  self : DiffEditor,
+  listener : (Int?) -> Unit,
+) -> @base_common.Disposable {
+  self.widget.on_did_change_active_hunk(listener)
 }
 
 ///|

--- a/editor/viewer/diff_editor_facade.mbt
+++ b/editor/viewer/diff_editor_facade.mbt
@@ -414,3 +414,29 @@ pub extend DiffWordWrap with Eq::{equal, not_equal}
 
 ///|
 pub extend DiffWordWrap with Debug::{to_repr}
+
+///|
+/// Attach host-owned controls to each hunk. Replaces previous controls; passing
+/// None removes them. The callback receives the current zero-based hunk index.
+pub fn DiffEditor::set_hunk_action_renderer(
+  self : DiffEditor,
+  renderer : ((Int) -> @rdom.Element?)?,
+) -> Unit {
+  self.widget.set_hunk_action_renderer(renderer)
+}
+
+///|
+/// Current hunk bounds in viewport pixels, including pure deletion space.
+pub fn DiffEditor::get_hunk_viewport_bounds(
+  self : DiffEditor,
+  index : Int,
+) -> (Double, Double)? {
+  self.widget.get_hunk_viewport_bounds(index)
+}
+
+///|
+/// Select a hunk without moving focus, cursor, or scroll. Navigation continues
+/// from this hunk. Outer-scroll hosts use this to track the reading position.
+pub fn DiffEditor::select_hunk(self : DiffEditor, index : Int) -> Unit {
+  self.widget.select_hunk(index)
+}

--- a/editor/viewer/pkg.generated.mbti
+++ b/editor/viewer/pkg.generated.mbti
@@ -43,6 +43,7 @@ pub fn DiffEditor::focus(Self) -> Unit
 pub fn DiffEditor::get_active_hunk_index(Self) -> Int?
 pub fn DiffEditor::get_content_height(Self) -> Double
 pub fn DiffEditor::get_diff(Self) -> @diff.DocumentDiff?
+pub fn DiffEditor::get_hunk_viewport_bounds(Self, Int) -> (Double, Double)?
 pub fn DiffEditor::get_hunks(Self) -> Array[DiffHunk]
 pub fn DiffEditor::get_layout(Self) -> DiffEditorLayout
 pub fn DiffEditor::get_max_scroll_left(Self) -> Double
@@ -60,7 +61,9 @@ pub fn DiffEditor::reveal_next_change(Self) -> Bool
 pub fn DiffEditor::reveal_next_change_without_wrap(Self) -> Bool
 pub fn DiffEditor::reveal_previous_change(Self) -> Bool
 pub fn DiffEditor::reveal_previous_change_without_wrap(Self) -> Bool
+pub fn DiffEditor::select_hunk(Self, Int) -> Unit
 pub fn DiffEditor::set_diff_provider(Self, &@diff.DocumentDiffProvider) -> Unit
+pub fn DiffEditor::set_hunk_action_renderer(Self, ((Int) -> @dom.Element?)?) -> Unit
 pub fn DiffEditor::set_model(Self, DiffEditorModel?) -> DiffEditorModel?
 pub fn DiffEditor::set_scroll_left(Self, Double) -> Unit
 pub fn DiffEditor::update_options(Self, DiffEditorOptions) -> Unit

--- a/editor/viewer/pkg.generated.mbti
+++ b/editor/viewer/pkg.generated.mbti
@@ -40,14 +40,17 @@ type DiffEditor
 pub fn DiffEditor::create(@dom.Element, services? : ViewerServices, options? : DiffEditorOptions, provider? : &@diff.DocumentDiffProvider) -> Self
 pub fn DiffEditor::dispose(Self) -> Unit
 pub fn DiffEditor::focus(Self) -> Unit
+pub fn DiffEditor::get_active_hunk_index(Self) -> Int?
 pub fn DiffEditor::get_content_height(Self) -> Double
 pub fn DiffEditor::get_diff(Self) -> @diff.DocumentDiff?
+pub fn DiffEditor::get_hunks(Self) -> Array[DiffHunk]
 pub fn DiffEditor::get_layout(Self) -> DiffEditorLayout
 pub fn DiffEditor::get_max_scroll_left(Self) -> Double
 pub fn DiffEditor::get_model(Self) -> DiffEditorModel?
 pub fn DiffEditor::get_modified_vertical_reveal_bounds(Self, @common.Range) -> (Double, Double)?
 pub fn DiffEditor::is_diff_up_to_date(Self) -> Bool
 pub fn DiffEditor::layout(Self) -> Unit
+pub fn DiffEditor::on_did_change_active_hunk(Self, (Int?) -> Unit) -> @common.Disposable
 pub fn DiffEditor::on_did_change_content_height(Self, (Double) -> Unit) -> @common.Disposable
 pub fn DiffEditor::on_did_reveal_change(Self, (DiffEditorRevealEvent) -> Unit) -> @common.Disposable
 pub fn DiffEditor::on_did_update_diff(Self, () -> Unit) -> @common.Disposable
@@ -90,6 +93,10 @@ pub(all) struct DiffEditorRevealEvent {
 pub fn DiffEditorRevealEvent::equal(Self, Self) -> Bool
 pub fn DiffEditorRevealEvent::not_equal(Self, Self) -> Bool
 pub fn DiffEditorRevealEvent::to_repr(Self) -> @debug.Repr
+
+pub(all) struct DiffHunk {
+  members : Array[@diff.DetailedLineRangeMapping]
+}
 
 pub(all) enum DiffWordWrap {
   Inherit


### PR DESCRIPTION
Review tracks changed-line coverage across Line, Token, and Tree modes. Each hunk has a viewed toggle in a dedicated left gutter, including pure deletions. Marking all hunks completes the file; marking the file reviewed marks all hunks, and unmarking a hunk reopens the file for review. Coverage is shared across diff modes.

The hunk navigator follows manual scrolling, including the outer scroll container used by semantic sections. Next/previous navigation continues from the selected hunk, while explicit cursor movement restores cursor-relative navigation. Local hunk buttons preserve focus and forward wheel input to the appropriate scroll owner. The gutter stays before both panes’ line numbers in Split and Unified layouts. Source-only diffs also reclaim the obsolete 16px Markdown folding reserve while preserving Feedback’s independent lane.

Coverage uses actual original/modified changed ranges, excluding navigation context and Ignored changes. Whole-file coverage comes from the current ready logical Line diff, including when Token or Tree opens a file before the hidden Line editor has been laid out. Changed-file identity, diff generation, and surface generation fence stale updates; semantic filters do not redefine whole-file coverage.

Validation on head `9f90e159`:

- `moon info && moon fmt`, `git diff --check`, `just check`, and `just build` passed.
- `just test`: 3,252 Native tests, 3,225 JS tests, offline cram tests, and both real CLI lifecycle checks passed.
- `just editor-test`: 1,090 Wasm, 1,876 JS, and 1,224 Native tests passed.
- `just editor-test-browser`: 108 passed, including source-only gutter geometry, layout/option replay, and clickable Feedback controls.
- Rebuilt the Desktop browser bundle; 8 focused review tests passed, covering hunk/file progress, scrolling/navigation, and pure deletion actions in Split and Unified. Rendered screenshots were inspected for marker alignment.
- Built the release macOS SeekMoon.app from this head with `--no-open`; recursive strict signature verification and the embedded CLI help check passed. The new package was not launched for UI QA; current UI evidence comes from the browser suites.
