### PR TITLE
refactor(desktop): keep the durable event shape in the transcript model

### DIFF
--- a/desktop/e2e/tests/rabbita_dom.spec.js
+++ b/desktop/e2e/tests/rabbita_dom.spec.js
@@ -541,7 +541,10 @@ test('transcript overview previews failed turns and jumps among mounted messages
       ts: 1_781_144_352_123,
       item: {
         kind: 'assistant',
-        payload: { content: 'First answer recovered after the tool failed.' },
+        payload: {
+          content: 'First answer recovered after the tool failed.',
+          tool_calls: [{ id: 'failed-after-answer', name: 'shell', arguments: '{}' }],
+        },
       },
     },
     {
@@ -715,6 +718,56 @@ test('runtime notices keep the compact result-row presentation', async ({ page }
   await expect(result).not.toHaveAttribute('open', '');
   await result.locator('.tool-result-summary').click();
   await expect(result).toContainText('background job bg-1 finished (exit=0)');
+  expect(app.pageErrors).toEqual([]);
+});
+
+test('a model step shows its thought, then its prose, then its tool rows', async ({ page }) => {
+  const app = new DesktopBrowserHarness(page);
+  app.sessionEvents = [
+    {
+      sequence: 1,
+      item: {
+        kind: 'user',
+        payload: { content: 'Show the browser fixture model step' },
+      },
+    },
+    {
+      sequence: 2,
+      item: {
+        kind: 'assistant',
+        payload: {
+          content: 'I will inspect the project.',
+          reasoning_content: 'first thought',
+          tool_calls: [{ id: 'c1', name: 'read', arguments: '{"path":"moon.mod"}' }],
+        },
+      },
+    },
+    {
+      sequence: 3,
+      item: {
+        kind: 'tool_result',
+        payload: {
+          tool_call_id: 'c1',
+          tool_name: 'read',
+          content: 'module contents',
+          is_error: false,
+          brief: 'read moon.mod',
+        },
+      },
+    },
+  ];
+  await app.install();
+  await app.goto();
+  await app.openSession();
+
+  // One durable response is one step, whose parts keep the model's order:
+  // the thought it had, the prose it said, then the calls that prose announced.
+  const step = page.locator('.step');
+  await expect(step).toHaveCount(1);
+  await expect(step.locator(':scope > *')).toHaveClass(['activity-row', 'msg', 'activity-row']);
+  await expect(step.locator('.activity-row').first().locator('.activity-text')).toHaveText('#1 · Thought');
+  await expect(step.locator('.msg .msg-content.markdown')).toContainText('I will inspect the project.');
+  await expect(step.locator('.activity-row').last().locator('.tool-call-text')).toHaveText('read moon.mod');
   expect(app.pageErrors).toEqual([]);
 });
 

--- a/desktop/frontend/codex/model.mbt
+++ b/desktop/frontend/codex/model.mbt
@@ -2559,28 +2559,36 @@ fn CodexItem::text(self : CodexItem) -> String {
 /// OpenSeek's transcript renderer. This is the only place that knows both
 /// vocabularies; the shared view never switches on Codex JSON item names.
 fn CodexItem::transcript_item(self : CodexItem) -> @transcript.TranscriptItem {
-  let kind = match self.kind {
-    "userMessage" => @transcript.User
-    "agentMessage" | "plan" => @transcript.Assistant(is_danger=false)
-    "reasoning" => @transcript.Reasoning
-    "contextCompaction" => @transcript.Summary
+  // Every app-server item is one response-shaped item: prose, a thought, or
+  // one tool call, each with the other two parts empty. Codex commits them
+  // separately, so they are never folded into one numbered step.
+  let response = (reasoning : String?, calls : Array[@transcript.ToolCall]) => {
+    @transcript.Assistant(reasoning~, calls~, replay=false, finished=false)
+  }
+  let (kind, content) = match self.kind {
+    "userMessage" => (@transcript.User, self.text())
+    "agentMessage" | "plan" => (response(None, []), self.text())
+    "reasoning" => (response(Some(self.text()), []), "")
+    "contextCompaction" => (@transcript.Summary, self.text())
     _ =>
-      @transcript.Tool(
-        call_id=self.id,
-        name=self.tool_name(),
-        arguments=self.tool_arguments(),
-        has_result=self.tool_has_result(),
-        is_error=self.tool_failed(),
-        brief=self.tool_brief(),
+      (
+        response(None, [
+          {
+            call_id: self.id,
+            name: self.tool_name(),
+            arguments: self.tool_arguments(),
+            has_result: self.tool_has_result(),
+            is_error: self.tool_failed(),
+            brief: self.tool_brief(),
+            content: self.tool_output(),
+          },
+        ]),
+        "",
       )
   }
   {
     kind,
-    content: if kind is @transcript.Tool(..) {
-      self.tool_output()
-    } else {
-      self.text()
-    },
+    content,
     // The current app-server item snapshot has no durable display timestamp.
     // Leaving it absent is honest; the shared turn rule simply omits its clock.
     ts: None,
@@ -2708,7 +2716,7 @@ pub fn State::transcript_items(
   let items : Array[@transcript.TranscriptItem] = []
   if !self.notice.is_empty() {
     items.push({
-      kind: @transcript.Assistant(is_danger=true),
+      kind: @transcript.Failure,
       content: self.notice,
       ts: None,
       sequence: None,
@@ -2729,11 +2737,13 @@ pub fn State::transcript_items(
         let transcript_item = item.transcript_item()
         // GPT can commit a reasoning item whose only payload is encrypted:
         // until app-server exposes summary text, there is nothing the
-        // transcript can display and an empty Reasoning row becomes a blank
+        // transcript can display and an empty thought becomes a blank
         // "Thought" card. Keep the semantic item in Codex state so a later
         // summary delta can reveal it, but omit it from this display snapshot.
-        if !(transcript_item.kind is @transcript.Reasoning) ||
-          !transcript_item.content.is_blank() {
+        let blank_thought = transcript_item.kind
+          is @transcript.Assistant(reasoning=Some(summary), ..) &&
+          summary.is_blank()
+        if !blank_thought {
           items.push(transcript_item)
         }
       }
@@ -2747,7 +2757,7 @@ pub fn State::transcript_items(
       }
       if turn.error is Some(message) {
         items.push({
-          kind: @transcript.Assistant(is_danger=true),
+          kind: @transcript.Failure,
           content: message,
           ts: None,
           sequence: None,

--- a/desktop/frontend/codex/model.mbt
+++ b/desktop/frontend/codex/model.mbt
@@ -2562,33 +2562,51 @@ fn CodexItem::transcript_item(self : CodexItem) -> @transcript.TranscriptItem {
   // Every app-server item is one response-shaped item: prose, a thought, or
   // one tool call, each with the other two parts empty. Codex commits them
   // separately, so they are never folded into one numbered step.
-  let response = (reasoning : String?, calls : Array[@transcript.ToolCall]) => {
-    @transcript.Assistant(reasoning~, calls~, replay=false, finished=false)
+  let response = (
+    reasoning : String?,
+    prose : String?,
+    calls : Array[@transcript.ToolCall],
+  ) => {
+    @transcript.Assistant(
+      reasoning~,
+      prose~,
+      calls~,
+      replay=false,
+      finished=false,
+    )
   }
-  let (kind, content) = match self.kind {
-    "userMessage" => (@transcript.User, self.text())
-    "agentMessage" | "plan" => (response(None, []), self.text())
-    "reasoning" => (response(Some(self.text()), []), "")
-    "contextCompaction" => (@transcript.Summary, self.text())
-    _ =>
-      (
-        response(None, [
-          {
-            call_id: self.id,
-            name: self.tool_name(),
-            arguments: self.tool_arguments(),
-            has_result: self.tool_has_result(),
-            is_error: self.tool_failed(),
-            brief: self.tool_brief(),
-            content: self.tool_output(),
-          },
-        ]),
-        "",
-      )
+  let kind = match self.kind {
+    "userMessage" => @transcript.User(self.text())
+    "agentMessage" | "plan" => response(None, Some(self.text()), [])
+    "reasoning" => response(Some(self.text()), None, [])
+    "contextCompaction" => @transcript.Summary(self.text())
+    _ => {
+      // A command still running may have streamed part of its output; the
+      // app-server reports nothing at all as an empty string.
+      let output = self.tool_output()
+      let outcome : @transcript.ToolOutcome = if self.tool_has_result() {
+        Done(
+          content=output,
+          is_error=self.tool_failed(),
+          brief=self.tool_brief(),
+        )
+      } else if output.is_empty() {
+        Pending(output=None)
+      } else {
+        Pending(output=Some(output))
+      }
+      response(None, None, [
+        {
+          call_id: self.id,
+          name: self.tool_name(),
+          arguments: self.tool_arguments(),
+          outcome,
+        },
+      ])
+    }
   }
   {
     kind,
-    content,
     // The current app-server item snapshot has no durable display timestamp.
     // Leaving it absent is honest; the shared turn rule simply omits its clock.
     ts: None,
@@ -2716,8 +2734,7 @@ pub fn State::transcript_items(
   let items : Array[@transcript.TranscriptItem] = []
   if !self.notice.is_empty() {
     items.push({
-      kind: @transcript.Failure,
-      content: self.notice,
+      kind: @transcript.Failure(self.notice),
       ts: None,
       sequence: None,
     })
@@ -2725,8 +2742,7 @@ pub fn State::transcript_items(
   if self.waiting_for_first_user_item() &&
     self.submitted_first_prompt is Some(submitted) {
     items.push({
-      kind: @transcript.User,
-      content: submitted.prompt(),
+      kind: @transcript.User(submitted.prompt()),
       ts: None,
       sequence: None,
     })
@@ -2757,8 +2773,7 @@ pub fn State::transcript_items(
       }
       if turn.error is Some(message) {
         items.push({
-          kind: @transcript.Failure,
-          content: message,
+          kind: @transcript.Failure(message),
           ts: None,
           sequence: None,
         })

--- a/desktop/frontend/codex/steer_receipt.mbt
+++ b/desktop/frontend/codex/steer_receipt.mbt
@@ -195,10 +195,5 @@ fn State::with_observed_steer_item(
 fn CodexSteerReceipt::transcript_item(
   self : CodexSteerReceipt,
 ) -> @transcript.TranscriptItem {
-  {
-    kind: @transcript.User,
-    content: self.submitted.prompt(),
-    ts: None,
-    sequence: None,
-  }
+  { kind: @transcript.User(self.submitted.prompt()), ts: None, sequence: None, }
 }

--- a/desktop/frontend/codex/transcript_test.mbt
+++ b/desktop/frontend/codex/transcript_test.mbt
@@ -56,17 +56,22 @@ test "Codex adapts app-server items to the shared transcript model" {
       ),
     ],
   )
-  assert_true(items[1].kind is @transcript.Assistant(is_danger=false))
+  assert_true(
+    items[1].kind is @transcript.Assistant(reasoning=None, calls=[], ..),
+  )
   assert_eq(items[1].content, "**Working on it.**")
-  guard items[2].kind
-    is @transcript.Tool(name~, arguments=Some(arguments), is_error~, ..) else {
-    fail("expected commandExecution to become a shared tool item")
+  guard items[2].kind is @transcript.Assistant(reasoning=None, calls=[call], ..) else {
+    fail("expected commandExecution to become one shared tool call")
   }
-  assert_eq(name, "shell")
+  assert_eq(call.name, "shell")
+  guard call.arguments is Some(arguments) else {
+    fail("expected the command as the call's arguments")
+  }
   assert_true(arguments.contains("moon test"))
-  assert_true(is_error)
-  assert_eq(items[2].content, "test failed")
-  assert_true(items[3].kind is @transcript.Assistant(is_danger=true))
+  assert_true(call.is_error)
+  assert_eq(call.content, "test failed")
+  assert_eq(items[2].content, "")
+  assert_true(items[3].kind is @transcript.Failure)
   assert_eq(items[3].content, "turn failed")
 }
 
@@ -106,8 +111,14 @@ test "Codex omits reasoning without visible summary text" {
   })
   let items = state.transcript_items()
   assert_eq(items.length(), 2)
-  assert_true(items[0].kind is @transcript.Reasoning)
-  assert_eq(items[0].content, "Inspecting the fix")
-  assert_true(items[1].kind is @transcript.Assistant(is_danger=false))
+  guard items[0].kind
+    is @transcript.Assistant(reasoning=Some(thought), calls=[], ..) else {
+    fail("expected the visible thought as its own response")
+  }
+  assert_eq(thought, "Inspecting the fix")
+  assert_eq(items[0].content, "")
+  assert_true(
+    items[1].kind is @transcript.Assistant(reasoning=None, calls=[], ..),
+  )
   assert_eq(items[1].content, "Done.")
 }

--- a/desktop/frontend/codex/transcript_test.mbt
+++ b/desktop/frontend/codex/transcript_test.mbt
@@ -41,8 +41,10 @@ test "Codex adapts app-server items to the shared transcript model" {
   })
   let items = state.transcript_items()
   assert_eq(items.length(), 4)
-  assert_true(items[0].kind is @transcript.User)
-  guard @mention_context.parse(items[0].content) is Some(user) else {
+  guard items[0].kind is @transcript.User(prompt) else {
+    fail("expected the submitted prompt as the first item")
+  }
+  guard @mention_context.parse(prompt) is Some(user) else {
     fail("expected the user mention to use the shared display envelope")
   }
   assert_eq(user.task, "inspect this")
@@ -59,7 +61,7 @@ test "Codex adapts app-server items to the shared transcript model" {
   assert_true(
     items[1].kind is @transcript.Assistant(reasoning=None, calls=[], ..),
   )
-  assert_eq(items[1].content, "**Working on it.**")
+  assert_eq(items[1].text(), Some("**Working on it.**"))
   guard items[2].kind is @transcript.Assistant(reasoning=None, calls=[call], ..) else {
     fail("expected commandExecution to become one shared tool call")
   }
@@ -68,11 +70,10 @@ test "Codex adapts app-server items to the shared transcript model" {
     fail("expected the command as the call's arguments")
   }
   assert_true(arguments.contains("moon test"))
-  assert_true(call.is_error)
-  assert_eq(call.content, "test failed")
-  assert_eq(items[2].content, "")
-  assert_true(items[3].kind is @transcript.Failure)
-  assert_eq(items[3].content, "turn failed")
+  assert_true(call.outcome is Done(content="test failed", is_error=true, ..))
+  assert_true(items[2].text() is None)
+  assert_true(items[3].kind is @transcript.Failure(_))
+  assert_eq(items[3].text(), Some("turn failed"))
 }
 
 ///|
@@ -116,9 +117,9 @@ test "Codex omits reasoning without visible summary text" {
     fail("expected the visible thought as its own response")
   }
   assert_eq(thought, "Inspecting the fix")
-  assert_eq(items[0].content, "")
+  assert_true(items[0].text() is None)
   assert_true(
     items[1].kind is @transcript.Assistant(reasoning=None, calls=[], ..),
   )
-  assert_eq(items[1].content, "Done.")
+  assert_eq(items[1].text(), Some("Done."))
 }

--- a/desktop/frontend/codex/update.mbt
+++ b/desktop/frontend/codex/update.mbt
@@ -666,8 +666,8 @@ test "Codex project add stays local until the first prompt" {
   assert_true(submitting.waiting_for_first_user_item())
   let starting_items = submitting.transcript_items()
   assert_eq(starting_items.length(), 1)
-  assert_true(starting_items[0].kind is @transcript.User)
-  assert_eq(starting_items[0].content, "inspect this")
+  assert_true(starting_items[0].kind is @transcript.User(_))
+  assert_eq(starting_items[0].text(), Some("inspect this"))
   let (_, adopted) = update(
     dispatch,
     Reply(kind=CodexDraftThreadReply("desktop-draft-1"), value={
@@ -756,10 +756,10 @@ test "Codex project add stays local until the first prompt" {
   let observed_items = observed.transcript_items()
   assert_eq(observed.pending_steers.length(), 1)
   assert_eq(observed_items.length(), 2)
-  assert_true(observed_items[0].kind is @transcript.User)
-  assert_eq(observed_items[0].content, "inspect this")
-  assert_true(observed_items[1].kind is @transcript.User)
-  assert_eq(observed_items[1].content, "steer early")
+  assert_true(observed_items[0].kind is @transcript.User(_))
+  assert_eq(observed_items[0].text(), Some("inspect this"))
+  assert_true(observed_items[1].kind is @transcript.User(_))
+  assert_eq(observed_items[1].text(), Some("steer early"))
 
   let (_, steered) = update(
     dispatch,
@@ -859,8 +859,8 @@ test "Codex full steer replies replace their local receipt" {
   assert_true(once.pending_steers.is_empty())
   let items = once.transcript_items()
   assert_eq(items.length(), 2)
-  assert_eq(items[0].content, "initial")
-  assert_eq(items[1].content, "steer once")
+  assert_eq(items[0].text(), Some("initial"))
+  assert_eq(items[1].text(), Some("steer once"))
 }
 
 ///|
@@ -1133,8 +1133,8 @@ test "Codex steer receipts reconcile duplicate text by item id and FIFO" {
   assert_true(observed_second.pending_steers.is_empty())
   let items = observed_second.transcript_items()
   assert_eq(items.length(), 3)
-  assert_true(items.iter().all(item => item.kind is @transcript.User))
-  assert_true(items.iter().all(item => item.content == "same text"))
+  assert_true(items.iter().all(item => item.kind is @transcript.User(_)))
+  assert_true(items.iter().all(item => item.text() == Some("same text")))
 }
 
 ///|

--- a/desktop/frontend/goal.mbt
+++ b/desktop/frontend/goal.mbt
@@ -1157,9 +1157,7 @@ test "a goal on an unbound worktree conversation creates the worktree first" {
   assert_true(
     {
       ..unbound,
-      messages: [
-        { kind: User, content: "already talking", ts: None, sequence: None, },
-      ],
+      messages: [{ kind: User("already talking"), ts: None, sequence: None, }],
     }.goal_creates_worktree()
     is None,
   )

--- a/desktop/frontend/plan/pkg.generated.mbti
+++ b/desktop/frontend/plan/pkg.generated.mbti
@@ -10,13 +10,13 @@ import {
 // Values
 pub fn card(Array[Step]) -> @html.Html
 
-pub fn classify(@transcript.TranscriptItem) -> Call?
+pub fn classify(@transcript.ToolCall) -> Call?
 
 pub fn decode(String) -> Array[Step]?
 
-pub fn fold_progress(Array[@transcript.TranscriptItem]) -> @html.Html
+pub fn fold_progress(@transcript.ToolCall) -> @html.Html
 
-pub fn latest(Array[@transcript.TranscriptItem]) -> Array[Step]?
+pub fn latest(Array[@transcript.ToolCall]) -> Array[Step]?
 
 // Errors
 

--- a/desktop/frontend/plan/plan.mbt
+++ b/desktop/frontend/plan/plan.mbt
@@ -130,15 +130,17 @@ pub enum Call {
 /// available" may be a wall.
 pub fn classify(call : @transcript.ToolCall) -> Call? {
   guard call.name == "plan" else { return None }
-  if call.is_error {
-    return Some(Rejected)
+  let applied = match call.outcome {
+    @transcript.ToolOutcome::Done(is_error=true, ..) => return Some(Rejected)
+    @transcript.ToolOutcome::Done(..) => true
+    @transcript.ToolOutcome::Pending(..) => false
   }
   // Absent arguments are a call whose source recorded no payload. The payload
   // is gone, but the recorded call is still evidence it ran.
   guard call.arguments is Some(arguments) && decode(arguments) is Some(steps) else {
-    return Some(Unreadable(applied=call.has_result))
+    return Some(Unreadable(applied~))
   }
-  Some(if call.has_result { Applied(steps) } else { Pending(steps) })
+  Some(if applied { Applied(steps) } else { Pending(steps) })
 }
 
 ///|

--- a/desktop/frontend/plan/plan.mbt
+++ b/desktop/frontend/plan/plan.mbt
@@ -122,31 +122,27 @@ pub enum Call {
 }
 
 ///|
-/// Classify a transcript item as a `plan` call, or `None` when it is not one:
-/// another tool, or a legacy row with no recorded arguments.
+/// Classify a tool call as a `plan` call, or `None` when it is another tool.
 ///
-/// A plan row this build cannot read is `Unreadable`, never `None`. The
-/// difference matters to `latest`: "this row is not a plan call" is something
+/// A plan call this build cannot read is `Unreadable`, never `None`. The
+/// difference matters to `latest`: "this call is not a plan call" is something
 /// to scan past, while "a plan call landed here and its content is not
 /// available" may be a wall.
-pub fn classify(item : @transcript.TranscriptItem) -> Call? {
-  guard item.kind is Tool(name="plan", arguments~, has_result~, is_error~, ..) else {
-    return None
-  }
-  if is_error {
+pub fn classify(call : @transcript.ToolCall) -> Call? {
+  guard call.name == "plan" else { return None }
+  if call.is_error {
     return Some(Rejected)
   }
-  // Absent arguments are a result the loader could not pair back to its call
-  // — an older log, or an id it could not match. The payload is gone, but the
-  // recorded result is still evidence the call ran.
-  guard arguments is Some(arguments) && decode(arguments) is Some(steps) else {
-    return Some(Unreadable(applied=has_result))
+  // Absent arguments are a call whose source recorded no payload. The payload
+  // is gone, but the recorded call is still evidence it ran.
+  guard call.arguments is Some(arguments) && decode(arguments) is Some(steps) else {
+    return Some(Unreadable(applied=call.has_result))
   }
-  Some(if has_result { Applied(steps) } else { Pending(steps) })
+  Some(if call.has_result { Applied(steps) } else { Pending(steps) })
 }
 
 ///|
-/// The steps of the last applied `plan` call in `items`, or `None` when there
+/// The steps of the last applied `plan` call in `calls`, or `None` when there
 /// is none — including when the last one cleared the plan, which is the
 /// model saying the checklist no longer applies.
 ///
@@ -166,9 +162,9 @@ pub fn classify(item : @transcript.TranscriptItem) -> Call? {
 /// meter there would flicker on every one of them.
 ///
 /// Over one run of activity this is the plan as that run left it.
-pub fn latest(items : Array[@transcript.TranscriptItem]) -> Array[Step]? {
-  for item in items.rev_iter() {
-    match classify(item) {
+pub fn latest(calls : Array[@transcript.ToolCall]) -> Array[Step]? {
+  for call in calls.rev_iter() {
+    match classify(call) {
       Some(Applied(steps)) =>
         return if steps.is_empty() { None } else { Some(steps) }
       Some(Unreadable(applied=true)) => return None

--- a/desktop/frontend/plan/plan_test.mbt
+++ b/desktop/frontend/plan/plan_test.mbt
@@ -8,38 +8,30 @@ fn plan_call(
   arguments : String,
   is_error? : Bool = false,
   has_result? : Bool = true,
-) -> @transcript.TranscriptItem {
+) -> @transcript.ToolCall {
   {
-    kind: Tool(
-      call_id=id,
-      name="plan",
-      arguments=Some(arguments),
-      has_result~,
-      is_error~,
-      brief=None,
-    ),
+    call_id: id,
+    name: "plan",
+    arguments: Some(arguments),
+    has_result,
+    is_error,
+    brief: None,
     content: "",
-    ts: None,
-    sequence: None,
   }
 }
 
 ///|
-/// A successful `plan` result the loader could not pair back to its call, as
-/// `apply_session_item` records one: no arguments, but a result.
-fn unpaired_result() -> @transcript.TranscriptItem {
+/// A completed `plan` call whose source recorded no arguments, the way a
+/// Codex item without a payload reaches the transcript: a result, no call.
+fn unpaired_result() -> @transcript.ToolCall {
   {
-    kind: Tool(
-      call_id="c9",
-      name="plan",
-      arguments=None,
-      has_result=true,
-      is_error=false,
-      brief=None,
-    ),
+    call_id: "c9",
+    name: "plan",
+    arguments: None,
+    has_result: true,
+    is_error: false,
+    brief: None,
     content: "Plan updated.",
-    ts: None,
-    sequence: None,
   }
 }
 
@@ -134,17 +126,13 @@ test "classify names every state a plan call can be observed in" {
   // Not a plan call at all, and a plan call this build declines to decode.
   assert_true(
     @plan.classify({
-      kind: Tool(
-        call_id="c1",
-        name="shell",
-        arguments=Some("{}"),
-        has_result=true,
-        is_error=false,
-        brief=None,
-      ),
+      call_id: "c1",
+      name: "shell",
+      arguments: Some("{}"),
+      has_result: true,
+      is_error: false,
+      brief: None,
       content: "",
-      ts: None,
-      sequence: None,
     })
     is None,
   )
@@ -159,8 +147,8 @@ test "classify names every state a plan call can be observed in" {
     @plan.classify(plan_call("c1", "not json", has_result=false))
     is Some(Unreadable(applied=false)),
   )
-  // A successful result the loader could not pair back to its call keeps no
-  // arguments, and is still evidence that a plan call ran.
+  // A completed call recorded without its arguments is still evidence that a
+  // plan call ran.
   assert_true(
     @plan.classify(unpaired_result()) is Some(Unreadable(applied=true)),
   )
@@ -192,8 +180,8 @@ test "an unreadable plan call reports no plan instead of an older one" {
     fail("expected the plan recorded after the unreadable one")
   }
   assert_eq(steps[0].title, "two")
-  // A successful result with no recorded arguments is the same wall: the call
-  // ran, and its payload is simply not in the log.
+  // A completed call with no recorded arguments is the same wall: the call
+  // ran, and its payload is simply not in the record.
   assert_true(
     @plan.latest([plan_call("c1", readable), unpaired_result()]) is None,
   )

--- a/desktop/frontend/plan/plan_test.mbt
+++ b/desktop/frontend/plan/plan_test.mbt
@@ -13,10 +13,11 @@ fn plan_call(
     call_id: id,
     name: "plan",
     arguments: Some(arguments),
-    has_result,
-    is_error,
-    brief: None,
-    content: "",
+    outcome: if has_result {
+      Done(content="", is_error~, brief=None)
+    } else {
+      Pending(output=None)
+    },
   }
 }
 
@@ -28,10 +29,7 @@ fn unpaired_result() -> @transcript.ToolCall {
     call_id: "c9",
     name: "plan",
     arguments: None,
-    has_result: true,
-    is_error: false,
-    brief: None,
-    content: "Plan updated.",
+    outcome: Done(content="Plan updated.", is_error=false, brief=None),
   }
 }
 
@@ -129,10 +127,7 @@ test "classify names every state a plan call can be observed in" {
       call_id: "c1",
       name: "shell",
       arguments: Some("{}"),
-      has_result: true,
-      is_error: false,
-      brief: None,
-      content: "",
+      outcome: Done(content="", is_error=false, brief=None),
     })
     is None,
   )

--- a/desktop/frontend/plan/view.mbt
+++ b/desktop/frontend/plan/view.mbt
@@ -35,12 +35,11 @@ pub fn card(steps : Array[Step]) -> @html.Html {
 }
 
 ///|
-/// The meter for a run of activity, showing the plan as that run left it —
-/// riding the `plan` call's own row, so the checklist reads as it fills up
-/// without unfolding anything. `nothing` when the run carries no applied
-/// plan.
-pub fn fold_progress(items : Array[@transcript.TranscriptItem]) -> @html.Html {
-  guard latest(items) is Some(steps) else { return @html.nothing }
+/// The meter riding a `plan` call's own row, showing the plan as that call
+/// left it, so the checklist reads as it fills up without unfolding anything.
+/// `nothing` for every other call, and for a plan call that did not apply.
+pub fn fold_progress(call : @transcript.ToolCall) -> @html.Html {
+  guard latest([call]) is Some(steps) else { return @html.nothing }
   progress_view(steps, mini=true)
 }
 

--- a/desktop/frontend/transcript/component/component.mbt
+++ b/desktop/frontend/transcript/component/component.mbt
@@ -669,7 +669,7 @@ test "local pinned transitions are pure" {
       ..input,
       items: [
         {
-          item: { kind: User, content: "new turn", ts: None, sequence: None, },
+          item: { kind: User("new turn"), ts: None, sequence: None, },
           identity: "l0",
         },
       ],

--- a/desktop/frontend/transcript/component/component.mbt
+++ b/desktop/frontend/transcript/component/component.mbt
@@ -30,14 +30,9 @@ pub fn VisibleRow::history(
   items : Array[@transcript.TranscriptItem],
 ) -> Array[VisibleRow] {
   let rows : Array[VisibleRow] = []
-  let ordinals : Map[Int, Int] = Map([])
   for index, item in items {
     let identity = match item.sequence {
-      Some(sequence) => {
-        let ordinal = ordinals.get(sequence).unwrap_or(0)
-        ordinals.set(sequence, ordinal + 1)
-        "s\{sequence}\u{0}o\{ordinal}"
-      }
+      Some(sequence) => "s\{sequence}"
       None => "l\{index}"
     }
     rows.push({ item, identity, })
@@ -63,7 +58,7 @@ struct Input {
   // rows are the durable record and this is not durable yet.
   streaming_response : String?
   // Live reasoning is likewise provisional. It is plain text until complete;
-  // the durable reasoning row replaces it and renders Markdown once.
+  // the durable response replaces it and renders Markdown once.
   streaming_reasoning : String?
   reasoning_complete : Bool
   streaming_identity : String

--- a/desktop/frontend/transcript/component/rendering.mbt
+++ b/desktop/frontend/transcript/component/rendering.mbt
@@ -142,11 +142,11 @@ fn TranscriptRenderer::stream_children(
     let step_label = if self.input.source is OpenSeek &&
       item.kind is Assistant(replay=false, ..) {
       steps += 1
-      "#\{steps}"
+      Some("#\{steps}")
     } else {
-      ""
+      None
     }
-    let anchor = if item.kind is User {
+    let anchor = if item.kind is User(_) {
       Some(@transcript_overview.TurnKey::of(item, index~).anchor())
     } else {
       None
@@ -159,11 +159,11 @@ fn TranscriptRenderer::stream_children(
         anchor?,
         on_jump=self.on_jump,
         assistant_name=self.assistant_name(),
-        step_label~,
+        step_label?,
         subrun?=self.subrun_link(),
       ),
     )
-    if item.kind is User {
+    if item.kind is User(_) {
       items.set(
         TranscriptRenderKey::turn_rule(row.identity).wire(),
         turn_rule_view(ts?=item.ts),
@@ -183,10 +183,10 @@ fn TranscriptRenderer::stream_children(
         self.on_open,
         prose?=self.input.streaming_response,
         reasoning?=self.input.streaming_reasoning,
-        step_label=if self.input.source is OpenSeek {
-          "#\{steps + 1}"
+        step_label?=if self.input.source is OpenSeek {
+          Some("#\{steps + 1}")
         } else {
-          ""
+          None
         },
         assistant_name=self.assistant_name(),
         live=true,

--- a/desktop/frontend/transcript/component/rendering.mbt
+++ b/desktop/frontend/transcript/component/rendering.mbt
@@ -20,50 +20,15 @@ fn TranscriptRenderKey::turn_rule(identity : String) -> TranscriptRenderKey {
 }
 
 ///|
-/// An activity card belongs to the stable non-activity row on its left. New
-/// reasoning or tool rows can therefore extend either end of that card without
-/// replacing its browser-owned `<details>` element.
-fn TranscriptRenderKey::activity_after(
-  boundary : String?,
-) -> TranscriptRenderKey {
-  match boundary {
-    Some(identity) => { value: "activity\u{0}after\u{0}\{identity}", }
-    None => { value: "activity\u{0}head", }
-  }
-}
-
-///|
-fn TranscriptRenderKey::streaming(identity : String) -> TranscriptRenderKey {
-  { value: "streaming\u{0}\{identity}", }
+/// The response still streaming, keyed by its run: a new run gets a fresh
+/// node, and the durable commit that lands it replaces this one.
+fn TranscriptRenderKey::live(identity : String) -> TranscriptRenderKey {
+  { value: "live\u{0}\{identity}", }
 }
 
 ///|
 fn TranscriptRenderKey::empty() -> TranscriptRenderKey {
   { value: "empty", }
-}
-
-///|
-/// Every current-format provider response is persisted as one Assistant event.
-/// Its sequence is copied to the response's reasoning, prose, and tool rows, so
-/// step numbering is a direct grouping operation rather than a reconstruction
-/// from terminal or tool payloads. Checkpoint replays have their own item kind
-/// and deliberately do not contribute evidence.
-fn durable_step_ordinals(rows : Array[VisibleRow]) -> Map[Int, Int] {
-  let ordinals : Map[Int, Int] = Map([])
-  let mut next = 1
-  for row in rows {
-    guard row.item.sequence is Some(sequence) else { continue }
-    let evidence = match row.item.kind {
-      Reasoning | Tool(arguments=Some(_), ..) | Assistant(is_danger=false) =>
-        true
-      _ => false
-    }
-    if evidence && ordinals.get(sequence) is None {
-      ordinals.set(sequence, next)
-      next += 1
-    }
-  }
-  ordinals
 }
 
 ///|
@@ -121,60 +86,26 @@ fn TranscriptRenderer::subrun_link(self : TranscriptRenderer) -> SubrunLink? {
 }
 
 ///|
-/// Insert one non-activity transcript row. Activity rows are handled by the
-/// step-aware grouping pass below; keeping this path singular ensures user turn
-/// anchors and assistant/error rendering cannot drift between durable steps
-/// and rows from other transcript sources.
-fn TranscriptRenderer::insert_row(
-  self : TranscriptRenderer,
-  items : Map[String, @html.Html],
-  row : VisibleRow,
-  index : Int,
-) -> Unit {
-  let item = row.item
-  let anchor = if item.kind is User {
-    Some(@transcript_overview.TurnKey::of(item, index~).anchor())
-  } else {
-    None
-  }
-  items.set(
-    TranscriptRenderKey::row(row.identity).wire(),
-    transcript_item_view(
-      item,
-      self.on_open,
-      anchor?,
-      on_jump=self.on_jump,
-      assistant_name=match self.input.source {
-        OpenSeek => "OpenSeek"
-        Codex => "Codex"
-      },
-    ),
-  )
-  if item.kind is User {
-    items.set(
-      TranscriptRenderKey::turn_rule(row.identity).wire(),
-      turn_rule_view(ts?=item.ts),
-    )
+fn TranscriptRenderer::assistant_name(self : TranscriptRenderer) -> String {
+  match self.input.source {
+    OpenSeek => "OpenSeek"
+    Codex => "Codex"
   }
 }
 
 ///|
-/// Build the keyed direct children of `#stream` in display order. Map insertion
-/// order determines visual order; the strings only determine node identity.
+/// Build the keyed direct children of `#stream` in display order: one node
+/// per transcript item (a user turn also draws its closing rule), then the
+/// response still streaming. Map insertion order determines visual order; the
+/// strings only determine node identity.
 fn TranscriptRenderer::stream_children(
   self : TranscriptRenderer,
 ) -> Map[String, @html.Html] {
   let visible = self.input.items
   let items : Map[String, @html.Html] = Map([])
-  let mut left_boundary : String? = None
-  let step_ordinals = if self.input.source is OpenSeek {
-    durable_step_ordinals(visible)
-  } else {
-    Map([])
-  }
-  // The durable transcript plus client-local notices, rendered through one
-  // grouping pass. Live semantic events never synthesize durable-looking
-  // items here; their store commits populate the transcript.
+  // The durable transcript plus client-local notices. Live semantic events
+  // never synthesize durable-looking items here; their store commits populate
+  // the transcript.
   if visible.is_empty() &&
     self.input.streaming_reasoning is None &&
     self.input.streaming_response is None {
@@ -201,114 +132,65 @@ fn TranscriptRenderer::stream_children(
         ),
       ]),
     )
-  } else {
-    // OpenSeek's durable Assistant sequence is the model-step identity.
-    // Group each step's reasoning and tools under its ordinal — reasoning
-    // folded, every tool call on display — while keeping assistant prose
-    // visible beside the group. Legacy/Codex rows have no OpenSeek step map
-    // and retain the adjacent-activity behavior below.
-    let mut index = 0
-    while index < visible.length() {
-      if visible[index].item.sequence is Some(sequence) &&
-        step_ordinals.get(sequence) is Some(step_number) {
-        let start = index
-        let activity : Array[@transcript.TranscriptItem] = []
-        while index < visible.length() &&
-              visible[index].item.sequence == Some(sequence) {
-          if visible[index].item.kind is (Tool(..) | Reasoning) {
-            activity.push(visible[index].item)
-          }
-          index += 1
-        }
-        if !activity.is_empty() {
-          items.set(
-            TranscriptRenderKey::activity_after(left_boundary).wire(),
-            activity_view(
-              activity,
-              self.on_open,
-              step_label="#\{step_number}",
-              subrun?=self.subrun_link(),
-            ),
-          )
-        }
-        // Assistant narration and final answers remain visible. The activity
-        // is emitted first as the step's work disclosure; prose then becomes
-        // the stable left boundary for the next provisional/durable step.
-        let mut rendered_prose = false
-        for row_index in start..<index {
-          let row = visible[row_index]
-          if !(row.item.kind is (Tool(..) | Reasoning)) {
-            self.insert_row(items, row, row_index)
-            left_boundary = Some(row.identity)
-            rendered_prose = true
-          }
-        }
-        if !rendered_prose {
-          // A tool-only step has no prose row to become a boundary. Its final
-          // durable row is still a stable predecessor: before the next commit
-          // the live card keys after it, and after the commit the settled card
-          // uses that same key.
-          left_boundary = Some(visible[index - 1].identity)
-        }
-        continue
-      }
-      guard visible[index].item.kind is (Tool(..) | Reasoning) else {
-        let row = visible[index]
-        self.insert_row(items, row, index)
-        left_boundary = Some(row.identity)
-        index += 1
-        continue
-      }
-      let run : Array[@transcript.TranscriptItem] = []
-      while index < visible.length() &&
-            visible[index].item.kind is (Tool(..) | Reasoning) {
-        // An unnumbered runtime/goal card may sit immediately before a
-        // durable model step. Leave that row for the step-aware branch above
-        // instead of absorbing it into this fallback activity run.
-        if visible[index].item.sequence is Some(sequence) &&
-          step_ordinals.get(sequence) is Some(_) {
-          break
-        }
-        run.push(visible[index].item)
-        index += 1
-      }
+    return items
+  }
+  // OpenSeek numbers its model steps: every provider response that is not a
+  // checkpoint replay is one. Codex and legacy items carry no ordinal.
+  let mut steps = 0
+  for index, row in visible {
+    let item = row.item
+    let step_label = if self.input.source is OpenSeek &&
+      item.kind is Assistant(replay=false, ..) {
+      steps += 1
+      "#\{steps}"
+    } else {
+      ""
+    }
+    let anchor = if item.kind is User {
+      Some(@transcript_overview.TurnKey::of(item, index~).anchor())
+    } else {
+      None
+    }
+    items.set(
+      TranscriptRenderKey::row(row.identity).wire(),
+      transcript_item_view(
+        item,
+        self.on_open,
+        anchor?,
+        on_jump=self.on_jump,
+        assistant_name=self.assistant_name(),
+        step_label~,
+        subrun?=self.subrun_link(),
+      ),
+    )
+    if item.kind is User {
       items.set(
-        TranscriptRenderKey::activity_after(left_boundary).wire(),
-        activity_view(run, self.on_open, subrun?=self.subrun_link()),
+        TranscriptRenderKey::turn_rule(row.identity).wire(),
+        turn_rule_view(ts?=item.ts),
       )
-      left_boundary = Some(visible[index - 1].identity)
     }
   }
-  // Durable commits are untagged and cannot prove ownership of an in-flight
-  // preview. Keep ambiguous live reasoning visible as a provisional next step;
-  // `Conversation::reasoning_for_render` suppresses only an exact, completed
-  // duplicate after it has durably committed.
-  if self.input.streaming_reasoning is Some(reasoning) {
+  // The response still streaming, through the same view a settled response
+  // gets. Durable commits are untagged and cannot prove ownership of an
+  // in-flight preview, so the preview stays visible as the provisional next
+  // step; `Conversation::reasoning_for_render` suppresses only an exact,
+  // completed duplicate after it has durably committed.
+  if self.input.streaming_reasoning is Some(_) ||
+    self.input.streaming_response is Some(_) {
     items.set(
-      TranscriptRenderKey::activity_after(left_boundary).wire(),
-      activity_view(
-        [],
+      TranscriptRenderKey::live(self.input.streaming_identity).wire(),
+      assistant_view(
         self.on_open,
-        live_reasoning=reasoning,
-        reasoning_complete=self.input.reasoning_complete,
+        prose?=self.input.streaming_response,
+        reasoning?=self.input.streaming_reasoning,
         step_label=if self.input.source is OpenSeek {
-          "#\{step_ordinals.length() + 1}"
+          "#\{steps + 1}"
         } else {
           ""
         },
-      ),
-    )
-  }
-  if self.input.streaming_response is Some(streaming) {
-    items.set(
-      TranscriptRenderKey::streaming(self.input.streaming_identity).wire(),
-      streaming_response_view(
-        streaming,
-        self.on_open,
-        assistant_name=match self.input.source {
-          OpenSeek => "OpenSeek"
-          Codex => "Codex"
-        },
+        assistant_name=self.assistant_name(),
+        live=true,
+        reasoning_complete=self.input.reasoning_complete,
       ),
     )
   }

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -26,7 +26,7 @@ fn assistant_view(
   calls? : Array[@transcript.ToolCall] = [],
   sequence? : Int,
   ts? : Double,
-  step_label? : String = "",
+  step_label? : String,
   assistant_name? : String = "OpenSeek",
   finished? : Bool = false,
   live? : Bool = false,
@@ -41,8 +41,8 @@ fn assistant_view(
   // nothing variable-width sits between its entries and their anchor.
   let header : Array[@html.Html] = []
   let stamp = step_stamp(ts?)
-  if !step_label.is_empty() {
-    header.push(@html.span(class="activity-step", step_label))
+  if step_label is Some(label) {
+    header.push(@html.span(class="activity-step", label))
     // A real space, not a CSS margin, and only when the instant follows it: the
     // gap has to exist in the text as well, or the accessible name and anything
     // copied out of the row read "#1Committed 14:32:10".
@@ -145,7 +145,7 @@ fn notice_view(
   label : String,
   brief : String?,
   is_error : Bool,
-  content : String,
+  body : String?,
   ts? : Double,
   sequence? : Int,
 ) -> @html.Html {
@@ -153,16 +153,16 @@ fn notice_view(
   if step_stamp(ts?) is Some(stamp) {
     rows.push(@html.div(class="activity-heading", [stamp]))
   }
-  let call : @transcript.ToolCall = {
-    call_id: "",
-    name: label,
-    arguments: None,
-    has_result: true,
-    is_error,
-    brief,
-    content,
-  }
-  rows.push(@html.div(class="activity-work", tool_run_views([call], sequence?)))
+  let row = result_row_view(
+    label,
+    None,
+    pending=false,
+    is_error~,
+    brief~,
+    body,
+    tool_call_tabs_key(label, sequence),
+  )
+  rows.push(@html.div(class="activity-work", { "notice": row }))
   @html.div(class="activity-row", rows)
 }
 
@@ -226,8 +226,7 @@ fn tool_run_row_key(
   index : Int,
   side : String,
 ) -> String {
-  let identity = if call.call_id.is_empty() { call.name } else { call.call_id }
-  "\{side}\u{0}\{identity}\u{0}\{index}"
+  "\{side}\u{0}\{call.call_id}\u{0}\{index}"
 }
 
 ///|
@@ -263,11 +262,14 @@ fn subrun_chip(child : String, open : (String) -> @cmd.Cmd) -> @html.Html {
 
 ///|
 /// A completed result always gets its own row, including an empty one. Codex
-/// command items can also accumulate output while still in progress; surface
-/// that stream immediately, but let `has_result` keep the row labelled pending
-/// until the completed item arrives.
+/// command items can also stream output while still in progress; surface that
+/// stream immediately, with the row still labelled pending until the
+/// completed item arrives.
 fn tool_result_row_is_visible(call : @transcript.ToolCall) -> Bool {
-  call.has_result || !call.content.is_blank()
+  match call.outcome {
+    Done(..) => true
+    Pending(output~) => output is Some(_)
+  }
 }
 
 ///|
@@ -281,8 +283,11 @@ fn tool_request_view(
 ) -> @html.Html {
   guard call.arguments is Some(arguments) else { return @html.nothing }
   let name = call.name
-  let brief = call.brief
-  let is_error = call.is_error
+  // A pending call has no result to be wrong about, and no brief yet.
+  let (is_error, brief) = match call.outcome {
+    Done(is_error~, brief~, ..) => (is_error, brief)
+    Pending(..) => (false, None)
+  }
   let label = if brief is Some(brief) && !brief.is_blank() {
     brief
   } else {
@@ -375,21 +380,62 @@ fn tool_result_view(
   sequence? : Int,
   subrun? : SubrunLink,
 ) -> @html.Html {
-  let name = call.name
-  let arguments = call.arguments
-  let has_result = call.has_result
-  let is_error = call.is_error
-  let brief = call.brief
-  let label = match (arguments, brief, has_result) {
+  let key = tool_call_tabs_key(call.call_id, sequence)
+  match call.outcome {
+    Pending(output~) =>
+      result_row_view(
+        call.name,
+        call.arguments,
+        pending=true,
+        is_error=false,
+        brief=None,
+        output,
+        key,
+        subrun?,
+      )
+    Done(content~, is_error~, brief~) =>
+      result_row_view(
+        call.name,
+        call.arguments,
+        pending=false,
+        is_error~,
+        brief~,
+        // An empty result still gets its row; it just has nothing to expand.
+        if content.is_blank() {
+          None
+        } else {
+          Some(content)
+        },
+        key,
+        subrun?,
+      )
+  }
+}
+
+///|
+/// The result row itself: a tool result's, or a runtime notice's, which wears
+/// the same compact completed-result shape. `output` is the body the row
+/// expands to, when there is one.
+fn result_row_view(
+  name : String,
+  arguments : String?,
+  pending~ : Bool,
+  is_error~ : Bool,
+  brief~ : String?,
+  output : String?,
+  key : String,
+  subrun? : SubrunLink,
+) -> @html.Html {
+  let label = match (arguments, brief, pending) {
     (None, Some(brief), _) if !brief.is_blank() => brief
     (None, _, _) => name
-    (_, _, false) => "Tool output · \{name}"
+    (_, _, true) => "Tool output · \{name}"
     _ if is_error => "Tool error · \{name}"
     _ => "Tool result · \{name}"
   }
   let error_class = (if is_error { " error" } else { "" }) +
     failure_stage_class(name, brief, is_error, arguments)
-  let pending_class = if has_result { "" } else { " pending" }
+  let pending_class = if pending { " pending" } else { "" }
   let line : Array[@html.Html] = [
     @html.span(class="tool-flow", "←"),
     @html.span(class="tool-result-text", label),
@@ -420,9 +466,8 @@ fn tool_result_view(
       body.push(subrun_chip(child, link.open))
     }
   }
-  if !call.content.is_blank() {
-    let key = tool_call_tabs_key(call.call_id, sequence)
-    let output = tool_output_tabs(name, arguments, call.content)
+  if output is Some(text) {
+    let output = tool_output_tabs(name, arguments, text)
     if output is [tab] {
       body.push(
         @html.div(class="tool-call-section", [
@@ -760,57 +805,52 @@ fn turn_rule_view(ts? : Double) -> @html.Html {
 ///|
 /// One transcript item as its own stream child. `step_label` is the ordinal an
 /// OpenSeek provider response carries ("#3"); every other source and kind
-/// leaves it empty.
+/// has none.
 fn transcript_item_view(
   item : @transcript.TranscriptItem,
   on_open : (String) -> @cmd.Cmd,
   anchor? : String,
   on_jump? : (@mention_context.Target) -> @cmd.Cmd,
   assistant_name? : String = "OpenSeek",
-  step_label? : String = "",
+  step_label? : String,
   subrun? : SubrunLink,
 ) -> @html.Html {
   match item.kind {
-    User => user_message_view(item.content, anchor?, on_jump?)
-    Assistant(reasoning~, calls~, replay=_, finished~) =>
+    User(prompt) => user_message_view(prompt, anchor?, on_jump?)
+    Assistant(reasoning~, prose~, calls~, replay=_, finished~) =>
       assistant_view(
         on_open,
-        prose?=if item.content.is_empty() { None } else { Some(item.content) },
+        prose?,
         reasoning?,
         calls~,
         sequence?=item.sequence,
         ts?=item.ts,
-        step_label~,
+        step_label?,
         assistant_name~,
         finished~,
         subrun?,
       )
-    Answer =>
+    Answer(text) =>
       assistant_message_view(
-        item.content,
+        text,
         on_open,
         assistant_name,
         is_danger=false,
         completed_at?=item.ts,
         show_actions=true,
       )
-    Failure =>
-      assistant_message_view(
-        item.content,
-        on_open,
-        assistant_name,
-        is_danger=true,
-      )
-    Notice(label~, brief~, is_error~) =>
+    Failure(text) =>
+      assistant_message_view(text, on_open, assistant_name, is_danger=true)
+    Notice(label~, brief~, is_error~, body~) =>
       notice_view(
         label,
         brief,
         is_error,
-        item.content,
+        body,
         ts?=item.ts,
         sequence?=item.sequence,
       )
-    Summary => summary_card_view(item.content, on_open)
+    Summary(text) => summary_card_view(text, on_open)
   }
 }
 

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -1,28 +1,36 @@
 ///|
-/// One durable model step's work, or adjacent activity from another source.
-/// Every tool call is always on display as its own one-line row
-/// (`tool_call_view`), expandable to that call's arguments and output — so a
-/// step that ran ten tools reads as ten scannable rows, not one folded line
-/// hiding them. Only reasoning stays behind a fold: a step that opens with a
-/// thought carries the ordinal and commit instant on that fold's summary
-/// ("#2 14:32:10 · Thought"), and a step that goes straight to tools puts
-/// the same columns on a plain heading line instead. The open state of every
-/// disclosure is the browser's (`<details>`), so a reader's toggle survives
-/// re-renders and the run growing while live.
+/// One provider response as the transcript shows it: its thought behind a
+/// fold, its prose as a bubble, and every tool call on display as its own
+/// one-line row (`tool_request_view`), expandable to that call's arguments and
+/// output — in the order the model produced them, so a step that ran ten
+/// tools reads as ten scannable rows after the narration that announced them.
+/// Only reasoning stays behind a fold: a step that opens with a thought
+/// carries the ordinal and commit instant on that fold's summary
+/// ("#2 14:32:10 · Thought"), and a numbered step that goes straight to
+/// tools puts the same columns on a plain heading line instead. The open
+/// state of every disclosure is the browser's (`<details>`), so a reader's
+/// toggle survives re-renders and the run growing while live.
+///
+/// The response still streaming renders through this same view (`live`), so
+/// nothing shown live restyles when its durable event lands: the thought
+/// stays plain text until it completes, and the prose bubble is marked
+/// streaming until the commit replaces it.
 ///
 /// Failures need no badge up here: a failed call's own row is visible and
 /// carries its own literal `failed` marker. Its potentially large arguments
 /// and output stay folded by default, like every other call.
-///
-/// Assistant prose is never in here: every assistant message is its own
-/// visible bubble, so a turn reads as narration, work, narration, work,
-/// answer — the agent's own words are never behind a fold.
-fn activity_view(
-  items : Array[@transcript.TranscriptItem],
+fn assistant_view(
   on_open : (String) -> @cmd.Cmd,
-  live_reasoning? : String,
-  reasoning_complete? : Bool = false,
+  prose? : String,
+  reasoning? : String,
+  calls? : Array[@transcript.ToolCall] = [],
+  sequence? : Int,
+  ts? : Double,
   step_label? : String = "",
+  assistant_name? : String = "OpenSeek",
+  finished? : Bool = false,
+  live? : Bool = false,
+  reasoning_complete? : Bool = true,
   subrun? : SubrunLink,
 ) -> @html.Html {
   // The step ordinal is its own span so it can carry the accent and a fixed
@@ -32,7 +40,7 @@ fn activity_view(
   // above and below, and comparing a column is the eye's job only when
   // nothing variable-width sits between its entries and their anchor.
   let header : Array[@html.Html] = []
-  let stamp = step_stamp(items)
+  let stamp = step_stamp(ts?)
   if !step_label.is_empty() {
     header.push(@html.span(class="activity-step", step_label))
     // A real space, not a CSS margin, and only when the instant follows it: the
@@ -45,143 +53,160 @@ fn activity_view(
   if stamp is Some(stamp) {
     header.push(stamp)
   }
-  // The header rides the leading thought fold's summary when the step opens
-  // with reasoning, keeping the common step's one-line "#2 · Thought" lead. A
-  // step that goes straight to tools gets a plain heading line instead: a
-  // call row's summary belongs to that call alone.
-  let leads_with_thought = match items {
-    [first, ..] => first.kind is Reasoning
-    [] => live_reasoning is Some(_)
-  }
-  let mut pending_header = !header.is_empty()
-  let rows : Array[@html.Html] = []
-  if pending_header && !leads_with_thought {
-    rows.push(@html.div(class="activity-heading", header))
-    pending_header = false
-  }
-  fn thought_fold(
-    label : String,
-    prose : @html.Html,
-    unfolded : Bool,
-  ) -> @html.Html {
-    let text : Array[@html.Html] = []
-    if pending_header {
-      text.append(header)
-      // The separator introduces the label only when something precedes it: a
-      // legacy run with no ordinal and no stamp is the label alone.
-      text.push(@html.text(" · \{label}"))
-      pending_header = false
+  // The header rides the thought fold's summary when the step opens with
+  // reasoning, keeping the common step's one-line "#2 · Thought" lead. A step
+  // that goes straight to tools gets a plain heading line instead: a call
+  // row's summary belongs to that call alone. Prose alone carries no heading.
+  let lead : Array[@html.Html] = []
+  if reasoning is Some(text) {
+    let thinking = live && !reasoning_complete
+    let label = if thinking { "Thinking…" } else { "Thought" }
+    let summary : Array[@html.Html] = []
+    if header.is_empty() {
+      // The separator introduces the label only when something precedes it:
+      // a Codex thought with no ordinal and no stamp is the label alone.
+      summary.push(@html.text(label))
     } else {
-      text.push(@html.text(label))
+      summary.append(header)
+      summary.push(@html.text(" · \{label}"))
     }
-    @html.details(class="activity", open=unfolded, [
-      @html.summary(class="activity-summary", [
-        @html.span(class="activity-text", text),
-      ]),
-      @html.div(class="activity-body", [prose]),
-    ])
-  }
-
-  let mut index = 0
-  while index < items.length() {
-    if items[index].kind is Tool(..) {
-      let tools : Array[@transcript.TranscriptItem] = []
-      while index < items.length() && items[index].kind is Tool(..) {
-        tools.push(items[index])
-        index += 1
-      }
-      rows.push(
-        @html.div(class="activity-work", tool_run_views(tools, subrun?)),
-      )
-    } else {
-      // Reasoning; callers never pass user messages, assistant prose, or
-      // error bubbles.
-      rows.push(
-        thought_fold(
-          "Thought",
-          @html.div(
-            class="msg-content markdown activity-thinking",
-            @markdown.markdown_nodes(items[index].content, open_file=on_open),
-          ),
-          false,
-        ),
-      )
-      index += 1
-    }
-  }
-  if live_reasoning is Some(content) {
-    let prose = if reasoning_complete {
-      // The semantic completion supplies one whole document, so Markdown is
-      // safe and cheap now. The durable item will take over the same card.
-      @html.div(
-        class="msg-content markdown activity-thinking",
-        @markdown.markdown_nodes(content, open_file=on_open),
-      )
-    } else {
+    let body = if thinking {
       // Do not parse an unfinished Markdown document on every provider token.
       // Newlines are preserved by CSS while fragments are still arriving.
       @html.div(
         class="msg-content activity-thinking activity-thinking-live",
-        @html.text(content),
+        @html.text(text),
+      )
+    } else {
+      @html.div(
+        class="msg-content markdown activity-thinking",
+        @markdown.markdown_nodes(text, open_file=on_open),
       )
     }
-    rows.push(
-      thought_fold(
-        if reasoning_complete {
-          "Thought"
-        } else {
-          "Thinking…"
-        },
-        prose,
-        true,
+    lead.push(
+      @html.details(class="activity", open=live, [
+        @html.summary(class="activity-summary", [
+          @html.span(class="activity-text", summary),
+        ]),
+        @html.div(class="activity-body", [body]),
+      ]),
+    )
+  } else if !header.is_empty() && !calls.is_empty() {
+    lead.push(@html.div(class="activity-heading", header))
+  }
+  let work = if calls.is_empty() {
+    None
+  } else {
+    Some(
+      @html.div(
+        class="activity-work",
+        tool_run_views(calls, sequence?, subrun?),
       ),
     )
   }
+  // The prose bubble separates the thought from the work it announced; a
+  // response without prose keeps both under one quiet guide line.
+  let parts : Array[@html.Html] = []
+  if prose is Some(text) {
+    if !lead.is_empty() {
+      parts.push(@html.div(class="activity-row", lead))
+    }
+    parts.push(
+      assistant_message_view(
+        text,
+        on_open,
+        assistant_name,
+        is_danger=false,
+        completed_at?=if finished { ts } else { None },
+        show_actions=finished,
+        streaming=live,
+      ),
+    )
+    if work is Some(work) {
+      parts.push(@html.div(class="activity-row", [work]))
+    }
+  } else {
+    if work is Some(work) {
+      lead.push(work)
+    }
+    if !lead.is_empty() {
+      parts.push(@html.div(class="activity-row", lead))
+    }
+  }
+  @html.div(class="step", parts)
+}
+
+///|
+/// A durable runtime notice — a goal marker, or an engine notice injected
+/// between turns — as the compact completed-result row a tool result gets,
+/// under the instant it committed. Never a numbered step: nothing in it is
+/// the model's work.
+fn notice_view(
+  label : String,
+  brief : String?,
+  is_error : Bool,
+  content : String,
+  ts? : Double,
+  sequence? : Int,
+) -> @html.Html {
+  let rows : Array[@html.Html] = []
+  if step_stamp(ts?) is Some(stamp) {
+    rows.push(@html.div(class="activity-heading", [stamp]))
+  }
+  let call : @transcript.ToolCall = {
+    call_id: "",
+    name: label,
+    arguments: None,
+    has_result: true,
+    is_error,
+    brief,
+    content,
+  }
+  rows.push(@html.div(class="activity-work", tool_run_views([call], sequence?)))
   @html.div(class="activity-row", rows)
 }
 
 ///|
-/// Render one consecutive run of tool-shaped transcript items. Calls emitted
-/// by the same durable Assistant event share a sequence: show every request
-/// first and every result after it, exactly as the viz HTML renderer's
-/// Assistant card followed by result cards makes a parallel burst readable.
-/// Different or absent sequences cannot prove a burst, so keep each request
-/// beside its own result instead of implying concurrency.
+/// Render one response's tool calls. Several calls of one provider response
+/// are a parallel burst: show every request first and every result after it,
+/// exactly as the viz HTML renderer's Assistant card followed by result cards
+/// makes a burst readable. A lone call — every Codex item, and a notice —
+/// keeps its request beside its own result instead of implying concurrency.
 fn tool_run_views(
-  items : Array[@transcript.TranscriptItem],
+  calls : Array[@transcript.ToolCall],
+  sequence? : Int,
   subrun? : SubrunLink,
 ) -> Map[String, @html.Html] {
   let rows : Map[String, @html.Html] = Map([])
-  let same_assistant_event = match items {
-    [first, ..] if items.length() > 1 && first.sequence is Some(sequence) =>
-      items.all(item => {
-        item.sequence == Some(sequence) &&
-        item.kind is Tool(arguments=Some(_), ..)
-      })
-    _ => false
-  }
-  if same_assistant_event {
-    for index, item in items {
-      if item.kind is Tool(arguments=Some(_), ..) {
-        rows[tool_run_row_key(item, index, "request")] = tool_request_view(item)
-      }
+  let burst = calls.length() > 1 && calls.all(call => call.arguments is Some(_))
+  if burst {
+    for index, call in calls {
+      rows[tool_run_row_key(call, index, "request")] = tool_request_view(
+        call,
+        sequence?,
+      )
     }
-    for index, item in items {
-      if tool_result_row_is_visible(item) {
-        rows[tool_run_row_key(item, index, "result")] = tool_result_view(
-          item,
+    for index, call in calls {
+      if tool_result_row_is_visible(call) {
+        rows[tool_run_row_key(call, index, "result")] = tool_result_view(
+          call,
+          sequence?,
           subrun?,
         )
       }
     }
   } else {
-    for index, item in items {
-      if item.kind is Tool(arguments=Some(_), ..) {
-        rows[tool_run_row_key(item, index, "request")] = tool_request_view(item)
+    for index, call in calls {
+      if call.arguments is Some(_) {
+        rows[tool_run_row_key(call, index, "request")] = tool_request_view(
+          call,
+          sequence?,
+        )
       }
-      if tool_result_row_is_visible(item) {
-        rows[tool_run_row_key(item, index, "result")] = tool_result_view(
-          item,
+      if tool_result_row_is_visible(call) {
+        rows[tool_run_row_key(call, index, "result")] = tool_result_view(
+          call,
+          sequence?,
           subrun?,
         )
       }
@@ -197,14 +222,11 @@ fn tool_run_views(
 /// array position. The index disambiguates malformed logs with duplicate ids;
 /// call order itself is stable in the transcript projection.
 fn tool_run_row_key(
-  item : @transcript.TranscriptItem,
+  call : @transcript.ToolCall,
   index : Int,
   side : String,
 ) -> String {
-  guard item.kind is Tool(call_id~, name~, ..) else {
-    return "\{side}\u{0}\{index}"
-  }
-  let identity = if call_id.is_empty() { name } else { call_id }
+  let identity = if call.call_id.is_empty() { call.name } else { call.call_id }
   "\{side}\u{0}\{identity}\u{0}\{index}"
 }
 
@@ -244,9 +266,8 @@ fn subrun_chip(child : String, open : (String) -> @cmd.Cmd) -> @html.Html {
 /// command items can also accumulate output while still in progress; surface
 /// that stream immediately, but let `has_result` keep the row labelled pending
 /// until the completed item arrives.
-fn tool_result_row_is_visible(item : @transcript.TranscriptItem) -> Bool {
-  guard item.kind is Tool(has_result~, ..) else { return false }
-  has_result || !item.content.is_blank()
+fn tool_result_row_is_visible(call : @transcript.ToolCall) -> Bool {
+  call.has_result || !call.content.is_blank()
 }
 
 ///|
@@ -254,11 +275,14 @@ fn tool_result_row_is_visible(item : @transcript.TranscriptItem) -> Bool {
 /// the result-derived caption the viz renderer also promotes onto the call;
 /// expanding reveals only what the model sent. Failed calls read red and carry
 /// a literal marker, while their separate result row owns the output.
-fn tool_request_view(item : @transcript.TranscriptItem) -> @html.Html {
-  guard item.kind
-    is Tool(call_id~, name~, arguments=Some(arguments), is_error~, brief~, ..) else {
-    return @html.nothing
-  }
+fn tool_request_view(
+  call : @transcript.ToolCall,
+  sequence? : Int,
+) -> @html.Html {
+  guard call.arguments is Some(arguments) else { return @html.nothing }
+  let name = call.name
+  let brief = call.brief
+  let is_error = call.is_error
   let label = if brief is Some(brief) && !brief.is_blank() {
     brief
   } else {
@@ -285,7 +309,7 @@ fn tool_request_view(item : @transcript.TranscriptItem) -> @html.Html {
     is Some(marker) {
     line.push(marker)
   }
-  line.push(@plan.fold_progress([item]))
+  line.push(@plan.fold_progress(call))
   let body : Array[@html.Html] = []
   // A `plan` call shows the checklist it recorded rather than its JSON, in
   // every state where that checklist is what the model asked for. A pending
@@ -293,10 +317,10 @@ fn tool_request_view(item : @transcript.TranscriptItem) -> @html.Html {
   // section already marks it unfinished. A rejected one does not — the
   // malformed arguments are what the reader needs, and dressing them up as a
   // checklist would report a plan that never took effect.
-  if @plan.classify(item) is Some(Applied(steps) | Pending(steps)) {
+  if @plan.classify(call) is Some(Applied(steps) | Pending(steps)) {
     body.push(@html.div(class="tool-call-section", [@plan.card(steps)]))
   } else if tool_arguments_tabbed_view(
-      tool_call_tabs_key(call_id, item.sequence),
+      tool_call_tabs_key(call.call_id, sequence),
       name,
       Some(arguments),
     )
@@ -347,13 +371,15 @@ fn tool_request_view(item : @transcript.TranscriptItem) -> @html.Html {
 /// Codex command gets a row only after it has streamed output, and its label
 /// deliberately says "output" rather than claiming completion.
 fn tool_result_view(
-  item : @transcript.TranscriptItem,
+  call : @transcript.ToolCall,
+  sequence? : Int,
   subrun? : SubrunLink,
 ) -> @html.Html {
-  guard item.kind
-    is Tool(call_id~, name~, arguments~, has_result~, is_error~, brief~) else {
-    return @html.nothing
-  }
+  let name = call.name
+  let arguments = call.arguments
+  let has_result = call.has_result
+  let is_error = call.is_error
+  let brief = call.brief
   let label = match (arguments, brief, has_result) {
     (None, Some(brief), _) if !brief.is_blank() => brief
     (None, _, _) => name
@@ -394,9 +420,9 @@ fn tool_result_view(
       body.push(subrun_chip(child, link.open))
     }
   }
-  if !item.content.is_blank() {
-    let key = tool_call_tabs_key(call_id, item.sequence)
-    let output = tool_output_tabs(name, arguments, item.content)
+  if !call.content.is_blank() {
+    let key = tool_call_tabs_key(call.call_id, sequence)
+    let output = tool_output_tabs(name, arguments, call.content)
     if output is [tab] {
       body.push(
         @html.div(class="tool-call-section", [
@@ -660,18 +686,18 @@ fn clock_label(unix_ms : Double) -> String {
 /// stamp — an unstamped row, or the `0` old stores wrote for "no time
 /// recorded".
 ///
-/// Every row of a step shares the one stamp of the Assistant event that
-/// produced it — a matched tool result deliberately keeps its call's stamp —
-/// so a step is an instant, not a span, and the column of instants down a turn
-/// is what shows where its time went.
+/// A step's stamp is the one stamp of the Assistant event that produced it — a
+/// matched tool result deliberately leaves its call's stamp alone — so a step
+/// is an instant, not a span, and the column of instants down a turn is what
+/// shows where its time went.
 ///
 /// The visible label is time-only so the column stays narrow, which leaves one
 /// thing it cannot say: which day. A turn running through midnight shows a
 /// later step at an earlier clock time. The dated form rides along as the
 /// title rather than in the column, since the ambiguity is rare and checking
 /// it is deliberate.
-fn step_stamp(items : Array[@transcript.TranscriptItem]) -> @html.Html? {
-  guard items is [first, ..] && first.ts is Some(ts) else { return None }
+fn step_stamp(ts? : Double) -> @html.Html? {
+  guard ts is Some(ts) else { return None }
   let label = step_time_label(ts)
   guard !label.is_empty() else { return None }
   Some(
@@ -732,25 +758,34 @@ fn turn_rule_view(ts? : Double) -> @html.Html {
 }
 
 ///|
+/// One transcript item as its own stream child. `step_label` is the ordinal an
+/// OpenSeek provider response carries ("#3"); every other source and kind
+/// leaves it empty.
 fn transcript_item_view(
   item : @transcript.TranscriptItem,
   on_open : (String) -> @cmd.Cmd,
   anchor? : String,
   on_jump? : (@mention_context.Target) -> @cmd.Cmd,
   assistant_name? : String = "OpenSeek",
+  step_label? : String = "",
+  subrun? : SubrunLink,
 ) -> @html.Html {
   match item.kind {
     User => user_message_view(item.content, anchor?, on_jump?)
-    Assistant(is_danger~) =>
-      assistant_message_view(item.content, on_open, assistant_name, is_danger~)
-    AssistantReplay =>
-      assistant_message_view(
-        item.content,
+    Assistant(reasoning~, calls~, replay=_, finished~) =>
+      assistant_view(
         on_open,
-        assistant_name,
-        is_danger=false,
+        prose?=if item.content.is_empty() { None } else { Some(item.content) },
+        reasoning?,
+        calls~,
+        sequence?=item.sequence,
+        ts?=item.ts,
+        step_label~,
+        assistant_name~,
+        finished~,
+        subrun?,
       )
-    TerminalAnswer =>
+    Answer =>
       assistant_message_view(
         item.content,
         on_open,
@@ -759,16 +794,32 @@ fn transcript_item_view(
         completed_at?=item.ts,
         show_actions=true,
       )
-    // Unreachable in practice — the transcript loop batches every reasoning
-    // and tool item into a run and builds the activity card itself — but the
-    // match must cover them, so a stray item gets the same one-item card.
-    Reasoning => activity_view([item], on_open)
-    Tool(..) => activity_view([item], on_open)
+    Failure =>
+      assistant_message_view(
+        item.content,
+        on_open,
+        assistant_name,
+        is_danger=true,
+      )
+    Notice(label~, brief~, is_error~) =>
+      notice_view(
+        label,
+        brief,
+        is_error,
+        item.content,
+        ts?=item.ts,
+        sequence?=item.sequence,
+      )
     Summary => summary_card_view(item.content, on_open)
   }
 }
 
 ///|
+/// The agent's prose. A bubble still `streaming` is the in-flight answer
+/// rendered live from the engine's deltas: the partial text is re-parsed as
+/// markdown on every delta, and an unterminated construct (an open code
+/// fence, say) simply renders as plain text until its closing marker streams
+/// in. The committed response replaces it.
 fn assistant_message_view(
   content : String,
   on_open : (String) -> @cmd.Cmd,
@@ -776,6 +827,7 @@ fn assistant_message_view(
   is_danger~ : Bool,
   completed_at? : Double,
   show_actions? : Bool = false,
+  streaming? : Bool = false,
 ) -> @html.Html {
   // Errors and abort notices are durable run status rather than assistant
   // prose. Keep their exact text and inline code readable in an unboxed status
@@ -828,9 +880,14 @@ fn assistant_message_view(
     }
     children.push(@html.div(class="assistant-message-actions", actions))
   }
-  @html.div(class=if is_danger { "msg transcript-error" } else { "msg" }, [
-    @html.div(class="msg-body", children),
-  ])
+  let class = if is_danger {
+    "msg transcript-error"
+  } else if streaming {
+    "msg streaming"
+  } else {
+    "msg"
+  }
+  @html.div(class~, [@html.div(class="msg-body", children)])
 }
 
 ///|
@@ -851,28 +908,6 @@ fn summary_card_view(
       ]),
       @html.div(
         class="msg-content markdown summary-card-body",
-        @markdown.markdown_nodes(content, open_file=on_open),
-      ),
-    ]),
-  ])
-}
-
-///|
-/// The in-flight assistant turn, rendered live from the engine's streamed
-/// deltas. The committed `assistant_message` replaces it in the transcript.
-/// The partial text is re-parsed as markdown on every delta; an unterminated
-/// construct (e.g. an open code fence) simply renders as plain text until its
-/// closing marker streams in.
-fn streaming_response_view(
-  content : String,
-  on_open : (String) -> @cmd.Cmd,
-  assistant_name? : String = "OpenSeek",
-) -> @html.Html {
-  @html.div(class="msg streaming", [
-    @html.div(class="msg-body", [
-      speaker_label(assistant_name),
-      @html.div(
-        class="msg-content markdown",
         @markdown.markdown_nodes(content, open_file=on_open),
       ),
     ]),

--- a/desktop/frontend/transcript/component/view_tests.mbt
+++ b/desktop/frontend/transcript/component/view_tests.mbt
@@ -1,15 +1,17 @@
 ///|
 test "transcript stream children use stable typed keys in display order" {
-  let first_tool : @transcript.TranscriptItem = {
-    kind: Tool(
-      call_id="c1",
-      name="shell",
-      arguments=None,
-      has_result=true,
-      is_error=false,
-      brief=Some("moon check"),
-    ),
-    content: "output",
+  let call : @transcript.ToolCall = {
+    call_id: "c1",
+    name: "shell",
+    arguments: Some("{}"),
+    has_result: false,
+    is_error: false,
+    brief: None,
+    content: "",
+  }
+  let response : @transcript.TranscriptItem = {
+    kind: Assistant(reasoning=None, calls=[call], replay=false, finished=false),
+    content: "I will check it.",
     ts: None,
     sequence: Some(42),
   }
@@ -22,9 +24,9 @@ test "transcript stream children use stable typed keys in display order" {
     items=[
       {
         item: { kind: User, content: "question", ts: None, sequence: Some(41), },
-        identity: "s41\u{0}o0",
+        identity: "s41",
       },
-      { item: first_tool, identity: "s42\u{0}o0", },
+      { item: response, identity: "s42", },
     ],
     streaming_response=Some("partial answer"),
     streaming_identity="r7",
@@ -36,34 +38,98 @@ test "transcript stream children use stable typed keys in display order" {
     on_open_session: _ => @cmd.none,
   }
   let keys = renderer.stream_children().to_array().map(pair => pair.0)
-  assert_eq(keys, [
-    "row\u{0}s41\u{0}o0", "rule\u{0}s41\u{0}o0", "activity\u{0}after\u{0}s41\u{0}o0",
-    "streaming\u{0}r7",
-  ])
-  // A newly discovered row from the same durable Assistant step extends the
-  // same card; it does not replace its browser-owned disclosure.
-  let extended = {
+  assert_eq(keys, ["row\u{0}s41", "rule\u{0}s41", "row\u{0}s42", "live\u{0}r7"])
+  // The result filling the call, and the durable reasoning the same event
+  // turns out to carry, change the response's node, never its identity: the
+  // browser-owned disclosures inside it survive both.
+  let settled = {
     ..input,
     items: [
       input.items[0],
       {
         item: {
-          kind: Reasoning,
-          content: "thinking",
-          ts: None,
-          sequence: Some(42),
+          ..response,
+          kind: Assistant(
+            reasoning=Some("thinking"),
+            calls=[{ ..call, has_result: true, content: "output", }],
+            replay=false,
+            finished=false,
+          ),
         },
-        identity: "s42\u{0}o0",
+        identity: "s42",
       },
-      { item: first_tool, identity: "s42\u{0}o1", },
     ],
   }
-  let extended_renderer = { ..renderer, input: extended, }
-  let extended_keys = extended_renderer
+  let settled_renderer = { ..renderer, input: settled, }
+  let settled_keys = settled_renderer
     .stream_children()
     .to_array()
     .map(pair => pair.0)
-  assert_eq(extended_keys, keys)
+  assert_eq(settled_keys, keys)
+}
+
+///|
+test "the live response is one node, replaced by the durable one" {
+  let user : VisibleRow = {
+    item: { kind: User, content: "question", ts: None, sequence: Some(1), },
+    identity: "s1",
+  }
+  let live_input = Input(
+    source=OpenSeek,
+    focused=@interop.ChannelId::Local,
+    active_session="desktop-test",
+    root=None,
+    submission_generation=1,
+    items=[user],
+    streaming_response=None,
+    streaming_reasoning="next thought",
+    streaming_identity="r7",
+  )
+  let renderer : TranscriptRenderer = {
+    input: live_input,
+    on_open: _ => @cmd.none,
+    on_jump: _ => @cmd.none,
+    on_open_session: _ => @cmd.none,
+  }
+  let live_keys = renderer.stream_children().to_array().map(pair => pair.0)
+  assert_eq(live_keys, ["row\u{0}s1", "rule\u{0}s1", "live\u{0}r7"])
+  // The answer streaming after the thought joins the same node.
+  let answering = {
+    ..renderer,
+    input: { ..live_input, streaming_response: Some("partial"), },
+  }
+  assert_eq(
+    answering.stream_children().to_array().map(pair => pair.0),
+    live_keys,
+  )
+  // The durable commit is its own node; the preview is gone with the run.
+  let settled = {
+    ..renderer,
+    input: {
+      ..live_input,
+      items: [
+        user,
+        {
+          item: {
+            kind: Assistant(
+              reasoning=Some("next thought"),
+              calls=[],
+              replay=false,
+              finished=false,
+            ),
+            content: "answer",
+            ts: None,
+            sequence: Some(2),
+          },
+          identity: "s2",
+        },
+      ],
+      streaming_reasoning: None,
+    },
+  }
+  assert_eq(settled.stream_children().to_array().map(pair => pair.0), [
+    "row\u{0}s1", "rule\u{0}s1", "row\u{0}s2",
+  ])
 }
 
 ///|

--- a/desktop/frontend/transcript/component/view_tests.mbt
+++ b/desktop/frontend/transcript/component/view_tests.mbt
@@ -4,14 +4,16 @@ test "transcript stream children use stable typed keys in display order" {
     call_id: "c1",
     name: "shell",
     arguments: Some("{}"),
-    has_result: false,
-    is_error: false,
-    brief: None,
-    content: "",
+    outcome: Pending(output=None),
   }
   let response : @transcript.TranscriptItem = {
-    kind: Assistant(reasoning=None, calls=[call], replay=false, finished=false),
-    content: "I will check it.",
+    kind: Assistant(
+      reasoning=None,
+      prose=Some("I will check it."),
+      calls=[call],
+      replay=false,
+      finished=false,
+    ),
     ts: None,
     sequence: Some(42),
   }
@@ -23,7 +25,7 @@ test "transcript stream children use stable typed keys in display order" {
     submission_generation=1,
     items=[
       {
-        item: { kind: User, content: "question", ts: None, sequence: Some(41), },
+        item: { kind: User("question"), ts: None, sequence: Some(41), },
         identity: "s41",
       },
       { item: response, identity: "s42", },
@@ -51,7 +53,13 @@ test "transcript stream children use stable typed keys in display order" {
           ..response,
           kind: Assistant(
             reasoning=Some("thinking"),
-            calls=[{ ..call, has_result: true, content: "output", }],
+            prose=Some("I will check it."),
+            calls=[
+              {
+                ..call,
+                outcome: Done(content="output", is_error=false, brief=None),
+              },
+            ],
             replay=false,
             finished=false,
           ),
@@ -71,7 +79,7 @@ test "transcript stream children use stable typed keys in display order" {
 ///|
 test "the live response is one node, replaced by the durable one" {
   let user : VisibleRow = {
-    item: { kind: User, content: "question", ts: None, sequence: Some(1), },
+    item: { kind: User("question"), ts: None, sequence: Some(1), },
     identity: "s1",
   }
   let live_input = Input(
@@ -113,11 +121,11 @@ test "the live response is one node, replaced by the durable one" {
           item: {
             kind: Assistant(
               reasoning=Some("next thought"),
+              prose=Some("answer"),
               calls=[],
               replay=false,
               finished=false,
             ),
-            content: "answer",
             ts: None,
             sequence: Some(2),
           },

--- a/desktop/frontend/transcript/pkg.generated.mbti
+++ b/desktop/frontend/transcript/pkg.generated.mbti
@@ -16,8 +16,6 @@ pub fn decode_engine_event(@protocol.AgentStreamEvent) -> EngineEvent?
 
 pub fn goal_marker(String) -> GoalMarker?
 
-pub fn parse_runtime_update(String) -> RuntimeUpdateView
-
 pub fn session_from_reply(@protocol.LoadSessionReply) -> SessionLoadView
 
 pub fn session_tree(Array[SessionListItem]) -> Array[SessionTreeRow]
@@ -39,7 +37,7 @@ pub(all) enum EngineEvent {
   ReasoningDelta(String)
   ReasoningMessage(String)
   AssistantMessage(String)
-  RuntimeUpdate(String)
+  BackgroundNotice(String)
   Usage(prompt_tokens~ : Int, completion_tokens~ : Int)
   ToolResult(tool_name~ : String, is_error~ : Bool, content~ : String, brief~ : String?)
   ToolCallDecodeError(tool_name~ : String, reason~ : String)
@@ -79,20 +77,14 @@ pub fn GoalStanding::not_equal(Self, Self) -> Bool
 
 pub(all) enum ItemKind {
   User
-  Assistant(is_danger~ : Bool)
-  AssistantReplay
-  TerminalAnswer
-  Reasoning
-  Tool(call_id~ : String, name~ : String, arguments~ : String?, has_result~ : Bool, is_error~ : Bool, brief~ : String?)
+  Assistant(reasoning~ : String?, calls~ : Array[ToolCall], replay~ : Bool, finished~ : Bool)
+  Answer
+  Failure
+  Notice(label~ : String, brief~ : String?, is_error~ : Bool)
   Summary
 } derive(Eq)
 pub fn ItemKind::equal(Self, Self) -> Bool
 pub fn ItemKind::not_equal(Self, Self) -> Bool
-
-pub struct RuntimeUpdateView {
-  status : String?
-  diagnostics : Array[String]
-}
 
 pub(all) struct SessionListItem {
   id : String
@@ -117,6 +109,18 @@ pub struct SessionTreeRow {
 } derive(Eq)
 pub fn SessionTreeRow::equal(Self, Self) -> Bool
 pub fn SessionTreeRow::not_equal(Self, Self) -> Bool
+
+pub(all) struct ToolCall {
+  call_id : String
+  name : String
+  arguments : String?
+  has_result : Bool
+  is_error : Bool
+  brief : String?
+  content : String
+} derive(Eq)
+pub fn ToolCall::equal(Self, Self) -> Bool
+pub fn ToolCall::not_equal(Self, Self) -> Bool
 
 pub(all) struct TranscriptItem {
   kind : ItemKind

--- a/desktop/frontend/transcript/pkg.generated.mbti
+++ b/desktop/frontend/transcript/pkg.generated.mbti
@@ -76,12 +76,12 @@ pub fn GoalStanding::equal(Self, Self) -> Bool
 pub fn GoalStanding::not_equal(Self, Self) -> Bool
 
 pub(all) enum ItemKind {
-  User
-  Assistant(reasoning~ : String?, calls~ : Array[ToolCall], replay~ : Bool, finished~ : Bool)
-  Answer
-  Failure
-  Notice(label~ : String, brief~ : String?, is_error~ : Bool)
-  Summary
+  User(String)
+  Assistant(reasoning~ : String?, prose~ : String?, calls~ : Array[ToolCall], replay~ : Bool, finished~ : Bool)
+  Answer(String)
+  Failure(String)
+  Notice(label~ : String, brief~ : String?, is_error~ : Bool, body~ : String?)
+  Summary(String)
 } derive(Eq)
 pub fn ItemKind::equal(Self, Self) -> Bool
 pub fn ItemKind::not_equal(Self, Self) -> Bool
@@ -114,22 +114,26 @@ pub(all) struct ToolCall {
   call_id : String
   name : String
   arguments : String?
-  has_result : Bool
-  is_error : Bool
-  brief : String?
-  content : String
+  outcome : ToolOutcome
 } derive(Eq)
 pub fn ToolCall::equal(Self, Self) -> Bool
 pub fn ToolCall::not_equal(Self, Self) -> Bool
 
+pub(all) enum ToolOutcome {
+  Pending(output~ : String?)
+  Done(content~ : String, is_error~ : Bool, brief~ : String?)
+} derive(Eq)
+pub fn ToolOutcome::equal(Self, Self) -> Bool
+pub fn ToolOutcome::not_equal(Self, Self) -> Bool
+
 pub(all) struct TranscriptItem {
   kind : ItemKind
-  content : String
   ts : Double?
   sequence : Int?
 } derive(Eq)
 pub fn TranscriptItem::equal(Self, Self) -> Bool
 pub fn TranscriptItem::not_equal(Self, Self) -> Bool
+pub fn TranscriptItem::text(Self) -> String?
 
 // Type aliases
 

--- a/desktop/frontend/transcript/sessions.mbt
+++ b/desktop/frontend/transcript/sessions.mbt
@@ -315,16 +315,17 @@ fn transcript_from_session(
 
 ///|
 /// Project one durable session item — a `session.event` commit's
-/// `{kind, payload}` — onto the transcript. Most events append 0..N rows; a
-/// tool result instead fills its earlier call row when the ids match. Returns
-/// whether the visible transcript changed. Unknown items deliberately change
-/// nothing: their event sequence still advances the durable watermark, while
-/// their raw JSON stays available to newer code. The same projector replays
-/// snapshots and live commits, so both paths agree by construction. `ts` is
-/// the committing event's stamp, carried onto every row the item appends so
-/// the view can date a turn; a store (or fixture) written without one leaves
-/// the rows undated. `sequence` is the committing event's sequence, likewise
-/// carried onto every appended row as its durable identity.
+/// `{kind, payload}` — onto the transcript. Every event appends at most one
+/// item, kept in the event's own shape; a tool result instead fills its call
+/// inside the response that made it. Returns whether the visible transcript
+/// changed. Unknown items deliberately change nothing: their event sequence
+/// still advances the durable watermark, while their raw JSON stays available
+/// to newer code. The same projector replays snapshots and live commits, so
+/// both paths agree by construction. `ts` is the committing event's stamp,
+/// carried onto the item it appends so the view can date a turn; a store (or
+/// fixture) written without one leaves the item undated. `sequence` is the
+/// committing event's sequence, likewise carried onto the appended item as
+/// its durable identity.
 pub fn apply_session_item(
   items : Array[TranscriptItem],
   item : @desktop_protocol.SessionItem,
@@ -343,110 +344,84 @@ pub fn apply_session_item(
     @desktop_protocol.Assistant(payload) => {
       let is_replay = payload.is_replay == Some(true)
       // Thinking-mode turns store the reasoning alongside the answer (the
-      // store omits the field entirely otherwise); the live transcript
-      // showed it first, so replay does too. A checkpoint replay already has
-      // its reasoning on the original durable provider response, so do not
-      // duplicate that activity or let it masquerade as a new step.
-      if !is_replay && payload.reasoning_content is Some(reasoning) {
-        let reasoning = reasoning.trim().to_owned()
-        if !reasoning.is_empty() {
-          items.push({ kind: Reasoning, content: reasoning, ts, sequence, })
-        }
+      // store omits the field entirely otherwise). A checkpoint replay
+      // already has its reasoning on the original durable provider response,
+      // so it carries none here rather than duplicating that activity.
+      let reasoning = if !is_replay &&
+        payload.reasoning_content is Some(text) &&
+        !text.is_blank() {
+        Some(text.trim().to_owned())
+      } else {
+        None
       }
       let content = payload.content.trim().to_owned()
-      if !content.is_empty() {
-        items.push({
-          kind: if is_replay {
-            AssistantReplay
+      // Tool calls stay in the exact order the model emitted them. Their
+      // results arrive as later durable events and fill them in by id.
+      let calls : Array[ToolCall] = []
+      for call in payload.tool_calls.unwrap_or([]) {
+        calls.push({
+          call_id: call.id,
+          name: if call.name.is_blank() {
+            "tool"
           } else {
-            Assistant(is_danger=false)
+            call.name
           },
-          content,
-          ts,
-          sequence,
+          arguments: Some(call.arguments),
+          has_result: false,
+          is_error: false,
+          brief: None,
+          content: "",
         })
       }
-      // Tool calls belong after this assistant event's reasoning and visible
-      // prose, in the exact order the model emitted them. Their results arrive
-      // as later durable events and fill these rows by id without reordering.
-      for call in payload.tool_calls.unwrap_or([]) {
+      if reasoning is Some(_) || !content.is_empty() || !calls.is_empty() {
         items.push({
-          kind: Tool(
-            call_id=call.id,
-            name=if call.name.is_blank() { "tool" } else { call.name },
-            arguments=Some(call.arguments),
-            has_result=false,
-            is_error=false,
-            brief=None,
-          ),
-          content: "",
+          kind: Assistant(reasoning~, calls~, replay=is_replay, finished=false),
+          content,
           ts,
           sequence,
         })
       }
     }
     @desktop_protocol.ToolResult(payload) => {
-      // A valid result updates one unambiguous, still-pending recorded call in
-      // place. Completed calls must not match again, and duplicate pending ids
-      // are ambiguous: in either case the append-only result remains visible as
-      // an unmatched row instead of overwriting or guessing a call.
-      let mut matched : Int? = None
-      let mut pending_matches = 0
-      if !payload.tool_call_id.is_empty() {
-        for index, existing in items {
-          if existing.kind
-            is Tool(call_id~, arguments=Some(_), has_result=false, ..) &&
-            call_id == payload.tool_call_id {
-            matched = Some(index)
-            pending_matches += 1
-          }
+      // A result answers the still-pending call recorded with its id. The
+      // engine appends every response before running its calls, so the call
+      // is always on record; a result nothing is waiting for changes nothing,
+      // exactly as the engine's own replay projection drops it.
+      let mut index = items.length()
+      while index > 0 {
+        index -= 1
+        guard items[index].kind
+          is Assistant(reasoning~, calls~, replay~, finished~) else {
+          continue
         }
-      }
-      if pending_matches == 1 &&
-        matched is Some(index) &&
-        items[index].kind is Tool(call_id~, name=call_name, arguments~, ..) {
-        let tool_name = if payload.tool_name.is_blank() {
-          call_name
-        } else {
-          payload.tool_name
+        guard calls.search_by(call => {
+            call.call_id == payload.tool_call_id && !call.has_result
+          })
+          is Some(position) else {
+          continue
+        }
+        let call = calls[position]
+        // The response keeps its own stamp and sequence: the call is dated
+        // when the agent made it, not when its output came back.
+        let filled = calls.copy()
+        filled[position] = {
+          ..call,
+          name: if payload.tool_name.is_blank() {
+            call.name
+          } else {
+            payload.tool_name
+          },
+          has_result: true,
+          is_error: payload.is_error,
+          brief: payload.brief,
+          content: payload.content,
         }
         items[index] = {
-          kind: Tool(
-            call_id~,
-            name=tool_name,
-            arguments~,
-            has_result=true,
-            is_error=payload.is_error,
-            brief=payload.brief,
-          ),
-          content: payload.content,
-          // The row keeps the call's own stamp and sequence: it is one tool
-          // call, dated when the agent made it, not when its output came back.
-          ts: items[index].ts,
-          sequence: items[index].sequence,
+          ..items[index],
+          kind: Assistant(reasoning~, calls=filled, replay~, finished~),
         }
         updated_existing = true
-      } else {
-        // Older or malformed logs can contain an unmatched result. Keep the
-        // existing Desktop behavior for those records instead of hiding them.
-        let tool_name = if payload.tool_name.is_blank() {
-          "tool"
-        } else {
-          payload.tool_name
-        }
-        items.push({
-          kind: Tool(
-            call_id=payload.tool_call_id,
-            name=tool_name,
-            arguments=None,
-            has_result=true,
-            is_error=payload.is_error,
-            brief=payload.brief,
-          ),
-          content: payload.content,
-          ts,
-          sequence,
-        })
+        break
       }
     }
     @desktop_protocol.RuntimeNotice(payload) =>
@@ -458,13 +433,10 @@ pub fn apply_session_item(
           // label; a multi-line goal expands to its full text.
           Some(GoalSet(text)) =>
             items.push({
-              kind: Tool(
-                call_id="",
-                name="goal",
-                arguments=None,
-                has_result=true,
-                is_error=false,
+              kind: Notice(
+                label="goal",
                 brief=Some(goal_brief("Goal set", text)),
+                is_error=false,
               ),
               content: goal_body(text),
               ts,
@@ -472,13 +444,10 @@ pub fn apply_session_item(
             })
           Some(GoalCleared) =>
             items.push({
-              kind: Tool(
-                call_id="",
-                name="goal",
-                arguments=None,
-                has_result=true,
-                is_error=false,
+              kind: Notice(
+                label="goal",
                 brief=Some("Goal cleared"),
+                is_error=false,
               ),
               content: "",
               ts,
@@ -486,13 +455,10 @@ pub fn apply_session_item(
             })
           Some(GoalBlocked(reason)) =>
             items.push({
-              kind: Tool(
-                call_id="",
-                name="goal",
-                arguments=None,
-                has_result=true,
-                is_error=true,
+              kind: Notice(
+                label="goal",
                 brief=Some(goal_brief("Goal blocked", reason)),
+                is_error=true,
               ),
               content: goal_body(reason),
               ts,
@@ -500,13 +466,10 @@ pub fn apply_session_item(
             })
           Some(GoalUnblocked) =>
             items.push({
-              kind: Tool(
-                call_id="",
-                name="goal",
-                arguments=None,
-                has_result=true,
-                is_error=false,
+              kind: Notice(
+                label="goal",
                 brief=Some("Goal resumed"),
+                is_error=false,
               ),
               content: "",
               ts,
@@ -521,14 +484,7 @@ pub fn apply_session_item(
                 // Runtime notices keep the compact completed-result row used
                 // by the old projection, but the generic label no longer
                 // claims every background event came from `moon_check`.
-                kind: Tool(
-                  call_id="",
-                  name="runtime notice",
-                  arguments=None,
-                  has_result=true,
-                  is_error=false,
-                  brief=None,
-                ),
+                kind: Notice(label="runtime notice", brief=None, is_error=false),
                 content: payload.content,
                 ts,
                 sequence,
@@ -573,32 +529,31 @@ fn SessionTerminalProjection::append_to(
   }
   let message = message.trim().to_owned()
   match kind {
-    // A current no-tool final is already the last assistant message. Promote
-    // that row instead of duplicating it, and replace its model-step stamp
-    // with the later terminal stamp that marks when the whole turn ended.
+    // A current no-tool final is already the last provider response. Mark
+    // that response finished instead of duplicating its prose; it keeps its
+    // own stamp and sequence, so the settled bubble stays the same keyed node.
     "finished" =>
       if !message.is_empty() &&
         items is [.., last] &&
-        last.kind is Assistant(is_danger=false) &&
+        last.kind
+        is Assistant(reasoning~, calls=[], replay=false, finished=false) &&
         last.content == message {
         items[items.length() - 1] = {
-          kind: TerminalAnswer,
-          content: message,
-          ts,
-          sequence,
+          ..last,
+          kind: Assistant(reasoning~, calls=[], replay=false, finished=true),
         }
         true
       } else {
         if !message.is_empty() {
           // A differing terminal message, such as a completion-tool answer,
           // remains a new final bubble.
-          items.push({ kind: TerminalAnswer, content: message, ts, sequence, })
+          items.push({ kind: Answer, content: message, ts, sequence, })
         }
         false
       }
     "aborted" => {
       items.push({
-        kind: Assistant(is_danger=true),
+        kind: Failure,
         content: if message.is_empty() {
           "aborted"
         } else {
@@ -611,7 +566,7 @@ fn SessionTerminalProjection::append_to(
     }
     "interrupted" => {
       items.push({
-        kind: Assistant(is_danger=true),
+        kind: Failure,
         content: if message.is_empty() {
           "cancelled"
         } else {
@@ -624,7 +579,7 @@ fn SessionTerminalProjection::append_to(
     }
     "failed" => {
       items.push({
-        kind: Assistant(is_danger=true),
+        kind: Failure,
         content: if message.is_empty() {
           "failed"
         } else {
@@ -961,17 +916,19 @@ test "projected rows carry their event's stamp, tool rows the call's own" {
     #|{"sequence":2,"ts":1781144352000,"item":{"kind":"assistant","payload":{"content":"answer","tool_calls":[{"id":"c1","name":"read","arguments":"{}"}]}}},
     #|{"sequence":3,"ts":1781144399000,"item":{"kind":"tool_result","payload":{"tool_call_id":"c1","tool_name":"read","content":"out","is_error":false}}}
   let items = session_from_reply(session_reply(events)).items
-  inspect(items.length(), content="3")
+  inspect(items.length(), content="2")
   assert_true(items[0].ts is Some(1781144351123))
   assert_true(items[0].sequence is Some(1))
+  // The result filled the call inside its response; the response is dated
+  // when the call was made, not when its output came back — and keeps that
+  // event's sequence for the same reason.
+  guard items[1].kind is Assistant(calls=[call], ..) else {
+    fail("expected the response with its one call")
+  }
+  assert_true(call.has_result)
+  inspect(call.content, content="out")
   assert_true(items[1].ts is Some(1781144352000))
   assert_true(items[1].sequence is Some(2))
-  // The result filled the call row in place; the row is dated when the call
-  // was made, not when its output came back — and keeps that event's
-  // sequence for the same reason.
-  assert_true(items[2].kind is Tool(has_result=true, ..))
-  assert_true(items[2].ts is Some(1781144352000))
-  assert_true(items[2].sequence is Some(2))
 }
 
 ///|
@@ -1027,23 +984,19 @@ test "transcript mapping replays a finished conversation" {
     #|{"sequence":3,"ts":1000,"item":{"kind":"assistant","payload":{"content":"answer","tool_calls":[],"reasoning_content":"thought"}}},
     #|{"sequence":4,"ts":2000,"item":{"kind":"terminal","payload":{"kind":"finished","message":"answer"}}}
   let items = transcript_from_session(session_reply(events))
-  inspect(items.length(), content="4")
+  // The result at sequence 2 answers no recorded call and is dropped.
+  inspect(items.length(), content="2")
   guard items[0].kind is User else { fail("expected user item") }
   inspect(items[0].content, content="question")
   guard items[1].kind
-    is Tool(name="shell", is_error=true, brief=Some(brief), ..) else {
-    fail("expected tool card")
+    is Assistant(reasoning=Some(thought), calls=[], replay=false, finished=true) else {
+    fail("expected the terminal-confirmed answer with its reasoning")
   }
-  inspect(brief, content="ran ls → exit 1")
-  inspect(items[1].content, content="output")
-  guard items[2].kind is Reasoning else { fail("expected reasoning item") }
-  inspect(items[2].content, content="thought")
-  guard items[3].kind is TerminalAnswer else {
-    fail("expected terminal-confirmed answer")
-  }
-  inspect(items[3].content, content="answer")
-  assert_true(items[3].ts is Some(2000))
-  assert_true(items[3].sequence is Some(4))
+  inspect(thought, content="thought")
+  inspect(items[1].content, content="answer")
+  // The confirming terminal leaves the response its own stamp and sequence.
+  assert_true(items[1].ts is Some(1000))
+  assert_true(items[1].sequence is Some(3))
 }
 
 ///|
@@ -1055,16 +1008,17 @@ test "a finished turn marks only its last assistant message as final" {
     #|{"sequence":4,"ts":2000,"item":{"kind":"assistant","payload":{"content":"Done.","tool_calls":[]}}},
     #|{"sequence":5,"ts":3000,"item":{"kind":"terminal","payload":{"kind":"finished","message":"Done."}}}
   let items = transcript_from_session(session_reply(events))
-  inspect(items.length(), content="4")
-  guard items[1].kind is Assistant(is_danger=false) else {
+  inspect(items.length(), content="3")
+  guard items[1].kind is Assistant(calls=[call], finished=false, ..) else {
     fail("expected tool-prefacing narration to stay non-final")
   }
   inspect(items[1].content, content="I will inspect it.")
-  guard items[3].kind is TerminalAnswer else {
+  assert_true(call.has_result)
+  guard items[2].kind is Assistant(calls=[], finished=true, ..) else {
     fail("expected only the last answer to be terminal-confirmed")
   }
-  inspect(items[3].content, content="Done.")
-  assert_true(items[3].ts is Some(3000))
+  inspect(items[2].content, content="Done.")
+  assert_true(items[2].ts is Some(2000))
 }
 
 ///|
@@ -1073,8 +1027,8 @@ test "checkpoint assistant provenance projects without duplicate reasoning" {
     #|{"sequence":1,"item":{"kind":"assistant","payload":{"content":"kept answer","tool_calls":[],"reasoning_content":"old thought","is_replay":true}}}
   let items = transcript_from_session(session_reply(events))
   inspect(items.length(), content="1")
-  guard items[0].kind is AssistantReplay else {
-    fail("expected a checkpoint replay")
+  guard items[0].kind is Assistant(reasoning=None, replay=true, ..) else {
+    fail("expected a checkpoint replay without its reasoning")
   }
   inspect(items[0].content, content="kept answer")
 }
@@ -1087,97 +1041,41 @@ test "tool results fill calls by id without changing call order" {
     #|{"sequence":3,"item":{"kind":"tool_result","payload":{"tool_call_id":"c1","tool_name":"","content":"module contents","is_error":false,"brief":"read moon.mod"}}}
   let view = session_from_reply(session_reply(events))
   let items = view.items
-  inspect(items.length(), content="2")
-  guard items[0].kind
-    is Tool(
-      call_id="c1",
-      name="read",
-      arguments=Some(read_args),
-      has_result=true,
-      is_error=false,
-      brief=Some("read moon.mod")
-    ) else {
-    fail("expected the first call to remain first")
+  inspect(items.length(), content="1")
+  guard items[0].kind is Assistant(calls=[read, shell], ..) else {
+    fail("expected one response carrying both calls in order")
   }
-  inspect(read_args, content="{\"path\":\"moon.mod\"}")
-  inspect(items[0].content, content="module contents")
-  guard items[1].kind
-    is Tool(
-      call_id="c2",
-      name="shell",
-      arguments=Some(shell_args),
-      has_result=true,
-      is_error=false,
-      brief=Some("ran moon test")
-    ) else {
-    fail("expected the second call to remain second")
-  }
-  inspect(shell_args, content="{\"cmd\":\"moon test\"}")
-  inspect(items[1].content, content="tests passed")
+  inspect(read.call_id, content="c1")
+  inspect(read.name, content="read")
+  assert_true(read.arguments is Some("{\"path\":\"moon.mod\"}"))
+  assert_true(read.has_result)
+  assert_false(read.is_error)
+  assert_true(read.brief is Some("read moon.mod"))
+  inspect(read.content, content="module contents")
+  inspect(shell.call_id, content="c2")
+  inspect(shell.name, content="shell")
+  assert_true(shell.arguments is Some("{\"cmd\":\"moon test\"}"))
+  assert_true(shell.has_result)
+  assert_true(shell.brief is Some("ran moon test"))
+  inspect(shell.content, content="tests passed")
 }
 
 ///|
-test "duplicate tool results preserve every durable event" {
+test "a result no recorded call is waiting for changes nothing" {
   let events =
     #|{"sequence":1,"item":{"kind":"assistant","payload":{"content":"","tool_calls":[{"id":"d","name":"read","arguments":"{\"path\":\"x\"}"}]}}},
     #|{"sequence":2,"item":{"kind":"tool_result","payload":{"tool_call_id":"d","tool_name":"read","content":"one","is_error":false}}},
     #|{"sequence":3,"item":{"kind":"tool_result","payload":{"tool_call_id":"d","tool_name":"read","content":"two","is_error":false}}}
   let view = session_from_reply(session_reply(events))
   let items = view.items
-  inspect(items.length(), content="2")
-  // The first result fills the call in place; the duplicate result appends at
-  // its own durable boundary instead of replacing the completed call.
-  guard items[0].kind
-    is Tool(
-      call_id="d",
-      arguments=Some("{\"path\":\"x\"}"),
-      has_result=true,
-      ..
-    ) else {
+  inspect(items.length(), content="1")
+  // The first result fills the call; the second answers nothing pending, so
+  // it is dropped rather than shown as a call the model never made.
+  guard items[0].kind is Assistant(calls=[call], ..) else {
     fail("expected the recorded call with its first result")
   }
-  inspect(items[0].content, content="one")
-  guard items[1].kind is Tool(call_id="d", arguments=None, has_result=true, ..) else {
-    fail("expected the duplicate result as an unmatched row")
-  }
-  inspect(items[1].content, content="two")
-}
-
-///|
-test "duplicate tool call ids keep their result unpaired" {
-  let events =
-    #|{"sequence":1,"item":{"kind":"assistant","payload":{"content":"","tool_calls":[{"id":"dup","name":"read","arguments":"{\"path\":\"x\"}"},{"id":"dup","name":"shell","arguments":"{\"cmd\":\"pwd\"}"}]}}},
-    #|{"sequence":2,"item":{"kind":"tool_result","payload":{"tool_call_id":"dup","tool_name":"read","content":"result","is_error":false}}}
-  let view = session_from_reply(session_reply(events))
-  let items = view.items
-  inspect(items.length(), content="3")
-  // Both calls stay pending because their shared id cannot identify which one
-  // produced the result; the result is preserved at its own durable boundary.
-  guard items[0].kind
-    is Tool(
-      call_id="dup",
-      name="read",
-      arguments=Some("{\"path\":\"x\"}"),
-      has_result=false,
-      ..
-    ) else {
-    fail("expected the first duplicate call to remain pending")
-  }
-  guard items[1].kind
-    is Tool(
-      call_id="dup",
-      name="shell",
-      arguments=Some("{\"cmd\":\"pwd\"}"),
-      has_result=false,
-      ..
-    ) else {
-    fail("expected the second duplicate call to remain pending")
-  }
-  guard items[2].kind
-    is Tool(call_id="dup", name="read", arguments=None, has_result=true, ..) else {
-    fail("expected the ambiguous result as an unmatched row")
-  }
-  inspect(items[2].content, content="result")
+  assert_true(call.has_result)
+  inspect(call.content, content="one")
 }
 
 ///|
@@ -1197,9 +1095,7 @@ test "transcript mapping renders non-finished terminals as error bubbles" {
     #|{"sequence":3,"item":{"kind":"terminal","payload":{"kind":"failed","message":"engine error"}}}
   let items = transcript_from_session(session_reply(events))
   inspect(items.length(), content="3")
-  guard items[0].kind is Assistant(is_danger=true) else {
-    fail("expected error bubble")
-  }
+  guard items[0].kind is Failure else { fail("expected error bubble") }
   inspect(items[0].content, content="cancelled")
   inspect(items[1].content, content="aborted: the agent gave up")
   inspect(items[2].content, content="engine error")
@@ -1215,7 +1111,7 @@ test "transcript mapping keeps summaries and background notices" {
   inspect(items.length(), content="2")
   guard items[0].kind is Summary else { fail("expected summary") }
   guard items[1].kind
-    is Tool(name="runtime notice", arguments=None, is_error=false, ..) else {
+    is Notice(label="runtime notice", brief=None, is_error=false) else {
     fail("expected runtime notice row")
   }
   inspect(items[1].content, content="background job bg-1 finished (exit=0)")
@@ -1231,14 +1127,14 @@ test "transcript mapping renders goal markers as cards and reduces the standing 
   let view = session_from_reply(session_reply(events))
   inspect(view.items.length(), content="2")
   guard view.items[0].kind
-    is Tool(name="goal", is_error=false, brief=Some(set_brief), ..) else {
+    is Notice(label="goal", is_error=false, brief=Some(set_brief)) else {
     fail("expected the set card")
   }
   inspect(set_brief, content="Goal set: ship the feature")
   // A single-line goal is fully carried by its brief; no expandable body.
   inspect(view.items[0].content, content="")
   guard view.items[1].kind
-    is Tool(name="goal", is_error=true, brief=Some(blocked_brief), ..) else {
+    is Notice(label="goal", is_error=true, brief=Some(blocked_brief)) else {
     fail("expected the blocked card")
   }
   inspect(blocked_brief, content="Goal blocked: needs a decision")
@@ -1270,7 +1166,7 @@ test "transcript mapping drops the plan reminder instead of carding it" {
   let items = transcript_from_session(session_reply(events))
   inspect(items.length(), content="1")
   guard items[0].kind
-    is Tool(name="runtime notice", arguments=None, is_error=false, ..) else {
+    is Notice(label="runtime notice", brief=None, is_error=false) else {
     fail("expected only the runtime notice row")
   }
   inspect(items[0].content, content="background job bg-2 finished (exit=1)")
@@ -1283,7 +1179,7 @@ test "a cleared goal leaves cards but no standing goal" {
     #|{"sequence":2,"item":{"kind":"runtime_notice","payload":{"content":"[goal cleared]"}}}
   let view = session_from_reply(session_reply(events))
   inspect(view.items.length(), content="2")
-  guard view.items[0].kind is Tool(name="goal", brief=Some(set_brief), ..) else {
+  guard view.items[0].kind is Notice(label="goal", brief=Some(set_brief), ..) else {
     fail("expected the set card")
   }
   // A multi-line goal folds to its first line and expands to the full text.
@@ -1295,7 +1191,7 @@ test "a cleared goal leaves cards but no standing goal" {
       #|line two
     ),
   )
-  guard view.items[1].kind is Tool(name="goal", brief=Some(cleared), ..) else {
+  guard view.items[1].kind is Notice(label="goal", brief=Some(cleared), ..) else {
     fail("expected the cleared card")
   }
   inspect(cleared, content="Goal cleared")
@@ -1311,9 +1207,7 @@ test "transcript mapping replays a context checkpoint and yield guidance" {
   inspect(items.length(), content="2")
   guard items[0].kind is Summary else { fail("expected checkpoint summary") }
   inspect(items[0].content, content="checkpoint recap")
-  guard items[1].kind is TerminalAnswer else {
-    fail("expected context-yield guidance")
-  }
+  guard items[1].kind is Answer else { fail("expected context-yield guidance") }
   inspect(items[1].content, content="[context ceiling] continue in a new turn")
 }
 

--- a/desktop/frontend/transcript/sessions.mbt
+++ b/desktop/frontend/transcript/sessions.mbt
@@ -338,7 +338,7 @@ pub fn apply_session_item(
     @desktop_protocol.User(payload) => {
       let content = payload.content.trim().to_owned()
       if !content.is_empty() {
-        items.push({ kind: User, content, ts, sequence, })
+        items.push({ kind: User(content), ts, sequence, })
       }
     }
     @desktop_protocol.Assistant(payload) => {
@@ -354,7 +354,12 @@ pub fn apply_session_item(
       } else {
         None
       }
-      let content = payload.content.trim().to_owned()
+      // The store writes an empty string for a response that said nothing.
+      let prose = if payload.content.is_blank() {
+        None
+      } else {
+        Some(payload.content.trim().to_owned())
+      }
       // Tool calls stay in the exact order the model emitted them. Their
       // results arrive as later durable events and fill them in by id.
       let calls : Array[ToolCall] = []
@@ -367,16 +372,18 @@ pub fn apply_session_item(
             call.name
           },
           arguments: Some(call.arguments),
-          has_result: false,
-          is_error: false,
-          brief: None,
-          content: "",
+          outcome: Pending(output=None),
         })
       }
-      if reasoning is Some(_) || !content.is_empty() || !calls.is_empty() {
+      if reasoning is Some(_) || prose is Some(_) || !calls.is_empty() {
         items.push({
-          kind: Assistant(reasoning~, calls~, replay=is_replay, finished=false),
-          content,
+          kind: Assistant(
+            reasoning~,
+            prose~,
+            calls~,
+            replay=is_replay,
+            finished=false,
+          ),
           ts,
           sequence,
         })
@@ -391,11 +398,11 @@ pub fn apply_session_item(
       while index > 0 {
         index -= 1
         guard items[index].kind
-          is Assistant(reasoning~, calls~, replay~, finished~) else {
+          is Assistant(reasoning~, prose~, calls~, replay~, finished~) else {
           continue
         }
         guard calls.search_by(call => {
-            call.call_id == payload.tool_call_id && !call.has_result
+            call.call_id == payload.tool_call_id && call.outcome is Pending(..)
           })
           is Some(position) else {
           continue
@@ -411,14 +418,15 @@ pub fn apply_session_item(
           } else {
             payload.tool_name
           },
-          has_result: true,
-          is_error: payload.is_error,
-          brief: payload.brief,
-          content: payload.content,
+          outcome: Done(
+            content=payload.content,
+            is_error=payload.is_error,
+            brief=payload.brief,
+          ),
         }
         items[index] = {
           ..items[index],
-          kind: Assistant(reasoning~, calls=filled, replay~, finished~),
+          kind: Assistant(reasoning~, prose~, calls=filled, replay~, finished~),
         }
         updated_existing = true
         break
@@ -437,8 +445,8 @@ pub fn apply_session_item(
                 label="goal",
                 brief=Some(goal_brief("Goal set", text)),
                 is_error=false,
+                body=goal_body(text),
               ),
-              content: goal_body(text),
               ts,
               sequence,
             })
@@ -448,8 +456,8 @@ pub fn apply_session_item(
                 label="goal",
                 brief=Some("Goal cleared"),
                 is_error=false,
+                body=None,
               ),
-              content: "",
               ts,
               sequence,
             })
@@ -459,8 +467,8 @@ pub fn apply_session_item(
                 label="goal",
                 brief=Some(goal_brief("Goal blocked", reason)),
                 is_error=true,
+                body=goal_body(reason),
               ),
-              content: goal_body(reason),
               ts,
               sequence,
             })
@@ -470,8 +478,8 @@ pub fn apply_session_item(
                 label="goal",
                 brief=Some("Goal resumed"),
                 is_error=false,
+                body=None,
               ),
-              content: "",
               ts,
               sequence,
             })
@@ -484,8 +492,12 @@ pub fn apply_session_item(
                 // Runtime notices keep the compact completed-result row used
                 // by the old projection, but the generic label no longer
                 // claims every background event came from `moon_check`.
-                kind: Notice(label="runtime notice", brief=None, is_error=false),
-                content: payload.content,
+                kind: Notice(
+                  label="runtime notice",
+                  brief=None,
+                  is_error=false,
+                  body=Some(payload.content),
+                ),
                 ts,
                 sequence,
               })
@@ -495,7 +507,7 @@ pub fn apply_session_item(
     @desktop_protocol.Summary(payload) => {
       let content = payload.content.trim().to_owned()
       if !content.is_empty() {
-        items.push({ kind: Summary, content, ts, sequence, })
+        items.push({ kind: Summary(content), ts, sequence, })
       }
     }
     @desktop_protocol.Terminal(terminal) =>
@@ -536,29 +548,42 @@ fn SessionTerminalProjection::append_to(
       if !message.is_empty() &&
         items is [.., last] &&
         last.kind
-        is Assistant(reasoning~, calls=[], replay=false, finished=false) &&
-        last.content == message {
+        is Assistant(
+          reasoning~,
+          prose=Some(prose),
+          calls=[],
+          replay=false,
+          finished=false
+        ) &&
+        prose == message {
         items[items.length() - 1] = {
           ..last,
-          kind: Assistant(reasoning~, calls=[], replay=false, finished=true),
+          kind: Assistant(
+            reasoning~,
+            prose=Some(prose),
+            calls=[],
+            replay=false,
+            finished=true,
+          ),
         }
         true
       } else {
         if !message.is_empty() {
           // A differing terminal message, such as a completion-tool answer,
           // remains a new final bubble.
-          items.push({ kind: Answer, content: message, ts, sequence, })
+          items.push({ kind: Answer(message), ts, sequence, })
         }
         false
       }
     "aborted" => {
       items.push({
-        kind: Failure,
-        content: if message.is_empty() {
-          "aborted"
-        } else {
-          "aborted: \{message}"
-        },
+        kind: Failure(
+          if message.is_empty() {
+            "aborted"
+          } else {
+            "aborted: \{message}"
+          },
+        ),
         ts,
         sequence,
       })
@@ -566,12 +591,13 @@ fn SessionTerminalProjection::append_to(
     }
     "interrupted" => {
       items.push({
-        kind: Failure,
-        content: if message.is_empty() {
-          "cancelled"
-        } else {
-          "cancelled: \{message}"
-        },
+        kind: Failure(
+          if message.is_empty() {
+            "cancelled"
+          } else {
+            "cancelled: \{message}"
+          },
+        ),
         ts,
         sequence,
       })
@@ -579,12 +605,7 @@ fn SessionTerminalProjection::append_to(
     }
     "failed" => {
       items.push({
-        kind: Failure,
-        content: if message.is_empty() {
-          "failed"
-        } else {
-          message
-        },
+        kind: Failure(if message.is_empty() { "failed" } else { message }),
         ts,
         sequence,
       })
@@ -606,13 +627,13 @@ fn goal_brief(label : String, text : String) -> String {
 }
 
 ///|
-/// A single-line goal is fully carried by its brief — an empty body keeps
-/// the card a plain label instead of an expandable fold around a duplicate.
-fn goal_body(text : String) -> String {
+/// A single-line goal is fully carried by its brief — with no body the card
+/// stays a plain label instead of an expandable fold around a duplicate.
+fn goal_body(text : String) -> String? {
   if text.contains("\n") {
-    text
+    Some(text)
   } else {
-    ""
+    None
   }
 }
 
@@ -925,8 +946,7 @@ test "projected rows carry their event's stamp, tool rows the call's own" {
   guard items[1].kind is Assistant(calls=[call], ..) else {
     fail("expected the response with its one call")
   }
-  assert_true(call.has_result)
-  inspect(call.content, content="out")
+  assert_true(call.outcome is Done(content="out", ..))
   assert_true(items[1].ts is Some(1781144352000))
   assert_true(items[1].sequence is Some(2))
 }
@@ -960,8 +980,8 @@ test "session load keeps unknown items without hiding known transcript" {
   let view = session_from_reply(reply)
   inspect(view.watermark, content="3")
   inspect(view.items.length(), content="2")
-  inspect(view.items[0].content, content="question")
-  inspect(view.items[1].content, content="answer")
+  assert_eq(view.items[0].text(), Some("question"))
+  assert_eq(view.items[1].text(), Some("answer"))
 }
 
 ///|
@@ -986,14 +1006,20 @@ test "transcript mapping replays a finished conversation" {
   let items = transcript_from_session(session_reply(events))
   // The result at sequence 2 answers no recorded call and is dropped.
   inspect(items.length(), content="2")
-  guard items[0].kind is User else { fail("expected user item") }
-  inspect(items[0].content, content="question")
+  guard items[0].kind is User(_) else { fail("expected user item") }
+  assert_eq(items[0].text(), Some("question"))
   guard items[1].kind
-    is Assistant(reasoning=Some(thought), calls=[], replay=false, finished=true) else {
+    is Assistant(
+      reasoning=Some(thought),
+      prose=Some(_),
+      calls=[],
+      replay=false,
+      finished=true
+    ) else {
     fail("expected the terminal-confirmed answer with its reasoning")
   }
   inspect(thought, content="thought")
-  inspect(items[1].content, content="answer")
+  assert_eq(items[1].text(), Some("answer"))
   // The confirming terminal leaves the response its own stamp and sequence.
   assert_true(items[1].ts is Some(1000))
   assert_true(items[1].sequence is Some(3))
@@ -1012,12 +1038,12 @@ test "a finished turn marks only its last assistant message as final" {
   guard items[1].kind is Assistant(calls=[call], finished=false, ..) else {
     fail("expected tool-prefacing narration to stay non-final")
   }
-  inspect(items[1].content, content="I will inspect it.")
-  assert_true(call.has_result)
+  assert_eq(items[1].text(), Some("I will inspect it."))
+  assert_true(call.outcome is Done(..))
   guard items[2].kind is Assistant(calls=[], finished=true, ..) else {
     fail("expected only the last answer to be terminal-confirmed")
   }
-  inspect(items[2].content, content="Done.")
+  assert_eq(items[2].text(), Some("Done."))
   assert_true(items[2].ts is Some(2000))
 }
 
@@ -1030,7 +1056,7 @@ test "checkpoint assistant provenance projects without duplicate reasoning" {
   guard items[0].kind is Assistant(reasoning=None, replay=true, ..) else {
     fail("expected a checkpoint replay without its reasoning")
   }
-  inspect(items[0].content, content="kept answer")
+  assert_eq(items[0].text(), Some("kept answer"))
 }
 
 ///|
@@ -1048,16 +1074,21 @@ test "tool results fill calls by id without changing call order" {
   inspect(read.call_id, content="c1")
   inspect(read.name, content="read")
   assert_true(read.arguments is Some("{\"path\":\"moon.mod\"}"))
-  assert_true(read.has_result)
-  assert_false(read.is_error)
-  assert_true(read.brief is Some("read moon.mod"))
-  inspect(read.content, content="module contents")
+  assert_true(
+    read.outcome
+    is Done(
+      content="module contents",
+      is_error=false,
+      brief=Some("read moon.mod")
+    ),
+  )
   inspect(shell.call_id, content="c2")
   inspect(shell.name, content="shell")
   assert_true(shell.arguments is Some("{\"cmd\":\"moon test\"}"))
-  assert_true(shell.has_result)
-  assert_true(shell.brief is Some("ran moon test"))
-  inspect(shell.content, content="tests passed")
+  assert_true(
+    shell.outcome
+    is Done(content="tests passed", is_error=false, brief=Some("ran moon test")),
+  )
 }
 
 ///|
@@ -1074,8 +1105,7 @@ test "a result no recorded call is waiting for changes nothing" {
   guard items[0].kind is Assistant(calls=[call], ..) else {
     fail("expected the recorded call with its first result")
   }
-  assert_true(call.has_result)
-  inspect(call.content, content="one")
+  assert_true(call.outcome is Done(content="one", ..))
 }
 
 ///|
@@ -1095,10 +1125,10 @@ test "transcript mapping renders non-finished terminals as error bubbles" {
     #|{"sequence":3,"item":{"kind":"terminal","payload":{"kind":"failed","message":"engine error"}}}
   let items = transcript_from_session(session_reply(events))
   inspect(items.length(), content="3")
-  guard items[0].kind is Failure else { fail("expected error bubble") }
-  inspect(items[0].content, content="cancelled")
-  inspect(items[1].content, content="aborted: the agent gave up")
-  inspect(items[2].content, content="engine error")
+  guard items[0].kind is Failure(_) else { fail("expected error bubble") }
+  assert_eq(items[0].text(), Some("cancelled"))
+  assert_eq(items[1].text(), Some("aborted: the agent gave up"))
+  assert_eq(items[2].text(), Some("engine error"))
 }
 
 ///|
@@ -1109,12 +1139,12 @@ test "transcript mapping keeps summaries and background notices" {
     #|{"sequence":3,"item":{"kind":"runtime_notice","payload":{"content":""}}}
   let items = transcript_from_session(session_reply(events))
   inspect(items.length(), content="2")
-  guard items[0].kind is Summary else { fail("expected summary") }
+  guard items[0].kind is Summary(_) else { fail("expected summary") }
   guard items[1].kind
-    is Notice(label="runtime notice", brief=None, is_error=false) else {
+    is Notice(label="runtime notice", brief=None, is_error=false, ..) else {
     fail("expected runtime notice row")
   }
-  inspect(items[1].content, content="background job bg-1 finished (exit=0)")
+  assert_eq(items[1].text(), Some("background job bg-1 finished (exit=0)"))
 }
 
 ///|
@@ -1127,14 +1157,14 @@ test "transcript mapping renders goal markers as cards and reduces the standing 
   let view = session_from_reply(session_reply(events))
   inspect(view.items.length(), content="2")
   guard view.items[0].kind
-    is Notice(label="goal", is_error=false, brief=Some(set_brief)) else {
+    is Notice(label="goal", is_error=false, brief=Some(set_brief), ..) else {
     fail("expected the set card")
   }
   inspect(set_brief, content="Goal set: ship the feature")
   // A single-line goal is fully carried by its brief; no expandable body.
-  inspect(view.items[0].content, content="")
+  assert_true(view.items[0].text() is None)
   guard view.items[1].kind
-    is Notice(label="goal", is_error=true, brief=Some(blocked_brief)) else {
+    is Notice(label="goal", is_error=true, brief=Some(blocked_brief), ..) else {
     fail("expected the blocked card")
   }
   inspect(blocked_brief, content="Goal blocked: needs a decision")
@@ -1166,10 +1196,10 @@ test "transcript mapping drops the plan reminder instead of carding it" {
   let items = transcript_from_session(session_reply(events))
   inspect(items.length(), content="1")
   guard items[0].kind
-    is Notice(label="runtime notice", brief=None, is_error=false) else {
+    is Notice(label="runtime notice", brief=None, is_error=false, ..) else {
     fail("expected only the runtime notice row")
   }
-  inspect(items[0].content, content="background job bg-2 finished (exit=1)")
+  assert_eq(items[0].text(), Some("background job bg-2 finished (exit=1)"))
 }
 
 ///|
@@ -1184,8 +1214,11 @@ test "a cleared goal leaves cards but no standing goal" {
   }
   // A multi-line goal folds to its first line and expands to the full text.
   inspect(set_brief, content="Goal set: line one …")
+  guard view.items[0].text() is Some(body) else {
+    fail("expected the full goal text as the card's body")
+  }
   inspect(
-    view.items[0].content,
+    body,
     content=(
       #|line one
       #|line two
@@ -1205,10 +1238,12 @@ test "transcript mapping replays a context checkpoint and yield guidance" {
     #|{"sequence":2,"item":{"kind":"terminal","payload":{"kind":"finished","message":"[context ceiling] continue in a new turn"}}}
   let items = transcript_from_session(session_reply(events))
   inspect(items.length(), content="2")
-  guard items[0].kind is Summary else { fail("expected checkpoint summary") }
-  inspect(items[0].content, content="checkpoint recap")
-  guard items[1].kind is Answer else { fail("expected context-yield guidance") }
-  inspect(items[1].content, content="[context ceiling] continue in a new turn")
+  guard items[0].kind is Summary(_) else { fail("expected checkpoint summary") }
+  assert_eq(items[0].text(), Some("checkpoint recap"))
+  guard items[1].kind is Answer(_) else {
+    fail("expected context-yield guidance")
+  }
+  assert_eq(items[1].text(), Some("[context ceiling] continue in a new turn"))
 }
 
 ///|

--- a/desktop/frontend/transcript/types.mbt
+++ b/desktop/frontend/transcript/types.mbt
@@ -4,21 +4,25 @@
 // construct and consume them freely, so the types are fully public.
 
 ///|
-/// What one transcript item is. An item is one durable session event (or one
-/// client-local bubble) kept in the shape the event had: a provider response
-/// stays one `Assistant` item carrying its reasoning and tool calls, so the
-/// view never has to reassemble a model step from adjacent rows.
+/// What one transcript item is, text included. An item is one durable session
+/// event (or one client-local bubble) kept in the shape the event had: a
+/// provider response stays one `Assistant` item carrying its reasoning and
+/// tool calls, so the view never has to reassemble a model step from adjacent
+/// rows. Each kind carries only the text it can have, so a part that may be
+/// absent (a response's prose, a notice's body) is an option, never an empty
+/// string.
 pub(all) enum ItemKind {
-  User
-  // One provider response. The item's `content` is the visible prose, empty
-  // for a tool-only response; `reasoning` is the thinking that preceded it
-  // and `calls` the tool calls that followed it, in the model's own order.
+  User(String)
+  // One provider response. `reasoning` is the thinking that preceded the
+  // prose, `prose` what the model said (absent for a tool-only response), and
+  // `calls` the tool calls that followed it, in the model's own order.
   // `replay` marks a checkpoint copy of an answer an earlier response already
   // owns: it renders as prose but never counts as a model step. `finished`
   // marks the answer a durable Finished terminal confirmed as the turn's
   // final one, which is what earns it the copy action and completion stamp.
   Assistant(
     reasoning~ : String?,
+    prose~ : String?,
     calls~ : Array[ToolCall],
     replay~ : Bool,
     finished~ : Bool
@@ -26,45 +30,48 @@ pub(all) enum ItemKind {
   // A turn's final answer carried by a Finished terminal whose text is not
   // the preceding response's prose: a completion-tool answer, or the
   // context-ceiling guidance.
-  Answer
+  Answer(String)
   // A turn that ended without an answer — an abort/cancel/failure terminal —
   // or a notice the frontend raised itself. It wears the assistant's bubble
   // but renders as plain red text, never markdown: an error's own `*` and
   // `#` are not formatting.
-  Failure
+  Failure(String)
   // A durable runtime notice with a display presence: a goal marker, or an
   // engine notice injected between turns. `label` names the family (`goal`,
   // `runtime notice`), `brief` is the one-line caption a notice folds to,
-  // and `is_error` marks a blocked goal. The item's `content` is the body a
-  // multi-line notice expands to.
-  Notice(label~ : String, brief~ : String?, is_error~ : Bool)
-  // A compaction checkpoint: the turns before it were summarized into the
-  // item's content and dropped from the context. Its own kind so the view
-  // renders it as a standalone card between turns.
-  Summary
+  // `is_error` marks a blocked goal, and `body` is what a multi-line notice
+  // expands to.
+  Notice(label~ : String, brief~ : String?, is_error~ : Bool, body~ : String?)
+  // A compaction checkpoint: the turns before it were summarized into this
+  // text and dropped from the context. Its own kind so the view renders it
+  // as a standalone card between turns.
+  Summary(String)
 } derive(Eq)
 
 ///|
 /// One tool call of a provider response, in its original order. `call_id`
-/// pairs the later durable result into this same call. `arguments` is what
-/// the model sent; a Codex file change can carry none. `has_result`
-/// distinguishes a pending call from a completed one even when the result has
-/// empty content, `is_error=false`, and no brief. `content` is the result's
-/// output — or, for a Codex command still running, the output streamed so far.
+/// pairs the later durable result into this same call; `arguments` is what
+/// the model sent (a Codex file change can carry none).
 pub(all) struct ToolCall {
   call_id : String
   name : String
   arguments : String?
-  has_result : Bool
-  is_error : Bool
-  brief : String?
-  content : String
+  outcome : ToolOutcome
+} derive(Eq)
+
+///|
+/// Where a tool call stands. A call is `Pending` until its durable result
+/// lands; a Codex command can stream `output` while still pending. `Done`
+/// carries the result — its content may legitimately be empty — with the
+/// error flag and the display brief the result came with.
+pub(all) enum ToolOutcome {
+  Pending(output~ : String?)
+  Done(content~ : String, is_error~ : Bool, brief~ : String?)
 } derive(Eq)
 
 ///|
 pub(all) struct TranscriptItem {
   kind : ItemKind
-  content : String
   // When the durable event that produced this item was committed (unix
   // milliseconds, as the store stamps it). `None` for a client-local bubble
   // that never became a durable event, and for records written before the
@@ -75,6 +82,18 @@ pub(all) struct TranscriptItem {
   // item's stable identity.
   sequence : Int?
 } derive(Eq)
+
+///|
+/// The item's own text, when it has one: a user prompt, a response's prose,
+/// an answer, a failure, a notice body, or a summary. A response that only
+/// thought or only called tools has none.
+pub fn TranscriptItem::text(self : TranscriptItem) -> String? {
+  match self.kind {
+    User(text) | Answer(text) | Failure(text) | Summary(text) => Some(text)
+    Assistant(prose~, ..) => prose
+    Notice(body~, ..) => body
+  }
+}
 
 ///|
 /// One sidebar entry from the engine's durable session list: the session id
@@ -100,6 +119,9 @@ pub extend ItemKind with Eq::{equal, not_equal}
 
 ///|
 pub extend ToolCall with Eq::{equal, not_equal}
+
+///|
+pub extend ToolOutcome with Eq::{equal, not_equal}
 
 ///|
 pub extend SessionListItem with Eq::{equal, not_equal}

--- a/desktop/frontend/transcript/types.mbt
+++ b/desktop/frontend/transcript/types.mbt
@@ -4,42 +4,61 @@
 // construct and consume them freely, so the types are fully public.
 
 ///|
+/// What one transcript item is. An item is one durable session event (or one
+/// client-local bubble) kept in the shape the event had: a provider response
+/// stays one `Assistant` item carrying its reasoning and tool calls, so the
+/// view never has to reassemble a model step from adjacent rows.
 pub(all) enum ItemKind {
   User
-  // Something the agent said. `is_danger` marks the ones that aren't a reply
-  // at all — an abort/cancel/failure terminal, or a notice the frontend
-  // raised itself. They wear the assistant's bubble but render as plain red
-  // text, never markdown: an error's own `*` and `#` are not formatting.
-  Assistant(is_danger~ : Bool)
-  // A durable checkpoint copy of an answer already owned by an earlier model
-  // step. It renders as normal assistant prose but never starts another step.
-  AssistantReplay
-  // The final visible answer confirmed by a durable Finished terminal. The
-  // terminal may carry new text or confirm that the preceding Assistant text
-  // is final; either shape becomes this kind so the view can distinguish a
-  // turn-ending answer from tool-prefacing assistant narration.
-  TerminalAnswer
-  Reasoning
-  // One tool call in its original assistant-message order. `call_id` pairs the
-  // later durable result into this same item instead of adding a second row;
-  // `arguments` is `Some` for a recorded call and `None` for an unmatched
-  // legacy result or a synthetic runtime notice. `has_result` distinguishes a
-  // pending call from a completed call even when the legitimate result has
-  // empty content, `is_error=false`, and no brief.
-  Tool(
-    call_id~ : String,
-    name~ : String,
-    arguments~ : String?,
-    has_result~ : Bool,
-    is_error~ : Bool,
-    brief~ : String?
+  // One provider response. The item's `content` is the visible prose, empty
+  // for a tool-only response; `reasoning` is the thinking that preceded it
+  // and `calls` the tool calls that followed it, in the model's own order.
+  // `replay` marks a checkpoint copy of an answer an earlier response already
+  // owns: it renders as prose but never counts as a model step. `finished`
+  // marks the answer a durable Finished terminal confirmed as the turn's
+  // final one, which is what earns it the copy action and completion stamp.
+  Assistant(
+    reasoning~ : String?,
+    calls~ : Array[ToolCall],
+    replay~ : Bool,
+    finished~ : Bool
   )
+  // A turn's final answer carried by a Finished terminal whose text is not
+  // the preceding response's prose: a completion-tool answer, or the
+  // context-ceiling guidance.
+  Answer
+  // A turn that ended without an answer — an abort/cancel/failure terminal —
+  // or a notice the frontend raised itself. It wears the assistant's bubble
+  // but renders as plain red text, never markdown: an error's own `*` and
+  // `#` are not formatting.
+  Failure
+  // A durable runtime notice with a display presence: a goal marker, or an
+  // engine notice injected between turns. `label` names the family (`goal`,
+  // `runtime notice`), `brief` is the one-line caption a notice folds to,
+  // and `is_error` marks a blocked goal. The item's `content` is the body a
+  // multi-line notice expands to.
+  Notice(label~ : String, brief~ : String?, is_error~ : Bool)
   // A compaction checkpoint: the turns before it were summarized into the
   // item's content and dropped from the context. Its own kind so the view
-  // renders it as a standalone card — batched into a turn's activity it
-  // would read as an anonymous tool call row and swallow the preceding
-  // answer bubble into the step's group.
+  // renders it as a standalone card between turns.
   Summary
+} derive(Eq)
+
+///|
+/// One tool call of a provider response, in its original order. `call_id`
+/// pairs the later durable result into this same call. `arguments` is what
+/// the model sent; a Codex file change can carry none. `has_result`
+/// distinguishes a pending call from a completed one even when the result has
+/// empty content, `is_error=false`, and no brief. `content` is the result's
+/// output — or, for a Codex command still running, the output streamed so far.
+pub(all) struct ToolCall {
+  call_id : String
+  name : String
+  arguments : String?
+  has_result : Bool
+  is_error : Bool
+  brief : String?
+  content : String
 } derive(Eq)
 
 ///|
@@ -51,10 +70,9 @@ pub(all) struct TranscriptItem {
   // that never became a durable event, and for records written before the
   // store stamped them — the view simply shows no time for those.
   ts : Double?
-  // The durable event sequence this row came from, `None` for a client-local
-  // row. One event can append several rows (reasoning, answer, tool calls),
-  // which then share its sequence — but at most one of them is a User row,
-  // so the sequence is a stable identity for a user turn.
+  // The durable event sequence this item came from, `None` for a client-local
+  // item. One event projects to at most one item, so the sequence is the
+  // item's stable identity.
   sequence : Int?
 } derive(Eq)
 
@@ -79,6 +97,9 @@ pub(all) struct SessionListItem {
 
 ///|
 pub extend ItemKind with Eq::{equal, not_equal}
+
+///|
+pub extend ToolCall with Eq::{equal, not_equal}
 
 ///|
 pub extend SessionListItem with Eq::{equal, not_equal}

--- a/desktop/frontend/transcript_overview/transcript_overview_test.mbt
+++ b/desktop/frontend/transcript_overview/transcript_overview_test.mbt
@@ -4,19 +4,19 @@
 ///|
 fn item(
   kind : @transcript.ItemKind,
-  content : String,
   sequence? : Int,
 ) -> @transcript.TranscriptItem {
-  { kind, content, ts: None, sequence, }
+  { kind, ts: None, sequence, }
 }
 
 ///|
 /// A provider response: prose alone unless it thought or called tools.
 fn response(
   reasoning? : String,
+  prose? : String,
   calls? : Array[@transcript.ToolCall] = [],
 ) -> @transcript.ItemKind {
-  Assistant(reasoning~, calls~, replay=false, finished=false)
+  Assistant(reasoning~, prose~, calls~, replay=false, finished=false)
 }
 
 ///|
@@ -25,14 +25,11 @@ fn shell_call(is_error : Bool) -> @transcript.ToolCall {
     call_id: "c1",
     name: "shell",
     arguments: Some("{}"),
-    has_result: true,
-    is_error,
-    brief: None,
-    content: if is_error {
-      "boom"
-    } else {
-      "fine"
-    },
+    outcome: Done(
+      content=if is_error { "boom" } else { "fine" },
+      is_error~,
+      brief=None,
+    ),
   }
 }
 
@@ -40,18 +37,17 @@ fn shell_call(is_error : Bool) -> @transcript.ToolCall {
 test "entries pick user turns and pair each with its first answer" {
   let rows = @transcript_overview.entries(
     [
-      item(User, "first question", sequence=1),
+      item(User("first question"), sequence=1),
       // A response that only thought and read is not an answer yet.
       item(
         response(reasoning="thinking", calls=[
           { ..shell_call(false), name: "read", },
         ]),
-        "",
         sequence=2,
       ),
-      item(response(), "first answer", sequence=3),
-      item(response(), "afterthought", sequence=4),
-      item(User, "second question", sequence=5),
+      item(response(prose="first answer"), sequence=3),
+      item(response(prose="afterthought"), sequence=4),
+      item(User("second question"), sequence=5),
     ],
     display=text => text,
   )
@@ -69,15 +65,15 @@ test "entries pick user turns and pair each with its first answer" {
 test "a turn marks failed for any tool error it contains, answered or not" {
   let rows = @transcript_overview.entries(
     [
-      item(User, "first question", sequence=1),
-      item(response(calls=[shell_call(true)]), "", sequence=2),
-      item(response(), "recovered", sequence=3),
+      item(User("first question"), sequence=1),
+      item(response(calls=[shell_call(true)]), sequence=2),
+      item(response(prose="recovered"), sequence=3),
       // A failure after the answer is still this turn's failure: the reply
       // search stops at the first answer, the failure scan must not.
-      item(response(calls=[shell_call(true)]), "", sequence=4),
-      item(User, "second question", sequence=5),
-      item(response(calls=[shell_call(false)]), "", sequence=6),
-      item(response(), "done", sequence=7),
+      item(response(calls=[shell_call(true)]), sequence=4),
+      item(User("second question"), sequence=5),
+      item(response(calls=[shell_call(false)]), sequence=6),
+      item(response(prose="done"), sequence=7),
     ],
     display=text => text,
   )
@@ -88,8 +84,8 @@ test "a turn marks failed for any tool error it contains, answered or not" {
   // The scan stops at the next prompt: turn one's failures are not turn two's.
   let single = @transcript_overview.entries(
     [
-      item(User, "question", sequence=1),
-      item(response(calls=[shell_call(true)]), "", sequence=2),
+      item(User("question"), sequence=1),
+      item(response(calls=[shell_call(true)]), sequence=2),
     ],
     display=text => text,
   )
@@ -97,10 +93,14 @@ test "a turn marks failed for any tool error it contains, answered or not" {
   // A blocked goal is the turn's failure too.
   let blocked = @transcript_overview.entries(
     [
-      item(User, "question", sequence=1),
+      item(User("question"), sequence=1),
       item(
-        Notice(label="goal", brief=Some("Goal blocked: why"), is_error=true),
-        "",
+        Notice(
+          label="goal",
+          brief=Some("Goal blocked: why"),
+          is_error=true,
+          body=None,
+        ),
         sequence=2,
       ),
     ],
@@ -112,7 +112,7 @@ test "a turn marks failed for any tool error it contains, answered or not" {
 ///|
 test "an abort bubble is the answer a turn got" {
   let rows = @transcript_overview.entries(
-    [item(User, "question", sequence=1), item(Failure, "aborted", sequence=2)],
+    [item(User("question"), sequence=1), item(Failure("aborted"), sequence=2)],
     display=text => text,
   )
   @debug.assert_eq(rows[0].reply, Some("aborted"))
@@ -122,8 +122,8 @@ test "an abort bubble is the answer a turn got" {
 test "a terminal-carried final is the answer a turn got" {
   let rows = @transcript_overview.entries(
     [
-      item(User, "question", sequence=1),
-      item(Answer, "final answer", sequence=2),
+      item(User("question"), sequence=1),
+      item(Answer("final answer"), sequence=2),
     ],
     display=text => text,
   )
@@ -133,7 +133,7 @@ test "a terminal-carried final is the answer a turn got" {
 ///|
 test "a row without a sequence keys by its position" {
   let rows = @transcript_overview.entries(
-    [item(response(), "notice"), item(User, "local bubble")],
+    [item(response(prose="notice")), item(User("local bubble"))],
     display=text => text,
   )
   inspect(rows.length(), content="1")
@@ -143,7 +143,7 @@ test "a row without a sequence keys by its position" {
 ///|
 test "the display projection owns the prompt's shown form" {
   let rows = @transcript_overview.entries(
-    [item(User, "raw envelope", sequence=1)],
+    [item(User("raw envelope"), sequence=1)],
     display=_ => "typed text $skill",
   )
   inspect(rows[0].text, content="typed text $skill")

--- a/desktop/frontend/transcript_overview/transcript_overview_test.mbt
+++ b/desktop/frontend/transcript_overview/transcript_overview_test.mbt
@@ -11,62 +11,73 @@ fn item(
 }
 
 ///|
+/// A provider response: prose alone unless it thought or called tools.
+fn response(
+  reasoning? : String,
+  calls? : Array[@transcript.ToolCall] = [],
+) -> @transcript.ItemKind {
+  Assistant(reasoning~, calls~, replay=false, finished=false)
+}
+
+///|
+fn shell_call(is_error : Bool) -> @transcript.ToolCall {
+  {
+    call_id: "c1",
+    name: "shell",
+    arguments: Some("{}"),
+    has_result: true,
+    is_error,
+    brief: None,
+    content: if is_error {
+      "boom"
+    } else {
+      "fine"
+    },
+  }
+}
+
+///|
 test "entries pick user turns and pair each with its first answer" {
   let rows = @transcript_overview.entries(
     [
       item(User, "first question", sequence=1),
-      item(Reasoning, "thinking", sequence=2),
+      // A response that only thought and read is not an answer yet.
       item(
-        Tool(
-          call_id="c1",
-          name="read",
-          arguments=None,
-          has_result=true,
-          is_error=false,
-          brief=None,
-        ),
+        response(reasoning="thinking", calls=[
+          { ..shell_call(false), name: "read", },
+        ]),
         "",
         sequence=2,
       ),
-      item(Assistant(is_danger=false), "first answer", sequence=2),
-      item(Assistant(is_danger=false), "afterthought", sequence=3),
-      item(User, "second question", sequence=4),
+      item(response(), "first answer", sequence=3),
+      item(response(), "afterthought", sequence=4),
+      item(User, "second question", sequence=5),
     ],
     display=text => text,
   )
   inspect(rows.length(), content="2")
   @debug.assert_eq(rows[0].key, @transcript_overview.Durable(1))
   inspect(rows[0].text, content="first question")
-  // The first assistant row answers the turn; the afterthought does not
-  // replace it, and the open second turn has no answer yet.
+  // The first prose answers the turn; the afterthought does not replace it,
+  // and the open second turn has no answer yet.
   @debug.assert_eq(rows[0].reply, Some("first answer"))
-  @debug.assert_eq(rows[1].key, @transcript_overview.Durable(4))
+  @debug.assert_eq(rows[1].key, @transcript_overview.Durable(5))
   @debug.assert_eq(rows[1].reply, None)
 }
 
 ///|
 test "a turn marks failed for any tool error it contains, answered or not" {
-  let tool = is_error => {
-    @transcript.ItemKind::Tool(
-      call_id="c1",
-      name="shell",
-      arguments=None,
-      has_result=true,
-      is_error~,
-      brief=None,
-    )
-  }
   let rows = @transcript_overview.entries(
     [
       item(User, "first question", sequence=1),
-      item(tool(true), "boom", sequence=2),
-      item(Assistant(is_danger=false), "recovered", sequence=3),
+      item(response(calls=[shell_call(true)]), "", sequence=2),
+      item(response(), "recovered", sequence=3),
       // A failure after the answer is still this turn's failure: the reply
       // search stops at the first answer, the failure scan must not.
-      item(tool(true), "boom again", sequence=4),
+      item(response(calls=[shell_call(true)]), "", sequence=4),
       item(User, "second question", sequence=5),
-      item(tool(false), "fine", sequence=6),
-      item(Assistant(is_danger=false), "done", sequence=7),
+      item(response(calls=[shell_call(false)]), "", sequence=6),
+      item(response(), "done", sequence=7),
     ],
     display=text => text,
   )
@@ -76,19 +87,32 @@ test "a turn marks failed for any tool error it contains, answered or not" {
   inspect(rows[1].failed, content="false")
   // The scan stops at the next prompt: turn one's failures are not turn two's.
   let single = @transcript_overview.entries(
-    [item(User, "question", sequence=1), item(tool(true), "boom", sequence=2)],
+    [
+      item(User, "question", sequence=1),
+      item(response(calls=[shell_call(true)]), "", sequence=2),
+    ],
     display=text => text,
   )
   inspect(single[0].failed, content="true")
+  // A blocked goal is the turn's failure too.
+  let blocked = @transcript_overview.entries(
+    [
+      item(User, "question", sequence=1),
+      item(
+        Notice(label="goal", brief=Some("Goal blocked: why"), is_error=true),
+        "",
+        sequence=2,
+      ),
+    ],
+    display=text => text,
+  )
+  inspect(blocked[0].failed, content="true")
 }
 
 ///|
 test "an abort bubble is the answer a turn got" {
   let rows = @transcript_overview.entries(
-    [
-      item(User, "question", sequence=1),
-      item(Assistant(is_danger=true), "aborted", sequence=2),
-    ],
+    [item(User, "question", sequence=1), item(Failure, "aborted", sequence=2)],
     display=text => text,
   )
   @debug.assert_eq(rows[0].reply, Some("aborted"))
@@ -99,7 +123,7 @@ test "a terminal-carried final is the answer a turn got" {
   let rows = @transcript_overview.entries(
     [
       item(User, "question", sequence=1),
-      item(TerminalAnswer, "final answer", sequence=2),
+      item(Answer, "final answer", sequence=2),
     ],
     display=text => text,
   )
@@ -109,7 +133,7 @@ test "a terminal-carried final is the answer a turn got" {
 ///|
 test "a row without a sequence keys by its position" {
   let rows = @transcript_overview.entries(
-    [item(Assistant(is_danger=false), "notice"), item(User, "local bubble")],
+    [item(response(), "notice"), item(User, "local bubble")],
     display=text => text,
   )
   inspect(rows.length(), content="1")

--- a/desktop/frontend/transcript_overview/types.mbt
+++ b/desktop/frontend/transcript_overview/types.mbt
@@ -84,7 +84,7 @@ pub fn entries(
 ) -> Array[Entry] {
   let result : Array[Entry] = []
   for index, item in items {
-    guard item.kind is User else { continue }
+    guard item.kind is User(prompt) else { continue }
     // The turn's answer is the first prose the agent said — a response that
     // only thought or only ran tools is not an answer yet. An abort/failure
     // bubble counts: it is what the turn got.
@@ -96,26 +96,24 @@ pub fn entries(
     let mut failed = false
     for cursor in (index + 1)..<items.length() {
       let item = items[cursor]
-      if item.kind is User {
+      if item.kind is User(_) {
         break
       }
       match item.kind {
         Assistant(calls~, ..) =>
-          if calls.iter().any(call => call.is_error) {
+          if calls.iter().any(call => call.outcome is Done(is_error=true, ..)) {
             failed = true
           }
         Notice(is_error=true, ..) => failed = true
         _ => ()
       }
-      if reply is None &&
-        item.kind is (Assistant(..) | Answer | Failure) &&
-        !item.content.is_empty() {
-        reply = Some(item.content)
+      if reply is None && item.kind is (Assistant(..) | Answer(_) | Failure(_)) {
+        reply = item.text()
       }
     }
     result.push({
       key: TurnKey::of(item, index~),
-      text: display(item.content),
+      text: display(prompt),
       ts: item.ts,
       reply,
       failed,

--- a/desktop/frontend/transcript_overview/types.mbt
+++ b/desktop/frontend/transcript_overview/types.mbt
@@ -85,25 +85,32 @@ pub fn entries(
   let result : Array[Entry] = []
   for index, item in items {
     guard item.kind is User else { continue }
-    // The turn's answer is its first assistant row — reasoning and tool
-    // cards in between belong to the same turn. An abort/failure bubble
-    // counts: it is what the turn got.
+    // The turn's answer is the first prose the agent said — a response that
+    // only thought or only ran tools is not an answer yet. An abort/failure
+    // bubble counts: it is what the turn got.
     //
     // Failures are collected over the whole turn rather than stopping at the
-    // answer: a tool that failed after the first assistant row still failed in
-    // this turn, and the reply search stops early by design.
+    // answer: a tool that failed after the first answer still failed in this
+    // turn, and the reply search stops early by design.
     let mut reply : String? = None
     let mut failed = false
     for cursor in (index + 1)..<items.length() {
-      if items[cursor].kind is User {
+      let item = items[cursor]
+      if item.kind is User {
         break
       }
-      if items[cursor].kind is Tool(is_error=true, ..) {
-        failed = true
+      match item.kind {
+        Assistant(calls~, ..) =>
+          if calls.iter().any(call => call.is_error) {
+            failed = true
+          }
+        Notice(is_error=true, ..) => failed = true
+        _ => ()
       }
       if reply is None &&
-        items[cursor].kind is (Assistant(_) | AssistantReplay | TerminalAnswer) {
-        reply = Some(items[cursor].content)
+        item.kind is (Assistant(..) | Answer | Failure) &&
+        !item.content.is_empty() {
+        reply = Some(item.content)
       }
     }
     result.push({

--- a/desktop/frontend/transcript_rendering.mbt
+++ b/desktop/frontend/transcript_rendering.mbt
@@ -84,18 +84,28 @@ test "transcript row identities key by event sequence" {
   let conv = {
     ..test_conversation(),
     messages: [
-      { kind: User, content: "question", ts: None, sequence: Some(41), },
+      { kind: User("question"), ts: None, sequence: Some(41), },
       {
-        kind: Assistant(reasoning=None, calls=[], replay=false, finished=false),
-        content: "answer",
+        kind: Assistant(
+          reasoning=None,
+          prose=Some("answer"),
+          calls=[],
+          replay=false,
+          finished=false,
+        ),
         ts: None,
         sequence: Some(42),
       },
       // A fixture from before events carried sequences falls back to its
       // position, which cannot collide with any `s<n>` key.
       {
-        kind: Assistant(reasoning=None, calls=[], replay=false, finished=false),
-        content: "old",
+        kind: Assistant(
+          reasoning=None,
+          prose=Some("old"),
+          calls=[],
+          replay=false,
+          finished=false,
+        ),
         ts: None,
         sequence: None,
       },

--- a/desktop/frontend/transcript_rendering.mbt
+++ b/desktop/frontend/transcript_rendering.mbt
@@ -1,20 +1,18 @@
 ///|
-/// Stable identity for one visible transcript row. Durable events may expand
-/// into several rows, so their event sequence alone is not unique; the ordinal
-/// is the row's position within that event. Old fixtures without a sequence use
-/// their durable-array position.
+/// Stable identity for one visible transcript row: the durable event it came
+/// from, which projects to at most one row. Old fixtures without a sequence
+/// use their durable-array position.
 priv enum TranscriptRowIdentity {
-  DurableTranscriptRow(sequence~ : Int, ordinal~ : Int)
+  DurableTranscriptRow(Int)
   LegacyTranscriptRow(Int)
 }
 
 ///|
-/// Serialize a row identity for Rabbita's keyed-children map. NUL is an
-/// internal field separator already used by the frontend's composite keys; the
-/// result is renderer-private and is never emitted as a DOM id or attribute.
+/// Serialize a row identity for Rabbita's keyed-children map. The result is
+/// renderer-private and is never emitted as a DOM id or attribute.
 fn TranscriptRowIdentity::wire(self : TranscriptRowIdentity) -> String {
   match self {
-    DurableTranscriptRow(sequence~, ordinal~) => "s\{sequence}\u{0}o\{ordinal}"
+    DurableTranscriptRow(sequence) => "s\{sequence}"
     LegacyTranscriptRow(index) => "l\{index}"
   }
 }
@@ -27,14 +25,9 @@ fn Conversation::visible_transcript_rows(
   self : Conversation,
 ) -> Array[@transcript_component.VisibleRow] {
   let durable : Array[@transcript_component.VisibleRow] = []
-  let ordinals : Map[Int, Int] = Map([])
   for index, item in self.messages {
     let identity = match item.sequence {
-      Some(sequence) => {
-        let ordinal = ordinals.get(sequence).unwrap_or(0)
-        ordinals.set(sequence, ordinal + 1)
-        DurableTranscriptRow(sequence~, ordinal~)
-      }
+      Some(sequence) => DurableTranscriptRow(sequence)
       None => LegacyTranscriptRow(index)
     }
     durable.push({ item, identity: identity.wire(), })
@@ -73,10 +66,10 @@ fn Conversation::reasoning_for_render(self : Conversation) -> (String?, Bool) {
     let mut index = self.messages.length()
     while index > 0 {
       index -= 1
-      if self.messages[index].kind is Reasoning {
+      if self.messages[index].kind is Assistant(reasoning=Some(thought), ..) {
         if self.messages[index].sequence is Some(sequence) &&
           sequence > self.turn.reasoning_frontier &&
-          self.messages[index].content.trim() == candidate {
+          thought.trim() == candidate {
           return (None, live.complete)
         }
         break
@@ -87,21 +80,21 @@ fn Conversation::reasoning_for_render(self : Conversation) -> (String?, Bool) {
 }
 
 ///|
-test "transcript row identities include event ordinals" {
+test "transcript row identities key by event sequence" {
   let conv = {
     ..test_conversation(),
     messages: [
       { kind: User, content: "question", ts: None, sequence: Some(41), },
       {
-        kind: Assistant(is_danger=false),
+        kind: Assistant(reasoning=None, calls=[], replay=false, finished=false),
         content: "answer",
         ts: None,
-        sequence: Some(41),
+        sequence: Some(42),
       },
       // A fixture from before events carried sequences falls back to its
       // position, which cannot collide with any `s<n>` key.
       {
-        kind: Assistant(is_danger=false),
+        kind: Assistant(reasoning=None, calls=[], replay=false, finished=false),
         content: "old",
         ts: None,
         sequence: None,
@@ -109,6 +102,6 @@ test "transcript row identities include event ordinals" {
     ],
   }
   assert_eq(conv.visible_transcript_rows().map(row => row.identity), [
-    "s41\u{0}o0", "s41\u{0}o1", "l2",
+    "s41", "s42", "l2",
   ])
 }

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -8691,11 +8691,11 @@ test "a later run does not confuse identical historical reasoning for its commit
       {
         kind: Assistant(
           reasoning=Some("shared opening"),
+          prose=Some("older answer"),
           calls=[],
           replay=false,
           finished=false,
         ),
-        content: "older answer",
         ts: None,
         sequence: Some(2),
       },
@@ -8732,11 +8732,11 @@ test "a new model step advances past identical reasoning from the prior step" {
       {
         kind: Assistant(
           reasoning=Some("shared opening"),
+          prose=None,
           calls=[],
           replay=false,
           finished=false,
         ),
-        content: "",
         ts: None,
         sequence: Some(2),
       },
@@ -8968,15 +8968,15 @@ test "finished run reloads the named durable session for an old host" {
       goal_markers=[],
       session="desktop-test",
       items=[
-        { kind: User, content: "question", ts: None, sequence: None, },
+        { kind: User("question"), ts: None, sequence: None, },
         {
           kind: Assistant(
             reasoning=None,
+            prose=Some("done"),
             calls=[],
             replay=false,
             finished=false,
           ),
-          content: "done",
           ts: None,
           sequence: None,
         },
@@ -8987,7 +8987,7 @@ test "finished run reloads the named durable session for an old host" {
     finished,
   )
   inspect(loaded.active().messages.length(), content="2")
-  inspect(loaded.active().messages[1].content, content="done")
+  assert_eq(loaded.active().messages[1].text(), Some("done"))
   inspect(loaded.active().watermark, content="3")
   assert_true(loaded.active().sync is Synced)
 }
@@ -9172,7 +9172,7 @@ test "session rotation activates a fresh conversation, keeping the old one" {
   let dispatch = test_dispatch()
   let model = test_model().replace_conversation({
     ..running_conversation(),
-    messages: [{ kind: User, content: "hi", ts: None, sequence: None, }],
+    messages: [{ kind: User("hi"), ts: None, sequence: None, }],
   })
   let (_, next) = update(
     dispatch,
@@ -9652,7 +9652,7 @@ test "sessions failure pops a toast without touching the transcript" {
   let dispatch = test_dispatch()
   let model = test_model().replace_conversation({
     ..test_conversation(),
-    messages: [{ kind: User, content: "hi", ts: None, sequence: None, }],
+    messages: [{ kind: User("hi"), ts: None, sequence: None, }],
   })
   let (_, next) = update_dev(dispatch, SessionsFailed("engine exploded"), model)
   inspect(next.notifications.length(), content="1")
@@ -9685,9 +9685,7 @@ test "open session keeps live state on screen while re-reading the store" {
       @interop.ChannelId::Local.test_project(),
     ),
     run: Open(run_id="r9", stage=Opened),
-    messages: [
-      { kind: User, content: "background task", ts: None, sequence: None, },
-    ],
+    messages: [{ kind: User("background task"), ts: None, sequence: None, }],
     turn: {
       ..empty_conversation(
         @interop.ChannelId::Local,
@@ -9731,7 +9729,7 @@ test "reconnect refresh is single-flight and preserves its commit buffer" {
   let dispatch = test_dispatch()
   let model = test_model().replace_conversation({
     ..test_conversation(),
-    messages: [{ kind: User, content: "kept", ts: None, sequence: None, }],
+    messages: [{ kind: User("kept"), ts: None, sequence: None, }],
     watermark: 1,
   })
   let (_, refreshing) = update_dev(dispatch, BridgeReady, model)
@@ -10144,7 +10142,7 @@ test "open session tracks the latest load and ignores stale replies" {
     is Some({ channel: Local, session: "desktop-b", }),
   )
   let a_items : Array[@transcript.TranscriptItem] = [
-    { kind: User, content: "old selection", ts: None, sequence: None, },
+    { kind: User("old selection"), ts: None, sequence: None, },
   ]
   let (_, after_a) = update_dev(
     dispatch,
@@ -10164,7 +10162,7 @@ test "open session tracks the latest load and ignores stale replies" {
     is Some({ channel: Local, session: "desktop-b", }),
   )
   let b_items : Array[@transcript.TranscriptItem] = [
-    { kind: User, content: "latest selection", ts: None, sequence: None, },
+    { kind: User("latest selection"), ts: None, sequence: None, },
   ]
   let (_, after_b) = update_dev(
     dispatch,
@@ -10180,7 +10178,7 @@ test "open session tracks the latest load and ignores stale replies" {
   )
   inspect(after_b.active_session, content="desktop-b")
   assert_true(after_b.loading_conversation is None)
-  inspect(after_b.active().messages[0].content, content="latest selection")
+  assert_eq(after_b.active().messages[0].text(), Some("latest selection"))
 }
 
 ///|
@@ -10249,11 +10247,11 @@ test "same-id session loads are fenced by channel owner" {
       "shared",
       @interop.ChannelId::Local.test_project(),
     ),
-    messages: [{ kind: User, content: "local", ts: None, sequence: None, }],
+    messages: [{ kind: User("local"), ts: None, sequence: None, }],
   }
   let remote_conv = {
     ..empty_conversation(remote, "shared", remote.test_project()),
-    messages: [{ kind: User, content: "remote", ts: None, sequence: None, }],
+    messages: [{ kind: User("remote"), ts: None, sequence: None, }],
   }
   let model = {
     ..test_model(),
@@ -10290,11 +10288,11 @@ test "same-id session loads are fenced by channel owner" {
           {
             kind: Assistant(
               reasoning=None,
+              prose=Some("remote loaded"),
               calls=[],
               replay=false,
               finished=false,
             ),
-            content: "remote loaded",
             ts: None,
             sequence: None,
           },
@@ -10306,7 +10304,7 @@ test "same-id session loads are fenced by channel owner" {
     loading_local,
   )
   assert_true(remote_reply.focused is Local)
-  inspect(remote_reply.active().messages[0].content, content="local")
+  assert_eq(remote_reply.active().messages[0].text(), Some("local"))
   assert_true(
     remote_reply.loading_conversation
     is Some({ channel: Local, session: "shared", }),
@@ -10314,7 +10312,7 @@ test "same-id session loads are fenced by channel owner" {
   guard remote_reply.find_conversation(remote, "shared") is Some(loaded) else {
     fail("remote conversation disappeared")
   }
-  inspect(loaded.messages[0].content, content="remote loaded")
+  assert_eq(loaded.messages[0].text(), Some("remote loaded"))
 }
 
 ///|
@@ -10364,11 +10362,11 @@ test "reselecting a synced active session reloads idle external writes" {
         {
           kind: Assistant(
             reasoning=None,
+            prose=Some("written elsewhere"),
             calls=[],
             replay=false,
             finished=false,
           ),
-          content: "written elsewhere",
           ts: None,
           sequence: None,
         },
@@ -10379,7 +10377,7 @@ test "reselecting a synced active session reloads idle external writes" {
     still_single_flight,
   )
   inspect(loaded.active().messages.length(), content="1")
-  inspect(loaded.active().messages[0].content, content="written elsewhere")
+  assert_eq(loaded.active().messages[0].text(), Some("written elsewhere"))
   inspect(loaded.active().watermark, content="1")
   assert_true(loaded.active().sync is Synced)
 }
@@ -10444,9 +10442,7 @@ test "pruning and reopening cannot reuse a transcript request token" {
       goal=None,
       goal_markers=[],
       session="desktop-pruned",
-      items=[
-        { kind: User, content: "late old snapshot", ts: None, sequence: None, },
-      ],
+      items=[{ kind: User("late old snapshot"), ts: None, sequence: None, }],
       watermark=9,
       generation=1,
     ),
@@ -10469,16 +10465,14 @@ test "pruning and reopening cannot reuse a transcript request token" {
       goal=None,
       goal_markers=[],
       session="desktop-pruned",
-      items=[
-        { kind: User, content: "fresh snapshot", ts: None, sequence: None, },
-      ],
+      items=[{ kind: User("fresh snapshot"), ts: None, sequence: None, }],
       watermark=1,
       generation=2,
     ),
     stale,
   )
   inspect(fresh.active_session, content="desktop-pruned")
-  inspect(fresh.active().messages[0].content, content="fresh snapshot")
+  assert_eq(fresh.active().messages[0].text(), Some("fresh snapshot"))
 }
 
 ///|
@@ -10521,12 +10515,7 @@ test "archive removal and reopening cannot reuse a transcript request token" {
       goal_markers=[],
       session="desktop-archived",
       items=[
-        {
-          kind: User,
-          content: "late archived snapshot",
-          ts: None,
-          sequence: None,
-        },
+        { kind: User("late archived snapshot"), ts: None, sequence: None, },
       ],
       watermark=4,
       generation=1,
@@ -10809,7 +10798,7 @@ test "session loaded swaps the active conversation onto the stored session" {
   let model = test_model()
     .replace_conversation({
       ..test_conversation(),
-      messages: [{ kind: User, content: "old chat", ts: None, sequence: None, }],
+      messages: [{ kind: User("old chat"), ts: None, sequence: None, }],
       turn: {
         ..test_conversation().turn,
         usage_tokens: 42,
@@ -10836,10 +10825,15 @@ test "session loaded swaps the active conversation onto the stored session" {
     model,
   )
   let items : Array[@transcript.TranscriptItem] = [
-    { kind: User, content: "stored question", ts: None, sequence: None, },
+    { kind: User("stored question"), ts: None, sequence: None, },
     {
-      kind: Assistant(reasoning=None, calls=[], replay=false, finished=false),
-      content: "stored answer",
+      kind: Assistant(
+        reasoning=None,
+        prose=Some("stored answer"),
+        calls=[],
+        replay=false,
+        finished=false,
+      ),
       ts: None,
       sequence: None,
     },
@@ -10870,7 +10864,7 @@ test "session loaded swaps the active conversation onto the stored session" {
   )
   inspect(once.active_session, content="desktop-stored")
   inspect(once.active().messages.length(), content="2")
-  inspect(once.active().messages[0].content, content="stored question")
+  assert_eq(once.active().messages[0].text(), Some("stored question"))
   assert_eq(once.active().turn.streaming_response, None)
   inspect(once.active().turn.usage_tokens, content="0")
   assert_eq(
@@ -10886,7 +10880,7 @@ test "session loaded adopts the store transcript and keeps live run state" {
   let dispatch = test_dispatch()
   let model = running_model().with_listed(["desktop-stored"])
   let items : Array[@transcript.TranscriptItem] = [
-    { kind: User, content: "stored", ts: None, sequence: None, },
+    { kind: User("stored"), ts: None, sequence: None, },
   ]
   // The active conversation runs; loading some other stored session is fine.
   let (_, loading_other) = update(
@@ -10942,7 +10936,7 @@ test "session loaded adopts the store transcript and keeps live run state" {
     loading_same,
   )
   inspect(same.active().messages.length(), content="1")
-  inspect(same.active().messages[0].content, content="stored")
+  assert_eq(same.active().messages[0].text(), Some("stored"))
   inspect(same.active().is_running(), content="true")
   assert_eq(same.active().turn.streaming_response, Some("mid-step"))
 }
@@ -11249,7 +11243,7 @@ test "a repeated started id is idempotent" {
   }
   assert_eq(next.active().turn.streaming_response, Some("current fragment"))
   inspect(next.active().pending_steers.length(), content="1")
-  inspect(next.active().pending_steers[0].content, content="current steer")
+  assert_eq(next.active().pending_steers[0].content, "current steer")
   inspect(next.transcript_request_generation, content="0")
   assert_true(next.active().sync is Synced)
 }
@@ -11424,19 +11418,19 @@ test "an accepted start response opens the run without Started" {
       goal_markers=[],
       session="desktop-test",
       items=[
-        { kind: User, content: "external prompt", ts: None, sequence: None, },
+        { kind: User("external prompt"), ts: None, sequence: None, },
         {
           kind: Assistant(
             reasoning=None,
+            prose=Some("external answer"),
             calls=[],
             replay=false,
             finished=false,
           ),
-          content: "external answer",
           ts: None,
           sequence: None,
         },
-        { kind: User, content: "prompt", ts: None, sequence: None, },
+        { kind: User("prompt"), ts: None, sequence: None, },
       ],
       watermark=4,
       generation=1,
@@ -12073,9 +12067,7 @@ test "a background run finishes without disturbing the conversation on screen" {
       @interop.ChannelId::Local.test_project(),
     ),
     run: Open(run_id="r8", stage=Opened),
-    messages: [
-      { kind: User, content: "background ask", ts: None, sequence: None, },
-    ],
+    messages: [{ kind: User("background ask"), ts: None, sequence: None, }],
   }
   let model = running_model().replace_conversation(second)
   let (_, next) = update_dev(
@@ -12105,7 +12097,7 @@ test "send while running queues a steer instead of a prompt" {
   let (_, twice) = update(dispatch, Send, model)
   inspect(once.active().task, content="")
   inspect(once.active().pending_steers.length(), content="1")
-  inspect(once.active().pending_steers[0].content, content="focus on the tests")
+  assert_eq(once.active().pending_steers[0].content, "focus on the tests")
   // The steer is pending, not part of the transcript yet.
   inspect(once.active().messages.length(), content="0")
   inspect(once.active().is_running(), content="true")
@@ -12278,7 +12270,7 @@ test "a snapshot never settles a local steer by text" {
   let conv = with_pending_steers(
     {
       ..running_conversation(),
-      messages: [{ kind: User, content: "same", ts: None, sequence: None, }],
+      messages: [{ kind: User("same"), ts: None, sequence: None, }],
       watermark: 1,
       sync: test_reloading([]),
     },
@@ -12291,7 +12283,7 @@ test "a snapshot never settles a local steer by text" {
       goal=None,
       goal_markers=[],
       session="desktop-test",
-      items=[{ kind: User, content: "same", ts: None, sequence: None, }],
+      items=[{ kind: User("same"), ts: None, sequence: None, }],
       watermark=1,
       generation=1,
     ),
@@ -12337,7 +12329,7 @@ test "an identical-text settle removes exactly one pending entry" {
     model,
   )
   inspect(next.active().pending_steers.length(), content="1")
-  inspect(next.active().pending_steers[0].content, content="again")
+  assert_eq(next.active().pending_steers[0].content, "again")
   inspect(next.active().pending_steers[0].submission_id, content="test-steer-1")
 }
 
@@ -12513,15 +12505,15 @@ test "a foreign background run schedules one causal read after Started" {
         {
           kind: Assistant(
             reasoning=None,
+            prose=Some("previous answer"),
             calls=[],
             replay=false,
             finished=false,
           ),
-          content: "previous answer",
           ts: None,
           sequence: None,
         },
-        { kind: User, content: "current question", ts: None, sequence: None, },
+        { kind: User("current question"), ts: None, sequence: None, },
       ],
       watermark=4,
       goal=None,
@@ -14717,11 +14709,11 @@ test "switching same-id archived stores fences the first transcript load" {
         {
           kind: Assistant(
             reasoning=None,
+            prose=Some("first store answer"),
             calls=[],
             replay=false,
             finished=false,
           ),
-          content: "first store answer",
           ts: None,
           sequence: Some(1),
         },
@@ -14743,11 +14735,11 @@ test "switching same-id archived stores fences the first transcript load" {
         {
           kind: Assistant(
             reasoning=None,
+            prose=Some("second store answer"),
             calls=[],
             replay=false,
             finished=false,
           ),
-          content: "second store answer",
           ts: None,
           sequence: Some(1),
         },
@@ -14760,9 +14752,9 @@ test "switching same-id archived stores fences the first transcript load" {
     stale_first,
   )
   inspect(loaded_second.active().messages.length(), content="1")
-  inspect(
-    loaded_second.active().messages[0].content,
-    content="second store answer",
+  assert_eq(
+    loaded_second.active().messages[0].text(),
+    Some("second store answer"),
   )
 }
 
@@ -14811,11 +14803,11 @@ test "an archived snapshot stays open across archived-list reconciliation" {
         {
           kind: Assistant(
             reasoning=None,
+            prose=Some("archived answer"),
             calls=[],
             replay=false,
             finished=false,
           ),
-          content: "archived answer",
           ts: None,
           sequence: Some(1),
         },
@@ -14826,11 +14818,11 @@ test "an archived snapshot stays open across archived-list reconciliation" {
     loading,
   )
   assert_true(loaded.active().record is ArchivedRecord)
-  inspect(loaded.active().messages[0].content, content="archived answer")
+  assert_eq(loaded.active().messages[0].text(), Some("archived answer"))
   let (_, reconciled) = update(dispatch, archived_loaded([item]), loaded)
   inspect(reconciled.active_session, content="desktop-archived")
   assert_true(reconciled.active().record is ArchivedRecord)
-  inspect(reconciled.active().messages[0].content, content="archived answer")
+  assert_eq(reconciled.active().messages[0].text(), Some("archived answer"))
 }
 
 ///|
@@ -14846,8 +14838,13 @@ test "unarchiving an open transcript fences its archived snapshot" {
     record: ArchivedRecord,
     messages: [
       {
-        kind: Assistant(reasoning=None, calls=[], replay=false, finished=false),
-        content: "visible archived answer",
+        kind: Assistant(
+          reasoning=None,
+          prose=Some("visible archived answer"),
+          calls=[],
+          replay=false,
+          finished=false,
+        ),
         ts: None,
         sequence: Some(1),
       },
@@ -14884,11 +14881,11 @@ test "unarchiving an open transcript fences its archived snapshot" {
         {
           kind: Assistant(
             reasoning=None,
+            prose=Some("late archived answer"),
             calls=[],
             replay=false,
             finished=false,
           ),
-          content: "late archived answer",
           ts: None,
           sequence: Some(1),
         },
@@ -14899,7 +14896,7 @@ test "unarchiving an open transcript fences its archived snapshot" {
     restoring,
   )
   assert_true(stale.active().record is LiveRecord)
-  inspect(stale.active().messages[0].content, content="visible archived answer")
+  assert_eq(stale.active().messages[0].text(), Some("visible archived answer"))
 }
 
 ///|
@@ -15251,7 +15248,7 @@ test "a new Started incarnation retires its exact deleted tombstone" {
   assert_true(
     recreated.messages
     .iter()
-    .any(message => message.content == "new incarnation"),
+    .any(message => message.text() == Some("new incarnation")),
   )
 }
 
@@ -15589,11 +15586,11 @@ test "a background archive removes only its channel's same-id conversation" {
       "shared",
       @interop.ChannelId::Local.test_project(),
     ),
-    messages: [{ kind: User, content: "local", ts: None, sequence: None, }],
+    messages: [{ kind: User("local"), ts: None, sequence: None, }],
   }
   let remote_conv = {
     ..empty_conversation(remote, "shared", remote.test_project()),
-    messages: [{ kind: User, content: "remote", ts: None, sequence: None, }],
+    messages: [{ kind: User("remote"), ts: None, sequence: None, }],
   }
   let model = {
     ..test_model(),
@@ -15623,7 +15620,7 @@ test "a background archive removes only its channel's same-id conversation" {
     is Some(kept) else {
     fail("the focused same-id conversation was removed")
   }
-  inspect(kept.messages[0].content, content="local")
+  assert_eq(kept.messages[0].text(), Some("local"))
   assert_true(next.find_conversation(remote, "shared") is None)
 }
 
@@ -15668,8 +15665,13 @@ test "BridgeReady replaces archive overrides with fresh-list truth" {
     record: ArchivedRecord,
     messages: [
       {
-        kind: Assistant(reasoning=None, calls=[], replay=false, finished=false),
-        content: "cached archived answer",
+        kind: Assistant(
+          reasoning=None,
+          prose=Some("cached archived answer"),
+          calls=[],
+          replay=false,
+          finished=false,
+        ),
         ts: None,
         sequence: Some(1),
       },
@@ -15722,11 +15724,11 @@ test "BridgeReady replaces archive overrides with fresh-list truth" {
         {
           kind: Assistant(
             reasoning=None,
+            prose=Some("late archived answer"),
             calls=[],
             replay=false,
             finished=false,
           ),
-          content: "late archived answer",
           ts: None,
           sequence: Some(1),
         },
@@ -15737,9 +15739,9 @@ test "BridgeReady replaces archive overrides with fresh-list truth" {
     live,
   )
   assert_true(stale_archived.active().record is LiveRecord)
-  inspect(
-    stale_archived.active().messages[0].content,
-    content="cached archived answer",
+  assert_eq(
+    stale_archived.active().messages[0].text(),
+    Some("cached archived answer"),
   )
   let (_, live_again) = update_dev(
     dispatch,
@@ -16895,8 +16897,11 @@ test "Codex original-side diff feedback queues in the Codex draft" {
   )
   let queued = applied.codex.transcript_items()
   assert_eq(queued.length(), 1)
-  assert_true(queued[0].content.contains("side=\"original\""))
-  assert_true(queued[0].content.contains("keep this removal"))
+  guard queued[0].kind is @transcript.User(prompt) else {
+    fail("expected the queued feedback as a user prompt")
+  }
+  assert_true(prompt.contains("side=\"original\""))
+  assert_true(prompt.contains("keep this removal"))
 }
 
 ///|
@@ -16995,9 +17000,11 @@ test "Codex ApplyAllFeedback steers the running task through its composer" {
   )
   let queued = applied.codex.transcript_items()
   assert_eq(queued.length(), 1)
-  assert_true(queued[0].kind is @transcript.User)
-  assert_true(queued[0].content.contains("<user_mentions>"))
-  assert_true(queued[0].content.contains("rename this"))
+  guard queued[0].kind is @transcript.User(prompt) else {
+    fail("expected the queued comment as a user prompt")
+  }
+  assert_true(prompt.contains("<user_mentions>"))
+  assert_true(prompt.contains("rename this"))
 }
 
 ///|
@@ -17744,7 +17751,7 @@ test "send does not show a prompt until its commit lands" {
     sent,
   )
   inspect(committed.active().messages.length(), content="1")
-  guard committed.active().messages[0].kind is User else {
+  guard committed.active().messages[0].kind is User(_) else {
     fail("expected a user item")
   }
   inspect(committed.active().watermark, content="1")
@@ -17755,9 +17762,7 @@ test "a replayed commit at or below the watermark is dropped" {
   let dispatch = test_dispatch()
   let model = test_model().replace_conversation({
     ..test_conversation(),
-    messages: [
-      { kind: User, content: "already there", ts: None, sequence: None, },
-    ],
+    messages: [{ kind: User("already there"), ts: None, sequence: None, }],
     watermark: 2,
   })
   let (_, next) = update_dev(
@@ -17855,15 +17860,15 @@ test "a snapshot drains buffered commits in sequence order" {
       goal_markers=[],
       session="desktop-test",
       items=[
-        { kind: User, content: "one", ts: None, sequence: None, },
+        { kind: User("one"), ts: None, sequence: None, },
         {
           kind: Assistant(
             reasoning=None,
+            prose=Some("two"),
             calls=[],
             replay=false,
             finished=false,
           ),
-          content: "two",
           ts: None,
           sequence: None,
         },
@@ -17874,8 +17879,8 @@ test "a snapshot drains buffered commits in sequence order" {
     model,
   )
   inspect(next.active().messages.length(), content="4")
-  inspect(next.active().messages[2].content, content="three")
-  inspect(next.active().messages[3].content, content="four")
+  assert_eq(next.active().messages[2].text(), Some("three"))
+  assert_eq(next.active().messages[3].text(), Some("four"))
   inspect(next.active().watermark, content="4")
   assert_true(next.active().sync is Synced)
 }
@@ -17900,8 +17905,8 @@ test "a snapshot already containing the buffered commits drops them" {
       goal_markers=[],
       session="desktop-test",
       items=[
-        { kind: User, content: "one", ts: None, sequence: None, },
-        { kind: User, content: "dup", ts: None, sequence: None, },
+        { kind: User("one"), ts: None, sequence: None, },
+        { kind: User("dup"), ts: None, sequence: None, },
       ],
       watermark=2,
       generation=1,
@@ -17932,7 +17937,7 @@ test "a snapshot with a still-gapped buffer keeps reloading" {
       goal=None,
       goal_markers=[],
       session="desktop-test",
-      items=[{ kind: User, content: "one", ts: None, sequence: None, }],
+      items=[{ kind: User("one"), ts: None, sequence: None, }],
       watermark=2,
       generation=1,
     ),
@@ -17951,7 +17956,7 @@ test "background retries preserve buffered commits until a later success" {
   let dispatch = test_dispatch()
   let model = test_model().replace_conversation({
     ..test_conversation(),
-    messages: [{ kind: User, content: "kept", ts: None, sequence: None, }],
+    messages: [{ kind: User("kept"), ts: None, sequence: None, }],
     watermark: 1,
     sync: test_reloading([
       {
@@ -18002,15 +18007,15 @@ test "background retries preserve buffered commits until a later success" {
       goal=None,
       goal_markers=[],
       session="desktop-test",
-      items=[{ kind: User, content: "kept", ts: None, sequence: None, }],
+      items=[{ kind: User("kept"), ts: None, sequence: None, }],
       watermark=1,
       generation=2,
     ),
     retrying,
   )
   inspect(healed.active().messages.length(), content="3")
-  inspect(healed.active().messages[1].content, content="next")
-  inspect(healed.active().messages[2].content, content="x")
+  assert_eq(healed.active().messages[1].text(), Some("next"))
+  assert_eq(healed.active().messages[2].text(), Some("x"))
   inspect(healed.active().watermark, content="3")
   assert_true(healed.active().sync is Synced)
 }
@@ -18020,7 +18025,7 @@ test "reopening an active failed reload restarts it and keeps the buffer" {
   let dispatch = test_dispatch()
   let model = test_model().replace_conversation({
     ..test_conversation(),
-    messages: [{ kind: User, content: "kept", ts: None, sequence: None, }],
+    messages: [{ kind: User("kept"), ts: None, sequence: None, }],
     watermark: 1,
     sync: ReloadFailed(generation=1, buffered=[
       {
@@ -18051,7 +18056,7 @@ test "reopening an active failed reload restarts it and keeps the buffer" {
       goal=None,
       goal_markers=[],
       session="desktop-test",
-      items=[{ kind: User, content: "kept", ts: None, sequence: None, }],
+      items=[{ kind: User("kept"), ts: None, sequence: None, }],
       watermark=1,
       generation=2,
     ),
@@ -18070,7 +18075,7 @@ test "stale and lower-watermark snapshots cannot overwrite current state" {
   let model = test_model().replace_conversation({
     ..test_conversation(),
     workspace: Project(root=current_root),
-    messages: [{ kind: User, content: "current", ts: None, sequence: None, }],
+    messages: [{ kind: User("current"), ts: None, sequence: None, }],
     watermark: 5,
     sync: Reloading(
       generation=2,
@@ -18091,15 +18096,13 @@ test "stale and lower-watermark snapshots cannot overwrite current state" {
       goal=None,
       goal_markers=[],
       session="desktop-test",
-      items=[
-        { kind: User, content: "stale generation", ts: None, sequence: None, },
-      ],
+      items=[{ kind: User("stale generation"), ts: None, sequence: None, }],
       watermark=9,
       generation=1,
     ),
     model,
   )
-  inspect(stale.active().messages[0].content, content="current")
+  assert_eq(stale.active().messages[0].text(), Some("current"))
   inspect(stale.active().watermark, content="5")
   assert_eq(stale.active().workspace, Project(root=current_root))
   guard stale.active().sync is Reloading(generation=2, attempt=1, ..) else {
@@ -18111,15 +18114,13 @@ test "stale and lower-watermark snapshots cannot overwrite current state" {
       goal=None,
       goal_markers=[],
       session="desktop-test",
-      items=[
-        { kind: User, content: "older snapshot", ts: None, sequence: None, },
-      ],
+      items=[{ kind: User("older snapshot"), ts: None, sequence: None, }],
       watermark=4,
       generation=2,
     ),
     stale,
   )
-  inspect(lower.active().messages[0].content, content="current")
+  assert_eq(lower.active().messages[0].text(), Some("current"))
   inspect(lower.active().watermark, content="5")
   assert_eq(lower.active().workspace, Project(root=current_root))
   guard lower.active().sync is Reloading(generation=2, attempt=2, buffered~, ..) else {
@@ -18171,8 +18172,9 @@ test "tool decode semantics wait for their durable error tool result" {
   guard committed_after.active().messages[0].kind is Assistant(calls=[edit], ..) else {
     fail("expected the response carrying the failed call")
   }
-  assert_true(edit.is_error)
-  inspect(edit.content, content="invalid arguments")
+  assert_true(
+    edit.outcome is Done(content="invalid arguments", is_error=true, ..),
+  )
   let (_, called_first) = update_dev(dispatch, call, running_model())
   let (_, committed_first) = update_dev(dispatch, result, called_first)
   let (_, semantic_after) = update_dev(dispatch, semantic, committed_first)
@@ -18215,7 +18217,7 @@ test "assistant semantic events wait for their durable commit" {
     committed.active().messages[0].kind
     is Assistant(reasoning=Some("think"), ..),
   )
-  inspect(committed.active().messages[0].content, content="answer")
+  assert_eq(committed.active().messages[0].text(), Some("answer"))
   inspect(committed.active().watermark, content="1")
 }
 
@@ -18248,9 +18250,10 @@ test "a committed tool result visibly changes its existing call row" {
   guard completed.messages[0].kind is Assistant(calls=[call], ..) else {
     fail("expected the response to keep its one call")
   }
-  assert_true(call.has_result)
-  inspect(call.content, content="module contents")
-  assert_true(call.brief is Some("read moon.mod"))
+  assert_true(
+    call.outcome
+    is Done(content="module contents", brief=Some("read moon.mod"), ..),
+  )
 }
 
 ///|
@@ -18298,9 +18301,7 @@ test "a delayed terminal commit never clears a newer live delta" {
   let dispatch = test_dispatch()
   let model = running_model().replace_conversation({
     ..running_conversation(),
-    messages: [
-      { kind: User, content: "older prompt", ts: None, sequence: None, },
-    ],
+    messages: [{ kind: User("older prompt"), ts: None, sequence: None, }],
     watermark: 1,
     turn: {
       ..running_conversation().turn,
@@ -18383,7 +18384,7 @@ test "a sequence-one commit materializes an unknown hidden conversation" {
     fail("unknown commit did not materialize its session")
   }
   inspect(hidden.messages.length(), content="1")
-  inspect(hidden.messages[0].content, content="hi")
+  assert_eq(hidden.messages[0].text(), Some("hi"))
   inspect(hidden.watermark, content="1")
   inspect(next.dev().sessions_request_generation, content="1")
   let (_, repeated) = update_dev(
@@ -19523,11 +19524,11 @@ test "a sub-run's progress refreshes the child transcript on screen" {
         {
           kind: Assistant(
             reasoning=Some("child thought"),
+            prose=None,
             calls=[],
             replay=false,
             finished=false,
           ),
-          content: "",
           ts: None,
           sequence: Some(5),
         },

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -8601,8 +8601,11 @@ test "a matching durable commit de-duplicates without mutating the preview" {
     Some({ content: "think", complete: true, }),
   )
   assert_eq(committed.active().reasoning_for_render(), (None, true))
-  assert_eq(committed.active().messages.length(), 2)
-  assert_true(committed.active().messages[0].kind is Reasoning)
+  assert_eq(committed.active().messages.length(), 1)
+  assert_true(
+    committed.active().messages[0].kind
+    is Assistant(reasoning=Some("think"), ..),
+  )
 }
 
 ///|
@@ -8686,13 +8689,12 @@ test "a later run does not confuse identical historical reasoning for its commit
     ..running_conversation(),
     messages: [
       {
-        kind: Reasoning,
-        content: "shared opening",
-        ts: None,
-        sequence: Some(2),
-      },
-      {
-        kind: Assistant(is_danger=false),
+        kind: Assistant(
+          reasoning=Some("shared opening"),
+          calls=[],
+          replay=false,
+          finished=false,
+        ),
         content: "older answer",
         ts: None,
         sequence: Some(2),
@@ -8728,8 +8730,13 @@ test "a new model step advances past identical reasoning from the prior step" {
     ..running_conversation(),
     messages: [
       {
-        kind: Reasoning,
-        content: "shared opening",
+        kind: Assistant(
+          reasoning=Some("shared opening"),
+          calls=[],
+          replay=false,
+          finished=false,
+        ),
+        content: "",
         ts: None,
         sequence: Some(2),
       },
@@ -8963,7 +8970,12 @@ test "finished run reloads the named durable session for an old host" {
       items=[
         { kind: User, content: "question", ts: None, sequence: None, },
         {
-          kind: Assistant(is_danger=false),
+          kind: Assistant(
+            reasoning=None,
+            calls=[],
+            replay=false,
+            finished=false,
+          ),
           content: "done",
           ts: None,
           sequence: None,
@@ -10276,7 +10288,12 @@ test "same-id session loads are fenced by channel owner" {
         session="shared",
         items=[
           {
-            kind: Assistant(is_danger=false),
+            kind: Assistant(
+              reasoning=None,
+              calls=[],
+              replay=false,
+              finished=false,
+            ),
             content: "remote loaded",
             ts: None,
             sequence: None,
@@ -10345,7 +10362,12 @@ test "reselecting a synced active session reloads idle external writes" {
       session="desktop-test",
       items=[
         {
-          kind: Assistant(is_danger=false),
+          kind: Assistant(
+            reasoning=None,
+            calls=[],
+            replay=false,
+            finished=false,
+          ),
           content: "written elsewhere",
           ts: None,
           sequence: None,
@@ -10816,7 +10838,7 @@ test "session loaded swaps the active conversation onto the stored session" {
   let items : Array[@transcript.TranscriptItem] = [
     { kind: User, content: "stored question", ts: None, sequence: None, },
     {
-      kind: Assistant(is_danger=false),
+      kind: Assistant(reasoning=None, calls=[], replay=false, finished=false),
       content: "stored answer",
       ts: None,
       sequence: None,
@@ -11404,7 +11426,12 @@ test "an accepted start response opens the run without Started" {
       items=[
         { kind: User, content: "external prompt", ts: None, sequence: None, },
         {
-          kind: Assistant(is_danger=false),
+          kind: Assistant(
+            reasoning=None,
+            calls=[],
+            replay=false,
+            finished=false,
+          ),
           content: "external answer",
           ts: None,
           sequence: None,
@@ -12484,7 +12511,12 @@ test "a foreign background run schedules one causal read after Started" {
       session~,
       items=[
         {
-          kind: Assistant(is_danger=false),
+          kind: Assistant(
+            reasoning=None,
+            calls=[],
+            replay=false,
+            finished=false,
+          ),
           content: "previous answer",
           ts: None,
           sequence: None,
@@ -14683,7 +14715,12 @@ test "switching same-id archived stores fences the first transcript load" {
       session=first_item.id,
       items=[
         {
-          kind: Assistant(is_danger=false),
+          kind: Assistant(
+            reasoning=None,
+            calls=[],
+            replay=false,
+            finished=false,
+          ),
           content: "first store answer",
           ts: None,
           sequence: Some(1),
@@ -14704,7 +14741,12 @@ test "switching same-id archived stores fences the first transcript load" {
       session=second_item.id,
       items=[
         {
-          kind: Assistant(is_danger=false),
+          kind: Assistant(
+            reasoning=None,
+            calls=[],
+            replay=false,
+            finished=false,
+          ),
           content: "second store answer",
           ts: None,
           sequence: Some(1),
@@ -14767,7 +14809,12 @@ test "an archived snapshot stays open across archived-list reconciliation" {
       session=item.id,
       items=[
         {
-          kind: Assistant(is_danger=false),
+          kind: Assistant(
+            reasoning=None,
+            calls=[],
+            replay=false,
+            finished=false,
+          ),
           content: "archived answer",
           ts: None,
           sequence: Some(1),
@@ -14799,7 +14846,7 @@ test "unarchiving an open transcript fences its archived snapshot" {
     record: ArchivedRecord,
     messages: [
       {
-        kind: Assistant(is_danger=false),
+        kind: Assistant(reasoning=None, calls=[], replay=false, finished=false),
         content: "visible archived answer",
         ts: None,
         sequence: Some(1),
@@ -14835,7 +14882,12 @@ test "unarchiving an open transcript fences its archived snapshot" {
       session=item.id,
       items=[
         {
-          kind: Assistant(is_danger=false),
+          kind: Assistant(
+            reasoning=None,
+            calls=[],
+            replay=false,
+            finished=false,
+          ),
           content: "late archived answer",
           ts: None,
           sequence: Some(1),
@@ -15616,7 +15668,7 @@ test "BridgeReady replaces archive overrides with fresh-list truth" {
     record: ArchivedRecord,
     messages: [
       {
-        kind: Assistant(is_danger=false),
+        kind: Assistant(reasoning=None, calls=[], replay=false, finished=false),
         content: "cached archived answer",
         ts: None,
         sequence: Some(1),
@@ -15668,7 +15720,12 @@ test "BridgeReady replaces archive overrides with fresh-list truth" {
       session=item.id,
       items=[
         {
-          kind: Assistant(is_danger=false),
+          kind: Assistant(
+            reasoning=None,
+            calls=[],
+            replay=false,
+            finished=false,
+          ),
           content: "late archived answer",
           ts: None,
           sequence: Some(1),
@@ -17800,7 +17857,12 @@ test "a snapshot drains buffered commits in sequence order" {
       items=[
         { kind: User, content: "one", ts: None, sequence: None, },
         {
-          kind: Assistant(is_danger=false),
+          kind: Assistant(
+            reasoning=None,
+            calls=[],
+            replay=false,
+            finished=false,
+          ),
           content: "two",
           ts: None,
           sequence: None,
@@ -18074,12 +18136,26 @@ test "tool decode semantics wait for their durable error tool result" {
     ToolCallDecodeError(tool_name="edit", reason="invalid arguments"),
     session=None,
   )
-  let commit = SessionCommitted(
+  // The engine records the response with its undecodable call, then the
+  // error result that closes it; the semantic event is only news.
+  let call = SessionCommitted(
     session="desktop-test",
     sequence=1,
     ts=None,
+    item=@protocol.Assistant({
+      content: "",
+      tool_calls: Some([{ id: "c1", name: "edit", arguments: "{", }]),
+      reasoning_content: None,
+      is_replay: None,
+    }),
+    session_root=@interop.ChannelId::Local.test_store_root(),
+  )
+  let result = SessionCommitted(
+    session="desktop-test",
+    sequence=2,
+    ts=None,
     item=@protocol.ToolResult({
-      tool_call_id: "",
+      tool_call_id: "c1",
       tool_name: "edit",
       content: "invalid arguments",
       is_error: true,
@@ -18089,17 +18165,16 @@ test "tool decode semantics wait for their durable error tool result" {
   )
   let (_, semantic_first) = update_dev(dispatch, semantic, running_model())
   inspect(semantic_first.active().messages.length(), content="0")
-  let (_, committed_after) = update_dev(dispatch, commit, semantic_first)
+  let (_, called) = update_dev(dispatch, call, semantic_first)
+  let (_, committed_after) = update_dev(dispatch, result, called)
   inspect(committed_after.active().messages.length(), content="1")
-  guard committed_after.active().messages[0].kind
-    is Tool(name="edit", is_error=true, ..) else {
-    fail("expected the canonical error tool result")
+  guard committed_after.active().messages[0].kind is Assistant(calls=[edit], ..) else {
+    fail("expected the response carrying the failed call")
   }
-  inspect(
-    committed_after.active().messages[0].content,
-    content="invalid arguments",
-  )
-  let (_, committed_first) = update_dev(dispatch, commit, running_model())
+  assert_true(edit.is_error)
+  inspect(edit.content, content="invalid arguments")
+  let (_, called_first) = update_dev(dispatch, call, running_model())
+  let (_, committed_first) = update_dev(dispatch, result, called_first)
   let (_, semantic_after) = update_dev(dispatch, semantic, committed_first)
   inspect(semantic_after.active().messages.length(), content="1")
 }
@@ -18134,8 +18209,13 @@ test "assistant semantic events wait for their durable commit" {
     ),
     answered,
   )
-  // One durable item projects as reasoning + answer exactly once.
-  inspect(committed.active().messages.length(), content="2")
+  // One durable item projects as one response, thought and answer together.
+  inspect(committed.active().messages.length(), content="1")
+  assert_true(
+    committed.active().messages[0].kind
+    is Assistant(reasoning=Some("think"), ..),
+  )
+  inspect(committed.active().messages[0].content, content="answer")
   inspect(committed.active().watermark, content="1")
 }
 
@@ -18165,7 +18245,12 @@ test "a committed tool result visibly changes its existing call row" {
   )
   assert_true(changed)
   inspect(completed.messages.length(), content="1")
-  inspect(completed.messages[0].content, content="module contents")
+  guard completed.messages[0].kind is Assistant(calls=[call], ..) else {
+    fail("expected the response to keep its one call")
+  }
+  assert_true(call.has_result)
+  inspect(call.content, content="module contents")
+  assert_true(call.brief is Some("read moon.mod"))
 }
 
 ///|
@@ -18272,7 +18357,7 @@ test "commit-first assistant semantics do not append again" {
     Engine(Some("r7"), AssistantMessage("answer"), session=None),
     thought,
   )
-  inspect(answered.active().messages.length(), content="2")
+  inspect(answered.active().messages.length(), content="1")
   inspect(answered.active().watermark, content="1")
   assert_eq(answered.active().turn.streaming_response, None)
 }
@@ -19436,8 +19521,13 @@ test "a sub-run's progress refreshes the child transcript on screen" {
       session="desktop-test-sr-1",
       items=[
         {
-          kind: Reasoning,
-          content: "child thought",
+          kind: Assistant(
+            reasoning=Some("child thought"),
+            calls=[],
+            replay=false,
+            finished=false,
+          ),
+          content: "",
           ts: None,
           sequence: Some(5),
         },

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -42,10 +42,10 @@ fn SelectMenu::setting_control(
 fn conversation_title(conv : Conversation) -> String {
   // Titles follow the committed user transcript.
   for item in conv.messages {
-    if item.kind is User {
+    if item.kind is User(prompt) {
       // A prompt sent with chips titles by what was typed (or, chips alone,
       // by their labels) — never by the raw `<user_mentions>` envelope.
-      let title = user_display_text(item.content).trim().to_owned()
+      let title = user_display_text(prompt).trim().to_owned()
       if !title.is_empty() {
         return title
       }

--- a/desktop/frontend/worktrees.mbt
+++ b/desktop/frontend/worktrees.mbt
@@ -703,7 +703,7 @@ test "the launch mode toggles only before the conversation begins" {
   let begun = test_model().replace_conversation({
     ..test_conversation(),
     workspace: Project(root=workspace),
-    messages: [{ kind: User, content: "hi", ts: None, sequence: None, }],
+    messages: [{ kind: User("hi"), ts: None, sequence: None, }],
   })
   let (_, still) = update(dispatch, ToggleWorktreeMode, begun)
   assert_false(still.active().worktree_mode)

--- a/desktop/styles/transcript.css
+++ b/desktop/styles/transcript.css
@@ -653,6 +653,16 @@
   color: var(--bg, var(--color-on-accent));
 }
 
+/* One provider response: its thought fold, its prose, and its tool rows, in
+   the order the model produced them. The same grid and gap as the stream, so
+   a response's parts space exactly as separate stream children would. */
+.step {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 20px;
+}
+
 /* One model step's work: a heading (or thought fold) carrying the ordinal
    and commit instant, then every tool call on display as its own row. Flush
    with the agent's prose, not indented: the work is the agent's, and an
@@ -816,7 +826,7 @@
 }
 
 /* Reasoning inside the work log — and the live stream before it commits
-   (`reasoning_view`): full-width muted prose, never a labelled
+   (`assistant_view`): full-width muted prose, never a labelled
    "Thinking" row of its own. */
 .activity-thinking {
   color: var(--color-text-secondary);


### PR DESCRIPTION
Closes #1075. Supersedes #1163.

## Summary

The desktop transcript projector now keeps the durable event's own shape instead of flattening one Assistant event into Reasoning / Assistant / Tool rows that the renderer re-grouped by sequence. One durable event projects to at most one `TranscriptItem`, and `stream_children` is a plain per-item keyed loop.

- `ItemKind` carries each kind's text: `User(String) | Assistant(reasoning~, prose~, calls~, replay~, finished~) | Answer(String) | Failure(String) | Notice(label~, brief~, is_error~, body~) | Summary(String)`. A part that may be absent (a response's prose, a notice's body) is an option, never an empty string; `TranscriptItem::text()` is the one accessor for "the item's text, if any".
- `ToolCall { call_id, name, arguments, outcome }` with `ToolOutcome::Pending(output~)` (Codex may stream output before the item completes) and `ToolOutcome::Done(content~, is_error~, brief~)`.
- `apply_session_item`: an Assistant event is one item; a `ToolResult` fills the pending call inside the response that made it; a `Finished` terminal matching the last response's prose marks it `finished` (the response keeps its own stamp and sequence, so the settled bubble stays the same keyed node); other terminals are `Failure`; goal markers and runtime notices are `Notice`.
- Unmatched tool results are ignored, as `agent_session/projection.mbt` already does. Store format v1 has always persisted `tool_calls`, the engine appends the response before any result, and a scan of every local store (172 sessions, 11797 results) found no unmatched result, so the orphan row had no producer.
- Renderer: row identity is `s<sequence>`; the step ordinal is a render-time count of non-replay responses; the live preview is one `live\0<run>` node rendered by the same `assistant_view` a settled response gets. `durable_step_ordinals`, `left_boundary`, `activity_after` and the `rendered_prose` special case are gone.
- A response renders as one `div.step` whose parts keep the model's order: thought fold, prose, tool rows (the viz renderer's `assistant_card` order). `.step` reuses the stream grid so spacing is unchanged. A notice renders through the same result-row view a tool result uses, without pretending to be a tool call.
- Consumers follow the model: overview `entries` (reply = first item with text among responses, answers and failures; failed = any errored call or blocked goal), `plan.classify/latest/fold_progress` take a `ToolCall`, Codex maps each app-server item to its own response-shaped item.

## Behaviour changes worth a look

- Codex adjacent reasoning and tool items are no longer merged into one card; each is its own step (stream gap instead of the card's 6px).
- The overview reply skips responses without prose (a thought-only or tool-only response is not an answer yet).
- The live preview node is replaced by the durable node at commit instead of being relocated; the fold's `open` attribute flipped at that moment already.

## Tests

- `moon check --target js` / `--target native`: clean.
- `moon test --target js`: 3182 passed. `moon test --target native`: 3410 passed.
- Playwright: new case "a model step shows its thought, then its prose, then its tool rows" asserts the step's DOM order (js has no SSR, so the layout is covered end to end). The overview fixture gained the assistant call its error result was answering. The rest of the suite passes locally except "sidebar menu dismissal and pending selection follow the clicked row", which fails identically on `main` in this environment.
- js-only `pkg.generated.mbti` synced from `_build`; the transcript interface also drops two entries that were already stale (`RuntimeUpdate`, `parse_runtime_update`).

## Not verified

- No run in the desktop app itself; the live-to-durable handoff and the Codex spacing deserve a look there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYEUEQDanXg32aFCFMXH8a
