### PR TITLE
refactor(desktop): consolidate shared CSS contracts

### DIFF
--- a/desktop/frontend/archive.mbt
+++ b/desktop/frontend/archive.mbt
@@ -205,7 +205,11 @@ fn archived_delete_modal(
           "“\{confirm.title}” and all of its archived subagent history will be permanently deleted. This cannot be undone. Project files and Git branches will remain.",
         ),
         @html.div(class="modal-actions", [
-          @html.button(on_click=dispatch(CancelDeleteArchivedSession), "Cancel"),
+          @html.button(
+            class="secondary",
+            on_click=dispatch(CancelDeleteArchivedSession),
+            "Cancel",
+          ),
           @html.button(
             class="danger",
             on_click=dispatch(ConfirmDeleteArchivedSession),

--- a/desktop/frontend/archive.mbt
+++ b/desktop/frontend/archive.mbt
@@ -206,12 +206,12 @@ fn archived_delete_modal(
         ),
         @html.div(class="modal-actions", [
           @html.button(
-            class="secondary",
+            class="button secondary",
             on_click=dispatch(CancelDeleteArchivedSession),
             "Cancel",
           ),
           @html.button(
-            class="danger",
+            class="button danger",
             on_click=dispatch(ConfirmDeleteArchivedSession),
             "Delete permanently",
           ),

--- a/desktop/frontend/codex/completion.mbt
+++ b/desktop/frontend/codex/completion.mbt
@@ -258,7 +258,7 @@ fn CodexPermissionPicker::confirmation_dialog(
             "Codex will be able to access the internet and read or modify any file on this computer without asking. Approve for me is safer because it keeps the workspace sandbox in place.",
           ),
           @html.div(class="modal-actions", [
-            @html.button(on_click=cancel, "Cancel"),
+            @html.button(class="secondary", on_click=cancel, "Cancel"),
             @html.button(
               class="danger",
               on_click=dispatch(ConfirmFullAccess),

--- a/desktop/frontend/codex/completion.mbt
+++ b/desktop/frontend/codex/completion.mbt
@@ -258,9 +258,9 @@ fn CodexPermissionPicker::confirmation_dialog(
             "Codex will be able to access the internet and read or modify any file on this computer without asking. Approve for me is safer because it keeps the workspace sandbox in place.",
           ),
           @html.div(class="modal-actions", [
-            @html.button(class="secondary", on_click=cancel, "Cancel"),
+            @html.button(class="button secondary", on_click=cancel, "Cancel"),
             @html.button(
-              class="danger",
+              class="button danger",
               on_click=dispatch(ConfirmFullAccess),
               "Enable full access",
             ),

--- a/desktop/frontend/composer/codex_request.mbt
+++ b/desktop/frontend/composer/codex_request.mbt
@@ -432,6 +432,7 @@ fn CodexRequestInput::render(
                 answer=value,
               )
             }),
+            attrs=@html.Attrs::build().data_set("focus-owner", ""),
           ),
         )
         body.push(@html.div(class="codex-question", controls))
@@ -466,6 +467,7 @@ fn CodexRequestInput::render(
               answer=value,
             )
           }),
+          attrs=@html.Attrs::build().data_set("focus-owner", ""),
           "",
         ),
       )

--- a/desktop/frontend/composer/view.mbt
+++ b/desktop/frontend/composer/view.mbt
@@ -660,9 +660,13 @@ pub fn WorktreeArchiveDialog::render(
       @html.div(class="modal-title", "Archive this \{self.conversation_noun}?"),
       @html.div(class="modal-body", self.message()),
       @html.div(class="modal-actions", [
-        @html.button(class="secondary", on_click=self.cancel, "Keep working"),
         @html.button(
-          class="primary",
+          class="button secondary",
+          on_click=self.cancel,
+          "Keep working",
+        ),
+        @html.button(
+          class="button primary",
           on_click=self.confirm,
           "Discard local changes and archive",
         ),

--- a/desktop/frontend/composer/view.mbt
+++ b/desktop/frontend/composer/view.mbt
@@ -660,7 +660,7 @@ pub fn WorktreeArchiveDialog::render(
       @html.div(class="modal-title", "Archive this \{self.conversation_noun}?"),
       @html.div(class="modal-body", self.message()),
       @html.div(class="modal-actions", [
-        @html.button(on_click=self.cancel, "Keep working"),
+        @html.button(class="secondary", on_click=self.cancel, "Keep working"),
         @html.button(
           class="primary",
           on_click=self.confirm,

--- a/desktop/frontend/project_picker/view.mbt
+++ b/desktop/frontend/project_picker/view.mbt
@@ -351,7 +351,12 @@ fn picker_footer(emit : @cmd.Emit[Msg], picker : State) -> @html.Html {
   @html.div(class="picker-footer", [
     current_location(picker),
     @html.div(class="modal-actions", [
-      @html.button(type_="button", on_click=emit(Close), "Cancel"),
+      @html.button(
+        class="secondary",
+        type_="button",
+        on_click=emit(Close),
+        "Cancel",
+      ),
       @html.button(
         class="primary",
         type_="button",

--- a/desktop/frontend/project_picker/view.mbt
+++ b/desktop/frontend/project_picker/view.mbt
@@ -352,13 +352,13 @@ fn picker_footer(emit : @cmd.Emit[Msg], picker : State) -> @html.Html {
     current_location(picker),
     @html.div(class="modal-actions", [
       @html.button(
-        class="secondary",
+        class="button secondary",
         type_="button",
         on_click=emit(Close),
         "Cancel",
       ),
       @html.button(
-        class="primary",
+        class="button primary",
         type_="button",
         disabled=!can_confirm,
         on_click=emit(Confirm),

--- a/desktop/frontend/sidebar/sidebar.mbt
+++ b/desktop/frontend/sidebar/sidebar.mbt
@@ -151,7 +151,7 @@ pub fn component(
     if input.update_label is Some(label) {
       footer.push(
         @html.button(
-          class="sidebar-button primary",
+          class="sidebar-button sidebar-button-accent",
           disabled=!input.update_enabled,
           on_click=actions.update,
           [

--- a/desktop/frontend/sidebar/sidebar.mbt
+++ b/desktop/frontend/sidebar/sidebar.mbt
@@ -151,7 +151,7 @@ pub fn component(
     if input.update_label is Some(label) {
       footer.push(
         @html.button(
-          class="sidebar-button sidebar-button-accent",
+          class="sidebar-button primary",
           disabled=!input.update_enabled,
           on_click=actions.update,
           [

--- a/desktop/frontend/skills/view.mbt
+++ b/desktop/frontend/skills/view.mbt
@@ -44,7 +44,7 @@ fn installed_row(
     children.push(
       @html.div(class="skill-actions", [
         @html.button(
-          class="secondary skill-action",
+          class="button secondary skill-action",
           disabled=busy,
           on_click=emit(Uninstall(skill.id)),
           if busy {
@@ -90,7 +90,7 @@ fn market_row(
   } else {
     @html.div(class="skill-actions", [
       @html.button(
-        class="secondary skill-action",
+        class="button secondary skill-action",
         disabled=busy,
         on_click=emit(Install(item)),
         if busy {
@@ -181,7 +181,7 @@ fn detail_shell(
   @html.section(class="skills-page", [
     @html.div(class="skills-page-inner skill-detail-page", [
       @html.button(
-        class="secondary skill-back",
+        class="button secondary skill-back",
         on_click=emit(BackToList),
         "← Back to skills",
       ),
@@ -197,7 +197,7 @@ fn detail_shell(
           match state.preview {
             Ready(content~, ..) =>
               @html.button(
-                class="secondary skill-copy-button",
+                class="button secondary skill-copy-button",
                 attrs=@html.Attrs::build().aria_label("Copy SKILL.md"),
                 on_click=copy_content(content),
                 "Copy",
@@ -252,7 +252,7 @@ fn detail_action(
         @html.span(class="skill-check ok", "✓ Installed")
       } else {
         @html.button(
-          class="primary skill-detail-action",
+          class="button primary skill-detail-action",
           disabled=busy,
           on_click=emit(Install(item)),
           if busy {
@@ -269,7 +269,7 @@ fn detail_action(
       } else {
         let busy = state.busy.contains(item.id)
         @html.button(
-          class="secondary skill-detail-action",
+          class="button secondary skill-detail-action",
           disabled=busy,
           on_click=emit(Uninstall(item.id)),
           if busy {
@@ -387,7 +387,7 @@ fn list_page(state : State, input : Input, emit : @cmd.Emit[Msg]) -> @html.Html 
         icon(icon_package),
         @html.h2("Mooncakes registry"),
         @html.button(
-          class="secondary skills-refresh",
+          class="button secondary skills-refresh",
           disabled=catalog_loading,
           on_click=emit(RefreshCatalog),
           if catalog_loading {

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -1670,7 +1670,7 @@ fn conversation_load_failed_view(
     @html.strong("Could not load conversation"),
     @html.span(class="conversation-load-state-message", message),
     @html.button(
-      class="secondary",
+      class="button secondary",
       type_="button",
       on_click=dispatch(RetrySelectedConversation),
       "Retry",

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -658,7 +658,7 @@ fn codex_account_rows(
         "Account",
         [
           @html.button(
-            class="secondary",
+            class="button secondary",
             disabled=codex.is_busy(),
             on_click=dispatch(Codex(channel~, @codex.Msg::logout())),
             "Sign out",
@@ -673,7 +673,7 @@ fn codex_account_rows(
         "Sign in",
         [
           @html.button(
-            class="primary",
+            class="button primary",
             disabled=codex.is_busy(),
             on_click=dispatch(Codex(channel~, @codex.Msg::login())),
             "Sign in with ChatGPT",
@@ -691,14 +691,14 @@ fn codex_account_rows(
           // The shared external-link listener keeps the desktop webview in
           // place and hands this URL to the system browser.
           @html.a(
-            class="setting-link",
+            class="button secondary setting-link",
             href=url,
             target=Blank,
             rel="noopener noreferrer",
             [icon(icon_link_external), @html.span("Open")],
           ),
           @html.button(
-            class="secondary",
+            class="button secondary",
             disabled=codex.is_busy(),
             on_click=dispatch(Codex(channel~, @codex.Msg::cancel_login())),
             "Cancel sign-in",
@@ -713,7 +713,7 @@ fn codex_account_rows(
       "Configuration",
       [
         @html.button(
-          class="secondary",
+          class="button secondary",
           on_click=dispatch(OpenCodexConfig),
           "Open config.toml",
         ),
@@ -756,7 +756,7 @@ fn remote_access_rows(
             "Signed in as",
             [
               @html.button(
-                class="secondary",
+                class="button secondary",
                 on_click=dispatch(RemoteDisconnectClicked),
                 "Disconnect",
               ),
@@ -773,7 +773,7 @@ fn remote_access_rows(
                 // The shared external-link listener keeps the desktop webview
                 // in place and hands this URL to the system browser.
                 @html.a(
-                  class="setting-link",
+                  class="button secondary setting-link",
                   href=url,
                   target=Blank,
                   rel="noopener noreferrer",
@@ -793,7 +793,7 @@ fn remote_access_rows(
         }
         let controls : Array[@html.Html] = [
           @html.button(
-            class="primary",
+            class="button primary",
             disabled=model.remote_connecting,
             on_click=dispatch(RemoteConnectClicked),
             if model.remote_connecting {
@@ -808,7 +808,7 @@ fn remote_access_rows(
         if model.remote_connecting {
           controls.push(
             @html.button(
-              class="secondary",
+              class="button secondary",
               on_click=dispatch(RemoteCancelClicked),
               "Cancel",
             ),
@@ -842,7 +842,7 @@ fn update_check_controls(
       if installable {
         controls.push(
           @html.button(
-            class="primary",
+            class="button primary",
             on_click=dispatch(UpdateClicked),
             "Update to \{version}",
           ),
@@ -858,7 +858,9 @@ fn update_check_controls(
     ConfirmingRestart(version~) =>
       // The interrupt modal is up over this row; keep the button visible
       // behind it so the row does not blink while the user decides.
-      controls.push(@html.button(class="primary", "Update to \{version}"))
+      controls.push(
+        @html.button(class="button primary", "Update to \{version}"),
+      )
     DownloadingUpdate(version~, progress~) => {
       let (fill_class, fill_style) = match progress.percentage() {
         Some(percent) =>
@@ -886,7 +888,7 @@ fn update_check_controls(
   }
   controls.push(
     @html.button(
-      class="secondary",
+      class="button secondary",
       disabled=model.update_ux
         is (CheckingForUpdate | DownloadingUpdate(..) | RestartingForUpdate(..)),
       on_click=dispatch(CheckForUpdates),
@@ -950,7 +952,7 @@ fn byok_setup_guide(provider : ApiProvider) -> @html.Html {
       ..if provider is Deepseek {
         [
           @html.a(
-            class="setting-link",
+            class="button secondary setting-link",
             href="https://platform.deepseek.com/api_keys",
             target=Blank,
             rel="noopener noreferrer",
@@ -964,7 +966,7 @@ fn byok_setup_guide(provider : ApiProvider) -> @html.Html {
       ..if provider is Glm {
         [
           @html.a(
-            class="setting-link",
+            class="button secondary setting-link",
             href="https://z.ai/manage-apikey/apikey-list",
             target=Blank,
             rel="noopener noreferrer",
@@ -1067,7 +1069,7 @@ fn api_settings_rows(
             // The id is layout only (grid placement); the fill is the
             // shared primary style.
             id="saveApiKey",
-            class="primary",
+            class="button primary",
             disabled=!settings_loaded || model.setup_api_key.is_blank(),
             on_click=dispatch(SaveApiKey),
             "Save API key",
@@ -1431,7 +1433,7 @@ fn onboarding_view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
       )
       card.push(
         @html.button(
-          class="primary",
+          class="button primary",
           type_="button",
           on_click=dispatch(PickProject(dev.channel)),
           "Add a project",
@@ -1497,7 +1499,7 @@ fn console_gate_view(
         if console.notice is Some(_) {
           card.push(
             @html.button(
-              class="primary",
+              class="button primary",
               on_click=dispatch(Console(RefreshClicked)),
               "Try again",
             ),
@@ -1523,7 +1525,7 @@ fn console_gate_view(
             card.push(@html.p(message))
             card.push(
               @html.button(
-                class="primary",
+                class="button primary",
                 on_click=dispatch(Console(RefreshClicked)),
                 "Try again",
               ),
@@ -1555,7 +1557,7 @@ fn console_gate_view(
             }
             card.push(
               @html.button(
-                class="primary",
+                class="button primary",
                 on_click=dispatch(Console(RefreshClicked)),
                 "Refresh",
               ),
@@ -1576,7 +1578,7 @@ fn console_gate_view(
   if console.auth is AuthSignedIn(..) {
     card.push(
       @html.button(
-        class="secondary",
+        class="button secondary",
         disabled=console.busy,
         on_click=dispatch(Console(SignOutClicked)),
         if console.busy {
@@ -1918,12 +1920,12 @@ fn update_confirm_modal(
       ),
       @html.div(class="modal-actions", [
         @html.button(
-          class="secondary",
+          class="button secondary",
           on_click=dispatch(CancelUpdateRestart),
           "Keep working",
         ),
         @html.button(
-          class="primary",
+          class="button primary",
           on_click=dispatch(ConfirmUpdateRestart),
           "Update and restart",
         ),
@@ -1960,7 +1962,7 @@ fn api_setup_modal(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
         @html.div(class="setup-modal-form", api_settings_rows(dispatch, model)),
         @html.div(class="modal-actions", [
           @html.button(
-            class="secondary",
+            class="button secondary",
             on_click=dispatch(DismissApiSetup),
             "Not now",
           ),

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -1917,7 +1917,11 @@ fn update_confirm_modal(
         "A conversation is still running. Updating restarts the app and interrupts it; the transcript so far is saved.",
       ),
       @html.div(class="modal-actions", [
-        @html.button(on_click=dispatch(CancelUpdateRestart), "Keep working"),
+        @html.button(
+          class="secondary",
+          on_click=dispatch(CancelUpdateRestart),
+          "Keep working",
+        ),
         @html.button(
           class="primary",
           on_click=dispatch(ConfirmUpdateRestart),
@@ -1955,7 +1959,11 @@ fn api_setup_modal(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
         @html.div(class="modal-title", title),
         @html.div(class="setup-modal-form", api_settings_rows(dispatch, model)),
         @html.div(class="modal-actions", [
-          @html.button(on_click=dispatch(DismissApiSetup), "Not now"),
+          @html.button(
+            class="secondary",
+            on_click=dispatch(DismissApiSetup),
+            "Not now",
+          ),
         ]),
       ],
     ),

--- a/desktop/styles/README.md
+++ b/desktop/styles/README.md
@@ -60,3 +60,20 @@ attributes, so Desktop focus rules cannot restyle them.
 Buttons, links, and other discrete actions are not form fields. They may use a
 component-appropriate `:focus-visible` indicator because they often have no
 persistent border to recolor.
+
+## Button ownership
+
+A button's geometry belongs to a recognized component base, while short intent
+classes only choose that component's appearance:
+
+- `.button` owns the padding, type size, focus ring, and responsive target size
+  of ordinary labeled actions.
+- Specialized controls such as `.sidebar-button`, `.icon-button`, and
+  `.queued-input-action` own their own geometry.
+- `primary`, `secondary`, and `danger` may be nested variants of those bases,
+  but must not define dimensions on their own or through a global selector such
+  as `button.danger`.
+
+This contract makes stylesheet order irrelevant to component geometry: adding
+`danger` to an icon action may change its semantic color, but cannot turn it
+into a labeled action button.

--- a/desktop/styles/base.css
+++ b/desktop/styles/base.css
@@ -54,6 +54,35 @@ button {
   }
 }
 
+/* App-owned text-entry controls share one content and state contract. Their
+   existing focus markers also keep this rule out of embedded Viewer content;
+   no second opt-in class is required. Components may replace frame geometry
+   when a field lives inside a composite surface. */
+:where(
+  input[data-focus-owner],
+  input[data-focus-target],
+  textarea[data-focus-owner],
+  textarea[data-focus-target]
+) {
+  min-width: 0;
+  padding: 9px 10px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg-subtle);
+  color: var(--color-text-primary);
+  font-size: var(--font-size-md);
+
+  &::placeholder {
+    color: var(--color-text-muted);
+    opacity: 1;
+  }
+
+  &:disabled {
+    cursor: default;
+    opacity: 0.55;
+  }
+}
+
 /* Code-bearing content follows the same stack as the editor and terminal,
    while ordinary application controls continue to inherit the sans stack. */
 code,

--- a/desktop/styles/base.css
+++ b/desktop/styles/base.css
@@ -39,6 +39,21 @@ textarea {
   font: inherit;
 }
 
+/* Every app button starts from the same neutral chrome. Feature styles add
+   their own geometry and intent; the shared action variants live in pages.css. */
+button {
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--color-text-primary);
+  cursor: pointer;
+
+  &:disabled {
+    cursor: default;
+    opacity: 0.5;
+  }
+}
+
 /* Code-bearing content follows the same stack as the editor and terminal,
    while ordinary application controls continue to inherit the sans stack. */
 code,

--- a/desktop/styles/codex.css
+++ b/desktop/styles/codex.css
@@ -86,6 +86,10 @@
   font-size: 11px;
   line-height: 1.5;
   white-space: pre-wrap;
+
+  &:where(.danger) {
+    color: var(--color-danger);
+  }
 }
 
 .codex-request-details {

--- a/desktop/styles/composer.css
+++ b/desktop/styles/composer.css
@@ -593,12 +593,7 @@
   background: transparent;
   padding: 6px 6px 2px;
   resize: none;
-  color: var(--color-text-primary);
-  font-size: var(--font-size-md);
   line-height: var(--line-height-relaxed);
-}
-.composer textarea::placeholder {
-  color: var(--color-text-muted);
 }
 
 .composer-toolbar {

--- a/desktop/styles/composer.css
+++ b/desktop/styles/composer.css
@@ -363,7 +363,7 @@
 }
 /* The notice's own text/action split, used by the vanished-worktree banner:
    the sentence takes the slack so the actions stay right-aligned. Metrics
-   live here rather than on `.secondary` — see the generic-buttons note. */
+   live here because this compact inline control is not an ordinary `.button`. */
 .composer-notice-text {
   flex: 1;
   min-width: 0;
@@ -564,6 +564,10 @@
   padding: 0;
   color: var(--color-text-muted);
   cursor: pointer;
+
+  &:where(.danger):hover {
+    color: var(--color-danger);
+  }
 }
 .queued-input-action:hover,
 .queued-input-action.active {
@@ -572,9 +576,6 @@
 }
 .queued-input-action.active {
   color: var(--color-accent-strong);
-}
-.queued-input-action.danger:hover {
-  color: var(--color-danger);
 }
 .queued-input-action:focus-visible {
   outline: 1px solid var(--color-focus-ring);

--- a/desktop/styles/file_panel.css
+++ b/desktop/styles/file_panel.css
@@ -477,13 +477,7 @@ html.is-resizing * {
 }
 .browser-address {
   flex: 1 1 auto;
-  min-width: 0;
   padding: 5px 10px;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-  background: var(--color-bg-subtle);
-  color: var(--color-text-primary);
-  font-size: var(--font-size-md);
 }
 .browser-failure {
   flex: 0 0 auto;
@@ -534,12 +528,7 @@ html.is-resizing * {
   min-width: 80px;
   height: 28px;
   padding: 4px 8px;
-  border: 1px solid var(--color-border);
   border-radius: var(--radius-xs);
-  outline: none;
-  background: var(--color-bg-subtle);
-  color: var(--color-text-primary);
-  font: inherit;
   font-size: var(--font-size-sm);
 }
 .search-option {
@@ -689,15 +678,9 @@ html.is-resizing * {
   font-size: var(--font-size-xs);
 }
 .search-details input {
-  min-width: 0;
   height: 26px;
   padding: 3px 7px;
-  border: 1px solid var(--color-border);
   border-radius: var(--radius-xs);
-  outline: none;
-  background: var(--color-bg-subtle);
-  color: var(--color-text-primary);
-  font: inherit;
   font-size: var(--font-size-sm);
 }
 .search-query-row > .search-mode {

--- a/desktop/styles/overlays.css
+++ b/desktop/styles/overlays.css
@@ -134,36 +134,6 @@
   gap: 8px;
   margin-top: 16px;
 }
-.modal-actions button {
-  padding: 6px 12px;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-  background: var(--color-bg-surface);
-  color: var(--color-text-primary);
-  cursor: pointer;
-}
-.modal-actions button:hover {
-  background: var(--color-bg-subtle);
-}
-/* Re-assert the accent fill: the generic .modal-actions button rule
-   above outranks button.primary by document order. */
-.modal-actions button.primary {
-  border-color: var(--color-accent);
-  background: var(--color-accent);
-  color: var(--color-on-accent);
-}
-.modal-actions button.primary:hover {
-  background: var(--color-accent-strong);
-  border-color: var(--color-accent-strong);
-}
-.modal-actions button.danger {
-  border-color: var(--color-danger-border);
-  background: var(--color-danger-soft);
-  color: var(--color-danger);
-}
-.modal-actions button.danger:hover {
-  background: color-mix(in srgb, var(--color-danger-soft) 75%, var(--color-danger));
-}
 /* The standing-goal banner above the composer input (the compaction
    notice's slot) and the composer's goal-editing mode. */
 .composer-goal {

--- a/desktop/styles/overlays.css
+++ b/desktop/styles/overlays.css
@@ -346,18 +346,12 @@
 }
 
 .quick-open-input-wrap input {
-  min-width: 0;
   flex: 1 1 auto;
   padding: 13px 0;
   border: 0;
   background: transparent;
-  color: var(--color-text-primary);
   font: var(--font-weight-regular) var(--font-size-md) /
     var(--line-height-normal) var(--font-family-sans);
-}
-
-.quick-open-input-wrap input::placeholder {
-  color: var(--color-text-muted);
 }
 
 .quick-open-group-label {

--- a/desktop/styles/pages.css
+++ b/desktop/styles/pages.css
@@ -1,29 +1,68 @@
 
 /* ---------- shared action buttons ---------- */
-/* Action roles provide the ordinary dialog/settings geometry and palette.
-   `:where()` keeps that default below a feature class, so a specialized
-   control can opt into an intent without inheriting accidental dimensions. */
-:where(button.secondary, button.primary, button.danger, a.setting-link):focus-visible {
-  outline: 2px solid var(--color-focus-ring);
-  outline-offset: 2px;
-}
+/* The base owns ordinary labeled-action geometry. Intent classes only paint a
+   recognized action, so an icon control may use `danger` without inheriting
+   this component's dimensions. */
+.button {
+  --button-color: var(--color-text-primary);
+  --button-border-color: transparent;
+  --button-background: transparent;
+  --button-hover-color: var(--button-color);
+  --button-hover-border-color: var(--button-border-color);
+  --button-hover-background: var(--button-background);
+  --button-disabled-opacity: 0.5;
 
-button:where(.secondary, .primary, .danger),
-a:where(.setting-link) {
   padding: 6px 12px;
+  border: 1px solid var(--button-border-color);
+  border-radius: var(--radius-sm);
+  background: var(--button-background);
+  color: var(--button-color);
   font-size: var(--font-size-sm);
-}
+  line-height: var(--line-height-normal);
+  cursor: pointer;
 
-button:where(.secondary),
-a:where(.setting-link) {
-  border-color: var(--color-border);
-  background: var(--color-bg-surface);
-  color: var(--color-text-primary);
-}
+  &:focus-visible {
+    outline: 2px solid var(--color-focus-ring);
+    outline-offset: 2px;
+  }
 
-button:where(.secondary):not(:disabled):hover,
-a:where(.setting-link):hover {
-  background: var(--color-bg-subtle);
+  &:not(:disabled):hover {
+    border-color: var(--button-hover-border-color);
+    background: var(--button-hover-background);
+    color: var(--button-hover-color);
+  }
+
+  &:disabled {
+    cursor: default;
+    opacity: var(--button-disabled-opacity);
+  }
+
+  &:where(.secondary) {
+    --button-border-color: var(--color-border);
+    --button-background: var(--color-bg-surface);
+    --button-hover-background: var(--color-bg-subtle);
+  }
+
+  &:where(.primary) {
+    --button-color: var(--color-on-accent);
+    --button-border-color: var(--color-accent);
+    --button-background: var(--color-accent);
+    --button-hover-color: var(--color-on-accent);
+    --button-hover-border-color: var(--color-accent-strong);
+    --button-hover-background: var(--color-accent-strong);
+    --button-disabled-opacity: 0.7;
+  }
+
+  &:where(.danger) {
+    --button-color: var(--color-danger);
+    --button-border-color: var(--color-danger-border);
+    --button-background: var(--color-danger-soft);
+    --button-hover-background: color-mix(
+      in srgb,
+      var(--color-danger-soft) 75%,
+      var(--color-danger)
+    );
+  }
 }
 
 /* A Device page is navigation, so it remains an anchor while matching the
@@ -34,41 +73,7 @@ a:where(.setting-link) {
   align-items: center;
   gap: 6px;
   border-radius: var(--radius-sm);
-  line-height: 1.2;
   text-decoration: none;
-}
-
-/* The accent-filled call to action, button.secondary's counterpart: Save API
-   key, self-update controls, and modal confirmations. */
-button:where(.primary) {
-  border-color: var(--color-accent);
-  background: var(--color-accent);
-  color: var(--color-on-accent);
-
-  &:not(:disabled):hover {
-    border-color: var(--color-accent-strong);
-    background: var(--color-accent-strong);
-    color: var(--color-on-accent);
-  }
-
-  &:disabled {
-    cursor: default;
-    opacity: 0.7;
-  }
-}
-
-button:where(.danger) {
-  border-color: var(--color-danger-border);
-  background: var(--color-danger-soft);
-  color: var(--color-danger);
-
-  &:not(:disabled):hover {
-    background: color-mix(
-      in srgb,
-      var(--color-danger-soft) 75%,
-      var(--color-danger)
-    );
-  }
 }
 
 /* ---------- onboarding (no conversation on screen) ---------- */
@@ -412,6 +417,10 @@ h2 {
   font-size: var(--font-size-sm);
   white-space: nowrap;
   flex-shrink: 0;
+
+  &:where(.ok) {
+    color: var(--color-success);
+  }
 }
 
 .skill-avatar {
@@ -722,6 +731,10 @@ h2 {
 .skills-notice {
   color: var(--color-text-muted);
   font-size: var(--font-size-sm);
+
+  &:where(.danger) {
+    color: var(--color-danger);
+  }
 }
 
 .settings-group-card .skills-empty {
@@ -736,14 +749,4 @@ h2 {
   color: var(--color-text-faint);
   font-size: var(--font-size-xs);
   white-space: nowrap;
-}
-
-.ok {
-  color: var(--color-success);
-}
-.warn {
-  color: var(--color-warning);
-}
-.danger {
-  color: var(--color-danger);
 }

--- a/desktop/styles/pages.css
+++ b/desktop/styles/pages.css
@@ -292,21 +292,16 @@ h2 {
   align-self: flex-end;
 }
 
-/* Settings, Skills, and the API-setup modal own these form defaults. Keep
-   them scoped to those shells so later-loaded app CSS cannot restyle inputs
-   inside the Viewer. */
-.settings-page :where(input, textarea),
-.skills-page :where(input, textarea),
-.setup-modal :where(input, textarea) {
+/* Page fields fill their grid column; their shared paint and states live in
+   base.css, while compact controls below retain their local geometry. */
+:where(.settings-page, .skills-page, .setup-modal)
+  :where(
+    input[data-focus-owner],
+    input[data-focus-target],
+    textarea[data-focus-owner],
+    textarea[data-focus-target]
+  ) {
   width: 100%;
-  min-width: 0;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-  background: var(--color-bg-subtle);
-  color: var(--color-text-primary);
-  padding: 9px 10px;
-  font-size: var(--font-size-md);
-  letter-spacing: -0.01em;
 }
 
 .setting-control input {

--- a/desktop/styles/pages.css
+++ b/desktop/styles/pages.css
@@ -1,85 +1,74 @@
 
-/* ---------- generic buttons ---------- */
-/* `button` below is the app-wide reset (colors only). `.secondary` /
-   `.primary` are the settings pages' opt-in button system and DO carry
-   metrics (padding, font-size) at element+class specificity — a new
-   component must define its own classes, never reuse these modifier names
-   next to its own (that ambush is how the worktree confirm buttons once
-   came out two sizes). */
-button {
-  border: 1px solid transparent;
-  border-radius: var(--radius-sm);
-  background: transparent;
-  color: var(--color-text-primary);
-  cursor: pointer;
-}
-button:disabled {
-  cursor: default;
-  opacity: 0.5;
-}
-
-/* These opt-in app controls have no enclosing focus surface, so they draw the
-   shared keyboard ring themselves. Component controls define theirs locally. */
-button.secondary:focus-visible,
-button.primary:focus-visible,
-a.setting-link:focus-visible {
+/* ---------- shared action buttons ---------- */
+/* Action roles provide the ordinary dialog/settings geometry and palette.
+   `:where()` keeps that default below a feature class, so a specialized
+   control can opt into an intent without inheriting accidental dimensions. */
+:where(button.secondary, button.primary, button.danger, a.setting-link):focus-visible {
   outline: 2px solid var(--color-focus-ring);
   outline-offset: 2px;
 }
 
-button.secondary {
-  border-color: var(--color-border);
-  background: var(--color-bg-surface);
-  color: var(--color-text-primary);
+button:where(.secondary, .primary, .danger),
+a:where(.setting-link) {
   padding: 6px 12px;
   font-size: var(--font-size-sm);
 }
-button.secondary:not(:disabled):hover {
+
+button:where(.secondary),
+a:where(.setting-link) {
+  border-color: var(--color-border);
+  background: var(--color-bg-surface);
+  color: var(--color-text-primary);
+}
+
+button:where(.secondary):not(:disabled):hover,
+a:where(.setting-link):hover {
   background: var(--color-bg-subtle);
 }
 
 /* A Device page is navigation, so it remains an anchor while matching the
    secondary controls beside it. The desktop's delegated link handler opens it
    in the system browser instead of navigating the app frame. */
-a.setting-link {
+a:where(.setting-link) {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
-  background: var(--color-bg-surface);
-  color: var(--color-text-primary);
-  padding: 6px 12px;
-  font-size: var(--font-size-sm);
   line-height: 1.2;
   text-decoration: none;
 }
-a.setting-link:hover {
-  background: var(--color-bg-subtle);
-}
-/* The accent-filled call to action, button.secondary's counterpart:
-   Save API key, the self-update controls, modal confirms. As a
-   sidebar-button it keeps the sidebar's geometry, only the fill. */
-button.primary {
+
+/* The accent-filled call to action, button.secondary's counterpart: Save API
+   key, self-update controls, and modal confirmations. */
+button:where(.primary) {
   border-color: var(--color-accent);
   background: var(--color-accent);
   color: var(--color-on-accent);
+
+  &:not(:disabled):hover {
+    border-color: var(--color-accent-strong);
+    background: var(--color-accent-strong);
+    color: var(--color-on-accent);
+  }
+
+  &:disabled {
+    cursor: default;
+    opacity: 0.7;
+  }
 }
-button.primary:not(.sidebar-button) {
-  padding: 6px 12px;
-  font-size: var(--font-size-sm);
-}
-button.primary .sidebar-icon {
-  color: var(--color-on-accent);
-}
-button.primary:not(:disabled):hover {
-  background: var(--color-accent-strong);
-  border-color: var(--color-accent-strong);
-  color: var(--color-on-accent);
-}
-button.primary:disabled {
-  opacity: 0.7;
-  cursor: default;
+
+button:where(.danger) {
+  border-color: var(--color-danger-border);
+  background: var(--color-danger-soft);
+  color: var(--color-danger);
+
+  &:not(:disabled):hover {
+    background: color-mix(
+      in srgb,
+      var(--color-danger-soft) 75%,
+      var(--color-danger)
+    );
+  }
 }
 
 /* ---------- onboarding (no conversation on screen) ---------- */

--- a/desktop/styles/responsive.css
+++ b/desktop/styles/responsive.css
@@ -162,10 +162,10 @@
     top: 4px;
   }
   button.secondary,
-  button.primary:not(.sidebar-button),
+  button.primary,
+  button.danger,
   a.setting-link,
-  .portal-button-link,
-  .modal-actions button {
+  .portal-button-link {
     min-height: 44px;
     padding-top: 10px;
     padding-bottom: 10px;

--- a/desktop/styles/responsive.css
+++ b/desktop/styles/responsive.css
@@ -161,10 +161,7 @@
     > .topbar-toggle {
     top: 4px;
   }
-  button.secondary,
-  button.primary,
-  button.danger,
-  a.setting-link,
+  .button,
   .portal-button-link {
     min-height: 44px;
     padding-top: 10px;

--- a/desktop/styles/sidebar.css
+++ b/desktop/styles/sidebar.css
@@ -815,14 +815,10 @@ button.row-twisty:hover {
 }
 .picker-path-editor input {
   width: 100%;
-  min-width: 0;
   height: 26px;
   padding: 0 5px;
   border: 0;
-  outline: 0;
   background: transparent;
-  color: var(--color-text-primary);
-  font: inherit;
   font-size: var(--font-size-sm);
 }
 .picker-path-editor-cancel {
@@ -1027,15 +1023,9 @@ button.row-twisty:hover {
 }
 .picker-create-row input {
   width: 100%;
-  min-width: 0;
   height: 34px;
   padding: 0 9px;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-  outline: 0;
   background: var(--color-bg-surface);
-  color: var(--color-text-primary);
-  font: inherit;
 }
 .picker-create-cancel,
 .picker-create-submit {

--- a/desktop/styles/sidebar.css
+++ b/desktop/styles/sidebar.css
@@ -1121,17 +1121,9 @@ button.row-twisty:hover {
   flex: none;
   margin-top: 0;
 }
-.picker-footer .modal-actions button {
-  min-height: 34px;
-  padding: 0 13px;
-  border-radius: var(--radius-sm);
-  font-size: var(--font-size-sm);
-}
-.picker-footer .modal-actions button.primary {
-  min-width: 96px;
+.picker-footer .modal-actions .button:where(.primary) {
   box-shadow: 0 1px 2px color-mix(in srgb, var(--color-accent) 30%, transparent);
 }
-.picker-modal button:disabled,
 .picker-modal input:disabled {
   cursor: default;
   opacity: 0.5;
@@ -1225,32 +1217,28 @@ button.row-twisty:hover {
   padding: 0 8px;
   text-align: left;
   cursor: pointer;
-}
-
-.sidebar-button .sidebar-icon {
-  color: var(--color-text-muted);
-}
-
-.sidebar-button.active {
-  background: var(--color-bg-subtle);
-  color: var(--color-text-primary);
-}
-
-button:where(.sidebar-button):not(:disabled):hover {
-  background: var(--color-bg-subtle);
-  color: var(--color-text-primary);
-}
-
-.sidebar-button-accent {
-  background: var(--color-accent);
-  color: var(--color-on-accent);
 
   & .sidebar-icon {
-    color: var(--color-on-accent);
+    color: var(--color-text-muted);
   }
 
+  &.active,
   &:not(:disabled):hover {
-    background: var(--color-accent-strong);
+    background: var(--color-bg-subtle);
+    color: var(--color-text-primary);
+  }
+
+  &:where(.primary) {
+    background: var(--color-accent);
     color: var(--color-on-accent);
+
+    & .sidebar-icon {
+      color: var(--color-on-accent);
+    }
+
+    &:not(:disabled):hover {
+      background: var(--color-accent-strong);
+      color: var(--color-on-accent);
+    }
   }
 }

--- a/desktop/styles/sidebar.css
+++ b/desktop/styles/sidebar.css
@@ -1246,7 +1246,21 @@ button.row-twisty:hover {
   color: var(--color-text-primary);
 }
 
-button.sidebar-button:not(:disabled):hover {
+button:where(.sidebar-button):not(:disabled):hover {
   background: var(--color-bg-subtle);
   color: var(--color-text-primary);
+}
+
+.sidebar-button-accent {
+  background: var(--color-accent);
+  color: var(--color-on-accent);
+
+  & .sidebar-icon {
+    color: var(--color-on-accent);
+  }
+
+  &:not(:disabled):hover {
+    background: var(--color-accent-strong);
+    color: var(--color-on-accent);
+  }
 }

--- a/desktop/styles/tokens.css
+++ b/desktop/styles/tokens.css
@@ -3,6 +3,27 @@
 
    Keep only app-wide visual decisions here. Component geometry, such as the
    topbar height or editor resize handle width, stays with its component. */
+/* xterm consumes these three tokens through getComputedStyle rather than a CSS
+   declaration. Registering their color type makes the CSSOM expose the
+   resolved light-dark() color instead of its unevaluated token stream. */
+@property --color-bg-surface {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #ffffff;
+}
+
+@property --color-text-primary {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #121418;
+}
+
+@property --color-text-selection {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #eef2fe;
+}
+
 :root {
   color-scheme: light dark;
 
@@ -31,15 +52,15 @@
   --icon-lg: 16px;
 
   /* Surfaces and text */
-  --color-bg-canvas: #fbfbf9;
-  --color-bg-surface: #ffffff;
-  --color-bg-subtle: #f6f6f3;
-  --color-text-primary: #121418;
-  --color-text-secondary: #5c5f66;
-  --color-text-muted: #9a9da4;
-  --color-text-faint: #a8aab0;
-  --color-border: #e9e8e3;
-  --color-border-subtle: #f0efea;
+  --color-bg-canvas: light-dark(#fbfbf9, #16181d);
+  --color-bg-surface: light-dark(#ffffff, #1c1f26);
+  --color-bg-subtle: light-dark(#f6f6f3, #23272f);
+  --color-text-primary: light-dark(#121418, #f1f3f7);
+  --color-text-secondary: light-dark(#5c5f66, #a3a8b4);
+  --color-text-muted: light-dark(#9a9da4, #6f7480);
+  --color-text-faint: light-dark(#a8aab0, #656b76);
+  --color-border: light-dark(#e9e8e3, #2c313b);
+  --color-border-subtle: light-dark(#f0efea, #262b33);
 
   /* Structural seams should recede behind content. Persistent control
      grouping comes from a quiet fill; the stronger border remains available
@@ -55,24 +76,24 @@
     transparent
   );
 
-  --color-accent: #3b6ef5;
-  --color-accent-strong: #2a55cc;
+  --color-accent: light-dark(#3b6ef5, #5b8cff);
+  --color-accent-strong: light-dark(#2a55cc, #9db8ff);
   --color-on-accent: #fff;
-  --color-on-accent-strong: #fff;
-  --color-accent-soft: #eef2fe;
-  --color-accent-border: #d6e0fd;
+  --color-on-accent-strong: light-dark(#fff, #10131a);
+  --color-accent-soft: light-dark(#eef2fe, #1e2740);
+  --color-accent-border: light-dark(#d6e0fd, #2f3e63);
   /* Text selection is shared by normal DOM text, the editor, and xterm.
      xterm paints it on a canvas, so keep this opaque in both themes. */
-  --color-text-selection: #eef2fe;
+  --color-text-selection: light-dark(#eef2fe, #344a78);
 
   /* Status colors */
-  --color-success: #1f8a5b;
-  --color-danger: #c0453b;
-  --color-danger-soft: #fcefed;
-  --color-danger-border: #f2d4cf;
-  --color-warning: #b7791f;
+  --color-success: light-dark(#1f8a5b, #3fd089);
+  --color-danger: light-dark(#c0453b, #ff8a80);
+  --color-danger-soft: light-dark(#fcefed, #2a1b1b);
+  --color-danger-border: light-dark(#f2d4cf, #4a2f2f);
+  --color-warning: light-dark(#b7791f, #e3b341);
 
-  --color-code: #20242b;
+  --color-code: light-dark(#20242b, #edf0f5);
 
   /* Keyboard focus must be obvious without turning every interactive surface
      into another accent claim. Blue remains for selection and primary action. */
@@ -114,9 +135,16 @@
   --radius-md: 9px;
   --radius-lg: 14px;
   --radius-pill: 999px;
-  --shadow-surface: 0 1px 2px rgba(20, 23, 26, 0.04),
-    0 6px 22px -10px rgba(20, 23, 26, 0.1);
-  --shadow-overlay: 0 8px 30px -8px rgba(20, 23, 26, 0.22);
+  --shadow-surface:
+    0 1px 2px light-dark(rgba(20, 23, 26, 0.04), rgba(0, 0, 0, 0.3)),
+    0 6px 22px -10px light-dark(
+      rgba(20, 23, 26, 0.1),
+      rgba(0, 0, 0, 0.5)
+    );
+  --shadow-overlay: 0 8px 30px -8px light-dark(
+      rgba(20, 23, 26, 0.22),
+      rgba(0, 0, 0, 0.6)
+    );
 
   /* App-wide stacking order. Values inside a component's own stacking
      context stay local because they do not compete with these surfaces. */
@@ -191,104 +219,14 @@
   --ui-font-size: var(--font-size-sm);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --color-bg-canvas: #16181d;
-    --color-bg-surface: #1c1f26;
-    --color-bg-subtle: #23272f;
-    --color-text-primary: #f1f3f7;
-    --color-text-secondary: #a3a8b4;
-    --color-text-muted: #6f7480;
-    --color-text-faint: #656b76;
-    --color-border: #2c313b;
-    --color-border-subtle: #262b33;
-
-    --color-accent: #5b8cff;
-    --color-accent-strong: #9db8ff;
-    --color-on-accent-strong: #10131a;
-    --color-accent-soft: #1e2740;
-    --color-accent-border: #2f3e63;
-    --color-text-selection: #344a78;
-
-    --color-success: #3fd089;
-    --color-danger: #ff8a80;
-    --color-danger-soft: #2a1b1b;
-    --color-danger-border: #4a2f2f;
-    --color-warning: #e3b341;
-
-    --color-code: #edf0f5;
-
-    --shadow-surface: 0 1px 2px rgba(0, 0, 0, 0.3),
-      0 6px 22px -10px rgba(0, 0, 0, 0.5);
-    --shadow-overlay: 0 8px 30px -8px rgba(0, 0, 0, 0.6);
-  }
-}
-
-/* A user selection wins over the host media query. The explicit blocks repeat
-   every theme-owned color and shadow, so the shell, forms, overlays, editor
-   chrome, and terminal never split themes. */
+/* A user selection narrows the available color scheme, so the same
+   light-dark() palette follows the override instead of the host preference. */
 :root[data-theme="light"] {
   color-scheme: light;
-
-  --color-bg-canvas: #fbfbf9;
-  --color-bg-surface: #ffffff;
-  --color-bg-subtle: #f6f6f3;
-  --color-text-primary: #121418;
-  --color-text-secondary: #5c5f66;
-  --color-text-muted: #9a9da4;
-  --color-text-faint: #a8aab0;
-  --color-border: #e9e8e3;
-  --color-border-subtle: #f0efea;
-
-  --color-accent: #3b6ef5;
-  --color-accent-strong: #2a55cc;
-  --color-on-accent-strong: #fff;
-  --color-accent-soft: #eef2fe;
-  --color-accent-border: #d6e0fd;
-  --color-text-selection: #eef2fe;
-
-  --color-success: #1f8a5b;
-  --color-danger: #c0453b;
-  --color-danger-soft: #fcefed;
-  --color-danger-border: #f2d4cf;
-  --color-warning: #b7791f;
-
-  --color-code: #20242b;
-  --shadow-surface: 0 1px 2px rgba(20, 23, 26, 0.04),
-    0 6px 22px -10px rgba(20, 23, 26, 0.1);
-  --shadow-overlay: 0 8px 30px -8px rgba(20, 23, 26, 0.22);
 }
 
 :root[data-theme="dark"] {
   color-scheme: dark;
-
-  --color-bg-canvas: #16181d;
-  --color-bg-surface: #1c1f26;
-  --color-bg-subtle: #23272f;
-  --color-text-primary: #f1f3f7;
-  --color-text-secondary: #a3a8b4;
-  --color-text-muted: #6f7480;
-  --color-text-faint: #656b76;
-  --color-border: #2c313b;
-  --color-border-subtle: #262b33;
-
-  --color-accent: #5b8cff;
-  --color-accent-strong: #9db8ff;
-  --color-on-accent-strong: #10131a;
-  --color-accent-soft: #1e2740;
-  --color-accent-border: #2f3e63;
-  --color-text-selection: #344a78;
-
-  --color-success: #3fd089;
-  --color-danger: #ff8a80;
-  --color-danger-soft: #2a1b1b;
-  --color-danger-border: #4a2f2f;
-  --color-warning: #e3b341;
-
-  --color-code: #edf0f5;
-  --shadow-surface: 0 1px 2px rgba(0, 0, 0, 0.3),
-    0 6px 22px -10px rgba(0, 0, 0, 0.5);
-  --shadow-overlay: 0 8px 30px -8px rgba(0, 0, 0, 0.6);
 }
 
 * {

--- a/desktop/viewer_theme.css
+++ b/desktop/viewer_theme.css
@@ -152,7 +152,7 @@
   /* Forms inside viewer widgets mirror the app controls: bordered surface
      inputs, accent-filled primary button, subtle-filled secondary. The
      shared button border stays transparent so the accent fill reads like
-     button.primary. */
+     .button.primary. */
   --vscode-input-background: var(--color-bg-surface);
   --vscode-input-foreground: var(--color-text-primary);
   --vscode-input-border: var(--color-border);


### PR DESCRIPTION
## Why

Desktop theme values and common control styles had accumulated in feature stylesheets. That duplicated light/dark palettes, coupled the sidebar update control to the primary action role, and let text fields drift or fall back to browser-default chrome.

## What changed

- Express paired theme colors once with color-scheme and light-dark(), while preserving explicit light and dark overrides.
- Centralize primary, secondary, and danger action roles, while keeping sidebar emphasis component-local.
- Derive shared text-field paint and states from the existing focus-owner markers, so views do not need another opt-in class.
- Use low-specificity selectors and native nesting so feature styles continue to own geometry.

## Why this is correct and scoped

The shared rules encode palette and interaction intent only; component styles still control layout, density, and special surfaces. Focus markers keep field styling limited to app-owned controls and out of embedded Viewer content. The work is split into three focused commits and does not change public APIs.