### PR TITLE
Refactor desktop selects with anchored popovers

### DIFF
--- a/desktop/frontend/select_control/view.mbt
+++ b/desktop/frontend/select_control/view.mbt
@@ -72,16 +72,6 @@ fn Presentation::menu_class(self : Presentation) -> String {
 }
 
 ///|
-/// The initial direction prevents a misplaced first frame before the opened
-/// menu has been measured. Its AfterRender command may flip this value.
-fn Presentation::initial_placement(self : Presentation) -> String {
-  match self {
-    Composer(_, _) => "up"
-    Setting => "down"
-  }
-}
-
-///|
 fn Presentation::trigger_contents(
   self : Presentation,
   selected_label : String,
@@ -144,78 +134,29 @@ fn Control::focus(
 }
 
 ///|
-/// Prefer placing an opened menu below its trigger. It flips upward only when
-/// the rendered menu does not fit below and the upper side has more room. The
-/// viewport is intersected with every clipping ancestor, so a select inside
-/// the scrolling Settings page or setup modal reacts to that surface rather
-/// than assuming the whole window is available.
-fn Control::position_menu(self : Control) -> @cmd.Cmd {
+/// Lift the menu into CEF's top layer after Rabbita commits it. CSS anchor
+/// positioning keeps it attached to the trigger and chooses the side that
+/// fits, so opening a select needs no geometry measurement or clipping-parent
+/// traversal in application code.
+fn Control::show_menu(self : Control) -> @cmd.Cmd {
   @cmd.custom_cmd(
     _ => {
-      guard @dom.document().get_element_by_id(self.root_id()).to_option()
-        is Some(root) &&
-        @dom.document().get_element_by_id(self.id).to_option() is Some(trigger) &&
-        @dom.document().get_element_by_id(self.menu_id()).to_option()
-        is Some(menu) else {
+      guard @dom.document().get_element_by_id(self.menu_id()).to_option()
+        is Some(element) &&
+        element.to_html_element() is Some(menu) else {
         return
       }
-      let window = @dom.window()
-      let mut visible_top = 0.0
-      let mut visible_bottom = window.inner_height().to_double()
-      if window.get_visual_viewport() is Some(viewport) {
-        visible_top = viewport.get_offset_top()
-        visible_bottom = visible_top + viewport.get_height()
-      }
-      let mut parent = root.get_parent_element()
-      while parent is Some(ancestor) {
-        let overflow = window
-          .get_computed_style(ancestor)
-          .get_property_value("overflow-y")
-        if overflow == "auto" ||
-          overflow == "scroll" ||
-          overflow == "hidden" ||
-          overflow == "clip" {
-          let rect = ancestor.get_bounding_client_rect()
-          let top = rect.get_top() + ancestor.get_client_top()
-          let bottom = top + ancestor.get_client_height()
-          if top > visible_top {
-            visible_top = top
-          }
-          if bottom < visible_bottom {
-            visible_bottom = bottom
-          }
-        }
-        parent = ancestor.get_parent_element()
-      }
-      let trigger_rect = trigger.get_bounding_client_rect()
-      let gap = 6.0
-      let above = trigger_rect.get_top() - visible_top - gap
-      let below = visible_bottom - trigger_rect.get_bottom() - gap
-      let menu_height = menu.get_bounding_client_rect().get_height()
-      let (placement, available) = if below >= menu_height || below >= above {
-        ("down", below)
-      } else {
-        ("up", above)
-      }
-      menu.set_attribute("data-placement", placement)
-      let height = if available > 0.0 { available } else { 0.0 }
-      let style : @js.Value = @js.Value::cast_from(menu).get_with_string(
-        "style",
-      )
-      let _ : @js.Value = style.apply_with_string("setProperty", [
-        @js.Value::cast_from("--custom-select-available-height"),
-        @js.Value::cast_from("\{height.to_int()}px"),
-      ])
+      menu.show_popover()
     },
     kind=@cmd.after_render,
   )
 }
 
 ///|
-/// Toggling changes whether the menu exists, so placement is measured only
-/// after Rabbita has committed that render.
+/// Toggling changes whether the menu exists, so it enters the browser's top
+/// layer only after Rabbita has committed that render.
 fn Control::toggle_menu(self : Control) -> @cmd.Cmd {
-  @cmd.batch([self.toggle, self.position_menu()])
+  @cmd.batch([self.toggle, self.show_menu()])
 }
 
 ///|
@@ -397,7 +338,7 @@ pub fn Control::render(self : Control) -> @html.Html {
           .id(self.menu_id())
           .role("listbox")
           .aria_label(self.aria_label)
-          .data_set("placement", self.presentation.initial_placement()),
+          .popover("manual"),
         menu,
       ),
     )

--- a/desktop/styles/README.md
+++ b/desktop/styles/README.md
@@ -5,6 +5,24 @@ concatenates the same files in the same order, so every application style must
 live in one of the listed sources. Viewer styles are separate and must not be
 targeted through global element selectors.
 
+## Browser baseline
+
+The Desktop's pinned Proton 0.2.5 runtime bundles CEF 150.0.19, based on
+Chromium 150.0.7871.252. The canonical version comes from the resolved
+`proton_cefsetup` package's `requirements.json`; update this section when the
+Proton dependencies change. `.proton/runtime.json` describes only the locally
+prepared runtime and may lag until setup runs again.
+
+Prefer the strongest stable CSS feature available in that Chromium baseline
+when it makes layout ownership clearer, removes JavaScript measurement, or
+replaces a hand-built browser primitive. No fallback for older browsers is
+needed. Examples include container queries for resizable panes and CSS anchor
+positioning with the Popover API for floating controls.
+
+Using a newer feature is not itself a design goal. Keep application state such
+as persisted user-resized dimensions in the model, and do not add motion or
+visual treatment merely because the engine supports it.
+
 ## Tokens
 
 Define shared semantic values in `tokens.css`: palette roles, the small type

--- a/desktop/styles/base.css
+++ b/desktop/styles/base.css
@@ -66,14 +66,17 @@ samp,
 }
 
 /* Every app-owned select uses the same popup surface and option semantics.
-   Individual pages only choose trigger geometry; the component measures the
-   visible room and flips upward only when the menu cannot fit below. */
+   Reusing one scoped anchor name gives each select a private positioning seam;
+   its top-layer menu escapes pane clipping without exposing unique CSS names
+   to callers. */
 .custom-select {
+  anchor-scope: --custom-select-trigger;
   position: relative;
   min-width: 0;
 }
 
 .custom-select-button {
+  anchor-name: --custom-select-trigger;
   margin: 0;
   font: inherit;
   cursor: pointer;
@@ -85,14 +88,15 @@ samp,
 }
 
 .custom-select-menu {
-  position: absolute;
+  position: fixed;
+  position-anchor: --custom-select-trigger;
+  position-visibility: anchors-visible;
+  position-area: block-end span-inline-end;
+  position-try-fallbacks: flip-block;
+  inset: auto;
   z-index: var(--z-menu);
-  display: grid;
-  max-height: min(
-    360px,
-    calc(100vh - 140px),
-    var(--custom-select-available-height, 360px)
-  );
+  max-height: min(360px, calc(100dvh - 24px));
+  margin: 6px 0 0;
   overflow-x: hidden;
   overflow-y: auto;
   overscroll-behavior: contain;
@@ -103,14 +107,8 @@ samp,
   box-shadow: var(--shadow-surface);
 }
 
-.custom-select-menu[data-placement="down"] {
-  top: calc(100% + 6px);
-  bottom: auto;
-}
-
-.custom-select-menu[data-placement="up"] {
-  top: auto;
-  bottom: calc(100% + 6px);
+.custom-select-menu:popover-open {
+  display: grid;
 }
 
 .custom-select-group + .custom-select-group {

--- a/desktop/styles/codex.css
+++ b/desktop/styles/codex.css
@@ -370,7 +370,9 @@
   font-size: 11px;
 }
 
-@media (max-width: 720px) {
+/* These controls belong to the conversation pane, whose width can change
+   independently when the sidebar or file panel is resized. */
+@container main-pane (max-width: 720px) {
   .codex-request-action {
     min-height: 44px;
     padding-top: 10px;

--- a/desktop/styles/composer.css
+++ b/desktop/styles/composer.css
@@ -783,10 +783,10 @@
   transform: rotate(45deg);
 }
 
-/* Container units keep the menu inside a chat column narrowed by the editor
-   panel. Shared select placement prefers below and flips when needed. */
+/* Container units keep the top-layer menu sized to a chat column narrowed by
+   the editor panel. Shared anchor positioning prefers below and flips when
+   needed. */
 .composer-picker-menu {
-  left: 0;
   width: max-content;
   min-width: min(170px, calc(100cqi - 20px));
   max-width: min(340px, calc(100cqi - 20px));
@@ -795,8 +795,7 @@
 /* The reasoning chip follows the model chip. Right anchoring makes its short
    menu grow back toward the composer's safe left edge on narrow layouts. */
 .composer-picker-right .composer-picker-menu {
-  right: 0;
-  left: auto;
+  position-area: block-end span-inline-start;
 }
 
 .composer-picker .custom-select-option {

--- a/desktop/styles/main_header.css
+++ b/desktop/styles/main_header.css
@@ -15,6 +15,7 @@ main {
   /* Descendants use the live main-pane height to keep the composer inside the
      conversation row while the terminal is resized. */
   container-type: size;
+  container-name: main-pane;
   min-width: 0;
   min-height: 0;
   overflow: hidden;

--- a/desktop/styles/pages.css
+++ b/desktop/styles/pages.css
@@ -365,13 +365,11 @@ h2 {
   pointer-events: none;
 }
 
-/* Settings menus retain the row's exact width while shared select placement
-   prefers below and flips when needed. */
+/* Settings menus retain the trigger's exact width while the top-layer menu
+   remains free of the page or setup modal's clipping. */
 .setting-select-menu {
-  right: 0;
-  left: 0;
-  width: 100%;
-  min-width: min(220px, 100%);
+  width: anchor-size(width);
+  min-width: min(220px, anchor-size(width));
 }
 
 /* ---------- skills page ---------- */


### PR DESCRIPTION
## Why

Desktop custom selects manually measured the viewport, traversed clipping ancestors, calculated available height, and wrote positioning state back into CSS. That duplicated layout work the bundled browser already provides and made every clipped or resizable surface part of the select implementation.

The Desktop now pins CEF 150.0.19 / Chromium 150.0.7871.252, where top-layer popovers and CSS anchor positioning are stable. Conversation compaction also needs to follow the resizable main pane rather than the outer window.

## What changed

- Render shared select menus as manual top-layer popovers.
- Use scoped CSS anchors, browser-selected block flipping, anchor visibility, and anchor-based sizing for composer and settings menus.
- Remove the MoonBit geometry measurement and clipping-ancestor traversal.
- Make Codex compact styling query the named main pane container.
- Document the pinned browser baseline and the policy for adopting stable CSS features it supports.

## Why this is correct

Caller-owned open state, selection, focus restoration, keyboard navigation, and dismissal remain unchanged. The shared select interface also stays unchanged; only popup presentation moves behind the browser positioning primitive. Scoped anchor names keep repeated controls independent, while the top layer lets menus escape pane and modal clipping.

The global narrow breakpoint remains responsible for actual drawer and drill-down behavior. Only presentation that belongs to the resizable conversation pane moved to a container query.

## Scope

This is one shared-control and responsive-ownership refactor. It does not include the postponed sidebar header redesign or the local UX prototypes.