### PR TITLE
chore: add just cef-setup for the Proton CEF runtime

### DIFF
--- a/justfile
+++ b/justfile
@@ -12,6 +12,14 @@ build:
     moon build --target native
     moon build --target js
 
+# The runtime lives outside the repository in ~/.proton/store, keyed by the CEF
+# archive digest and layout version pinned in the Proton release, so every
+# Proton upgrade that moves either key is a cache miss. The resulting failure
+# reads as a missing cef_browser_capi.h rather than a missing runtime.
+# Install the CEF runtime Desktop's Proton dependency compiles against.
+cef-setup:
+    moonx moonbit-community/proton_cefsetup
+
 # Serve recorded sessions in the browser; flags pass through to the server
 # (e.g. just inspect --session-root path/to/sessions --port 8081).
 inspect *args:


### PR DESCRIPTION
Adds a `just cef-setup` recipe wrapping `moonx moonbit-community/proton_cefsetup`.

## Why

Desktop's Proton dependency compiles against a CEF SDK that lives outside the repository, at `~/.proton/store/<platform>/cef-<sha256>-layout-<N>/sdk`. Both keys — the archive digest and `runtimeLayoutVersion` — are pinned per Proton release in `cef_requirements.generated.mjs`, so any upgrade that moves either one is a cache miss for everyone.

Proton's `build.mjs` emits `-I<cefSdkRoot>` without checking the directory exists, so a missing runtime doesn't report itself. It surfaces as clang failing on every `#include "include/capi/cef_browser_capi.h"`, under a `Failed with 0 warnings, 0 errors` summary line. Nothing in the repo ran cefsetup, so the fix had to be rediscovered each time.

This hit me again after #1100 moved Desktop to Proton 0.2.5, which switched the store layout from the older `~/.proton/runtimes/` path.

## Notes

- The recipe is idempotent — a second run resolves the installed runtime without re-downloading.
- The comment block deliberately ends with the summary sentence: `just --list` renders only the last comment line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JPsKua9rS4H1E1ST9yD3o1