### PR TITLE
perf(desktop): memoize transcript rows behind assoc_by so deltas re-render only the live row

### DIFF
--- a/desktop/frontend/transcript/component/component.mbt
+++ b/desktop/frontend/transcript/component/component.mbt
@@ -230,6 +230,14 @@ fn Model::update(
 
 ///|
 /// Build the transcript state and return its independently updating Html.
+///
+/// The stream's rows are rendered behind Rabbita's `assoc_by`: each input
+/// snapshot is reduced to a pure, `Eq` block list, one incremental branch per
+/// key owns its row's Html, and a branch recomputes — reparsing the row's
+/// Markdown — only when that row's block actually changed. A streaming delta
+/// therefore re-renders just the live row; the historical rows' Html is reused
+/// as-is. Branches are plain `Val::map`, never stateful, and are keyed under
+/// the stream's own scope key so two conversations never share a branch.
 pub fn component(
   input : @rabbita.Val[Input],
   actions : Actions,
@@ -255,16 +263,62 @@ pub fn component(
     update=(state, input, msg, emit) => state.update(input, msg, emit),
     subscriptions=(_, _, emit) => transcript_subscription(emit),
   )
-  state.view2(input, (state, input) => {
+  // The row callbacks are captured by the branch closures below, never stored
+  // in a `Block`, so `Block` stays `Eq`.
+  let on_open = path => (actions.open)(path)
+  let on_jump = target => (actions.jump)(target)
+  let on_open_session = session => (actions.open_session)(session)
+  // One pure block list per input snapshot. The stream's section key scopes
+  // the assoc keys, so switching conversations never reuses a branch whose
+  // wire key happens to match.
+  let rows = input.map(input => {
+    let renderer : TranscriptRenderer = {
+      input,
+      on_open,
+      on_jump,
+      on_open_session,
+    }
+    let scope = TranscriptSectionKey::stream(input).wire()
+    renderer.blocks().map(block => (scope, block))
+  })
+  let rendered = rows.assoc_by(
+    (_, row) => {
+      row.map(row => {
+        match row {
+          (_, block) => block.render(on_open, on_jump, on_open_session)
+        }
+      })
+    },
+    by=row => {
+      match row {
+        (scope, block) => "\{scope}\u{0}\{block.key}"
+      }
+    },
+  )
+  state.view3(input, rendered, (state, input, rendered) => {
+    let renderer : TranscriptRenderer = {
+      input,
+      on_open,
+      on_jump,
+      on_open_session,
+    }
+    // `rendered` follows the source block list in order, so the same
+    // snapshot's keys zip it back into the keyed map `#stream` diffs.
+    let blocks = renderer.blocks()
+    let stream_children : Map[String, @html.Html] = Map([])
+    for index in 0..<rendered.length() {
+      stream_children.set(blocks.at(index).key, rendered.at(index))
+    }
     transcript_view(
       input,
       pinned=state.pinned,
       overview=state.overview,
       overview_emit=emit.map(msg => Overview(msg)),
-      path => (actions.open)(path),
-      target => (actions.jump)(target),
-      session => (actions.open_session)(session),
+      on_open,
+      on_jump,
+      on_open_session,
       on_jump_latest=emit(JumpToLatest),
+      stream_children~,
     )
   })
 }

--- a/desktop/frontend/transcript/component/component.mbt
+++ b/desktop/frontend/transcript/component/component.mbt
@@ -230,14 +230,6 @@ fn Model::update(
 
 ///|
 /// Build the transcript state and return its independently updating Html.
-///
-/// The stream's rows are rendered behind Rabbita's `assoc_by`: each input
-/// snapshot is reduced to a pure, `Eq` block list, one incremental branch per
-/// key owns its row's Html, and a branch recomputes — reparsing the row's
-/// Markdown — only when that row's block actually changed. A streaming delta
-/// therefore re-renders just the live row; the historical rows' Html is reused
-/// as-is. Branches are plain `Val::map`, never stateful, and are keyed under
-/// the stream's own scope key so two conversations never share a branch.
 pub fn component(
   input : @rabbita.Val[Input],
   actions : Actions,
@@ -263,62 +255,23 @@ pub fn component(
     update=(state, input, msg, emit) => state.update(input, msg, emit),
     subscriptions=(_, _, emit) => transcript_subscription(emit),
   )
-  // The row callbacks are captured by the branch closures below, never stored
-  // in a `Block`, so `Block` stays `Eq`.
-  let on_open = path => (actions.open)(path)
-  let on_jump = target => (actions.jump)(target)
-  let on_open_session = session => (actions.open_session)(session)
-  // One pure block list per input snapshot. The stream's section key scopes
-  // the assoc keys, so switching conversations never reuses a branch whose
-  // wire key happens to match.
-  let rows = input.map(input => {
-    let renderer : TranscriptRenderer = {
-      input,
-      on_open,
-      on_jump,
-      on_open_session,
-    }
-    let scope = TranscriptSectionKey::stream(input).wire()
-    renderer.blocks().map(block => (scope, block))
-  })
-  let rendered = rows.assoc_by(
-    (_, row) => {
-      row.map(row => {
-        match row {
-          (_, block) => block.render(on_open, on_jump, on_open_session)
-        }
-      })
-    },
-    by=row => {
-      match row {
-        (scope, block) => "\{scope}\u{0}\{block.key}"
-      }
-    },
+  // Every stream child renders in its own branch, keyed by the block within
+  // its stream. A streaming delta then recomputes only the live block's Html;
+  // each settled row keeps the Html it already has, so the cost of a delta no
+  // longer grows with the length of the transcript.
+  let blocks = input.map(stream_blocks)
+  let rendered = blocks.assoc_by(
+    (_, block) => block.map(block => (block.key.wire(), block.render(actions))),
+    by=block => block.branch_key(),
   )
   state.view3(input, rendered, (state, input, rendered) => {
-    let renderer : TranscriptRenderer = {
-      input,
-      on_open,
-      on_jump,
-      on_open_session,
-    }
-    // `rendered` follows the source block list in order, so the same
-    // snapshot's keys zip it back into the keyed map `#stream` diffs.
-    let blocks = renderer.blocks()
-    let stream_children : Map[String, @html.Html] = Map([])
-    for index in 0..<rendered.length() {
-      stream_children.set(blocks.at(index).key, rendered.at(index))
-    }
     transcript_view(
       input,
       pinned=state.pinned,
       overview=state.overview,
       overview_emit=emit.map(msg => Overview(msg)),
-      on_open,
-      on_jump,
-      on_open_session,
+      stream=keyed_stream(rendered),
       on_jump_latest=emit(JumpToLatest),
-      stream_children~,
     )
   })
 }

--- a/desktop/frontend/transcript/component/moon.pkg
+++ b/desktop/frontend/transcript/component/moon.pkg
@@ -9,6 +9,7 @@ import {
   "moonbit-community/rabbita/js",
   "moonbit-community/rabbita/sub",
   "moonbitlang/core/debug",
+  "moonbitlang/core/immut/vector",
   "moonbitlang/core/json",
   "moonbitlang/editor/base/common",
   "moonbitlang/editor/viewer/html" @syntax_html,

--- a/desktop/frontend/transcript/component/rendering.mbt
+++ b/desktop/frontend/transcript/component/rendering.mbt
@@ -2,7 +2,7 @@
 /// One renderer-private key for a direct child of `#stream`.
 priv struct TranscriptRenderKey {
   value : String
-}
+} derive(Eq)
 
 ///|
 fn TranscriptRenderKey::wire(self : TranscriptRenderKey) -> String {
@@ -35,7 +35,7 @@ fn TranscriptRenderKey::empty() -> TranscriptRenderKey {
 /// One renderer-private key for a direct child of `#transcript`.
 priv struct TranscriptSectionKey {
   value : String
-}
+} derive(Eq)
 
 ///|
 fn TranscriptSectionKey::wire(self : TranscriptSectionKey) -> String {
@@ -62,86 +62,100 @@ fn TranscriptSectionKey::jump_latest() -> TranscriptSectionKey {
 }
 
 ///|
-/// Pure rendering context for one transcript component. `blocks` builds the
-/// stream's children as data; `stream_children` renders them eagerly into the
-/// keyed map Rabbita uses to preserve a child by key while moving, inserting,
-/// or removing its siblings.
-priv struct TranscriptRenderer {
-  input : Input
-  on_open : (String) -> @cmd.Cmd
-  on_jump : (@mention_context.Target) -> @cmd.Cmd
-  on_open_session : (String) -> @cmd.Cmd
+fn Source::assistant_name(self : Source) -> String {
+  match self {
+    OpenSeek => "OpenSeek"
+    Codex => "Codex"
+  }
 }
 
 ///|
-/// One direct child of `#stream` as pure data: the wire key plus every input
-/// its views read, with no callbacks and no Html. A `Block` is `Eq`, so an
-/// unchanged block can skip re-rendering — and the Markdown parse its row
-/// owns — while a sibling streams. The callback-carrying context
-/// (`SubrunLink`) is rebuilt inside `Block::render` from `subrun_parent`.
+/// The session a sub-run tool card links its child transcript under, or
+/// `None` when this transcript can hold no sub-run.
+///
+/// Only OpenSeek writes `<parent>-sr-N` child records; a Codex or legacy
+/// transcript with a coincidentally-shaped brief must not be given a link to a
+/// session that does not exist. An unsaved conversation has no parent id to
+/// hang a child off, and `subrun_child_session` rejects the empty parent.
+fn Input::subrun_parent(self : Input) -> String? {
+  guard self.source is OpenSeek else { return None }
+  Some(self.active_session)
+}
+
+///|
+/// One direct child of `#stream`, as the data its Html is a function of. The
+/// callbacks a rendered block needs are supplied at render time rather than
+/// stored, so blocks compare by value: the component recomputes a block's
+/// Html only when the block itself changed, and a streaming delta leaves every
+/// settled row's Html untouched.
 priv struct Block {
-  key : String
-  kind : BlockKind
-  // The OpenSeek step ordinal this row carries ("#3"), `None` for every other
-  // source and kind.
-  step_label : String?
-  // The user bubble's turn anchor, present only on user rows.
-  anchor : String?
-  source : Source
-  // The session a sub-run result card links back to, present only under an
-  // OpenSeek transcript that can hold sub-runs.
-  subrun_parent : String?
+  /// The stream the block belongs to. It is part of the block's branch
+  /// identity so a conversation switch never continues another conversation's
+  /// branch, even where durable sequence numbers coincide.
+  stream : TranscriptSectionKey
+  key : TranscriptRenderKey
+  content : BlockContent
 } derive(Eq)
 
 ///|
-/// What one block shows. Each kind carries only the data its own view reads.
-priv enum BlockKind {
-  /// A durable transcript item, rendered by `transcript_item_view`.
-  Item(@transcript.TranscriptItem)
-  /// The hairline closing a user turn, dated by the prompt's send time.
-  Rule(ts~ : Double?)
-  /// The in-flight response under `live\0<run>`, still arriving.
-  Live(prose~ : String?, reasoning~ : String?, reasoning_complete~ : Bool)
-  /// The transcript's empty state.
-  Empty
+priv enum BlockContent {
+  /// Nothing to show: no durable items and nothing streaming.
+  Empty(Source)
+  /// One transcript item. `step_label` is the ordinal an OpenSeek provider
+  /// response carries ("#3"); `anchor` is a user turn's overview anchor;
+  /// `subrun_parent` is the session a sub-run tool card links its child
+  /// transcript under, when this transcript can hold one.
+  Item(
+    item~ : @transcript.TranscriptItem,
+    anchor~ : String?,
+    step_label~ : String?,
+    assistant_name~ : String,
+    subrun_parent~ : String?
+  )
+  /// The rule closing a user turn.
+  TurnRule(ts~ : Double?)
+  /// The response still streaming, shown through the same view a settled
+  /// response gets. Durable commits are untagged and cannot prove ownership
+  /// of an in-flight preview, so the preview stays visible as the provisional
+  /// next step; `Conversation::reasoning_for_render` suppresses only an
+  /// exact, completed duplicate after it has durably committed.
+  Live(
+    prose~ : String?,
+    reasoning~ : String?,
+    reasoning_complete~ : Bool,
+    step_label~ : String?,
+    assistant_name~ : String
+  )
 } derive(Eq)
 
 ///|
-/// The direct children of `#stream` in display order as data: one block per
-/// visible row (a user turn also contributes its closing rule), then the
-/// response still streaming, or the single empty-state block when the
-/// transcript holds nothing at all. Building blocks never parses Markdown or
-/// constructs Html; that cost stays in `Block::render`.
-fn TranscriptRenderer::blocks(
-  self : TranscriptRenderer,
-) -> @vector.Vector[Block] {
-  let visible = self.input.items
-  let live = self.input.streaming_reasoning is Some(_) ||
-    self.input.streaming_response is Some(_)
-  if visible.is_empty() && !live {
+/// The direct children of `#stream` in display order: one block per
+/// transcript item (a user turn also draws its closing rule), then the
+/// response still streaming; or the empty state alone. Vector order determines
+/// visual order; the keys only determine node identity.
+fn stream_blocks(input : Input) -> @vector.Vector[Block] {
+  let stream = TranscriptSectionKey::stream(input)
+  // The durable transcript plus client-local notices. Live semantic events
+  // never synthesize durable-looking items here; their store commits populate
+  // the transcript.
+  guard !input.items.is_empty() ||
+    input.streaming_reasoning is Some(_) ||
+    input.streaming_response is Some(_) else {
     return @vector.singleton({
-      key: TranscriptRenderKey::empty().wire(),
-      kind: Empty,
-      step_label: None,
-      anchor: None,
-      source: self.input.source,
-      subrun_parent: None,
+      stream,
+      key: TranscriptRenderKey::empty(),
+      content: Empty(input.source),
     })
   }
-  let subrun_parent = if self.input.source is OpenSeek {
-    Some(self.input.active_session)
-  } else {
-    None
-  }
+  let assistant_name = input.source.assistant_name()
+  let subrun_parent = input.subrun_parent()
+  let blocks : Array[Block] = []
   // OpenSeek numbers its model steps: every provider response that is not a
-  // checkpoint replay is one. Codex and legacy items carry no ordinal. A
-  // durable transcript is append-only, so the label an item already carries
-  // never changes and its block stays Eq-stable between streaming deltas.
+  // checkpoint replay is one. Codex and legacy items carry no ordinal.
   let mut steps = 0
-  let mut blocks = @vector.new()
-  for index, row in visible {
+  for index, row in input.items {
     let item = row.item
-    let step_label = if self.input.source is OpenSeek &&
+    let step_label = if input.source is OpenSeek &&
       item.kind is Assistant(replay=false, ..) {
       steps += 1
       Some("#\{steps}")
@@ -153,85 +167,136 @@ fn TranscriptRenderer::blocks(
     } else {
       None
     }
-    blocks = blocks.push({
-      key: TranscriptRenderKey::row(row.identity).wire(),
-      kind: Item(item),
-      step_label,
-      anchor,
-      source: self.input.source,
-      subrun_parent,
+    blocks.push({
+      stream,
+      key: TranscriptRenderKey::row(row.identity),
+      content: Item(
+        item~,
+        anchor~,
+        step_label~,
+        assistant_name~,
+        subrun_parent~,
+      ),
     })
     if item.kind is User(_) {
-      blocks = blocks.push({
-        key: TranscriptRenderKey::turn_rule(row.identity).wire(),
-        kind: Rule(ts=item.ts),
-        step_label: None,
-        anchor: None,
-        source: self.input.source,
-        subrun_parent: None,
+      blocks.push({
+        stream,
+        key: TranscriptRenderKey::turn_rule(row.identity),
+        content: TurnRule(ts=item.ts),
       })
     }
   }
-  // The response still streaming, through the same view a settled response
-  // gets. Durable commits are untagged and cannot prove ownership of an
-  // in-flight preview, so the preview stays visible as the provisional next
-  // step; `Conversation::reasoning_for_render` suppresses only an exact,
-  // completed duplicate after it has durably committed.
-  if live {
-    blocks = blocks.push({
-      key: TranscriptRenderKey::live(self.input.streaming_identity).wire(),
-      kind: Live(
-        prose=self.input.streaming_response,
-        reasoning=self.input.streaming_reasoning,
-        reasoning_complete=self.input.reasoning_complete,
+  if input.streaming_reasoning is Some(_) || input.streaming_response is Some(_) {
+    blocks.push({
+      stream,
+      key: TranscriptRenderKey::live(input.streaming_identity),
+      content: Live(
+        prose=input.streaming_response,
+        reasoning=input.streaming_reasoning,
+        reasoning_complete=input.reasoning_complete,
+        step_label=if input.source is OpenSeek {
+          Some("#\{steps + 1}")
+        } else {
+          None
+        },
+        assistant_name~,
       ),
-      step_label: if self.input.source is OpenSeek {
-        Some("#\{steps + 1}")
-      } else {
-        None
-      },
-      anchor: None,
-      source: self.input.source,
-      subrun_parent: None,
     })
   }
-  blocks
+  @vector.from_array(blocks)
 }
 
 ///|
-/// The keyed direct children of `#stream` in display order, composed eagerly
-/// from `blocks`. Map insertion order determines visual order; the strings
-/// only determine node identity. The live component instead renders each
-/// block behind Rabbita's `assoc_by`, so an unchanged block's Html — and its
-/// Markdown parse — is reused across streaming deltas.
-fn TranscriptRenderer::stream_children(
-  self : TranscriptRenderer,
-) -> Map[String, @html.Html] {
-  let items : Map[String, @html.Html] = Map([])
-  for block in self.blocks() {
-    items.set(
-      block.key,
-      block.render(self.on_open, self.on_jump, self.on_open_session),
-    )
+/// The identity of the block's memoized branch: its stream, then its key.
+fn Block::branch_key(self : Block) -> String {
+  "\{self.stream.wire()}\u{0}\{self.key.wire()}"
+}
+
+///|
+/// The block's Html. The parent's actions are captured by the component and
+/// passed through here; a block never stores them.
+fn Block::render(self : Block, actions : Actions) -> @html.Html {
+  let on_open = path => (actions.open)(path)
+  match self.content {
+    Empty(source) => empty_view(source)
+    Item(item~, anchor~, step_label~, assistant_name~, subrun_parent~) =>
+      transcript_item_view(
+        item,
+        on_open,
+        anchor?,
+        on_jump=target => (actions.jump)(target),
+        assistant_name~,
+        step_label?,
+        subrun?=subrun_parent.map(parent => SubrunLink::{
+          parent,
+          open: session => (actions.open_session)(session),
+        }),
+      )
+    TurnRule(ts~) => turn_rule_view(ts?)
+    Live(prose~, reasoning~, reasoning_complete~, step_label~, assistant_name~) =>
+      assistant_view(
+        on_open,
+        prose?,
+        reasoning?,
+        step_label?,
+        assistant_name~,
+        live=true,
+        reasoning_complete~,
+      )
   }
-  items
 }
 
 ///|
-/// Build the keyed direct children of `#transcript`. The stream key includes
-/// channel and session, so switching conversations replaces the entire stream
-/// instead of reusing rows whose durable sequence numbers happen to match.
-/// `stream_children` is the already-rendered stream map (the component's
-/// memoized rows, or an eager `stream_children()` call when none is supplied).
-fn TranscriptRenderer::section_children(
-  self : TranscriptRenderer,
-  pinned : Bool,
-  overview : @transcript_overview.State,
-  overview_emit : @cmd.Emit[@transcript_overview.Msg],
-  on_jump_latest : @cmd.Cmd,
-  stream_children~ : Map[String, @html.Html],
+fn empty_view(source : Source) -> @html.Html {
+  @html.div(class="empty", [
+    @html.div(class="empty-badge", [
+      @icons.icon(
+        match source {
+          OpenSeek => @icons.icon_logo
+          Codex => @icons.icon_sparkle
+        },
+      ),
+    ]),
+    @html.div(class="empty-title", "What should we build?"),
+    @html.div(
+      class="empty-sub",
+      match source {
+        OpenSeek =>
+          "SeekMoon plans the work, edits files across your workspace, runs your tests, and hands back a reviewable result."
+        Codex =>
+          "Codex inspects, edits, and runs this workspace with its own account, sandbox, and approvals."
+      },
+    ),
+  ])
+}
+
+///|
+/// The rendered blocks as Rabbita's keyed children of `#stream`: map
+/// insertion order is the display order, and a key pairs a block's node with
+/// its own element while its siblings move, appear, or leave.
+fn keyed_stream(
+  rendered : @vector.Vector[(String, @html.Html)],
 ) -> Map[String, @html.Html] {
-  let visible_items = self.input.items.map(row => row.item)
+  let children : Map[String, @html.Html] = Map([])
+  for pair in rendered {
+    children[pair.0] = pair.1
+  }
+  children
+}
+
+///|
+/// The keyed direct children of `#transcript`. The stream key includes channel
+/// and session, so switching conversations replaces the entire stream instead
+/// of reusing rows whose durable sequence numbers happen to match.
+fn section_children(
+  input : Input,
+  stream~ : Map[String, @html.Html],
+  pinned~ : Bool,
+  overview~ : @transcript_overview.State,
+  overview_emit~ : @cmd.Emit[@transcript_overview.Msg],
+  on_jump_latest~ : @cmd.Cmd,
+) -> Map[String, @html.Html] {
+  let visible_items = input.items.map(row => row.item)
   let children : Map[String, @html.Html] = Map([])
   // The overview rail leads the scroller: sticky-top only works from the
   // content's head, and rendering it unconditionally gives it a stable key (it
@@ -251,8 +316,8 @@ fn TranscriptRenderer::section_children(
     ),
   )
   children.set(
-    TranscriptSectionKey::stream(self.input).wire(),
-    @html.div(id="stream", class="stream", stream_children),
+    TranscriptSectionKey::stream(input).wire(),
+    @html.div(id="stream", class="stream", stream),
   )
   // Reading history unpins auto-follow (see `watch_transcript_scroll`); the
   // floating button is the way back to the live tail. Sticky inside the

--- a/desktop/frontend/transcript/component/rendering.mbt
+++ b/desktop/frontend/transcript/component/rendering.mbt
@@ -62,9 +62,10 @@ fn TranscriptSectionKey::jump_latest() -> TranscriptSectionKey {
 }
 
 ///|
-/// Pure rendering context for one transcript component. Its child-building
-/// methods return `Map[String, Html]`, which is the Rabbita API that preserves
-/// a child by key while moving, inserting, or removing its siblings.
+/// Pure rendering context for one transcript component. `blocks` builds the
+/// stream's children as data; `stream_children` renders them eagerly into the
+/// keyed map Rabbita uses to preserve a child by key while moving, inserting,
+/// or removing its siblings.
 priv struct TranscriptRenderer {
   input : Input
   on_open : (String) -> @cmd.Cmd
@@ -73,70 +74,71 @@ priv struct TranscriptRenderer {
 }
 
 ///|
-/// The context a sub-run tool card needs to link to its child transcript, or
-/// `None` when this transcript can hold no sub-run.
-///
-/// Only OpenSeek writes `<parent>-sr-N` child records; a Codex or legacy
-/// transcript with a coincidentally-shaped brief must not be given a link to a
-/// session that does not exist. An unsaved conversation has no parent id to
-/// hang a child off, and `subrun_child_session` rejects the empty parent.
-fn TranscriptRenderer::subrun_link(self : TranscriptRenderer) -> SubrunLink? {
-  guard self.input.source is OpenSeek else { return None }
-  Some({ parent: self.input.active_session, open: self.on_open_session, })
-}
+/// One direct child of `#stream` as pure data: the wire key plus every input
+/// its views read, with no callbacks and no Html. A `Block` is `Eq`, so an
+/// unchanged block can skip re-rendering — and the Markdown parse its row
+/// owns — while a sibling streams. The callback-carrying context
+/// (`SubrunLink`) is rebuilt inside `Block::render` from `subrun_parent`.
+priv struct Block {
+  key : String
+  kind : BlockKind
+  // The OpenSeek step ordinal this row carries ("#3"), `None` for every other
+  // source and kind.
+  step_label : String?
+  // The user bubble's turn anchor, present only on user rows.
+  anchor : String?
+  source : Source
+  // The session a sub-run result card links back to, present only under an
+  // OpenSeek transcript that can hold sub-runs.
+  subrun_parent : String?
+} derive(Eq)
 
 ///|
-fn TranscriptRenderer::assistant_name(self : TranscriptRenderer) -> String {
-  match self.input.source {
-    OpenSeek => "OpenSeek"
-    Codex => "Codex"
-  }
-}
+/// What one block shows. Each kind carries only the data its own view reads.
+priv enum BlockKind {
+  /// A durable transcript item, rendered by `transcript_item_view`.
+  Item(@transcript.TranscriptItem)
+  /// The hairline closing a user turn, dated by the prompt's send time.
+  Rule(ts~ : Double?)
+  /// The in-flight response under `live\0<run>`, still arriving.
+  Live(prose~ : String?, reasoning~ : String?, reasoning_complete~ : Bool)
+  /// The transcript's empty state.
+  Empty
+} derive(Eq)
 
 ///|
-/// Build the keyed direct children of `#stream` in display order: one node
-/// per transcript item (a user turn also draws its closing rule), then the
-/// response still streaming. Map insertion order determines visual order; the
-/// strings only determine node identity.
-fn TranscriptRenderer::stream_children(
+/// The direct children of `#stream` in display order as data: one block per
+/// visible row (a user turn also contributes its closing rule), then the
+/// response still streaming, or the single empty-state block when the
+/// transcript holds nothing at all. Building blocks never parses Markdown or
+/// constructs Html; that cost stays in `Block::render`.
+fn TranscriptRenderer::blocks(
   self : TranscriptRenderer,
-) -> Map[String, @html.Html] {
+) -> @vector.Vector[Block] {
   let visible = self.input.items
-  let items : Map[String, @html.Html] = Map([])
-  // The durable transcript plus client-local notices. Live semantic events
-  // never synthesize durable-looking items here; their store commits populate
-  // the transcript.
-  if visible.is_empty() &&
-    self.input.streaming_reasoning is None &&
-    self.input.streaming_response is None {
-    items.set(
-      TranscriptRenderKey::empty().wire(),
-      @html.div(class="empty", [
-        @html.div(class="empty-badge", [
-          @icons.icon(
-            match self.input.source {
-              OpenSeek => @icons.icon_logo
-              Codex => @icons.icon_sparkle
-            },
-          ),
-        ]),
-        @html.div(class="empty-title", "What should we build?"),
-        @html.div(
-          class="empty-sub",
-          match self.input.source {
-            OpenSeek =>
-              "SeekMoon plans the work, edits files across your workspace, runs your tests, and hands back a reviewable result."
-            Codex =>
-              "Codex inspects, edits, and runs this workspace with its own account, sandbox, and approvals."
-          },
-        ),
-      ]),
-    )
-    return items
+  let live = self.input.streaming_reasoning is Some(_) ||
+    self.input.streaming_response is Some(_)
+  if visible.is_empty() && !live {
+    return @vector.singleton({
+      key: TranscriptRenderKey::empty().wire(),
+      kind: Empty,
+      step_label: None,
+      anchor: None,
+      source: self.input.source,
+      subrun_parent: None,
+    })
+  }
+  let subrun_parent = if self.input.source is OpenSeek {
+    Some(self.input.active_session)
+  } else {
+    None
   }
   // OpenSeek numbers its model steps: every provider response that is not a
-  // checkpoint replay is one. Codex and legacy items carry no ordinal.
+  // checkpoint replay is one. Codex and legacy items carry no ordinal. A
+  // durable transcript is append-only, so the label an item already carries
+  // never changes and its block stays Eq-stable between streaming deltas.
   let mut steps = 0
+  let mut blocks = @vector.new()
   for index, row in visible {
     let item = row.item
     let step_label = if self.input.source is OpenSeek &&
@@ -151,23 +153,23 @@ fn TranscriptRenderer::stream_children(
     } else {
       None
     }
-    items.set(
-      TranscriptRenderKey::row(row.identity).wire(),
-      transcript_item_view(
-        item,
-        self.on_open,
-        anchor?,
-        on_jump=self.on_jump,
-        assistant_name=self.assistant_name(),
-        step_label?,
-        subrun?=self.subrun_link(),
-      ),
-    )
+    blocks = blocks.push({
+      key: TranscriptRenderKey::row(row.identity).wire(),
+      kind: Item(item),
+      step_label,
+      anchor,
+      source: self.input.source,
+      subrun_parent,
+    })
     if item.kind is User(_) {
-      items.set(
-        TranscriptRenderKey::turn_rule(row.identity).wire(),
-        turn_rule_view(ts?=item.ts),
-      )
+      blocks = blocks.push({
+        key: TranscriptRenderKey::turn_rule(row.identity).wire(),
+        kind: Rule(ts=item.ts),
+        step_label: None,
+        anchor: None,
+        source: self.input.source,
+        subrun_parent: None,
+      })
     }
   }
   // The response still streaming, through the same view a settled response
@@ -175,23 +177,41 @@ fn TranscriptRenderer::stream_children(
   // in-flight preview, so the preview stays visible as the provisional next
   // step; `Conversation::reasoning_for_render` suppresses only an exact,
   // completed duplicate after it has durably committed.
-  if self.input.streaming_reasoning is Some(_) ||
-    self.input.streaming_response is Some(_) {
-    items.set(
-      TranscriptRenderKey::live(self.input.streaming_identity).wire(),
-      assistant_view(
-        self.on_open,
-        prose?=self.input.streaming_response,
-        reasoning?=self.input.streaming_reasoning,
-        step_label?=if self.input.source is OpenSeek {
-          Some("#\{steps + 1}")
-        } else {
-          None
-        },
-        assistant_name=self.assistant_name(),
-        live=true,
+  if live {
+    blocks = blocks.push({
+      key: TranscriptRenderKey::live(self.input.streaming_identity).wire(),
+      kind: Live(
+        prose=self.input.streaming_response,
+        reasoning=self.input.streaming_reasoning,
         reasoning_complete=self.input.reasoning_complete,
       ),
+      step_label: if self.input.source is OpenSeek {
+        Some("#\{steps + 1}")
+      } else {
+        None
+      },
+      anchor: None,
+      source: self.input.source,
+      subrun_parent: None,
+    })
+  }
+  blocks
+}
+
+///|
+/// The keyed direct children of `#stream` in display order, composed eagerly
+/// from `blocks`. Map insertion order determines visual order; the strings
+/// only determine node identity. The live component instead renders each
+/// block behind Rabbita's `assoc_by`, so an unchanged block's Html — and its
+/// Markdown parse — is reused across streaming deltas.
+fn TranscriptRenderer::stream_children(
+  self : TranscriptRenderer,
+) -> Map[String, @html.Html] {
+  let items : Map[String, @html.Html] = Map([])
+  for block in self.blocks() {
+    items.set(
+      block.key,
+      block.render(self.on_open, self.on_jump, self.on_open_session),
     )
   }
   items
@@ -201,12 +221,15 @@ fn TranscriptRenderer::stream_children(
 /// Build the keyed direct children of `#transcript`. The stream key includes
 /// channel and session, so switching conversations replaces the entire stream
 /// instead of reusing rows whose durable sequence numbers happen to match.
+/// `stream_children` is the already-rendered stream map (the component's
+/// memoized rows, or an eager `stream_children()` call when none is supplied).
 fn TranscriptRenderer::section_children(
   self : TranscriptRenderer,
   pinned : Bool,
   overview : @transcript_overview.State,
   overview_emit : @cmd.Emit[@transcript_overview.Msg],
   on_jump_latest : @cmd.Cmd,
+  stream_children~ : Map[String, @html.Html],
 ) -> Map[String, @html.Html] {
   let visible_items = self.input.items.map(row => row.item)
   let children : Map[String, @html.Html] = Map([])
@@ -229,7 +252,7 @@ fn TranscriptRenderer::section_children(
   )
   children.set(
     TranscriptSectionKey::stream(self.input).wire(),
-    @html.div(id="stream", class="stream", self.stream_children()),
+    @html.div(id="stream", class="stream", stream_children),
   )
   // Reading history unpins auto-follow (see `watch_transcript_scroll`); the
   // floating button is the way back to the live tail. Sticky inside the

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -855,6 +855,92 @@ fn transcript_item_view(
 }
 
 ///|
+/// Render one block with the component's callbacks. Subrun links are rebuilt
+/// from `subrun_parent` because `SubrunLink` holds a callback and therefore
+/// never lives in the `Eq` block itself.
+fn Block::render(
+  self : Block,
+  on_open : (String) -> @cmd.Cmd,
+  on_jump : (@mention_context.Target) -> @cmd.Cmd,
+  on_open_session : (String) -> @cmd.Cmd,
+) -> @html.Html {
+  match self.kind {
+    Item(item) =>
+      transcript_item_view(
+        item,
+        on_open,
+        anchor?=self.anchor,
+        on_jump~,
+        assistant_name=self.assistant_name(),
+        step_label?=self.step_label,
+        subrun?=self.subrun(on_open_session),
+      )
+    Rule(ts~) => turn_rule_view(ts?)
+    Live(prose~, reasoning~, reasoning_complete~) =>
+      assistant_view(
+        on_open,
+        prose?,
+        reasoning?,
+        step_label?=self.step_label,
+        assistant_name=self.assistant_name(),
+        live=true,
+        reasoning_complete~,
+      )
+    Empty => empty_stream_view(self.source)
+  }
+}
+
+///|
+fn Block::assistant_name(self : Block) -> String {
+  match self.source {
+    OpenSeek => "OpenSeek"
+    Codex => "Codex"
+  }
+}
+
+///|
+/// The sub-run link this block's tool results can offer, rebuilt from the
+/// session the block was produced under. `None` for every transcript source
+/// that has no sub-runs, which is also what keeps the chip out of rendering
+/// tests that do not supply one.
+fn Block::subrun(
+  self : Block,
+  on_open_session : (String) -> @cmd.Cmd,
+) -> SubrunLink? {
+  match self.subrun_parent {
+    Some(parent) => Some({ parent, open: on_open_session, })
+    None => None
+  }
+}
+
+///|
+/// The transcript's empty state: the badge and copy for whichever source owns
+/// the stream. One block, so a session that gains its first row replaces this
+/// single node instead of diffing a list.
+fn empty_stream_view(source : Source) -> @html.Html {
+  @html.div(class="empty", [
+    @html.div(class="empty-badge", [
+      @icons.icon(
+        match source {
+          OpenSeek => @icons.icon_logo
+          Codex => @icons.icon_sparkle
+        },
+      ),
+    ]),
+    @html.div(class="empty-title", "What should we build?"),
+    @html.div(
+      class="empty-sub",
+      match source {
+        OpenSeek =>
+          "SeekMoon plans the work, edits files across your workspace, runs your tests, and hands back a reviewable result."
+        Codex =>
+          "Codex inspects, edits, and runs this workspace with its own account, sandbox, and approvals."
+      },
+    ),
+  ])
+}
+
+///|
 /// The agent's prose. A bubble still `streaming` is the in-flight answer
 /// rendered live from the engine's deltas: the partial text is re-parsed as
 /// markdown on every delta, and an unterminated construct (an open code
@@ -964,6 +1050,7 @@ fn transcript_view(
   on_jump : (@mention_context.Target) -> @cmd.Cmd,
   on_open_session : (String) -> @cmd.Cmd,
   on_jump_latest~ : @cmd.Cmd,
+  stream_children? : Map[String, @html.Html],
 ) -> @html.Html {
   let renderer : TranscriptRenderer = {
     input,
@@ -971,8 +1058,16 @@ fn transcript_view(
     on_jump,
     on_open_session,
   }
+  let stream_children = match stream_children {
+    Some(children) => children
+    None => renderer.stream_children()
+  }
   let children = renderer.section_children(
-    pinned, overview, overview_emit, on_jump_latest,
+    pinned,
+    overview,
+    overview_emit,
+    on_jump_latest,
+    stream_children~,
   )
   // These identity attributes make conversation and root changes observable
   // even when the rendered children stay identical. The component subscription

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -855,92 +855,6 @@ fn transcript_item_view(
 }
 
 ///|
-/// Render one block with the component's callbacks. Subrun links are rebuilt
-/// from `subrun_parent` because `SubrunLink` holds a callback and therefore
-/// never lives in the `Eq` block itself.
-fn Block::render(
-  self : Block,
-  on_open : (String) -> @cmd.Cmd,
-  on_jump : (@mention_context.Target) -> @cmd.Cmd,
-  on_open_session : (String) -> @cmd.Cmd,
-) -> @html.Html {
-  match self.kind {
-    Item(item) =>
-      transcript_item_view(
-        item,
-        on_open,
-        anchor?=self.anchor,
-        on_jump~,
-        assistant_name=self.assistant_name(),
-        step_label?=self.step_label,
-        subrun?=self.subrun(on_open_session),
-      )
-    Rule(ts~) => turn_rule_view(ts?)
-    Live(prose~, reasoning~, reasoning_complete~) =>
-      assistant_view(
-        on_open,
-        prose?,
-        reasoning?,
-        step_label?=self.step_label,
-        assistant_name=self.assistant_name(),
-        live=true,
-        reasoning_complete~,
-      )
-    Empty => empty_stream_view(self.source)
-  }
-}
-
-///|
-fn Block::assistant_name(self : Block) -> String {
-  match self.source {
-    OpenSeek => "OpenSeek"
-    Codex => "Codex"
-  }
-}
-
-///|
-/// The sub-run link this block's tool results can offer, rebuilt from the
-/// session the block was produced under. `None` for every transcript source
-/// that has no sub-runs, which is also what keeps the chip out of rendering
-/// tests that do not supply one.
-fn Block::subrun(
-  self : Block,
-  on_open_session : (String) -> @cmd.Cmd,
-) -> SubrunLink? {
-  match self.subrun_parent {
-    Some(parent) => Some({ parent, open: on_open_session, })
-    None => None
-  }
-}
-
-///|
-/// The transcript's empty state: the badge and copy for whichever source owns
-/// the stream. One block, so a session that gains its first row replaces this
-/// single node instead of diffing a list.
-fn empty_stream_view(source : Source) -> @html.Html {
-  @html.div(class="empty", [
-    @html.div(class="empty-badge", [
-      @icons.icon(
-        match source {
-          OpenSeek => @icons.icon_logo
-          Codex => @icons.icon_sparkle
-        },
-      ),
-    ]),
-    @html.div(class="empty-title", "What should we build?"),
-    @html.div(
-      class="empty-sub",
-      match source {
-        OpenSeek =>
-          "SeekMoon plans the work, edits files across your workspace, runs your tests, and hands back a reviewable result."
-        Codex =>
-          "Codex inspects, edits, and runs this workspace with its own account, sandbox, and approvals."
-      },
-    ),
-  ])
-}
-
-///|
 /// The agent's prose. A bubble still `streaming` is the in-flight answer
 /// rendered live from the engine's deltas: the partial text is re-parsed as
 /// markdown on every delta, and an unterminated construct (an open code
@@ -1041,33 +955,24 @@ fn summary_card_view(
 }
 
 ///|
+/// The transcript section around its already rendered stream children (see
+/// `stream_blocks`): the component memoizes those per block, so this view
+/// only assembles them.
 fn transcript_view(
   input : Input,
   pinned~ : Bool,
   overview~ : @transcript_overview.State,
   overview_emit~ : @cmd.Emit[@transcript_overview.Msg],
-  on_open : (String) -> @cmd.Cmd,
-  on_jump : (@mention_context.Target) -> @cmd.Cmd,
-  on_open_session : (String) -> @cmd.Cmd,
+  stream~ : Map[String, @html.Html],
   on_jump_latest~ : @cmd.Cmd,
-  stream_children? : Map[String, @html.Html],
 ) -> @html.Html {
-  let renderer : TranscriptRenderer = {
+  let children = section_children(
     input,
-    on_open,
-    on_jump,
-    on_open_session,
-  }
-  let stream_children = match stream_children {
-    Some(children) => children
-    None => renderer.stream_children()
-  }
-  let children = renderer.section_children(
-    pinned,
-    overview,
-    overview_emit,
-    on_jump_latest,
-    stream_children~,
+    stream~,
+    pinned~,
+    overview~,
+    overview_emit~,
+    on_jump_latest~,
   )
   // These identity attributes make conversation and root changes observable
   // even when the rendered children stay identical. The component subscription

--- a/desktop/frontend/transcript/component/view_tests.mbt
+++ b/desktop/frontend/transcript/component/view_tests.mbt
@@ -184,3 +184,69 @@ test "tool output truncation keeps the head and tail around a skip marker" {
   assert_true(bounded.has_suffix("x".repeat(8_000)))
   assert_true(bounded.contains("10000 UTF-16 code units skipped"))
 }
+
+///|
+test "blocks for a streaming delta differ only in the live block" {
+  let call : @transcript.ToolCall = {
+    call_id: "c1",
+    name: "shell",
+    arguments: Some("{}"),
+    outcome: Pending(output=None),
+  }
+  let response : @transcript.TranscriptItem = {
+    kind: Assistant(
+      reasoning=None,
+      prose=Some("I will check it."),
+      calls=[call],
+      replay=false,
+      finished=false,
+    ),
+    ts: None,
+    sequence: Some(42),
+  }
+  let input = Input(
+    source=OpenSeek,
+    focused=@interop.ChannelId::Local,
+    active_session="desktop-test",
+    root=None,
+    submission_generation=1,
+    items=[
+      {
+        item: { kind: User("question"), ts: None, sequence: Some(41), },
+        identity: "s41",
+      },
+      { item: response, identity: "s42", },
+    ],
+    streaming_response=Some("part"),
+    streaming_identity="r7",
+  )
+  let renderer : TranscriptRenderer = {
+    input,
+    on_open: _ => @cmd.none,
+    on_jump: _ => @cmd.none,
+    on_open_session: _ => @cmd.none,
+  }
+  let before = renderer.blocks()
+  let after = {
+    ..renderer,
+    input: { ..input, streaming_response: Some("partial"), },
+  }.blocks()
+  assert_eq(
+    [
+      for index in 0..<before.length() => before.at(index).key
+    ],
+    [
+      for index in 0..<after.length() => after.at(index).key
+    ],
+  )
+  let changed : Array[Int] = []
+  for index in 0..<before.length() {
+    if before.at(index) != after.at(index) {
+      changed.push(index)
+    }
+  }
+  // Only the live response changed; the durable rows — and the Markdown
+  // parses their render owns — are Eq-stable across the delta.
+  assert_eq(changed, [before.length() - 1])
+  assert_true(before.at(before.length() - 1).key.has_prefix("live\u{0}"))
+}

--- a/desktop/frontend/transcript/component/view_tests.mbt
+++ b/desktop/frontend/transcript/component/view_tests.mbt
@@ -1,4 +1,9 @@
 ///|
+fn stream_keys(input : Input) -> Array[String] {
+  stream_blocks(input).to_array().map(block => block.key.wire())
+}
+
+///|
 test "transcript stream children use stable typed keys in display order" {
   let call : @transcript.ToolCall = {
     call_id: "c1",
@@ -33,13 +38,7 @@ test "transcript stream children use stable typed keys in display order" {
     streaming_response=Some("partial answer"),
     streaming_identity="r7",
   )
-  let renderer : TranscriptRenderer = {
-    input,
-    on_open: _ => @cmd.none,
-    on_jump: _ => @cmd.none,
-    on_open_session: _ => @cmd.none,
-  }
-  let keys = renderer.stream_children().to_array().map(pair => pair.0)
+  let keys = stream_keys(input)
   assert_eq(keys, ["row\u{0}s41", "rule\u{0}s41", "row\u{0}s42", "live\u{0}r7"])
   // The result filling the call, and the durable reasoning the same event
   // turns out to carry, change the response's node, never its identity: the
@@ -68,12 +67,7 @@ test "transcript stream children use stable typed keys in display order" {
       },
     ],
   }
-  let settled_renderer = { ..renderer, input: settled, }
-  let settled_keys = settled_renderer
-    .stream_children()
-    .to_array()
-    .map(pair => pair.0)
-  assert_eq(settled_keys, keys)
+  assert_eq(stream_keys(settled), keys)
 }
 
 ///|
@@ -93,51 +87,80 @@ test "the live response is one node, replaced by the durable one" {
     streaming_reasoning="next thought",
     streaming_identity="r7",
   )
-  let renderer : TranscriptRenderer = {
-    input: live_input,
-    on_open: _ => @cmd.none,
-    on_jump: _ => @cmd.none,
-    on_open_session: _ => @cmd.none,
-  }
-  let live_keys = renderer.stream_children().to_array().map(pair => pair.0)
+  let live_keys = stream_keys(live_input)
   assert_eq(live_keys, ["row\u{0}s1", "rule\u{0}s1", "live\u{0}r7"])
   // The answer streaming after the thought joins the same node.
-  let answering = {
-    ..renderer,
-    input: { ..live_input, streaming_response: Some("partial"), },
-  }
-  assert_eq(
-    answering.stream_children().to_array().map(pair => pair.0),
-    live_keys,
-  )
+  let answering = { ..live_input, streaming_response: Some("partial"), }
+  assert_eq(stream_keys(answering), live_keys)
   // The durable commit is its own node; the preview is gone with the run.
   let settled = {
-    ..renderer,
-    input: {
-      ..live_input,
-      items: [
-        user,
-        {
-          item: {
-            kind: Assistant(
-              reasoning=Some("next thought"),
-              prose=Some("answer"),
-              calls=[],
-              replay=false,
-              finished=false,
-            ),
-            ts: None,
-            sequence: Some(2),
-          },
-          identity: "s2",
+    ..live_input,
+    items: [
+      user,
+      {
+        item: {
+          kind: Assistant(
+            reasoning=Some("next thought"),
+            prose=Some("answer"),
+            calls=[],
+            replay=false,
+            finished=false,
+          ),
+          ts: None,
+          sequence: Some(2),
         },
-      ],
-      streaming_reasoning: None,
-    },
+        identity: "s2",
+      },
+    ],
+    streaming_reasoning: None,
   }
-  assert_eq(settled.stream_children().to_array().map(pair => pair.0), [
-    "row\u{0}s1", "rule\u{0}s1", "row\u{0}s2",
-  ])
+  assert_eq(stream_keys(settled), ["row\u{0}s1", "rule\u{0}s1", "row\u{0}s2"])
+}
+
+///|
+test "a streaming delta changes only the live block" {
+  let input = Input(
+    source=OpenSeek,
+    focused=@interop.ChannelId::Local,
+    active_session="desktop-test",
+    root=None,
+    submission_generation=1,
+    items=[
+      {
+        item: { kind: User("question"), ts: Some(1.0e12), sequence: Some(1), },
+        identity: "s1",
+      },
+      {
+        item: {
+          kind: Assistant(
+            reasoning=Some("thinking"),
+            prose=Some("I will check it."),
+            calls=[],
+            replay=false,
+            finished=false,
+          ),
+          ts: None,
+          sequence: Some(2),
+        },
+        identity: "s2",
+      },
+    ],
+    streaming_response=Some("partial"),
+    streaming_identity="r7",
+  )
+  let before = stream_blocks(input).to_array()
+  let after = stream_blocks({
+    ..input,
+    streaming_response: Some("partial answer"),
+  }).to_array()
+  assert_eq(after.length(), before.length())
+  let changed : Array[String] = []
+  for index, block in before {
+    if block != after[index] {
+      changed.push(block.key.wire())
+    }
+  }
+  assert_eq(changed, ["live\u{0}r7"])
 }
 
 ///|
@@ -164,6 +187,15 @@ test "transcript stream section key scopes equal session ids by channel" {
     TranscriptSectionKey::stream(remote).wire(),
     "stream\u{0}openseek\u{0}remote.device-a\u{0}desktop-test",
   )
+  // A block's memoized branch is scoped the same way: the same key in another
+  // stream is another branch.
+  assert_eq(
+    stream_blocks(local_input).to_array().map(block => block.branch_key()),
+    ["stream\u{0}openseek\u{0}local\u{0}desktop-test\u{0}empty"],
+  )
+  assert_eq(stream_blocks(remote).to_array().map(block => block.branch_key()), [
+    "stream\u{0}openseek\u{0}remote.device-a\u{0}desktop-test\u{0}empty",
+  ])
 }
 
 ///|
@@ -183,70 +215,4 @@ test "tool output truncation keeps the head and tail around a skip marker" {
   assert_true(bounded.has_prefix("x".repeat(12_000)))
   assert_true(bounded.has_suffix("x".repeat(8_000)))
   assert_true(bounded.contains("10000 UTF-16 code units skipped"))
-}
-
-///|
-test "blocks for a streaming delta differ only in the live block" {
-  let call : @transcript.ToolCall = {
-    call_id: "c1",
-    name: "shell",
-    arguments: Some("{}"),
-    outcome: Pending(output=None),
-  }
-  let response : @transcript.TranscriptItem = {
-    kind: Assistant(
-      reasoning=None,
-      prose=Some("I will check it."),
-      calls=[call],
-      replay=false,
-      finished=false,
-    ),
-    ts: None,
-    sequence: Some(42),
-  }
-  let input = Input(
-    source=OpenSeek,
-    focused=@interop.ChannelId::Local,
-    active_session="desktop-test",
-    root=None,
-    submission_generation=1,
-    items=[
-      {
-        item: { kind: User("question"), ts: None, sequence: Some(41), },
-        identity: "s41",
-      },
-      { item: response, identity: "s42", },
-    ],
-    streaming_response=Some("part"),
-    streaming_identity="r7",
-  )
-  let renderer : TranscriptRenderer = {
-    input,
-    on_open: _ => @cmd.none,
-    on_jump: _ => @cmd.none,
-    on_open_session: _ => @cmd.none,
-  }
-  let before = renderer.blocks()
-  let after = {
-    ..renderer,
-    input: { ..input, streaming_response: Some("partial"), },
-  }.blocks()
-  assert_eq(
-    [
-      for index in 0..<before.length() => before.at(index).key
-    ],
-    [
-      for index in 0..<after.length() => after.at(index).key
-    ],
-  )
-  let changed : Array[Int] = []
-  for index in 0..<before.length() {
-    if before.at(index) != after.at(index) {
-      changed.push(index)
-    }
-  }
-  // Only the live response changed; the durable rows — and the Markdown
-  // parses their render owns — are Eq-stable across the delta.
-  assert_eq(changed, [before.length() - 1])
-  assert_true(before.at(before.length() - 1).key.has_prefix("live\u{0}"))
 }


### PR DESCRIPTION
Closes #1261

Every streaming delta rebuilt the whole transcript: `TranscriptRenderer::stream_children` re-ran `transcript_item_view` for every historical item, re-parsing its Markdown, and Rabbita then diffed the resulting keyed children. The DOM stayed stable because the keys are stable, but the CPU cost of a delta grew with transcript length even though only the live row changed.

## Approach

- `stream_blocks(input)` reduces an input snapshot to a pure, `Eq` `Vector[Block]` in display order: one block per row, the user-turn rule, the live row, or the single empty-state block. Building blocks parses no Markdown and constructs no Html.
- `Block` is `{ stream, key, content }`: the stream's section key, the row's render key, and a `BlockContent` (`Empty` / `Item` / `TurnRule` / `Live`) that carries only the data its own view reads. `Block::branch_key()` is `<stream>\0<key>`, so assoc_by branches are never reused across conversations even where durable sequence numbers coincide.
- `Block::render(actions)` is the unchanged `transcript_item_view` / `assistant_view` / `turn_rule_view` family, fed the component's `Actions` at render time; `SubrunLink` is rebuilt from `subrun_parent`, so no callback ever lives in the `Eq` block.
- `component()` maps the input to blocks, renders each behind Rabbita's `assoc_by` (plain `Val::map` branches returning `(key, Html)`, no state), and `view3` assembles the ordered map for `#stream`. An unchanged block's Html — and its Markdown parse — is reused across streaming deltas.
- `transcript_view` now takes the rendered `stream~` map and no callbacks; `TranscriptRenderer` is gone. The key-order tests read keys from `stream_blocks` through a small helper.

## Verification

- New unit test: `stream_blocks` for an input and for the same input plus a streaming delta differ only in the live block; the section-key test also asserts that equal row keys in different streams get different branch keys.
- `moon check --target js|native --deny-warn` and `moon fmt --check`: clean. Public `pkg.generated.mbti` unchanged.
- `moon test --target js frontend/transcript/component`: 18/18.
- `moon test --target js` (whole desktop module): 3184/3184; `moon test --target native`: 3231/3231.
- `just test-browser`: 32/33 locally on macOS; the one failure ("sidebar menu dismissal and pending selection follow the clicked row") reproduces on the baseline bundle at `main` and is a macOS-only scrollbar-gutter coordinate issue in that test, not this change. The suite is green on CI.

## Measured after this change (long OpenSeek transcript, dev bundle, CDP profile)

The Markdown parse and vnode build are gone from the profile. What remains per render is Rabbita's `diff_document` walking every element (76k here, 86% of them highlighted code inside folded `<details>`) because `diff_node` has no pointer-equality shortcut, plus the header `pulseDot` `box-shadow` animation forcing continuous repaints while a run is active. Both are follow-ups outside this PR.

Generated with SeekMoon; second commit via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01412HtYLqJQ5X5Qf2szNzau
