### PR TITLE
feat(desktop): use WebView text input context menus

### DIFF
--- a/desktop/frontend/action_menu/browser_dom.mbt
+++ b/desktop/frontend/action_menu/browser_dom.mbt
@@ -107,10 +107,6 @@ extern "js" fn TextControl::set_selection(
   #| (input, start, end, direction) => input.setSelectionRange(start, end, direction)
 
 ///|
-extern "js" fn TextControl::select_all(self : TextControl) -> Unit =
-  #| input => input.select()
-
-///|
 extern "js" fn focus_without_scroll(element : @dom.HTMLElement) -> Unit =
   #| element => element.focus({ preventScroll: true })
 
@@ -128,10 +124,6 @@ extern "js" fn browser_edit_command(
   text : @js.Nullable[String],
 ) -> Bool =
   #| (command, text) => document.execCommand(command, false, text)
-
-///|
-extern "js" fn browser_edit_enabled(command : String) -> Bool =
-  #| command => document.queryCommandEnabled(command)
 
 ///|
 extern "js" fn anchor_href(anchor : @dom.Element) -> String =

--- a/desktop/frontend/action_menu/browser_dom.mbt
+++ b/desktop/frontend/action_menu/browser_dom.mbt
@@ -1,0 +1,146 @@
+// Missing Rabbita DOM bindings only. Menu policy and listener lifetimes live
+// in MoonBit; these bindings do not own application state.
+
+///|
+#external
+priv type BrowserSelection
+
+///|
+#external
+priv type BrowserRange
+
+///|
+#external
+priv type TextControl
+
+///|
+extern "js" fn browser_selection() -> @js.Nullable[BrowserSelection] =
+  #| () => document.getSelection()
+
+///|
+extern "js" fn BrowserSelection::collapsed(self : BrowserSelection) -> Bool =
+  #| selection => selection.isCollapsed
+
+///|
+extern "js" fn BrowserSelection::count(self : BrowserSelection) -> Int =
+  #| selection => selection.rangeCount
+
+///|
+extern "js" fn BrowserSelection::text(self : BrowserSelection) -> String =
+  #| selection => selection.toString()
+
+///|
+extern "js" fn BrowserSelection::range(
+  self : BrowserSelection,
+  index : Int,
+) -> BrowserRange =
+  #| (selection, index) => selection.getRangeAt(index)
+
+///|
+extern "js" fn BrowserRange::intersects(
+  self : BrowserRange,
+  element : @dom.Element,
+) -> Bool =
+  #| (range, element) => range.intersectsNode(element)
+
+///|
+extern "js" fn BrowserRange::rects(
+  self : BrowserRange,
+) -> FixedArray[@dom.DOMRect] =
+  #| range => Array.from(range.getClientRects())
+
+///|
+extern "js" fn BrowserRange::bounds(self : BrowserRange) -> @dom.DOMRect =
+  #| range => range.getBoundingClientRect()
+
+///|
+extern "js" fn TextControl::from_element(
+  element : @dom.Element,
+) -> @js.Nullable[TextControl] =
+  #| element => element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement ? element : null
+
+///|
+extern "js" fn TextControl::element(self : TextControl) -> @dom.HTMLElement =
+  #| input => input
+
+///|
+extern "js" fn TextControl::kind(self : TextControl) -> String =
+  #| input => input.type
+
+///|
+extern "js" fn TextControl::value(self : TextControl) -> String =
+  #| input => input.value
+
+///|
+extern "js" fn TextControl::disabled(self : TextControl) -> Bool =
+  #| input => input.disabled
+
+///|
+extern "js" fn TextControl::read_only(self : TextControl) -> Bool =
+  #| input => input.readOnly
+
+///|
+extern "js" fn TextControl::selection_start(
+  self : TextControl,
+) -> @js.Nullable[Int] =
+  #| input => input.selectionStart
+
+///|
+extern "js" fn TextControl::selection_end(
+  self : TextControl,
+) -> @js.Nullable[Int] =
+  #| input => input.selectionEnd
+
+///|
+extern "js" fn TextControl::selection_direction(
+  self : TextControl,
+) -> @js.Nullable[String] =
+  #| input => input.selectionDirection
+
+///|
+extern "js" fn TextControl::set_selection(
+  self : TextControl,
+  start : Int,
+  end : Int,
+  direction : @js.Nullable[String],
+) -> Unit =
+  #| (input, start, end, direction) => input.setSelectionRange(start, end, direction)
+
+///|
+extern "js" fn TextControl::select_all(self : TextControl) -> Unit =
+  #| input => input.select()
+
+///|
+extern "js" fn focus_without_scroll(element : @dom.HTMLElement) -> Unit =
+  #| element => element.focus({ preventScroll: true })
+
+///|
+extern "js" fn blur_event(
+  related : @js.Nullable[@dom.EventTarget],
+) -> @dom.Event =
+  #| relatedTarget => new FocusEvent("blur", { relatedTarget })
+
+///|
+// Deprecated browser editing commands remain necessary for native undo
+// history. Call through Error_::wrap when a command can throw.
+extern "js" fn browser_edit_command(
+  command : String,
+  text : @js.Nullable[String],
+) -> Bool =
+  #| (command, text) => document.execCommand(command, false, text)
+
+///|
+extern "js" fn browser_edit_enabled(command : String) -> Bool =
+  #| command => document.queryCommandEnabled(command)
+
+///|
+extern "js" fn anchor_href(anchor : @dom.Element) -> String =
+  #| anchor => anchor.href
+
+///|
+extern "js" fn anchor_protocol(anchor : @dom.Element) -> String =
+  #| anchor => anchor.protocol
+
+///|
+extern "js" fn decode_uri_component(text : String) -> String =
+  #| text => decodeURIComponent(text)

--- a/desktop/frontend/action_menu/context_menu.mbt
+++ b/desktop/frontend/action_menu/context_menu.mbt
@@ -28,6 +28,7 @@ pub(all) struct ContextActions {
   open_external_link : (String) -> @cmd.Cmd
   open_file : (String) -> @cmd.Cmd
   reveal_file : (String) -> @cmd.Cmd
+  edit_failed : (String) -> @cmd.Cmd
 }
 
 ///|
@@ -36,6 +37,7 @@ priv enum ContextTarget {
   WebLink(String)
   EmailLink(url~ : String, address~ : String)
   FileLink(String)
+  TextInput(TextEdit)
 } derive(Eq)
 
 ///|
@@ -67,225 +69,255 @@ priv enum ContextMsg {
 const GlobalContextTarget : String = "app-context-menu"
 
 ///|
-fn context_string_field(value : @js.Value, key : String) -> String? {
-  let field : @js.Value = value.get_with_string(key)
-  if field.is_string() {
-    Some(field.cast())
+fn ContextRequest::finish(self : ContextRequest) -> @cmd.Cmd {
+  match self.target {
+    TextInput(edit) => @cmd.custom_cmd(_ => edit.finish())
+    _ => @cmd.none
+  }
+}
+
+///|
+fn event_element(event : @dom.Event) -> @dom.Element? {
+  match event.target().to_element() {
+    Some(element) => Some(element)
+    None => event.target().to_node().bind(node => node.get_parent_element())
+  }
+}
+
+///|
+fn is_context_surface(element : @dom.Element?) -> Bool {
+  element.bind(element => {
+    element.closest("[data-action-menu-surface=\"app-context-menu\"]")
+  })
+  is Some(_)
+}
+
+///|
+fn selected_at(
+  element : @dom.Element,
+  x : Int,
+  y : Int,
+  keyboard : Bool,
+) -> String? {
+  guard browser_selection().to_option() is Some(selection) &&
+    !selection.collapsed() &&
+    selection.count() > 0 else {
+    return None
+  }
+  let text = selection.text()
+  guard !text.is_empty() else { return None }
+  for index in 0..<selection.count() {
+    let range = selection.range(index)
+    if keyboard && range.intersects(element) {
+      return Some(text)
+    }
+    for rect in range.rects() {
+      if x.to_double() >= rect.get_left() &&
+        x.to_double() <= rect.get_right() &&
+        y.to_double() >= rect.get_top() &&
+        y.to_double() <= rect.get_bottom() {
+        return Some(text)
+      }
+    }
+  }
+  None
+}
+
+///|
+fn keyboard_anchor(element : @dom.Element, use_selection : Bool) -> (Int, Int) {
+  let rect = if use_selection &&
+    browser_selection().to_option() is Some(selection) &&
+    selection.count() > 0 {
+    let rect = selection.range(0).bounds()
+    if rect.get_width() > 0 || rect.get_height() > 0 {
+      rect
+    } else {
+      element.get_bounding_client_rect()
+    }
   } else {
-    None
+    element.get_bounding_client_rect()
   }
+  (
+    @math.round(rect.get_left()).to_int(),
+    @math.round(rect.get_bottom()).to_int(),
+  )
 }
 
 ///|
-fn context_target(value : @js.Value) -> Result[ContextTarget, Unit] {
-  if value.is_null() {
-    return Ok(NoTarget)
+fn element_context(element : @dom.Element) -> ContextTarget {
+  if element.closest("[data-context-file]") is Some(file) &&
+    file.get_attribute("data-context-file") is Some(path) {
+    return FileLink(path)
   }
-  if value.is_undefined() {
-    return Err(())
+  guard element.closest("a[href]") is Some(anchor) &&
+    !anchor.has_attribute("download") else {
+    return NoTarget
   }
-  guard context_string_field(value, "kind") is Some(kind) else {
-    return Err(())
-  }
-  match kind {
-    "web" =>
-      match context_string_field(value, "url") {
-        Some(url) => Ok(WebLink(url))
-        None => Err(())
+  match anchor_protocol(anchor).to_lower() {
+    "http:" | "https:" => WebLink(anchor_href(anchor))
+    "mailto:" => {
+      let href = anchor.get_attribute("href").unwrap_or(anchor_href(anchor))
+      let raw = href[7:].split("?").next().unwrap_or(href[7:]).to_owned()
+      let address = @js.Error_::wrap(() => {
+        @js.Value::cast_from(decode_uri_component(raw))
+      }) catch {
+        _ => raw
       }
-    "email" =>
-      match
-        (
-          context_string_field(value, "url"),
-          context_string_field(value, "address"),
-        ) {
-        (Some(url), Some(address)) => Ok(EmailLink(url~, address~))
-        _ => Err(())
-      }
-    "file" =>
-      match context_string_field(value, "path") {
-        Some(path) => Ok(FileLink(path))
-        None => Err(())
-      }
-    _ => Err(())
+      EmailLink(url=anchor_href(anchor), address~)
+    }
+    _ => NoTarget
   }
 }
 
 ///|
-fn optional_context_string(value : @js.Value) -> Result[String?, Unit] {
-  if value.is_null() {
-    Ok(None)
-  } else if value.is_string() {
-    Ok(Some(value.cast()))
-  } else {
-    Err(())
+fn discard_temporary_focus(element : @dom.Element?) -> Unit {
+  if element is Some(element) &&
+    element.get_attribute("id") is Some(id) &&
+    element.get_attribute(TemporaryFocusAttribute) == Some(id) {
+    element.remove_attribute(TemporaryFocusAttribute)
+    element.remove_attribute("id")
   }
 }
 
 ///|
-fn context_request(
-  target : @js.Value,
-  selected_text : @js.Value,
-) -> ContextRequest? {
-  match (context_target(target), optional_context_string(selected_text)) {
-    (Ok(target), Ok(selected_text)) => Some({ target, selected_text, })
-    _ => None
-  }
-}
-
-///|
-extern "js" fn install_context_menu_listener(
+fn install_context_menu_listener(
   close : () -> Unit,
-  open : (@js.Value, @js.Value, @js.Value, Int, Int) -> Unit,
-) -> @js.Value =
-  #| (close, open) => {
-  #|   let rememberedSelection = null;
-  #|   let temporaryFocus = null;
-  #|   let nextFocusId = 0;
-  #|
-  #|   const discardTemporaryFocus = () => {
-  #|     if (temporaryFocus &&
-  #|         temporaryFocus.getAttribute("data-action-menu-temporary-focus") === temporaryFocus.id) {
-  #|       temporaryFocus.removeAttribute("data-action-menu-temporary-focus");
-  #|       temporaryFocus.removeAttribute("id");
-  #|     }
-  #|     temporaryFocus = null;
-  #|   };
-  #|
-  #|   const rememberFocus = () => {
-  #|     discardTemporaryFocus();
-  #|     const active = document.activeElement;
-  #|     if (!(active instanceof HTMLElement) || active === document.body) return null;
-  #|     if (active.id) return active.id;
-  #|     const id = `app-context-focus:${++nextFocusId}`;
-  #|     active.id = id;
-  #|     active.setAttribute("data-action-menu-temporary-focus", id);
-  #|     temporaryFocus = active;
-  #|     return id;
-  #|   };
-  #|
-  #|   const eventElement = (event) => {
-  #|     const target = event.target;
-  #|     if (target instanceof Element) return target;
-  #|     return target?.parentElement ?? null;
-  #|   };
-  #|
-  #|   const editable = (element) => {
-  #|     const control = element?.closest?.("input, textarea, select, [contenteditable]");
-  #|     if (!control) return false;
-  #|     return control.getAttribute("contenteditable") !== "false";
-  #|   };
-  #|
-  #|   const selectedAt = (element, x, y, keyboard) => {
-  #|     const selection = document.getSelection?.();
-  #|     if (!selection || selection.isCollapsed || selection.rangeCount === 0) return null;
-  #|     const text = selection.toString();
-  #|     if (text.length === 0) return null;
-  #|     for (let index = 0; index < selection.rangeCount; index += 1) {
-  #|       const range = selection.getRangeAt(index);
-  #|       if (keyboard) {
-  #|         try {
-  #|           if (element && range.intersectsNode(element)) return text;
-  #|         } catch (_) {}
-  #|       }
-  #|       for (const rect of range.getClientRects()) {
-  #|         if (x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom) {
-  #|           return text;
-  #|         }
-  #|       }
-  #|     }
-  #|     return null;
-  #|   };
-  #|
-  #|   const onMouseDown = (event) => {
-  #|     if (event.button !== 2) return;
-  #|     const element = eventElement(event);
-  #|     rememberedSelection = {
-  #|       x: event.clientX,
-  #|       y: event.clientY,
-  #|       text: selectedAt(element, event.clientX, event.clientY, false),
-  #|     };
-  #|   };
-  #|
-  #|   // Closing in capture means an editor-owned menu that stops propagation
-  #|   // still dismisses this surface. An unhandled event reopens it in the
-  #|   // bubble listener below, after every more-specific owner had a chance.
-  #|   const onContextCapture = () => {
-  #|     discardTemporaryFocus();
-  #|     close();
-  #|   };
-  #|
-  #|   const onContextMenu = (event) => {
-  #|     if (event.defaultPrevented) return;
-  #|     const element = eventElement(event);
-  #|     if (!element || editable(element)) return;
-  #|
-  #|     event.preventDefault();
-  #|     const keyboard = event.clientX === 0 && event.clientY === 0;
-  #|     let selected = selectedAt(element, event.clientX, event.clientY, keyboard);
-  #|     if (!selected && rememberedSelection &&
-  #|         Math.abs(rememberedSelection.x - event.clientX) <= 2 &&
-  #|         Math.abs(rememberedSelection.y - event.clientY) <= 2) {
-  #|       selected = rememberedSelection.text;
-  #|     }
-  #|     rememberedSelection = null;
-  #|
-  #|     let target = null;
-  #|     const file = element.closest?.("[data-context-file]");
-  #|     if (file) {
-  #|       const path = file.getAttribute("data-context-file");
-  #|       if (path !== null) target = { kind: "file", path };
-  #|     } else {
-  #|       const anchor = element.closest?.("a[href]");
-  #|       if (anchor && !anchor.hasAttribute("download")) {
-  #|         const protocol = anchor.protocol.toLowerCase();
-  #|         if (protocol === "http:" || protocol === "https:") {
-  #|           target = { kind: "web", url: anchor.href };
-  #|         } else if (protocol === "mailto:") {
-  #|           const raw = anchor.getAttribute("href")?.slice(7).split("?")[0] ?? "";
-  #|           let address = raw;
-  #|           try { address = decodeURIComponent(raw); } catch (_) {}
-  #|           target = { kind: "email", url: anchor.href, address };
-  #|         }
-  #|       }
-  #|     }
-  #|
-  #|     let x = event.clientX;
-  #|     let y = event.clientY;
-  #|     if (keyboard) {
-  #|       const selection = document.getSelection?.();
-  #|       const rangeRect = selection && selection.rangeCount > 0
-  #|         ? selection.getRangeAt(0).getBoundingClientRect()
-  #|         : null;
-  #|       const rect = rangeRect && (rangeRect.width > 0 || rangeRect.height > 0)
-  #|         ? rangeRect
-  #|         : element.getBoundingClientRect();
-  #|       x = rect.left;
-  #|       y = rect.bottom;
-  #|     }
-  #|     open(
-  #|       target,
-  #|       selected,
-  #|       rememberFocus(),
-  #|       Math.round(x),
-  #|       Math.round(y),
-  #|     );
-  #|   };
-  #|
-  #|   document.addEventListener("mousedown", onMouseDown, true);
-  #|   document.addEventListener("contextmenu", onContextCapture, true);
-  #|   document.addEventListener("contextmenu", onContextMenu);
-  #|   return { onMouseDown, onContextCapture, onContextMenu, discardTemporaryFocus };
-  #| }
-
-///|
-extern "js" fn remove_context_menu_listener(listeners : @js.Value) -> Unit =
-  #| (listeners) => {
-  #|   document.removeEventListener("mousedown", listeners.onMouseDown, true);
-  #|   document.removeEventListener("contextmenu", listeners.onContextCapture, true);
-  #|   document.removeEventListener("contextmenu", listeners.onContextMenu);
-  #|   listeners.discardTemporaryFocus();
-  #| }
+  open : (ContextRequest, String?, Int, Int) -> Unit,
+) -> () -> Unit {
+  let document = @dom.document()
+  let mut remembered_selection : (Int, Int, String?)? = None
+  let mut temporary_focus : @dom.Element? = None
+  let mut next_focus_id = 0
+  let remember_focus = () => {
+    discard_temporary_focus(temporary_focus)
+    temporary_focus = None
+    guard document.get_active_element() is Some(active) &&
+      active.to_html_element() is Some(_) &&
+      !active.matches("body") else {
+      return None
+    }
+    if active.get_attribute("id") is Some(id) && !id.is_empty() {
+      return Some(id)
+    }
+    next_focus_id += 1
+    let id = "app-context-focus:\{next_focus_id}"
+    active.set_attribute("id", id)
+    active.set_attribute(TemporaryFocusAttribute, id)
+    temporary_focus = Some(active)
+    Some(id)
+  }
+  let on_mouse_down : @dom.Listener = event => {
+    guard event.to_mouse_event() is Some(mouse) &&
+      mouse.get_button() == 2 &&
+      event_element(event) is Some(element) else {
+      return
+    }
+    let x = mouse.get_client_x()
+    let y = mouse.get_client_y()
+    remembered_selection = Some((x, y, selected_at(element, x, y, false)))
+  }
+  // Capture dismisses the previous surface even when an editor handles the
+  // event. App-owned text controls also run here, ahead of row handlers.
+  let on_context_capture : @dom.Listener = event => {
+    guard event_element(event) is Some(element) else { return }
+    if element.closest("[data-action-menu-surface]") is Some(_) {
+      return
+    }
+    discard_temporary_focus(temporary_focus)
+    temporary_focus = None
+    close()
+    guard element.closest("input, textarea") is Some(element) &&
+      element.closest(".monaco-editor, .xterm") is None &&
+      TextControl::from_element(element).to_option() is Some(input) &&
+      input.kind()
+      is ("text"
+      | "search"
+      | "url"
+      | "tel"
+      | "email"
+      | "password"
+      | "number"
+      | "textarea") &&
+      event.to_mouse_event() is Some(mouse) else {
+      return
+    }
+    event.prevent_default()
+    event.stop_propagation()
+    if input.disabled() {
+      return
+    }
+    focus_without_scroll(input.element())
+    let (x, y) = if mouse.get_client_x() == 0 && mouse.get_client_y() == 0 {
+      keyboard_anchor(element, false)
+    } else {
+      (mouse.get_client_x(), mouse.get_client_y())
+    }
+    let restore = remember_focus()
+    open(
+      { target: TextInput(capture_text_edit(input)), selected_text: None, },
+      restore,
+      x,
+      y,
+    )
+  }
+  // Other owners get first refusal through ordinary DOM bubbling.
+  let on_context_menu : @dom.Listener = event => {
+    guard !event.get_default_prevented() &&
+      event_element(event) is Some(element) &&
+      event.to_mouse_event() is Some(mouse) else {
+      return
+    }
+    if element.closest("input, textarea, select, [contenteditable]")
+      is Some(control) &&
+      control.get_attribute("contenteditable") != Some("false") {
+      return
+    }
+    event.prevent_default()
+    let x = mouse.get_client_x()
+    let y = mouse.get_client_y()
+    let keyboard = x == 0 && y == 0
+    let mut selected_text = selected_at(element, x, y, keyboard)
+    if selected_text is None &&
+      remembered_selection is Some((old_x, old_y, text)) &&
+      (old_x - x).abs() <= 2 &&
+      (old_y - y).abs() <= 2 {
+      selected_text = text
+    }
+    remembered_selection = None
+    let (x, y) = if keyboard { keyboard_anchor(element, true) } else { (x, y) }
+    open(
+      { target: element_context(element), selected_text, },
+      remember_focus(),
+      x,
+      y,
+    )
+  }
+  document.add_event_listener_with_options(
+    "mousedown",
+    on_mouse_down,
+    capture=true,
+  )
+  document.add_event_listener_with_options(
+    "contextmenu",
+    on_context_capture,
+    capture=true,
+  )
+  document.add_event_listener("contextmenu", on_context_menu)
+  () => {
+    document.remove_event_listener_with_options(
+      "mousedown",
+      on_mouse_down,
+      capture=true,
+    )
+    document.remove_event_listener_with_options(
+      "contextmenu",
+      on_context_capture,
+      capture=true,
+    )
+    document.remove_event_listener("contextmenu", on_context_menu)
+    discard_temporary_focus(temporary_focus)
+  }
+}
 
 ///|
 priv suberror ContextMenuSubscription {
@@ -300,22 +332,14 @@ fn context_menu_subscription(emit : @cmd.Emit[ContextMsg]) -> @sub.Sub {
   ) => {
     guard payload is ContextMenuSubscription(emit) else { return None }
     let mut emit = emit
-    let listeners = install_context_menu_listener(
+    let unload = install_context_menu_listener(
       () => scheduler.add(emit(CloseContext)),
-      (target, selected_text, restore_focus, x, y) => {
-        match
-          (
-            context_request(target, selected_text),
-            optional_context_string(restore_focus),
-          ) {
-          (Some(request), Ok(restore_focus_id)) =>
-            scheduler.add(emit(Requested(request, x, y, restore_focus_id)))
-          _ => ()
-        }
+      (request, restore, x, y) => {
+        scheduler.add(emit(Requested(request, x, y, restore)))
       },
     )
     Some({
-      unload: _ => remove_context_menu_listener(listeners),
+      unload: _ => unload(),
       update_tagger: payload => {
         guard payload is ContextMenuSubscription(next) else { return }
         emit = next
@@ -365,6 +389,8 @@ fn context_definition(
   let navigation : Array[Entry] = []
   let clipboard : Array[Entry] = []
   match request.target {
+    TextInput(edit) =>
+      return Some(text_edit_definition(edit, actions.edit_failed))
     NoTarget => ()
     WebLink(url) => {
       if input.platform is Web {
@@ -474,12 +500,12 @@ pub fn context_component(
   let (state, emit) = @rabbita.create_state_with_input(
     input~,
     init=(_, _) => ({ open_context: None, }, @cmd.none),
-    update=(_state, input, msg, _) => {
+    update=(state, input, msg, _) => {
       match msg {
         Requested(request, x, y, restore_focus_id) => {
           guard context_definition(input, request, actions) is Some(definition) &&
             definition.enabled_indices() is [_, ..] else {
-            return ({ open_context: None, }, @cmd.none)
+            return ({ open_context: None, }, request.finish())
           }
           let open : ContextOpen = { request, x, y, restore_focus_id, }
           (
@@ -490,7 +516,13 @@ pub fn context_component(
             ]),
           )
         }
-        CloseContext => ({ open_context: None, }, @cmd.none)
+        CloseContext => {
+          let finish = match state.open_context {
+            Some(open) => open.request.finish()
+            _ => @cmd.none
+          }
+          ({ open_context: None, }, finish)
+        }
       }
     },
     subscriptions=(state, input, emit) => {

--- a/desktop/frontend/action_menu/moon.pkg
+++ b/desktop/frontend/action_menu/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "moonbitlang/core/math",
   "moonbit-community/rabbita",
   "moonbit-community/rabbita/clipboard",
   "moonbit-community/rabbita/cmd",
@@ -7,6 +8,7 @@ import {
   "moonbit-community/rabbita/js",
   "moonbit-community/rabbita/sub",
   "openseek_desktop/frontend/icons",
+  "openseek_desktop/frontend/interop",
 }
 
 supported_targets = "js"

--- a/desktop/frontend/action_menu/text_edit.mbt
+++ b/desktop/frontend/action_menu/text_edit.mbt
@@ -16,12 +16,9 @@ fn TextControl::selection(self : TextControl) -> TextSelection? {
 
 ///|
 priv enum EditAction {
-  Undo
-  Redo
   Cut
   Copy
   Paste
-  SelectAll
 } derive(Eq)
 
 ///|
@@ -51,12 +48,6 @@ fn capture_text_edit(input : TextControl) -> TextEdit {
   let readable = !input.disabled() && input.kind() != "password"
   let selected = selection is Some({ start, end, .. }) && start != end
   let enabled : Array[EditAction] = []
-  if writable && browser_edit_enabled("undo") {
-    enabled.push(Undo)
-  }
-  if writable && browser_edit_enabled("redo") {
-    enabled.push(Redo)
-  }
   if writable && readable && selected {
     enabled.push(Cut)
   }
@@ -65,9 +56,6 @@ fn capture_text_edit(input : TextControl) -> TextEdit {
   }
   if writable {
     enabled.push(Paste)
-  }
-  if !input.disabled() && !value.is_empty() {
-    enabled.push(SelectAll)
   }
   let on_blur : @dom.Listener = event => {
     guard event.to_focus_event() is Some(focus) else { return }
@@ -259,9 +247,6 @@ async fn TextEdit::execute(self : TextEdit, action : EditAction) -> Unit {
         self.apply("insertText", text~)
       }
     }
-    SelectAll => self.input.select_all()
-    Undo => self.apply("undo")
-    Redo => self.apply("redo")
   }
 }
 
@@ -271,19 +256,8 @@ fn text_edit_definition(
   failed : (String) -> @cmd.Cmd,
 ) -> Definition {
   let entries : Array[Entry] = []
-  for
-    pair in [
-      (Undo, "Undo"),
-      (Redo, "Redo"),
-      (Cut, "Cut"),
-      (Copy, "Copy"),
-      (Paste, "Paste"),
-      (SelectAll, "Select All"),
-    ] {
+  for pair in [(Cut, "Cut"), (Copy, "Copy"), (Paste, "Paste")] {
     let (action, label) = pair
-    if action is (Cut | SelectAll) {
-      entries.push(Separator)
-    }
     entries.push(
       Action({
         label,

--- a/desktop/frontend/action_menu/text_edit.mbt
+++ b/desktop/frontend/action_menu/text_edit.mbt
@@ -1,0 +1,310 @@
+///|
+priv struct TextSelection {
+  start : Int
+  end : Int
+  direction : String?
+} derive(Eq)
+
+///|
+fn TextControl::selection(self : TextControl) -> TextSelection? {
+  match (self.selection_start().to_option(), self.selection_end().to_option()) {
+    (Some(start), Some(end)) =>
+      Some({ start, end, direction: self.selection_direction().to_option(), })
+    _ => None
+  }
+}
+
+///|
+priv enum EditAction {
+  Undo
+  Redo
+  Cut
+  Copy
+  Paste
+  SelectAll
+} derive(Eq)
+
+///|
+priv struct TextEdit {
+  input : TextControl
+  value : String
+  selection : TextSelection?
+  enabled : Array[EditAction]
+  on_blur : @dom.Listener
+}
+
+///|
+impl Eq for TextEdit with fn equal(self, other) {
+  // Each capture owns a listener lifetime, even when its text is unchanged.
+  physical_equal(self, other)
+}
+
+///|
+// The input and menu form one logical focus region. Forward its eventual
+// blur to the input; consumers need not know the menu's DOM placement.
+fn capture_text_edit(input : TextControl) -> TextEdit {
+  let element = input.element()
+  focus_without_scroll(element)
+  let value = input.value()
+  let selection = input.selection()
+  let writable = !input.disabled() && !input.read_only()
+  let readable = !input.disabled() && input.kind() != "password"
+  let selected = selection is Some({ start, end, .. }) && start != end
+  let enabled : Array[EditAction] = []
+  if writable && browser_edit_enabled("undo") {
+    enabled.push(Undo)
+  }
+  if writable && browser_edit_enabled("redo") {
+    enabled.push(Redo)
+  }
+  if writable && readable && selected {
+    enabled.push(Cut)
+  }
+  if readable && selected {
+    enabled.push(Copy)
+  }
+  if writable {
+    enabled.push(Paste)
+  }
+  if !input.disabled() && !value.is_empty() {
+    enabled.push(SelectAll)
+  }
+  let on_blur : @dom.Listener = event => {
+    guard event.to_focus_event() is Some(focus) else { return }
+    let next = focus.related_target()
+    let next_is_input = next
+      .bind(target => target.to_node())
+      .map(node => element.is_same_node(node))
+      .unwrap_or(false)
+    let next_is_menu = is_context_surface(
+      next.bind(target => target.to_element()),
+    )
+    if event.target().to_node() is Some(node) &&
+      element.is_same_node(node) &&
+      next_is_menu {
+      event.stop_immediate_propagation()
+    } else if is_context_surface(event.target().to_element()) &&
+      !next_is_menu &&
+      !next_is_input {
+      element.dispatch_event(blur_event(@js.Nullable::from_option(next)))
+    }
+  }
+  @dom.document().add_event_listener_with_options("blur", on_blur, capture=true)
+  { input, value, selection, enabled, on_blur, }
+}
+
+///|
+fn TextEdit::finish(self : TextEdit) -> Unit {
+  let element = self.input.element()
+  if is_context_surface(@dom.document().get_active_element()) &&
+    element.get_is_connected() {
+    focus_without_scroll(element)
+  }
+  @dom.document().remove_event_listener_with_options(
+    "blur",
+    self.on_blur,
+    capture=true,
+  )
+}
+
+///|
+fn TextEdit::focused(self : TextEdit) -> Bool {
+  @dom.document()
+  .get_active_element()
+  .map(active => self.input.element().is_same_node(active.as_node()))
+  .unwrap_or(false)
+}
+
+///|
+fn TextEdit::restore(self : TextEdit) -> Bool {
+  let element = self.input.element()
+  guard element.get_is_connected() &&
+    !self.input.disabled() &&
+    self.input.value() == self.value else {
+    return false
+  }
+  focus_without_scroll(element)
+  if self.selection is Some(selection) {
+    self.input.set_selection(
+      selection.start,
+      selection.end,
+      @js.Nullable::from_option(selection.direction),
+    )
+  }
+  self.focused()
+}
+
+///|
+fn TextEdit::unchanged(self : TextEdit) -> Bool {
+  self.input.element().get_is_connected() &&
+  self.focused() &&
+  !self.input.disabled() &&
+  !self.input.read_only() &&
+  self.input.value() == self.value &&
+  self.input.selection() == self.selection
+}
+
+///|
+priv suberror TextEditError {
+  CommandFailed
+}
+
+///|
+// Preserve the browser's undo history and deliver exactly one input event.
+fn TextEdit::apply(
+  self : TextEdit,
+  command : String,
+  text? : String,
+) -> Unit raise {
+  let element = self.input.element()
+  let before = self.input.value()
+  let mut notified = false
+  let on_input : @dom.Listener = _ => notified = true
+  element.add_event_listener("input", on_input)
+  defer element.remove_event_listener("input", on_input)
+  let applied : Bool = @js.Error_::wrap(() => {
+    @js.Value::cast_from(
+      browser_edit_command(command, @js.Nullable::from_option(text)),
+    )
+  })
+  if !notified && self.input.value() != before {
+    element.dispatch_event(@dom.Event::new("input", bubbles=true))
+  }
+  if !applied {
+    raise CommandFailed
+  }
+}
+
+///|
+fn native_clipboard() -> @js.Value? {
+  @interop.moonbit_bridge_root().bind(root => {
+    @interop.js_prop(root, "clipboard")
+  })
+}
+
+///|
+async fn write_edit_clipboard(text : String) -> Unit {
+  match native_clipboard() {
+    Some(api) => {
+      let reply = @interop.js_method_promise(
+        api,
+        "writeText",
+        @js.Value::from_json({ "text": text }),
+      ).wait()
+      guard reply.to_json() is { "written": true, .. } else {
+        raise CommandFailed
+      }
+    }
+    None =>
+      @dom.window().navigator().clipboard().write_text(text).wait() |> ignore
+  }
+}
+
+///|
+async fn read_edit_clipboard() -> String? {
+  match native_clipboard() {
+    Some(api) => {
+      let reply = @interop.js_method_promise(
+        api,
+        "readText",
+        @js.Value::from_json({}),
+      ).wait()
+      match reply.to_json() {
+        { "text": String(text), .. } => Some(text)
+        { "text"? : None | Some(Null), .. } => None
+        _ => raise CommandFailed
+      }
+    }
+    None =>
+      Some(@dom.window().navigator().clipboard().read_text().wait().cast())
+  }
+}
+
+///|
+async fn TextEdit::execute(self : TextEdit, action : EditAction) -> Unit {
+  guard self.enabled.contains(action) && self.restore() else { return }
+  let element = self.input.element()
+  let document = @dom.document()
+  let mut cancelled = false
+  let cancel : @dom.Listener = _ => cancelled = true
+  element.add_event_listener("blur", cancel)
+  element.add_event_listener("input", cancel)
+  document.add_event_listener_with_options("contextmenu", cancel, capture=true)
+  defer element.remove_event_listener("blur", cancel)
+  defer element.remove_event_listener("input", cancel)
+  defer document.remove_event_listener_with_options(
+    "contextmenu",
+    cancel,
+    capture=true,
+  )
+  match action {
+    Copy | Cut => {
+      guard self.selection is Some(selection) else { return }
+      // DOM offsets count UTF-16 code units; view preserves those offsets.
+      write_edit_clipboard(
+        self.value
+        .view(start_offset=selection.start, end_offset=selection.end)
+        .to_owned(),
+      )
+      if action is Cut && !cancelled && self.unchanged() {
+        self.apply("delete")
+      }
+    }
+    Paste => {
+      let text = read_edit_clipboard()
+      if text is Some(text) &&
+        !text.is_empty() &&
+        !cancelled &&
+        self.unchanged() {
+        self.apply("insertText", text~)
+      }
+    }
+    SelectAll => self.input.select_all()
+    Undo => self.apply("undo")
+    Redo => self.apply("redo")
+  }
+}
+
+///|
+fn text_edit_definition(
+  edit : TextEdit,
+  failed : (String) -> @cmd.Cmd,
+) -> Definition {
+  let entries : Array[Entry] = []
+  for
+    pair in [
+      (Undo, "Undo"),
+      (Redo, "Redo"),
+      (Cut, "Cut"),
+      (Copy, "Copy"),
+      (Paste, "Paste"),
+      (SelectAll, "Select All"),
+    ] {
+    let (action, label) = pair
+    if action is (Cut | SelectAll) {
+      entries.push(Separator)
+    }
+    entries.push(
+      Action({
+        label,
+        title: label,
+        icon: None,
+        enabled: edit.enabled.contains(action),
+        destructive: false,
+        command: @cmd.custom_cmd(scheduler => {
+          @js.async_run(() => {
+            edit.execute(action) catch {
+              _ =>
+                scheduler.add(
+                  failed(
+                    "Text editing failed. Check clipboard permission or use the keyboard shortcut.",
+                  ),
+                )
+            }
+          })
+        }),
+      }),
+    )
+  }
+  { label: "Text editing", entries, }
+}

--- a/desktop/frontend/boot.mbt
+++ b/desktop/frontend/boot.mbt
@@ -573,6 +573,7 @@ pub fn boot() -> Unit {
         open_external_link: url => open_external_link(emit, url),
         open_file: path => emit(OpenFile(path)),
         reveal_file: path => emit(RevealFile(path)),
+        edit_failed: message => emit(HostActionFailed(message)),
       },
     )
     let skills_html = @skills.component(

--- a/desktop/main.mbt
+++ b/desktop/main.mbt
@@ -151,13 +151,14 @@ async fn main {
     )
   }
   let app = app
-    // Both command extensions are deliberately granted to the configured
+    // Command extensions are deliberately granted to the configured
     // entry page; registering backend handlers alone does not grant renderer
     // access.
     .capability(@extension.openseek_capability(state, bridge, views))
     // System notifications are an ordinary generated extension now: the
     // frontend posts them and receives `notification.click` with the run id.
     .capability(@notification.capability())
+    .capability(@clipboard.capability())
     // The connect request proves the page can issue commands; this paired
     // lifecycle supplies the window-owned event destination that remains
     // valid after that request returns — and the window handle the browser

--- a/desktop/moon.pkg
+++ b/desktop/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "moonbit-community/proton_ext/clipboard",
   "moonbitlang/async",
   "moonbit-community/proton",
   "moonbit-community/proton_ext/notification",


### PR DESCRIPTION
## Summary

- Use the shared WebView context menu for app-owned text inputs and textareas, including inline Rename, with Cut, Copy, and Paste only. Undo, Redo, and Select All remain available through native input keyboard shortcuts rather than menu items.
- Preserve browser undo history and selection, keep Rename active while its menu is open, and discard pending clipboard edits when the original input changes or loses focus.
- Move context-menu routing, listener lifetimes, and editing policy into MoonBit. Keep JavaScript FFI limited to small private browser bindings in `browser_dom.mbt`.
- Grant the existing Proton clipboard capability to the app entry page; use the browser clipboard API in the web host.

Browser-tab content, Monaco, and xterm retain their existing menu ownership. This does not change Rabbita dependencies or reintroduce native application menus.

## Validation

- `moon -C desktop check --target js`
- `moon -C desktop check --target native`
- `moon -C desktop test frontend --target js` — 458 passed
- `moon -C desktop run package/browser --target native`
- `npm --prefix desktop/e2e test` — 33 passed before the final menu-item reduction
- `moon -C desktop info --target js` and `moon -C desktop fmt`
- Browser interaction probe covering Rename editing, left/right menu-item activation, Escape, disabled items, selection, clipboard operations, keyboard navigation, and stale asynchronous paste cancellation. Clipboard transport was mocked; this is not native app runtime verification.
- After the final menu-item reduction, reran the JS check, all 458 frontend tests, browser packaging, and a browser interaction probe in both Rename and the composer: exactly three menu items; Cmd+Z, Cmd+Shift+Z, and Cmd+A still work; menu Cut/Paste remain undoable; Escape restores input focus. Clipboard transport was mocked.
