### PR TITLE
fix(desktop): contain anchored select popovers

### DIFF
--- a/desktop/e2e/tests/rabbita_dom.spec.js
+++ b/desktop/e2e/tests/rabbita_dom.spec.js
@@ -1082,6 +1082,59 @@ test('settings change and preserve the visible font size', async ({ page }) => {
   expect(app.pageErrors).toEqual([]);
 });
 
+test('a covering modal dismisses an open custom select', async ({ page }) => {
+  const app = new DesktopBrowserHarness(page);
+  await app.install();
+  await app.goto();
+
+  const model = page.getByRole('button', { name: 'Model', exact: true });
+  await model.click();
+  await expect(page.getByRole('listbox', { name: 'Model' })).toBeVisible();
+  app.notify('settings.changed', {
+    ...app.hostSettings,
+    revision: app.hostSettings.revision + 1,
+    has_deepseek_key: false,
+  });
+  await expect(page.getByText('Set up your DeepSeek API key')).toBeVisible();
+  await expect(page.getByRole('listbox', { name: 'Model' })).toHaveCount(0);
+  await expect(model).toHaveAttribute('aria-expanded', 'false');
+  expect(app.pageErrors).toEqual([]);
+});
+
+test('a bottom select flips above and yields to the narrow sidebar', async ({ page }) => {
+  await page.setViewportSize({ width: 500, height: 320 });
+  const app = new DesktopBrowserHarness(page);
+  await app.install();
+  await app.goto();
+
+  const trigger = page.getByRole('button', { name: 'Model', exact: true });
+  await trigger.click();
+  const menu = page.getByRole('listbox', { name: 'Model' });
+  await expect(menu).toBeVisible();
+  const geometry = await page.evaluate(() => {
+    const triggerRect = document.querySelector('#openseek-model-picker').getBoundingClientRect();
+    const menu = document.querySelector('#openseek-model-picker-menu');
+    const menuRect = menu.getBoundingClientRect();
+    return {
+      above: menuRect.bottom <= triggerRect.top,
+      insideViewport: menuRect.top >= 0 && menuRect.bottom <= innerHeight,
+      fullyExpanded: menu.clientHeight === menu.scrollHeight,
+    };
+  });
+  expect(geometry).toEqual({
+    above: true,
+    insideViewport: true,
+    fullyExpanded: true,
+  });
+
+  const shortcut = await page.evaluate(() =>
+    navigator.platform.includes('Mac') ? 'Meta+B' : 'Control+B');
+  await page.keyboard.press(shortcut);
+  await expect(page.getByRole('button', { name: 'Hide sidebar' })).toBeVisible();
+  await expect(menu).toHaveCount(0);
+  expect(app.pageErrors).toEqual([]);
+});
+
 test('settings persist host API changes through settings.set', async ({ page }) => {
   const app = new DesktopBrowserHarness(page);
   await app.install();

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1460,6 +1460,7 @@ fn sync_file_panel(
 /// this predicate forgets renders with the browser pane punched through it,
 /// swallowing the clicks that land there.
 fn covering_overlay(model : Model) -> Bool {
+  (model.narrow && model.sidebar_open) ||
   model.project_picker is Some(_) ||
   model.archive_confirm is Some(_) ||
   model.archived_delete_confirm is Some(_) ||
@@ -1491,7 +1492,6 @@ fn desired_browser_view(model : Model) -> Int? {
     !model.right_panel_menu_open &&
     model.select_menu is None &&
     !git_details_open &&
-    !(model.narrow && model.sidebar_open) &&
     !covering_overlay(model) else {
     return None
   }
@@ -1683,6 +1683,13 @@ fn update(
       composer_context_generation: previous.composer_context_generation + 1,
       select_menu: None,
     }
+  } else {
+    model
+  }
+  // Manual popovers sit above ordinary fixed backdrops in the browser's top
+  // layer, so a newly covering surface must retire the root-owned select.
+  let model = if !covering_overlay(previous) && covering_overlay(model) {
+    { ..model, select_menu: None, }
   } else {
     model
   }
@@ -14406,6 +14413,19 @@ test "custom select menus switch and dismiss deterministically" {
     open_before_switch,
   )
   assert_true(context_switched.select_menu is None)
+}
+
+///|
+test "a covering overlay dismisses an open custom select" {
+  let dispatch = test_dispatch()
+  let base = { ..test_model(), select_menu: Some(OpenSeekModelMenu), }
+  let (_, lost) = update(
+    dispatch,
+    FromDevice(Local, BridgeUnavailable("bridge stopped")),
+    base,
+  )
+  assert_true(lost.bridge_state() is BridgeLost(_))
+  assert_true(lost.select_menu is None)
 }
 
 ///|

--- a/desktop/styles/base.css
+++ b/desktop/styles/base.css
@@ -92,10 +92,13 @@ samp,
   position-anchor: --custom-select-trigger;
   position-visibility: anchors-visible;
   position-area: block-end span-inline-end;
+  position-try-order: most-block-size;
   position-try-fallbacks: flip-block;
   inset: auto;
   z-index: var(--z-menu);
-  max-height: min(360px, calc(100dvh - 24px));
+  /* 100% is the chosen position-area block, keeping overflow on one side of
+     the trigger instead of shifting the anchored box across it. */
+  max-height: min(360px, calc(100dvh - 24px), calc(100% - 12px));
   margin: 6px 0 0;
   overflow-x: hidden;
   overflow-y: auto;


### PR DESCRIPTION
## Why

Follow-up to #1230. Manual popovers enter the browser top layer, so an already-open root select could remain visible and interactive above a later fixed backdrop or narrow full-screen drawer. A tall anchored menu could also stay collapsed below a bottom-mounted trigger instead of flipping into ample space above.

## Why this is correct

- The covering-surface predicate now includes the narrow drawer, and the root update boundary clears its open select when the page becomes covered.
- The larger anchor side is selected before the area-relative height cap is applied, preserving fallback placement while keeping the menu within the viewport.
- Browser regressions exercise an asynchronous modal, a bottom-mounted composer at 500×320, full menu expansion above the trigger, and Cmd/Ctrl+B drawer takeover.

## Scope

The change keeps #1230's native popover and CSS-anchor design. It adds one state-predicate clause, one CSS ordering constraint, and focused regression coverage.