### PR TITLE
feat(editor): syntax-highlight .mbtx scripts like MoonBit source

### DIFF
--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -273,10 +273,17 @@ fn working_feedback_model(
 
 ///|
 /// Register syntax highlighting for the languages the panel can recognize.
-/// Files of any other type render as plain text.
+/// `.mbtx` scripts register under their own id but use the MoonBit tokenizer,
+/// so they color exactly like `.mbt` source. Files of any other type render
+/// as plain text.
 fn register_tokenizers() -> Unit {
   @languages.languages.set_tokens_provider(
     "moonbit",
+    @lang_moonbit.MoonBitTokenizer(),
+  )
+  |> ignore
+  @languages.languages.set_tokens_provider(
+    "mbtx",
     @lang_moonbit.MoonBitTokenizer(),
   )
   |> ignore
@@ -1505,13 +1512,17 @@ fn apply_diagnostics(
 }
 
 ///|
-/// The viewer language id for a file name. MoonBit source and manifests,
-/// JavaScript, and JSON have tokenizers; everything else falls back to
-/// unhighlighted plain text.
+/// The viewer language id for a file name. MoonBit source (`.mbt`, `.mbti`,
+/// `.mbt.md`), `.mbtx` scripts, MoonBit manifests, JavaScript, and JSON have
+/// tokenizers; everything else falls back to unhighlighted plain text. A
+/// `.mbtx` script carries its own id but shares the MoonBit tokenizer, so its
+/// top-of-file `import` block highlights exactly as MoonBit source does.
 fn language_id(name : String) -> String {
   let lower = name.to_lower()
   if lower == "moon.pkg" || lower == "moon.mod" {
     "moonbit-config"
+  } else if lower.has_suffix(".mbtx") {
+    "mbtx"
   } else if lower.has_suffix(".mbt") ||
     lower.has_suffix(".mbti") ||
     lower.has_suffix(".mbt.md") {

--- a/desktop/frontend/fileeditor/files.mbt
+++ b/desktop/frontend/fileeditor/files.mbt
@@ -389,6 +389,7 @@ test "language_id maps known extensions and falls back to plain text" {
   assert_eq(language_id("main.mbt"), "moonbit")
   assert_eq(language_id("pkg.generated.mbti"), "moonbit")
   assert_eq(language_id("README.mbt.md"), "moonbit")
+  assert_eq(language_id("run.mbtx"), "mbtx")
   assert_eq(language_id("bundle.js"), "javascript")
   assert_eq(language_id("config.mjs"), "javascript")
   assert_eq(language_id("moon.mod.json"), "json")

--- a/editor/internal/viewer/markdown/tokenized_code_block.mbt
+++ b/editor/internal/viewer/markdown/tokenized_code_block.mbt
@@ -49,6 +49,7 @@ fn markdown_code_language(
   }
   match language {
     "mbt" => "moonbit"
+    "mbtx" => "moonbit"
     "js" => "javascript"
     "ts" => "typescript"
     _ => language

--- a/editor/internal/viewer/markdown/tokenized_code_block_wbtest.mbt
+++ b/editor/internal/viewer/markdown/tokenized_code_block_wbtest.mbt
@@ -37,6 +37,34 @@ test "shared tokenized code override emits editor classes and threads active lan
 }
 
 ///|
+test "mbtx fences share the moonbit tokenizer with mbt fences" {
+  register_shared_markdown_test_tokenizer()
+  let mbt = render_markdown(
+    (
+      #|```mbt
+      #|let answer = 42
+      #|```
+    ),
+    code_block_renderer=render_tokenized_code_block,
+  )
+  let mbtx = render_markdown(
+    (
+      #|```mbtx
+      #|let answer = 42
+      #|```
+    ),
+    code_block_renderer=render_tokenized_code_block,
+  )
+  assert_true(mbtx.has_code_block)
+  assert_true(mbtx.html.contains("monaco-tokenized-source"))
+  assert_true(mbtx.html.contains("class=\"mtk3\""))
+  // Same program text, same tokenizer: an mbtx fence is an mbt fence, and
+  // the only extra construct mbtx adds — its `import` block — is already a
+  // MoonBit keyword in that shared tokenizer.
+  assert_eq(mbtx.html, mbt.html)
+}
+
+///|
 test "shared tokenized code override keeps unknown-language source as safe default tokens" {
   let rendered = render_markdown(
     (

--- a/editor/shell/workspace/source.mbt
+++ b/editor/shell/workspace/source.mbt
@@ -5,7 +5,8 @@ pub fn infer_language_id(path_or_name : String) -> String {
   if is_moon_config_path(path_or_name) {
     "moonbit-config"
   } else if path_or_name.has_suffix(".mbt") ||
-    path_or_name.has_suffix(".mbt.md") {
+    path_or_name.has_suffix(".mbt.md") ||
+    path_or_name.has_suffix(".mbtx") {
     "moonbit"
   } else if path_or_name.has_suffix(".js") || path_or_name.has_suffix(".mjs") {
     "javascript"

--- a/editor/shell/workspace/source_test.mbt
+++ b/editor/shell/workspace/source_test.mbt
@@ -83,6 +83,7 @@ test "infers language ids from source names" {
   assert_eq(@workspace.infer_language_id("src\\moon.mod"), "moonbit-config")
   assert_eq(@workspace.infer_language_id("main.mbt"), "moonbit")
   assert_eq(@workspace.infer_language_id("README.mbt.md"), "moonbit")
+  assert_eq(@workspace.infer_language_id("run.mbtx"), "moonbit")
   assert_eq(@workspace.infer_language_id("main.js"), "javascript")
   assert_eq(@workspace.infer_language_id("main.mjs"), "javascript")
   assert_eq(@workspace.infer_language_id("main.ts"), "typescript")

--- a/editor/syntax/lang_moonbit/lexer_test.mbt
+++ b/editor/syntax/lang_moonbit/lexer_test.mbt
@@ -263,3 +263,16 @@ test "extend and var classify as keywords" {
     ),
   )
 }
+
+///|
+test "import classifies as a keyword in script import blocks" {
+  inspect(
+    render_tokens("import { \"moonbitlang/async\" }"),
+    content=(
+      #|0-6 Keyword import
+      #|7-8 Delimiter {
+      #|9-28 String "moonbitlang/async"
+      #|29-30 Delimiter }
+    ),
+  )
+}


### PR DESCRIPTION
A `.mbtx` script is an `.mbt` file plus a top-of-file `import { ... }` block, so it
should highlight exactly like MoonBit source — and it now does everywhere a file
or markdown fence is routed to a tokenizer:

- **Desktop file editor**: `.mbtx` names now get their own `mbtx` language id,
  registered with the MoonBit tokenizer (same grammar, same colors), instead of
  falling back to unhighlighted plain text when you open an agent script.
- **Markdown fences**: a ` ```mbtx ` code block is tokenized as `moonbit`, exactly
  like ` ```mbt `, so mbtx fences inside `.mbt.md` prompts/docs color too.
- **Workspace inference**: `infer_language_id` now lists `.mbtx` explicitly as
  `moonbit` rather than relying on the unknown-name fallback.

The one keyword mbtx adds over mbt — `import` — was already in the MoonBit
tokenizer's keyword table (`editor/syntax/lang_moonbit/lexer.mbt`); a golden
lexer test now pins that an import block's `import` colors as a keyword.

Verified:
- `moon check` clean on the editor module and on the desktop fileeditor package (js).
- `moon test`: new import-keyword lexer test, new mbtx-fence markdown test,
  workspace language-inference test, and desktop `language_id` test all pass;
  full packages green (`syntax/lang_moonbit` 16/16, `internal/viewer/markdown`
  61/61, `shell/workspace` 13/13, `frontend/fileeditor` js).

Generated with SeekMoon