### PR TITLE
feat(desktop): animate drawer panels

### DIFF
--- a/desktop/frontend/browser_ops.mbt
+++ b/desktop/frontend/browser_ops.mbt
@@ -193,11 +193,10 @@ fn measure_browser_pane(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
 let browser_pane_watched : Ref[Bool] = Ref(false)
 
 ///|
-/// Watch the pane element's size, once. Size changes that never pass
-/// through the model — a window resize, the editor-width drag — reshape the
-/// pane without any message, so the element's own ResizeObserver is the
-/// signal; position-only shifts (the sidebar toggling) are model-driven and
-/// covered by the geometry signature in `sync_browser_view`.
+/// Watch the pane and its layout column once. The pane catches direct size
+/// changes; the content column catches a sliding sidebar even when a
+/// fixed-width pane only changes position. Both report the pane's current
+/// rectangle so a native Browser view follows CSS-driven drawer motion.
 fn watch_browser_pane(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
   @cmd.custom_cmd(
     scheduler => {
@@ -220,6 +219,14 @@ fn watch_browser_pane(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
       let _ : @js.Value = observer.apply_with_string("observe", [
         @js.Value::cast_from(element),
       ])
+      match @dom.document().query_selector(".content").to_option() {
+        Some(content) => {
+          let _ : @js.Value = observer.apply_with_string("observe", [
+            @js.Value::cast_from(content),
+          ])
+        }
+        None => ()
+      }
     },
     kind=@cmd.after_render,
   )

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -1827,13 +1827,18 @@ fn view(
       terminal_html,
     ]),
   ]
-  // On the narrow layout the open sidebar is a drawer over the content; the
-  // backdrop dims the page behind it and a tap there closes it. Appended
-  // after the stable shell children so toggling never re-keys them.
-  if model.narrow && model.sidebar_open {
+  // On the narrow layout the sidebar's stable backdrop fades with the drawer;
+  // keeping it mounted lets the closing transition finish before it becomes
+  // inert. Appended after the stable shell children so toggling never re-keys
+  // them.
+  if model.narrow {
     children.push(
       @html.div(
-        class="sidebar-backdrop",
+        class=if model.sidebar_open {
+          "sidebar-backdrop open"
+        } else {
+          "sidebar-backdrop"
+        },
         on_click=dispatch(ToggleSidebar),
         @html.nothing,
       ),

--- a/desktop/styles/base.css
+++ b/desktop/styles/base.css
@@ -308,16 +308,20 @@ html {
      rather than 100vh, so the two height bases can't disagree. */
   height: 100%;
   min-height: 0;
+  transition: grid-template-columns var(--drawer-duration)
+    var(--drawer-easing);
 }
 
 /* Collapsed: the sidebar column folds to zero and the conversation
    takes the full width. The aside stays in the DOM (merely unmounted
    from layout) so reopening keeps its scroll position. */
 .app.sidebar-collapsed {
-  grid-template-columns: minmax(0, 1fr);
+  grid-template-columns: 0 minmax(0, 1fr);
 }
 .app.sidebar-collapsed > aside {
-  display: none;
+  visibility: hidden;
+  pointer-events: none;
+  transition-delay: var(--drawer-duration);
 }
 
 /* Proton's overlay titlebar lets the page palette paint the native chrome.
@@ -425,9 +429,12 @@ html {
 .content {
   display: grid;
   grid-template-columns: minmax(0, 1fr) 0;
-  grid-template-rows: minmax(0, 1fr);
+  grid-template-rows: minmax(0, 1fr) 0;
   min-width: 0;
   min-height: 0;
+  transition:
+    grid-template-columns var(--drawer-duration) var(--drawer-easing),
+    grid-template-rows var(--drawer-duration) var(--drawer-easing);
 }
 
 /* Opening the terminal carves a resizable second row out of the conversation

--- a/desktop/styles/file_panel.css
+++ b/desktop/styles/file_panel.css
@@ -42,6 +42,14 @@ button.panel-toggle:not(:disabled):hover {
      conversation column, never the other way around. */
   position: relative;
   z-index: 1;
+  visibility: visible;
+  transition: visibility 0s linear;
+}
+
+.content:not(.panel-open) > .editor {
+  visibility: hidden;
+  pointer-events: none;
+  transition-delay: var(--drawer-duration);
 }
 
 /* The editor's top bar, the same height as the topbar so the header
@@ -206,8 +214,8 @@ button.panel-toggle:not(:disabled):hover {
   display: none;
 }
 /* The file tree as a flat bottom panel, Emacs-window style: full
-   width, a 1px seam against the viewer, no chrome of its own, shown
-   and hidden instantly. Non-modal — the viewer above stays live.
+   width, a 1px seam against the viewer, no chrome of its own. Non-modal —
+   the viewer above stays live while its flex basis opens or closes.
    The height is `--tree-height`, set as the user drags the handle on
    the top seam (see tree_resize.mbt); it defaults to a third and is
    clamped so the panel floors at 96px while the viewer keeps at
@@ -222,9 +230,16 @@ button.panel-toggle:not(:disabled):hover {
   overflow: hidden;
   border-top: 1px solid var(--color-separator);
   background: var(--color-bg-surface);
+  visibility: visible;
+  transition:
+    flex-basis var(--drawer-duration) var(--drawer-easing),
+    visibility 0s linear;
 }
 .editor:not(.tree-open) .file-tree-pane {
-  display: none;
+  flex-basis: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition-delay: 0s, var(--drawer-duration);
 }
 
 /* The right-sidebar layout (a Settings choice): same DOM, the body
@@ -240,6 +255,9 @@ button.panel-toggle:not(:disabled):hover {
   min-width: 0;
   border-top: none;
   border-left: 1px solid var(--color-separator);
+}
+.editor.tree-right:not(.tree-open) .file-tree-pane {
+  flex-basis: 0;
 }
 
 /* Drag-to-resize handle on the panel's viewer-facing seam — the

--- a/desktop/styles/responsive.css
+++ b/desktop/styles/responsive.css
@@ -11,6 +11,18 @@
   inset: 0;
   z-index: var(--z-sidebar-backdrop);
   background: var(--color-backdrop);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition:
+    opacity var(--drawer-duration) var(--drawer-easing),
+    visibility 0s linear var(--drawer-duration);
+}
+.sidebar-backdrop.open {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transition-delay: 0s;
 }
 
 @media (max-width: 760px) {
@@ -38,12 +50,22 @@
   .app {
     grid-template-columns: minmax(0, 1fr);
   }
+  .app.sidebar-collapsed {
+    grid-template-columns: minmax(0, 1fr);
+  }
   .app > aside {
     position: fixed;
     inset: 0 auto 0 0;
     z-index: var(--z-sidebar-drawer);
     width: min(320px, 86vw);
     box-shadow: var(--shadow-overlay);
+    transform: translateX(0);
+    transition:
+      transform var(--drawer-duration) var(--drawer-easing),
+      visibility 0s linear;
+  }
+  .app.sidebar-collapsed > aside {
+    transform: translateX(-100%);
   }
 
   /* The topbar keeps only what a phone needs: the toggle, the title,
@@ -69,11 +91,19 @@
   .content.panel-open.panel-expanded {
     grid-template-columns: minmax(0, 1fr) 0;
   }
-  .content.panel-open .editor {
+  .content > .editor {
     position: fixed;
     inset: 0;
     z-index: var(--z-editor-overlay);
     border-left: 0;
+    transform: translateX(100%);
+    transition:
+      transform var(--drawer-duration) var(--drawer-easing),
+      visibility 0s linear var(--drawer-duration);
+  }
+  .content.panel-open > .editor {
+    transform: translateX(0);
+    transition-delay: 0s;
   }
   /* Drill-down: exactly one of tree/viewer shows. Opening a file
      closes the tree (the fileeditor's narrow Ctx flag); the
@@ -182,6 +212,10 @@
 /* Keep status changes visible without forcing motion on users who disable it
    at the operating-system level. Static shape and color still show each state. */
 @media (prefers-reduced-motion: reduce) {
+  :root {
+    --drawer-duration: 0ms;
+  }
+
   .pending-steer-state,
   .queued-input-state.pending,
   .subrun-mark,

--- a/desktop/styles/sidebar.css
+++ b/desktop/styles/sidebar.css
@@ -13,6 +13,7 @@ aside {
   gap: 14px;
   min-width: 0;
   min-height: 0;
+  overflow: hidden;
   padding-bottom: 14px;
   border-right: 1px solid var(--color-separator);
   background: var(--color-bg-surface);
@@ -20,6 +21,8 @@ aside {
   /* The width-resize grab strip on the right edge positions against the
      aside itself. */
   position: relative;
+  visibility: visible;
+  transition: visibility 0s linear;
 }
 
 /* Drag-to-resize handle on the sidebar's right edge. A thin strip floated

--- a/desktop/styles/terminal.css
+++ b/desktop/styles/terminal.css
@@ -3,21 +3,31 @@
 /* The emulator host remains mounted while hidden so each imperative xterm
    instance retains its screen and scrollback. */
 .terminal-panel {
-  display: none;
+  display: flex;
   position: relative;
   grid-row: 2;
   grid-column: 1;
   min-width: 0;
   min-height: 0;
+  overflow: hidden;
   flex-direction: column;
   background: var(--color-bg-surface);
   border-top: 1px solid var(--color-separator);
+  visibility: hidden;
+  pointer-events: none;
+  transform: translateY(100%);
+  transition:
+    transform var(--drawer-duration) var(--drawer-easing),
+    visibility 0s linear var(--drawer-duration);
 }
 /* The state remains open while Settings, Skills, or workspace settings are on
    screen. Require the root layout's page-aware class too, so those pages hide
    the persistent emulator without tearing down its tab or PTY. */
 .content.terminal-open > .terminal-panel.open {
-  display: flex;
+  visibility: visible;
+  pointer-events: auto;
+  transform: translateY(0);
+  transition-delay: 0s;
 }
 
 .terminal-resize-handle {

--- a/desktop/styles/tokens.css
+++ b/desktop/styles/tokens.css
@@ -42,6 +42,11 @@
   --line-height-normal: 1.5;
   --line-height-relaxed: 1.6;
 
+  /* Drawer-like layout surfaces share one restrained motion curve. Their
+     direction still belongs to each component's edge and layout axis. */
+  --drawer-duration: 180ms;
+  --drawer-easing: cubic-bezier(0.2, 0, 0, 1);
+
   /* Icon sizes. A control declares `--icon-size` from this scale and `.icon`
      reads it, so no rule reaches into another element to size its glyph.
      Codicons are drawn on a 16px grid, so the steps are even: at odd sizes


### PR DESCRIPTION
## Summary

- animate the main sidebar, editor dock, file tree, and terminal instead of showing or hiding them abruptly
- keep drawer surfaces mounted through their exit transitions and add matching narrow-layout backdrop and slide behavior
- synchronize native Browser view geometry while the surrounding WebView layout animates
- use a shared 180 ms motion curve and disable drawer motion when reduced motion is requested

## Validation

- moon -C desktop check --target js
- moon -C desktop test frontend --target js (458 passed)
- npm --prefix desktop/e2e test (32 passed)
- packaged and verified desktop/dist/SeekMoon.app