### PR TITLE
fix(desktop): avoid duplicate loading animation

### DIFF
--- a/desktop/e2e/tests/rabbita_dom.spec.js
+++ b/desktop/e2e/tests/rabbita_dom.spec.js
@@ -987,10 +987,9 @@ test('sidebar menu dismissal and pending selection follow the clicked row', asyn
   const rowSpinner = second.locator('.conversation-load-spinner');
   const panelSpinner = page.locator('.conversation-load-state-spinner');
   await expect(rowSpinner).toHaveCSS('animation-name', 'conversation-load-spin');
-  await expect(panelSpinner).toHaveCSS('animation-name', 'conversation-load-spin');
+  await expect(panelSpinner).toHaveCount(0);
   await page.emulateMedia({ reducedMotion: 'reduce' });
   await expect(rowSpinner).toHaveCSS('animation-name', 'none');
-  await expect(panelSpinner).toHaveCSS('animation-name', 'none');
   await expect(page.getByText('Browser result', { exact: true })).toHaveCount(0);
   await expect.poll(() => app.requests.some(request =>
     request.method === 'session.load' && request.params?.session === 'session-2'))

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -1656,10 +1656,7 @@ fn Model::selected_conversation_loaded(self : Model) -> Bool {
 
 ///|
 fn conversation_loading_view() -> @html.Html {
-  @html.div(class="conversation-load-state", [
-    @html.span(class="conversation-load-state-spinner", ""),
-    @html.span("Loading conversation…"),
-  ])
+  @html.div(class="conversation-load-state", "Loading conversation…")
 }
 
 ///|

--- a/desktop/styles/responsive.css
+++ b/desktop/styles/responsive.css
@@ -196,7 +196,6 @@
   .activity-row,
   .browser-nav-button.loading .icon svg,
   .conversation-load-spinner,
-  .conversation-load-state-spinner,
   .run-dot.pulse,
   .run-dot.running {
     animation: none;

--- a/desktop/styles/sidebar.css
+++ b/desktop/styles/sidebar.css
@@ -220,8 +220,7 @@ html.is-resizing .sidebar-resize-handle {
   color: var(--color-danger);
 }
 
-.conversation-load-spinner,
-.conversation-load-state-spinner {
+.conversation-load-spinner {
   width: 12px;
   height: 12px;
   border: 2px solid var(--color-border);


### PR DESCRIPTION
## Summary

- keep the selected conversation row as the single animated loading indicator
- render the Chat panel's `Loading conversation…` state as static text instead of duplicating the spinner
- update the reduced-motion styling and browser regression to enforce the single-animation behavior

Follow-up to #1211.

## Testing

- `moon -C desktop check frontend --target js`
- `moon -C desktop run package/browser --target native`
- `npm --prefix desktop/e2e test -- --grep 'sidebar menu dismissal and pending selection follow the clicked row'`
