### PR TITLE
fix(editor): restore diff review gutter controls

### DIFF
--- a/desktop/e2e/tests/rabbita_dom.spec.js
+++ b/desktop/e2e/tests/rabbita_dom.spec.js
@@ -102,13 +102,86 @@ test('Review loads changed files and preserves its interactive diff workflow', a
     'true',
   );
 
+  const layout = page.getByRole('group', { name: 'Diff layout' });
+  await layout.getByRole('button', { name: 'Unified diff layout' }).click();
+  await expect(layout.getByRole('button', { name: 'Unified diff layout' })).toHaveAttribute(
+    'aria-pressed',
+    'true',
+  );
+  const semantic = page.locator(
+    '.semantic-review[data-mode="tree"][data-layout="unified"]',
+  );
+  await expect(semantic).toBeVisible();
+  const semanticDiffCandidate = semantic.locator('.semantic-diff-editor-host').filter({
+    has: page.locator(
+      '.moonbit-diff-editor-modified '
+        + '.view-lines[data-view-part="view-lines"] > .view-line',
+      { hasText: 'working tree' },
+    ),
+  }).first();
+  await expect(semanticDiffCandidate).toBeVisible();
+  const semanticDiffId = await semanticDiffCandidate.getAttribute('id');
+  expect(semanticDiffId).not.toBeNull();
+  const semanticDiff = semantic.locator(`[id=${JSON.stringify(semanticDiffId)}]`);
+  const semanticOriginal = semanticDiff.locator('.moonbit-diff-editor-original');
+  const semanticModified = semanticDiff.locator('.moonbit-diff-editor-modified');
+  await expect(semanticDiff).toBeVisible();
+  await expect(semanticDiff.locator('.moonbit-diff-editor').first())
+    .toHaveAttribute('data-render-mode', 'inline');
+  await expect(semanticOriginal.locator('.line-numbers:visible').first())
+    .toBeVisible();
+  await expect.poll(() => semanticOriginal.evaluate((node) => {
+    const host = node.getBoundingClientRect();
+    const margin = node.querySelector('.margin');
+    const lineNumber = Array.from(node.querySelectorAll('.line-numbers'))
+      .map((element) => element.getBoundingClientRect())
+      .find((rect) => rect.width > 0);
+    if (!margin || !lineNumber) return null;
+    const marginRect = margin.getBoundingClientRect();
+    return {
+      lineNumberAligned:
+        Math.abs(host.width - (lineNumber.right - host.left)) <= 0.5,
+      decorationsClipped: host.width < marginRect.width,
+    };
+  })).toEqual({ lineNumberAligned: true, decorationsClipped: true });
+
+  const feedbackLine = semanticModified.locator(
+    '.view-lines[data-view-part="view-lines"] > .view-line',
+  ).filter({ hasText: 'working tree' }).first();
+  await expect(feedbackLine).toBeVisible();
+  const feedbackLineBox = await feedbackLine.boundingBox();
+  const modifiedBox = await semanticModified.boundingBox();
+  expect(feedbackLineBox).not.toBeNull();
+  expect(modifiedBox).not.toBeNull();
+  await page.mouse.move(
+    Math.min(
+      feedbackLineBox.x + 20,
+      modifiedBox.x + modifiedBox.width - 10,
+    ),
+    feedbackLineBox.y + feedbackLineBox.height / 2,
+  );
+  const feedbackGlyph = semanticModified.locator(
+    '.agent-feedback-glyph.line-hover',
+  );
+  await expect(feedbackGlyph).toBeVisible();
+  const feedbackGlyphBox = await feedbackGlyph.boundingBox();
+  expect(feedbackGlyphBox).not.toBeNull();
+  await page.mouse.click(
+    feedbackGlyphBox.x + feedbackGlyphBox.width / 2,
+    feedbackGlyphBox.y + feedbackGlyphBox.height / 2,
+  );
+  const feedbackInput = semanticDiff.locator(
+    '.agent-feedback-input-widget textarea',
+  );
+  await expect(feedbackInput).toBeVisible();
+  await page.keyboard.press('Escape');
+  await expect(feedbackInput).toBeHidden();
+
   await reviewToolbar.getByRole('button', { name: 'Line diff' }).click();
   await expect(reviewToolbar.getByRole('button', { name: 'Line diff' })).toHaveAttribute(
     'aria-pressed',
     'true',
   );
-  const layout = page.getByRole('group', { name: 'Diff layout' });
-  await layout.getByRole('button', { name: 'Unified diff layout' }).click();
   await expect(layout.getByRole('button', { name: 'Unified diff layout' })).toHaveAttribute(
     'aria-pressed',
     'true',

--- a/editor/internal/viewer/code_editor_widget/agent_feedback_host.mbt
+++ b/editor/internal/viewer/code_editor_widget/agent_feedback_host.mbt
@@ -181,6 +181,32 @@ fn CodeEditorWidget::on_agent_feedback_model_changed(
 // --- reserved lane ----------------------------------------------------------------
 
 ///|
+/// Applies a complete host-owned options snapshot without dropping the
+/// contribution-owned gutter reservation. DiffEditor replays its saved pane
+/// options during every layout; once feedback is enabled, that replay must
+/// rebase the saved lane width and then add the 18px feedback lane again.
+///
+/// The feedback contribution itself continues to call `update_options`
+/// directly when it first reserves or finally restores the lane, because
+/// those calls already contain the effective width.
+pub fn CodeEditorWidget::update_host_options(
+  self : CodeEditorWidget,
+  options : CodeEditorOptions,
+) -> Unit {
+  guard self.agent_feedback_input_contribution() is Some(ic) &&
+    ic.lane_base_width is Some(_) else {
+    self.update_options(options)
+    return
+  }
+  ic.lane_base_width = Some(options.line_decorations_width)
+  self.update_options({
+    ..options,
+    line_decorations_width: options.line_decorations_width +
+    agent_feedback_reserved_gutter_px,
+  })
+}
+
+///|
 /// `_updateReservedGutterSpace`: reserve extra room in the line-decorations
 /// margin while the resource offers feedback, restore the host's base width
 /// when it no longer does (the comments contrib's store/restore shape; the

--- a/editor/internal/viewer/code_editor_widget/agent_feedback_host_wbtest.mbt
+++ b/editor/internal/viewer/code_editor_widget/agent_feedback_host_wbtest.mbt
@@ -87,6 +87,24 @@ test "feedback lane reserves 18px while enabled and restores the base" {
 }
 
 ///|
+test "host option updates rebase an active feedback lane" {
+  with_feedback_test_viewer("alpha", (viewer, service) => {
+    service.set_feedback_enabled(test_model_uri(), true)
+    assert_eq(viewer.get_options().line_decorations_width, 28)
+
+    viewer.update_host_options(CodeEditorOptions(line_decorations_width=14))
+    assert_eq(viewer.get_options().line_decorations_width, 32)
+    assert_eq(
+      viewer.test_feedback_input_contribution().lane_base_width,
+      Some(14),
+    )
+
+    service.set_feedback_enabled(test_model_uri(), false)
+    assert_eq(viewer.get_options().line_decorations_width, 14)
+  })
+}
+
+///|
 test "hover glyph follows non-empty lines of an enabled resource" {
   with_feedback_test_viewer("alpha\n   \ngamma", (viewer, service) => {
     // Disabled resource: no glyph.

--- a/editor/internal/viewer/code_editor_widget/contribution_descriptors.mbt
+++ b/editor/internal/viewer/code_editor_widget/contribution_descriptors.mbt
@@ -58,8 +58,9 @@ pub fn CodeEditorContributionDescriptors::standalone() -> CodeEditorContribution
 
 ///|
 /// Diff-pane code-editor surface. It keeps ordinary navigation, hover,
-/// context menu, references, and agent feedback. Folding is disabled because
-/// pinned VS Code diff sub-editors do not reserve folding controls.
+/// context menu, references, and agent feedback. The folding controller is
+/// excluded, while the host folding option remains available to retain the
+/// ordinary editor's decorations reserve for comment and feedback controls.
 /// Markdown-comment replacement remains installed so the diff coordinator can
 /// keep it live in both SideBySide panes and suppress only the clipped Inline
 /// original. Quick diff is excluded because a diff pane must not host a nested

--- a/editor/internal/viewer/code_editor_widget/contribution_descriptors.mbt
+++ b/editor/internal/viewer/code_editor_widget/contribution_descriptors.mbt
@@ -59,8 +59,8 @@ pub fn CodeEditorContributionDescriptors::standalone() -> CodeEditorContribution
 ///|
 /// Diff-pane code-editor surface. It keeps ordinary navigation, hover,
 /// context menu, references, and agent feedback. The folding controller is
-/// excluded, while the host folding option remains available to retain the
-/// ordinary editor's decorations reserve for comment and feedback controls.
+/// excluded; DiffEditor disables its option and independently reserves the
+/// shared decorations lane for comment and feedback controls.
 /// Markdown-comment replacement remains installed so the diff coordinator can
 /// keep it live in both SideBySide panes and suppress only the clipped Inline
 /// original. Quick diff is excluded because a diff pane must not host a nested

--- a/editor/internal/viewer/code_editor_widget/pkg.generated.mbti
+++ b/editor/internal/viewer/code_editor_widget/pkg.generated.mbti
@@ -73,6 +73,7 @@ pub fn CodeEditorOptions::equal(Self, Self) -> Bool
 pub fn CodeEditorOptions::line_height(Self) -> Double
 pub fn CodeEditorOptions::not_equal(Self, Self) -> Bool
 pub fn CodeEditorOptions::soft_wrap(Self) -> Bool
+pub fn CodeEditorOptions::with_additional_line_decorations_width(Self, Int) -> Self
 pub fn CodeEditorOptions::with_folding(Self, Bool) -> Self
 pub fn CodeEditorOptions::with_font_family(Self, String) -> Self
 pub fn CodeEditorOptions::with_font_size(Self, Double) -> Self

--- a/editor/internal/viewer/code_editor_widget/pkg.generated.mbti
+++ b/editor/internal/viewer/code_editor_widget/pkg.generated.mbti
@@ -286,6 +286,7 @@ pub fn CodeEditorWidget::set_selection(Self, @core.Selection, source? : String) 
 pub fn CodeEditorWidget::set_selections(Self, Array[@core.Selection], source? : String, reason? : @editor_api.CursorChangeReason) -> Unit
 pub fn CodeEditorWidget::set_value(Self, String) -> Unit
 pub fn CodeEditorWidget::show_references(Self, @common.Position, Array[@language.Location]) -> Unit
+pub fn CodeEditorWidget::update_host_options(Self, CodeEditorOptions) -> Unit
 pub fn CodeEditorWidget::update_options(Self, CodeEditorOptions) -> Unit
 
 type EditorDecorationsCollection

--- a/editor/internal/viewer/code_editor_widget/viewer_options.mbt
+++ b/editor/internal/viewer/code_editor_widget/viewer_options.mbt
@@ -265,8 +265,8 @@ pub fn CodeEditorOptions::with_soft_wrap(
 }
 
 ///|
-/// Returns a copy with Monaco's folding option changed. Diff panes use this
-/// to keep their shared line-decoration lane free of folding controls.
+/// Returns a copy with Monaco's folding option changed. The option also
+/// controls the line-decoration space reserved for folding affordances.
 pub fn CodeEditorOptions::with_folding(
   self : CodeEditorOptions,
   folding : Bool,

--- a/editor/internal/viewer/code_editor_widget/viewer_options.mbt
+++ b/editor/internal/viewer/code_editor_widget/viewer_options.mbt
@@ -304,6 +304,21 @@ pub fn CodeEditorOptions::with_line_decorations_width(
 }
 
 ///|
+/// Returns a copy with a non-negative width added to the line-decoration
+/// gutter. Hosts use this when their surface owns controls in that lane
+/// independently of the editor's folding affordances.
+pub fn CodeEditorOptions::with_additional_line_decorations_width(
+  self : CodeEditorOptions,
+  additional_width : Int,
+) -> CodeEditorOptions {
+  {
+    ..self,
+    line_decorations_width: self.line_decorations_width +
+    additional_width.max(0),
+  }
+}
+
+///|
 /// Returns a copy with the requested line height changed.
 pub fn CodeEditorOptions::with_line_height(
   self : CodeEditorOptions,

--- a/editor/internal/viewer/code_editor_widget/viewer_options_test.mbt
+++ b/editor/internal/viewer/code_editor_widget/viewer_options_test.mbt
@@ -13,6 +13,7 @@ test "CodeEditorOptions builders preserve an immutable opaque snapshot" {
     .with_soft_wrap(true)
     .with_line_numbers_min_chars(3)
     .with_line_decorations_width(17)
+    .with_additional_line_decorations_width(6)
     .with_line_height(21.0)
   assert_eq(
     updated,
@@ -27,7 +28,7 @@ test "CodeEditorOptions builders preserve an immutable opaque snapshot" {
       tab_size=4,
       soft_wrap=true,
       line_numbers_min_chars=3,
-      line_decorations_width=17,
+      line_decorations_width=23,
       line_height=21.0,
     ),
   )
@@ -50,5 +51,9 @@ test "CodeEditorOptions builders preserve constructor normalization" {
   assert_eq(
     CodeEditorOptions::default().with_line_decorations_width(-1),
     CodeEditorOptions(line_decorations_width=0),
+  )
+  assert_eq(
+    CodeEditorOptions::default().with_additional_line_decorations_width(-1),
+    CodeEditorOptions::default(),
   )
 }

--- a/editor/internal/viewer/diff_editor/editors.mbt
+++ b/editor/internal/viewer/diff_editor/editors.mbt
@@ -22,6 +22,27 @@ struct DiffEditorModelPairCommitBarrier {
 }
 
 ///|
+let diff_control_lane_reserved_px : Int = 16
+
+///|
+/// Diff panes never install the folding contribution, but Markdown-comment
+/// and feedback controls still need the ordinary editor's 16px control lane.
+/// Add that lane explicitly so caller folding settings cannot remove it.
+fn diff_pane_options(
+  editor_options : @code_widget.CodeEditorOptions,
+  diff_word_wrap : DiffWordWrap,
+  handle_mouse_wheel : Bool,
+) -> @code_widget.CodeEditorOptions {
+  (match diff_word_wrap {
+    Inherit => editor_options
+    Off => editor_options.with_soft_wrap(false)
+  })
+  .with_folding(false)
+  .with_additional_line_decorations_width(diff_control_lane_reserved_px)
+  .with_handle_mouse_wheel(handle_mouse_wheel)
+}
+
+///|
 fn new_diff_editor_model_pair_commit_barrier() -> DiffEditorModelPairCommitBarrier {
   { is_committing: false, committed_generation: 0, }
 }
@@ -44,14 +65,9 @@ fn DiffEditorEditors::create(
       (services, Some(services))
     }
   }
-  // `diff_pane()` excludes the folding contribution, so retaining the host's
-  // folding option cannot make source folds interactive here. It does retain
-  // the ordinary editor's 16px decorations reserve, which the Markdown fold
-  // toggle and agent-feedback affordance share.
-  let pane_options = (match diff_word_wrap {
-    Inherit => editor_options
-    Off => editor_options.with_soft_wrap(false)
-  }).with_handle_mouse_wheel(handle_mouse_wheel)
+  let pane_options = diff_pane_options(
+    editor_options, diff_word_wrap, handle_mouse_wheel,
+  )
   let editors : DiffEditorEditors = {
     original: @code_widget.CodeEditorWidget::create(
       original_host,
@@ -177,10 +193,9 @@ fn DiffEditorEditors::update_options(
   if self.disposed {
     return
   }
-  let pane_options = (match diff_word_wrap {
-    Inherit => editor_options
-    Off => editor_options.with_soft_wrap(false)
-  }).with_handle_mouse_wheel(handle_mouse_wheel)
+  let pane_options = diff_pane_options(
+    editor_options, diff_word_wrap, handle_mouse_wheel,
+  )
   // Pinned DiffEditorEditors always updates both kernels. Inline's clipped
   // original must never wrap: deleted text wraps with the modified editor and
   // paired original ViewZones supply the continuation height.

--- a/editor/internal/viewer/diff_editor/editors.mbt
+++ b/editor/internal/viewer/diff_editor/editors.mbt
@@ -44,9 +44,13 @@ fn DiffEditorEditors::create(
       (services, Some(services))
     }
   }
+  // `diff_pane()` excludes the folding contribution, so retaining the host's
+  // folding option cannot make source folds interactive here. It does retain
+  // the ordinary editor's 16px decorations reserve, which the Markdown fold
+  // toggle and agent-feedback affordance share.
   let pane_options = (match diff_word_wrap {
-    Inherit => editor_options.with_folding(false)
-    Off => editor_options.with_soft_wrap(false).with_folding(false)
+    Inherit => editor_options
+    Off => editor_options.with_soft_wrap(false)
   }).with_handle_mouse_wheel(handle_mouse_wheel)
   let editors : DiffEditorEditors = {
     original: @code_widget.CodeEditorWidget::create(
@@ -174,8 +178,8 @@ fn DiffEditorEditors::update_options(
     return
   }
   let pane_options = (match diff_word_wrap {
-    Inherit => editor_options.with_folding(false)
-    Off => editor_options.with_soft_wrap(false).with_folding(false)
+    Inherit => editor_options
+    Off => editor_options.with_soft_wrap(false)
   }).with_handle_mouse_wheel(handle_mouse_wheel)
   // Pinned DiffEditorEditors always updates both kernels. Inline's clipped
   // original must never wrap: deleted text wraps with the modified editor and
@@ -185,8 +189,8 @@ fn DiffEditorEditors::update_options(
   } else {
     pane_options
   }
-  self.original.update_options(original_options)
-  self.modified.update_options(pane_options)
+  self.original.update_host_options(original_options)
+  self.modified.update_host_options(pane_options)
 }
 
 ///|

--- a/editor/internal/viewer/diff_editor/editors_wbtest.mbt
+++ b/editor/internal/viewer/diff_editor/editors_wbtest.mbt
@@ -1,20 +1,16 @@
 ///|
 test "diff panes reserve controls independently of folding options" {
   assert_eq(
-    diff_pane_options(
-      @code_widget.CodeEditorOptions(folding=false),
-      Inherit,
-      true,
-    ),
-    @code_widget.CodeEditorOptions(folding=false, line_decorations_width=26),
+    diff_pane_options(CodeEditorOptions(folding=false), Inherit, true),
+    CodeEditorOptions(folding=false, line_decorations_width=26),
   )
   assert_eq(
     diff_pane_options(
-      @code_widget.CodeEditorOptions(show_folding_controls=Never),
+      CodeEditorOptions(show_folding_controls=Never),
       Inherit,
       true,
     ),
-    @code_widget.CodeEditorOptions(
+    CodeEditorOptions(
       folding=false,
       show_folding_controls=Never,
       line_decorations_width=26,
@@ -22,7 +18,7 @@ test "diff panes reserve controls independently of folding options" {
   )
   assert_eq(
     diff_pane_options(
-      @code_widget.CodeEditorOptions(
+      CodeEditorOptions(
         soft_wrap=true,
         folding=false,
         line_decorations_width=14,
@@ -30,7 +26,7 @@ test "diff panes reserve controls independently of folding options" {
       Off,
       false,
     ),
-    @code_widget.CodeEditorOptions(
+    CodeEditorOptions(
       folding=false,
       soft_wrap=false,
       handle_mouse_wheel=false,

--- a/editor/internal/viewer/diff_editor/editors_wbtest.mbt
+++ b/editor/internal/viewer/diff_editor/editors_wbtest.mbt
@@ -1,0 +1,40 @@
+///|
+test "diff panes reserve controls independently of folding options" {
+  assert_eq(
+    diff_pane_options(
+      @code_widget.CodeEditorOptions(folding=false),
+      Inherit,
+      true,
+    ),
+    @code_widget.CodeEditorOptions(folding=false, line_decorations_width=26),
+  )
+  assert_eq(
+    diff_pane_options(
+      @code_widget.CodeEditorOptions(show_folding_controls=Never),
+      Inherit,
+      true,
+    ),
+    @code_widget.CodeEditorOptions(
+      folding=false,
+      show_folding_controls=Never,
+      line_decorations_width=26,
+    ),
+  )
+  assert_eq(
+    diff_pane_options(
+      @code_widget.CodeEditorOptions(
+        soft_wrap=true,
+        folding=false,
+        line_decorations_width=14,
+      ),
+      Off,
+      false,
+    ),
+    @code_widget.CodeEditorOptions(
+      folding=false,
+      soft_wrap=false,
+      handle_mouse_wheel=false,
+      line_decorations_width=30,
+    ),
+  )
+}

--- a/editor/internal/viewer/diff_editor/moon.pkg
+++ b/editor/internal/viewer/diff_editor/moon.pkg
@@ -8,4 +8,8 @@ import {
   "moonbit-community/rabbita/dom" @rdom,
 }
 
+import {
+  "moonbitlang/editor/viewer/common/editor_api",
+} for "wbtest"
+
 supported_targets = "js"

--- a/editor/tests/browser/component/diff_markdown_comments.spec.js
+++ b/editor/tests/browser/component/diff_markdown_comments.spec.js
@@ -104,8 +104,8 @@ test('keeps normal editor gutter room for comment and feedback controls', async 
   const modified = root.locator('.moonbit-diff-editor-modified');
 
   // Diff panes do not install the folding controller, but their shared
-  // comment/feedback lane still starts with the normal editor's 10px base +
-  // 16px folding-control reserve.
+  // comment/feedback lane still starts with the host's 10px base plus an
+  // explicit 16px diff-control reserve.
   await expectDecorationsLane(modified, 26);
 
   await control(page, 'set_feedback_enabled', true);
@@ -192,6 +192,22 @@ test('keeps normal editor gutter room for comment and feedback controls', async 
   await expect(comment).toHaveAttribute('data-documentation-expanded', 'true');
   await commentToggle.click();
   await expect(comment).toHaveAttribute('data-documentation-expanded', 'false');
+});
+
+test('keeps diff controls independent of host folding settings', async ({ page }) => {
+  const root = await openFixture(page);
+  const modified = root.locator('.moonbit-diff-editor-modified');
+
+  await control(page, 'set_folding_mode', 'disabled');
+  await expectDecorationsLane(modified, 26);
+  await control(page, 'set_feedback_enabled', true);
+  await expectDecorationsLane(modified, 44);
+
+  await control(page, 'set_feedback_enabled', false);
+  await control(page, 'set_folding_mode', 'never');
+  await expectDecorationsLane(modified, 26);
+  await control(page, 'set_feedback_enabled', true);
+  await expectDecorationsLane(modified, 44);
 });
 
 test('keeps rich comments in both split panes and only the modified inline pane', async ({ page }) => {

--- a/editor/tests/browser/component/diff_markdown_comments.spec.js
+++ b/editor/tests/browser/component/diff_markdown_comments.spec.js
@@ -81,6 +81,119 @@ async function contentHeightState(page) {
   });
 }
 
+async function expectDecorationsLane(pane, expectedWidth) {
+  await expect.poll(() => pane.evaluate((node) => {
+    const margin = node.querySelector('.margin');
+    const lineNumber = node.querySelector('.line-numbers');
+    const toggle = node.querySelector(
+      '.moonbit-viewer-markdown-comment-margin-toggle',
+    );
+    if (!margin || !lineNumber || !toggle) return null;
+    const marginRect = margin.getBoundingClientRect();
+    const lineNumberRect = lineNumber.getBoundingClientRect();
+    return {
+      lane: marginRect.right - lineNumberRect.right,
+      toggle: Number.parseFloat(getComputedStyle(toggle).width),
+    };
+  })).toEqual({ lane: expectedWidth, toggle: expectedWidth });
+}
+
+test('keeps normal editor gutter room for comment and feedback controls', async ({ page }) => {
+  const root = await openFixture(page);
+  const original = root.locator('.moonbit-diff-editor-original');
+  const modified = root.locator('.moonbit-diff-editor-modified');
+
+  // Diff panes do not install the folding controller, but their shared
+  // comment/feedback lane still starts with the normal editor's 10px base +
+  // 16px folding-control reserve.
+  await expectDecorationsLane(modified, 26);
+
+  await control(page, 'set_feedback_enabled', true);
+  await expectDecorationsLane(modified, 44);
+
+  // DiffEditor reapplies its host options on every layout. Those updates must
+  // preserve the live 18px feedback reservation instead of shrinking the
+  // lane back to the host base.
+  await control(page, 'resize', 620);
+  await waitForFrames(page);
+  await expectDecorationsLane(modified, 44);
+
+  await control(page, 'set_layout', 'split');
+  await expectDecorationsLane(original, 44);
+  await expectDecorationsLane(modified, 44);
+
+  await control(page, 'set_layout', 'inline');
+  await expectDecorationsLane(modified, 44);
+  const inlineOriginalGeometry = await original.evaluate((node) => {
+    const host = node.getBoundingClientRect();
+    const margin = node.querySelector('.margin').getBoundingClientRect();
+    const lineNumber = Array.from(node.querySelectorAll('.line-numbers'))
+      .map((element) => element.getBoundingClientRect())
+      .find((rect) => rect.width > 0);
+    return {
+      hostWidth: host.width,
+      marginWidth: margin.width,
+      lineNumberWidth: lineNumber.right - host.left,
+    };
+  });
+  expect(Math.abs(
+    inlineOriginalGeometry.hostWidth - inlineOriginalGeometry.lineNumberWidth,
+  )).toBeLessThanOrEqual(0.5);
+  expect(inlineOriginalGeometry.hostWidth).toBeLessThan(
+    inlineOriginalGeometry.marginWidth,
+  );
+
+  const quietLine = modified.locator('.view-line', {
+    hasText: 'let before = 1',
+  });
+  await quietLine.hover();
+  const glyph = modified.locator(
+    '.margin-view-overlays .cldr.agent-feedback-glyph.line-hover',
+  );
+  await expect(glyph).toHaveCount(1);
+  const glyphGeometry = await glyph.evaluate((element) => {
+    const margin = element.closest('.margin').getBoundingClientRect();
+    const glyphRect = element.getBoundingClientRect();
+    const before = getComputedStyle(element, '::before');
+    const visibleLeft = glyphRect.left + Number.parseFloat(before.left);
+    const visibleRight = visibleLeft + Number.parseFloat(before.width);
+    return {
+      marginLeft: margin.left,
+      marginRight: margin.right,
+      visibleLeft,
+      visibleRight,
+    };
+  });
+  expect(glyphGeometry.visibleLeft).toBeGreaterThanOrEqual(
+    glyphGeometry.marginLeft - 0.5,
+  );
+  expect(glyphGeometry.visibleRight).toBeLessThanOrEqual(
+    glyphGeometry.marginRight + 0.5,
+  );
+
+  const glyphBox = await glyph.boundingBox();
+  expect(glyphBox).not.toBeNull();
+  await page.mouse.click(
+    glyphBox.x + glyphBox.width / 2,
+    glyphBox.y + glyphBox.height / 2,
+  );
+  await expect(
+    modified.locator('.agent-feedback-input-widget textarea'),
+  ).toBeVisible();
+  await page.keyboard.press('Escape');
+
+  const comment = modified.locator(commentSelector);
+  const commentToggle = modified.locator(
+    '.moonbit-viewer-markdown-comment-margin-toggle',
+  );
+  await expect(commentToggle).toBeVisible();
+  await expect(comment).toHaveAttribute('data-documentation-expanded', 'false');
+  await commentToggle.click();
+  await expect(comment).toHaveAttribute('data-documentation-expanded', 'true');
+  await commentToggle.click();
+  await expect(comment).toHaveAttribute('data-documentation-expanded', 'false');
+});
+
 test('keeps rich comments in both split panes and only the modified inline pane', async ({ page }) => {
   const root = await openFixture(page);
   const original = root.locator('.moonbit-diff-editor-original');

--- a/editor/tests/browser/moonbit/component/diff_markdown_comments_scenario.mbt
+++ b/editor/tests/browser/moonbit/component/diff_markdown_comments_scenario.mbt
@@ -90,6 +90,34 @@ fn diff_markdown_comment_partial_modified_source() -> String {
 }
 
 ///|
+fn diff_markdown_comment_editor_options(
+  folding_mode : String,
+) -> @viewer.ViewerOptions {
+  match folding_mode {
+    "disabled" =>
+      @viewer.ViewerOptions(
+        soft_wrap=true,
+        smooth_scrolling=false,
+        line_numbers_min_chars=1,
+        folding=false,
+      )
+    "never" =>
+      @viewer.ViewerOptions(
+        soft_wrap=true,
+        smooth_scrolling=false,
+        line_numbers_min_chars=1,
+        show_folding_controls=Never,
+      )
+    _ =>
+      @viewer.ViewerOptions(
+        soft_wrap=true,
+        smooth_scrolling=false,
+        line_numbers_min_chars=1,
+      )
+  }
+}
+
+///|
 priv struct DiffMarkdownCommentProvider {}
 
 ///|
@@ -164,17 +192,14 @@ fn run_diff_markdown_comments_test() -> Unit {
     languages=languages.language_handle(log_service.log_handle()),
     log_service=log_service.log_handle(),
   )
-  let editor_options = @viewer.ViewerOptions(
-    soft_wrap=true,
-    smooth_scrolling=false,
-    line_numbers_min_chars=1,
-  )
+  let editor_options = Ref(diff_markdown_comment_editor_options("default"))
+  let layout : Ref[@viewer.DiffEditorLayout] = Ref(Inline)
   let diff_editor = @viewer.DiffEditor::create(
     host,
     services~,
     options=DiffEditorOptions(
-      editor_options~,
-      layout=Inline,
+      editor_options=editor_options.val,
+      layout=layout.val,
       automatic_inline=false,
     ),
   )
@@ -240,13 +265,13 @@ fn run_diff_markdown_comments_test() -> Unit {
       diff_editor.set_model(Some(pair)) |> ignore
     },
     layout_name => {
-      let layout : @viewer.DiffEditorLayout = if layout_name == "inline" {
-        Inline
-      } else {
-        SideBySide
-      }
+      layout.val = if layout_name == "inline" { Inline } else { SideBySide }
       diff_editor.update_options(
-        DiffEditorOptions(editor_options~, layout~, automatic_inline=false),
+        DiffEditorOptions(
+          editor_options=editor_options.val,
+          layout=layout.val,
+          automatic_inline=false,
+        ),
       )
     },
     width => {
@@ -256,6 +281,16 @@ fn run_diff_markdown_comments_test() -> Unit {
     enabled => {
       feedback.set_feedback_enabled(unchanged_original.uri, enabled)
       feedback.set_feedback_enabled(unchanged_modified.uri, enabled)
+    },
+    folding_mode => {
+      editor_options.val = diff_markdown_comment_editor_options(folding_mode)
+      diff_editor.update_options(
+        DiffEditorOptions(
+          editor_options=editor_options.val,
+          layout=layout.val,
+          automatic_inline=false,
+        ),
+      )
     },
     () => {
       auto_height_enabled.val = true
@@ -272,16 +307,18 @@ extern "js" fn install_diff_markdown_comments_controls(
   set_layout : (String) -> Unit,
   resize : (Int) -> Unit,
   set_feedback_enabled : (Bool) -> Unit,
+  set_folding_mode : (String) -> Unit,
   enable_auto_height : () -> Unit,
   content_height_event_count : () -> Int,
   content_height : () -> Double,
 ) -> Unit =
-  #| (setFixture, setLayout, resize, setFeedbackEnabled, enableAutoHeight, contentHeightEventCount, contentHeight) => {
+  #| (setFixture, setLayout, resize, setFeedbackEnabled, setFoldingMode, enableAutoHeight, contentHeightEventCount, contentHeight) => {
   #|   globalThis.__diffMarkdownCommentsControls = Object.freeze({
   #|     set_fixture: setFixture,
   #|     set_layout: setLayout,
   #|     resize,
   #|     set_feedback_enabled: setFeedbackEnabled,
+  #|     set_folding_mode: setFoldingMode,
   #|     enable_auto_height: enableAutoHeight,
   #|     content_height_event_count: contentHeightEventCount,
   #|     content_height: contentHeight,

--- a/editor/tests/browser/moonbit/component/diff_markdown_comments_scenario.mbt
+++ b/editor/tests/browser/moonbit/component/diff_markdown_comments_scenario.mbt
@@ -95,21 +95,21 @@ fn diff_markdown_comment_editor_options(
 ) -> @viewer.ViewerOptions {
   match folding_mode {
     "disabled" =>
-      @viewer.ViewerOptions(
+      ViewerOptions(
         soft_wrap=true,
         smooth_scrolling=false,
         line_numbers_min_chars=1,
         folding=false,
       )
     "never" =>
-      @viewer.ViewerOptions(
+      ViewerOptions(
         soft_wrap=true,
         smooth_scrolling=false,
         line_numbers_min_chars=1,
         show_folding_controls=Never,
       )
     _ =>
-      @viewer.ViewerOptions(
+      ViewerOptions(
         soft_wrap=true,
         smooth_scrolling=false,
         line_numbers_min_chars=1,

--- a/editor/tests/browser/moonbit/component/diff_markdown_comments_scenario.mbt
+++ b/editor/tests/browser/moonbit/component/diff_markdown_comments_scenario.mbt
@@ -158,7 +158,9 @@ fn run_diff_markdown_comments_test() -> Unit {
     foldable=true,
   )
   |> ignore
+  let feedback = @feedback_contrib.AgentFeedbackService()
   let services = @viewer.ViewerServices(
+    agent_feedback=feedback.agent_feedback_handle(),
     languages=languages.language_handle(log_service.log_handle()),
     log_service=log_service.log_handle(),
   )
@@ -251,6 +253,10 @@ fn run_diff_markdown_comments_test() -> Unit {
       host.set_attribute("style", "width:\{width}px;height:640px;")
       diff_editor.layout()
     },
+    enabled => {
+      feedback.set_feedback_enabled(unchanged_original.uri, enabled)
+      feedback.set_feedback_enabled(unchanged_modified.uri, enabled)
+    },
     () => {
       auto_height_enabled.val = true
       apply_content_height(diff_editor.get_content_height())
@@ -265,15 +271,17 @@ extern "js" fn install_diff_markdown_comments_controls(
   set_fixture : (String) -> Unit,
   set_layout : (String) -> Unit,
   resize : (Int) -> Unit,
+  set_feedback_enabled : (Bool) -> Unit,
   enable_auto_height : () -> Unit,
   content_height_event_count : () -> Int,
   content_height : () -> Double,
 ) -> Unit =
-  #| (setFixture, setLayout, resize, enableAutoHeight, contentHeightEventCount, contentHeight) => {
+  #| (setFixture, setLayout, resize, setFeedbackEnabled, enableAutoHeight, contentHeightEventCount, contentHeight) => {
   #|   globalThis.__diffMarkdownCommentsControls = Object.freeze({
   #|     set_fixture: setFixture,
   #|     set_layout: setLayout,
   #|     resize,
+  #|     set_feedback_enabled: setFeedbackEnabled,
   #|     enable_auto_height: enableAutoHeight,
   #|     content_height_event_count: contentHeightEventCount,
   #|     content_height: contentHeight,

--- a/editor/tests/browser/moonbit/component/moon.pkg
+++ b/editor/tests/browser/moonbit/component/moon.pkg
@@ -6,6 +6,7 @@ import {
   "moonbitlang/editor/viewer",
   "moonbitlang/editor/internal/viewer/browser/testing" @viewer_testing,
   "moonbitlang/editor/internal/viewer/code_editor_widget" @code_widget,
+  "moonbitlang/editor/internal/viewer/contrib/agent_feedback" @feedback_contrib,
   "moonbitlang/editor/internal/viewer/diff_editor",
   "moonbitlang/editor/viewer/common/editor_api",
   "moonbitlang/editor/viewer/common/diff",

--- a/editor/viewer/viewer_facade_forwarding.mbt
+++ b/editor/viewer/viewer_facade_forwarding.mbt
@@ -21,7 +21,7 @@ pub fn Viewer::get_value(self : Viewer) -> String {
 ///|
 pub fn Viewer::update_options(self : Viewer, options : ViewerOptions) -> Unit {
   self.options = options
-  self.widget.update_options(options.code_options())
+  self.widget.update_host_options(options.code_options())
 }
 
 ///|


### PR DESCRIPTION
## Summary

- reserve DiffEditor's control lane independently of host folding settings so Markdown comment and feedback controls keep their full clickable width
- preserve the feedback lane when editor options are replayed during resize and Split/Unified transitions, while keeping Unified's original line-number strip compact
- cover `folding=false`, `show_folding_controls=Never`, Unified feedback controls, and gutter widths in browser tests

## Testing

- `moon info --frozen`
- `moon fmt`
- `just check`
- `just test`
- `just build`
- `just editor-test`
- `READONLY_EDITOR_BASE_URL=http://127.0.0.1:5184 ./node_modules/.bin/playwright test tests/browser/component/diff_markdown_comments.spec.js` (6 passed)
- `OPENSEEK_DESKTOP_BROWSER_BASE_URL=http://127.0.0.1:5185 npx playwright test tests/rabbita_dom.spec.js --grep 'Review loads changed files'` (1 passed)
- packaged SeekMoon Expand-view QA across Line/Token/Tree Unified modes
