### PR TITLE
feat(prompt): prefer `!` negation and `clamped_view` excerpts

### DIFF
--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -168,6 +168,11 @@ When a probe captures a command's output, do not bind it to the name `test`:
 `let test_out = @shell.Cmd("moon", ["test"]).output()` or `let result = ...`
 instead, and keep `test` for `test { ... }` blocks.
 
+When a probe prints only a bounded excerpt of captured output, do not slice
+with a fixed end: `println(out.stdout()[:8000])` panics when the output is
+shorter than 8000 chars. Use `out.stdout().clamped_view(start=0, end=8000)`
+(or guard the length first) for best-effort truncation.
+
 For compiler feedback, stream the line-delimited JSON from one `moon check`
 rather than collecting it and parsing it afterward:
 
@@ -708,6 +713,9 @@ pkgtype(kind: "executable")
   `opaque`, and `member` cannot name a variable, parameter, or field —
   `let test = 0` is a parse error (`unexpected token `test``). Write
   `test_count`, `suberror_lines`, `method_`.
+- Negate booleans with the `!` prefix operator — `!pending`, never
+  `pending.not()`: `Bool` has no `not` method, so `pending.not()` is a type
+  error. Write `if !pending { ... }`.
 - Empty no-op expression is `()`. Do not write `{ }`; that is an empty map.
 - Match arms are separated by newlines or semicolons, not `|`:
 

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -173,6 +173,11 @@ fn default_prompt() -> String {
     #|`let test_out = @shell.Cmd("moon", ["test"]).output()` or `let result = ...`
     #|instead, and keep `test` for `test { ... }` blocks.
     #|
+    #|When a probe prints only a bounded excerpt of captured output, do not slice
+    #|with a fixed end: `println(out.stdout()[:8000])` panics when the output is
+    #|shorter than 8000 chars. Use `out.stdout().clamped_view(start=0, end=8000)`
+    #|(or guard the length first) for best-effort truncation.
+    #|
     #|For compiler feedback, stream the line-delimited JSON from one `moon check`
     #|rather than collecting it and parsing it afterward:
     #|
@@ -713,6 +718,9 @@ fn default_prompt() -> String {
     #|  `opaque`, and `member` cannot name a variable, parameter, or field —
     #|  `let test = 0` is a parse error (`unexpected token `test``). Write
     #|  `test_count`, `suberror_lines`, `method_`.
+    #|- Negate booleans with the `!` prefix operator — `!pending`, never
+    #|  `pending.not()`: `Bool` has no `not` method, so `pending.not()` is a type
+    #|  error. Write `if !pending { ... }`.
     #|- Empty no-op expression is `()`. Do not write `{ }`; that is an empty map.
     #|- Match arms are separated by newlines or semicolons, not `|`:
     #|


### PR DESCRIPTION
## Summary

Two probe-writing slips observed in live agent sessions:

1. **`pending.not()` instead of `!pending`** — `Bool` has no `not` method,
   so `pending.not()` is a type error (`Type Bool has no method not`).
   Agents write it naturally; the prompt now teaches the `!` prefix
   operator under Syntax And API Discipline.
2. **Fixed-end slicing of captured output** — `println(out.stdout()[:8000])`
   panics when the output is shorter than 8000 chars (raw slice syntax
   aborts out of range). Next to the `.output()` example in Running
   Commands, the prompt now teaches
   `out.stdout().clamped_view(start=0, end=8000)` for best-effort
   truncation.

## Changes

- `prompt/default_prompt.mbt.md`: add both teachings.
- `prompt/generated_default_prompt.mbt`: regenerated by the
  `md_to_mbt_string` dev-build rule.

## Verification

- `moon check --deny-warn prompt`: clean
- `moon test prompt`: 20/20 passed
- `moon fmt --check prompt`: clean

Generated with SeekMoon