### PR TITLE
feat(desktop): ship moonbit-docs inside the toolchain seed and advertise them to engines

### DIFF
--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -1181,6 +1181,14 @@ async fn skills_prompt_section_for_cwd(
 /// workspace wholesale. A durable session stores the prompt at creation, so
 /// the recorded directory is where the session was started — resume it from
 /// the same project root.
+///
+/// When the process environment names a MoonBit reference-docs directory
+/// (`OPENSEEK_REFERENCES`), the section additionally points the model at the
+/// bundled moonbit-docs pages and tells it how to consult them. The tail
+/// position keeps that optional, install-dependent text out of the
+/// cache-shared prefix. The variable is set by the desktop host only after it
+/// resolved an existing `references` directory next to the engine, so no
+/// existence check is needed here.
 async fn environment_prompt_section(workspace_root? : String = ".") -> String {
   let target = if workspace_root == "" { "." } else { workspace_root }
   let cwd = @fs.realpath(target) catch { _ => target }
@@ -1195,7 +1203,7 @@ async fn environment_prompt_section(workspace_root? : String = ".") -> String {
         sb <+ "(empty directory): use `moon new` to create a new project here"
     }
   }
-  (
+  let section =
     $|## Environment
     $|
     $|Working directory: \{cwd}
@@ -1203,6 +1211,34 @@ async fn environment_prompt_section(workspace_root? : String = ".") -> String {
     $|Parent and sibling directories belong to other projects. Never pass a cwd you have not verified exists.
     $|Project layout (directories; hidden, build, and vendored dirs omitted):
     $|\{sb=>layout(sb)}
+  match references_dir_from_environment() {
+    Some(dir) => "\{section}\n\n\{references_environment_block(dir)}"
+    None => section
+  }
+}
+
+///|
+/// The bundled MoonBit reference-docs directory, when the process environment
+/// sets `OPENSEEK_REFERENCES` to a non-empty value.
+fn references_dir_from_environment() -> String? {
+  match @env.get_env_var("OPENSEEK_REFERENCES") {
+    Some(dir) if !dir.trim().is_empty() => Some(dir)
+    _ => None
+  }
+}
+
+///|
+/// The environment-section tail naming `references_dir` — the bundled
+/// moonbit-docs markdown build — and how to consult it. The pages live
+/// outside the workspace, so the block must say both that reading them is
+/// expected and how: find the relevant page by listing or searching a
+/// subtree, then read only that file in bounded reads, never the whole tree.
+fn references_environment_block(references_dir : String) -> String {
+  (
+    $|MoonBit reference docs: \{references_dir}
+    $|This installation bundles the official MoonBit documentation (the moonbit-docs markdown build) at the path above. It sits outside the workspace and is read-only; treat it as the authoritative source for language, standard-library, toolchain, and tutorial facts — look facts up there instead of guessing or inventing them.
+    $|Top-level layout: language/ (language guide, attributes, error codes), toolchain/, tutorial/, example/, and index.md (the site map).
+    $|Read on demand, never wholesale: find the page you need with a subtree listing or search (@shell.glob or rg over "\{references_dir}"), then open only that page with the read tool, keeping each read bounded.
   )
 }
 

--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -1393,10 +1393,22 @@ async fn add_moonbit_path_for_native_engine(
   // naming the cause now.
   let toolchain = @moonbit.resolve_toolchain(config.engine, runtime_dir?)
   toolchain.apply_to_env(env)
+  // The prepared payload also carries the seed's `docs/` (the moonbit-docs
+  // markdown build), which the engine advertises to the model as its MoonBit
+  // reference. Durable session prompts embed the path, and the payload lives
+  // in the per-user runtime directory, so it survives bundle moves and
+  // AppImage relaunches. A toolchain without docs — an external one, or a
+  // seed staged without them — advertises none, and the ambient value is
+  // scrubbed so the child never names docs the host did not resolve.
+  match toolchain.references {
+    Some(docs) => env["OPENSEEK_REFERENCES"] = docs.to_string()
+    None => env.remove("OPENSEEK_REFERENCES")
+  }
   @xlog.debug() <?
     {
       "event": "desktop_engine_moonbit_path",
       "bin_dir": toolchain.bin_dir.to_string(),
+      "references": toolchain.references.map(docs => docs.to_string()),
       "path_prefix": first_path_entry(path_env_value(env)),
     }
 }
@@ -2764,6 +2776,19 @@ async test "native engine env has one authoritative bundled moon path" {
   let env = engine_process_env(config, Some(runtime))
   assert_eq(env["OPENSEEK_THINKING"], "high")
   assert_eq(env["DEEPSEEK"], "k")
+  // This payload carries no `docs/` yet: the engine env must not invent an
+  // OPENSEEK_REFERENCES the host did not resolve.
+  assert_true(env.get("OPENSEEK_REFERENCES") is None)
+  // The moonbit-docs markdown build travels inside the seed and therefore
+  // inside the prepared payload, so the engine is pointed at the runtime
+  // copy — the durable prompt embeds this path, and it must never name a
+  // bundle location that unmounts when the app exits.
+  write_fake_file(moon_home.join("docs/language/index.md"))
+  let env_with_references = engine_process_env(config, Some(runtime))
+  assert_eq(
+    env_with_references["OPENSEEK_REFERENCES"],
+    moon_home.join("docs").to_string(),
+  )
   // A GLM run's key travels in GLM, and the resolved variable — not a
   // hardcoded DEEPSEEK — is what the process env honors.
   let glm_env = engine_process_env(

--- a/desktop/internal/moonbit/pkg.generated.mbti
+++ b/desktop/internal/moonbit/pkg.generated.mbti
@@ -18,6 +18,7 @@ pub impl Show for ToolchainUnavailable
 pub struct ResolvedToolchain {
   bin_dir : @pathx.Absolute
   moon : @pathx.Absolute
+  references : @pathx.Absolute?
 }
 pub fn ResolvedToolchain::apply_to_env(Self, Map[String, String]) -> Unit
 pub fn ResolvedToolchain::tool_env(Self) -> Map[String, String]

--- a/desktop/internal/moonbit/toolchain_paths.mbt
+++ b/desktop/internal/moonbit/toolchain_paths.mbt
@@ -113,6 +113,13 @@ fn moonbit_bin_dir(moon_home : @pathx.Path) -> @pathx.Path {
 }
 
 ///|
+/// The moonbit-docs markdown build packaging stages inside the seed, so the
+/// prepared payload carries the docs describing exactly its toolchain.
+fn moonbit_docs_dir(moon_home : @pathx.Path) -> @pathx.Path {
+  moon_home.join("docs")
+}
+
+///|
 #cfg(platform="windows")
 const ExecutableSuffix : String = ".exe"
 

--- a/desktop/internal/moonbit/toolchain_resolve.mbt
+++ b/desktop/internal/moonbit/toolchain_resolve.mbt
@@ -10,6 +10,11 @@
 pub struct ResolvedToolchain {
   bin_dir : @pathx.Absolute
   moon : @pathx.Absolute
+  /// The MoonBit reference docs shipped with this toolchain, when it carries
+  /// them: the bundled payload's `docs/`, the moonbit-docs markdown build the
+  /// packager stages into the seed. An external toolchain never has any. The
+  /// engine advertises the directory to the model as `OPENSEEK_REFERENCES`.
+  references : @pathx.Absolute?
 }
 
 ///|
@@ -23,7 +28,7 @@ pub struct ResolvedToolchain {
 async fn toolchain_at(bin_dir : @pathx.Absolute) -> ResolvedToolchain? {
   let moon = bin_dir.join("moon" + ExecutableSuffix)
   guard @fsx.is_executable_file(moon.to_path()) else { return None }
-  Some({ bin_dir, moon, })
+  Some({ bin_dir, moon, references: None, })
 }
 
 ///|
@@ -62,7 +67,12 @@ pub async fn resolve_toolchain(
       toolchain_at(bin_dir) is Some(toolchain) else {
       fail("bundled MoonBit toolchain payload is not a complete toolchain")
     }
-    return toolchain
+    // The seed's `docs/` came along in the payload copy, so the reference
+    // path is exactly as stable as `moon` itself: the per-user runtime
+    // directory, never the bundle (an AppImage mounts afresh per launch).
+    let docs = moonbit_docs_dir(payload)
+    let references = if @fsx.is_dir(docs) { docs.to_absolute() } else { None }
+    return { ..toolchain, references, }
   }
   external_toolchain(path_env?=@env.get("PATH"), home_dir?=@home.dir())
 }

--- a/desktop/internal/moonbit/toolchain_resolve_wbtest.mbt
+++ b/desktop/internal/moonbit/toolchain_resolve_wbtest.mbt
@@ -138,13 +138,29 @@ async test "no toolchain anywhere raises ToolchainUnavailable" {
 }
 
 ///|
+/// Reference docs ship only inside the bundled seed's payload; a toolchain
+/// found on the path or under `~/.moon` never advertises any, even with a
+/// `docs` directory sitting beside its `bin`.
+async test "an external toolchain carries no reference docs" {
+  with_toolchain_test_tree(async fn(root) {
+    let moon_root = root.join("home").join(".moon")
+    @fs.mkdir(moon_root.join("bin").to_string(), recursive=true)
+    @fs.mkdir(moon_root.join("docs").to_string(), recursive=true)
+    touch_fake_toolchain(moon_root.join("bin"))
+    let toolchain = external_toolchain(home_dir=root.join("home").to_path())
+    assert_eq(toolchain.bin_dir.to_string(), moon_root.join("bin").to_string())
+    assert_true(toolchain.references is None)
+  })
+}
+
+///|
 /// The environment policy is a path prepend and nothing else — in
 /// particular the ambient `MOON_HOME` must survive untouched, or spawned
 /// sessions lose the user's registry credentials.
 async test "toolchain env policy leaves MOON_HOME alone" {
   let env : Map[String, String] = { "MOON_HOME": "/custom", "PATH": "/usr/bin" }
   let bin_dir = @pathx.Path("found/bin").resolve()
-  { bin_dir, moon: bin_dir.join("moon"), }.apply_to_env(env)
+  { bin_dir, moon: bin_dir.join("moon"), references: None, }.apply_to_env(env)
   assert_eq(env.get("MOON_HOME"), Some("/custom"))
   assert_true(
     env.get("PATH").map(path => path.has_prefix(bin_dir.to_string())) ==

--- a/desktop/package/internal/moonbit/toolchain.mbt
+++ b/desktop/package/internal/moonbit/toolchain.mbt
@@ -11,6 +11,36 @@ const MoonbitCliBaseUrl : String = "https://cli.moonbitlang.com"
 const MoonbitSeedVersionFile : String = ".openseek-moonbit-seed-version"
 
 ///|
+/// The moonbit-docs `markdown-build` commit whose generated Markdown pages
+/// ship inside every toolchain seed as `docs/`. The engine advertises that
+/// tree to the model as its MoonBit reference (`OPENSEEK_REFERENCES`), so it
+/// rides with the toolchain it documents: the runtime mirrors the whole seed
+/// into the per-user runtime directory, and a bump here refreshes that mirror
+/// through the seed version stamp exactly like a compiler bump does.
+const MoonbitDocsCommit : String = "750cc5a41679256441a3efa75487420028cff2e1"
+
+///|
+/// The pinned commit's source archive, fetched from codeload directly:
+/// `github.com/.../archive/<commit>.tar.gz` only redirects there, and the
+/// download helper does not follow redirects.
+fn moonbit_docs_archive_url() -> String {
+  "https://codeload.github.com/moonbitlang/moonbit-docs/tar.gz/" +
+  MoonbitDocsCommit
+}
+
+///|
+fn moonbit_docs_cache_path() -> String {
+  MoonbitToolchainCacheDir + "/moonbit-docs-" + MoonbitDocsCommit + ".tar.gz"
+}
+
+///|
+/// The seed version stamp names both pins: the runtime compares it whole
+/// against its mirror's stamp, so a docs-only bump rebuilds the mirror too.
+fn moonbit_seed_version(version : String) -> String {
+  version + " docs=" + MoonbitDocsCommit
+}
+
+///|
 /// Platform-specific descriptor for the MoonBit toolchain seed staged into a
 /// desktop package.
 struct MoonbitToolchainTarget {
@@ -192,12 +222,13 @@ async fn extract_tar_gz_archive(
   ws : @packaging.Workspace,
   archive : String,
   destination : String,
+  strip_components? : Int,
 ) -> Unit {
-  @packaging.run_checked(
-    "tar",
-    ["-xzf", archive, "-C", destination],
-    dir=ws.dir(),
-  )
+  let args = ["-xzf", archive, "-C", destination]
+  if strip_components is Some(depth) {
+    args.push("--strip-components=\{depth}")
+  }
+  @packaging.run_checked("tar", args, dir=ws.dir())
 }
 
 ///|
@@ -269,9 +300,35 @@ async fn compiler_version(
 }
 
 ///|
+/// Stage the pinned moonbit-docs markdown build as the seed's `docs/` tree.
+/// Only the archive is reused across runs; the tree is re-extracted every
+/// time so a stale partial extraction cannot ship. The Sphinx theme assets
+/// the build carries are dropped: the references are the Markdown pages.
+async fn stage_moonbit_docs(
+  ws : @packaging.Workspace,
+  docs_dir : String,
+) -> Unit {
+  let archive = moonbit_docs_cache_path()
+  download_file_if_missing(moonbit_docs_archive_url(), ws.at(archive))
+  @packaging.remove_path_if_exists(ws.at(docs_dir))
+  @packaging.ensure_dir(ws.at(docs_dir))
+  // The archive wraps the tree in a `moonbit-docs-<commit>/` root.
+  extract_tar_gz_archive(ws, archive, docs_dir, strip_components=1)
+  @packaging.remove_path_if_exists(ws.at(docs_dir + "/_sphinx_design_static"))
+  for entry in ["index.md", "language", "toolchain"] {
+    if !@asyncfs.exists(ws.at(docs_dir + "/" + entry)) {
+      raise @packaging.PackageError(
+        "moonbit-docs archive \{archive} is missing \{entry}",
+      )
+    }
+  }
+}
+
+///|
 /// Download and stage a platform-specific MoonBit toolchain seed into a
-/// package directory. The seed is intentionally not bundled in place; runtime
-/// initialization copies it to the per-user writable runtime directory first.
+/// package directory, with the pinned moonbit-docs as its `docs/`. The seed
+/// is intentionally not bundled in place; runtime initialization copies it to
+/// the per-user writable runtime directory first.
 pub async fn stage_moonbit_toolchain_seed(
   ws : @packaging.Workspace,
   target : MoonbitToolchainTarget,
@@ -301,8 +358,9 @@ pub async fn stage_moonbit_toolchain_seed(
       "downloaded MoonBit version \{actual_version}, expected \{version}",
     )
   }
+  stage_moonbit_docs(ws, payload_dir + "/docs")
   @packaging.write_text(
     ws.at(payload_dir + "/" + MoonbitSeedVersionFile),
-    version,
+    moonbit_seed_version(version),
   )
 }


### PR DESCRIPTION
## What

Bundle the official MoonBit documentation (the moonbit-docs markdown build) into the desktop installs and make the agent use it as its MoonBit reference.

1. **Docs ride in the toolchain seed.** `stage_moonbit_toolchain_seed` now downloads the pinned `markdown-build` commit's archive into the existing toolchain cache (`dist/tools/moonbit`) and extracts it as `docs/` inside every platform's seed, dropping the Sphinx theme assets. The seed version stamp names both the compiler version and the docs commit, so a docs-only bump refreshes the per-user mirror exactly like a compiler bump. No new packager wiring: the three packagers call the same staging function as before.
2. **Stable engine env for free.** The runtime already mirrors the seed into the per-user runtime directory (stamp + lock + `moon bundle`), so the docs land there with it. `resolve_toolchain` reports the payload's `docs/` as `ResolvedToolchain::references` (external toolchains never carry any), and the engine spawn sets `OPENSEEK_REFERENCES` from it or scrubs the ambient value. Durable session prompts embed this path; it never names the bundle, so an AppImage relaunch cannot orphan it.
3. **system prompt** (unchanged from the first revision): the `## Environment` section appends the references path plus how-to-read guidance whenever `OPENSEEK_REFERENCES` is set. Unset variables leave the prompt byte-identical.

Compared with the first revision this drops `package/internal/moonbit_docs_assets` and `desktop/internal/references` entirely — the download path and the seed→mirror path were copies of what the toolchain packages already do — and ties the docs pin to the toolchain they describe.

## Validation

- `moon check --deny-warn` (root) and `moon -C desktop check --target native --deny-warn` pass with zero warnings; `moon fmt --check` clean on both modules.
- `moon -C desktop test --target native`: 3222 passed. `moon test -p cmd/openseek`: 82 passed. This covers the engine env test (payload without `docs/` → no variable; with `docs/` → the runtime payload path) and the new external-toolchain-has-no-references case.
- The docs download + extraction was exercised by hand against the pinned commit: the codeload URL serves the archive directly (SHA-256 `8376eee0…`, byte-identical to what `github.com/…/archive/<commit>.tar.gz` redirects to), and `tar -xzf --strip-components=1` yields `index.md`, `language/`, `toolchain/`, `tutorial/`, `example/` (383 files, ~2 MB).
- Not run: the full `moon run package/{macos,linux,windows}` packaging builds.

## Notes

- `markdown-build` is a rolling branch; refresh by bumping `MoonbitDocsCommit` in `package/internal/moonbit/toolchain.mbt`.
- Docs are extracted with `tar` on every packaging host, including Windows (the toolchain zips there still go through `Expand-Archive`); Windows 10+ ships `tar.exe`.
- Sessions created before this change keep their stored prompt and never see the references block; only new sessions do. Same as the first revision — fixing it means rendering the environment tail at request time rather than at session creation, which is a separate engine change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RafPYGSUxugV2tFcqCVTV1
