### PR TITLE
test(desktop): click the sidebar row's title in the menu-dismissal e2e

### DIFF
--- a/desktop/e2e/tests/rabbita_dom.spec.js
+++ b/desktop/e2e/tests/rabbita_dom.spec.js
@@ -1145,7 +1145,9 @@ test('sidebar menu dismissal and pending selection follow the clicked row', asyn
   await expect(page.getByRole('menu', { name: 'Workspace actions' })).toBeVisible();
 
   const first = page.locator('.conversation-row[title="session-1"]');
-  await first.click({ position: { x: 220, y: 16 } });
+  // Click the title, not a fixed offset: the row's right end is the
+  // hover-revealed archive button, and the row's width is platform-dependent.
+  await first.locator('.sidebar-label').click();
   await expect(page.getByRole('menu')).toHaveCount(0);
   await expect(first).toHaveClass(/active/);
   await expect(page.getByText('Browser result', { exact: true })).toBeVisible();


### PR DESCRIPTION
## Summary

`sidebar menu dismissal and pending selection follow the clicked row` fails on macOS at baseline `main` while the Desktop workflow on Linux is green. The test clicked the session-1 row at a fixed `x: 220`, which on macOS is inside the hover-revealed archive button: the click sends `session.archive`, the row disappears, and the following `toHaveClass(/active/)` times out.

This PR clicks the row's title (`.sidebar-label`) instead, so the row itself receives the click regardless of how wide the platform makes it.

## Root cause

Measured with the same `dist/browser` bundle on macOS headless and inside `mcr.microsoft.com/playwright:v1.60.0-noble` (Playwright 1.60 / Chromium 148, viewport 1440×900 in both):

- Playwright launches headless Chromium with `--hide-scrollbars`, so the startup probe in `frontend/dom_helpers.mbt` measures `--scrollbar-lane: 0px` on **both** platforms and `.sidebar-main` keeps its full 12px right padding.
- `scrollbar-gutter: stable` on `.sidebar-main` still reserves the platform's classic scrollbar thickness: 15px on Linux (`clientWidth` 248 vs `offsetWidth` 263), 0 on macOS (overlay bars).

| | macOS headless | Linux headless (CI) |
|---|---|---|
| session-1 row width | 239px | 224px |
| archive button, row-relative x | [211, 231) | [196, 216) |
| `x: 220` hits | archive button → `session.archive` | row body → `session.load` |

So CI passes only because of a headless-only artifact. The packaged app (CEF, no `--hide-scrollbars`) would size Linux rows at 236px and put the button at [208, 228), where `x: 220` would archive as well. The fixed offset was fragile on every platform; the open Workspace menu (y 100–167) never overlaps session-1 (y 192–224), so the far-right offset was not needed to avoid it either.

Not changed here: the probe measures a scrollbar while the CSS subtracts a gutter, and the two only disagree under `--hide-scrollbars`. Switching the app to custom-drawn scrollbars would make both agree and remove the probe; that is a separate change.

## Verification

- macOS: `npx playwright test` → 33 passed (previously 32 passed, 1 failed at baseline).
- Linux (`mcr.microsoft.com/playwright:v1.60.0-noble`, same bundle): `npx playwright test -g "sidebar menu dismissal"` → 1 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KEVp9XAEDE28GHkoYLATAn
