### PR TITLE
refactor(desktop): stage moonbit-docs under the seed's share/doc/moonbit

### DIFF
--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -1393,13 +1393,13 @@ async fn add_moonbit_path_for_native_engine(
   // naming the cause now.
   let toolchain = @moonbit.resolve_toolchain(config.engine, runtime_dir?)
   toolchain.apply_to_env(env)
-  // The prepared payload also carries the seed's `docs/` (the moonbit-docs
-  // markdown build), which the engine advertises to the model as its MoonBit
-  // reference. Durable session prompts embed the path, and the payload lives
-  // in the per-user runtime directory, so it survives bundle moves and
-  // AppImage relaunches. A toolchain without docs — an external one, or a
-  // seed staged without them — advertises none, and the ambient value is
-  // scrubbed so the child never names docs the host did not resolve.
+  // The prepared payload also carries the seed's `share/doc/moonbit/` (the
+  // moonbit-docs markdown build), which the engine advertises to the model as
+  // its MoonBit reference. Durable session prompts embed the path, and the
+  // payload lives in the per-user runtime directory, so it survives bundle
+  // moves and AppImage relaunches. A toolchain without docs — an external
+  // one, or a seed staged without them — advertises none, and the ambient
+  // value is scrubbed so the child never names docs the host did not resolve.
   match toolchain.references {
     Some(docs) => env["OPENSEEK_REFERENCES"] = docs.to_string()
     None => env.remove("OPENSEEK_REFERENCES")
@@ -2776,18 +2776,18 @@ async test "native engine env has one authoritative bundled moon path" {
   let env = engine_process_env(config, Some(runtime))
   assert_eq(env["OPENSEEK_THINKING"], "high")
   assert_eq(env["DEEPSEEK"], "k")
-  // This payload carries no `docs/` yet: the engine env must not invent an
-  // OPENSEEK_REFERENCES the host did not resolve.
+  // This payload carries no `share/doc/moonbit/` yet: the engine env must
+  // not invent an OPENSEEK_REFERENCES the host did not resolve.
   assert_true(env.get("OPENSEEK_REFERENCES") is None)
   // The moonbit-docs markdown build travels inside the seed and therefore
   // inside the prepared payload, so the engine is pointed at the runtime
   // copy — the durable prompt embeds this path, and it must never name a
   // bundle location that unmounts when the app exits.
-  write_fake_file(moon_home.join("docs/language/index.md"))
+  write_fake_file(moon_home.join("share/doc/moonbit/language/index.md"))
   let env_with_references = engine_process_env(config, Some(runtime))
   assert_eq(
     env_with_references["OPENSEEK_REFERENCES"],
-    moon_home.join("docs").to_string(),
+    moon_home.join("share/doc/moonbit").to_string(),
   )
   // A GLM run's key travels in GLM, and the resolved variable — not a
   // hardcoded DEEPSEEK — is what the process env honors.

--- a/desktop/internal/moonbit/toolchain_paths.mbt
+++ b/desktop/internal/moonbit/toolchain_paths.mbt
@@ -5,6 +5,15 @@ const MoonbitBundleStampFile : String = ".openseek-moonbit-bundle-version"
 const MoonbitSeedVersionFile : String = ".openseek-moonbit-seed-version"
 
 ///|
+/// The seed-relative reference-docs path (FHS `share/doc/moonbit` under the
+/// toolchain prefix). Packaging stages the pinned moonbit-docs markdown build
+/// here (`MoonbitDocsRelDir` in
+/// `desktop/package/internal/moonbit/toolchain.mbt`), the payload copy
+/// carries it verbatim, and the engine advertises the tree to the model as
+/// `OPENSEEK_REFERENCES`.
+const MoonbitDocsRelDir : String = "share/doc/moonbit"
+
+///|
 fn moonbit_toolchain_dir(
   base : @pathx.Absolute,
   name : String,
@@ -113,10 +122,11 @@ fn moonbit_bin_dir(moon_home : @pathx.Path) -> @pathx.Path {
 }
 
 ///|
-/// The moonbit-docs markdown build packaging stages inside the seed, so the
-/// prepared payload carries the docs describing exactly its toolchain.
+/// The moonbit-docs markdown build packaging stages inside the seed at
+/// `share/doc/moonbit`, so the prepared payload carries the docs describing
+/// exactly its toolchain.
 fn moonbit_docs_dir(moon_home : @pathx.Path) -> @pathx.Path {
-  moon_home.join("docs")
+  moon_home.join(MoonbitDocsRelDir)
 }
 
 ///|

--- a/desktop/internal/moonbit/toolchain_resolve.mbt
+++ b/desktop/internal/moonbit/toolchain_resolve.mbt
@@ -11,9 +11,10 @@ pub struct ResolvedToolchain {
   bin_dir : @pathx.Absolute
   moon : @pathx.Absolute
   /// The MoonBit reference docs shipped with this toolchain, when it carries
-  /// them: the bundled payload's `docs/`, the moonbit-docs markdown build the
-  /// packager stages into the seed. An external toolchain never has any. The
-  /// engine advertises the directory to the model as `OPENSEEK_REFERENCES`.
+  /// them: the bundled payload's `share/doc/moonbit/`, the moonbit-docs
+  /// markdown build the packager stages into the seed. An external toolchain
+  /// never has any. The engine advertises the directory to the model as
+  /// `OPENSEEK_REFERENCES`.
   references : @pathx.Absolute?
 }
 
@@ -67,9 +68,10 @@ pub async fn resolve_toolchain(
       toolchain_at(bin_dir) is Some(toolchain) else {
       fail("bundled MoonBit toolchain payload is not a complete toolchain")
     }
-    // The seed's `docs/` came along in the payload copy, so the reference
-    // path is exactly as stable as `moon` itself: the per-user runtime
-    // directory, never the bundle (an AppImage mounts afresh per launch).
+    // The seed's `share/doc/moonbit/` came along in the payload copy, so the
+    // reference path is exactly as stable as `moon` itself: the per-user
+    // runtime directory, never the bundle (an AppImage mounts afresh per
+    // launch).
     let docs = moonbit_docs_dir(payload)
     let references = if @fsx.is_dir(docs) { docs.to_absolute() } else { None }
     return { ..toolchain, references, }

--- a/desktop/internal/moonbit/toolchain_resolve_wbtest.mbt
+++ b/desktop/internal/moonbit/toolchain_resolve_wbtest.mbt
@@ -140,12 +140,12 @@ async test "no toolchain anywhere raises ToolchainUnavailable" {
 ///|
 /// Reference docs ship only inside the bundled seed's payload; a toolchain
 /// found on the path or under `~/.moon` never advertises any, even with a
-/// `docs` directory sitting beside its `bin`.
+/// `share/doc/moonbit` reference tree sitting beside its `bin`.
 async test "an external toolchain carries no reference docs" {
   with_toolchain_test_tree(async fn(root) {
     let moon_root = root.join("home").join(".moon")
     @fs.mkdir(moon_root.join("bin").to_string(), recursive=true)
-    @fs.mkdir(moon_root.join("docs").to_string(), recursive=true)
+    @fs.mkdir(moon_root.join("share/doc/moonbit").to_string(), recursive=true)
     touch_fake_toolchain(moon_root.join("bin"))
     let toolchain = external_toolchain(home_dir=root.join("home").to_path())
     assert_eq(toolchain.bin_dir.to_string(), moon_root.join("bin").to_string())

--- a/desktop/package/internal/moonbit/toolchain.mbt
+++ b/desktop/package/internal/moonbit/toolchain.mbt
@@ -12,12 +12,20 @@ const MoonbitSeedVersionFile : String = ".openseek-moonbit-seed-version"
 
 ///|
 /// The moonbit-docs `markdown-build` commit whose generated Markdown pages
-/// ship inside every toolchain seed as `docs/`. The engine advertises that
-/// tree to the model as its MoonBit reference (`OPENSEEK_REFERENCES`), so it
-/// rides with the toolchain it documents: the runtime mirrors the whole seed
-/// into the per-user runtime directory, and a bump here refreshes that mirror
-/// through the seed version stamp exactly like a compiler bump does.
+/// ship inside every toolchain seed at `share/doc/moonbit/` (FHS-style under
+/// the toolchain prefix). The engine advertises that tree to the model as its
+/// MoonBit reference (`OPENSEEK_REFERENCES`), so it rides with the toolchain
+/// it documents: the runtime mirrors the whole seed into the per-user runtime
+/// directory, and a bump here refreshes that mirror through the seed version
+/// stamp exactly like a compiler bump does.
 const MoonbitDocsCommit : String = "750cc5a41679256441a3efa75487420028cff2e1"
+
+///|
+/// The seed-relative path that carries the moonbit-docs tree. Runtime
+/// resolution mirrors this layout through `MoonbitDocsRelDir` in
+/// `desktop/internal/moonbit/toolchain_paths.mbt`; the two must stay in step,
+/// or a seed ships docs the resolver never advertises as references.
+const MoonbitDocsRelDir : String = "share/doc/moonbit"
 
 ///|
 /// The pinned commit's source archive, fetched from codeload directly:
@@ -34,10 +42,11 @@ fn moonbit_docs_cache_path() -> String {
 }
 
 ///|
-/// The seed version stamp names both pins: the runtime compares it whole
-/// against its mirror's stamp, so a docs-only bump rebuilds the mirror too.
+/// The seed version stamp names every seed-content pin: the runtime compares
+/// it whole against its mirror's stamp, so a docs-only bump — or a change to
+/// where the docs tree sits in the seed — rebuilds the mirror too.
 fn moonbit_seed_version(version : String) -> String {
-  version + " docs=" + MoonbitDocsCommit
+  version + " docs=" + MoonbitDocsCommit + " docsdir=" + MoonbitDocsRelDir
 }
 
 ///|
@@ -300,8 +309,9 @@ async fn compiler_version(
 }
 
 ///|
-/// Stage the pinned moonbit-docs markdown build as the seed's `docs/` tree.
-/// Only the archive is reused across runs; the tree is re-extracted every
+/// Stage the pinned moonbit-docs markdown build as the seed's
+/// `share/doc/moonbit/` tree. Only the archive is reused across runs; the
+/// tree is re-extracted every
 /// time so a stale partial extraction cannot ship. The Sphinx theme assets
 /// the build carries are dropped: the references are the Markdown pages.
 async fn stage_moonbit_docs(
@@ -326,8 +336,10 @@ async fn stage_moonbit_docs(
 
 ///|
 /// Download and stage a platform-specific MoonBit toolchain seed into a
-/// package directory, with the pinned moonbit-docs as its `docs/`. The seed
-/// is intentionally not bundled in place; runtime initialization copies it to
+/// package directory, with the pinned moonbit-docs as its
+/// `share/doc/moonbit/`. The
+/// seed is intentionally not bundled in place; runtime initialization copies
+/// it to
 /// the per-user writable runtime directory first.
 pub async fn stage_moonbit_toolchain_seed(
   ws : @packaging.Workspace,
@@ -358,7 +370,7 @@ pub async fn stage_moonbit_toolchain_seed(
       "downloaded MoonBit version \{actual_version}, expected \{version}",
     )
   }
-  stage_moonbit_docs(ws, payload_dir + "/docs")
+  stage_moonbit_docs(ws, payload_dir + "/" + MoonbitDocsRelDir)
   @packaging.write_text(
     ws.at(payload_dir + "/" + MoonbitSeedVersionFile),
     moonbit_seed_version(version),

--- a/desktop/package/internal/moonbit/toolchain.mbt
+++ b/desktop/package/internal/moonbit/toolchain.mbt
@@ -42,10 +42,11 @@ fn moonbit_docs_cache_path() -> String {
 }
 
 ///|
-/// The seed version stamp names both pins: the runtime compares it whole
-/// against its mirror's stamp, so a docs-only bump rebuilds the mirror too.
+/// The seed version stamp names every seed-content pin: the runtime compares
+/// it whole against its mirror's stamp, so a docs-only bump — or a change to
+/// where the docs tree sits in the seed — rebuilds the mirror too.
 fn moonbit_seed_version(version : String) -> String {
-  version + " docs=" + MoonbitDocsCommit
+  version + " docs=" + MoonbitDocsCommit + " docsdir=" + MoonbitDocsRelDir
 }
 
 ///|

--- a/desktop/package/internal/moonbit/toolchain.mbt
+++ b/desktop/package/internal/moonbit/toolchain.mbt
@@ -42,11 +42,10 @@ fn moonbit_docs_cache_path() -> String {
 }
 
 ///|
-/// The seed version stamp names every seed-content pin: the runtime compares
-/// it whole against its mirror's stamp, so a docs-only bump — or a change to
-/// where the docs tree sits in the seed — rebuilds the mirror too.
+/// The seed version stamp names both pins: the runtime compares it whole
+/// against its mirror's stamp, so a docs-only bump rebuilds the mirror too.
 fn moonbit_seed_version(version : String) -> String {
-  version + " docs=" + MoonbitDocsCommit + " docsdir=" + MoonbitDocsRelDir
+  version + " docs=" + MoonbitDocsCommit
 }
 
 ///|


### PR DESCRIPTION
## What

Moves the pinned moonbit-docs tree inside the MoonBit toolchain seeds from `<moon_home>/docs` to `<moon_home>/share/doc/moonbit` (FHS-style under the toolchain prefix), on both the packaging side and the runtime side:

- **Packaging** (`desktop/package/internal/moonbit/toolchain.mbt`): new `MoonbitDocsRelDir` constant; `stage_moonbit_docs` now stages into `<payload>/share/doc/moonbit`.
- **Runtime** (`desktop/internal/moonbit/toolchain_paths.mbt`): `moonbit_docs_dir` resolves `<moon_home>/share/doc/moonbit` through a same-named constant; payload copies carry the subtree verbatim.
- Comments/tests updated: engine env test writes the fake docs under `share/doc/moonbit/language/index.md` and asserts `OPENSEEK_REFERENCES` points at `<moon_home>/share/doc/moonbit`; the external-toolchain test fakes a `share/doc/moonbit` tree and still asserts no references are advertised.

Note: a per-user payload prepared by an older build keeps its docs under the old `<home>/docs` until the next seed-version bump (compiler version or docs commit) refreshes the mirror; the resolver probes the new location only. The seed version stamp is intentionally left unchanged by the layout move.

## Verification
- `moon check --target native` (desktop module): 0 errors
- `moon test --target native internal/moonbit`: 10/10 passed
- engine test "native engine env has one authoritative bundled moon path": passed
- `moon fmt --check` clean

Generated with SeekMoon