### PR TITLE
refactor(desktop): fan out hub notifications through a broadcast log

### DIFF
--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -11193,6 +11193,38 @@ test "reconnect runs snapshot settles only its captured Starting submission" {
 }
 
 ///|
+test "reconnect recovers a Finished notification dropped behind a slow page" {
+  let dispatch = test_dispatch()
+  // The host has already finished r7, but this page missed that one live
+  // notification and still presents the run as open.
+  let (_, bridged) = update_dev(dispatch, BridgeReady, running_model())
+  let frontier = bridged.run_snapshot_frontier(@interop.ChannelId::Local)
+  let (_, recovered) = update_dev(
+    dispatch,
+    RunsLoaded(
+      runs=[],
+      settled=[
+        {
+          run_id: "r7",
+          session: "desktop-test",
+          submission_id: None,
+          status: "finished",
+        },
+      ],
+      approvals=[],
+      live=[],
+      frontier~,
+      connection_generation=bridged.dev().connection_generation,
+    ),
+    bridged,
+  )
+  assert_true(
+    recovered.active().run is NoRun(ended=Some(RunFinished(Completed))),
+  )
+  assert_true(recovered.active().last_run_id is Some("r7"))
+}
+
+///|
 test "an old empty runs snapshot cannot close a start sent after reconnect" {
   let dispatch = test_dispatch()
   let (_, bridged) = update_dev(dispatch, BridgeReady, test_model())

--- a/desktop/internal/api/api.mbt
+++ b/desktop/internal/api/api.mbt
@@ -307,23 +307,16 @@ pub fn ApiState::sink(self : ApiState) -> @engine.EventSink {
 }
 
 ///|
-/// Register a notification subscriber: a bounded queue the hub pushes every
-/// notification into. The caller drains it with `get` and MUST `unsubscribe`
-/// when done (a defer next to the subscribe). A subscriber that stops
-/// draining is kicked by the hub: its queue is closed, which ends the
-/// drain loop.
+/// Open a notification subscription: a cursor into the hub's bounded log
+/// that yields, through `next`, every notification published from now on.
+/// Nothing is registered, so dropping it is the whole of unsubscribing. A
+/// subscriber that stops draining lags: `next` raises `@broadcast.Lagged`
+/// once the log has rolled past it and resumes at the oldest retained
+/// notification; the transport turns the lag into its resync boundary.
 pub fn ApiState::subscribe(
   self : ApiState,
-) -> @async.Queue[@protocol.Notification] {
+) -> @broadcast.Subscription[@protocol.Notification] {
   self.hub.subscribe()
-}
-
-///|
-pub fn ApiState::unsubscribe(
-  self : ApiState,
-  queue : @async.Queue[@protocol.Notification],
-) -> Unit {
-  self.hub.unsubscribe(queue)
 }
 
 ///|

--- a/desktop/internal/api/hub.mbt
+++ b/desktop/internal/api/hub.mbt
@@ -1,21 +1,23 @@
 // The fan-out point between the engine's EventSink and every connected
-// client. Notifications are pushed to each subscriber's bounded queue; a
-// subscriber that cannot keep up is dropped, per the protocol's
-// reconnect-equals-resync contract (docs/remote-protocol.md) — the client
-// reconnects and rebuilds state through `session.list` + `agent.runs`.
+// client. Notifications are appended to one bounded broadcast log that every
+// subscriber reads through its own cursor. A subscriber that falls further
+// behind than the log retains has lagged: its next read says so instead of
+// handing over a stream with a hole in it, and the transport applies the
+// protocol's reconnect-equals-resync contract (docs/remote-protocol.md) —
+// the client rebuilds state through `session.list` + `agent.runs`.
 
 ///|
-/// A subscriber queue's bound. Generous — the desktop webview and a healthy
-/// browser drain far faster than the engine produces — so hitting it means
-/// the connection is wedged, and the protocol's answer to a wedged
-/// connection is to close it.
-const SubscriberQueueCapacity = 1024
+/// How many notifications the log retains behind its head. Generous — the
+/// desktop webview and a healthy browser drain far faster than the engine
+/// produces — so a subscriber this far behind is a wedged connection, and
+/// the protocol's answer to a wedged connection is to resync it.
+const NotificationLogCapacity = 1024
 
 ///|
 /// The hub is owned by `ApiState`; transports reach it through
-/// `ApiState::subscribe`/`unsubscribe`.
+/// `ApiState::subscribe`.
 priv struct Hub {
-  subscribers : Array[@async.Queue[@protocol.Notification]]
+  notifications : @broadcast.Channel[@protocol.Notification]
   // The typed `agent.started` payload of every run still in flight, keyed by run
   // id — the source for `agent.runs`, which is how a client that joins (or
   // reconnects) mid-run learns the run's identity. Insertion order is
@@ -42,7 +44,7 @@ priv struct Hub {
 ///|
 fn Hub::Hub() -> Hub {
   {
-    subscribers: [],
+    notifications: Channel(capacity=NotificationLogCapacity),
     active_starts: Map([]),
     settlements: Map([]),
     pending_approvals: Map([]),
@@ -109,13 +111,10 @@ fn Hub::record_finished(
 }
 
 ///|
-/// Push one notification to every live subscriber. `try_put` never
-/// suspends, so the order every subscriber sees is the publish order. A
-/// full queue marks its subscriber dead: the queue is closed (ending the
-/// connection's writer) and dropped. Only the hub ever closes a subscribed
-/// queue, and it removes the queue from `subscribers` in the same breath,
-/// so `try_put` on a closed queue cannot happen — `try!` turns that
-/// invariant into a hard stop instead of a silent discard.
+/// Record the notification's effect on the live-run tables, then append it
+/// to the log. Publishing never suspends, so the order every subscriber sees
+/// is the publish order. The hub keeps no list of subscribers: one that has
+/// fallen behind learns so on its own next read.
 fn Hub::publish(self : Hub, notification : @protocol.Notification) -> Unit {
   match notification {
     AgentStarted(payload) => self.active_starts[payload.run_id] = payload
@@ -134,17 +133,7 @@ fn Hub::publish(self : Hub, notification : @protocol.Notification) -> Unit {
     AgentEvent(payload) => self.track_approval(payload)
     _ => ()
   }
-  let wedged : Array[Int] = []
-  for index, queue in self.subscribers {
-    if !(try! queue.try_put(notification)) {
-      wedged.push(index)
-    }
-  }
-  // Back to front, so the collected indices stay valid while removing.
-  for cursor in wedged.rev_iter() {
-    let queue = self.subscribers.remove(cursor)
-    queue.close()
-  }
+  self.notifications.publish(notification)
 }
 
 ///|
@@ -197,29 +186,13 @@ fn Hub::forget_run_approvals(self : Hub, run_id : String) -> Unit {
 }
 
 ///|
-fn Hub::subscribe(self : Hub) -> @async.Queue[@protocol.Notification] {
-  let queue : @async.Queue[@protocol.Notification] = Queue(
-    kind=Blocking(SubscriberQueueCapacity),
-  )
-  self.subscribers.push(queue)
-  queue
-}
-
-///|
-/// Drop a subscriber by queue identity and close its queue, waking a writer
-/// blocked on `get`. Unsubscribing twice is fine; so is unsubscribing a
-/// queue the hub already kicked.
-fn Hub::unsubscribe(
+/// A cursor at the log's head: it yields every notification published from
+/// now on. The hub keeps no record of it, so dropping it is the whole of
+/// unsubscribing.
+fn Hub::subscribe(
   self : Hub,
-  queue : @async.Queue[@protocol.Notification],
-) -> Unit {
-  for index, candidate in self.subscribers {
-    if physical_equal(candidate, queue) {
-      ignore(self.subscribers.remove(index))
-      queue.close()
-      break
-    }
-  }
+) -> @broadcast.Subscription[@protocol.Notification] {
+  self.notifications.subscribe()
 }
 
 ///|
@@ -337,14 +310,70 @@ test "a real engine connection retires old active runs before readiness" {
   guard hub.runs().runs is [] else {
     fail("old active run survived a new engine pump")
   }
-  guard subscriber.try_get() is Some(started) else {
+  guard subscriber.try_next() is Some(started) else {
     fail("missing started notification")
   }
   assert_eq(started.wire_name(), "agent.started")
-  guard subscriber.try_get() is Some(connected) else {
+  guard subscriber.try_next() is Some(connected) else {
     fail("missing connected notification")
   }
   assert_eq(connected.wire_name(), "agent.connected")
+}
+
+///|
+test "a lagged subscriber learns what it missed and can still replay the finish" {
+  let hub = Hub::Hub()
+  let subscriber = hub.subscribe()
+  hub.publish(
+    AgentStarted(
+      @json.from_json({
+        "run_id": "r-overflow",
+        "session": "s-overflow",
+        "submission_id": "sub-overflow",
+      }),
+    ),
+  )
+  // Let the log roll past the subscriber without draining it. The terminal
+  // notification is the first one to push the start out of the window,
+  // reproducing a renderer that fell behind during a long, high-volume turn.
+  for _ in 1..<NotificationLogCapacity {
+    hub.publish(AgentConnected({ stage: Serving, }))
+  }
+  hub.publish(
+    AgentFinished(
+      @json.from_json({
+        "run_id": "r-overflow",
+        "status": "finished",
+        "exit_code": 0,
+      }),
+    ),
+  )
+  // The read reports exactly what was overwritten — the start — and resumes
+  // at the oldest retained notification. Whether that partial stream is
+  // worth rendering is the transport's decision; the finish itself is
+  // recoverable through `agent.runs` either way.
+  let missed = try subscriber.try_next() catch {
+    Lagged(missed~) => Some(missed)
+  } noraise {
+    _ => None
+  }
+  assert_eq(missed, Some(1))
+  guard subscriber.try_next() is Some(retained) else {
+    fail("the retained window was not readable after the lag")
+  }
+  assert_eq(retained.wire_name(), "agent.connected")
+  guard hub.runs(known=[
+      {
+        session: "s-overflow",
+        run_id: Some("r-overflow"),
+        submission_id: Some("sub-overflow"),
+      },
+    ]).settled
+    is [settlement] else {
+    fail("the missed finish was not retained for lifecycle resync")
+  }
+  assert_eq(settlement.status, "finished")
+  assert_eq(settlement.exit_code, Some(0))
 }
 
 ///|

--- a/desktop/internal/api/moon.pkg
+++ b/desktop/internal/api/moon.pkg
@@ -2,6 +2,7 @@ import {
   // Imported for the engine event constructors the hub matches on.
   "bobzhang/openseek_protocol",
   "openseek_desktop/internal/auth",
+  "openseek_desktop/internal/broadcast",
   "openseek_desktop/internal/commands",
   "openseek_desktop/internal/codex",
   "openseek_desktop/internal/engine",

--- a/desktop/internal/api/pkg.generated.mbti
+++ b/desktop/internal/api/pkg.generated.mbti
@@ -2,8 +2,8 @@
 package "openseek_desktop/internal/api"
 
 import {
-  "moonbitlang/async/aqueue",
   "openseek_desktop/internal/auth",
+  "openseek_desktop/internal/broadcast",
   "openseek_desktop/internal/codex",
   "openseek_desktop/internal/endpoint",
   "openseek_desktop/internal/engine",
@@ -27,8 +27,7 @@ pub fn ApiState::host_state(Self) -> @host.HostState
 pub fn ApiState::manager(Self) -> @engine.EngineManager
 pub fn ApiState::publish(Self, @protocol.Notification) -> Unit
 pub fn ApiState::sink(Self) -> @engine.EventSink
-pub fn ApiState::subscribe(Self) -> @aqueue.Queue[@protocol.Notification]
-pub fn ApiState::unsubscribe(Self, @aqueue.Queue[@protocol.Notification]) -> Unit
+pub fn ApiState::subscribe(Self) -> @broadcast.Subscription[@protocol.Notification]
 
 // Type aliases
 

--- a/desktop/internal/broadcast/broadcast.mbt
+++ b/desktop/internal/broadcast/broadcast.mbt
@@ -1,0 +1,125 @@
+// One bounded log shared by every reader, instead of one queue per reader.
+// A publisher appends once and wakes whoever is waiting; a subscription is
+// only a cursor into the log, so opening one registers nothing with the
+// channel and dropping it is the whole of unsubscribing. Every reader sees
+// the same sequence. A reader that falls further behind than the window
+// retains has lost the overwritten values for good: its next read raises
+// `Lagged` with their count and its cursor moves up to the oldest value still
+// retained, as tokio's broadcast channel does. Whether the retained remainder
+// is worth reading is the reader's call; `skip_to_head` says it is not.
+
+///|
+/// A bounded broadcast log of `T`. `capacity` is how many published values
+/// stay readable behind the head; a subscription further behind than that
+/// has lagged.
+struct Channel[T] {
+  capacity : Int
+  // The retained window, oldest first: `log[i]` carries sequence `base + i`.
+  log : @deque.Deque[T]
+  mut base : Int
+  // Broadcast on every publish. Readers wait on it only once caught up, and
+  // re-check the log after waking, so a wake with nothing new is harmless.
+  cond : @cond_var.Cond
+}
+
+///|
+pub fn[T] Channel::Channel(capacity~ : Int) -> Channel[T] {
+  { capacity, log: Deque([], capacity~), base: 0, cond: Cond(), }
+}
+
+///|
+/// The sequence the next published value will carry.
+fn[T] Channel::head(self : Channel[T]) -> Int {
+  self.base + self.log.length()
+}
+
+///|
+/// Append `value` for every subscription and wake the readers waiting for
+/// it. Never suspends, so publish order is the order every reader sees. When
+/// the window is full the oldest value falls out; a subscription still
+/// pointing at it has lagged, and learns so on its next read.
+pub fn[T] Channel::publish(self : Channel[T], value : T) -> Unit {
+  self.log.push_back(value)
+  if self.log.length() > self.capacity {
+    ignore(self.log.pop_front())
+    self.base += 1
+  }
+  self.cond.broadcast()
+}
+
+///|
+/// A subscription positioned at the head: it sees what is published from
+/// now on, nothing retained from before. Dropping it is all it takes to
+/// unsubscribe.
+pub fn[T] Channel::subscribe(self : Channel[T]) -> Subscription[T] {
+  { channel: self, cursor: self.head(), }
+}
+
+///|
+/// One reader's position in a channel's log.
+struct Subscription[T] {
+  channel : Channel[T]
+  mut cursor : Int
+}
+
+///|
+/// The subscription fell further behind than the channel retains: `missed`
+/// values were overwritten before it read them. Reading resumes at the
+/// oldest value still retained.
+pub suberror Lagged {
+  Lagged(missed~ : Int)
+} derive(Debug)
+
+///|
+pub impl Show for Lagged with fn output(self, logger) {
+  match self {
+    Lagged(missed~) =>
+      logger.write_string(
+        "subscription lagged: \{missed} values were overwritten before it read them",
+      )
+  }
+}
+
+///|
+/// The next value without waiting: `None` when the subscription is caught up
+/// with the head.
+pub fn[T] Subscription::try_next(self : Subscription[T]) -> T? raise Lagged {
+  let channel = self.channel
+  if self.cursor < channel.base {
+    let missed = channel.base - self.cursor
+    self.cursor = channel.base
+    raise Lagged(missed~)
+  }
+  guard channel.log.get(self.cursor - channel.base) is Some(value) else {
+    return None
+  }
+  self.cursor += 1
+  Some(value)
+}
+
+///|
+/// The next value, waiting for a publish while caught up. Raises `Lagged`
+/// when the window rolled past the cursor. Cancellation leaves the cursor
+/// where it was: nothing is consumed until a value is returned.
+pub async fn[T] Subscription::next(self : Subscription[T]) -> T {
+  for ;; {
+    if self.try_next() is Some(value) {
+      return value
+    }
+    self.channel.cond.wait()
+  }
+}
+
+///|
+/// Give up whatever the log still retains and continue from the head. For a
+/// reader to whom a stream with a hole in it is worth nothing after `Lagged`:
+/// it resyncs by other means and wants only what is published from now on.
+pub fn[T] Subscription::skip_to_head(self : Subscription[T]) -> Unit {
+  self.cursor = self.channel.head()
+}
+
+///|
+pub extend Lagged with Debug::{to_repr}
+
+///|
+pub extend Lagged with Show::{to_string, output}

--- a/desktop/internal/broadcast/broadcast_test.mbt
+++ b/desktop/internal/broadcast/broadcast_test.mbt
@@ -1,0 +1,100 @@
+///|
+test "every subscription reads the same published order" {
+  let channel : @broadcast.Channel[Int] = Channel(capacity=8)
+  let first = channel.subscribe()
+  let second = channel.subscribe()
+  channel.publish(1)
+  channel.publish(2)
+  assert_eq(first.try_next(), Some(1))
+  assert_eq(second.try_next(), Some(1))
+  assert_eq(second.try_next(), Some(2))
+  assert_eq(second.try_next(), None)
+  assert_eq(first.try_next(), Some(2))
+  assert_eq(first.try_next(), None)
+}
+
+///|
+test "a subscription starts at the head" {
+  let channel : @broadcast.Channel[String] = Channel(capacity=8)
+  channel.publish("before")
+  let subscription = channel.subscribe()
+  assert_eq(subscription.try_next(), None)
+  channel.publish("after")
+  assert_eq(subscription.try_next(), Some("after"))
+}
+
+///|
+test "falling behind the window lags once and resumes at the oldest retained value" {
+  let channel : @broadcast.Channel[Int] = Channel(capacity=2)
+  let behind = channel.subscribe()
+  let keeping_up = channel.subscribe()
+  for value in 1..<=5 {
+    channel.publish(value)
+    assert_eq(keeping_up.try_next(), Some(value))
+  }
+  let lagged = try behind.try_next() catch {
+    Lagged(missed~) => Some(missed)
+  } noraise {
+    _ => None
+  }
+  // Only the overwritten values count; the window still holds 4 and 5.
+  assert_eq(lagged, Some(3))
+  assert_eq(behind.try_next(), Some(4))
+  assert_eq(behind.try_next(), Some(5))
+  assert_eq(behind.try_next(), None)
+  channel.publish(6)
+  assert_eq(behind.try_next(), Some(6))
+  assert_eq(keeping_up.try_next(), Some(6))
+}
+
+///|
+test "skipping to the head gives up the retained window" {
+  let channel : @broadcast.Channel[Int] = Channel(capacity=2)
+  let subscription = channel.subscribe()
+  for value in 1..<=5 {
+    channel.publish(value)
+  }
+  let lagged = try subscription.try_next() catch {
+    Lagged(_) => true
+  } noraise {
+    _ => false
+  }
+  assert_true(lagged)
+  subscription.skip_to_head()
+  assert_eq(subscription.try_next(), None)
+  channel.publish(6)
+  assert_eq(subscription.try_next(), Some(6))
+}
+
+///|
+test "lag reads as a sentence" {
+  let channel : @broadcast.Channel[Int] = Channel(capacity=1)
+  let subscription = channel.subscribe()
+  channel.publish(1)
+  channel.publish(2)
+  let message = try subscription.try_next() catch {
+    error => "\{error}"
+  } noraise {
+    _ => "no error"
+  }
+  assert_eq(
+    message, "subscription lagged: 1 values were overwritten before it read them",
+  )
+}
+
+///|
+async test "next waits for a publish and consumes nothing when cancelled" {
+  let channel : @broadcast.Channel[Int] = Channel(capacity=2)
+  let subscription = channel.subscribe()
+  // Nothing published: the timeout cancels the wait.
+  assert_true(@async.with_timeout_opt(20, () => subscription.next()) is None)
+  @async.with_task_group(group => {
+    let reader = group.spawn(() => subscription.next())
+    // Let the reader park on the channel before publishing.
+    @async.pause()
+    channel.publish(7)
+    assert_eq(reader.wait(), 7)
+  })
+  // The cancelled wait consumed nothing, and the value was consumed once.
+  assert_eq(subscription.try_next(), None)
+}

--- a/desktop/internal/broadcast/moon.pkg
+++ b/desktop/internal/broadcast/moon.pkg
@@ -1,0 +1,12 @@
+import {
+  "moonbitlang/async/cond_var",
+  "moonbitlang/core/deque",
+}
+
+import {
+  "moonbitlang/async",
+} for "test"
+
+warnings = "+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"
+
+supported_targets = "+native"

--- a/desktop/internal/broadcast/pkg.generated.mbti
+++ b/desktop/internal/broadcast/pkg.generated.mbti
@@ -1,0 +1,32 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "openseek_desktop/internal/broadcast"
+
+import {
+  "moonbitlang/core/debug",
+}
+
+// Values
+
+// Errors
+pub suberror Lagged {
+  Lagged(missed~ : Int)
+} derive(@debug.Debug)
+pub fn Lagged::output(Self, &Logger) -> Unit
+pub fn Lagged::to_repr(Self) -> @debug.Repr
+pub fn Lagged::to_string(Self) -> String
+pub impl Show for Lagged
+
+// Types and methods
+type Channel[T]
+pub fn[T] Channel::Channel(capacity~ : Int) -> Self[T]
+pub fn[T] Channel::publish(Self[T], T) -> Unit
+pub fn[T] Channel::subscribe(Self[T]) -> Subscription[T]
+
+type Subscription[T]
+pub async fn[T] Subscription::next(Self[T]) -> T
+pub fn[T] Subscription::skip_to_head(Self[T]) -> Unit
+pub fn[T] Subscription::try_next(Self[T]) -> T? raise Lagged
+
+// Type aliases
+
+// Traits

--- a/desktop/internal/engine/README.mbt.md
+++ b/desktop/internal/engine/README.mbt.md
@@ -205,9 +205,9 @@ lifecycle boundaries cannot overtake the durable events they delimit.
 
 `EventSink` is deliberately not `async`: an event handed to the sink is public
 the moment the call returns, which is what lets lifecycle transitions and
-their announcements be one uninterruptible step. The real sink fans out with
-per-subscriber buffers and evicts a wedged reader rather than backpressuring
-lifecycle code.
+their announcements be one uninterruptible step. The real sink appends to a
+bounded broadcast log and lets a wedged reader lag out of it rather than
+backpressuring lifecycle code.
 
 ## The session follower
 

--- a/desktop/internal/extension/extension.mbt
+++ b/desktop/internal/extension/extension.mbt
@@ -257,6 +257,11 @@ async fn PageEventTarget::emit(
 priv enum BridgeInput {
   Control(BridgeControl)
   Deliver(PageNotification)
+  // The hub's log rolled past this subscription's cursor: at least one
+  // notification is gone for good, so only the ordinary BridgeReady resync
+  // can restore truthful state. The actor has already skipped the retained
+  // remainder, which is no longer a complete stream.
+  SubscriptionLagged
 }
 
 ///|
@@ -382,11 +387,37 @@ pub async fn DesktopBridgeActor::window_closed(
 }
 
 ///|
+/// The next hub notification, or the lag that stands in for the ones this
+/// subscription missed. Remote clients reconnect their socket over a lag;
+/// the desktop bridge is process-local with no socket supervisor, so it
+/// reports the lag as input and resyncs the page instead of ending its
+/// app-lifetime actor. The notifications the log still retains are skipped
+/// too: once one is missing, rendering the rest only paints stale state
+/// before the resync replaces it.
+async fn next_hub_input(
+  notifications : @broadcast.Subscription[@protocol.Notification],
+) -> BridgeInput {
+  Deliver(Hub(notifications.next())) catch {
+    @broadcast.Lagged(missed~) => {
+      @xlog.warn(category="transport") <?
+        {
+          "event": "hub_subscription_lagged",
+          "transport": "desktop",
+          "missed": missed,
+        }
+      notifications.skip_to_head()
+      SubscriptionLagged
+    }
+    error => raise error
+  }
+}
+
+///|
 /// Prefer pending lifecycle/control work over another notification. Once neither
 /// lane is ready, race their blocking reads; `any` cancels the losing read.
 async fn DesktopBridgeActor::next_input(
   self : DesktopBridgeActor,
-  notifications : @async.Queue[@protocol.Notification],
+  notifications : @broadcast.Subscription[@protocol.Notification],
   host_notifications : @async.Queue[@protocol.Notification],
 ) -> BridgeInput {
   if self.controls.try_get() is Some(control) {
@@ -394,7 +425,7 @@ async fn DesktopBridgeActor::next_input(
   }
   @async.any([
     () => Control(self.controls.get()),
-    () => Deliver(Hub(notifications.get())),
+    () => next_hub_input(notifications),
     () => Deliver(Hub(host_notifications.get())),
     () => Deliver(BrowserEvent(self.browser_events.get())),
   ])
@@ -407,7 +438,6 @@ async fn DesktopBridgeActor::next_input(
 /// sender installed by Proton's lifecycle hook.
 pub async fn DesktopBridgeActor::run(self : DesktopBridgeActor) -> Unit {
   let notifications = self.state.subscribe()
-  defer self.state.unsubscribe(notifications)
   let host_notifications : @async.Queue[@protocol.Notification] = Queue(
     kind=Blocking(64),
   )
@@ -456,17 +486,52 @@ pub async fn DesktopBridgeActor::run(self : DesktopBridgeActor) -> Unit {
             }
           }
         Deliver(notification) =>
-          if connected {
-            if target is Some(target) {
-              target.emit(notification)
-            } else {
-              if pending.length() == PendingNotificationCapacity {
-                ignore(pending.remove(0))
-              }
-              pending.push(notification)
-            }
-          }
+          deliver_to_page(connected, target, pending, notification)
+        // Readiness is the frontend's resync boundary. The subscription
+        // already sits at the log's head, so every notification published
+        // from here on queues behind this boundary.
+        SubscriptionLagged =>
+          deliver_to_page(
+            connected,
+            target,
+            pending,
+            Hub(AgentConnected({ stage: Accepted, })),
+          )
       }
     }
   })
+}
+
+///|
+async fn deliver_to_page(
+  connected : Bool,
+  target : PageEventTarget?,
+  pending : Array[PageNotification],
+  notification : PageNotification,
+) -> Unit {
+  guard connected else { return }
+  if target is Some(target) {
+    target.emit(notification)
+  } else {
+    if pending.length() == PendingNotificationCapacity {
+      ignore(pending.remove(0))
+    }
+    pending.push(notification)
+  }
+}
+
+///|
+async test "a lagged hub subscription becomes a reconnect boundary" {
+  let channel : @broadcast.Channel[@protocol.Notification] = Channel(capacity=1)
+  let notifications = channel.subscribe()
+  channel.publish(AgentConnected({ stage: Serving, }))
+  channel.publish(AgentConnected({ stage: Serving, }))
+  assert_true(next_hub_input(notifications) is SubscriptionLagged)
+  // The retained Serving notification was skipped with the lag; the same
+  // subscription keeps serving from the head.
+  channel.publish(AgentConnected({ stage: Accepted, }))
+  assert_true(
+    next_hub_input(notifications)
+    is Deliver(Hub(AgentConnected({ stage: Accepted, }))),
+  )
 }

--- a/desktop/internal/extension/moon.pkg
+++ b/desktop/internal/extension/moon.pkg
@@ -3,6 +3,7 @@ import {
   "moonbit-community/proton/extension" @proton_extension,
   "moonbit-community/proton_contract",
   "openseek_desktop/internal/api",
+  "openseek_desktop/internal/broadcast",
   "openseek_desktop/internal/commands",
   "openseek_desktop/internal/engine",
   "openseek_desktop/internal/endpoint",
@@ -12,6 +13,7 @@ import {
   "moonbitlang/async",
   "moonbitlang/async/fs",
   "moonbitlang/core/string",
+  "tonyfettes/xlog",
 }
 
 warnings = "+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"

--- a/desktop/internal/remote/moon.pkg
+++ b/desktop/internal/remote/moon.pkg
@@ -2,6 +2,7 @@ import {
   "bobzhang/openseek_protocol" @wire,
   "openseek_desktop/internal/api",
   "openseek_desktop/internal/auth",
+  "openseek_desktop/internal/broadcast",
   "openseek_desktop/internal/engine",
   "openseek_desktop/internal/endpoint",
   "openseek_desktop/internal/host",

--- a/desktop/internal/remote/serve.mbt
+++ b/desktop/internal/remote/serve.mbt
@@ -16,13 +16,14 @@ priv enum Outgoing {
 }
 
 ///|
-/// The two queues that make one remote subscription. Opening them also
-/// installs the readiness frame: because the fresh bounded outbound queue is
-/// empty, that `put` cannot suspend, so no hub publisher can run between
-/// subscribe and readiness. Forwarders may only start after this returns.
+/// The outbound queue and hub subscription that make one remote client.
+/// Opening them also installs the readiness frame: because the fresh bounded
+/// outbound queue is empty, that `put` cannot suspend, so no hub publisher
+/// can run between subscribe and readiness. Forwarders may only start after
+/// this returns.
 priv struct ClientSubscription {
   out : @async.Queue[Outgoing]
-  notifications : @async.Queue[@protocol.Notification]
+  notifications : @broadcast.Subscription[@protocol.Notification]
 }
 
 ///|
@@ -87,7 +88,8 @@ const PingIntervalMs = 30_000
 /// How many outbound frames may queue before writers suspend. This is also
 /// the slow-client limit: a socket that stalls long enough to fill it gets
 /// the connection torn down (the pump must not block on a full queue — a
-/// blocked `put` cannot be woken by the hub closing the subscription).
+/// pump parked in `put` would never get back to its subscription to notice
+/// that it lagged).
 const OutboundQueueCapacity = 64
 
 ///|
@@ -153,8 +155,8 @@ async fn WsClientActor::run(self : WsClientActor) -> Unit {
 }
 
 ///|
-/// Serve the actor's connected socket until it closes (or the hub kicks it
-/// for not draining notifications).
+/// Serve the actor's connected socket until it closes (or its hub
+/// subscription lags for want of draining).
 async fn WsClientActor::serve(
   self : WsClientActor,
   conn : @websocket.Conn,
@@ -169,7 +171,6 @@ async fn WsClientActor::serve(
   // Endpoint closures capture this connection's watch and PTY ownership once;
   // every request only performs a name lookup in the stable catalog.
   let endpoints = @api.endpoints(self.state, self.host_connection)
-  defer self.state.unsubscribe(notifications)
   @async.with_task_group(group => {
     group.spawn_bg(() => {
       for ;; {
@@ -187,12 +188,23 @@ async fn WsClientActor::serve(
     })
     group.spawn_bg(() => {
       // Tears the connection down either way it ends — the client
-      // reconnects into a resync: the hub kicking this subscriber (queue
-      // closed → `get` raises), or the outbound queue standing full (the
-      // socket has stalled for `OutboundQueueCapacity` frames, and the
-      // protocol promises a disconnect over a silent gap in the stream).
+      // reconnects into a resync: this subscription lagging behind the hub's
+      // log (`next` raises), or the outbound queue standing full (the socket
+      // has stalled for `OutboundQueueCapacity` frames, and the protocol
+      // promises a disconnect over a silent gap in the stream).
       for ;; {
-        let notification = notifications.get()
+        let notification = notifications.next() catch {
+          @broadcast.Lagged(missed~) as lagged => {
+            @xlog.warn(category="transport") <?
+              {
+                "event": "hub_subscription_lagged",
+                "transport": "remote",
+                "missed": missed,
+              }
+            raise lagged
+          }
+          error => raise error
+        }
         guard notification_for_client(notification) is Some(notification) else {
           continue
         }
@@ -426,7 +438,6 @@ fn error_envelope(id : Json, code : Int, message : String) -> Json {
 async test "readiness precedes the first forwarded hub notification" {
   let state = @api.ApiState(engine="unused")
   let subscription = WsClientActor::WsClientActor(state, "unused").open_subscription()
-  defer state.unsubscribe(subscription.notifications)
   state.publish(
     SessionEvent({
       session: "session-1",
@@ -439,7 +450,7 @@ async test "readiness precedes the first forwarded hub notification" {
       session_root: "/sessions/global",
     }),
   )
-  let notification = subscription.notifications.get()
+  let notification = subscription.notifications.next()
   assert_true(subscription.out.try_put(Notify(notification)))
   guard subscription.out.get() is Notify(readiness) else {
     fail("expected readiness notification")


### PR DESCRIPTION
## Problem

The hub fanned notifications out through one bounded `@async.Queue` per subscriber. The queue handle doubled as the subscription's identity (`unsubscribe` searched the array with `physical_equal`), the publish side decided a reader was dead by closing its queue, and the desktop bridge had to notice a closed queue and either die (main) or renew its subscription while retaining every previous handle (#1198).

## Change

- New package `desktop/internal/broadcast`: `Channel[T]` is a Deque plus a base sequence and a CondVar; `Subscription[T]` is a cursor into it. `publish` appends, rolls the window, and broadcasts. Subscribing registers nothing and dropping the subscription is the whole of unsubscribing, so `ApiState::unsubscribe` is gone.
- Lag semantics follow tokio's broadcast channel: `Lagged(missed~)` counts only the overwritten notifications and the cursor resumes at the oldest retained one. `skip_to_head()` is for a reader to whom the partial stream is worth nothing.
- Remote WebSocket: the forwarder logs `hub_subscription_lagged` (`transport=remote`, `missed`) and re-raises, so the connection is torn down and the client reconnects into a resync, as before.
- Desktop bridge: logs the lag, skips to the head, and delivers `agent.connected` (Accepted), which the frontend already maps to `BridgeReady`. The actor stays alive on the same subscription; no resubscribe, no retained handles.
- The eviction log line moves from the hub to the read side, where the transport is known.
- Includes the frontend regression test from 4ce90fadd (co-authored by Hongbo Zhang): the frontend half of the same scenario, a finish recovered through `agent.runs` settlements after the resync.

## Relationship to open PRs

- Supersedes the hub/extension part of #1198 (4ce90fadd). The composer commit on that branch is unrelated and untouched. If both land, `hub.mbt` and `extension.mbt` conflict; take this branch.
- Overlaps #1190 in the same two files.

## Verification

- `moon check --target native`: clean
- `moon test --target native` for `internal/broadcast`, `internal/api`, `internal/extension`, `internal/remote`: 45/45
- `moon test --target js frontend/update.mbt --filter "reconnect recovers a Finished notification dropped behind a slow page"`: 1/1
- Full `moon test --target native`: 3446 tests; the only failures are three pre-existing `agent_tool/job_output` cases that fail identically on an untouched worktree (moonx wasm tool environment), unrelated to this change
- `moon fmt` and `moon info` run; `.mbti` changes are limited to `internal/api` and the new package

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QL8qJuELCvN91TbAx1jVAg
