### PR TITLE
fix(desktop): increase notification log capacity

### DIFF
--- a/desktop/internal/api/hub.mbt
+++ b/desktop/internal/api/hub.mbt
@@ -11,7 +11,7 @@
 /// desktop webview and a healthy browser drain far faster than the engine
 /// produces — so a subscriber this far behind is a wedged connection, and
 /// the protocol's answer to a wedged connection is to resync it.
-const NotificationLogCapacity = 1024
+const NotificationLogCapacity = 4096
 
 ///|
 /// The hub is owned by `ApiState`; transports reach it through


### PR DESCRIPTION
This PR increase the desktop bridge queue, specifically from backend -> frontend. The WebView can be lagged and may take some time to process all these events, and we increase the capacity to 4096 as our first step to mitigate this issue.