### PR TITLE
chore: update to proton 0.2.6

### DIFF
--- a/desktop/internal/extension/browser_views.mbt
+++ b/desktop/internal/extension/browser_views.mbt
@@ -23,7 +23,7 @@ pub fn BrowserViews::window_ready(
   window : @proton.WindowHandle,
 ) -> Unit {
   self.window = Some(window)
-  let dark = (window.state().theme == "dark") catch { _ => false }
+  let dark = (window.state().theme == Dark) catch { _ => false }
   let _ = @platform.set_titlebar_dark_mode(dark)
 }
 

--- a/desktop/moon.mod
+++ b/desktop/moon.mod
@@ -12,15 +12,15 @@ import {
   "moonbit-community/rabbita@0.15.4",
   "moonbitlang/x@0.4.50",
   "moonbitlang/async@0.21.0",
-  "moonbit-community/proton@0.2.5",
-  "moonbit-community/proton_ext@0.2.5",
+  "moonbit-community/proton@0.2.6",
+  "moonbit-community/proton_ext@0.2.6",
   "tonyfettes/platform@0.1.1",
   "tonyfettes/xlog@0.4.0",
   "moonbitlang/editor@0.4.4",
-  "moonbit-community/proton_contract@0.2.5",
+  "moonbit-community/proton_contract@0.2.6",
   "bobzhang/openseek@0.2.2",
-  "moonbit-community/proton_cefsetup@0.2.5",
-  "moonbit-community/proton_config@0.2.5",
+  "moonbit-community/proton_cefsetup@0.2.6",
+  "moonbit-community/proton_config@0.2.6",
 }
 
 readme = "README.md"


### PR DESCRIPTION
This PR update proton to 0.2.6, including the title NULL check fix.