### PR TITLE
chore(desktop): use top-level target keys in moon.mod

### DIFF
--- a/desktop/moon.mod
+++ b/desktop/moon.mod
@@ -31,7 +31,6 @@ description = "SeekMoon — a Proton + Rabbita desktop client for the OpenSeek a
 
 warnings = "+implicit_impl_as_method"
 
-options(
-  preferred_target: "native",
-  supported_targets: "native+js",
-)
+preferred_target = "native"
+
+supported_targets = "native+js"


### PR DESCRIPTION
Align `desktop/moon.mod` with the flat top-level manifest style used by the sibling modules in this workspace (`moon.mod`, `editor/moon.mod`, `cmd/viz_app/moon.mod`): write `preferred_target` / `supported_targets` as top-level keys instead of inside `options(...)`.

Verified with the current toolchain (moon 0.1.20260827, rr_moon_mod enabled) that the two spellings are equivalent: both check clean, both read into the same manifest fields (writing a key in both places is a "duplicate key" error), a nested `supported_targets` restricts the build plan identically to a flat one, and `moon add` round-trips both forms unchanged. This change is purely stylistic consistency — no functional difference.

Generated with SeekMoon