### PR TITLE
[draft] cmd/edit: the edit tool as a standalone program for program tool calls

### DIFF
--- a/README.mbt.md
+++ b/README.mbt.md
@@ -72,6 +72,7 @@ git submodule update --init editor/vscode     # opt-in performance suite
 | `bobzhang/openseek/agent` | Native-only OpenSeek agent loop and local tool dispatch. | `agent/README.mbt.md` |
 | `bobzhang/openseek/agent_review` | Read-only, compiler-grounded code-review engine behind `openseek review`. | `agent_review/README.mbt.md` |
 | `bobzhang/openseek/cmd/openseek` | Native-only headless automation CLI (`openseek`). | `cmd/openseek/README.md` |
+| `bobzhang/openseek/cmd/edit` | Native-only standalone `edit` binary: the edit tool as a program, for programmatic composition from `mbtx`. | `cmd/edit/README.md` |
 | `bobzhang/openseek/cli` | Shared command-main helpers: the agent options (`--api-key`, `--model`, …) and failure-text sanitizer used by `openseek` and the out-of-tree `openseek_tui`. | — |
 | `bobzhang/openseek/viz` | Browser viewer for durable session logs (JS). | `viz/README.md` |
 | `bobzhang/inspect` (in `inspect/`, own module) | HTTP server (native or wasm) that serves the visualizer over recorded sessions. | `inspect/README.md` |
@@ -233,6 +234,9 @@ and exposes each on `PATH` as `<name>.exe` (e.g. `openseek.exe`).
 - [`tests/cram/cli.md`](tests/cram/cli.md) — offline `openseek` subcommand
   examples (top-level and `run` help, and the `run`/`serve`/`sessions` behaviors).
   They make no network calls and run in CI via `moon cram test tests/cram`.
+- [`tests/cram/edit.md`](tests/cram/edit.md) — offline `edit` examples: a
+  successful edit, stdin input, a failed match, the parse gate, and the
+  environment-supplied write confinement.
 - [`tests/cram/subrun.md`](tests/cram/subrun.md) — the offline internal child-mode
   wire contract: JSON input on stdin, JSONL events on stdout, typed reports, and
   failure-event delivery. It uses the modelless `echo` kind and needs no API key.

--- a/cmd/edit/README.md
+++ b/cmd/edit/README.md
@@ -1,0 +1,59 @@
+# OpenSeek Edit CLI
+
+The `edit` agent tool as a standalone program, so a **program tool call** (an
+`mbtx` snippet) can compose edits itself instead of the model emitting one tool
+call per change. The model can then derive edits from something it just
+computed — `moon check` output, a grep result — and apply them in a loop, inside
+a single turn.
+
+This package is deliberately thin. It builds `agent_tool/edit`'s definition and
+runs *that* package's own executor, so the decode, the exact-match discipline,
+the parse gate, and the response text are the same ones the in-process tool
+produces. There is no second implementation of edit to drift.
+
+```bash
+edit '{"path":"src/a.mbt","old_string":"one","new_string":"two","start_line":12}'
+echo "$payload" | edit          # or from stdin, for a large payload
+```
+
+Exit status is 0 when the tool responded normally and 1 when it reported an
+error, so a snippet can branch on the result instead of parsing the message. The
+tool's own text goes to stdout either way.
+
+## Confinement Comes From The Environment
+
+The caller writes the JSON, so the JSON cannot be what decides where writes may
+land — otherwise a snippet could widen its own reach just by asking. The bound
+comes from the environment instead, and the payload has no say in it:
+
+| Variable | Meaning |
+| --- | --- |
+| `OPENSEEK_EDIT_ROOT` | Workspace root. When set, every write is confined to it by a `write_scope`. When unset, the program runs unconfined against the working directory — the standalone, non-agent mode. |
+| `OPENSEEK_EDIT_ALLOWED_PATHS` | Newline-separated paths that narrow that scope further, matching a worker subagent's `allowed_paths`. Ignored without a root, since there is nothing to resolve against. |
+
+A malformed allowlist fails the run rather than silently widening to the whole
+root: a confinement that cannot be built is not a confinement. The scope
+resolves symlinks and `..` before deciding, so neither can smuggle a write out.
+
+## What This Does Not Carry
+
+Provenance. The engine's `FileStateMap` records which files the agent created or
+modified this session, and `remove` will only delete a file it can prove the
+agent created and that is byte-identical to what was written. That map is an
+in-memory handle inside the engine process, so edits made here are invisible to
+it.
+
+The effect is fail-closed and intentional: `remove` refuses to delete a file
+that only this program touched, because it cannot prove the provenance. Sharing
+the record across both paths is a separate piece of work, and it is what would
+let `remove` act on programmatic edits.
+
+## Tests
+
+[`tests/cram/edit.md`](../../tests/cram/edit.md) is executable documentation of
+this command line: a successful edit, stdin input, a failed match, the parse
+gate, and the environment confinement. It runs offline.
+
+```bash
+moon cram test tests/cram
+```

--- a/cmd/edit/README.md
+++ b/cmd/edit/README.md
@@ -35,6 +35,26 @@ A malformed allowlist fails the run rather than silently widening to the whole
 root: a confinement that cannot be built is not a confinement. The scope
 resolves symlinks and `..` before deciding, so neither can smuggle a write out.
 
+## Who May Spawn This
+
+The environment is the confinement, so whoever spawns this program decides its
+bound. That is sound when the spawner is the engine, which sets the variables
+itself. It is **not** sound when the spawner is a model-authored `mbtx` snippet:
+`@process.run` takes `extra_env` and `inherit_env`, so a snippet can start this
+program with any environment it likes, including none.
+
+That is why this binary is **not** on the mbtx spawn allowlist. A snippet today
+cannot write the workspace at all — moonrun's `fs` rules grant it only its temp
+directory and a read-only role's scratch lab, deliberately, so that a snippet
+cannot route around `remove`'s provenance check. Admitting an editor that takes
+its scope from a caller-supplied environment would hand back exactly that reach.
+
+Wiring this up for program tool calls therefore needs a confinement the caller
+cannot choose. The workable shape is discovery rather than instruction: the
+engine writes the policy inside the workspace, and this program finds it by
+walking up from the file it is about to modify. A snippet cannot plant a
+competing policy there, because it cannot write there.
+
 ## What This Does Not Carry
 
 Provenance. The engine's `FileStateMap` records which files the agent created or

--- a/cmd/edit/main.mbt
+++ b/cmd/edit/main.mbt
@@ -1,0 +1,124 @@
+///|
+/// `openseek-edit` — the `edit` agent tool as a standalone program, so a
+/// program tool call (an `mbtx` snippet) can compose edits itself instead of
+/// the model emitting one tool call per change. It is a thin main over
+/// `agent_tool/edit`: the same decode, the same parse gate, the same response
+/// text as the in-process tool, because it runs that package's own executor
+/// rather than reimplementing it.
+///
+/// The edit arguments are the tool's own JSON object, read from `argv[1]` when
+/// present and otherwise from stdin (stdin keeps large payloads off the command
+/// line). The write confinement is deliberately NOT part of that payload: a
+/// caller that authors the JSON must not be able to widen its own scope, so the
+/// bound comes from the environment instead.
+///
+/// - `OPENSEEK_EDIT_ROOT` — workspace root. When set, every write is confined
+///   to it by a `write_scope`; when unset the program runs unconfined against
+///   the working directory, which is the standalone (non-agent) mode.
+/// - `OPENSEEK_EDIT_ALLOWED_PATHS` — newline-separated paths that narrow that
+///   scope further, matching a worker subagent's `allowed_paths`. Ignored
+///   without `OPENSEEK_EDIT_ROOT`, since there is no root to resolve against.
+///
+/// Exit status is 0 when the tool responded normally and 1 when it reported an
+/// error, so a snippet can branch on the result; the tool's own message goes to
+/// stdout either way, error or not.
+async fn main {
+  run() catch {
+    error => {
+      @stdio.stderr.write("error: \{error}\n") catch {
+        _ => ()
+      }
+      @sys.exit(1)
+    }
+  }
+}
+
+///|
+/// Decode the arguments, build the tool with its environment-supplied
+/// confinement, and run the tool's own executor.
+async fn run() -> Unit {
+  let arguments = @json.parse(payload_text())
+  let root = match @env.get_env_var("OPENSEEK_EDIT_ROOT") {
+    Some(value) if value.trim() != "" => "\{value.trim()}"
+    _ => ""
+  }
+  let definition = if root == "" {
+    @edit_tool.definition(workspace_root=".")
+  } else {
+    let write_scope = Some(confinement(root))
+    @edit_tool.definition(workspace_root=root, write_scope?)
+  }
+  let action = match definition.execute {
+    Async(execute) => execute(arguments)
+    Sync(execute) => execute(arguments)
+  }
+  match action {
+    Respond(output) => {
+      println(output.content)
+      if output.is_error {
+        @sys.exit(1)
+      }
+    }
+    // `edit` only ever responds; a control action would mean the definition
+    // changed shape under us, which is a bug rather than a failed edit.
+    Control(_) => {
+      @stdio.stderr.write("error: edit returned a control action\n") catch {
+        _ => ()
+      }
+      @sys.exit(1)
+    }
+  }
+}
+
+///|
+/// The write scope for `root`, narrowed by `OPENSEEK_EDIT_ALLOWED_PATHS` when
+/// that is set. A malformed allowlist fails the run rather than silently
+/// widening to the whole root: a confinement that cannot be built is not a
+/// confinement.
+async fn confinement(root : String) -> @write_scope.WriteScope {
+  let created = match allowed_paths() {
+    Some(allowed_paths) =>
+      @write_scope.WriteScope::create(root~, allowed_paths~)
+    None => @write_scope.WriteScope::create(root~)
+  }
+  match created {
+    Ok(scope) => scope
+    Err(reason) => fail("cannot confine writes to '\{root}': \{reason}")
+  }
+}
+
+///|
+/// The `OPENSEEK_EDIT_ALLOWED_PATHS` entries, or `None` when the variable is
+/// unset or holds only blank lines.
+fn allowed_paths() -> Array[String]? {
+  guard @env.get_env_var("OPENSEEK_EDIT_ALLOWED_PATHS") is Some(raw) else {
+    return None
+  }
+  let paths = []
+  for line in raw.split("\n") {
+    let path = line.trim()
+    if path != "" {
+      paths.push("\{path}")
+    }
+  }
+  if paths.is_empty() {
+    None
+  } else {
+    Some(paths)
+  }
+}
+
+///|
+/// The raw JSON arguments: `argv[1]` when given, otherwise all of stdin.
+async fn payload_text() -> String {
+  match @env.args() {
+    [_, argument, ..] => argument
+    _ => {
+      let text = StringBuilder()
+      while @stdio.stdin.read_until("\n") is Some(line) {
+        text.write_string(line)
+      }
+      text.to_string()
+    }
+  }
+}

--- a/cmd/edit/moon.pkg
+++ b/cmd/edit/moon.pkg
@@ -1,0 +1,16 @@
+import {
+  "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/agent_tool/edit" @edit_tool,
+  "bobzhang/openseek/agent_tool/write_scope",
+  "moonbitlang/async",
+  "moonbitlang/async/stdio",
+  "moonbitlang/core/env",
+  "moonbitlang/core/json",
+  "moonbitlang/x/sys",
+}
+
+warnings = "+unnecessary_annotation"
+
+supported_targets = "+native"
+
+pkgtype(kind: "executable")

--- a/cmd/edit/pkg.generated.mbti
+++ b/cmd/edit/pkg.generated.mbti
@@ -1,0 +1,12 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/cmd/edit"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits

--- a/tests/cram/edit.md
+++ b/tests/cram/edit.md
@@ -1,0 +1,143 @@
+# Verified OpenSeek Edit CLI Documentation
+
+These examples are executed by `moon cram test tests/cram`. The Moon wrapper
+builds the native package at `cmd/edit` and exposes the executable on `PATH` as
+`edit.exe`.
+
+`edit.exe` is the `edit` agent tool as a standalone program, so a program tool
+call (an `mbtx` snippet) can compose edits itself instead of the model emitting
+one tool call per change. It is a thin main over `agent_tool/edit` and runs that
+package's own executor, so the decode, the parse gate, and the response text are
+the same ones the in-process tool produces.
+
+Every command here is offline: it only reads and writes files in its own
+scratch directory and never contacts a model.
+
+## An Edit Is One JSON Object
+
+The arguments are the tool's own JSON schema — `path`, `old_string`,
+`new_string`, and `start_line` are required. A successful edit reports what it
+replaced and exits zero.
+
+```mooncram
+$ sh <<'EOF'
+> d=$(mktemp -d); cd "$d"
+> printf 'one\ntwo\n' > a.txt
+> edit.exe '{"path":"a.txt","old_string":"two","new_string":"THREE","start_line":2}'
+> cat a.txt
+> cd /; rm -rf "$d"
+> EOF
+ok: replaced 1 occurrence(s) at line 2 in a.txt
+one
+THREE
+```
+
+## Arguments May Come From Stdin
+
+A large payload does not have to fit on the command line: with no argument, the
+program reads the JSON object from stdin instead.
+
+```mooncram
+$ sh <<'EOF'
+> d=$(mktemp -d); cd "$d"
+> printf 'one\n' > a.txt
+> echo '{"path":"a.txt","old_string":"one","new_string":"two","start_line":1}' | edit.exe
+> cd /; rm -rf "$d"
+> EOF
+ok: replaced 1 occurrence(s) at line 1 in a.txt
+```
+
+## A Failed Edit Exits Non-Zero
+
+The exact `old_string` is what proves the file still holds what the caller
+expects. When it does not match, nothing is written and the exit status is 1, so
+a snippet can branch on the result rather than parsing the message.
+
+```mooncram
+$ sh <<'EOF'
+> d=$(mktemp -d); cd "$d"
+> printf 'one\n' > a.txt
+> if edit.exe '{"path":"a.txt","old_string":"zzz","new_string":"x","start_line":1}' > out 2>&1; then echo exit-zero; else echo exit-non-zero; fi
+> sed -n '1p' out
+> cat a.txt
+> cd /; rm -rf "$d"
+> EOF
+exit-non-zero
+error editing a.txt: old_string not found from line 1
+one
+```
+
+## The Parse Gate Applies Here Too
+
+Because this is the same executor, an edit that would introduce new parse errors
+into a MoonBit file is refused and the file is left alone — the gate is not
+something the in-process tool adds on top.
+
+```mooncram
+$ sh <<'EOF'
+> d=$(mktemp -d); cd "$d"
+> printf 'fn main {\n  println("one")\n}\n' > a.mbt
+> edit.exe '{"path":"a.mbt","old_string":"fn main {","new_string":"fn main {{{","start_line":1}' 2>&1 | sed -n '1p'
+> sed -n '1p' a.mbt
+> cd /; rm -rf "$d"
+> EOF
+rejected: the edit would introduce 1 new parse error(s) in a.mbt, so the file was NOT modified.
+fn main {
+```
+
+## Confinement Comes From The Environment, Not The Payload
+
+The caller writes the JSON, so the JSON cannot be what decides where writes may
+land. `OPENSEEK_EDIT_ROOT` bounds every write to one root and
+`OPENSEEK_EDIT_ALLOWED_PATHS` narrows it further, matching a worker subagent's
+`allowed_paths`. A path inside the root but outside the allowlist is refused.
+
+```mooncram
+$ sh <<'EOF'
+> d=$(mktemp -d); cd "$d"
+> mkdir -p allowed other
+> printf 'one\n' > allowed/a.txt
+> printf 'one\n' > other/b.txt
+> export OPENSEEK_EDIT_ROOT=. OPENSEEK_EDIT_ALLOWED_PATHS=allowed
+> edit.exe '{"path":"allowed/a.txt","old_string":"one","new_string":"two","start_line":1}'
+> edit.exe '{"path":"other/b.txt","old_string":"one","new_string":"pwned","start_line":1}' 2>&1 | sed -n '1p'
+> cat other/b.txt
+> cd /; rm -rf "$d"
+> EOF
+ok: replaced 1 occurrence(s) at line 1 in allowed/a.txt
+error editing other/b.txt: write blocked: path is outside allowed_paths (allowed)
+one
+```
+
+Leaving the root escapes nothing either: the scope resolves symlinks and `..`
+before deciding, so the write is refused rather than followed.
+
+```mooncram
+$ sh <<'EOF'
+> d=$(mktemp -d); cd "$d"
+> mkdir -p work
+> cd work
+> OPENSEEK_EDIT_ROOT=. edit.exe '{"path":"../escape.txt","old_string":"","new_string":"x","start_line":1}' 2>&1 | sed -n '1p' | sed 's|/private||; s|'"$d"'|<tmp>|'
+> ls "$d"
+> cd /; rm -rf "$d"
+> EOF
+error editing ../escape.txt: write blocked: path resolves outside the writable root <tmp>/work (through a symlink or ..)
+work
+```
+
+## Malformed Input Is Reported, Not Guessed
+
+```mooncram
+$ sh <<'EOF'
+> d=$(mktemp -d); cd "$d"
+> if edit.exe 'not json' > out 2>&1; then echo exit-zero; else echo exit-non-zero; fi
+> sed -n '1p' out
+> if edit.exe '{"path":"a.txt"}' > out 2>&1; then echo exit-zero; else echo exit-non-zero; fi
+> sed -n '1p' out
+> cd /; rm -rf "$d"
+> EOF
+exit-non-zero
+error: Invalid character 'o' at line 1, column 1
+exit-non-zero
+error: edit requires arguments.old_string
+```


### PR DESCRIPTION
## Summary

First step of the program-tool-call plan: `cmd/edit` runs the `edit` agent tool as a standalone program, so an `mbtx` snippet can compose edits itself instead of the model emitting one tool call per change. Edits can then be derived from something the model just computed (a `moon check` run, a grep) and applied within a single turn.

It is deliberately thin: it builds `agent_tool/edit`'s definition and runs **that package's own executor**, so the decode, exact-match discipline, parse gate, and response text are the in-process tool's. There is no second implementation of edit to drift.

```bash
edit '{"path":"src/a.mbt","old_string":"one","new_string":"two","start_line":12}'
echo "$payload" | edit          # or stdin, for a large payload
```

Exit is 0 on a normal response and 1 on a reported error, so a snippet can branch without parsing the message.

## Confinement

The caller writes the JSON, so the JSON does not decide where writes may land. `OPENSEEK_EDIT_ROOT` bounds writes to one root; `OPENSEEK_EDIT_ALLOWED_PATHS` narrows it to a worker's `allowed_paths`. A malformed allowlist fails the run rather than widening to the whole root.

## Known limitation, and why mbtx wiring is NOT in this PR

Environment-supplied confinement binds a trusted spawner (the engine) but **not** a model-authored snippet: `@process.run` takes `extra_env` and `inherit_env`, so a snippet can start this program with any environment it chooses.

Today a snippet cannot write the workspace at all — moonrun's `fs` rules grant only its temp directory and a read-only role's scratch lab, specifically so a snippet cannot route around `remove`'s provenance check. Adding this binary to the mbtx spawn allowlist as it stands would hand that reach back, so it is not on the allowlist and this PR does not touch `spawnable_commands`.

The fix is discovery instead of instruction: the engine writes the policy inside the workspace and the program finds it by walking up from the file it is about to modify. A snippet cannot plant a competing policy there because it cannot write there. That is the next step and wants its own review.

Provenance is also not carried: `FileStateMap` is an in-memory handle in the engine, so `remove` refuses to delete a file only this program touched. Fail-closed and documented.

## Verification

- `moon fmt`, `moon check --deny-warn`, `moon info` (no interface drift)
- `moon test agent_tool/edit agent_tool/multi_edit agent_tool/write_scope cmd/edit --target native` — 103 passed
- `moon cram test tests/cram` — 30 passed, including the new `tests/cram/edit.md` covering a successful edit, stdin input, a failed match, the parse gate, out-of-allowlist denial, and a `..` escape attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHGA6k85VnewvkWC5miLzR
