### PR TITLE
Release moonbitlang/editor 0.4.5 and add its publish workflow

### DIFF
--- a/.github/workflows/publish-editor.yml
+++ b/.github/workflows/publish-editor.yml
@@ -1,0 +1,55 @@
+name: publish-editor
+
+# Publishes the `moonbitlang/editor` module (the `editor/` directory) to
+# mooncakes. Manual: bump `version` in editor/moon.mod first. The module is
+# published under the moonbitlang namespace, so it uses the organization's
+# mooncakes token, not a personal one. `bobzhang/openseek` (the root module)
+# depends on it, so a root publish that needs new editor packages must be
+# preceded by a run of this workflow.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish-editor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        # The editor's scoped moon.work keeps Proton setup out of this job,
+        # mirroring the editor CI gate.
+        working-directory: editor
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: install moon
+        run: |
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
+          echo "$HOME/.moon/bin" >> $GITHUB_PATH
+
+      - name: post install
+        run: |
+          moon version --all
+          moon update
+
+      - name: prepublish check
+        run: |
+          moon check --target all --warn-list +73 --deny-warn
+          moon test --target all
+
+      - name: publish
+        env:
+          SECRET: ${{ secrets.MOONCAKES_MOONBITLANG_TOKEN }}
+        shell: bash
+        run: |
+          if [ -z "$SECRET" ]; then
+            echo "Error: MOONCAKES_MOONBITLANG_TOKEN secret is not set."
+            echo "Please contact an admin to grant access to this secret."
+            exit 1
+          fi
+          echo "$SECRET" > ~/.moon/credentials.json
+          moon publish
+          rm ~/.moon/credentials.json

--- a/desktop/moon.mod
+++ b/desktop/moon.mod
@@ -16,7 +16,7 @@ import {
   "moonbit-community/proton_ext@0.2.6",
   "tonyfettes/platform@0.1.1",
   "tonyfettes/xlog@0.4.0",
-  "moonbitlang/editor@0.4.4",
+  "moonbitlang/editor@0.4.5",
   "moonbit-community/proton_contract@0.2.6",
   "bobzhang/openseek@0.2.2",
   "moonbit-community/proton_cefsetup@0.2.6",

--- a/editor/moon.mod
+++ b/editor/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbitlang/editor"
 
-version = "0.4.4"
+version = "0.4.5"
 
 readme = "README.md"
 

--- a/editor/server/moon.mod
+++ b/editor/server/moon.mod
@@ -13,6 +13,6 @@ preferred_target = "wasm"
 warnings = "+prefer_readonly_array+implicit_impl_as_method"
 
 import {
-  "moonbitlang/editor@0.4.4",
+  "moonbitlang/editor@0.4.5",
   "moonbitlang/async@0.21.0",
 }

--- a/moon.mod
+++ b/moon.mod
@@ -9,7 +9,7 @@ import {
   "bobzhang/jsonl@0.2.0",
   "bobzhang/openseek_protocol@0.1.0",
   "moonbit-community/rabbita@0.15.4",
-  "moonbitlang/editor@0.4.4",
+  "moonbitlang/editor@0.4.5",
   "moonbitlang/workflow@0.2.0",
 }
 


### PR DESCRIPTION
## Why

`bobzhang/openseek` (root module) imports `moonbitlang/editor/viewer/html` from `agent_tool/read/html`. The registry's `moonbitlang/editor@0.4.4` predates that package (the in-repo editor moved on without a re-publish), and Moon validates every package of a dependency module, so no consumer can build `bobzhang/openseek` from mooncakes today. The new standalone `moonbitlang/openseek_tui` repository (#1244) is the first such consumer.

## Changes

- `editor/moon.mod`: 0.4.4 → 0.4.5.
- Root, desktop, and editor/server pins: `moonbitlang/editor@0.4.5`.
- `.github/workflows/publish-editor.yml`: manual (workflow_dispatch) publish of the `editor/` module using `MOONCAKES_MOONBITLANG_TOKEN`, with the editor-scoped `moon check --target all --warn-list +73 --deny-warn` and `moon test --target all` gate first (mirrors `editor.yml`).

## Follow-up

Dispatch the workflow after merge, then publish `bobzhang/openseek@0.3.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHGA6k85VnewvkWC5miLzR
