### PR TITLE
desktop: update Proton to 0.2.6

### DIFF
--- a/desktop/frontend/browser_ops.mbt
+++ b/desktop/frontend/browser_ops.mbt
@@ -101,8 +101,8 @@ fn browser_set_theme_for_pages(
 }
 
 ///|
-/// Apply the effective palette to the native Windows caption controls. Other
-/// platforms accept the window-local command as a no-op.
+/// Apply the effective palette to native caption controls on platforms where
+/// Proton supports an explicit per-window theme.
 fn app_set_titlebar_theme(dispatch : @cmd.Emit[Msg], dark : Bool) -> @cmd.Cmd {
   browser_op(dispatch, @commands.app_set_titlebar_theme, { dark, }, quiet=true)
 }

--- a/desktop/internal/extension/browser_views.mbt
+++ b/desktop/internal/extension/browser_views.mbt
@@ -23,8 +23,6 @@ pub fn BrowserViews::window_ready(
   window : @proton.WindowHandle,
 ) -> Unit {
   self.window = Some(window)
-  let dark = (window.state().theme == "dark") catch { _ => false }
-  let _ = @platform.set_titlebar_dark_mode(dark)
 }
 
 ///|
@@ -104,7 +102,6 @@ priv suberror BrowserViewError {
   WindowNotReady
   UnknownView(Int)
   BlockedURL(String)
-  TitlebarThemeUnavailable
 } derive(Debug)
 
 ///|
@@ -113,8 +110,6 @@ impl Show for BrowserViewError with fn output(self, logger) {
     WindowNotReady => logger.write_string("The desktop window is not ready")
     UnknownView(id) => logger.write_string("Unknown browser view \{id}")
     BlockedURL(url) => logger.write_string("Blocked non-web page URL: \{url}")
-    TitlebarThemeUnavailable =>
-      logger.write_string("The Windows titlebar theme could not be applied")
   }
 }
 
@@ -300,9 +295,9 @@ fn BrowserViews::set_app_titlebar_theme(
   self : BrowserViews,
   payload : @protocol.AppTitlebarThemePayload,
 ) -> @protocol.EmptyReply raise {
-  let _ = self.attached_window()
-  guard @platform.set_titlebar_dark_mode(payload.dark) else {
-    raise TitlebarThemeUnavailable
+  let window = self.attached_window()
+  if @sys.win32 || @sys.win64 || @sys.apple_os_mac {
+    window.set_theme(if payload.dark { Dark } else { Light })
   }
   Acknowledged
 }

--- a/desktop/internal/extension/moon.pkg
+++ b/desktop/internal/extension/moon.pkg
@@ -13,6 +13,7 @@ import {
   "moonbitlang/async",
   "moonbitlang/async/fs",
   "moonbitlang/core/string",
+  "tonyfettes/platform" @sys,
   "tonyfettes/xlog",
 }
 

--- a/desktop/internal/platform/pkg.generated.mbti
+++ b/desktop/internal/platform/pkg.generated.mbti
@@ -10,8 +10,6 @@ pub async fn open_path(String) -> Int
 
 pub async fn open_url(String) -> Int
 
-pub fn set_titlebar_dark_mode(Bool) -> Bool
-
 // Errors
 
 // Types and methods

--- a/desktop/internal/platform/platform.mbt
+++ b/desktop/internal/platform/platform.mbt
@@ -18,36 +18,6 @@ pub fn is_darwin() -> Bool {
 extern "C" fn windows_open(target : String) -> Int = "moonbit_openseek_desktop_platform_open"
 
 ///|
-extern "C" fn windows_set_titlebar_dark_mode(dark : Int) -> Int = "moonbit_openseek_desktop_platform_set_titlebar_dark_mode"
-
-///|
-fn titlebar_dark_mode_flag(dark : Bool) -> Int {
-  if dark {
-    1
-  } else {
-    0
-  }
-}
-
-///|
-/// Keep the native Windows caption glyphs aligned with the app's effective
-/// palette. The C side retains this preference across activation and DPI
-/// changes because Proton 0.1.x reapplies its own overlay frame there.
-/// TODO(https://github.com/moonbit-community/proton/issues/214): After adopting
-/// a Proton release that resolves this issue, remove this host-owned Win32
-/// workaround, including its FFI entry point and window subclass.
-pub fn set_titlebar_dark_mode(dark : Bool) -> Bool {
-  guard @sys.win32 || @sys.win64 else { return true }
-  windows_set_titlebar_dark_mode(titlebar_dark_mode_flag(dark)) == 0
-}
-
-///|
-test "titlebar theme converts the effective palette to a native flag" {
-  assert_eq(titlebar_dark_mode_flag(false), 0)
-  assert_eq(titlebar_dark_mode_flag(true), 1)
-}
-
-///|
 /// Hand `path` to the platform's default opener, returning its exit code. The
 /// opener returns as soon as it has handed the file off (LaunchServices on
 /// macOS, the desktop portal on Linux), so the code reports the hand-off, not

--- a/desktop/internal/platform/platform_native.c
+++ b/desktop/internal/platform/platform_native.c
@@ -11,115 +11,17 @@
 #if defined(_WIN32)
 
 #include <windows.h>
-#include <commctrl.h>
-#include <dwmapi.h>
 #include <shellapi.h>
 
 #if !defined(_MSC_VER)
 #error "SeekMoon's Windows desktop host requires an MSVC-compatible compiler"
 #endif
 
-#pragma comment(lib, "comctl32.lib")
-#pragma comment(lib, "dwmapi.lib")
 #pragma comment(lib, "shell32.lib")
-#pragma comment(lib, "user32.lib")
 #pragma comment(linker, "/SUBSYSTEM:WINDOWS")
 #pragma comment(linker, "/ENTRY:mainCRTStartup")
 
-#define OPENSEEK_DWMWA_USE_IMMERSIVE_DARK_MODE 20
-#define OPENSEEK_DWMWA_USE_IMMERSIVE_DARK_MODE_BEFORE_20H1 19
-#define OPENSEEK_TITLEBAR_SUBCLASS_ID 0x53454B4D
-
-typedef struct openseek_window_search {
-  DWORD process_id;
-  HWND window;
-} openseek_window_search_t;
-
-static BOOL CALLBACK openseek_find_main_window(HWND window, LPARAM data) {
-  openseek_window_search_t *search = (openseek_window_search_t *)data;
-  DWORD process_id = 0;
-  GetWindowThreadProcessId(window, &process_id);
-  if (process_id != search->process_id || !IsWindowVisible(window) ||
-      GetWindow(window, GW_OWNER) != NULL ||
-      (GetWindowLongPtrW(window, GWL_EXSTYLE) & WS_EX_TOOLWINDOW) != 0) {
-    return TRUE;
-  }
-  search->window = window;
-  return FALSE;
-}
-
-static HWND openseek_main_window(void) {
-  const DWORD process_id = GetCurrentProcessId();
-  HWND window = GetForegroundWindow();
-  DWORD foreground_process_id = 0;
-  if (window != NULL) {
-    GetWindowThreadProcessId(window, &foreground_process_id);
-    if (foreground_process_id == process_id &&
-        GetWindow(window, GW_OWNER) == NULL) {
-      return window;
-    }
-  }
-  openseek_window_search_t search = {
-      .process_id = process_id,
-      .window = NULL,
-  };
-  EnumWindows(openseek_find_main_window, (LPARAM)&search);
-  return search.window;
-}
-
-static HRESULT openseek_apply_titlebar_dark_mode(HWND window, BOOL dark) {
-  HRESULT result = DwmSetWindowAttribute(
-      window, OPENSEEK_DWMWA_USE_IMMERSIVE_DARK_MODE, &dark, sizeof(dark));
-  if (FAILED(result)) {
-    result = DwmSetWindowAttribute(
-        window, OPENSEEK_DWMWA_USE_IMMERSIVE_DARK_MODE_BEFORE_20H1, &dark,
-        sizeof(dark));
-  }
-  if (SUCCEEDED(result)) {
-    RedrawWindow(window, NULL, NULL,
-                 RDW_FRAME | RDW_INVALIDATE | RDW_UPDATENOW);
-  }
-  return result;
-}
-
-static LRESULT CALLBACK openseek_titlebar_subclass(
-    HWND window, UINT message, WPARAM wparam, LPARAM lparam,
-    UINT_PTR subclass_id, DWORD_PTR data) {
-  if (message == WM_NCDESTROY) {
-    RemoveWindowSubclass(window, openseek_titlebar_subclass, subclass_id);
-    return DefSubclassProc(window, message, wparam, lparam);
-  }
-  LRESULT result = DefSubclassProc(window, message, wparam, lparam);
-  if (message == WM_ACTIVATE || message == WM_DPICHANGED ||
-      message == WM_THEMECHANGED || message == WM_SETTINGCHANGE) {
-    (void)openseek_apply_titlebar_dark_mode(window, data != 0);
-  }
-  return result;
-}
-
 #endif
-
-MOONBIT_FFI_EXPORT int32_t
-moonbit_openseek_desktop_platform_set_titlebar_dark_mode(int32_t dark) {
-#if defined(_WIN32)
-  HWND window = openseek_main_window();
-  if (window == NULL) {
-    return 1;
-  }
-  if (!SetWindowSubclass(window, openseek_titlebar_subclass,
-                         OPENSEEK_TITLEBAR_SUBCLASS_ID,
-                         dark != 0 ? 1 : 0)) {
-    return 2;
-  }
-  return SUCCEEDED(
-             openseek_apply_titlebar_dark_mode(window, dark != 0 ? TRUE : FALSE))
-             ? 0
-             : 3;
-#else
-  (void)dark;
-  return 0;
-#endif
-}
 
 MOONBIT_FFI_EXPORT int32_t
 moonbit_openseek_desktop_platform_open(moonbit_string_t target) {

--- a/desktop/moon.mod
+++ b/desktop/moon.mod
@@ -12,15 +12,15 @@ import {
   "moonbit-community/rabbita@0.15.4",
   "moonbitlang/x@0.4.50",
   "moonbitlang/async@0.21.0",
-  "moonbit-community/proton@0.2.5",
-  "moonbit-community/proton_ext@0.2.5",
+  "moonbit-community/proton@0.2.6",
+  "moonbit-community/proton_ext@0.2.6",
   "tonyfettes/platform@0.1.1",
   "tonyfettes/xlog@0.4.0",
   "moonbitlang/editor@0.4.4",
-  "moonbit-community/proton_contract@0.2.5",
+  "moonbit-community/proton_contract@0.2.6",
   "bobzhang/openseek@0.2.2",
-  "moonbit-community/proton_cefsetup@0.2.5",
-  "moonbit-community/proton_config@0.2.5",
+  "moonbit-community/proton_cefsetup@0.2.6",
+  "moonbit-community/proton_config@0.2.6",
 }
 
 readme = "README.md"


### PR DESCRIPTION
## Summary

- update the Proton dependency family to 0.2.6 in lockstep
- apply SeekMoon’s effective theme through Proton’s WindowHandle::set_theme API on Windows and macOS
- remove the obsolete Win32 DWM and window-subclass workaround for moonbit-community/proton#214

## Testing

- just check
- moon -C desktop test internal/extension --target native (8 passed)
- moon -C desktop test internal/platform --target native (no test entry)
- just build
- moon info && moon fmt

## Notes

Linux remains a no-op for explicit light/dark window themes because Proton does not support that preference there yet.

A local macOS build still reports proton/internal/logging/logging_io.o as targeting macOS 26.0, while the other inspected Proton objects target macOS 12.0. That residual upstream deployment-target issue is not addressed by this PR.