### PR TITLE
feat(prompt): teach string interpolation over `+` concatenation

### DIFF
--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -855,6 +855,10 @@ fn main raise {
 
 - String interpolation uses `\{expr}`. Keep interpolation expressions simple.
   Do not write `\(expr)`; that is not MoonBit interpolation.
+- Build strings with interpolation rather than `+`: `"stderr: \{err}"` compiles
+  whenever `err` implements `Show`, while `"stderr: " + err` requires `err` to
+  be a `String` — with an `Int` (or any non-`String`) the `+` form is a type
+  error. Interpolation also avoids allocating an intermediate joined string.
 - Multi-line raw strings use `#|`. Multi-line interpolated strings use `$|` and
   interpolation as `\{...}`:
 

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -860,6 +860,10 @@ fn default_prompt() -> String {
     #|
     #|- String interpolation uses `\{expr}`. Keep interpolation expressions simple.
     #|  Do not write `\(expr)`; that is not MoonBit interpolation.
+    #|- Build strings with interpolation rather than `+`: `"stderr: \{err}"` compiles
+    #|  whenever `err` implements `Show`, while `"stderr: " + err` requires `err` to
+    #|  be a `String` — with an `Int` (or any non-`String`) the `+` form is a type
+    #|  error. Interpolation also avoids allocating an intermediate joined string.
     #|- Multi-line raw strings use `#|`. Multi-line interpolated strings use `$|` and
     #|  interpolation as `\{...}`:
     #|


### PR DESCRIPTION
## Summary

Agents building a message from a non-String value write `"stderr: " + err`,
which only compiles when `err : String` — with an `Int` (or anything else)
the `+` form is a type error. Interpolation `"stderr: \{err}"` needs only
`Show`, so it works for any value and avoids building an intermediate
joined string.

## Changes

- `prompt/default_prompt.mbt.md`: add a bullet right after the String
  interpolation rule teaching `"stderr: \{err}"` over `"stderr: " + err`.
- `prompt/generated_default_prompt.mbt`: regenerated by the
  `md_to_mbt_string` dev-build rule.

## Verification

- `moon check --deny-warn prompt`: clean
- `moon test prompt`: 20/20 passed
- `moon fmt --check prompt`: clean

Generated with SeekMoon