### PR TITLE
test: defer temp-dir cleanup after tmpdir creation across tests

### DIFF
--- a/agent_session/store/store_test.mbt
+++ b/agent_session/store/store_test.mbt
@@ -12,6 +12,7 @@ fn session_file(store : @store.SessionStore, id : String) -> String {
 ///|
 async test "store creates and loads a session from one session file" {
   let store = new_store()
+  defer @fs.rmdir(store.root(), recursive=true)
   let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
     .append(User(UserMessage("hello")))
     .append(Terminal(Finished("done")))
@@ -22,12 +23,12 @@ async test "store creates and loads a session from one session file" {
   assert_eq(loaded.system_prompt(), "system")
   assert_eq(loaded.events().length(), 2)
   assert_eq(loaded.last_sequence(), 2)
-  @fs.rmdir(store.root(), recursive=true)
 }
 
 ///|
 async test "store writes the header record on the first line" {
   let store = new_store()
+  defer @fs.rmdir(store.root(), recursive=true)
   store.create(Session(SessionId("s1"), system_prompt="system"))
   let text = @fs.read_file(session_file(store, "s1")).text()
   assert_eq(
@@ -36,12 +37,12 @@ async test "store writes the header record on the first line" {
   let loaded = store.load(SessionId("s1"))
   assert_eq(loaded.events().length(), 0)
   assert_eq(loaded.system_prompt(), "system")
-  @fs.rmdir(store.root(), recursive=true)
 }
 
 ///|
 async test "store creates different sessions concurrently under one root" {
   let store = new_store()
+  defer @fs.rmdir(store.root(), recursive=true)
   ignore(
     @async.all(
       [
@@ -53,12 +54,12 @@ async test "store creates different sessions concurrently under one root" {
   )
   let ids = [ for id in store.list() => id.value() ]
   json_inspect(ids, content=["a", "b", "c", "d"])
-  @fs.rmdir(store.root(), recursive=true)
 }
 
 ///|
 async test "store creates different sessions concurrently under a missing root" {
   let parent = @fs.tmpdir(prefix="openseek-session-store-race-")
+  defer @fs.rmdir(parent, recursive=true)
   let store : @store.SessionStore = SessionStore("\{parent}/missing-root")
   ignore(
     @async.all(
@@ -71,12 +72,12 @@ async test "store creates different sessions concurrently under a missing root" 
   )
   let ids = [ for id in store.list() => id.value() ]
   json_inspect(ids, content=["a", "b", "c", "d", "e", "f", "g", "h"])
-  @fs.rmdir(parent, recursive=true)
 }
 
 ///|
 async test "store validates invalid ids before creating directories" {
   let parent = @fs.tmpdir(prefix="openseek-session-store-invalid-")
+  defer @fs.rmdir(parent, recursive=true)
   let root = "\{parent}/missing-root"
   let store : @store.SessionStore = SessionStore(root)
   try store.create(Session(SessionId("../bad"), system_prompt="system")) catch {
@@ -87,12 +88,12 @@ async test "store validates invalid ids before creating directories" {
   } noraise {
     _ => fail("invalid session id accepted")
   }
-  @fs.rmdir(parent, recursive=true)
 }
 
 ///|
 async test "store lists known sessions" {
   let store = new_store()
+  defer @fs.rmdir(store.root(), recursive=true)
   assert_eq(store.list().length(), 0)
   store.create(Session(SessionId("b"), system_prompt="system"))
   store.create(Session(SessionId("a"), system_prompt="system"))
@@ -100,12 +101,12 @@ async test "store lists known sessions" {
   assert_eq(ids.length(), 2)
   assert_eq(ids[0], "a")
   assert_eq(ids[1], "b")
-  @fs.rmdir(store.root(), recursive=true)
 }
 
 ///|
 async test "store picks the most recently active session as latest" {
   let store = new_store()
+  defer @fs.rmdir(store.root(), recursive=true)
   assert_true(store.latest() is None)
   store.create(Session(SessionId("first"), system_prompt="system"))
   // Filesystem mtimes need a beat between writes to order reliably.
@@ -119,12 +120,12 @@ async test "store picks the most recently active session as latest" {
   let _ = store.append(first, User(UserMessage("more")))
   guard store.latest() is Some(id) else { fail("expected a latest session") }
   assert_eq(id.value(), "first")
-  @fs.rmdir(store.root(), recursive=true)
 }
 
 ///|
 async test "listings order by recency and keep husk directories visible" {
   let store = new_store()
+  defer @fs.rmdir(store.root(), recursive=true)
   let older : @agent_session.Session = Session(
     SessionId("older"),
     system_prompt="system",
@@ -145,12 +146,12 @@ async test "listings order by recency and keep husk directories visible" {
   assert_eq(listings[2].id().value(), "husk")
   assert_true(listings[2].last_active_unix_seconds() is None)
   assert_eq(listings[2].first_prompt(), "")
-  @fs.rmdir(store.root(), recursive=true)
 }
 
 ///|
 async test "an explicit session title overrides the first prompt without rewriting it" {
   let store = new_store()
+  defer @fs.rmdir(store.root(), recursive=true)
   let id = @agent_session.SessionId("named")
   store.create(
     @agent_session.Session(id, system_prompt="system").append(
@@ -169,12 +170,12 @@ async test "an explicit session title overrides the first prompt without rewriti
     fail("renaming changed the first durable event")
   }
   assert_eq(message.content(), "original first prompt")
-  @fs.rmdir(store.root(), recursive=true)
 }
 
 ///|
 async test "session titles reject blank text and missing records" {
   let store = new_store()
+  defer @fs.rmdir(store.root(), recursive=true)
   let id : @agent_session.SessionId = SessionId("named")
   store.create(Session(id, system_prompt="system"))
   for title in ["", "   ", "\n\t"] {
@@ -190,12 +191,12 @@ async test "session titles reject blank text and missing records" {
   } noraise {
     _ => fail("title written for a missing session")
   }
-  @fs.rmdir(store.root(), recursive=true)
 }
 
 ///|
 async test "latest skips a corrupt newest session in favor of a loadable one" {
   let store = new_store()
+  defer @fs.rmdir(store.root(), recursive=true)
   store.create(Session(SessionId("valid"), system_prompt="system"))
   @async.sleep(50)
   store.create(Session(SessionId("corrupt"), system_prompt="system"))
@@ -207,12 +208,12 @@ async test "latest skips a corrupt newest session in favor of a loadable one" {
   )
   guard store.latest() is Some(id) else { fail("expected a latest session") }
   assert_eq(id.value(), "valid")
-  @fs.rmdir(store.root(), recursive=true)
 }
 
 ///|
 async test "store propagates non-missing list errors" {
   let store = new_store()
+  defer @fs.rmdir(store.root(), recursive=true)
   @fs.write_file(
     "\{store.root()}/sessions",
     "not a directory",
@@ -223,12 +224,12 @@ async test "store propagates non-missing list errors" {
   } noraise {
     _ => fail("list error was silently treated as empty")
   }
-  @fs.rmdir(store.root(), recursive=true)
 }
 
 ///|
 async test "store appends one event without rewriting the in-memory caller value" {
   let store = new_store()
+  defer @fs.rmdir(store.root(), recursive=true)
   let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
   store.create(session)
   let next = store.append(session, User(UserMessage("first")))
@@ -245,12 +246,12 @@ async test "store appends one event without rewriting the in-memory caller value
   // The store stamps each appended event with the wall clock, and the stamp
   // survives a reload.
   assert_true(loaded.events()[0].unix_ms() > 0)
-  @fs.rmdir(store.root(), recursive=true)
 }
 
 ///|
 async test "generic append persists summary events the projection honors" {
   let store = new_store()
+  defer @fs.rmdir(store.root(), recursive=true)
   let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
     .append(User(UserMessage("first task")))
     .append(Terminal(Finished("first answer")))
@@ -277,12 +278,12 @@ async test "generic append persists summary events the projection honors" {
   assert_true(messages[1].role is User)
   assert_true(messages[1].content.contains("[conversation summary]"))
   assert_true(messages[1].content.contains("handoff summary"))
-  @fs.rmdir(store.root(), recursive=true)
 }
 
 ///|
 async test "first append creates the session file with its header" {
   let store = new_store()
+  defer @fs.rmdir(store.root(), recursive=true)
   // No create(): the CLI resumes-or-starts sessions whose first durable write
   // is an append. The header line and the first event must land together.
   let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
@@ -297,7 +298,6 @@ async test "first append creates the session file with its header" {
   let loaded = store.load(SessionId("s1"))
   assert_eq(loaded.system_prompt(), "system")
   assert_eq(loaded.events().length(), 1)
-  @fs.rmdir(store.root(), recursive=true)
 }
 
 ///|
@@ -334,6 +334,7 @@ async fn race_two_appends(
 ///|
 async test "store serializes concurrent first appends from empty snapshots" {
   let store = new_store()
+  defer @fs.rmdir(store.root(), recursive=true)
   // Two writers race to be the first durable write for the same id. The loser
   // sees the winner's file and must not clobber the first event.
   let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
@@ -341,7 +342,6 @@ async test "store serializes concurrent first appends from empty snapshots" {
   let loaded = store.load(SessionId("s1"))
   assert_eq(loaded.events().length(), 1)
   assert_eq(loaded.last_sequence(), 1)
-  @fs.rmdir(store.root(), recursive=true)
 }
 
 ///|
@@ -349,6 +349,7 @@ async test "chained appends on returned values persist every event" {
   // The common agent loop: each append's return value feeds the next call,
   // which is exactly the shape the fingerprint fast path accelerates.
   let store = new_store()
+  defer @fs.rmdir(store.root(), recursive=true)
   let mut session = @agent_session.Session(
     SessionId("s1"),
     system_prompt="system",
@@ -366,7 +367,6 @@ async test "chained appends on returned values persist every event" {
     guard event.item() is Runtime(notice) else { fail("expected notice") }
     assert_eq(notice.content(), "step \{index}")
   }
-  @fs.rmdir(store.root(), recursive=true)
 }
 
 ///|
@@ -375,6 +375,7 @@ async test "another store instance's write defeats the fingerprint fast path" {
   // appends. store_a's snapshot is physically the value it last synced, so
   // only the on-disk fingerprint reveals the divergence.
   let store_a = new_store()
+  defer @fs.rmdir(store_a.root(), recursive=true)
   let store_b : @store.SessionStore = SessionStore(store_a.root())
   let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
   store_a.create(session)
@@ -390,12 +391,12 @@ async test "another store instance's write defeats the fingerprint fast path" {
   } noraise {
     _ => fail("stale append past the fast path was accepted")
   }
-  @fs.rmdir(store_a.root(), recursive=true)
 }
 
 ///|
 async test "a same-size rewrite by another store is still detected" {
   let store_a = new_store()
+  defer @fs.rmdir(store_a.root(), recursive=true)
   let store_b : @store.SessionStore = SessionStore(store_a.root())
   let session = @agent_session.Session(
     SessionId("s1"),
@@ -416,12 +417,12 @@ async test "a same-size rewrite by another store is still detected" {
   } noraise {
     _ => fail("same-size rewrite slipped past the fingerprint fast path")
   }
-  @fs.rmdir(store_a.root(), recursive=true)
 }
 
 ///|
 async test "store rejects stale snapshots before appending" {
   let store = new_store()
+  defer @fs.rmdir(store.root(), recursive=true)
   let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
   store.create(session)
   ignore(store.append(session, User(UserMessage("first"))))
@@ -434,12 +435,12 @@ async test "store rejects stale snapshots before appending" {
   } noraise {
     _ => fail("stale append was accepted")
   }
-  @fs.rmdir(store.root(), recursive=true)
 }
 
 ///|
 async test "store rejects divergent snapshots with the same sequence" {
   let store = new_store()
+  defer @fs.rmdir(store.root(), recursive=true)
   let session = @agent_session.Session(SessionId("s1"), system_prompt="system").append(
     User(UserMessage("first")),
   )
@@ -459,12 +460,12 @@ async test "store rejects divergent snapshots with the same sequence" {
   } noraise {
     _ => fail("divergent same-sequence append was accepted")
   }
-  @fs.rmdir(store.root(), recursive=true)
 }
 
 ///|
 async test "store rejects non-empty snapshots when the session file is missing" {
   let store = new_store()
+  defer @fs.rmdir(store.root(), recursive=true)
   let session = @agent_session.Session(SessionId("s1"), system_prompt="system").append(
     User(UserMessage("hello")),
   )
@@ -475,24 +476,24 @@ async test "store rejects non-empty snapshots when the session file is missing" 
   } noraise {
     _ => fail("append onto a missing session file was accepted")
   }
-  @fs.rmdir(store.root(), recursive=true)
 }
 
 ///|
 async test "store serializes concurrent appends from the same snapshot" {
   let store = new_store()
+  defer @fs.rmdir(store.root(), recursive=true)
   let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
   store.create(session)
   race_two_appends(store, session)
   let loaded = store.load(SessionId("s1"))
   assert_eq(loaded.events().length(), 1)
   assert_eq(loaded.last_sequence(), 1)
-  @fs.rmdir(store.root(), recursive=true)
 }
 
 ///|
 async test "store rejects stale snapshots before compacting" {
   let store = new_store()
+  defer @fs.rmdir(store.root(), recursive=true)
   let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
     .append(User(UserMessage("first")))
     .append(Assistant(AssistantMessage("second")))
@@ -514,12 +515,12 @@ async test "store rejects stale snapshots before compacting" {
   } noraise {
     _ => fail("stale compact was accepted")
   }
-  @fs.rmdir(store.root(), recursive=true)
 }
 
 ///|
 async test "store fails load when the session file is missing" {
   let store = new_store()
+  defer @fs.rmdir(store.root(), recursive=true)
   store.create(Session(SessionId("s1"), system_prompt="system"))
   @fs.remove(session_file(store, "s1"))
   try store.load(SessionId("s1")) catch {
@@ -527,12 +528,12 @@ async test "store fails load when the session file is missing" {
   } noraise {
     _ => fail("missing session file was accepted")
   }
-  @fs.rmdir(store.root(), recursive=true)
 }
 
 ///|
 async test "store rejects a session file without a header record" {
   let store = new_store()
+  defer @fs.rmdir(store.root(), recursive=true)
   let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
   let (_, event) = session.append_event(User(UserMessage("first")))
   @fs.mkdir("\{store.root()}/sessions/s1", recursive=true)
@@ -549,12 +550,12 @@ async test "store rejects a session file without a header record" {
   } noraise {
     _ => fail("header-less session file was accepted")
   }
-  @fs.rmdir(store.root(), recursive=true)
 }
 
 ///|
 async test "store rejects a malformed header line" {
   let store = new_store()
+  defer @fs.rmdir(store.root(), recursive=true)
   @fs.mkdir("\{store.root()}/sessions/s1", recursive=true)
   @fs.write_file(
     session_file(store, "s1"),
@@ -567,12 +568,12 @@ async test "store rejects a malformed header line" {
   } noraise {
     _ => fail("malformed header line was accepted")
   }
-  @fs.rmdir(store.root(), recursive=true)
 }
 
 ///|
 async test "store rejects a header whose id does not match the directory" {
   let store = new_store()
+  defer @fs.rmdir(store.root(), recursive=true)
   store.create(Session(SessionId("other"), system_prompt="system"))
   @fs.mkdir("\{store.root()}/sessions/s1", recursive=true)
   @fs.write_file(
@@ -585,12 +586,12 @@ async test "store rejects a header whose id does not match the directory" {
   } noraise {
     _ => fail("mismatched header id was accepted")
   }
-  @fs.rmdir(store.root(), recursive=true)
 }
 
 ///|
 async test "load drops a torn trailing record without mutating the file" {
   let store = new_store()
+  defer @fs.rmdir(store.root(), recursive=true)
   let session = @agent_session.Session(SessionId("s1"), system_prompt="system").append(
     User(UserMessage("first")),
   )
@@ -608,12 +609,12 @@ async test "load drops a torn trailing record without mutating the file" {
   assert_eq(loaded.events().length(), 1)
   assert_eq(loaded.last_sequence(), 1)
   assert_eq(@fs.read_file(session_file(store, "s1")).text(), text_before)
-  @fs.rmdir(store.root(), recursive=true)
 }
 
 ///|
 async test "load keeps a complete final record that lost only its newline" {
   let store = new_store()
+  defer @fs.rmdir(store.root(), recursive=true)
   let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
   let (_, event) = session.append_event(User(UserMessage("first")))
   store.create(session)
@@ -630,12 +631,12 @@ async test "load keeps a complete final record that lost only its newline" {
     fail("expected the unterminated user event")
   }
   assert_eq(message.content(), "first")
-  @fs.rmdir(store.root(), recursive=true)
 }
 
 ///|
 async test "append repairs a torn tail before persisting the next event" {
   let store = new_store()
+  defer @fs.rmdir(store.root(), recursive=true)
   let session = @agent_session.Session(SessionId("s1"), system_prompt="system").append(
     User(UserMessage("first")),
   )
@@ -657,12 +658,12 @@ async test "append repairs a torn tail before persisting the next event" {
   let reloaded = store.load(SessionId("s1"))
   assert_eq(reloaded.events().length(), 2)
   assert_eq(reloaded.last_sequence(), 2)
-  @fs.rmdir(store.root(), recursive=true)
 }
 
 ///|
 async test "append repairs and keeps a complete unterminated final event" {
   let store = new_store()
+  defer @fs.rmdir(store.root(), recursive=true)
   let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
   let (_, event) = session.append_event(User(UserMessage("first")))
   store.create(session)
@@ -684,12 +685,12 @@ async test "append repairs and keeps a complete unterminated final event" {
     fail("expected the recovered user event to survive the repair")
   }
   assert_eq(message.content(), "first")
-  @fs.rmdir(store.root(), recursive=true)
 }
 
 ///|
 async test "append rejects a stale snapshot against an unterminated durable event" {
   let store = new_store()
+  defer @fs.rmdir(store.root(), recursive=true)
   let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
   let (_, event) = session.append_event(User(UserMessage("first")))
   store.create(session)
@@ -715,12 +716,12 @@ async test "append rejects a stale snapshot against an unterminated durable even
   } noraise {
     _ => fail("stale append onto an unterminated durable event was accepted")
   }
-  @fs.rmdir(store.root(), recursive=true)
 }
 
 ///|
 async test "load tolerates unterminated tails in every torn shape" {
   let store = new_store()
+  defer @fs.rmdir(store.root(), recursive=true)
   // Valid JSON that is not a valid event: torn exactly inside the payload in
   // a way that still balances braces.
   store.create(Session(SessionId("json"), system_prompt="system"))
@@ -753,12 +754,12 @@ async test "load tolerates unterminated tails in every torn shape" {
     append=true,
   )
   assert_eq(store.load(SessionId("zero")).events().length(), 0)
-  @fs.rmdir(store.root(), recursive=true)
 }
 
 ///|
 async test "load keeps a header-only file that lost its newline" {
   let store = new_store()
+  defer @fs.rmdir(store.root(), recursive=true)
   // `create` can never produce this (tmp+rename is atomic), but the tolerance
   // rule is uniform: in a zero-event file the header is the final record.
   @fs.mkdir("\{store.root()}/sessions/s1", recursive=true)
@@ -775,12 +776,12 @@ async test "load keeps a header-only file that lost its newline" {
   let text = @fs.read_file(session_file(store, "s1")).text()
   assert_true(text.has_suffix("\n"))
   assert_eq(store.load(SessionId("s1")).events().length(), 1)
-  @fs.rmdir(store.root(), recursive=true)
 }
 
 ///|
 async test "compact repairs a torn tail before persisting the summary" {
   let store = new_store()
+  defer @fs.rmdir(store.root(), recursive=true)
   let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
     .append(User(UserMessage("first")))
     .append(Assistant(AssistantMessage("second")))
@@ -803,12 +804,12 @@ async test "compact repairs a torn tail before persisting the summary" {
   assert_true(text.has_suffix("\n"))
   assert_true(!text.contains("runt"))
   assert_eq(store.load(SessionId("s1")).events().length(), 3)
-  @fs.rmdir(store.root(), recursive=true)
 }
 
 ///|
 async test "latest can resume a session whose newest write was torn" {
   let store = new_store()
+  defer @fs.rmdir(store.root(), recursive=true)
   store.create(Session(SessionId("older"), system_prompt="system"))
   @async.sleep(50)
   let newest = @agent_session.Session(
@@ -824,12 +825,12 @@ async test "latest can resume a session whose newest write was torn" {
   )
   guard store.latest() is Some(id) else { fail("expected a latest session") }
   assert_eq(id.value(), "newest")
-  @fs.rmdir(store.root(), recursive=true)
 }
 
 ///|
 async test "load still fails on corruption that is not a torn tail" {
   let store = new_store()
+  defer @fs.rmdir(store.root(), recursive=true)
   let session = @agent_session.Session(SessionId("s1"), system_prompt="system").append(
     User(UserMessage("first")),
   )
@@ -862,12 +863,12 @@ async test "load still fails on corruption that is not a torn tail" {
   } noraise {
     _ => fail("terminated garbage line was accepted")
   }
-  @fs.rmdir(store.root(), recursive=true)
 }
 
 ///|
 async test "store propagates unreadable session files instead of dropping history" {
   let store = new_store()
+  defer @fs.rmdir(store.root(), recursive=true)
   let session = @agent_session.Session(SessionId("s1"), system_prompt="system").append(
     User(UserMessage("hello")),
   )
@@ -880,12 +881,12 @@ async test "store propagates unreadable session files instead of dropping histor
   } noraise {
     _ => fail("unreadable session file was silently accepted")
   }
-  @fs.rmdir(store.root(), recursive=true)
 }
 
 ///|
 async test "store names an unsupported session file version on load" {
   let store = new_store()
+  defer @fs.rmdir(store.root(), recursive=true)
   @fs.mkdir("\{store.root()}/sessions/s1", recursive=true)
   @fs.write_file(
     session_file(store, "s1"),
@@ -898,34 +899,34 @@ async test "store names an unsupported session file version on load" {
   } noraise {
     _ => fail("version-2 session file was accepted")
   }
-  @fs.rmdir(store.root(), recursive=true)
 }
 
 ///|
 async test "store rejects session ids containing NUL" {
   let store = new_store()
+  defer @fs.rmdir(store.root(), recursive=true)
   try store.exists(SessionId("bad\u{0}id")) catch {
     error => assert_true("\{error}".contains("NUL"))
   } noraise {
     _ => fail("NUL in session id accepted")
   }
-  @fs.rmdir(store.root(), recursive=true)
 }
 
 ///|
 async test "store rejects path-like session ids" {
   let store = new_store()
+  defer @fs.rmdir(store.root(), recursive=true)
   try store.exists(SessionId("../bad")) catch {
     error => assert_true("\{error}".contains("path separators"))
   } noraise {
     _ => fail("invalid session id accepted")
   }
-  @fs.rmdir(store.root(), recursive=true)
 }
 
 ///|
 async test "store compacts by appending a durable summary" {
   let store = new_store()
+  defer @fs.rmdir(store.root(), recursive=true)
   let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
     .append(User(UserMessage("first")))
     .append(Assistant(AssistantMessage("second")))
@@ -944,5 +945,4 @@ async test "store compacts by appending a durable summary" {
   }
   assert_eq(summary.content(), "first two events")
   assert_eq(loaded.chat_messages().length(), 2)
-  @fs.rmdir(store.root(), recursive=true)
 }

--- a/agent_subrun/child_test.mbt
+++ b/agent_subrun/child_test.mbt
@@ -259,6 +259,7 @@ async test "a store-backed append_item persists the child transcript" {
     }
     guard child_test_server(group, handle) is Some(url) else { return }
     let store = @store.SessionStore(@fs.tmpdir(prefix="openseek-subrun-child-"))
+    defer @fs.rmdir(store.root(), recursive=true)
     let value = @agent_subrun.execute_kind(
       session_id="parent-sr-1",
       system_prompt="You are a test subagent.",
@@ -290,6 +291,5 @@ async test "a store-backed append_item persists the child transcript" {
     assert_eq(loaded.system_prompt(), "You are a test subagent.")
     // The durable transcript holds the whole turn, not just a header.
     assert_true(loaded.events().length() >= 3)
-    @fs.rmdir(store.root(), recursive=true)
   }
 }

--- a/agent_workflow/subrun_runner_test.mbt
+++ b/agent_workflow/subrun_runner_test.mbt
@@ -171,6 +171,7 @@ async test "journal replay spares the child process entirely" {
     return
   }
   let dir = @fs.tmpdir(prefix="workflow-subrun-journal-")
+  defer (@fs.rmdir(dir, recursive=true) catch { _ => () })
   let path = "\{dir}/journal.jsonl"
   let live =
     #|read line
@@ -192,7 +193,4 @@ async test "journal replay spares the child process entirely" {
   assert_eq(wf2.agent("q", kind="explore"), first)
   assert_eq(wf2.calls_made(), 0)
   assert_eq(wf2.calls_replayed(), 1)
-  @fs.rmdir(dir, recursive=true) catch {
-    _ => ()
-  }
 }

--- a/agent_workflow/worker_test.mbt
+++ b/agent_workflow/worker_test.mbt
@@ -57,6 +57,7 @@ async test "a worker slice commits, integrates, and lands in the repo" {
     return
   }
   let repo = init_repo()
+  defer (@fs.rmdir(repo, recursive=true) catch { _ => () })
   let wf = worker_workflow(repo, edit_script)
   let outcome = @agent_workflow.worker(
     wf,
@@ -86,9 +87,6 @@ async test "a worker slice commits, integrates, and lands in the repo" {
     fail("expected the committed slice to integrate")
   }
   assert_eq(@fs.read_file("\{repo}/src/a.txt").text(), "two\n")
-  @fs.rmdir(repo, recursive=true) catch {
-    _ => ()
-  }
 }
 
 ///|
@@ -98,6 +96,7 @@ async test "an out-of-bounds edit is not mergeable and can be discarded" {
     return
   }
   let repo = init_repo()
+  defer (@fs.rmdir(repo, recursive=true) catch { _ => () })
   let rogue =
     #|read line
     #|printf 'rogue\n' > outside.txt
@@ -119,9 +118,6 @@ async test "an out-of-bounds edit is not mergeable and can be discarded" {
     is Ok(_) else {
     fail("expected the failed slice to be discardable")
   }
-  @fs.rmdir(repo, recursive=true) catch {
-    _ => ()
-  }
 }
 
 ///|
@@ -131,6 +127,7 @@ async test "overlapping slices are refused before any child spawns" {
     return
   }
   let repo = init_repo()
+  defer (@fs.rmdir(repo, recursive=true) catch { _ => () })
   let wf = worker_workflow(repo, edit_script)
   let _ = @agent_workflow.worker(wf, name="first", task="edit src", allowed_paths=[
     "src/",
@@ -145,9 +142,6 @@ async test "overlapping slices are refused before any child spawns" {
   assert_true(reason.contains("provision"))
   // A refused launch spent nothing beyond the first slice's child.
   assert_eq(wf.calls_made(), 2)
-  @fs.rmdir(repo, recursive=true) catch {
-    _ => ()
-  }
 }
 
 ///|
@@ -157,7 +151,9 @@ async test "a journalled worker slice replays without provisioning" {
     return
   }
   let repo = init_repo()
+  defer (@fs.rmdir(repo, recursive=true) catch { _ => () })
   let dir = @fs.tmpdir(prefix="workflow-worker-journal-")
+  defer (@fs.rmdir(dir, recursive=true) catch { _ => () })
   let path = "\{dir}/journal.jsonl"
   let wf1 = worker_workflow(
     repo,
@@ -190,12 +186,6 @@ async test "a journalled worker slice replays without provisioning" {
   assert_eq(second, first)
   assert_eq(wf2.calls_made(), 0)
   assert_eq(wf2.calls_replayed(), 1)
-  @fs.rmdir(dir, recursive=true) catch {
-    _ => ()
-  }
-  @fs.rmdir(repo, recursive=true) catch {
-    _ => ()
-  }
 }
 
 ///|
@@ -205,7 +195,9 @@ async test "a discarded slice does not replay: the veto reruns it live" {
     return
   }
   let repo = init_repo()
+  defer (@fs.rmdir(repo, recursive=true) catch { _ => () })
   let dir = @fs.tmpdir(prefix="workflow-worker-veto-")
+  defer (@fs.rmdir(dir, recursive=true) catch { _ => () })
   let path = "\{dir}/journal.jsonl"
   let wf1 = worker_workflow(
     repo,
@@ -239,12 +231,6 @@ async test "a discarded slice does not replay: the veto reruns it live" {
   }
   assert_eq(wf2.calls_made(), 1)
   assert_eq(wf2.calls_replayed(), 0)
-  @fs.rmdir(dir, recursive=true) catch {
-    _ => ()
-  }
-  @fs.rmdir(repo, recursive=true) catch {
-    _ => ()
-  }
 }
 
 ///|
@@ -254,6 +240,7 @@ async test "a dead child cannot become a clean-tree success" {
     return
   }
   let repo = init_repo()
+  defer (@fs.rmdir(repo, recursive=true) catch { _ => () })
   // No argv seam: the missing binary is really spawned and really dies.
   let wf = @workflow.Workflow(
     runner=@agent_workflow.openseek_runner(
@@ -268,9 +255,6 @@ async test "a dead child cannot become a clean-tree success" {
     is Err(@workflow.AgentFailed(..)) else {
     fail("a spawn failure must never look like a completed slice")
   }
-  @fs.rmdir(repo, recursive=true) catch {
-    _ => ()
-  }
 }
 
 ///|
@@ -280,6 +264,7 @@ async test "blank tasks and empty allowed_paths are refused pre-provision" {
     return
   }
   let repo = init_repo()
+  defer (@fs.rmdir(repo, recursive=true) catch { _ => () })
   let wf = worker_workflow(repo, edit_script)
   guard @agent_workflow.try_worker(wf, name="blank", task="  ", allowed_paths=[
       "src/",
@@ -298,9 +283,6 @@ async test "blank tasks and empty allowed_paths are refused pre-provision" {
     fail("expected a readable registry")
   }
   assert_eq(entries.length(), 0)
-  @fs.rmdir(repo, recursive=true) catch {
-    _ => ()
-  }
 }
 
 ///|
@@ -310,6 +292,7 @@ async test "names are reusable and lifecycle binds to the active generation" {
     return
   }
   let repo = init_repo()
+  defer (@fs.rmdir(repo, recursive=true) catch { _ => () })
   let wf = worker_workflow(repo, edit_script)
   let _ = @agent_workflow.worker(
     wf,
@@ -351,9 +334,6 @@ async test "names are reusable and lifecycle binds to the active generation" {
     .map(entry => Json(entry.state))
   assert_true(states.contains(Json("Integrated")))
   assert_true(states.contains(Json("Discarded")))
-  @fs.rmdir(repo, recursive=true) catch {
-    _ => ()
-  }
 }
 
 ///|
@@ -363,6 +343,7 @@ async test "an invalid report shape fails the slice at the trust boundary" {
     return
   }
   let repo = init_repo()
+  defer (@fs.rmdir(repo, recursive=true) catch { _ => () })
   // Edits land, but the report violates the contract (no schema_version,
   // unknown status): git salvage stays in the registry, the slice fails.
   let garbled =
@@ -377,9 +358,6 @@ async test "an invalid report shape fails the slice at the trust boundary" {
     fail("expected the garbled report to fail the slice")
   }
   assert_true(reason.contains("salvaged commit"))
-  @fs.rmdir(repo, recursive=true) catch {
-    _ => ()
-  }
 }
 
 ///|
@@ -389,6 +367,7 @@ async test "a clean no-op the child disclaims is a failure" {
     return
   }
   let repo = init_repo()
+  defer (@fs.rmdir(repo, recursive=true) catch { _ => () })
   let gave_up =
     #|read line
     #|printf '{"subrun_report": {"schema_version": 1, "status": "failed", "summary": "could not do it", "verification": "nothing ran"}}\n'
@@ -400,9 +379,6 @@ async test "a clean no-op the child disclaims is a failure" {
     fail("expected the disclaimed no-op to be a failure")
   }
   assert_true(reason.contains("reported failure"))
-  @fs.rmdir(repo, recursive=true) catch {
-    _ => ()
-  }
 }
 
 ///|
@@ -412,6 +388,7 @@ async test "a typed terminal with salvage names the salvaged commit" {
     return
   }
   let repo = init_repo()
+  defer (@fs.rmdir(repo, recursive=true) catch { _ => () })
   // The child makes a mergeable edit, then dies at its step ceiling
   // without a report: the failure must SAY a salvaged commit exists
   // rather than hiding it behind the bare terminal.
@@ -430,9 +407,6 @@ async test "a typed terminal with salvage names the salvaged commit" {
   assert_true(reason.contains("exhausted its steps"))
   // The message names the real branch, not a placeholder.
   assert_true(reason.contains("openseek/truncated"))
-  @fs.rmdir(repo, recursive=true) catch {
-    _ => ()
-  }
 }
 
 ///|

--- a/desktop/internal/auth/auth_wbtest.mbt
+++ b/desktop/internal/auth/auth_wbtest.mbt
@@ -149,6 +149,7 @@ async test "session commit persists before memory and wakes each local transitio
   assert_true(store.wakeups().try_get() is Some(_))
 
   let root : @pathx.Path = Path(@fs.tmpdir(prefix="openseek-auth-fail-"))
+  defer @fs.rmdir(root.to_string(), recursive=true)
   let unavailable = root.join("missing")
   let failing = AuthStore::load(runtime_dir=unavailable)
   failing.session = Some({
@@ -170,7 +171,6 @@ async test "session commit persists before memory and wakes each local transitio
   assert_true(failing.session_server() is Some("https://old.example"))
   assert_true(failing.connected)
   assert_true(failing.wakeups().try_get() is None)
-  @fs.rmdir(root.to_string(), recursive=true)
 }
 
 ///|

--- a/desktop/internal/codex/home.mbt
+++ b/desktop/internal/codex/home.mbt
@@ -75,6 +75,7 @@ test "codex home is a codex subdirectory of the runtime dir" {
 ///|
 async test "prepared codex home creates the directory" {
   let root : @pathx.Path = @fs.tmpdir(prefix="openseek-codex-home-")
+  defer @fs.rmdir(root.to_string(), recursive=true)
   let home = prepared_home(root)
   guard home is Some(home) else { fail("codex home was not prepared") }
   assert_eq(home, home_dir(root))
@@ -84,5 +85,4 @@ async test "prepared codex home creates the directory" {
   guard prepared_home(root) is Some(_) else {
     fail("codex home was not prepared again")
   }
-  @fs.rmdir(root.to_string(), recursive=true)
 }

--- a/desktop/internal/development/layout_test.mbt
+++ b/desktop/internal/development/layout_test.mbt
@@ -1,6 +1,7 @@
 ///|
 async test "Moon native host layout identifies checkout-local development paths" {
   let root : @path.Path = @fs.tmpdir(prefix="openseek-development-layout-")
+  defer @fs.rmdir(root.to_string(), recursive=true)
   let command_dir = root.join("_build/native/debug/build/openseek_desktop")
   @fs.mkdir(command_dir.to_string(), recursive=true)
   let executable = command_dir.join("openseek_desktop.exe").to_string()
@@ -28,5 +29,4 @@ async test "Moon native host layout identifies checkout-local development paths"
   assert_true(
     @development.Layout::detect(root.join("installed/app").to_string()) is None,
   )
-  @fs.rmdir(root.to_string(), recursive=true)
 }

--- a/desktop/internal/engine/archive.mbt
+++ b/desktop/internal/engine/archive.mbt
@@ -665,6 +665,7 @@ async test "archive refuses a durable record while the pump is stopped" {
   let previous = @sys.get_env_var("HOME")
   defer restore_home_env(previous)
   let dir = @fs.tmpdir(prefix="openseek-archive-stopped-")
+  defer @fs.rmdir(dir, recursive=true)
   @sys.set_env_var("HOME", dir + "/global")
   ignore(attach_run_workspace(Path(dir)))
   let store = dir + "/ws/.openseek"
@@ -687,7 +688,6 @@ async test "archive refuses a durable record while the pump is stopped" {
   assert_false(committed.val)
   assert_true(@fsx.is_dir(Path(store + "/sessions/s-stopped")))
   assert_false(@fsx.is_dir(Path(store + "/archived/sessions/s-stopped")))
-  @fs.rmdir(dir, recursive=true)
 }
 
 ///|
@@ -698,6 +698,7 @@ async test "archive publishes its move before a cancelled listing reply" {
   let previous = @sys.get_env_var("HOME")
   defer restore_home_env(previous)
   let dir = @fs.tmpdir(prefix="openseek-archive-commit-")
+  defer @fs.rmdir(dir, recursive=true)
   let root : @pathx.Path = Path(dir)
   let marker = dir + "/listing-started"
   let engine = dir + "/engine.sh"
@@ -740,7 +741,6 @@ async test "archive publishes its move before a cancelled listing reply" {
   assert_false(@fsx.is_dir(store.join("sessions/s-commit")))
   assert_true(@fsx.is_dir(store.join("archived/sessions/s-commit")))
   assert_true(manager.record_guards.get("s-commit") is None)
-  @fs.rmdir(dir, recursive=true)
 }
 
 ///|
@@ -751,6 +751,7 @@ async test "archive and restore move a subagent session family together" {
   let previous = @sys.get_env_var("HOME")
   defer restore_home_env(previous)
   let dir = @fs.tmpdir(prefix="openseek-archive-family-")
+  defer @fs.rmdir(dir, recursive=true)
   @sys.set_env_var("HOME", dir + "/global")
   ignore(attach_run_workspace(Path(dir)))
   let store = dir + "/ws/.openseek"
@@ -794,7 +795,6 @@ async test "archive and restore move a subagent session family together" {
     assert_false(@fsx.is_dir(Path(archived + session_id)))
   }
   assert_true(manager.record_guards.is_empty())
-  @fs.rmdir(dir, recursive=true)
 }
 
 ///|
@@ -805,6 +805,7 @@ async test "permanent deletion removes one archived session family only" {
   let previous = @sys.get_env_var("HOME")
   defer restore_home_env(previous)
   let dir = @fs.tmpdir(prefix="openseek-archive-delete-family-")
+  defer @fs.rmdir(dir, recursive=true)
   let home = dir + "/home"
   let global_root = home + "/.openseek"
   let workspace = dir + "/workspace"
@@ -844,7 +845,6 @@ async test "permanent deletion removes one archived session family only" {
     assert_false(@fsx.exists(Path(store + "/archived/deleting/" + session_id)))
   }
   assert_true(manager.record_guards.is_empty())
-  @fs.rmdir(dir, recursive=true)
 }
 
 ///|
@@ -855,6 +855,7 @@ async test "permanent deletion uses the selected archived store" {
   let previous = @sys.get_env_var("HOME")
   defer restore_home_env(previous)
   let dir = @fs.tmpdir(prefix="openseek-archive-delete-selected-store-")
+  defer @fs.rmdir(dir, recursive=true)
   let home = dir + "/home"
   let global_root = home + "/.openseek"
   let workspace = dir + "/workspace"
@@ -882,7 +883,6 @@ async test "permanent deletion uses the selected archived store" {
     @fsx.exists(Path(workspace + "/.openseek/archived/sessions/chat")),
   )
   assert_eq(deleted_workspaces, [workspace_token])
-  @fs.rmdir(dir, recursive=true)
 }
 
 ///|
@@ -893,6 +893,7 @@ async test "permanent deletion refuses a live twin in the selected store" {
   let previous = @sys.get_env_var("HOME")
   defer restore_home_env(previous)
   let dir = @fs.tmpdir(prefix="openseek-archive-delete-live-twin-")
+  defer @fs.rmdir(dir, recursive=true)
   let home = dir + "/home"
   let global_root = home + "/.openseek"
   let workspace = dir + "/workspace"
@@ -925,7 +926,6 @@ async test "permanent deletion refuses a live twin in the selected store" {
   assert_true(
     @fsx.is_dir(Path(workspace + "/.openseek/archived/sessions/chat")),
   )
-  @fs.rmdir(dir, recursive=true)
 }
 
 ///|
@@ -936,6 +936,7 @@ async test "startup sweep erases condemned records" {
   let previous = @sys.get_env_var("HOME")
   defer restore_home_env(previous)
   let dir = @fs.tmpdir(prefix="openseek-archive-delete-sweep-")
+  defer @fs.rmdir(dir, recursive=true)
   @sys.set_env_var("HOME", dir + "/global")
   ignore(attach_run_workspace(Path(dir)))
   let store = dir + "/ws/.openseek"
@@ -949,7 +950,6 @@ async test "startup sweep erases condemned records" {
   assert_false(@fsx.exists(Path(store + "/archived/deleting/.chat")))
   assert_false(@fsx.exists(Path(store + "/archived/deleting/chat-sr-1")))
   assert_true(@fsx.is_dir(Path(store + "/archived/sessions/other")))
-  @fs.rmdir(dir, recursive=true)
 }
 
 ///|
@@ -960,6 +960,7 @@ async test "selected archived store is revalidated after detachment" {
   let previous = @sys.get_env_var("HOME")
   defer restore_home_env(previous)
   let dir = @fs.tmpdir(prefix="openseek-archive-delete-detached-selection-")
+  defer @fs.rmdir(dir, recursive=true)
   let home = dir + "/home"
   let global_root = home + "/.openseek"
   let workspace = @pathx.Path(dir + "/workspace").resolve()
@@ -993,7 +994,6 @@ async test "selected archived store is revalidated after detachment" {
   assert_true(
     @fsx.is_dir(workspace.join(".openseek/archived/sessions/chat").to_path()),
   )
-  @fs.rmdir(dir, recursive=true)
 }
 
 ///|
@@ -1004,6 +1004,7 @@ async test "a claimed child prevents a partial family archive" {
   let previous = @sys.get_env_var("HOME")
   defer restore_home_env(previous)
   let dir = @fs.tmpdir(prefix="openseek-archive-family-busy-")
+  defer @fs.rmdir(dir, recursive=true)
   @sys.set_env_var("HOME", dir + "/global")
   ignore(attach_run_workspace(Path(dir)))
   let store = dir + "/ws/.openseek"
@@ -1031,5 +1032,4 @@ async test "a claimed child prevents a partial family archive" {
   assert_true(@fsx.is_dir(Path(store + "/sessions/chat-sr-1")))
   assert_false(@fsx.exists(Path(store + "/archived/sessions")))
   assert_true(manager.record_guards.is_empty())
-  @fs.rmdir(dir, recursive=true)
 }

--- a/desktop/internal/engine/archive_lookup_wbtest.mbt
+++ b/desktop/internal/engine/archive_lookup_wbtest.mbt
@@ -12,6 +12,7 @@ async test "archive names the missing store after a workspace detach" {
   let previous = @sys.get_env_var("HOME")
   defer restore_home_env(previous)
   let dir = @fs.tmpdir(prefix="openseek-archive-detach-")
+  defer @fs.rmdir(dir, recursive=true)
   let workspace = dir + "/ws"
   let home = dir + "/home"
   let global_root = home + "/.openseek"
@@ -67,7 +68,6 @@ async test "archive names the missing store after a workspace detach" {
       #|"no durable record for this conversation in the global store or any attached workspace"
     ),
   )
-  @fs.rmdir(dir, recursive=true)
 }
 
 ///|
@@ -78,6 +78,7 @@ async test "archive reports a workspace record whose directory vanished" {
   let previous = @sys.get_env_var("HOME")
   defer restore_home_env(previous)
   let dir = @fs.tmpdir(prefix="openseek-archive-gone-")
+  defer @fs.rmdir(dir, recursive=true)
   let workspace = dir + "/ws"
   let home = dir + "/home"
   let global_root = home + "/.openseek"
@@ -108,7 +109,6 @@ async test "archive reports a workspace record whose directory vanished" {
       #|"no durable record for this conversation in the global store or any attached workspace"
     ),
   )
-  @fs.rmdir(dir, recursive=true)
 }
 
 ///|
@@ -119,6 +119,7 @@ async test "loading a conversation from a detached workspace names that state" {
   let previous = @sys.get_env_var("HOME")
   defer restore_home_env(previous)
   let dir = @fs.tmpdir(prefix="openseek-load-detached-")
+  defer @fs.rmdir(dir, recursive=true)
   let workspace = dir + "/ws"
   let home = dir + "/home"
   let global_root = home + "/.openseek"
@@ -151,7 +152,6 @@ async test "loading a conversation from a detached workspace names that state" {
       #|"no attached workspace holds this conversation; attach its project first"
     ),
   )
-  @fs.rmdir(dir, recursive=true)
 }
 
 ///|
@@ -162,6 +162,7 @@ async test "archiving an already-archived conversation names that state" {
   let previous = @sys.get_env_var("HOME")
   defer restore_home_env(previous)
   let dir = @fs.tmpdir(prefix="openseek-archive-again-")
+  defer @fs.rmdir(dir, recursive=true)
   @sys.set_env_var("HOME", dir + "/global")
   ignore(attach_run_workspace(Path(dir)))
   let store = dir + "/ws/.openseek"
@@ -183,5 +184,4 @@ async test "archiving an already-archived conversation names that state" {
     ),
   )
   assert_true(@fsx.is_dir(Path(store + "/archived/sessions/s-done")))
-  @fs.rmdir(dir, recursive=true)
 }

--- a/desktop/internal/engine/archive_submodule_wbtest.mbt
+++ b/desktop/internal/engine/archive_submodule_wbtest.mbt
@@ -9,6 +9,7 @@ async test "archive deletes a submodule checkout that git worktree remove refuse
   defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("HOME")
   let root = worktree_test_root("openseek-worktree-sub-archive-")
+  defer @fs.rmdir(root.to_string(), recursive=true)
   @sys.set_env_var("HOME", root.join("global").to_string())
   defer restore_home_env(previous)
   @fsx.ensure_dir(root.join("global").to_path())
@@ -107,7 +108,6 @@ async test "archive deletes a submodule checkout that git worktree remove refuse
   )
   assert_false(first.present)
   assert_false(second.present)
-  @fs.rmdir(root.to_string(), recursive=true)
 }
 
 ///|
@@ -117,6 +117,7 @@ async test "worktree deletion refuses a replaced checkout" {
   defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("HOME")
   let root = worktree_test_root("openseek-worktree-replaced-")
+  defer @fs.rmdir(root.to_string(), recursive=true)
   @sys.set_env_var("HOME", root.join("global").to_string())
   defer restore_home_env(previous)
   @fsx.ensure_dir(root.join("global").to_path())
@@ -181,5 +182,4 @@ async test "worktree deletion refuses a replaced checkout" {
   // The unrelated repository survives untouched, registry entry and all.
   assert_true(@fsx.is_dir(target.join(".git").to_path()))
   assert_eq(@worktree.list(repo.to_string()).worktrees.length(), 1)
-  @fs.rmdir(root.to_string(), recursive=true)
 }

--- a/desktop/internal/engine/command.mbt
+++ b/desktop/internal/engine/command.mbt
@@ -58,6 +58,7 @@ pub async fn engine_command(framework_command : String) -> String {
 ///|
 async test "packaged sibling wins before the matching Moon build engine" {
   let root : @pathx.Path = @fs.tmpdir(prefix="openseek-development-engine-")
+  defer @fs.rmdir(root.to_string(), recursive=true)
   let build = root.join("_build/native/debug/build")
   let command_dir = build.join("openseek_desktop")
   let host = command_dir.join("openseek_desktop.exe").to_string()
@@ -70,5 +71,4 @@ async test "packaged sibling wins before the matching Moon build engine" {
   let bundled = command_dir.join("openseek").to_string()
   @fs.write_file(bundled, "bundled", create_mode=CreateOrTruncate)
   assert_eq(engine_command(host), bundled)
-  @fs.rmdir(root.to_string(), recursive=true)
 }

--- a/desktop/internal/engine/config.mbt
+++ b/desktop/internal/engine/config.mbt
@@ -403,6 +403,7 @@ async test "run config ignores OPENSEEK_API_URL in favor of the settings" {
   // A run needs a workspace before the endpoint matters; attach one so this
   // test fails only for the reason it is named after.
   let root : @pathx.Path = Path(@fs.tmpdir(prefix="openseek-config-endpoint-"))
+  defer @fs.rmdir(root.to_string(), recursive=true)
   set_test_home(root.join("home").to_string())
   let workspace = attach_run_workspace(root)
   let manager = new_engine_manager("openseek", runtime_dir=root)
@@ -425,7 +426,6 @@ async test "run config ignores OPENSEEK_API_URL in favor of the settings" {
   })
   assert_true(config.api_url is None)
   assert_eq(config.api_key, "sk-official")
-  @fs.rmdir(root.to_string(), recursive=true)
 }
 
 ///|
@@ -472,6 +472,7 @@ async test "host chooses durable placement from workspace state" {
   // The registry canonicalizes workspace paths, so build the fixture from
   // the tmpdir's physical spelling (`/tmp` is a symlink on macOS).
   let dir = @fs.realpath(@fs.tmpdir(prefix="openseek-config-workspace-"))
+  defer @fs.rmdir(dir, recursive=true)
   let home = dir + "/home"
   let global_root = home + "/.openseek"
   let workspace = dir + "/workspace"
@@ -540,5 +541,4 @@ async test "host chooses durable placement from workspace state" {
     Some(workspace + "/.openseek"),
   )
   assert_eq(attached.cwd.map(cwd => cwd.to_string()), Some(workspace))
-  @fs.rmdir(dir, recursive=true)
 }

--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -2881,6 +2881,7 @@ async fn write_fake_executable(path : @pathx.Path) -> Unit {
 #cfg(not(platform="windows"))
 async test "engine startup rolls back follower on pre-spawn failure" {
   let dir = @fs.tmpdir(prefix="openseek-engine-startup-")
+  defer @fs.rmdir(dir, recursive=true)
   let baseline_engine = dir + "/baseline.sh"
   @fs.write_file(
     baseline_engine,
@@ -2916,7 +2917,6 @@ async test "engine startup rolls back follower on pre-spawn failure" {
     assert_true(manager.followers.get("s-startup-failure") is None)
     assert_true(slot.engine is None)
   })
-  @fs.rmdir(dir, recursive=true)
 }
 
 ///|

--- a/desktop/internal/engine/follower.mbt
+++ b/desktop/internal/engine/follower.mbt
@@ -680,6 +680,7 @@ fn follower_test_config(
 #cfg(not(platform="windows"))
 async test "a follower barrier broadcasts the durable tail before returning" {
   let dir = @fs.tmpdir(prefix="openseek-follower-barrier-")
+  defer @fs.rmdir(dir, recursive=true)
   let engine = dir + "/engine.sh"
   let session = "s-barrier"
   let root : @pathx.Absolute = @pathx.Path(dir + "/root").resolve()
@@ -707,7 +708,6 @@ async test "a follower barrier broadcasts the durable tail before returning" {
     stop_follower(manager, session, writer_exited=true)
     group.return_immediately(())
   })
-  @fs.rmdir(dir, recursive=true)
 }
 
 ///|
@@ -719,6 +719,7 @@ async test "a follower barrier broadcasts the durable tail before returning" {
 #cfg(not(platform="windows"))
 async test "an unreadable existing record refuses the spawn baseline" {
   let dir = @fs.tmpdir(prefix="openseek-follower-baseline-")
+  defer @fs.rmdir(dir, recursive=true)
   let engine = dir + "/engine.sh"
   let root : @pathx.Absolute = @pathx.Path(dir + "/root").resolve()
   let manager = new_engine_manager(engine)
@@ -762,13 +763,13 @@ async test "an unreadable existing record refuses the spawn baseline" {
     assert_true(manager.followers.get("s-baseline") is None)
     group.return_immediately(())
   })
-  @fs.rmdir(dir, recursive=true)
 }
 
 ///|
 #cfg(not(platform="windows"))
 async test "failed final scan keeps the follower active and propagates" {
   let dir = @fs.tmpdir(prefix="openseek-follower-stop-")
+  defer @fs.rmdir(dir, recursive=true)
   let engine = dir + "/engine.sh"
   let root : @pathx.Absolute = @pathx.Path(dir + "/root").resolve()
   // The record must be readable while the follower baselines — a spawn over
@@ -806,7 +807,6 @@ async test "failed final scan keeps the follower active and propagates" {
     assert_false(follower.stopping)
     group.return_immediately(())
   })
-  @fs.rmdir(dir, recursive=true)
 }
 
 ///|
@@ -817,6 +817,7 @@ async test "failed final scan keeps the follower active and propagates" {
 #cfg(not(platform="windows"))
 async test "an absent record retires as an empty drain" {
   let dir = @fs.tmpdir(prefix="openseek-follower-durable-absent-")
+  defer @fs.rmdir(dir, recursive=true)
   let engine = dir + "/engine.sh"
   let session = "s-durable-absent"
   let root : @pathx.Absolute = @pathx.Path(dir + "/root").resolve()
@@ -840,13 +841,13 @@ async test "an absent record retires as an empty drain" {
     assert_true(manager.followers.get(session) is None)
     group.return_immediately(())
   })
-  @fs.rmdir(dir, recursive=true)
 }
 
 ///|
 #cfg(not(platform="windows"))
 async test "the drain that finally succeeds broadcasts what it could not read" {
   let dir = @fs.tmpdir(prefix="openseek-follower-durable-tail-")
+  defer @fs.rmdir(dir, recursive=true)
   let engine = dir + "/engine.sh"
   let session = "s-durable-tail"
   let root : @pathx.Absolute = @pathx.Path(dir + "/root").resolve()
@@ -889,7 +890,6 @@ async test "the drain that finally succeeds broadcasts what it could not read" {
     assert_eq(session_root, root.resource_path())
     group.return_immediately(())
   })
-  @fs.rmdir(dir, recursive=true)
 }
 
 ///|
@@ -900,6 +900,7 @@ async test "the drain that finally succeeds broadcasts what it could not read" {
 #cfg(not(platform="windows"))
 async test "a committed terminal does not settle a run the stream never ended" {
   let dir = @fs.tmpdir(prefix="openseek-eof-durable-close-")
+  defer @fs.rmdir(dir, recursive=true)
   let session = "s-eof-close"
   let root : @pathx.Absolute = @pathx.Path(dir + "/root").resolve()
   write_session_record(root, session, [])
@@ -966,13 +967,13 @@ async test "a committed terminal does not settle a run the stream never ended" {
     assert_eq(settlements, 1)
     group.return_immediately(())
   })
-  @fs.rmdir(dir, recursive=true)
 }
 
 ///|
 #cfg(not(platform="windows"))
 async test "abrupt EOF leaves a failed drain for a later caller to retry" {
   let dir = @fs.tmpdir(prefix="openseek-follower-abrupt-eof-")
+  defer @fs.rmdir(dir, recursive=true)
   let engine_path = dir + "/engine.sh"
   let session = "s-abrupt-eof"
   let root : @pathx.Absolute = @pathx.Path(dir + "/root").resolve()
@@ -1044,7 +1045,6 @@ async test "abrupt EOF leaves a failed drain for a later caller to retry" {
     assert_true(follower.retired)
     group.return_immediately(())
   })
-  @fs.rmdir(dir, recursive=true)
 }
 
 ///|
@@ -1054,6 +1054,7 @@ async test "workspace detach drains an orphaned pending follower before commit" 
   defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("HOME")
   let dir = @fs.tmpdir(prefix="openseek-detach-orphan-follower-")
+  defer @fs.rmdir(dir, recursive=true)
   let global_root : @pathx.Absolute = @pathx.Path(dir + "/global").resolve()
   let workspace : @pathx.Absolute = @pathx.Path(dir + "/workspace").resolve()
   let root = @workspaces.store_root(workspace)
@@ -1104,13 +1105,13 @@ async test "workspace detach drains an orphaned pending follower before commit" 
     assert_true(manager.followers.get(session) is None)
     group.return_immediately(())
   })
-  @fs.rmdir(dir, recursive=true)
 }
 
 ///|
 #cfg(not(platform="windows"))
 async test "workspace detach refuses an idle engine whose follower cannot drain" {
   let dir = @fs.tmpdir(prefix="openseek-detach-follower-stop-")
+  defer @fs.rmdir(dir, recursive=true)
   let workspace : @pathx.Absolute = @pathx.Path(dir + "/workspace").resolve()
   let root = @workspaces.store_root(workspace)
   let engine_path = dir + "/engine.sh"
@@ -1177,13 +1178,13 @@ async test "workspace detach refuses an idle engine whose follower cannot drain"
     discard_follower_startup(manager, follower)
     group.return_immediately(())
   })
-  @fs.rmdir(dir, recursive=true)
 }
 
 ///|
 #cfg(not(platform="windows"))
 async test "record stat failure is not mistaken for an empty final drain" {
   let dir = @fs.tmpdir(prefix="openseek-follower-stat-")
+  defer @fs.rmdir(dir, recursive=true)
   let engine = dir + "/engine.sh"
   let root : @pathx.Absolute = @pathx.Path(dir + "/root").resolve()
   // Opening the pinned record beneath a regular file deterministically raises
@@ -1234,13 +1235,13 @@ async test "record stat failure is not mistaken for an empty final drain" {
     discard_follower_startup(manager, follower)
     group.return_immediately(())
   })
-  @fs.rmdir(dir, recursive=true)
 }
 
 ///|
 #cfg(not(platform="windows"))
 async test "root change retires the old follower before installing another" {
   let dir = @fs.tmpdir(prefix="openseek-follower-root-")
+  defer @fs.rmdir(dir, recursive=true)
   let engine = dir + "/engine.sh"
   let manager = new_engine_manager(engine)
   let sink = EventSink(fn(_) { () })
@@ -1277,13 +1278,13 @@ async test "root change retires the old follower before installing another" {
     assert_eq(second.root.to_string(), root_b.to_string())
     discard_follower_startup(manager, second)
   })
-  @fs.rmdir(dir, recursive=true)
 }
 
 ///|
 #cfg(not(platform="windows"))
 async test "one Load control message answers a bounded request batch" {
   let dir = @fs.tmpdir(prefix="openseek-follower-load-")
+  defer @fs.rmdir(dir, recursive=true)
   let engine = dir + "/engine.sh"
   let root : @pathx.Absolute = @pathx.Path(dir + "/root").resolve()
   write_session_record(root, "s-load", [session_user_event(1, "hello")])
@@ -1323,7 +1324,6 @@ async test "one Load control message answers a bounded request batch" {
     assert_eq(session_max_sequence(document), 1)
     discard_follower_startup(manager, follower)
   })
-  @fs.rmdir(dir, recursive=true)
 }
 
 ///|
@@ -1407,6 +1407,7 @@ async test "identity-scoped stop never retires a successor" {
 #cfg(not(platform="windows"))
 async test "cancelling follower baseline removes its startup identity" {
   let dir = @fs.tmpdir(prefix="openseek-follower-cancel-")
+  defer @fs.rmdir(dir, recursive=true)
   let engine = dir + "/engine.sh"
   let root : @pathx.Absolute = @pathx.Path(dir + "/root").resolve()
   // A record long enough that its baseline spans many reads, so the cancel
@@ -1444,7 +1445,6 @@ async test "cancelling follower baseline removes its startup identity" {
     assert_true(manager.followers.get("s-cancel") is None)
     group.return_immediately(())
   })
-  @fs.rmdir(dir, recursive=true)
 }
 
 ///|

--- a/desktop/internal/engine/migrate_global_store_wbtest.mbt
+++ b/desktop/internal/engine/migrate_global_store_wbtest.mbt
@@ -21,6 +21,7 @@ async test "the migration relocates live and archived records one by one" {
   ambient_env_test_lock.acquire()
   defer ambient_env_test_lock.release()
   let dir = @fs.tmpdir(prefix="openseek-migrate-global-")
+  defer @fs.rmdir(dir, recursive=true)
   let root : @pathx.Path = Path(dir)
   let previous_home = @sys.get_env_var("HOME")
   @sys.set_env_var("HOME", root.join("home").to_string())
@@ -87,7 +88,6 @@ async test "the migration relocates live and archived records one by one" {
   assert_false(@fsx.exists(destination.join(StagingDirName).to_path()))
   // A second launch finds nothing to do rather than repeating itself.
   assert_eq(migrate_global_store(), 0)
-  @fs.rmdir(dir, recursive=true)
 }
 
 ///|
@@ -98,6 +98,7 @@ async test "the migration relocates live and archived records one by one" {
 #cfg(not(platform="windows"))
 async test "copying a record across filesystems leaves the destination whole" {
   let dir = @fs.tmpdir(prefix="openseek-migrate-copy-")
+  defer @fs.rmdir(dir, recursive=true)
   let root : @pathx.Path = Path(dir)
   guard root.to_absolute() is Some(root) else { fail("expected \{root}") }
   let record = root.join("global/sessions/chat")
@@ -114,7 +115,6 @@ async test "copying a record across filesystems leaves the destination whole" {
   assert_eq(@fsx.read_text(destination.join("meta.json").to_path()), "{}")
   assert_false(@fsx.exists(record.to_path()))
   assert_false(@fsx.exists(staging.to_path()))
-  @fs.rmdir(dir, recursive=true)
 }
 
 ///|

--- a/desktop/internal/engine/ops.mbt
+++ b/desktop/internal/engine/ops.mbt
@@ -934,6 +934,7 @@ async fn attach_run_workspace(root : @pathx.Path) -> String {
 #cfg(not(platform="windows"))
 async test "start echoes the client submission id in Started" {
   let dir = @fs.tmpdir(prefix="openseek-start-submission-")
+  defer @fs.rmdir(dir, recursive=true)
   let root : @pathx.Path = Path(dir)
   // A run is handed the global skills library under `HOME`. Own it, so this
   // test neither races one that moves `HOME` nor reads the developer's own.
@@ -1000,7 +1001,6 @@ async test "start echoes the client submission id in Started" {
     assert_eq(echoed, Some("submission-start"))
     group.return_immediately(())
   })
-  @fs.rmdir(dir, recursive=true)
 }
 
 ///|
@@ -1011,6 +1011,7 @@ async test "start echoes the client submission id in Started" {
 #cfg(not(platform="windows"))
 async test "a goal is delivered only once its command is on the wire" {
   let dir = @fs.tmpdir(prefix="openseek-goal-ack-")
+  defer @fs.rmdir(dir, recursive=true)
   let root : @pathx.Path = Path(dir)
   // A run is handed the global skills library under `HOME`. Own it, so this
   // test neither races one that moves `HOME` nor reads the developer's own.
@@ -1084,7 +1085,6 @@ async test "a goal is delivered only once its command is on the wire" {
     )
     group.return_immediately(())
   })
-  @fs.rmdir(dir, recursive=true)
 }
 
 ///|
@@ -1252,6 +1252,7 @@ async test "setup failure retires the writer before an immediate next start" {
 #cfg(not(platform="windows"))
 async test "a prompt bigger than the pipe still settles exactly once" {
   let dir = @fs.tmpdir(prefix="openseek-backpressured-command-")
+  defer @fs.rmdir(dir, recursive=true)
   let root : @pathx.Path = Path(dir)
   // A run is handed the global skills library under `HOME`. Own it, so this
   // test neither races one that moves `HOME` nor reads the developer's own.
@@ -1340,7 +1341,6 @@ async test "a prompt bigger than the pipe still settles exactly once" {
     assert_true(open_run_engine(manager, run_id~) is None)
     group.return_immediately(())
   })
-  @fs.rmdir(dir, recursive=true)
 }
 
 ///|
@@ -1349,6 +1349,7 @@ async test "named session retries after its first prompt creates no record" {
   ambient_env_test_lock.acquire()
   defer ambient_env_test_lock.release()
   let dir = @fs.tmpdir(prefix="openseek-first-prompt-retry-")
+  defer @fs.rmdir(dir, recursive=true)
   let root : @pathx.Path = Path(dir)
   let previous_home = @sys.get_env_var("HOME")
   @sys.set_env_var("HOME", root.join("home").to_string())
@@ -1466,7 +1467,6 @@ async test "named session retries after its first prompt creates no record" {
     assert_eq(@fs.read_file(count.to_string()).text(), "2")
     group.return_immediately(())
   })
-  @fs.rmdir(dir, recursive=true)
 }
 
 ///|
@@ -1476,6 +1476,7 @@ async test "session load preserves a future item without hiding known events" {
   defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("HOME")
   let dir = @fs.tmpdir(prefix="openseek-load-future-item-")
+  defer @fs.rmdir(dir, recursive=true)
   @sys.set_env_var("HOME", dir + "/global")
   defer restore_home_env(previous)
   // A hint-less load resolves the store from where the record actually
@@ -1502,7 +1503,6 @@ async test "session load preserves a future item without hiding known events" {
   assert_eq(events.length(), 3)
   assert_true(events[1].item is Unknown(_))
   assert_eq(reply.watermark, Some(3))
-  @fs.rmdir(dir, recursive=true)
 }
 
 ///|
@@ -1512,6 +1512,7 @@ async test "archived session load reads without restoring the record" {
   defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("HOME")
   let dir = @fs.tmpdir(prefix="openseek-load-archived-")
+  defer @fs.rmdir(dir, recursive=true)
   @sys.set_env_var("HOME", dir + "/global")
   defer restore_home_env(previous)
   // A hint-less load resolves the store from where the record actually
@@ -1539,7 +1540,6 @@ async test "archived session load reads without restoring the record" {
   assert_true(@fsx.is_dir(Path(store + "/archived/sessions/s-archived")))
   assert_false(@fsx.exists(Path(store + "/sessions/s-archived")))
   assert_true(manager.record_guards.is_empty())
-  @fs.rmdir(dir, recursive=true)
 }
 
 ///|
@@ -1549,6 +1549,7 @@ async test "load rejects a detached workspace hint instead of probing global" {
   defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("HOME")
   let dir = @fs.tmpdir(prefix="openseek-load-detached-")
+  defer @fs.rmdir(dir, recursive=true)
   let marker = dir + "/engine-ran"
   let engine = dir + "/engine.sh"
   @sys.set_env_var("HOME", dir)
@@ -1576,7 +1577,6 @@ async test "load rejects a detached workspace hint instead of probing global" {
   }
   assert_true(detail.contains("not a registered workspace"))
   assert_false(@fsx.exists(Path(marker)))
-  @fs.rmdir(dir, recursive=true)
 }
 
 ///|
@@ -1590,6 +1590,7 @@ async test "workspace detach refuses a running conversation without hiding it" {
   let root : @pathx.Path = Path(
     @fs.realpath(@fs.tmpdir(prefix="openseek-detach-running-")),
   )
+  defer @fs.rmdir(root.to_string(), recursive=true)
   let global_store = root.join("global")
   let workspace = root.join("workspace")
   let engine = root.join("bin/engine.sh")
@@ -1662,7 +1663,6 @@ async test "workspace detach refuses a running conversation without hiding it" {
     assert_true(@workspaces.registered().contains(workspace_path))
     group.return_immediately(())
   })
-  @fs.rmdir(root.to_string(), recursive=true)
 }
 
 ///|
@@ -1676,6 +1676,7 @@ async test "workspace detach drains an idle writer and its follower first" {
   let root : @pathx.Path = Path(
     @fs.realpath(@fs.tmpdir(prefix="openseek-detach-idle-")),
   )
+  defer @fs.rmdir(root.to_string(), recursive=true)
   let global_store = root.join("global")
   let workspace = root.join("workspace")
   let engine = root.join("bin/engine.sh")
@@ -1751,7 +1752,6 @@ async test "workspace detach drains an idle writer and its follower first" {
     assert_true(sessions.get("s-detach-idle") is None)
     group.return_immediately(())
   })
-  @fs.rmdir(root.to_string(), recursive=true)
 }
 
 ///|

--- a/desktop/internal/engine/worktree_seam_wbtest.mbt
+++ b/desktop/internal/engine/worktree_seam_wbtest.mbt
@@ -70,6 +70,7 @@ async test "session workspace dir follows the worktree mapping while it exists" 
   defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("HOME")
   let root = worktree_test_root("openseek-worktree-seam-")
+  defer @fs.rmdir(root.to_string(), recursive=true)
   @sys.set_env_var("HOME", root.join("global").to_string())
   defer restore_home_env(previous)
   let ws = root.join("ws")
@@ -127,7 +128,6 @@ async test "session workspace dir follows the worktree mapping while it exists" 
   assert_true(
     @work_dir.resolve_in_workspace("s-wt", "", workspace=ws_resource) is None,
   )
-  @fs.rmdir(root.to_string(), recursive=true)
 }
 
 ///|
@@ -137,6 +137,7 @@ async test "attached workspace dir resolves registered worktree paths" {
   defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("HOME")
   let root = worktree_test_root("openseek-worktree-attached-")
+  defer @fs.rmdir(root.to_string(), recursive=true)
   @sys.set_env_var("HOME", root.join("global").to_string())
   defer restore_home_env(previous)
   let ws = root.join("ws")
@@ -182,7 +183,6 @@ async test "attached workspace dir resolves registered worktree paths" {
     }),
     Some(ws.to_string()),
   )
-  @fs.rmdir(root.to_string(), recursive=true)
 }
 
 ///|
@@ -192,6 +192,7 @@ async test "a bound session routes every start through its checkout" {
   defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("HOME")
   let root = worktree_test_root("openseek-worktree-route-")
+  defer @fs.rmdir(root.to_string(), recursive=true)
   @sys.set_env_var("HOME", root.join("global").to_string())
   defer restore_home_env(previous)
   // BYOK: the default provider needs a key. Set one here so worktree
@@ -246,7 +247,6 @@ async test "a bound session routes every start through its checkout" {
     resumed.session_root.map(dir => dir.to_string()),
     Some(ws.join(".openseek").to_string()),
   )
-  @fs.rmdir(root.to_string(), recursive=true)
 }
 
 ///|
@@ -256,6 +256,7 @@ async test "worktree remove refuses a running conversation without unmapping it"
   defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("HOME")
   let root = worktree_test_root("openseek-worktree-busy-")
+  defer @fs.rmdir(root.to_string(), recursive=true)
   let engine = root.join("bin/engine.sh")
   let runtime = root.join("runtime")
   @sys.set_env_var("HOME", root.join("global").to_string())
@@ -336,7 +337,6 @@ async test "worktree remove refuses a running conversation without unmapping it"
     assert_eq(info.session, Some("s-wt-run"))
     group.return_immediately(())
   })
-  @fs.rmdir(root.to_string(), recursive=true)
 }
 
 ///|
@@ -346,6 +346,7 @@ async test "a checkout deleted outside the app refuses runs and is repairable" {
   defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("HOME")
   let root = worktree_test_root("openseek-worktree-vanished-")
+  defer @fs.rmdir(root.to_string(), recursive=true)
   @sys.set_env_var("HOME", root.join("global").to_string())
   defer restore_home_env(previous)
   // BYOK: the default provider needs a key. Set one here so the vanished
@@ -501,7 +502,6 @@ async test "a checkout deleted outside the app refuses runs and is repairable" {
   assert_eq(replayed_info.name, repaired.name)
   assert_eq(replayed_info.session, Some("s-vanish"))
   assert_true(replayed_info.present)
-  @fs.rmdir(root.to_string(), recursive=true)
 }
 
 ///|
@@ -511,6 +511,7 @@ async test "archive keeps worktree placement for explicit repair after unarchive
   defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("HOME")
   let root = worktree_test_root("openseek-worktree-archive-")
+  defer @fs.rmdir(root.to_string(), recursive=true)
   @sys.set_env_var("HOME", root.join("global").to_string())
   defer restore_home_env(previous)
   @fsx.ensure_dir(root.join("global").to_path())
@@ -661,7 +662,6 @@ async test "archive keeps worktree placement for explicit repair after unarchive
     fail("Codex archive must retain its registry placement")
   }
   assert_false(codex_archived.present)
-  @fs.rmdir(root.to_string(), recursive=true)
 }
 
 ///|
@@ -672,6 +672,7 @@ async test "permanent archived deletion drops placement but keeps files and bran
   let previous = @sys.get_env_var("HOME")
   defer restore_home_env(previous)
   let root = worktree_test_root("openseek-archive-delete-worktree-")
+  defer @fs.rmdir(root.to_string(), recursive=true)
   let global = root.join("global")
   let workspace = root.join("workspace")
   @sys.set_env_var("HOME", global.to_string())
@@ -721,5 +722,4 @@ async test "permanent archived deletion drops placement but keeps files and bran
       "openseek/chat",
     ),
   )
-  @fs.rmdir(root.to_string(), recursive=true)
 }

--- a/desktop/internal/fsx/copy_dir_wbtest.mbt
+++ b/desktop/internal/fsx/copy_dir_wbtest.mbt
@@ -5,6 +5,7 @@
 #cfg(not(platform="windows"))
 async test "copy_dir reproduces a nested tree over what is already there" {
   let dir = @fs.tmpdir(prefix="openseek-copy-dir-")
+  defer @fs.rmdir(dir, recursive=true)
   let root : @pathx.Path = Path(dir)
   let source = root.join("source")
   ensure_dir(source.join("events"))
@@ -20,5 +21,4 @@ async test "copy_dir reproduces a nested tree over what is already there" {
   assert_eq(read_text(destination.join("only-here.json")), "kept")
   // The source stays: the caller decides when — and whether — to erase it.
   assert_eq(read_text(source.join("meta.json")), "{}")
-  @fs.rmdir(dir, recursive=true)
 }

--- a/desktop/internal/host/browse_ops.mbt
+++ b/desktop/internal/host/browse_ops.mbt
@@ -174,6 +174,7 @@ async fn windows_drive_list() -> Array[String] {
 ///|
 async test "directory browsing accepts native input and returns URI paths" {
   let dir = @fs.tmpdir(prefix="openseek-browse-path-")
+  defer @fs.rmdir(dir, recursive=true)
   @fsx.ensure_dir(Path(dir + "/child"))
   let absolute = @pathx.Path(dir).resolve().normalize()
   guard browse_directory_op({ path: Some(dir), })
@@ -187,7 +188,6 @@ async test "directory browsing accepts native input and returns URI paths" {
     fail("expected a listing for the resource path")
   }
   assert_eq(again, path)
-  @fs.rmdir(dir, recursive=true)
 }
 
 ///|
@@ -216,6 +216,7 @@ async test "a bad browse path reports its refusal in the reply" {
 ///|
 async test "directory creation makes and enters one direct child" {
   let dir = @fs.tmpdir(prefix="openseek-create-directory-")
+  defer @fs.rmdir(dir, recursive=true)
   let parent = @pathx.Path(dir).resolve().normalize()
   guard create_directory_op({
       parent: parent.resource_path(),
@@ -233,12 +234,12 @@ async test "directory creation makes and enters one direct child" {
   assert_true(
     @fs.exists(parent.join(("new project" : @pathx.Relative)).to_string()),
   )
-  @fs.rmdir(dir, recursive=true)
 }
 
 ///|
 async test "directory creation rejects traversal and existing names" {
   let dir = @fs.tmpdir(prefix="openseek-create-directory-refusal-")
+  defer @fs.rmdir(dir, recursive=true)
   let parent = @pathx.Path(dir).resolve().normalize()
   @fs.mkdir(parent.join(("taken" : @pathx.Relative)).to_string())
   for name in ["../outside", "taken"] {
@@ -247,5 +248,4 @@ async test "directory creation rejects traversal and existing names" {
       fail("expected folder creation to reject \{name}")
     }
   }
-  @fs.rmdir(dir, recursive=true)
 }

--- a/desktop/internal/host/bundle.mbt
+++ b/desktop/internal/host/bundle.mbt
@@ -262,6 +262,7 @@ async test "ripgrep resolution uses only packaged or recognized development layo
 ///|
 async test "packaged frontend wins before the matching checkout document" {
   let root : @pathx.Path = @fs.tmpdir(prefix="openseek-development-frontend-")
+  defer @fs.rmdir(root.to_string(), recursive=true)
   let command_dir = root.join("_build/native/debug/build/openseek_desktop")
   @fs.mkdir(command_dir.to_string(), recursive=true)
   let host = command_dir.join("openseek_desktop.exe").to_string()
@@ -273,7 +274,6 @@ async test "packaged frontend wins before the matching checkout document" {
   let packaged = assets.join("index.html").to_string()
   @fs.write_file(packaged, "packaged", create_mode=CreateOrTruncate)
   assert_eq(frontend_entry_path(host), packaged)
-  @fs.rmdir(root.to_string(), recursive=true)
 }
 
 ///|

--- a/desktop/internal/host/runtime.mbt
+++ b/desktop/internal/host/runtime.mbt
@@ -83,6 +83,7 @@ async test "platform_app_data_dir uses %LOCALAPPDATA% on Windows, falls back to 
   runtime_env_test_lock.acquire()
   defer runtime_env_test_lock.release()
   let dir = @fs.tmpdir(prefix="openseek-runtime-test-")
+  defer @fs.rmdir(dir, recursive=true)
   let previous_local = @sys.get_env_var("LOCALAPPDATA")
   let previous_userprofile = @sys.get_env_var("USERPROFILE")
   @sys.set_env_var("LOCALAPPDATA", dir + "\\AppData\\Local")
@@ -98,7 +99,6 @@ async test "platform_app_data_dir uses %LOCALAPPDATA% on Windows, falls back to 
   assert_eq(app_data.to_string(), dir + "\\AppData\\Local")
   restore_env("LOCALAPPDATA", previous_local)
   restore_env("USERPROFILE", previous_userprofile)
-  @fs.rmdir(dir, recursive=true)
 }
 
 ///|
@@ -112,6 +112,7 @@ async test "platform_app_data_dir uses XDG_DATA_HOME on Linux, falls back to ~/.
   runtime_env_test_lock.acquire()
   defer runtime_env_test_lock.release()
   let dir = @fs.tmpdir(prefix="openseek-runtime-test-")
+  defer @fs.rmdir(dir, recursive=true)
   let previous_xdg = @sys.get_env_var("XDG_DATA_HOME")
   let previous_home = @sys.get_env_var("HOME")
   @sys.set_env_var("XDG_DATA_HOME", dir + "/xdg-data")
@@ -127,12 +128,12 @@ async test "platform_app_data_dir uses XDG_DATA_HOME on Linux, falls back to ~/.
   assert_eq(app_data.to_string(), dir + "/.local/share")
   restore_env("XDG_DATA_HOME", previous_xdg)
   restore_env("HOME", previous_home)
-  @fs.rmdir(dir, recursive=true)
 }
 
 ///|
 async test "development state stays inside the detected checkout" {
   let root : @pathx.Path = @fs.tmpdir(prefix="openseek-development-state-")
+  defer @fs.rmdir(root.to_string(), recursive=true)
   let command_dir = root.join("_build/native/debug/build/openseek_desktop")
   @fs.mkdir(command_dir.to_string(), recursive=true)
   let executable = command_dir.join("openseek_desktop.exe").to_string()
@@ -142,5 +143,4 @@ async test "development state stays inside the detected checkout" {
   }
   assert_eq(actual.to_string(), expected)
   assert_true(@fs.kind(expected) is Directory)
-  @fs.rmdir(root.to_string(), recursive=true)
 }

--- a/desktop/internal/host/runtime.mbt
+++ b/desktop/internal/host/runtime.mbt
@@ -85,9 +85,11 @@ async test "platform_app_data_dir uses %LOCALAPPDATA% on Windows, falls back to 
   let dir = @fs.tmpdir(prefix="openseek-runtime-test-")
   defer @fs.rmdir(dir, recursive=true)
   let previous_local = @sys.get_env_var("LOCALAPPDATA")
-  let previous_userprofile = @sys.get_env_var("USERPROFILE")
   @sys.set_env_var("LOCALAPPDATA", dir + "\\AppData\\Local")
+  defer restore_env("LOCALAPPDATA", previous_local)
+  let previous_userprofile = @sys.get_env_var("USERPROFILE")
   @sys.set_env_var("USERPROFILE", dir)
+  defer restore_env("USERPROFILE", previous_userprofile)
   guard platform_app_data_dir() is Some(app_data) else {
     fail("platform_app_data_dir returned None")
   }
@@ -97,8 +99,6 @@ async test "platform_app_data_dir uses %LOCALAPPDATA% on Windows, falls back to 
     fail("platform_app_data_dir returned None after unsetting LOCALAPPDATA")
   }
   assert_eq(app_data.to_string(), dir + "\\AppData\\Local")
-  restore_env("LOCALAPPDATA", previous_local)
-  restore_env("USERPROFILE", previous_userprofile)
 }
 
 ///|
@@ -114,9 +114,11 @@ async test "platform_app_data_dir uses XDG_DATA_HOME on Linux, falls back to ~/.
   let dir = @fs.tmpdir(prefix="openseek-runtime-test-")
   defer @fs.rmdir(dir, recursive=true)
   let previous_xdg = @sys.get_env_var("XDG_DATA_HOME")
-  let previous_home = @sys.get_env_var("HOME")
   @sys.set_env_var("XDG_DATA_HOME", dir + "/xdg-data")
+  defer restore_env("XDG_DATA_HOME", previous_xdg)
+  let previous_home = @sys.get_env_var("HOME")
   @sys.set_env_var("HOME", dir)
+  defer restore_env("HOME", previous_home)
   guard platform_app_data_dir() is Some(app_data) else {
     fail("platform_app_data_dir returned None with XDG_DATA_HOME set")
   }
@@ -126,8 +128,6 @@ async test "platform_app_data_dir uses XDG_DATA_HOME on Linux, falls back to ~/.
     fail("platform_app_data_dir returned None after unsetting XDG_DATA_HOME")
   }
   assert_eq(app_data.to_string(), dir + "/.local/share")
-  restore_env("XDG_DATA_HOME", previous_xdg)
-  restore_env("HOME", previous_home)
 }
 
 ///|

--- a/desktop/internal/moonbit/toolchain_paths.mbt
+++ b/desktop/internal/moonbit/toolchain_paths.mbt
@@ -203,6 +203,7 @@ async fn write_fake_seed(root : @pathx.Absolute) -> Unit {
 /// never spawns — `resolve_toolchain` raises before it.
 async test "the seed is found beside the engine and one level above it" {
   let tmp = @pathx.Path(@fs.tmpdir(prefix="openseek-moonbit-seed-layout-")).resolve()
+  defer (@fs.rmdir(tmp.to_string(), recursive=true) catch { _ => () })
   // macOS: `<input>/bin/openseek` with `<input>/toolchains/…`.
   let bundle = tmp.join("proton-package-input")
   let bundle_seed = bundle.join("toolchains/moonbit/macos-arm64")
@@ -219,9 +220,6 @@ async test "the seed is found beside the engine and one level above it" {
       dir.to_string()
     },
   )
-  @fs.rmdir(tmp.to_string(), recursive=true) catch {
-    _ => ()
-  }
   assert_eq(bundle_found, Some(bundle_seed.normalize().to_string()))
   assert_eq(flat_found, Some(flat_seed.normalize().to_string()))
 }

--- a/desktop/internal/update/stage_wbtest.mbt
+++ b/desktop/internal/update/stage_wbtest.mbt
@@ -23,6 +23,7 @@ async test "package download streams to disk and reports byte progress" {
       )
     }
     let dir = @fs.tmpdir(prefix="openseek-update-download-")
+    defer @fs.rmdir(dir, recursive=true)
     let destination = "\{dir}/package.zip"
     let progress : Array[(Int, Int?)] = []
     download(
@@ -39,6 +40,5 @@ async test "package download streams to disk and reports byte progress" {
     let last = progress[progress.length() - 1]
     assert_eq(last.0, 6)
     assert_eq(last.1, Some(6))
-    @fs.rmdir(dir, recursive=true)
   }
 }

--- a/desktop/internal/workspaces/registry_wbtest.mbt
+++ b/desktop/internal/workspaces/registry_wbtest.mbt
@@ -25,6 +25,7 @@ async test "the default workspace is attached once and never re-attached" {
   registry_env_test_lock.acquire()
   defer registry_env_test_lock.release()
   let dir = @fs.tmpdir(prefix="openseek-default-workspace-")
+  defer @fs.rmdir(dir, recursive=true)
   let root : @pathx.Path = Path(dir)
   let previous_home = @sys.get_env_var("HOME")
   @sys.set_env_var("HOME", root.join("home").to_string())
@@ -47,7 +48,6 @@ async test "the default workspace is attached once and never re-attached" {
   assert_eq(registered(), [])
   assert_true(initialize() is None)
   assert_eq(registered(), [])
-  @fs.rmdir(dir, recursive=true)
 }
 
 ///|
@@ -60,6 +60,7 @@ async test "a registry without the marker still receives the default workspace" 
   registry_env_test_lock.acquire()
   defer registry_env_test_lock.release()
   let dir = @fs.tmpdir(prefix="openseek-legacy-registry-")
+  defer @fs.rmdir(dir, recursive=true)
   let root : @pathx.Path = Path(dir)
   let previous_home = @sys.get_env_var("HOME")
   @sys.set_env_var("HOME", root.join("home").to_string())
@@ -82,7 +83,6 @@ async test "a registry without the marker still receives the default workspace" 
   assert_eq(registered.length(), 2)
   assert_eq(registered[1], attached)
   assert_true(initialize() is None)
-  @fs.rmdir(dir, recursive=true)
 }
 
 ///|

--- a/desktop/internal/worktree/submodules.mbt
+++ b/desktop/internal/worktree/submodules.mbt
@@ -82,6 +82,7 @@ async test "submodule checkout stops at its hard timeout" {
   worktree_env_test_lock.acquire()
   defer worktree_env_test_lock.release()
   let root = worktree_test_root("openseek-worktree-sub-timeout-")
+  defer @fs.rmdir(root.to_string(), recursive=true)
   let dependency = root.join("dependency")
   prepare_git_repo(dependency)
   let repo = root.join("repo")
@@ -117,7 +118,6 @@ async test "submodule checkout stops at its hard timeout" {
   assert_eq(
     detail, "Submodules did not finish initializing within 0 seconds. Increase the checkout timeout in Workspace Settings or leave submodules uninitialized.",
   )
-  @fs.rmdir(root.to_string(), recursive=true)
 }
 
 ///|
@@ -127,6 +127,7 @@ async test "worktree lifecycle mirrors initialized submodules" {
   defer worktree_env_test_lock.release()
   let previous = @sys.get_env_var("HOME")
   let root = worktree_test_root("openseek-worktree-submodules-")
+  defer @fs.rmdir(root.to_string(), recursive=true)
   @sys.set_env_var("HOME", root.join("global").to_string())
   defer restore_home_env(previous)
   let required = root.join("required")
@@ -247,5 +248,4 @@ async test "worktree lifecycle mirrors initialized submodules" {
   assert_false(
     @fsx.exists(skipped_checkout.join("deps/required/.git").to_path()),
   )
-  @fs.rmdir(root.to_string(), recursive=true)
 }

--- a/desktop/internal/worktree/worktree.mbt
+++ b/desktop/internal/worktree/worktree.mbt
@@ -1238,6 +1238,7 @@ test "worktree names are one branch-safe path component" {
 ///|
 async test "worktree registry decode drops malformed entries" {
   let root = worktree_test_root("openseek-worktree-decode-")
+  defer @fs.rmdir(root.to_string(), recursive=true)
   @fsx.ensure_dir(@workspaces.store_root(root).to_path())
   @fsx.write_text(worktrees_file(root).to_path(), "{ not json")
   assert_eq(read_worktrees_unlocked(root).length(), 0)
@@ -1284,12 +1285,12 @@ async test "worktree registry decode drops malformed entries" {
   assert_eq(entries[2].name, "blank")
   assert_true(entries[2].session is None)
   assert_true(entries[2].codex_thread is None)
-  @fs.rmdir(root.to_string(), recursive=true)
 }
 
 ///|
 async test "failed worktree registry staging preserves every live row" {
   let root = worktree_test_root("openseek-worktree-atomic-write-")
+  defer @fs.rmdir(root.to_string(), recursive=true)
   let retained : WorktreeEntry = {
     name: "retained",
     branch: "openseek/retained",
@@ -1317,7 +1318,6 @@ async test "failed worktree registry staging preserves every live row" {
   assert_eq(after.branch, retained.branch)
   assert_eq(after.base, retained.base)
   assert_eq(after.session, retained.session)
-  @fs.rmdir(root.to_string(), recursive=true)
 }
 
 ///|
@@ -1340,6 +1340,7 @@ async test "attach refuses a linked worktree, keeps main and non-git attachable"
   defer worktree_env_test_lock.release()
   let previous = @sys.get_env_var("HOME")
   let root = worktree_test_root("openseek-worktree-attach-")
+  defer @fs.rmdir(root.to_string(), recursive=true)
   @sys.set_env_var("HOME", root.join("global").to_string())
   defer restore_home_env(previous)
   let repo = root.join("repo")
@@ -1366,7 +1367,6 @@ async test "attach refuses a linked worktree, keeps main and non-git attachable"
   let plain = root.join("plain")
   @fsx.ensure_dir(plain.to_path())
   assert_true(@workspaces.add(plain.to_string(), fn(_) {  }).contains(plain))
-  @fs.rmdir(root.to_string(), recursive=true)
 }
 
 ///|
@@ -1376,6 +1376,7 @@ async test "worktree create provisions checkout, branch, registry, exclusion" {
   defer worktree_env_test_lock.release()
   let previous = @sys.get_env_var("HOME")
   let root = worktree_test_root("openseek-worktree-create-")
+  defer @fs.rmdir(root.to_string(), recursive=true)
   @sys.set_env_var("HOME", root.join("global").to_string())
   defer restore_home_env(previous)
   let repo = root.join("repo")
@@ -1429,7 +1430,6 @@ async test "worktree create provisions checkout, branch, registry, exclusion" {
   }
   assert_eq(listed.name, "fix-auth")
   assert_true(listed.present)
-  @fs.rmdir(root.to_string(), recursive=true)
 }
 
 ///|
@@ -1439,6 +1439,7 @@ async test "explicit registry removal can prune a vanished worktree" {
   defer worktree_env_test_lock.release()
   let previous = @sys.get_env_var("HOME")
   let root = worktree_test_root("openseek-worktree-release-")
+  defer @fs.rmdir(root.to_string(), recursive=true)
   @sys.set_env_var("HOME", root.join("global").to_string())
   defer restore_home_env(previous)
   let repo = root.join("repo")
@@ -1462,7 +1463,6 @@ async test "explicit registry removal can prune a vanished worktree" {
   assert_eq(reply.worktrees.length(), 0)
   // Unbound, the conversation runs in the workspace again — no refusal.
   assert_eq(run_dir(repo, "s-release").to_string(), repo.to_string())
-  @fs.rmdir(root.to_string(), recursive=true)
 }
 
 ///|
@@ -1472,6 +1472,7 @@ async test "worktree names are host-generated and skip surviving branches" {
   defer worktree_env_test_lock.release()
   let previous = @sys.get_env_var("HOME")
   let root = worktree_test_root("openseek-worktree-autoname-")
+  defer @fs.rmdir(root.to_string(), recursive=true)
   @sys.set_env_var("HOME", root.join("global").to_string())
   defer restore_home_env(previous)
   let repo = root.join("repo")
@@ -1538,7 +1539,6 @@ async test "worktree names are host-generated and skip surviving branches" {
   }
   assert_eq(codex_info.session, None)
   assert_eq(codex_info.codex_thread, Some("thread-1"))
-  @fs.rmdir(root.to_string(), recursive=true)
 }
 
 ///|
@@ -1574,6 +1574,7 @@ async test "worktree create names the holder in every refusal" {
   defer worktree_env_test_lock.release()
   let previous = @sys.get_env_var("HOME")
   let root = worktree_test_root("openseek-worktree-refuse-")
+  defer @fs.rmdir(root.to_string(), recursive=true)
   @sys.set_env_var("HOME", root.join("global").to_string())
   defer restore_home_env(previous)
   let repo = root.join("repo")
@@ -1679,7 +1680,6 @@ async test "worktree create names the holder in every refusal" {
       "repository subdirectory",
     ),
   )
-  @fs.rmdir(root.to_string(), recursive=true)
 }
 
 ///|
@@ -1707,6 +1707,7 @@ async test "worktree remove enforces the dirty check and keeps the branch" {
   defer worktree_env_test_lock.release()
   let previous = @sys.get_env_var("HOME")
   let root = worktree_test_root("openseek-worktree-remove-")
+  defer @fs.rmdir(root.to_string(), recursive=true)
   @sys.set_env_var("HOME", root.join("global").to_string())
   defer restore_home_env(previous)
   let repo = root.join("repo")
@@ -1773,7 +1774,6 @@ async test "worktree remove enforces the dirty check and keeps the branch" {
     ])
     is Some(_),
   )
-  @fs.rmdir(root.to_string(), recursive=true)
 }
 
 ///|
@@ -1783,6 +1783,7 @@ async test "worktree remove prunes an externally deleted checkout" {
   defer worktree_env_test_lock.release()
   let previous = @sys.get_env_var("HOME")
   let root = worktree_test_root("openseek-worktree-prune-")
+  defer @fs.rmdir(root.to_string(), recursive=true)
   @sys.set_env_var("HOME", root.join("global").to_string())
   defer restore_home_env(previous)
   let repo = root.join("repo")
@@ -1810,7 +1811,6 @@ async test "worktree remove prunes an externally deleted checkout" {
       ".worktrees/gone",
     ),
   )
-  @fs.rmdir(root.to_string(), recursive=true)
 }
 
 ///|


### PR DESCRIPTION
Backports the fix from #1269 (`defer @fs.rmdir` right after `@fs.tmpdir`, deleting the end-of-test rmdir) to every remaining test site that removed its temp dir only in its last statement.

**Why**: when an `assert` / `fail` / early `return` fires mid-test, the trailing `@fs.rmdir` never runs and the temp dir leaks (`/tmp/openseek-*` accumulate in CI). `defer` runs on every exit path (error, return, cancellation), so hoisting cleanup to the binding is the robust form — exactly what #1269 did for one engine test.

**Changed**: 135 conversions across 26 test files (+135/−165).

- `desktop/internal/engine` — 51 sites (ops, archive, follower, config, command, engine, migrate_global_store, archive_lookup, archive_submodule, worktree_seam)
- desktop host/worktree/workspaces/fsx/development/codex/auth/update/moonbit — 26 sites
- agent tests — 58 sites (agent_session/store 43, agent_workflow 14, agent_subrun 1)

Each conversion: `defer @fs.rmdir(<same arg>, recursive=true)` inserted immediately after the dir binding (keeping the tail's exact argument, plus `catch { _ => () }` or `@async.protect_from_cancel(...)` where the tail used them), and the trailing rmdir statement removed.

**Deliberately not changed**:
- production delete logic (archive sweep/delete, worktree rollback, agent_subtask worker_root removal)
- mid-body removals that are part of the test (simulated external deletion, stat-failure fixture)
- sites already group-scoped via `group.add_defer` + `@async.protect_from_cancel` (host/file_search, host/fs_watch, update/apply_wbtest) — a function-level `defer` would mis-scope these
- work_dir.mbt, which must finish rmdir before asserting
- sites already using `@vfs.with_tmpdir`

**Verified locally**:
- `moon check --target native` clean on all 13 touched packages
- `moon fmt --check` clean on all 26 files
- ran tests: agent_session/store 48/48, agent_subrun 28/28, agent_workflow 20/20, engine spot filters 6/6 (incl. #1269's own test)

**Not verified**: the full engine/host/worktree suites and the `#cfg(platform="windows")`-gated tests — draft left open for CI.

Generated with SeekMoon