### PR TITLE
feat(prompt): teach probes not to bind output to `test`

### DIFF
--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -161,6 +161,13 @@ directory, and that directory is the one place a snippet may write (`/tmp`
 itself is refused) — and read only the needed excerpt; `.status()` returns just the exit code when the output does not
 matter. You can use `moon ide doc @moonbitlang/async/shell` for the full API.
 
+When a probe captures a command's output, do not bind it to the name `test`:
+`test` is the MoonBit keyword that opens a test block. A binding like
+`let test = @shell.Cmd("moon", ["test"]).output()` is a parse error
+(`unexpected token `test``); write
+`let test_out = @shell.Cmd("moon", ["test"]).output()` or `let result = ...`
+instead, and keep `test` for `test { ... }` blocks.
+
 For compiler feedback, stream the line-delimited JSON from one `moon check`
 rather than collecting it and parsing it afterward:
 

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -166,6 +166,13 @@ fn default_prompt() -> String {
     #|itself is refused) — and read only the needed excerpt; `.status()` returns just the exit code when the output does not
     #|matter. You can use `moon ide doc @moonbitlang/async/shell` for the full API.
     #|
+    #|When a probe captures a command's output, do not bind it to the name `test`:
+    #|`test` is the MoonBit keyword that opens a test block. A binding like
+    #|`let test = @shell.Cmd("moon", ["test"]).output()` is a parse error
+    #|(`unexpected token `test``); write
+    #|`let test_out = @shell.Cmd("moon", ["test"]).output()` or `let result = ...`
+    #|instead, and keep `test` for `test { ... }` blocks.
+    #|
     #|For compiler feedback, stream the line-delimited JSON from one `moon check`
     #|rather than collecting it and parsing it afterward:
     #|


### PR DESCRIPTION
## Summary

SeekMoon agents running `moon test` through an mbtx probe repeatedly wrote
`let test = @shell.Cmd("moon", ["test"]).output()`, which is a parse error:
`test` is a MoonBit keyword (the `unexpected token `test`` diagnostic). The
generic "Keywords are not identifiers" bullet further down the prompt did not
stop the slip — a session minutes before this task still produced the exact
binding once before self-correcting.

Teach the trap where probes are written: right after the `.output()` example
in Running Commands, the default prompt now says to bind the captured Output
as `test_out` (or `result`), never `test`, and to keep `test` for
`test { ... }` blocks.

## Changes

- `prompt/default_prompt.mbt.md`: add the probe-binding warning after the
  `.output()` example in Running Commands.
- `prompt/generated_default_prompt.mbt`: regenerated from the `.md` by the
  `md_to_mbt_string` dev-build rule.

## Verification

- `moon check --deny-warn prompt`: clean
- `moon test prompt`: 20/20 passed
- `moon fmt --check prompt`: clean
- root `moon check`: no work to do

Generated with SeekMoon