### PR TITLE
chore(editor): update moondiff to 0.0.7

### DIFF
--- a/editor/moon.mod
+++ b/editor/moon.mod
@@ -20,7 +20,7 @@ warnings = "+prefer_readonly_array+implicit_impl_as_method"
 
 import {
   "moonbit-community/cmark@0.4.5",
-  "moonbit-community/moondiff@0.0.6",
+  "moonbit-community/moondiff@0.0.7",
   "moonbitlang/async@0.21.0",
   "moonbit-community/rabbita@0.15.4",
   "Milky2018/diago@0.3.0",


### PR DESCRIPTION
## Summary

- update the editor's MoonDiff dependency from 0.0.6 to 0.0.7
- use the newly published package without additional adapter changes

## Testing

- `just editor-test` (Wasm 1081, JS 1862, Native 1215)
- `just check`
- `just test` (Native 3223, JS 3177, cram 23)
- `just build`
- `moon info && moon fmt`
