### PR TITLE
fix(desktop): reuse existing new chat after archive

### DIFF
--- a/desktop/e2e/tests/rabbita_dom.spec.js
+++ b/desktop/e2e/tests/rabbita_dom.spec.js
@@ -850,6 +850,33 @@ test('new chat, archive, and restore update the conversation sidebar', async ({ 
   expect(app.pageErrors).toEqual([]);
 });
 
+test('archiving a selected chat reuses an existing New chat draft', async ({ page }) => {
+  const app = new DesktopBrowserHarness(page);
+  await app.install();
+  await app.goto();
+
+  await page.locator('.workspace-row', { hasText: 'workspace' }).hover();
+  await page.getByTitle('New conversation in this project').click();
+  const newChat = page.locator('.conversation-row', { hasText: 'New chat' });
+  await expect(newChat).toHaveCount(1);
+  await page.locator('#task').fill('Keep this draft');
+
+  const stored = page.locator('.conversation-row[title="session-1"]');
+  await stored.click();
+  await expect(page.getByText('Browser result', { exact: true })).toBeVisible();
+  await page.locator('#task').fill('Discard this archived draft');
+  await stored.click({ button: 'right', position: { x: 18, y: 18 } });
+  await page.getByRole('menuitem', { name: 'Archive' }).click();
+
+  await expect.poll(() => app.requests.some(request =>
+    request.method === 'session.archive' &&
+    request.params?.session === 'session-1')).toBe(true);
+  await expect(newChat).toHaveCount(1);
+  await expect(newChat).toHaveClass(/active/);
+  await expect(page.locator('#task')).toHaveValue('Keep this draft');
+  expect(app.pageErrors).toEqual([]);
+});
+
 test('shared WebView action menu supports context position, keyboard, and rename', async ({ page }) => {
   const app = new DesktopBrowserHarness(page);
   app.workspaces.push('/other');

--- a/desktop/frontend/codex/completion.mbt
+++ b/desktop/frontend/codex/completion.mbt
@@ -378,7 +378,6 @@ pub fn State::composer_input(
     installed_skills: self.installed_codex_skills(),
     context_generation: 0,
     submission_sequence: self.submission_sequence,
-    replacements: [],
     retirements: [],
     file_candidates: context.file_candidates,
     open_files: context.open_files,
@@ -518,7 +517,6 @@ fn State::apply_composer_action(
     | @composer.SelectMenuDismissed(..)
     | @composer.ApprovalAnswered(..)
     | @composer.ApiSetupRequested(..)
-    | @composer.ArchivedInputDismissed(..)
     | @composer.QueuedInputEditRequested(..)
     | @composer.QueuedInputSteerRequested(..)
     | @composer.QueuedInputDeleteRequested(..)

--- a/desktop/frontend/composer/component.mbt
+++ b/desktop/frontend/composer/component.mbt
@@ -263,7 +263,6 @@ fn Entry::reconciled(self : Entry, input : Input) -> Entry {
 priv struct Model {
   entries : Array[Entry]
   applied_retirements : Int
-  applied_replacements : Int
   // The clock the running row's elapsed span is measured against, advanced by
   // `ClockTicked` and only while a turn is open. Component state rather than
   // the application's: a value that changes every second belongs to the one
@@ -277,7 +276,6 @@ fn Model::Model(input : Input) -> Model {
   {
     entries: [Entry(input)],
     applied_retirements: input.retirements.length(),
-    applied_replacements: input.replacements.length(),
     clock_ms: @interop.now_ms(),
   }
 }
@@ -307,34 +305,7 @@ fn Model::with_retirements_applied(self : Model, input : Input) -> Model {
 }
 
 ///|
-fn Model::with_replacements_applied(self : Model, input : Input) -> Model {
-  let mut entries = self.entries
-  for index in self.applied_replacements..<input.replacements.length() {
-    let replacement = input.replacements[index]
-    let snapshot = entries
-    for archived_entry in snapshot {
-      if archived_entry.owner == replacement.archived {
-        entries = entries.filter(existing => {
-          existing.owner != replacement.archived &&
-          existing.owner != replacement.fresh
-        })
-        entries.push({
-          ..archived_entry,
-          owner: replacement.fresh,
-          completion: None,
-          symbol_cache: SymbolCache(),
-          pending_submission: None,
-        })
-        break
-      }
-    }
-  }
-  { ..self, entries, applied_replacements: input.replacements.length(), }
-}
-
-///|
 fn Model::active(self : Model, input : Input) -> Entry {
-  let self = self.with_replacements_applied(input)
   for entry in self.entries {
     if entry.owner == input.identity.owner &&
       !self.owner_has_pending_retirement(input, entry.owner) {
@@ -364,7 +335,6 @@ priv enum Msg {
   CompletionAccept
   CompletionPick(Int)
   CompletionDismiss
-  EntriesTransferred
   EntriesRetired
   CompletionPump
   // A second passed while a turn was open. Carries nothing: the handler reads
@@ -611,9 +581,7 @@ fn Model::update(
   emit : @cmd.Emit[Msg],
   action_emit : @cmd.Emit[Action],
 ) -> (Model, @cmd.Cmd) {
-  let self = self
-    .with_replacements_applied(input)
-    .with_retirements_applied(input)
+  let self = self.with_retirements_applied(input)
   let entry = self.active(input)
   let self = self.with_entry(entry)
   match msg {
@@ -653,7 +621,7 @@ fn Model::update(
       let (next, command) = entry.accept_completion(item, action_emit)
       self.commit_entry_change(entry, next, command, action_emit)
     }
-    EntriesTransferred | EntriesRetired => (self, @cmd.none)
+    EntriesRetired => (self, @cmd.none)
     MentionRemoved(index) => {
       guard entry.draft.mentions.get(index) is Some(mention) else {
         return (self.with_entry(entry), @cmd.none)
@@ -874,9 +842,6 @@ fn Model::editing_subscriptions(
 ) -> @sub.Sub {
   if self.applied_retirements < input.retirements.length() {
     return @sub.every(150, emit(EntriesRetired))
-  }
-  if self.applied_replacements < input.replacements.length() {
-    return @sub.every(150, emit(EntriesTransferred))
   }
   let entry = self.active(input)
   guard entry.completion is Some(completion) && completion.menu.loading() else {

--- a/desktop/frontend/composer/component_xxtest.mbt
+++ b/desktop/frontend/composer/component_xxtest.mbt
@@ -14,7 +14,6 @@ fn Input::fixture(task : String) -> Input {
     installed_skills: [],
     context_generation: 0,
     submission_sequence: 0,
-    replacements: [],
     retirements: [],
     file_candidates: [],
     open_files: [],
@@ -121,50 +120,6 @@ test "background retirement prevents an old draft from reviving" {
     Action::test_emit(),
   )
   inspect(without_old.active(retired).draft.task, content="")
-}
-
-///|
-test "queued archive replacements preserve every draft handoff" {
-  let input = Input::fixture("")
-  let (drafted, _) = Model(input).update(
-    input,
-    TextChanged("draft through two rotations"),
-    Msg::test_emit(),
-    Action::test_emit(),
-  )
-  let first_fresh : @interop.ConversationKey = {
-    channel: @interop.ChannelId::Local,
-    session: "composer-fresh-one",
-  }
-  let second_fresh : @interop.ConversationKey = {
-    channel: @interop.ChannelId::Local,
-    session: "composer-fresh-two",
-  }
-  let rotated = {
-    ..input,
-    identity: { owner: second_fresh, archive_generation: 2, },
-    replacements: [
-      {
-        archived: input.identity.owner,
-        fresh: first_fresh,
-        archive_generation: 1,
-      },
-      { archived: first_fresh, fresh: second_fresh, archive_generation: 2, },
-    ],
-    retirements: [input.identity.owner, first_fresh],
-  }
-  let (moved, _) = drafted.update(
-    rotated,
-    EntriesTransferred,
-    Msg::test_emit(),
-    Action::test_emit(),
-  )
-  let entry = moved.active(rotated)
-  inspect(entry.draft.task, content="draft through two rotations")
-  assert_true(entry.owner == second_fresh)
-  // The moved draft keeps the generation at which it was authored. The root
-  // follows later archive facts from that cursor to resolve queued actions.
-  inspect(entry.identity().archive_generation, content="0")
 }
 
 ///|

--- a/desktop/frontend/composer/contract.mbt
+++ b/desktop/frontend/composer/contract.mbt
@@ -16,19 +16,9 @@ pub(all) struct Draft {
 ///|
 /// The conversation owner plus the archive-fact cursor at which its local
 /// composer entry was created. Every conversation-scoped action carries this
-/// identity so the root can reject or redirect a command after navigation or
-/// archive changes.
+/// identity so the root can reject a stale command after archive changes.
 pub(all) struct Identity {
   owner : @interop.ConversationKey
-  archive_generation : Int
-} derive(Eq, @debug.Debug)
-
-///|
-/// One active archive rotation. The root appends these facts; the composer
-/// consumes their ordered tail to move a cached draft to the fresh owner.
-pub(all) struct Replacement {
-  archived : @interop.ConversationKey
-  fresh : @interop.ConversationKey
   archive_generation : Int
 } derive(Eq, @debug.Debug)
 
@@ -130,7 +120,6 @@ pub(all) enum ContextComponent {
   ApiSetupNotice(text~ : String)
   ApprovalRequest(ApprovalNotice)
   CodexRequests(requests~ : Array[CodexRequestInput])
-  ArchivedInputNotice(text~ : String)
   PendingSteerPanel(items~ : Array[String])
   QueuedInputPanel(items~ : Array[QueuedInput])
   CompactionNotice(queued~ : Bool)
@@ -224,7 +213,6 @@ pub(all) struct Input {
   installed_skills : Array[@skills.InstalledItem]
   context_generation : Int
   submission_sequence : Int
-  replacements : Array[Replacement]
   retirements : Array[@interop.ConversationKey]
   file_candidates : Array[@pathx.Relative]
   open_files : Array[@pathx.Relative]
@@ -278,7 +266,6 @@ pub(all) enum Action {
   GitDetailsToggled(identity~ : Identity)
   WorktreeModeToggled(identity~ : Identity)
   ApiSetupRequested(identity~ : Identity)
-  ArchivedInputDismissed(identity~ : Identity)
   QueuedInputEditRequested(identity~ : Identity, id~ : String)
   QueuedInputSteerRequested(identity~ : Identity, id~ : String)
   QueuedInputDeleteRequested(identity~ : Identity, id~ : String)
@@ -317,7 +304,6 @@ pub fn Action::identity(self : Action) -> Identity {
     | GitDetailsToggled(identity~)
     | WorktreeModeToggled(identity~)
     | ApiSetupRequested(identity~)
-    | ArchivedInputDismissed(identity~)
     | QueuedInputEditRequested(identity~, ..)
     | QueuedInputSteerRequested(identity~, ..)
     | QueuedInputDeleteRequested(identity~, ..)
@@ -408,12 +394,6 @@ pub extend RunningSubmit with Debug::{to_repr}
 
 ///|
 pub extend RunningSubmit with Eq::{equal, not_equal}
-
-///|
-pub extend Replacement with Debug::{to_repr}
-
-///|
-pub extend Replacement with Eq::{equal, not_equal}
 
 ///|
 pub extend RunHeartbeat with Debug::{to_repr}

--- a/desktop/frontend/composer/view.mbt
+++ b/desktop/frontend/composer/view.mbt
@@ -331,17 +331,6 @@ pub fn ContextComponent::render(
       }
       @html.div(class="codex-pending", rendered)
     }
-    ArchivedInputNotice(text~) =>
-      @html.div(class="composer-notice", [
-        @html.span(class="composer-notice-text", text),
-        @html.button(
-          class="composer-notice-btn",
-          type_="button",
-          title="Dismiss this notice",
-          on_click=action_emit(ArchivedInputDismissed(identity~)),
-          "Got it",
-        ),
-      ])
     PendingSteerPanel(items~) => {
       let rows : Array[@html.Html] = []
       for shown in items {

--- a/desktop/frontend/composer_contract_wbtest.mbt
+++ b/desktop/frontend/composer_contract_wbtest.mbt
@@ -129,56 +129,12 @@ test "annotation-only composer submission starts its conversation" {
 }
 
 ///|
-test "archive cursor separates transferred actions from a reopened id" {
-  let archived : @interop.ConversationKey = {
-    channel: @interop.ChannelId::Local,
-    session: "desktop-test",
-  }
-  let fresh : @interop.ConversationKey = {
-    channel: @interop.ChannelId::Local,
-    session: "archive-replacement",
-  }
-  let reopened = test_conversation()
-  let replacement = empty_conversation(
-    fresh.channel,
-    fresh.session,
-    fresh.channel.test_project(),
-  )
-  let model = {
-    ..test_model(),
-    conversations: [reopened, replacement],
-    composer_entry_retirements: [archived],
-    composer_entry_replacements: [{ archived, fresh, archive_generation: 1, }],
-  }
-  let old_identity : @composer.Identity = {
-    owner: archived,
-    archive_generation: 0,
-  }
-  let reopened_identity : @composer.Identity = {
-    owner: archived,
-    archive_generation: 1,
-  }
-  guard model.conversation_for_composer_action(old_identity) is Some(old) else {
-    fail("the old entry should follow its recorded replacement")
-  }
-  guard model.conversation_for_composer_action(reopened_identity) is Some(new) else {
-    fail("the reopened entry should resolve to the reused id")
-  }
-  inspect(old.session_id, content="archive-replacement")
-  inspect(new.session_id, content="desktop-test")
-}
-
-///|
 test "a background retirement expires old actions without poisoning a reopened id" {
   let owner : @interop.ConversationKey = {
     channel: @interop.ChannelId::Local,
     session: "desktop-test",
   }
-  let model = {
-    ..test_model(),
-    composer_entry_retirements: [owner],
-    composer_entry_replacements: [],
-  }
+  let model = { ..test_model(), composer_entry_retirements: [owner], }
   assert_true(
     model.conversation_for_composer_action({ owner, archive_generation: 0, })
     is None,

--- a/desktop/frontend/composer_input.mbt
+++ b/desktop/frontend/composer_input.mbt
@@ -102,13 +102,6 @@ fn Model::composer_input(self : Model) -> @composer.Input {
       }),
     )
   }
-  // Advice about the draft this composer is now holding, so it belongs to the
-  // composer. It stands until the user acts on it: whether the archived record
-  // got the prompt is a question only that record answers, and a toast would
-  // be gone before they could go and look.
-  if conv.archived_pending_input {
-    context.push(@composer.ArchivedInputNotice(text=ArchivedPendingInputNotice))
-  }
   let steering = conv.pending_steers.filter(input => {
     input.behavior is FollowupSteer
   })
@@ -198,7 +191,6 @@ fn Model::composer_input(self : Model) -> @composer.Input {
     installed_skills: self.installed_skills,
     context_generation: self.composer_context_generation,
     submission_sequence: self.submission_sequence,
-    replacements: self.composer_entry_replacements,
     retirements: self.composer_entry_retirements,
     file_candidates: self.file_search().candidates,
     open_files: self.live_editor_files(),
@@ -304,7 +296,6 @@ fn Model::dormant_composer_input(self : Model) -> @composer.Input {
     installed_skills: self.installed_skills,
     context_generation: self.composer_context_generation,
     submission_sequence: self.submission_sequence,
-    replacements: self.composer_entry_replacements,
     retirements: self.composer_entry_retirements,
     file_candidates: [],
     open_files: [],

--- a/desktop/frontend/goal.mbt
+++ b/desktop/frontend/goal.mbt
@@ -578,11 +578,8 @@ test "re-asserting a blocked goal waits for its own marker" {
 }
 
 ///|
-test "archiving carries the goal draft to the replacement" {
+test "archiving discards the goal draft with its conversation" {
   let dispatch = test_dispatch()
-  // The row's Archive can be clicked while goal mode holds unsent writing,
-  // and that writing exists nowhere else — the salvage that recovers the
-  // prompt draft has to recover this one too.
   let model = test_model()
     .replace_conversation({
       ..test_conversation(),
@@ -606,20 +603,13 @@ test "archiving carries the goal draft to the replacement" {
     model,
   )
   inspect(next.active_session, content="desktop-restored")
-  guard next.active().goal_edit is Some(edit) else {
-    fail("the goal draft should come across")
-  }
-  inspect(edit.draft, content="a goal still being written")
-  // And it stays out of the prompt: it is not something to send.
-  inspect(next.active().task, content="a prompt typed too")
+  assert_true(next.active().goal_edit is None)
+  inspect(next.active().task, content="")
 }
 
 ///|
-test "archiving carries a goal that was sent but never confirmed" {
+test "archiving discards a goal that was sent but never confirmed" {
   let dispatch = test_dispatch()
-  // A Set whose marker never came back is not the archived record's yet —
-  // nothing proves the record received it, so this is still the only copy,
-  // exactly like the initial prompts the same salvage recovers.
   let model = test_model()
     .replace_conversation({
       ..test_conversation(),
@@ -641,12 +631,8 @@ test "archiving carries a goal that was sent but never confirmed" {
     ),
     model,
   )
-  guard next.active().goal_edit is Some(edit) else {
-    fail("an unconfirmed goal should come across")
-  }
-  inspect(edit.draft, content="a goal still in flight")
-  // The command itself does not: it was issued against the archived session.
-  inspect(next.active().goal_pending is None, content="true")
+  assert_true(next.active().goal_edit is None)
+  assert_true(next.active().goal_pending is None)
 }
 
 ///|

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -889,11 +889,6 @@ priv struct Conversation {
   // Where the durable transcript stands relative to the store; see
   // `TranscriptSync`.
   sync : TranscriptSync
-  // This conversation replaced one archived while a prompt was in flight. The
-  // composer says so, because what it is advice about is the draft the
-  // composer is now holding — the prompt may or may not have reached the
-  // archived record, and only that record can say.
-  archived_pending_input : Bool
   // The standing goal mirrored from the durable record's `[goal]` markers:
   // seeded by each snapshot's reduction and folded forward by marker
   // commits in `apply_commit`. Nothing local writes it — goal mode only
@@ -1286,12 +1281,6 @@ fn empty_device_state(channel : @interop.ChannelId) -> DeviceState {
 }
 
 ///|
-/// One active conversation replaced after it was archived. The root records
-/// every identity handoff so the composer can move all local entries that
-/// accumulate before its next subscription tick.
-type ComposerEntryReplacement = @composer.Replacement
-
-///|
 /// The owner key plus the archive-fact cursor at which its component entry
 /// was created. A reused session id can therefore name a new entry without
 /// intercepting commands that were already queued by the archived entry.
@@ -1543,10 +1532,6 @@ priv struct Model {
   // Transient presentation for the visible custom select. It closes on
   // context changes, selection, and click-away dismissal.
   select_menu : SelectMenu?
-  // Every archive rotation appends its identity handoff. Component-local draft
-  // text remains in the component; this ordered page-lifetime log keeps two
-  // rotations between subscription ticks from overwriting each other.
-  composer_entry_replacements : Array[ComposerEntryReplacement]
   // Every newly observed archive appends its exact owner. The composer consumes
   // this page-lifetime log in order, so a background session cannot regain an
   // old component-local draft when the same session id is later unarchived.
@@ -1787,9 +1772,6 @@ priv enum Msg {
   NotificationExpired(Int)
   // A toast was clicked: dismiss it now.
   DismissNotification(Int)
-  // The active conversation's "archived while a prompt was in flight" advice
-  // was acknowledged.
-  DismissArchivedPendingInput
   // The Settings "Check for updates" button.
   CheckForUpdates
   // An `auth.status` reply or `auth.changed` broadcast: the host's relay
@@ -2511,7 +2493,6 @@ fn empty_conversation(
     messages: [],
     watermark: 0,
     sync: Synced,
-    archived_pending_input: false,
     goal: None,
     goal_edit: None,
     goal_pending: None,
@@ -2631,7 +2612,6 @@ fn initial_model() -> Model {
     installed_skills: [],
     composer_context_generation: 0,
     select_menu: None,
-    composer_entry_replacements: [],
     composer_entry_retirements: [],
     quick_open: @quick_open.State::empty(),
     git_request_generation: 0,
@@ -3326,32 +3306,17 @@ fn Model::conversation_selection(self : Model) -> ConversationSelection? {
 
 ///|
 /// Resolve a component action against the conversation that currently owns
-/// its local entry. A command queued just before archive replacement still
-/// names the archived owner, so that one identity maps to the fresh record.
+/// its local entry. An archive fact newer than the entry expires the action;
+/// it must not reach either the archived record or a later reused id.
 fn Model::conversation_for_composer_action(
   self : Model,
   identity : ComposerActionIdentity,
 ) -> Conversation? {
-  let mut owner = identity.owner
-  // Follow only archive facts appended after this entry was born. An active
-  // archive has an exact handoff for its fact; a background archive has none,
-  // so its old actions expire instead of reaching a later unarchived record.
+  let owner = identity.owner
   for
     index in identity.archive_generation..<self.composer_entry_retirements.length() {
     if self.composer_entry_retirements[index] == owner {
-      let archive_generation = index + 1
-      let mut transferred = false
-      for replacement in self.composer_entry_replacements {
-        if replacement.archived == owner &&
-          replacement.archive_generation == archive_generation {
-          owner = replacement.fresh
-          transferred = true
-          break
-        }
-      }
-      if !transferred {
-        return None
-      }
+      return None
     }
   }
   self.find_conversation(owner.channel, owner.session)
@@ -3364,12 +3329,18 @@ fn Model::conversation_for_composer_action(
 /// the first send.
 fn Model::composing_new_chat(self : Model) -> Bool {
   guard self.active_conversation() is Some(conv) else { return false }
-  if conv.has_begun() {
+  self.conversation_is_new_chat(conv)
+}
+
+///|
+/// Whether `conv` is a live conversation the store does not know yet.
+fn Model::conversation_is_new_chat(self : Model, conv : Conversation) -> Bool {
+  if conv.has_begun() || conv.is_archived_read_only() {
     return false
   }
-  guard self.focused_device() is Some(dev) else { return true }
+  guard self.device_state(conv.device) is Some(dev) else { return true }
   for item in dev.sessions {
-    if item.id == conv.session_id {
+    if item.id == conv.session_id && item.workspace == conv.project() {
       return false
     }
   }
@@ -3879,59 +3850,6 @@ fn Conversation::restore_submission(
     mentions.push(mention)
   }
   { ..self, task, mentions, }
-}
-
-///|
-/// Recover everything the user can still resubmit when this conversation is
-/// archived out from under the composer. A prompt still in flight comes first
-/// in send order, followed by text typed since; no run or receipt state
-/// crosses into the replacement conversation.
-fn Conversation::archive_salvage(self : Conversation) -> ArchiveSalvage {
-  let drafts : Array[String] = []
-  let mentions : Array[Mention] = []
-  let pending_initial = self.pending_prompt is Some(_)
-  if self.pending_prompt is Some(pending) {
-    if !pending.draft.is_blank() {
-      drafts.push(pending.draft)
-    }
-    for mention in pending.mentions {
-      mentions.push(mention)
-    }
-  }
-  if !self.task.is_blank() {
-    drafts.push(self.task)
-  }
-  for mention in self.mentions {
-    mentions.push(mention)
-  }
-  // The goal draft rides beside the prompt rather than inside it: it is not
-  // something to send, and folding it into `task` would turn writing meant
-  // for the goal row into a prompt.
-  //
-  // Unsent writing comes first, and behind it a Set still waiting on its
-  // marker: sent, but with no proof it landed, which puts its text in exactly
-  // the position of the unconfirmed initial prompts above — the record may
-  // never have received it, and this is the only other copy. A Clearing asks
-  // for nothing to stand, so it carries nothing. Neither does a goal the
-  // record has already confirmed: that one is the archived record's.
-  let goal_draft = if self.goal_edit is Some(edit) && !edit.draft.is_blank() {
-    Some(edit.draft)
-  } else if self.goal_pending is Some({ request: Setting(text), .. }) &&
-    !text.is_blank() {
-    Some(text)
-  } else {
-    None
-  }
-  { task: drafts.join("\n\n"), mentions, goal_draft, pending_initial, }
-}
-
-///|
-/// What survives a conversation being archived out from under the composer.
-priv struct ArchiveSalvage {
-  task : String
-  mentions : Array[Mention]
-  goal_draft : String?
-  pending_initial : Bool
 }
 
 ///|

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -2,9 +2,6 @@
 const TranscriptReloadMaxAttempts : Int = 3
 
 ///|
-const ArchivedPendingInputNotice : String = "This conversation was archived while a prompt was being sent. The input was restored here; check the archived transcript before resubmitting."
-
-///|
 /// Build the request for one transcript generation. Foreground loads may
 /// activate a selected stored session; background refreshes only reconcile
 /// the conversation already in the model.
@@ -1569,9 +1566,10 @@ fn sync_browser_view(
 
 ///|
 /// Replace a selected record that disappeared while it was active or loading,
-/// carrying only its resubmittable composer state into the supplied fresh id.
-/// List replies and identity notifications share this transition because either
-/// can win their delivery race.
+/// returning to an existing New chat draft or the supplied fresh id. The
+/// removed record's composer state ends with it. List replies and identity
+/// notifications share this transition because either can win their delivery
+/// race.
 fn replace_removed_selection(
   model : Model,
   channel : @interop.ChannelId,
@@ -1591,73 +1589,47 @@ fn replace_removed_selection(
       conv.project() == workspace &&
       conv.is_archived_read_only() == (record is ArchivedRecord)
     })
-    is Some(removed_conv) else {
+    is Some(_) else {
     return model
   }
-  let salvaged = removed_conv.archive_salvage()
-  let restored_task = salvaged.task
-  let restored_mentions = salvaged.mentions
-  let pending_initial = salvaged.pending_initial
   let conversations = model.conversations.filter(conv => {
     conv.device != channel ||
     conv.session_id != session ||
     conv.project() != workspace ||
     conv.is_archived_read_only() != (record is ArchivedRecord)
   })
-  let activated = { ..model, conversations, }.activate(
-    channel, fresh_session, workspace,
-  )
-  // `activate` just placed `fresh_session`, so it is the one on screen.
-  guard activated.active_conversation() is Some(fresh) else { return model }
-  let task = if fresh.task.is_empty() {
-    restored_task
-  } else if restored_task.is_empty() || fresh.task == restored_task {
-    fresh.task
-  } else {
-    restored_task + "\n\n" + fresh.task
+  let fallback = conversations
+    .rev_iter()
+    .find_first(conv => {
+      conv.device == channel &&
+      conv.project() == workspace &&
+      model.conversation_is_new_chat(conv) &&
+      conv.worth_keeping()
+    })
+  let fallback_session = match fallback {
+    Some(draft) => draft.session_id
+    None => fresh_session
   }
-  let mentions = restored_mentions
-  for mention in fresh.mentions {
-    mentions.push(mention)
+  let activated = { ..model, conversations, }
+    .activate(channel, fallback_session, workspace)
+    .with_active_project(Some(workspace))
+  let activated = match fallback {
+    Some(_) => activated
+    None =>
+      match activated.active_conversation() {
+        Some(fresh) =>
+          activated.replace_conversation({
+            ..fresh,
+            worktree_mode: model.default_worktree_mode(channel, workspace),
+          })
+        None => activated
+      }
   }
-  // Goal mode comes across with its text: the replacement conversation is
-  // where the user goes on writing it.
-  let goal_edit = match (salvaged.goal_draft, fresh.goal_edit) {
-    (Some(draft), None) => Some({ draft, })
-    (_, existing) => existing
-  }
-  let fresh = {
-    ..fresh,
-    task,
-    mentions,
-    // The component still owns the text, but this bit keeps the replacement
-    // reachable until that local entry is submitted or cleared.
-    composer_draft_present: removed_conv.composer_draft_present ||
-    fresh.composer_draft_present,
-    workspace: Project(root=workspace),
-    worktree_mode: model.default_worktree_mode(channel, workspace),
-    goal_edit,
-  }
-  let fresh = { ..fresh, archived_pending_input: pending_initial, }
-  let composer_entry_replacements = model.composer_entry_replacements.copy()
-  let archived_owner : @interop.ConversationKey = { channel, session, }
-  let mut archive_generation = 0
-  for index, retired in model.composer_entry_retirements {
-    if retired == archived_owner {
-      archive_generation = index + 1
-    }
-  }
-  composer_entry_replacements.push({
-    archived: archived_owner,
-    fresh: { channel, session: fresh_session, },
-    archive_generation,
-  })
   {
-    ..activated.replace_conversation(fresh).with_active_project(Some(workspace)),
+    ..activated,
     screen: Chat,
     loading_conversation: None,
     conversation_load_failure: None,
-    composer_entry_replacements,
   }
 }
 
@@ -2092,7 +2064,6 @@ fn update_msg(
         | @composer.GitDetailsToggled(..)
         | @composer.WorktreeModeToggled(..)
         | @composer.ApiSetupRequested(..)
-        | @composer.ArchivedInputDismissed(..)
         | @composer.QueuedInputEditRequested(..)
         | @composer.QueuedInputSteerRequested(..)
         | @composer.QueuedInputDeleteRequested(..)
@@ -2129,8 +2100,6 @@ fn update_msg(
               update_msg(dispatch, ToggleWorktreeMode, model)
             @composer.ApiSetupRequested(..) =>
               update_msg(dispatch, OpenApiSetup, model)
-            @composer.ArchivedInputDismissed(..) =>
-              update_msg(dispatch, DismissArchivedPendingInput, model)
             @composer.QueuedInputEditRequested(id~, ..) => {
               guard conv.run is Open(stage~, ..) &&
                 !(stage is Cancelling) &&
@@ -3050,15 +3019,6 @@ fn update_msg(
         @cmd.none,
         { ..model, notifications: model.notifications.filter(t => t.id != id), },
       )
-    DismissArchivedPendingInput =>
-      if model.active_conversation() is Some(conv) {
-        (
-          @cmd.none,
-          model.replace_conversation({ ..conv, archived_pending_input: false, }),
-        )
-      } else {
-        (@cmd.none, model)
-      }
     RemoteStatusLoaded(status) =>
       (@cmd.none, { ..model, remote_access: Some(status), })
     RemoteConnectClicked =>
@@ -14986,7 +14946,7 @@ test "archived deletion keeps same-id rows in other stores" {
   )
   assert_true(deleted.dev().archived == [unplaced])
   inspect(deleted.active_session, content="desktop-fresh")
-  inspect(deleted.active().task, content="project draft")
+  inspect(deleted.active().task, content="")
 }
 
 ///|
@@ -15036,7 +14996,7 @@ test "delete response tombstones a family before stale list replies" {
   inspect(deleted.active_session, content="desktop-fresh")
   assert_eq(same_input.active_session, deleted.active_session)
   assert_eq(same_input.active().task, deleted.active().task)
-  inspect(deleted.active().task, content="keep local draft")
+  inspect(deleted.active().task, content="")
   assert_eq(deleted.dev().archived.length(), 1)
   assert_eq(deleted.dev().archived[0].id, "desktop-other")
   assert_false(deleted.dev().sessions.contains(parent))
@@ -15228,7 +15188,7 @@ test "deleted broadcast is immediate and idempotent" {
   inspect(deleted.active_session, content="desktop-fresh")
   assert_eq(same_input.active_session, deleted.active_session)
   assert_eq(same_input.active().task, deleted.active().task)
-  inspect(deleted.active().task, content="carry this draft")
+  inspect(deleted.active().task, content="")
   assert_true(
     deleted.find_conversation(@interop.ChannelId::Local, "desktop-gone") is None,
   )
@@ -15277,7 +15237,7 @@ test "deleted broadcast rotates the active conversation's exact store" {
     model,
   )
   inspect(deleted.active_session, content="desktop-fresh")
-  inspect(deleted.active().task, content="project draft")
+  inspect(deleted.active().task, content="")
   assert_true(deleted.dev().sessions == [unplaced])
   assert_true(deleted.dev().archived.is_empty())
 }
@@ -15320,14 +15280,14 @@ test "archive facts rotate the open conversation's exact store" {
     model,
   )
   inspect(notified.active_session, content="notification-fresh")
-  inspect(notified.active().task, content="project draft")
+  inspect(notified.active().task, content="")
   assert_true(
     notified.find_conversation(@interop.ChannelId::Local, "shared") is None,
   )
   assert_true(notified.dev().sessions == [unplaced])
   let (_, listed) = update(dispatch, archived_loaded([project_item]), model)
   inspect(listed.active_session, content="desktop-archive-replacement")
-  inspect(listed.active().task, content="project draft")
+  inspect(listed.active().task, content="")
   assert_true(
     listed.find_conversation(@interop.ChannelId::Local, "shared") is None,
   )
@@ -15378,11 +15338,8 @@ test "archive broadcast invalidates the active send target before list replies" 
   assert_eq(invalidated.dev().active_project, Some(workspace))
   assert_eq(invalidated.active().workspace, Project(root=workspace))
   assert_true(invalidated.active().worktree_mode)
-  inspect(invalidated.active().task, content="must not target archived session")
-  inspect(invalidated.active().mentions.length(), content="1")
-  assert_true(
-    invalidated.active().mentions[0].ref_ is Skill(name="draft-skill"),
-  )
+  inspect(invalidated.active().task, content="")
+  assert_true(invalidated.active().mentions.is_empty())
   assert_true(
     invalidated.dev().archived.iter().any(item => item.id == "desktop-test"),
   )
@@ -15405,7 +15362,7 @@ test "archive broadcast invalidates the active send target before list replies" 
 }
 
 ///|
-test "an archive response arriving before its notification preserves the draft once" {
+test "an archive response arriving before its notification discards the draft once" {
   let dispatch = test_dispatch()
   let model = test_model()
     .replace_conversation({ ..test_conversation(), task: "keep this draft", })
@@ -15419,7 +15376,7 @@ test "an archive response arriving before its notification preserves the draft o
     model,
   )
   inspect(responded.active_session, content="desktop-archive-replacement")
-  inspect(responded.active().task, content="keep this draft")
+  inspect(responded.active().task, content="")
   let (_, notified) = update_dev(
     dispatch,
     SessionsChanged(
@@ -15433,13 +15390,13 @@ test "an archive response arriving before its notification preserves the draft o
     responded,
   )
   // The late duplicate only refreshes the tombstone; it cannot rotate the
-  // already-safe composer a second time or lose its recovered text.
+  // fallback composer a second time.
   inspect(notified.active_session, content="desktop-archive-replacement")
-  inspect(notified.active().task, content="keep this draft")
+  inspect(notified.active().task, content="")
 }
 
 ///|
-test "archiving a pending start restores its original composer without ownership" {
+test "archiving a pending start discards its composer without ownership" {
   let dispatch = test_dispatch()
   let sent_mention : Mention = { ref_: Skill(name="sent-skill"), range: None, }
   let newer_mention : Mention = {
@@ -15478,15 +15435,10 @@ test "archiving a pending start restores its original composer without ownership
     model,
   )
   inspect(next.active_session, content="desktop-restored")
-  inspect(next.active().task, content="original draft\n\ntyped afterward")
-  inspect(next.active().mentions.length(), content="2")
+  inspect(next.active().task, content="")
+  assert_true(next.active().mentions.is_empty())
   assert_true(next.active().run is NoRun(ended=None))
   inspect(next.active().pending_steers.length(), content="0")
-  // The advice is about the draft the composer is now holding, so it stands
-  // there until acknowledged rather than expiring as a toast.
-  assert_true(next.active().archived_pending_input)
-  let (_, acknowledged) = update(dispatch, DismissArchivedPendingInput, next)
-  assert_false(acknowledged.active().archived_pending_input)
 }
 
 ///|


### PR DESCRIPTION
## Summary

- reuse the newest existing New chat draft after the selected conversation is archived or deleted
- discard composer state with the removed conversation instead of transferring it into the fallback
- remove the obsolete archive-salvage, composer-entry replacement, and restored-input notice infrastructure
- cover the user flow where both the existing New chat and the archived chat contain unsent text

## Validation

- moon -C desktop test frontend --target js
- targeted desktop browser E2E tests
- just check
- just test
- just build
- moon -C desktop info
- moon -C desktop fmt