### PR TITLE
feat(prompt): recommend argparse for every CLI and verify the pattern

### DIFF
--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -935,13 +935,20 @@ test {
 
 ## CLI Parsing And Native IO
 
-- For CLI parsing, prefer `moonbitlang/core/argparse` and call
-  `@argparse.parse(...)` on a `Command`. Do not hand-roll option parsing with
-  `@env.args()` except for tiny throwaway probes.
+- Whenever you write a CLI — a `cmd/...` executable you probe with `moon run ...
+  -- args`, or anything the user invokes with options or positionals — parse
+  with `moonbitlang/core/argparse` (MoonBit core, no new dependency): build a
+  `Command` and call `@argparse.parse(...)`, which returns `Matches` or raises
+  a display-ready usage error. Do not hand-roll a loop over `@env.args()` that
+  walks indices and concatenates `"--flag " + value` pairs — argparse also
+  gives you `--help`/`--version`, flags, positionals, and defaults for free,
+  and the reusable pattern is right below.
 - `FlagArg.long` omits leading dashes: use `long="stdin"`, not
   `long="--stdin"`.
 - Convert `@argparse.Matches` into a small config record or local values before
-  doing real work; keep validation near that conversion.
+  doing real work; keep validation near that conversion. Precedence is
+  argv > env > default_values, so state defaults on the
+  `FlagArg`/`PositionArg` and let argparse fill them in.
 - Do not implement ordinary file/stdin IO with C FFI. Use `moonbitlang/async/fs`
   and `moonbitlang/async/stdio`.
 - A native CLI that reads either a path or stdin usually needs `async fn main`.
@@ -976,12 +983,14 @@ async fn main {
           FlagArg("stdin", long="stdin", about="Read stdin instead of a file."),
         ],
         positionals=[
-          PositionArg("input", default_values=["-"], about="Input file path."),
+          PositionArg(
+            "input", default_values=["-"], about="Input file (\"-\" reads stdin).",
+          ),
         ],
       ),
     )
     |> config_from_matches
-  let input = if config.stdin {
+  let input = if config.stdin || config.input == "-" {
     @stdio.stdin.read_all().text()
   } else {
     @fs.read_file(config.input).text()
@@ -1006,6 +1015,10 @@ fn config_from_matches(matches : @argparse.Matches) -> Config raise {
   }
 }
 ```
+
+- The `-` default follows the usual `-`-means-stdin convention, so a bare
+  invocation reads stdin instead of failing on a file literally named `-`;
+  unknown flags still surface as `@argparse` usage errors.
 
 - In `moon run`, the package path goes before `--`; program arguments go after
   `--`. Example file probe:

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -940,13 +940,20 @@ fn default_prompt() -> String {
     #|
     #|## CLI Parsing And Native IO
     #|
-    #|- For CLI parsing, prefer `moonbitlang/core/argparse` and call
-    #|  `@argparse.parse(...)` on a `Command`. Do not hand-roll option parsing with
-    #|  `@env.args()` except for tiny throwaway probes.
+    #|- Whenever you write a CLI — a `cmd/...` executable you probe with `moon run ...
+    #|  -- args`, or anything the user invokes with options or positionals — parse
+    #|  with `moonbitlang/core/argparse` (MoonBit core, no new dependency): build a
+    #|  `Command` and call `@argparse.parse(...)`, which returns `Matches` or raises
+    #|  a display-ready usage error. Do not hand-roll a loop over `@env.args()` that
+    #|  walks indices and concatenates `"--flag " + value` pairs — argparse also
+    #|  gives you `--help`/`--version`, flags, positionals, and defaults for free,
+    #|  and the reusable pattern is right below.
     #|- `FlagArg.long` omits leading dashes: use `long="stdin"`, not
     #|  `long="--stdin"`.
     #|- Convert `@argparse.Matches` into a small config record or local values before
-    #|  doing real work; keep validation near that conversion.
+    #|  doing real work; keep validation near that conversion. Precedence is
+    #|  argv > env > default_values, so state defaults on the
+    #|  `FlagArg`/`PositionArg` and let argparse fill them in.
     #|- Do not implement ordinary file/stdin IO with C FFI. Use `moonbitlang/async/fs`
     #|  and `moonbitlang/async/stdio`.
     #|- A native CLI that reads either a path or stdin usually needs `async fn main`.
@@ -981,12 +988,14 @@ fn default_prompt() -> String {
     #|          FlagArg("stdin", long="stdin", about="Read stdin instead of a file."),
     #|        ],
     #|        positionals=[
-    #|          PositionArg("input", default_values=["-"], about="Input file path."),
+    #|          PositionArg(
+    #|            "input", default_values=["-"], about="Input file (\"-\" reads stdin).",
+    #|          ),
     #|        ],
     #|      ),
     #|    )
     #|    |> config_from_matches
-    #|  let input = if config.stdin {
+    #|  let input = if config.stdin || config.input == "-" {
     #|    @stdio.stdin.read_all().text()
     #|  } else {
     #|    @fs.read_file(config.input).text()
@@ -1011,6 +1020,10 @@ fn default_prompt() -> String {
     #|  }
     #|}
     #|```
+    #|
+    #|- The `-` default follows the usual `-`-means-stdin convention, so a bare
+    #|  invocation reads stdin instead of failing on a file literally named `-`;
+    #|  unknown flags still surface as `@argparse` usage errors.
     #|
     #|- In `moon run`, the package path goes before `--`; program arguments go after
     #|  `--`. Example file probe:


### PR DESCRIPTION
## What

Strengthens the `## CLI Parsing And Native IO` guidance in the default
prompt so agents reach for `moonbitlang/core/argparse` by default when
they write a CLI, and verifies the existing mbtx Pattern actually runs.

## Changes

- First bullet now makes argparse the default for **any** CLI the agent
  writes (`cmd/...` executables probed with `moon run ... -- args`, or
  anything invoked with options/positionals), instead of only saying
  "prefer" it and carving out "tiny throwaway probes" (the loophole a
  hand-rolled `@env.args()` while-loop slips through). It names that loop
  explicitly as the anti-pattern and points at the reusable pattern below.
- Notes that precedence is argv > env > default_values and that defaults
  belong on the `FlagArg`/`PositionArg`.
- Pattern fix (verified by running it through the mbtx tool): a bare
  invocation previously failed with `OSError: "-": No such file or
  directory` because the positional defaulted to "-" and the code read it
  as a file. "-" now means stdin (the usual convention), so no-arg runs
  read stdin, and unknown flags still surface as argparse usage errors.
- Added a one-line note right after the pattern documenting that
  convention.

## Verified

- Updated pattern run verbatim through the mbtx tool (no-arg run: reads
  stdin, prints `0`; the previous version errored).
- `moon check --deny-warn` in the prompt package: clean (regenerates
  `prompt/generated_default_prompt.mbt`, included in this PR).
- `moon test prompt`: 20/20 passed.
- `moon fmt`: no changes.
- Not verified: real `moon run ... -- args` argv behavior end-to-end
  (the mbtx sandbox cannot pass argv); argparse semantics were instead
  checked by driving `@argparse.parse` with explicit `argv` values, which
  confirmed flags/positionals/defaults parse as the pattern assumes.

Generated with SeekMoon