### PR TITLE
fixit: drop the removed workflow/ path from the worker slice's allowed_paths

### DIFF
--- a/agent_workflow/fixit/main.mbt
+++ b/agent_workflow/fixit/main.mbt
@@ -47,9 +47,7 @@ async fn main {
       wf,
       name="fixit",
       task="Apply EXACTLY this one documentation correction and nothing else: \{clip(brief, 1500)}",
-      allowed_paths=[
-        "workflow/", "agent_workflow/", "agent_subrun/", "agent_subtask/",
-      ],
+      allowed_paths=["agent_workflow/", "agent_subrun/", "agent_subtask/"],
       max_steps=40,
     ) {
     Ok(outcome) => {


### PR DESCRIPTION
Follow-up to #1222, which merged before this one-line fix landed on its branch: the `fixit` example's worker slice still listed `workflow/` in `allowed_paths`, a path that no longer exists in this repository now that the module lives at https://github.com/moonbitlang/workflow.

Verified: `moon check --target native --deny-warn` and `moon fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzvyN6ApxnFnSbBk5SPG6R