### PR TITLE
test(editor): stabilize wrapped-indent browser coverage

### DIFF
--- a/editor/tests/browser/component/browser_geometry.spec.js
+++ b/editor/tests/browser/component/browser_geometry.spec.js
@@ -125,6 +125,34 @@ async function injectedGeometry(page, font) {
   });
 }
 
+async function firstGlyphGeometry(lineContent) {
+  return lineContent.evaluate((content) => {
+    const text = content.textContent || '';
+    const index = text.search(/\S/u);
+    if (index < 0) return null;
+
+    const walker = document.createTreeWalker(content, NodeFilter.SHOW_TEXT);
+    let remaining = index;
+    for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+      if (remaining >= node.textContent.length) {
+        remaining -= node.textContent.length;
+        continue;
+      }
+      const range = document.createRange();
+      range.setStart(node, remaining);
+      range.setEnd(node, remaining + 1);
+      const rect = range.getBoundingClientRect();
+      const contentRect = content.getBoundingClientRect();
+      return {
+        text,
+        left: rect.left - contentRect.left,
+        width: rect.width,
+      };
+    }
+    return null;
+  });
+}
+
 function expectNear(actual, expected, tolerance = 1) {
   expect(Math.abs(actual - expected)).toBeLessThanOrEqual(tolerance);
 }
@@ -170,6 +198,38 @@ test('embedded mono and proportional fonts give fixed tabs fullwidth and combini
     expectNear((await state(page, 'monospace', 2, 5)).offset, 76.8, 1);
     expectNear((await state(page, 'proportional', 2, 3)).offset, 22.72, 1);
     expectNear((await state(page, 'proportional', 2, 5)).offset, 45.44, 1);
+  } finally {
+    reporter.dispose();
+  }
+});
+
+test('wrapped continuations render Same indentation at exactly two fixed-font columns', async ({
+  page,
+}, testInfo) => {
+  const reporter = await mountGeometry(page, testInfo);
+  try {
+    await page.evaluate(() => document.fonts.ready);
+    const unwrapped = await state(page, 'monospace', 5, 3);
+    expect(unwrapped.softWrap).toBe(false);
+
+    await control(page, 'set_wrap', 'monospace', true);
+    await expect
+      .poll(async () => (await state(page, 'monospace', 5, 3)).viewLines)
+      .toBeGreaterThan(unwrapped.viewLines);
+    await settle(page);
+
+    const wrappedSegments = page
+      .locator(`${hostSelector('monospace')} .view-line-content`)
+      .filter({ hasText: /q{4}/u });
+    await expect(wrappedSegments).toHaveCount(2);
+    const continuation = wrappedSegments.nth(1);
+    await expect(continuation).toBeVisible();
+
+    const glyph = await firstGlyphGeometry(continuation);
+    expect(glyph).not.toBeNull();
+    expect(glyph.text).toMatch(/^\u00a0\u00a0q/u);
+    expectNear(glyph.width, 9.6, 0.15);
+    expectNear(glyph.left, glyph.width * 2, 0.15);
   } finally {
     reporter.dispose();
   }

--- a/editor/tests/browser/component/viewer_api.spec.js
+++ b/editor/tests/browser/component/viewer_api.spec.js
@@ -21,38 +21,6 @@ test('runs MoonBit viewer API component checks in the browser', async ({ page },
     // are in the DOM, so it is asserted after the scroll further down.
     const wrappedHoverLine = page.locator('.view-line').filter({ hasText: 'keeps' });
     await expect(wrappedHoverLine).toHaveCount(0);
-    const firstGlyphLeft = (locator) =>
-      locator.first().evaluate((node) => {
-        const text = node.textContent || '';
-        const idx = text.search(/\S/);
-        if (idx < 0) return null;
-        const walker = document.createTreeWalker(node, NodeFilter.SHOW_TEXT);
-        let remaining = idx;
-        let target = null;
-        let offset = 0;
-        let current;
-        while ((current = walker.nextNode())) {
-          const len = current.textContent.length;
-          if (remaining < len) {
-            target = current;
-            offset = remaining;
-            break;
-          }
-          remaining -= len;
-        }
-        if (!target) return null;
-        const range = document.createRange();
-        range.setStart(target, offset);
-        range.setEnd(target, offset + 1);
-        const root = node.closest('.monaco-editor');
-        return Math.round(
-          range.getBoundingClientRect().left - root.getBoundingClientRect().left,
-        );
-      });
-    // Captured while line 1 is still rendered; the horizontal offset is
-    // unaffected by the vertical scroll below.
-    const flushLeftGlyph = await firstGlyphLeft(page.locator('.view-line[data-line="1"]'));
-    expect(flushLeftGlyph).not.toBeNull();
     const componentZone = page.locator(
       '.component-zone.host-zone-class[monaco-view-zone]',
     );
@@ -124,13 +92,6 @@ test('runs MoonBit viewer API component checks in the browser', async ({ page },
     expect(Number(await wrappedHoverLine.getAttribute('data-line'))).toBeGreaterThan(
       report.metrics.modelLines,
     );
-    // wrappingIndent=Same (the default): the wrapped continuation of the
-    // two-space-indented line is itself indented, so its first visible glyph
-    // sits to the right of a flush-left line's first glyph (the DOM left offset
-    // proves the indent renders, not just that the content carries spaces).
-    const wrappedGlyph = await firstGlyphLeft(wrappedHoverLine);
-    expect(wrappedGlyph).not.toBeNull();
-    expect(wrappedGlyph).toBeGreaterThan(flushLeftGlyph + 5);
     // The warning squiggle renders as an absolutely positioned overlay piece
     // (`<div class="cdr squiggly-warning">`, Monaco's DecorationsOverlay), not
     // as an inline span inside the view line. Its 'keeps' range is only

--- a/editor/tests/browser/moonbit/component/browser_geometry_scenario.mbt
+++ b/editor/tests/browser/moonbit/component/browser_geometry_scenario.mbt
@@ -115,7 +115,8 @@ fn browser_geometry_source(hidden_widest : Bool) -> String {
     "a\tb\tc ｍ e\u{0301}",
     "pre anchor post",
     "visible_widest_\{"W".repeat(36)}",
-    "line_05",
+    // Two source spaces plus enough fixed-width glyphs to force one continuation.
+    "  \{"q".repeat(44)}",
     "line_06",
     "line_07",
     "line_08",


### PR DESCRIPTION
## Summary

- move wrapped-continuation DOM geometry coverage out of the stateful viewer API scenario and into the fixed-font browser geometry fixture
- wait for font readiness and rendered view-line convergence before measuring
- replace the loose cross-scroll pixel comparison with an exact two-column DOM Range check
- retain the viewer API coverage for ViewZone layout, native selection and copy, scrolling, warning decorations, and hover re-entry

## CI failure

Addresses the flaky assertion observed in [Editor Browser Tests](https://github.com/moonbitlang/openseek/actions/runs/33607696639/job/100175364040?pr=1216). The semantic contract remains covered without relying on accumulated interaction state, smooth scrolling, host fonts, sleeps, or retries.

## Test plan

- just editor-test — 4154 passed
- just editor-test-browser — 96 passed
- targeted repeated run of the migrated geometry test and viewer API test — 20 passed
- moon info, MoonBit formatting, JavaScript syntax checks, and diff checks