### PR TITLE
Clarify sidebar action hierarchy

### DIFF
--- a/desktop/frontend/boot.mbt
+++ b/desktop/frontend/boot.mbt
@@ -361,10 +361,6 @@ fn SidebarDispatcher::actions(self : SidebarDispatcher) -> @sidebar.Actions {
     conversation,
   }
   {
-    toggle: self.emit(ToggleSidebar),
-    // The global header action attaches a project. New conversations stay
-    // scoped to the project rows that own them.
-    new_chat: self.emit(AddProjectRequested),
     update: self.emit(UpdateClicked),
     open_skills: self.emit(OpenSkills),
     open_settings: self.emit(OpenSetup),

--- a/desktop/frontend/codex/view.mbt
+++ b/desktop/frontend/codex/view.mbt
@@ -423,16 +423,20 @@ pub fn State::page(
   // Account actions (sign in/out, the pending sign-in page) live in the
   // Settings page's Codex group; the topbar keeps only the status label.
   let topbar : Array[@html.Html] = []
-  if !sidebar_open {
-    topbar.push(
-      @html.button(
-        class="topbar-toggle",
-        title="Show sidebar",
-        on_click=actions.toggle_sidebar,
-        icon(icon_layout_sidebar_left),
-      ),
-    )
+  let sidebar_toggle_label = if sidebar_open {
+    "Hide sidebar"
+  } else {
+    "Show sidebar"
   }
+  topbar.push(
+    @html.button(
+      class="topbar-toggle sidebar-boundary-toggle",
+      title=sidebar_toggle_label,
+      on_click=actions.toggle_sidebar,
+      attrs=@html.Attrs::build().aria_label(sidebar_toggle_label),
+      icon(icon_layout_sidebar_left),
+    ),
+  )
   let title = match self.selection {
     CodexDraftTask(_) => "New chat"
     CodexStoredTask(thread) => thread.title

--- a/desktop/frontend/sidebar/pkg.generated.mbti
+++ b/desktop/frontend/sidebar/pkg.generated.mbti
@@ -23,10 +23,11 @@ pub(all) struct Account {
   busy : Bool
   notice : String?
 } derive(Eq, @debug.Debug)
+pub fn Account::equal(Self, Self) -> Bool
+pub fn Account::not_equal(Self, Self) -> Bool
+pub fn Account::to_repr(Self) -> @debug.Repr
 
 pub(all) struct Actions {
-  toggle : @cmd.Cmd
-  new_chat : @cmd.Cmd
   update : @cmd.Cmd
   open_skills : @cmd.Cmd
   open_settings : @cmd.Cmd
@@ -44,6 +45,9 @@ pub(all) struct Input {
   settings_active : Bool
   account : Account?
 } derive(Eq, @debug.Debug)
+pub fn Input::equal(Self, Self) -> Bool
+pub fn Input::not_equal(Self, Self) -> Bool
+pub fn Input::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/desktop/frontend/sidebar/project/project.mbt
+++ b/desktop/frontend/sidebar/project/project.mbt
@@ -244,6 +244,7 @@ pub fn component(
         ],
       ),
     ]
+    // Keep the action order aligned with the sidebar: menu first, new chat last.
     if input.managed {
       row_children.push(
         @html.button(
@@ -263,10 +264,12 @@ pub fn component(
           class="row-archive",
           type_="button",
           title="New conversation in this project",
-          attrs=@html.Attrs::build().on_click(event => {
-            event.stop_propagation()
-            (actions.new_conversation)(input.id)
-          }),
+          attrs=@html.Attrs::build()
+            .on_click(event => {
+              event.stop_propagation()
+              (actions.new_conversation)(input.id)
+            })
+            .aria_label("New conversation in this project"),
           @icons.icon(@icons.icon_new_chat),
         ),
       )

--- a/desktop/frontend/sidebar/section/section.mbt
+++ b/desktop/frontend/sidebar/section/section.mbt
@@ -259,24 +259,27 @@ pub fn component(
     let heading : Array[@html.Html] = [
       @html.span(class="sidebar-label", input.label),
     ]
-    if input.action is Some(action) {
-      heading.push(
-        @html.button(
-          class="row-archive",
-          type_="button",
-          title=action.title,
-          disabled=action.disabled,
-          attrs=@html.Attrs::build().on_click(event => {
-            event.stop_propagation()
-            (actions.primary)(input.id)
-          }),
-          @icons.icon(@icons.icon_add),
-        ),
-      )
-    }
     let rows : Array[(String, @html.Html)] = [
       (input.id.key(), @html.div(class~, on_click=emit(Toggle), heading)),
     ]
+    if input.action is Some(action) {
+      rows.push(
+        (
+          "\{input.id.key()}:action",
+          @html.button(
+            class="section-primary-action",
+            type_="button",
+            title=action.title,
+            disabled=action.disabled,
+            on_click=(actions.primary)(input.id),
+            [
+              @html.span(class="sidebar-icon", @icons.icon(@icons.icon_add)),
+              @html.span(class="sidebar-label", action.title),
+            ],
+          ),
+        ),
+      )
+    }
     if !collapsed {
       for group in entry_rows {
         for row in group {

--- a/desktop/frontend/sidebar/sidebar.mbt
+++ b/desktop/frontend/sidebar/sidebar.mbt
@@ -28,8 +28,6 @@ pub(all) struct Input {
 
 ///|
 pub(all) struct Actions {
-  toggle : @cmd.Cmd
-  new_chat : @cmd.Cmd
   update : @cmd.Cmd
   open_skills : @cmd.Cmd
   open_settings : @cmd.Cmd
@@ -227,21 +225,10 @@ pub fn component(
       }
     }
     @html.aside([
-      @html.div(class="sidebar-header", [
-        @html.button(
-          class="topbar-toggle",
-          title="Hide sidebar",
-          on_click=actions.toggle,
-          @icons.icon(@icons.icon_layout_sidebar_left),
-        ),
-        @html.button(
-          class="topbar-toggle header-add-project",
-          title="Add a project",
-          on_click=actions.new_chat,
-          attrs=@html.Attrs::build().aria_label("Add a project"),
-          @icons.icon(@icons.icon_add),
-        ),
-      ]),
+      // Navigation actions live with the hierarchy they affect. This empty
+      // strip exists only under the macOS overlay titlebar, where it protects
+      // the traffic-light controls and remains a native drag region.
+      @html.div(class="sidebar-header", @html.nothing),
       @html.div(class="sidebar-main", [
         @html.div(class="sidebar-section sessions", rows),
       ]),

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -1349,20 +1349,22 @@ fn topbar_view(
   conv : Conversation,
 ) -> @html.Html {
   let items : Array[@html.Html] = []
-  // The sidebar toggle rides the window's left edge. While the sidebar is open
-  // it lives in the sidebar's own header; only when the sidebar is closed does
-  // it fall back to the topbar's left, so it holds the same screen position
-  // either way (the same trick the right-panel toggle uses on the right edge).
-  if !model.sidebar_open {
-    items.push(
-      @html.button(
-        class="topbar-toggle",
-        title="Show sidebar",
-        on_click=dispatch(ToggleSidebar),
-        icon(icon_layout_sidebar_left),
-      ),
-    )
+  // The layout action sits at the boundary it controls: beside the sidebar
+  // while open, and at the window edge while collapsed.
+  let sidebar_toggle_label = if model.sidebar_open {
+    "Hide sidebar"
+  } else {
+    "Show sidebar"
   }
+  items.push(
+    @html.button(
+      class="topbar-toggle sidebar-boundary-toggle",
+      title=sidebar_toggle_label,
+      on_click=dispatch(ToggleSidebar),
+      attrs=@html.Attrs::build().aria_label(sidebar_toggle_label),
+      icon(icon_layout_sidebar_left),
+    ),
+  )
   items.push(
     @html.span(
       class="topbar-title",
@@ -1473,28 +1475,28 @@ fn onboarding_view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
 }
 
 ///|
-/// Skills and Settings have no topbar, so while the sidebar is closed they
-/// float their own reopen button at the sidebar toggle's screen position —
-/// without it the sidebar, their only way back to any other screen, would be
-/// unrecoverable.
+/// Skills and Settings have no topbar, so they float the layout control at the
+/// same sidebar boundary used by conversation topbars.
 fn page_with_toggle(
   dispatch : @cmd.Emit[Msg],
   model : Model,
   page : @html.Html,
 ) -> Array[@html.Html] {
-  if model.sidebar_open {
-    [page]
+  let sidebar_toggle_label = if model.sidebar_open {
+    "Hide sidebar"
   } else {
-    [
-      @html.button(
-        class="topbar-toggle page-sidebar-toggle",
-        title="Show sidebar",
-        on_click=dispatch(ToggleSidebar),
-        icon(icon_layout_sidebar_left),
-      ),
-      page,
-    ]
+    "Show sidebar"
   }
+  [
+    @html.button(
+      class="topbar-toggle page-sidebar-toggle sidebar-boundary-toggle",
+      title=sidebar_toggle_label,
+      on_click=dispatch(ToggleSidebar),
+      attrs=@html.Attrs::build().aria_label(sidebar_toggle_label),
+      icon(icon_layout_sidebar_left),
+    ),
+    page,
+  ]
 }
 
 ///|

--- a/desktop/styles/base.css
+++ b/desktop/styles/base.css
@@ -295,15 +295,31 @@ html {
      Component styles consume the dimension that matches their seam. */
   --resize-handle-width: 6px;
   --resize-handle-height: 6px;
+  --sidebar-column-width: clamp(220px, var(--sidebar-width, 264px), 480px);
+  --sidebar-drawer-width: min(320px, 86vw);
+  --sidebar-boundary-width: var(--sidebar-column-width);
+  --sidebar-toggle-size: 28px;
+  --topbar-inline-padding: 18px;
+  --topbar-leading-toggle-offset: -4px;
+  --sidebar-toggle-inline-inset: calc(
+    var(--topbar-inline-padding) + var(--topbar-leading-toggle-offset)
+  );
+  --sidebar-toggle-trailing-gap: 12px;
+  --sidebar-toggle-inline-start: min(
+    calc(var(--sidebar-boundary-width) + var(--sidebar-toggle-inline-inset)),
+    calc(100vw - var(--sidebar-toggle-size))
+  );
+  --sidebar-toggle-reserved-width: calc(
+    var(--sidebar-toggle-inline-inset) + var(--sidebar-toggle-size) +
+      var(--sidebar-toggle-trailing-gap)
+  );
   display: grid;
   /* The sidebar track reads `--sidebar-width`, set as the user drags the
      handle on the aside's right edge (see frontend/sidebar_resize.mbt); it
      defaults to the old fixed maximum and is clamped so the sidebar keeps
      at least 220px while the content column keeps the rest. The clamp also
      re-fits the panel on window resize without any script. */
-  grid-template-columns:
-    clamp(220px, var(--sidebar-width, 264px), 480px)
-    minmax(0, 1fr);
+  grid-template-columns: var(--sidebar-column-width) minmax(0, 1fr);
   /* Track #app's content box (which already accounts for any scrollbar)
      rather than 100vh, so the two height bases can't disagree. */
   height: 100%;
@@ -316,6 +332,7 @@ html {
    takes the full width. The aside stays in the DOM (merely unmounted
    from layout) so reopening keeps its scroll position. */
 .app.sidebar-collapsed {
+  --sidebar-column-width: 0px;
   grid-template-columns: 0 minmax(0, 1fr);
 }
 .app.sidebar-collapsed > aside {
@@ -364,28 +381,17 @@ html {
   height: 46px;
 }
 
-/* macOS keeps its traffic-light controls in the top-left corner. Reserve that
-   native hit area only in the Apple desktop shell. The four rules cover the
-   same sidebar toggle in each place it can live: open sidebar, ordinary
-   collapsed topbar, Settings/Skills fallback, and expanded editor overlay. */
+/* macOS keeps its traffic-light controls in the top-left corner. The open
+   sidebar reserves them with its empty titlebar strip; once collapsed, the
+   main column reaches that corner and its visible chrome takes the inset. */
 .app.native-apple-titlebar {
   --native-titlebar-leading-inset: 88px;
 }
-.app.native-apple-titlebar .sidebar-header,
+.app.native-apple-titlebar.sidebar-collapsed {
+  --sidebar-toggle-inline-inset: var(--native-titlebar-leading-inset);
+}
 .app.native-apple-titlebar.sidebar-collapsed .topbar {
-  padding-left: var(--native-titlebar-leading-inset);
-}
-.app.native-apple-titlebar.sidebar-collapsed .page-sidebar-toggle,
-.app.native-apple-titlebar.sidebar-collapsed
-  .content.panel-expanded
-  .topbar
-  > .topbar-toggle {
-  left: var(--native-titlebar-leading-inset);
-}
-.app.native-apple-titlebar.sidebar-collapsed
-  .content.panel-expanded
-  .editor-tabsbar {
-  padding-left: calc(var(--native-titlebar-leading-inset) + 40px);
+  padding-inline-start: var(--native-titlebar-leading-inset);
 }
 
 /* Windows keeps its real minimize/maximize/close cluster in the top-right.
@@ -414,14 +420,6 @@ html {
   right: var(--native-titlebar-caption-inset);
   height: var(--native-titlebar-height);
 }
-.app.native-windows-titlebar.sidebar-collapsed .page-sidebar-toggle,
-.app.native-windows-titlebar.sidebar-collapsed
-  .content.panel-expanded
-  .topbar
-  > .topbar-toggle {
-  top: 6px;
-}
-
 /* The conversation (left) and the editor (right) live side by side as two
    independent parts. The editor track is zero-width until the panel
    opens, so the viewer host element stays in the DOM but takes no
@@ -472,20 +470,18 @@ html {
   grid-template-columns: 0 minmax(0, 1fr);
 }
 
-/* Expanded normally hides the zero-width conversation column behind the
-   editor. When that column owns the only sidebar reopen button, float the
-   button back to its normal window-edge position above the editor and reserve
-   the same space in the tab strip so open tabs never sit underneath it. */
-.app.sidebar-collapsed
-  .content.panel-expanded
-  .topbar
-  > .topbar-toggle {
+/* Expanded hides the zero-width conversation column behind the editor. Float
+   its sidebar control back to the boundary it owns and reserve matching room
+   in the tab strip so open tabs never sit underneath it. */
+.content.panel-expanded :where(.topbar > .sidebar-boundary-toggle) {
   position: fixed;
-  top: 9px;
-  left: 14px;
-  z-index: calc(var(--z-editor-overlay) + 1);
-  margin-left: 0;
+  inset-block-start: calc(
+    (var(--topbar-height) - var(--sidebar-toggle-size)) / 2
+  );
+  inset-inline-start: var(--sidebar-toggle-inline-start);
+  z-index: var(--z-editor-overlay-control);
+  margin-inline-start: 0;
 }
-.app.sidebar-collapsed .content.panel-expanded .editor-tabsbar {
-  padding-left: 54px;
+.content.panel-expanded .editor-tabsbar {
+  padding-inline-start: var(--sidebar-toggle-reserved-width);
 }

--- a/desktop/styles/main_header.css
+++ b/desktop/styles/main_header.css
@@ -28,17 +28,19 @@ main {
   align-items: center;
   gap: 10px;
   height: var(--topbar-height);
-  padding: 0 18px;
+  padding-block: 0;
+  padding-inline: var(--topbar-inline-padding);
   border-bottom: 1px solid var(--color-separator);
   background: var(--color-bg-surface);
 }
 
 .topbar-toggle {
+  flex: none;
   display: grid;
   place-items: center;
-  width: 28px;
-  height: 28px;
-  margin-left: -4px;
+  inline-size: var(--sidebar-toggle-size);
+  block-size: var(--sidebar-toggle-size);
+  margin-inline-start: var(--topbar-leading-toggle-offset);
   border: 0;
   border-radius: var(--radius-sm);
   background: transparent;
@@ -52,16 +54,15 @@ main {
   color: var(--color-text-primary);
 }
 
-/* The sidebar toggle's fallback on screens without a topbar (Skills,
-   Settings): fixed at the exact screen position the sidebar-header
-   toggle holds while the sidebar is open (46px header, 18px padding,
-   -4px pull), shown only while the sidebar is closed. */
+/* Pages without a topbar float the same control at the live sidebar boundary. */
 .page-sidebar-toggle {
   position: fixed;
-  top: 9px;
-  left: 14px;
-  z-index: 5;
-  margin-left: 0;
+  inset-block-start: calc(
+    (var(--topbar-height) - var(--sidebar-toggle-size)) / 2
+  );
+  inset-inline-start: var(--sidebar-toggle-inline-start);
+  z-index: var(--z-titlebar-control);
+  margin-inline-start: 0;
 }
 
 .topbar-title {

--- a/desktop/styles/responsive.css
+++ b/desktop/styles/responsive.css
@@ -48,16 +48,25 @@
   /* The sidebar leaves the grid and overlays it as a drawer; the
      content column always has the full width. */
   .app {
+    --sidebar-column-width: 0px;
+    --sidebar-boundary-width: 0px;
+    --sidebar-toggle-size: 44px;
+    --topbar-inline-padding: 12px;
     grid-template-columns: minmax(0, 1fr);
   }
   .app.sidebar-collapsed {
     grid-template-columns: minmax(0, 1fr);
   }
+  .app:not(.sidebar-collapsed) {
+    --sidebar-boundary-width: var(--sidebar-drawer-width);
+    --sidebar-toggle-inline-inset: 0px;
+  }
   .app > aside {
     position: fixed;
-    inset: 0 auto 0 0;
+    inset-block: 0;
+    inset-inline-start: 0;
     z-index: var(--z-sidebar-drawer);
-    width: min(320px, 86vw);
+    width: var(--sidebar-drawer-width);
     box-shadow: var(--shadow-overlay);
     transform: translateX(0);
     transition:
@@ -158,19 +167,27 @@
   .editor-tabsbar {
     height: 52px;
   }
-  /* Center the 44px fallback toggle in the 52px header band. */
-  .page-sidebar-toggle {
-    top: 4px;
-    left: 8px;
-  }
-  .topbar-toggle,
   .panel-toggle {
     min-width: 44px;
     min-height: 44px;
   }
+  /* The drawer overlays the main column, so its layout control leaves normal
+     flow and sits on the drawer boundary above the dimmed backdrop. */
+  .app:not(.sidebar-collapsed) .sidebar-boundary-toggle {
+    position: fixed;
+    inset-block-start: calc(
+      (var(--topbar-height) - var(--sidebar-toggle-size)) / 2
+    );
+    inset-inline-start: var(--sidebar-toggle-inline-start);
+    z-index: var(--z-sidebar-drawer-control);
+    margin-inline-start: 0;
+  }
   /* A narrow Windows desktop window still shares its first row with native
      caption buttons. Keep that row compact instead of applying phone touch
      geometry that would make native and web chrome diverge. */
+  .app.native-windows-titlebar {
+    --sidebar-toggle-size: 32px;
+  }
   .app.native-windows-titlebar main {
     --topbar-height: var(--native-titlebar-height);
   }
@@ -179,17 +196,9 @@
   .app.native-windows-titlebar .editor-tabsbar {
     height: var(--native-titlebar-height);
   }
-  .app.native-windows-titlebar .topbar-toggle,
   .app.native-windows-titlebar .panel-toggle {
     min-width: 32px;
     min-height: 32px;
-  }
-  .app.native-windows-titlebar.sidebar-collapsed .page-sidebar-toggle,
-  .app.native-windows-titlebar.sidebar-collapsed
-    .content.panel-expanded
-    .topbar
-    > .topbar-toggle {
-    top: 4px;
   }
   .button,
   .portal-button-link {
@@ -198,6 +207,7 @@
     padding-bottom: 10px;
   }
   .conversation-row,
+  .section-primary-action,
   .sidebar-button {
     min-height: 44px;
   }

--- a/desktop/styles/sidebar.css
+++ b/desktop/styles/sidebar.css
@@ -43,24 +43,16 @@ html.is-resizing .sidebar-resize-handle {
   background: var(--color-accent-soft);
 }
 
-/* The sidebar's own 46px header, matching the topbar so the sidebar
-   toggle sitting here (while the sidebar is open) lands at the same
-   screen position as the topbar's toggle (while it's closed), and the
-   bottom divider continues the topbar's across the two columns. */
+/* The hierarchy starts at the top of the sidebar. macOS alone keeps an empty
+   native-titlebar strip so project controls never sit beneath the traffic
+   lights; the main-column toggle owns the visible layout action. */
 .sidebar-header {
-  display: flex;
-  align-items: center;
+  display: none;
   height: 46px;
-  padding: 0 18px;
   border-bottom: 1px solid var(--color-separator);
 }
-
-/* Add project holds the header's right edge. The -4px mirrors the
-   toggle's left pull so both icons sit the same optical distance from
-   their window edge. */
-.sidebar-header .header-add-project {
-  margin-left: auto;
-  margin-right: -4px;
+.app.native-apple-titlebar .sidebar-header {
+  display: block;
 }
 
 .sidebar-main {
@@ -78,8 +70,13 @@ html.is-resizing .sidebar-resize-handle {
      off the edge on its own; an overlay bar (macOS) floats above the content
      and reserves nothing, so there the whole inset has to be real padding.
      `--scrollbar-lane` is the measured width of the gutter the bar claims. */
+  padding-top: 12px;
   padding-right: max(0px, var(--sidebar-inset) - var(--scrollbar-lane));
   scrollbar-gutter: stable;
+}
+.app.native-apple-titlebar .sidebar-main {
+  /* The titlebar strip already contributes the sidebar's leading rhythm. */
+  padding-top: 0;
 }
 
 .sidebar-section {
@@ -336,9 +333,8 @@ html.is-resizing .sidebar-resize-handle {
   visibility: visible;
 }
 
-/* The chat list's two section headings ("Workspaces", "Chats"): the
-   sidebar-heading type with a hover-revealed ＋ that adds to the
-   section, sharing the row-archive treatment. */
+/* Section headings disclose their hierarchy. A section-owned creation action
+   is a labeled row beneath its heading, not another ambiguous plus in chrome. */
 .section-heading {
   display: flex;
   align-items: center;
@@ -352,9 +348,6 @@ html.is-resizing .sidebar-resize-handle {
 .section-heading > .sidebar-label {
   flex: 1 1 auto;
 }
-.section-heading:hover .row-archive {
-  visibility: visible;
-}
 /* Every peer conversation section uses the same heading disclosure. */
 .section-heading.collapsible {
   cursor: pointer;
@@ -366,8 +359,35 @@ html.is-resizing .sidebar-resize-handle {
 .section-heading.collapsible.collapsed > .sidebar-label::after {
   content: " ▸";
 }
-.section-heading.active {
-  color: var(--color-accent-strong);
+.section-primary-action {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  min-height: 34px;
+  margin: 0 0 4px;
+  padding: 0 8px;
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--color-text-secondary);
+  font: inherit;
+  font-size: var(--font-size-sm);
+  text-align: left;
+  cursor: pointer;
+}
+.section-primary-action:hover:not(:disabled) {
+  border-color: var(--color-accent-border);
+  background: var(--color-accent-soft);
+  color: var(--color-text-primary);
+}
+.section-primary-action:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: -2px;
+}
+.section-primary-action:disabled {
+  cursor: default;
+  opacity: 0.5;
 }
 
 /* An attached workspace: a folder row whose main disclosure button folds its

--- a/desktop/styles/tokens.css
+++ b/desktop/styles/tokens.css
@@ -152,11 +152,16 @@
     );
 
   /* App-wide stacking order. Values inside a component's own stacking
-     context stay local because they do not compete with these surfaces. */
+     context stay local because they do not compete with these surfaces.
+     Controls that escape an overlay sit on the named layer immediately above
+     the surface they control. */
+  --z-titlebar-control: 5;
   --z-menu: 31;
   --z-editor-overlay: 45;
+  --z-editor-overlay-control: 46;
   --z-sidebar-backdrop: 51;
   --z-sidebar-drawer: 52;
+  --z-sidebar-drawer-control: 53;
   --z-notification: 55;
   --z-modal: 60;
   --z-quick-open: 70;


### PR DESCRIPTION
## Why

The sidebar header combined two unlabeled icons with unrelated scopes: one controlled the overall layout while the other added a project. Their corner placement made both actions harder to discover and left the collapse control visually detached from the boundary it changes.

## What changed

- keep the sidebar toggle on the main-column side of the sidebar boundary across OpenSeek, Codex, secondary pages, expanded editor mode, and the narrow drawer
- present Add a project as a labeled action directly beneath the Projects heading
- use a pencil action for starting a conversation in a project and keep the project overflow menu at the row edge
- retain the macOS titlebar drag strip without making it visible on other platforms

## Why this is correct

The layout control is positioned from the same clamped width that defines the sidebar grid track, so resizing, collapse, expanded editor mode, and responsive drawer mode share one boundary. Creation actions now sit beside the hierarchy level they affect: projects at the section level and conversations at the project level.

## Scope

This is limited to sidebar action placement, labels, icons, and their responsive geometry. It does not change conversation state, project state, protocols, or persistence.