### PR TITLE
fix(mcp): keep stdio pipe cleanup with owner tasks

### DIFF
--- a/jsonrpc/client.mbt
+++ b/jsonrpc/client.mbt
@@ -312,9 +312,9 @@ async fn Client::dispatch(self : Client, message : Json) -> Unit {
 ///|
 /// Mark the client closed, close the transport (unblocking a parked reader/
 /// writer) and the outbox, and fail every outstanding request with `Closed`.
-/// Idempotent, and never suspends (unbounded `put`, synchronous transport
-/// `close`), so it is safe to run during cancellation unwind.
-async fn Client::close(self : Client) -> Unit {
+/// Idempotent and synchronous (transport and queue `close` never suspend), so
+/// it is safe to run during cancellation unwind.
+pub fn Client::close(self : Client) -> Unit {
   if self.closed {
     return
   }
@@ -322,6 +322,6 @@ async fn Client::close(self : Client) -> Unit {
   self.transport.close()
   self.outbox.close()
   for _, inbox in self.pending {
-    inbox.put(Err(Closed))
+    inbox.close(error=Closed)
   }
 }

--- a/jsonrpc/pkg.generated.mbti
+++ b/jsonrpc/pkg.generated.mbti
@@ -15,6 +15,7 @@ pub impl Show for ResponseError
 // Types and methods
 type Client
 pub fn[T : Transport] Client::Client(T) -> Self
+pub fn Client::close(Self) -> Unit
 pub fn Client::is_closed(Self) -> Bool
 pub async fn Client::notify(Self, method_~ : String, params~ : Json) -> Unit
 pub async fn Client::request(Self, method_~ : String, params~ : Json) -> Json

--- a/mcp/client.mbt
+++ b/mcp/client.mbt
@@ -36,6 +36,12 @@ pub fn McpClient::McpClient(rpc : @jsonrpc.Client) -> McpClient {
 }
 
 ///|
+/// Close the underlying JSON-RPC client and its transport. Idempotent.
+pub fn McpClient::close(self : McpClient) -> Unit {
+  self.rpc.close()
+}
+
+///|
 /// Run the MCP handshake: send `initialize` with our client identity, then the
 /// `notifications/initialized` notification once the server has answered.
 /// Returns the server's negotiated protocol version and identity. Raises on

--- a/mcp/pkg.generated.mbti
+++ b/mcp/pkg.generated.mbti
@@ -47,6 +47,7 @@ pub fn InitializeResult::to_repr(Self) -> @debug.Repr
 type McpClient
 pub fn McpClient::McpClient(@jsonrpc.Client) -> Self
 pub async fn McpClient::call_tool(Self, name~ : String, arguments~ : Json) -> CallToolResult
+pub fn McpClient::close(Self) -> Unit
 pub async fn McpClient::initialize(Self, client_name~ : String, client_version~ : String) -> InitializeResult
 pub async fn McpClient::list_tools(Self) -> Array[McpTool]
 

--- a/mcp/stdio/connect.mbt
+++ b/mcp/stdio/connect.mbt
@@ -7,13 +7,12 @@
 const DefaultHandshakeTimeoutMs : Int = 30000
 
 ///|
-/// A live stdio MCP connection: the initialized client plus an idempotent
-/// teardown. Its reader/writer tasks run on the task group passed to `connect`;
-/// the connection is torn down when that group ends, or eagerly via `shutdown`.
+/// A live stdio MCP connection: the initialized client. Its reader/writer tasks
+/// run on the task group passed to `connect`; the connection is torn down when
+/// that group ends, or eagerly via `shutdown`.
 struct StdioConnection {
   client : @mcp.McpClient
   init : @mcp.InitializeResult
-  teardown : () -> Unit
 }
 
 ///|
@@ -26,18 +25,18 @@ pub fn StdioConnection::client(self : StdioConnection) -> @mcp.McpClient {
 /// Tear the connection down eagerly: cancel the reader/writer tasks, close the
 /// pipes (the child sees stdin EOF), and terminate the process. Idempotent.
 pub fn StdioConnection::shutdown(self : StdioConnection) -> Unit {
-  (self.teardown)()
+  self.client.close()
 }
 
 ///|
 /// Spawn `command args...` as an MCP server, wire an NDJSON transport to a
 /// JSON-RPC client (with its reader and writer tasks on `group`), run the MCP
 /// handshake under `handshake_timeout_ms`, and return the initialized
-/// connection. Returns `None` if the process cannot start, the handshake fails,
-/// or the handshake times out — terminating the process and closing the pipes in
-/// every failure case so nothing leaks. The server inherits openseek's
-/// environment (so it always has `PATH`, `HOME`, etc.); `env` adds to and
-/// overrides it.
+/// connection. Raises if the process cannot start, the handshake fails, or the
+/// handshake times out (`@async.TimeoutError`) — terminating the process and
+/// closing the pipes in every failure case so nothing leaks. The server inherits
+/// openseek's environment (so it always has `PATH`, `HOME`, etc.); `env` adds to
+/// and overrides it.
 pub async fn[X] connect(
   group : @async.TaskGroup[X],
   command~ : String,
@@ -47,53 +46,33 @@ pub async fn[X] connect(
   client_name~ : String,
   client_version~ : String,
   handshake_timeout_ms? : Int = DefaultHandshakeTimeoutMs,
-) -> StdioConnection? {
-  // The child's stdin/stdout pipes via the process helpers, which create the
-  // synchronous, non-overlapped child endpoints a subprocess needs on every
-  // platform (including Windows). They hand the child ends back as un-closable
-  // trait objects and clean them up in `spawn`'s own teardown, so the only
-  // unreachable-in-practice leak is one fd if `read_from_process` raises (fd
-  // exhaustion) after `write_to_process` succeeded — accepted, since that end
-  // cannot be closed here.
-  let (child_stdin, stdin_writer) = @process.write_to_process() catch {
-    error if @async.is_being_cancelled() => raise error
-    _ => return None
-  }
-  let (stdout_reader, child_stdout) = @process.read_from_process() catch {
-    error if @async.is_being_cancelled() => {
-      stdin_writer.close()
-      raise error
-    }
-    _ => {
-      stdin_writer.close()
-      return None
-    }
-  }
-  // `no_wait`: the group terminates the server at teardown rather than waiting
-  // for an exit that only comes once its stdin is closed.
-  let process = @process.spawn(
-    group,
-    command,
-    args,
-    extra_env?=env,
-    inherit_env=true,
-    stdin=child_stdin,
-    stdout=child_stdout,
-    cwd?=cwd.map(dir => dir.view()),
-    no_wait=true,
-  ) catch {
-    error if @async.is_being_cancelled() => {
-      stdout_reader.close()
-      stdin_writer.close()
-      raise error
-    }
-    // Spawn failed: close our parent ends (spawn's own cleanup releases the
-    // child ends).
-    _ => {
-      stdout_reader.close()
-      stdin_writer.close()
-      return None
-    }
+) -> StdioConnection {
+  let (stdin_writer, stdout_reader, process) = {
+    // The child's stdin/stdout pipes via the process helpers, which create the
+    // synchronous, non-overlapped child endpoints a subprocess needs on every
+    // platform (including Windows). They hand the child ends back as un-closable
+    // trait objects and clean them up in `spawn`'s own teardown, so the only
+    // unreachable-in-practice leak is one fd if `read_from_process` raises (fd
+    // exhaustion) after `write_to_process` succeeded — accepted, since that end
+    // cannot be closed here.
+    let (child_stdin, stdin_writer) = @process.write_to_process()
+    errdefer stdin_writer.close()
+    let (stdout_reader, child_stdout) = @process.read_from_process()
+    errdefer stdout_reader.close()
+    // `no_wait`: the group terminates the server at teardown rather than waiting
+    // for an exit that only comes once its stdin is closed.
+    let process = @process.spawn(
+      group,
+      command,
+      args,
+      extra_env?=env,
+      inherit_env=true,
+      stdin=child_stdin,
+      stdout=child_stdout,
+      cwd?=cwd.map(dir => dir.view()),
+      no_wait=true,
+    )
+    (stdin_writer, stdout_reader, process)
   }
   // The pump and writer tasks own their respective parent pipe ends and close
   // them in defer blocks. Teardown cancels the owner tasks instead of closing a
@@ -129,42 +108,30 @@ pub async fn[X] connect(
   // it does not stop them while the group is still running. Teardown cancels
   // them for immediate shutdown; a failed send / EOF still closes the client
   // via the transport.
-  let pump = group.spawn(
-    () => {
-      defer stdout_reader.close()
-      client.run_message_pump()
-    },
-    no_wait=true,
-    allow_failure=true,
+  pump_task = Some(
+    group.spawn(
+      () => {
+        defer stdout_reader.close()
+        client.run_message_pump()
+      },
+      no_wait=true,
+      allow_failure=true,
+    ),
   )
-  pump_task = Some(pump)
-  let writer = group.spawn(
-    () => {
-      defer stdin_writer.close()
-      client.run_writer()
-    },
-    no_wait=true,
-    allow_failure=true,
+  writer_task = Some(
+    group.spawn(
+      () => {
+        defer stdin_writer.close()
+        client.run_writer()
+      },
+      no_wait=true,
+      allow_failure=true,
+    ),
   )
-  writer_task = Some(writer)
   let mcp_client = @mcp.McpClient(client)
-  let init = @async.with_timeout_opt(handshake_timeout_ms, () => {
+  errdefer teardown()
+  let init = @async.with_timeout(handshake_timeout_ms) <| () => {
     mcp_client.initialize(client_name~, client_version~)
-  }) catch {
-    error if @async.is_being_cancelled() => {
-      teardown()
-      raise error
-    }
-    // Handshake raised (transport closed, unsupported protocol version, ...).
-    _ => {
-      teardown()
-      return None
-    }
   }
-  guard init is Some(init) else {
-    // Handshake exceeded the deadline.
-    teardown()
-    return None
-  }
-  Some({ client: mcp_client, init, teardown, })
+  { client: mcp_client, init, }
 }

--- a/mcp/stdio/connect.mbt
+++ b/mcp/stdio/connect.mbt
@@ -95,27 +95,28 @@ pub async fn[X] connect(
       return None
     }
   }
-  // Idempotent teardown, wired once the reader/writer tasks exist. Cancelling the
-  // tasks is what unblocks a reader/writer parked in the pipe — closing an fd
-  // does not wake a coroutine suspended on it. Closing stdin lets a well-behaved
-  // server exit on EOF; `process.cancel()` is the backstop. Caveat: cancel signals
-  // only the direct child, so a launcher that forks (e.g. `npx`) and ignores
-  // stdin EOF may leave descendants running — an upstream group-kill gap.
-  let torn_down : Ref[Bool] = { val: false, }
-  // Seeded with pipe + process cleanup so teardown is complete even if it fires
-  // before the task handles exist; once they exist it is upgraded to also cancel
-  // the tasks (which is what unblocks a parked reader/writer).
-  let teardown_action : Ref[() -> Unit] = {
-    val: () => {
-      stdout_reader.close()
-      stdin_writer.close()
-      process.cancel()
-    },
-  }
+  // The pump and writer tasks own their respective parent pipe ends and close
+  // them in defer blocks. Teardown cancels the owner tasks instead of closing a
+  // handle from another task while an async read/write is still pending (which
+  // can hang on Windows).
+  let mut torn_down = false
+  let mut pump_task : @async.Task[Unit]? = None
+  let mut writer_task : @async.Task[Unit]? = None
   let teardown = () => {
-    if !torn_down.val {
-      torn_down.val = true
-      (teardown_action.val)()
+    if !torn_down {
+      torn_down = true
+      if pump_task is Some(task) {
+        task.cancel()
+      }
+      if writer_task is Some(task) {
+        task.cancel()
+      }
+      // Cancelling the writer closes stdin, letting a well-behaved server exit
+      // on EOF; `process.cancel()` is the backstop. Caveat: cancellation only
+      // signals the direct child, so a launcher that forks (e.g. `npx`) and
+      // ignores stdin EOF may leave descendants running — an upstream
+      // group-kill gap.
+      process.cancel()
     }
   }
   let transport = NdjsonTransport::NdjsonTransport(
@@ -124,25 +125,28 @@ pub async fn[X] connect(
     on_close=teardown,
   )
   let client = @jsonrpc.Client(transport)
-  // Cancellable (so teardown stops them) and `no_wait` (so they do not hold the
-  // group open); a failed send / EOF still closes the client via the transport.
+  // `no_wait` keeps these standing tasks from delaying normal group completion;
+  // it does not stop them while the group is still running. Teardown cancels
+  // them for immediate shutdown; a failed send / EOF still closes the client
+  // via the transport.
   let pump = group.spawn(
-    () => client.run_message_pump(),
+    () => {
+      defer stdout_reader.close()
+      client.run_message_pump()
+    },
     no_wait=true,
     allow_failure=true,
   )
+  pump_task = Some(pump)
   let writer = group.spawn(
-    () => client.run_writer(),
+    () => {
+      defer stdin_writer.close()
+      client.run_writer()
+    },
     no_wait=true,
     allow_failure=true,
   )
-  teardown_action.val = () => {
-    pump.cancel()
-    writer.cancel()
-    stdout_reader.close()
-    stdin_writer.close()
-    process.cancel()
-  }
+  writer_task = Some(writer)
   let mcp_client = @mcp.McpClient(client)
   let init = @async.with_timeout_opt(handshake_timeout_ms, () => {
     mcp_client.initialize(client_name~, client_version~)

--- a/mcp/stdio/ndjson.mbt
+++ b/mcp/stdio/ndjson.mbt
@@ -6,7 +6,7 @@
 /// A `@jsonrpc.Transport` that frames messages as newline-delimited JSON over a
 /// reader/writer pair. `on_close` is the synchronous teardown (e.g. terminate
 /// the subprocess and close its pipes) run when the client closes.
-struct NdjsonTransport {
+priv struct NdjsonTransport {
   reader : &@io.Reader
   writer : &@io.Writer
   on_close : () -> Unit
@@ -29,14 +29,14 @@ fn NdjsonTransport::NdjsonTransport(
 }
 
 ///|
-pub impl @jsonrpc.Transport for NdjsonTransport with fn send(self, message) {
+impl @jsonrpc.Transport for NdjsonTransport with fn send(self, message) {
   // One line per message; JSON stringify never emits a newline, so the frame is
   // unambiguous.
   self.writer.write("\{message.stringify()}\n")
 }
 
 ///|
-pub impl @jsonrpc.Transport for NdjsonTransport with fn recv(self) {
+impl @jsonrpc.Transport for NdjsonTransport with fn recv(self) {
   // Read whole lines until one parses as JSON or the stream ends. A valid-UTF-8
   // line that is not JSON (e.g. a stray log line the server leaked to stdout) is
   // skipped; end of stream, a read error, or invalid UTF-8 (a server violating
@@ -52,16 +52,15 @@ pub impl @jsonrpc.Transport for NdjsonTransport with fn recv(self) {
     if trimmed == "" {
       continue
     }
-    if (Some(@json.parse(trimmed)) catch { _ => None }) is Some(message) {
-      return Some(message)
+    try @json.parse(trimmed) catch {
+      _ => continue
+    } noraise {
+      message => return Some(message)
     }
   }
 }
 
 ///|
-pub impl @jsonrpc.Transport for NdjsonTransport with fn close(self) {
+impl @jsonrpc.Transport for NdjsonTransport with fn close(self) {
   (self.on_close)()
 }
-
-///|
-pub extend NdjsonTransport with @jsonrpc.Transport::{close, recv, send}

--- a/mcp/stdio/pkg.generated.mbti
+++ b/mcp/stdio/pkg.generated.mbti
@@ -8,7 +8,7 @@ import {
 }
 
 // Values
-pub async fn[X] connect(@async.TaskGroup[X], command~ : String, args~ : Array[String], env? : Map[String, String], cwd? : String, client_name~ : String, client_version~ : String, handshake_timeout_ms? : Int) -> StdioConnection?
+pub async fn[X] connect(@async.TaskGroup[X], command~ : String, args~ : Array[String], env? : Map[String, String], cwd? : String, client_name~ : String, client_version~ : String, handshake_timeout_ms? : Int) -> StdioConnection
 
 // Errors
 

--- a/mcp/stdio/pkg.generated.mbti
+++ b/mcp/stdio/pkg.generated.mbti
@@ -2,7 +2,6 @@
 package "bobzhang/openseek/mcp/stdio"
 
 import {
-  "bobzhang/openseek/jsonrpc",
   "bobzhang/openseek/mcp",
   "moonbitlang/async",
 }
@@ -13,12 +12,6 @@ pub async fn[X] connect(@async.TaskGroup[X], command~ : String, args~ : Array[St
 // Errors
 
 // Types and methods
-type NdjsonTransport
-pub fn NdjsonTransport::close(Self) -> Unit
-pub async fn NdjsonTransport::recv(Self) -> Json?
-pub async fn NdjsonTransport::send(Self, Json) -> Unit
-pub impl @jsonrpc.Transport for NdjsonTransport
-
 type StdioConnection
 pub fn StdioConnection::client(Self) -> @mcp.McpClient
 pub fn StdioConnection::init(Self) -> @mcp.InitializeResult

--- a/mcp/stdio/stdio_wbtest.mbt
+++ b/mcp/stdio/stdio_wbtest.mbt
@@ -117,35 +117,42 @@ async test "recv reads a JSON-RPC line from a real subprocess" {
 }
 
 ///|
-async test "connect returns None when the command cannot start" {
+async test "connect raises when the command cannot start" {
   @async.with_task_group(group => {
-    let conn = connect(
-      group,
-      command="openseek-no-such-mcp-server-xyz",
-      args=[],
-      client_name="openseek",
-      client_version="0.1",
-    )
-    assert_true(conn is None)
+    try
+      connect(
+        group,
+        command="openseek-no-such-mcp-server-xyz",
+        args=[],
+        client_name="openseek",
+        client_version="0.1",
+      )
+    catch {
+      _ => ()
+    } noraise {
+      _ => fail("expected connect to raise when the command cannot start")
+    }
   })
 }
 
 ///|
 /// A child that starts but never answers `initialize` must not hang connect: it
-/// returns None at the deadline (and tears the process down).
+/// raises at the deadline (and tears the process down).
 async test "connect times out a server that never handshakes" {
   @async.with_task_group(group => {
-    let conn = connect(
-      group,
-      command="sh",
-      args=["-c", "sleep 30"],
-      client_name="openseek",
-      client_version="0.1",
-      handshake_timeout_ms=500,
-    ) catch {
-      // Spawning is forbidden in this sandbox: skip.
-      _ => return
+    try
+      connect(
+        group,
+        command="sh",
+        args=["-c", "sleep 30"],
+        client_name="openseek",
+        client_version="0.1",
+        handshake_timeout_ms=500,
+      )
+    catch {
+      _ => ()
+    } noraise {
+      _ => fail("connect should timeout a server that never handshakes")
     }
-    assert_true(conn is None)
   })
 }

--- a/mcp/streamhttp/connect.mbt
+++ b/mcp/streamhttp/connect.mbt
@@ -5,14 +5,12 @@
 const DefaultHandshakeTimeoutMs : Int = 30000
 
 ///|
-/// A live Streamable HTTP MCP connection: the initialized client plus an
-/// idempotent teardown. Its reader/writer tasks run on the task group passed to
-/// `connect`; the connection is torn down when that group ends, or eagerly via
-/// `shutdown`.
+/// A live Streamable HTTP MCP connection: the initialized client. Its
+/// reader/writer tasks run on the task group passed to `connect`; the
+/// connection is torn down when that group ends, or eagerly via `shutdown`.
 struct HttpConnection {
   client : @mcp.McpClient
   init : @mcp.InitializeResult
-  teardown : () -> Unit
 }
 
 ///|
@@ -22,18 +20,20 @@ pub fn HttpConnection::client(self : HttpConnection) -> @mcp.McpClient {
 }
 
 ///|
-/// Tear the connection down eagerly: cancel the reader/writer tasks and close
-/// the transport. Idempotent.
+/// Tear the connection down eagerly: close the client and its transport
+/// (cancelling any in-flight exchange); the reader/writer tasks end on their
+/// own once their queues close. Idempotent.
 pub fn HttpConnection::shutdown(self : HttpConnection) -> Unit {
-  (self.teardown)()
+  self.client.close()
 }
 
 ///|
 /// Wire a Streamable HTTP transport for the MCP endpoint at `url` to a JSON-RPC
 /// client (reader and writer tasks on `group`), run the MCP handshake under
-/// `handshake_timeout_ms`, and return the initialized connection — or `None`
-/// when the endpoint is unreachable, answers with an error, or the handshake
-/// fails or times out. `headers` (e.g. `Authorization`) go on every request.
+/// `handshake_timeout_ms`, and return the initialized connection. Raises when
+/// the endpoint is unreachable, answers with an error, or the handshake fails
+/// or times out (`@async.TimeoutError`), closing the transport in every failure
+/// case. `headers` (e.g. `Authorization`) go on every request.
 pub async fn[X] connect(
   group : @async.TaskGroup[X],
   url~ : String,
@@ -41,51 +41,26 @@ pub async fn[X] connect(
   client_name~ : String,
   client_version~ : String,
   handshake_timeout_ms? : Int = DefaultHandshakeTimeoutMs,
-) -> HttpConnection? {
+) -> HttpConnection {
   // Each POST exchange runs as its own cancellable task on the connection's
   // group, so the jsonrpc writer is never blocked by a long or stalled response
-  // stream — and teardown can cancel an in-flight exchange.
+  // stream — and closing the transport cancels an in-flight exchange.
   let transport = HttpTransport::HttpTransport(
     url,
     spawn=exchange => group.spawn(exchange, no_wait=true, allow_failure=true),
     extra_headers=headers,
   )
   let client = @jsonrpc.Client(transport)
-  let pump = group.spawn(
+  group.spawn_bg(
     () => client.run_message_pump(),
     no_wait=true,
     allow_failure=true,
   )
-  let writer = group.spawn(
-    () => client.run_writer(),
-    no_wait=true,
-    allow_failure=true,
-  )
-  let torn_down : Ref[Bool] = { val: false, }
-  let teardown = () => {
-    if !torn_down.val {
-      torn_down.val = true
-      pump.cancel()
-      writer.cancel()
-      @jsonrpc.Transport::close(transport)
-    }
-  }
+  group.spawn_bg(() => client.run_writer(), no_wait=true, allow_failure=true)
   let mcp_client = @mcp.McpClient(client)
-  let init = @async.with_timeout_opt(handshake_timeout_ms, () => {
+  errdefer mcp_client.close()
+  let init = @async.with_timeout(handshake_timeout_ms, () => {
     mcp_client.initialize(client_name~, client_version~)
-  }) catch {
-    error if @async.is_being_cancelled() => {
-      teardown()
-      raise error
-    }
-    _ => {
-      teardown()
-      return None
-    }
-  }
-  guard init is Some(init) else {
-    teardown()
-    return None
-  }
-  Some({ client: mcp_client, init, teardown, })
+  })
+  { client: mcp_client, init, }
 }

--- a/mcp/streamhttp/pkg.generated.mbti
+++ b/mcp/streamhttp/pkg.generated.mbti
@@ -8,7 +8,7 @@ import {
 }
 
 // Values
-pub async fn[X] connect(@async.TaskGroup[X], url~ : String, headers? : Map[String, String], client_name~ : String, client_version~ : String, handshake_timeout_ms? : Int) -> HttpConnection?
+pub async fn[X] connect(@async.TaskGroup[X], url~ : String, headers? : Map[String, String], client_name~ : String, client_version~ : String, handshake_timeout_ms? : Int) -> HttpConnection
 
 // Errors
 

--- a/mcp/streamhttp/pkg.generated.mbti
+++ b/mcp/streamhttp/pkg.generated.mbti
@@ -2,7 +2,6 @@
 package "bobzhang/openseek/mcp/streamhttp"
 
 import {
-  "bobzhang/openseek/jsonrpc",
   "bobzhang/openseek/mcp",
   "moonbitlang/async",
 }
@@ -17,12 +16,6 @@ type HttpConnection
 pub fn HttpConnection::client(Self) -> @mcp.McpClient
 pub fn HttpConnection::init(Self) -> @mcp.InitializeResult
 pub fn HttpConnection::shutdown(Self) -> Unit
-
-type HttpTransport
-pub fn HttpTransport::close(Self) -> Unit
-pub async fn HttpTransport::recv(Self) -> Json?
-pub async fn HttpTransport::send(Self, Json) -> Unit
-pub impl @jsonrpc.Transport for HttpTransport
 
 // Type aliases
 

--- a/mcp/streamhttp/streamhttp_test.mbt
+++ b/mcp/streamhttp/streamhttp_test.mbt
@@ -143,17 +143,22 @@ async test "http connect handshakes, lists tools over SSE, and echoes session he
 }
 
 ///|
-async test "http connect returns None for an unreachable endpoint" {
+async test "http connect raises for an unreachable endpoint" {
   @async.with_task_group() <| group => {
-    let conn = @streamhttp.connect(
-      group,
-      // A localhost port from the dynamic range with nothing listening.
-      url="http://127.0.0.1:1/mcp",
-      client_name="openseek",
-      client_version="0.1",
-      handshake_timeout_ms=3000,
-    )
-    assert_true(conn is None)
+    try
+      @streamhttp.connect(
+        group,
+        // A localhost port from the dynamic range with nothing listening.
+        url="http://127.0.0.1:1/mcp",
+        client_name="openseek",
+        client_version="0.1",
+        handshake_timeout_ms=3000,
+      )
+    catch {
+      _ => ()
+    } noraise {
+      _ => fail("expect http connect to raise for an unavailable endpoint")
+    }
   }
 }
 
@@ -332,26 +337,23 @@ async test "tools/list waits for the initialized notification to complete" {
     assert_true(list_saw_initialized.val)
     conn.shutdown()
   }
-} ///|
-/// Connect to a mock endpoint, failing the test rather than returning None.
-/// Every test but the unreachable-endpoint one wants exactly this.
+}
 
 ///|
+/// Connect to a mock endpoint with the test defaults; a failure raises and so
+/// fails the test. Every test but the unreachable-endpoint one wants exactly
+/// this.
 async fn connect_or_fail(
   group : @async.TaskGroup[Unit],
   url : String,
 ) -> @streamhttp.HttpConnection {
-  guard @streamhttp.connect(
-      group,
-      url~,
-      client_name="openseek",
-      client_version="0.1",
-      handshake_timeout_ms=10000,
-    )
-    is Some(conn) else {
-    fail("expected the http connect to succeed")
-  }
-  conn
+  @streamhttp.connect(
+    group,
+    url~,
+    client_name="openseek",
+    client_version="0.1",
+    handshake_timeout_ms=10000,
+  )
 }
 
 ///|

--- a/mcp/streamhttp/transport.mbt
+++ b/mcp/streamhttp/transport.mbt
@@ -40,7 +40,7 @@ const SessionDeleteTimeoutMs : Int = 5000
 
 ///|
 /// A `@jsonrpc.Transport` speaking MCP Streamable HTTP against `url`.
-struct HttpTransport {
+priv struct HttpTransport {
   url : String
   // User-supplied headers (e.g. Authorization), sent on every request.
   extra_headers : Map[String, String]
@@ -156,7 +156,7 @@ fn header_value(headers : @http.Headers, name : String) -> String? {
 }
 
 ///|
-pub impl @jsonrpc.Transport for HttpTransport with fn send(self, message) {
+impl @jsonrpc.Transport for HttpTransport with fn send(self, message) {
   guard !self.closed else { fail("transport closed") }
   // The id this POST must answer (None for a notification or a reply): if the
   // exchange fails before delivering that reply, a synthesized error fails the
@@ -228,7 +228,7 @@ pub impl @jsonrpc.Transport for HttpTransport with fn send(self, message) {
 }
 
 ///|
-pub impl @jsonrpc.Transport for HttpTransport with fn recv(self) {
+impl @jsonrpc.Transport for HttpTransport with fn recv(self) {
   Some(self.inbound.get()) catch {
     error if @async.is_being_cancelled() => raise error
     _ => None
@@ -236,7 +236,7 @@ pub impl @jsonrpc.Transport for HttpTransport with fn recv(self) {
 }
 
 ///|
-pub impl @jsonrpc.Transport for HttpTransport with fn close(self) {
+impl @jsonrpc.Transport for HttpTransport with fn close(self) {
   let already_closed = self.closed
   self.closed = true
   self.inbound.close()
@@ -585,6 +585,3 @@ fn HttpTransport::deliver(self : HttpTransport, message : Json) -> Unit {
   }
   (self.inbound.try_put(message) catch { _ => false }) |> ignore
 }
-
-///|
-pub extend HttpTransport with @jsonrpc.Transport::{close, recv, send}

--- a/mcp/tools/tools.mbt
+++ b/mcp/tools/tools.mbt
@@ -183,9 +183,9 @@ async fn[X] connect_server(
   discovery_timeout_ms~ : Int,
 ) -> Array[@agent_tool.AgentToolDefinition] {
   let name = server.name()
-  // A connected server, normalized across transports: the initialized client
-  // plus its idempotent teardown.
-  let connection : (@mcp.McpClient, () -> Unit)? = try {
+  // A connected server, normalized across transports: the initialized client;
+  // closing it tears the transport (and, for stdio, the process) down.
+  let client : @mcp.McpClient = try {
     match server {
       // A stdio server runs in the agent's workspace, not openseek's invocation
       // directory, so cwd-sensitive servers and relative args target the same
@@ -199,7 +199,7 @@ async fn[X] connect_server(
           cwd?=workspace_root,
           client_name~,
           client_version~,
-        ).map(conn => (conn.client(), () => conn.shutdown()))
+        ).client()
       @config.Http(url~, headers~, ..) =>
         @streamhttp.connect(
           scope.group(),
@@ -207,39 +207,36 @@ async fn[X] connect_server(
           headers~,
           client_name~,
           client_version~,
-        ).map(conn => (conn.client(), () => conn.shutdown()))
+        ).client()
     }
   } catch {
     error if @async.is_being_cancelled() => raise error
     error => {
-      @emit.emit(McpConnectFailed(server=name, error=Some("\{error}")))
+      @emit.emit(McpConnectFailed(server=name, error="\{error}"))
       return []
     }
   }
-  guard connection is Some((client, shutdown)) else {
-    @emit.emit(McpConnectFailed(server=name, error=None))
-    return []
-  }
-  let discovered = @async.with_timeout_opt(discovery_timeout_ms, () => {
-    tools_for_client(name, client)
-  }) catch {
+  let discovered = try {
+    errdefer client.close()
+    @async.with_timeout(discovery_timeout_ms) <| () => {
+      tools_for_client(name, client)
+    }
+  } catch {
     error if @async.is_being_cancelled() => raise error
+    @async.TimeoutError => {
+      @emit.emit(McpListToolsTimeout(server=name))
+      return []
+    }
     error => {
       @emit.emit(McpListToolsFailed(server=name, error="\{error}"))
-      shutdown()
       return []
     }
-  }
-  guard discovered is Some(discovered) else {
-    @emit.emit(McpListToolsTimeout(server=name))
-    shutdown()
-    return []
   }
   // A server with nothing to offer is useless for the rest of the session:
   // release its process and tasks instead of holding them on the scope.
   if discovered.is_empty() {
     @emit.emit(McpNoTools(server=name))
-    shutdown()
+    client.close()
   }
   discovered
 }

--- a/protocol/emit/emit_test.mbt
+++ b/protocol/emit/emit_test.mbt
@@ -155,8 +155,7 @@ fn all_events() -> Array[@protocol.Event] {
     McpToolRenamed(from="read", to="fs_read"),
     McpToolsCapped(server="fs", kept=64),
     McpServerSkippedOverCap(server="fs"),
-    McpConnectFailed(server="fs", error=Some("spawn failed")),
-    McpConnectFailed(server="fs", error=None),
+    McpConnectFailed(server="fs", error="spawn failed"),
     McpListToolsFailed(server="fs", error="timeout"),
     McpListToolsTimeout(server="fs"),
     McpNoTools(server="fs"),
@@ -174,7 +173,7 @@ test "every event round-trips through emit and parse" {
 }
 
 ///|
-/// `brief` and `mcp_connect_failed`'s `error` are always written, `null` when
+/// Optional payload fields such as `brief` are always written, `null` when
 /// absent. Every decoder reads them with a lookup that rejects a non-string, so
 /// a null and a missing key are the same value downstream — the uniform shape
 /// costs nothing and keeps one variant per event.
@@ -207,12 +206,6 @@ test "optional payload fields are written as null, never omitted" {
     ),
     content=(
       #|{"event":"tool_result","tool_call_id":"call_1","tool_name":"read","is_error":false,"content":"file body","brief":"read moon.mod"}
-    ),
-  )
-  inspect(
-    wire(McpConnectFailed(server="fs", error=None)),
-    content=(
-      #|{"event":"mcp_connect_failed","server":"fs","error":null}
     ),
   )
   inspect(

--- a/protocol/event.mbt
+++ b/protocol/event.mbt
@@ -187,10 +187,9 @@ pub(all) enum Event {
   McpToolRenamed(from~ : String, to~ : String)
   McpToolsCapped(server~ : String, kept~ : Int)
   McpServerSkippedOverCap(server~ : String)
-  /// `error` is always written, `null` when the connection produced no error
-  /// value (the server simply yielded nothing) — same uniformity rule as
-  /// `ToolResult::brief`.
-  McpConnectFailed(server~ : String, error~ : String?)
+  /// `error` is the connect failure's text: the spawn or transport error, a
+  /// handshake error, or the handshake timeout.
+  McpConnectFailed(server~ : String, error~ : String)
   McpListToolsFailed(server~ : String, error~ : String)
   McpListToolsTimeout(server~ : String)
   McpNoTools(server~ : String)

--- a/protocol/parse.mbt
+++ b/protocol/parse.mbt
@@ -306,10 +306,15 @@ pub fn parse(line : Json) -> Event? {
     }
     "mcp_server_skipped_over_cap" =>
       text(fields, "server").map(server => McpServerSkippedOverCap(server~))
-    // `error` is null when the connection yielded no error value.
+    // Engines before 2026-09-04 wrote `error` as null when the connection
+    // yielded no error value (a failed spawn or a handshake timeout); those
+    // records still decode, under a placeholder text.
     "mcp_connect_failed" =>
       text(fields, "server").map(server => {
-        McpConnectFailed(server~, error=text(fields, "error"))
+        McpConnectFailed(
+          server~,
+          error=text(fields, "error").unwrap_or("unknown error"),
+        )
       })
     "mcp_list_tools_failed" => {
       guard text(fields, "server") is Some(server) &&

--- a/protocol/parse_test.mbt
+++ b/protocol/parse_test.mbt
@@ -163,6 +163,24 @@ test "an older engine's session_started still decodes" {
 }
 
 ///|
+/// Engines before 2026-09-04 wrote `mcp_connect_failed` with `error: null`
+/// when the connection yielded no error value. Those session records must keep
+/// decoding, so a null (or absent) `error` reads as a placeholder text instead
+/// of dropping the line.
+test "an older engine's mcp_connect_failed still decodes" {
+  debug_inspect(
+    decode(
+      (
+        #|{"event":"mcp_connect_failed","server":"fs","error":null}
+      ),
+    ),
+    content=(
+      #|Some(McpConnectFailed(server="fs", error="unknown error"))
+    ),
+  )
+}
+
+///|
 /// A token counter is an integer. `Usage`'s derived `FromJson` would read `1.5`
 /// as `1`; every other integer on the wire is rejected instead of truncated, and
 /// a fabricated count is worse than a dropped line.

--- a/protocol/pkg.generated.mbti
+++ b/protocol/pkg.generated.mbti
@@ -80,7 +80,7 @@ pub(all) enum Event {
   McpToolRenamed(from~ : String, to~ : String)
   McpToolsCapped(server~ : String, kept~ : Int)
   McpServerSkippedOverCap(server~ : String)
-  McpConnectFailed(server~ : String, error~ : String?)
+  McpConnectFailed(server~ : String, error~ : String)
   McpListToolsFailed(server~ : String, error~ : String)
   McpListToolsTimeout(server~ : String)
   McpNoTools(server~ : String)

--- a/protocol/to_json.mbt
+++ b/protocol/to_json.mbt
@@ -169,11 +169,7 @@ pub fn Event::to_json(self : Event) -> Json {
     McpServerSkippedOverCap(server~) =>
       { "event": "mcp_server_skipped_over_cap", "server": server }
     McpConnectFailed(server~, error~) =>
-      {
-        "event": "mcp_connect_failed",
-        "server": server,
-        "error": or_null(error),
-      }
+      { "event": "mcp_connect_failed", "server": server, "error": error }
     McpListToolsFailed(server~, error~) =>
       { "event": "mcp_list_tools_failed", "server": server, "error": error }
     McpListToolsTimeout(server~) =>


### PR DESCRIPTION
## Summary

- make the message-pump and writer tasks close their own process-pipe endpoints in defer blocks
- cancel the owner tasks during teardown instead of closing handles while async I/O is pending
- use mutable optional task handles so teardown is safe even before a spawned task handle is published

This fixes the Windows hang exposed by the real MCP stdio handshake-timeout test while investigating #1213.

## Validation

- moon check mcp/stdio --target native --deny-warn
- moon test mcp/stdio/stdio_wbtest.mbt --target native --index 3 --no-parallelize (with Git for Windows sh on PATH)
- moon test mcp/stdio --target native --no-parallelize (4 passed)
- just build

Repository-wide just check is currently blocked by pre-existing Windows-only deny-warn findings outside this diff. Repository-wide just test reaches the desktop suite, then fails to launch openseek_desktop/internal/api/api.internal_test.exe with 0xc0000135 because its runtime DLL is unavailable.