### PR TITLE
fix(desktop): pass macOS deployment target to Proton

### DIFF
--- a/desktop/package/macos/main.mbt
+++ b/desktop/package/macos/main.mbt
@@ -264,6 +264,9 @@ async fn @packaging.Workspace::package_with_proton(
 ) -> Unit {
   let args = options.proton_args(self)
   let package_env : Map[String, String] = {
+    // Proton performs the final native build while packaging, so this target
+    // must reach that nested Moon process as well as the prebuild above.
+    "MACOSX_DEPLOYMENT_TARGET": MinMacOSVersion,
     "PROTON_MACOS_ENTITLEMENTS": self.at(SigningEntitlementsPath),
   }
   match options.sign.identity {


### PR DESCRIPTION
## Summary

- pass `MACOSX_DEPLOYMENT_TARGET=12.0` into the Proton package environment
- ensure the final nested Moon build preserves the supported macOS deployment target

## Validation

- `moon -C desktop check package/macos --target native`
- `moon -C desktop test package/macos --target native` (5 passed)
- `moon -C desktop info`
- `moon -C desktop fmt`
- the final `moon ... --build-only` artifact reports `minos 12.0` with `vtool -show-build`

## Validation limit

- full `.app` assembly was not completed because the Mermaid 11.16.0 npm tarball download did not finish; packaging had already passed CEF and frontend preparation