### PR TITLE
fix(editor): align EOF line hunks with inner diffs

### DIFF
--- a/editor/viewer/common/diff/default_lines_diff_computer.mbt
+++ b/editor/viewer/common/diff/default_lines_diff_computer.mbt
@@ -93,25 +93,33 @@ fn LineDocumentDiffProvider::compute_lines_diff(
   )
   let changes : Array[DetailedLineRangeMapping] = []
   for diff in line_diffs {
-    let original = @base_common.LineRange(
+    let original_line_range = @base_common.LineRange(
       diff.original.start + 1,
       diff.original.end_exclusive + 1,
     )
-    let modified = @base_common.LineRange(
+    let modified_line_range = @base_common.LineRange(
       diff.modified.start + 1,
       diff.modified.end_exclusive + 1,
     )
+    let inner_changes = compute_inner_changes(
+      original_lines,
+      modified_lines,
+      original_line_range,
+      modified_line_range,
+      options.ignore_trim_whitespace,
+    )
+    let line_mapping = match inner_changes {
+      Some(inner_changes) =>
+        line_range_mapping_from_inner_changes(
+          inner_changes, original_lines, modified_lines,
+        ).unwrap_or(LineRangeMapping(original_line_range, modified_line_range))
+      None => LineRangeMapping(original_line_range, modified_line_range)
+    }
     changes.push(
       DetailedLineRangeMapping(
-        original,
-        modified,
-        compute_inner_changes(
-          original_lines,
-          modified_lines,
-          original,
-          modified,
-          options.ignore_trim_whitespace,
-        ),
+        line_mapping.original,
+        line_mapping.modified,
+        inner_changes,
       ),
     )
   }

--- a/editor/viewer/common/diff/document_diff_provider_test.mbt
+++ b/editor/viewer/common/diff/document_diff_provider_test.mbt
@@ -57,10 +57,10 @@ test "line provider keeps EOF inner changes inside their line hunks" {
     (
       after,
       before,
-      @base_common.LineRange(2, 4),
-      @base_common.LineRange(2, 2),
-      @base_common.Range(2, 1, 4, 1),
-      @base_common.Range(2, 1, 2, 1),
+      LineRange(2, 4),
+      LineRange(2, 2),
+      Range(2, 1, 4, 1),
+      Range(2, 1, 2, 1),
     ),
   ]
   let provider = @diff.LineDocumentDiffProvider()

--- a/editor/viewer/common/diff/document_diff_provider_test.mbt
+++ b/editor/viewer/common/diff/document_diff_provider_test.mbt
@@ -37,3 +37,61 @@ test "an external package can implement the provider and construct mappings" {
   assert_eq(result.additional_alignments.length(), 1)
   assert_eq(result.changes[0].inner_changes.unwrap()[0].modified.end_column, 3)
 }
+
+///|
+test "line provider keeps EOF inner changes inside their line hunks" {
+  // Reduced from the ci.yml failure in moonbitlang/openseek#1224: the old
+  // document already ends in a newline, and the appended block starts with a
+  // blank line. The line and character refinements must use one EOF anchor.
+  let before = "          retention-days: 7\n"
+  let after = "          retention-days: 7\n\n      # blocks.\n"
+  let cases = [
+    (
+      before,
+      after,
+      @base_common.LineRange(2, 2),
+      @base_common.LineRange(2, 4),
+      @base_common.Range(2, 1, 2, 1),
+      @base_common.Range(2, 1, 4, 1),
+    ),
+    (
+      after,
+      before,
+      @base_common.LineRange(2, 4),
+      @base_common.LineRange(2, 2),
+      @base_common.Range(2, 1, 4, 1),
+      @base_common.Range(2, 1, 2, 1),
+    ),
+  ]
+  let provider = @diff.LineDocumentDiffProvider()
+  for case in cases {
+    let (
+      original,
+      modified,
+      original_lines,
+      modified_lines,
+      original_inner,
+      modified_inner,
+    ) = case
+    let result = provider.compute_diff(
+      TextSnapshot(original),
+      TextSnapshot(modified),
+      { ignore_trim_whitespace: false, },
+    )
+    guard result.changes is [change] && change.inner_changes is Some([inner]) else {
+      fail("expected one refined EOF change")
+    }
+    assert_eq(change.original, original_lines)
+    assert_eq(change.modified, modified_lines)
+    assert_eq(inner.original, original_inner)
+    assert_eq(inner.modified, modified_inner)
+    assert_eq(
+      @diff.normalize_and_validate_document_diff(
+        result,
+        TextSnapshot(original),
+        TextSnapshot(modified),
+      ),
+      Some(result),
+    )
+  }
+}

--- a/editor/viewer/common/diff/range_mapping.mbt
+++ b/editor/viewer/common/diff/range_mapping.mbt
@@ -78,6 +78,75 @@ pub fn DetailedLineRangeMapping::line_mapping(
 }
 
 ///|
+// Port of VS Code's `getLineRangeMapping` (`rangeMapping.ts`). Character
+// refinement can include the newline immediately before an EOF-only change;
+// derive the final line hunk from that mapping so both coordinate layers use
+// the same anchor.
+fn line_range_mapping_from_range_mapping(
+  range_mapping : RangeMapping,
+  original_lines : Array[String],
+  modified_lines : Array[String],
+) -> LineRangeMapping {
+  let mut line_start_delta = 0
+  let mut line_end_delta = 0
+  if range_mapping.modified.end_column == 1 &&
+    range_mapping.original.end_column == 1 &&
+    range_mapping.original.start_line_number + line_start_delta <=
+    range_mapping.original.end_line_number &&
+    range_mapping.modified.start_line_number + line_start_delta <=
+    range_mapping.modified.end_line_number {
+    line_end_delta = -1
+  }
+  if range_mapping.modified.start_column - 1 >=
+    modified_lines[range_mapping.modified.start_line_number - 1].length() &&
+    range_mapping.original.start_column - 1 >=
+    original_lines[range_mapping.original.start_line_number - 1].length() &&
+    range_mapping.original.start_line_number <=
+    range_mapping.original.end_line_number + line_end_delta &&
+    range_mapping.modified.start_line_number <=
+    range_mapping.modified.end_line_number + line_end_delta {
+    line_start_delta = 1
+  }
+  LineRangeMapping(
+    LineRange(
+      range_mapping.original.start_line_number + line_start_delta,
+      range_mapping.original.end_line_number + 1 + line_end_delta,
+    ),
+    LineRange(
+      range_mapping.modified.start_line_number + line_start_delta,
+      range_mapping.modified.end_line_number + 1 + line_end_delta,
+    ),
+  )
+}
+
+///|
+fn line_range_mapping_from_inner_changes(
+  inner_changes : Array[RangeMapping],
+  original_lines : Array[String],
+  modified_lines : Array[String],
+) -> LineRangeMapping? {
+  if inner_changes.is_empty() {
+    return None
+  }
+  let first = line_range_mapping_from_range_mapping(
+    inner_changes[0],
+    original_lines,
+    modified_lines,
+  )
+  let last = line_range_mapping_from_range_mapping(
+    inner_changes[inner_changes.length() - 1],
+    original_lines,
+    modified_lines,
+  )
+  Some(
+    LineRangeMapping(
+      first.original.join(last.original),
+      first.modified.join(last.modified),
+    ),
+  )
+}
+
+///|
 pub extend LineRangeMapping with Debug::{to_repr}
 
 ///|


### PR DESCRIPTION
## Summary

- derive each refined line hunk from its character-level range mappings, matching VS Code's `getLineRangeMapping` behavior
- keep EOF insertions and deletions inside their parent line hunks while preserving the existing line-only fallback when character refinement is unavailable
- add a black-box regression test that runs the built-in provider output through the public diff validator in both directions

## Reproduction

The exact `.github/workflows/ci.yml` change behind #1224 produces `TextSnapshot` line counts of 234 and 307. Before this change, the line diff used `[235, 235)` / `[235, 308)` while the inner mapping was anchored at line 234, so validation rejected the provider result.

After deriving the outer hunk from the refined mapping, the same input produces `[234, 234)` / `[234, 307)` and validates successfully.

Fixes #1224

## Testing

- `moon -C editor test viewer/common/diff --target wasm` (36/36)
- `moon -C editor test viewer/common/diff --target js` (36/36)
- `moon -C editor test viewer/common/diff --target native` (36/36)
- `just editor-test` (wasm 1079/1079, js 1864/1864, native 1214/1214)
- `just editor-test-browser` (96/96)
- `just check`
- `just test` (native 3397/3397, js 3175/3175, cram 28/28)
- `just build`
- `moon info && moon fmt` (`.mbti` unchanged)
- packaged SeekMoon.app with `--no-open`; the real Expand view rendered the full `ci.yml` diff through line 307 with no diff-computation error, page error, or console warning
