### PR TITLE
refactor(desktop): narrow context menu JavaScript FFI

### DIFF
--- a/desktop/frontend/action_menu/browser_dom.mbt
+++ b/desktop/frontend/action_menu/browser_dom.mbt
@@ -1,0 +1,62 @@
+// Missing Rabbita DOM bindings only. Menu policy and listener lifetimes live
+// in MoonBit; these bindings do not own application state.
+
+///|
+#external
+priv type BrowserSelection
+
+///|
+#external
+priv type BrowserRange
+
+///|
+extern "js" fn browser_selection() -> @js.Nullable[BrowserSelection] =
+  #| () => document.getSelection()
+
+///|
+extern "js" fn BrowserSelection::collapsed(self : BrowserSelection) -> Bool =
+  #| selection => selection.isCollapsed
+
+///|
+extern "js" fn BrowserSelection::count(self : BrowserSelection) -> Int =
+  #| selection => selection.rangeCount
+
+///|
+extern "js" fn BrowserSelection::text(self : BrowserSelection) -> String =
+  #| selection => selection.toString()
+
+///|
+extern "js" fn BrowserSelection::range(
+  self : BrowserSelection,
+  index : Int,
+) -> BrowserRange =
+  #| (selection, index) => selection.getRangeAt(index)
+
+///|
+extern "js" fn BrowserRange::intersects(
+  self : BrowserRange,
+  element : @dom.Element,
+) -> Bool =
+  #| (range, element) => range.intersectsNode(element)
+
+///|
+extern "js" fn BrowserRange::rects(
+  self : BrowserRange,
+) -> FixedArray[@dom.DOMRect] =
+  #| range => Array.from(range.getClientRects())
+
+///|
+extern "js" fn BrowserRange::bounds(self : BrowserRange) -> @dom.DOMRect =
+  #| range => range.getBoundingClientRect()
+
+///|
+extern "js" fn anchor_href(anchor : @dom.Element) -> String =
+  #| anchor => anchor.href
+
+///|
+extern "js" fn anchor_protocol(anchor : @dom.Element) -> String =
+  #| anchor => anchor.protocol
+
+///|
+extern "js" fn decode_uri_component(text : String) -> String =
+  #| text => decodeURIComponent(text)

--- a/desktop/frontend/action_menu/context_menu.mbt
+++ b/desktop/frontend/action_menu/context_menu.mbt
@@ -67,225 +67,211 @@ priv enum ContextMsg {
 const GlobalContextTarget : String = "app-context-menu"
 
 ///|
-fn context_string_field(value : @js.Value, key : String) -> String? {
-  let field : @js.Value = value.get_with_string(key)
-  if field.is_string() {
-    Some(field.cast())
+fn event_element(event : @dom.Event) -> @dom.Element? {
+  match event.target().to_element() {
+    Some(element) => Some(element)
+    None => event.target().to_node().bind(node => node.get_parent_element())
+  }
+}
+
+///|
+fn selected_at(
+  element : @dom.Element,
+  x : Int,
+  y : Int,
+  keyboard : Bool,
+) -> String? {
+  guard browser_selection().to_option() is Some(selection) &&
+    !selection.collapsed() &&
+    selection.count() > 0 else {
+    return None
+  }
+  let text = selection.text()
+  guard !text.is_empty() else { return None }
+  for index in 0..<selection.count() {
+    let range = selection.range(index)
+    if keyboard {
+      let intersects : Bool = @js.Error_::wrap(() => {
+        @js.Value::cast_from(range.intersects(element))
+      }) catch {
+        _ => false
+      }
+      if intersects {
+        return Some(text)
+      }
+    }
+    for rect in range.rects() {
+      if x.to_double() >= rect.get_left() &&
+        x.to_double() <= rect.get_right() &&
+        y.to_double() >= rect.get_top() &&
+        y.to_double() <= rect.get_bottom() {
+        return Some(text)
+      }
+    }
+  }
+  None
+}
+
+///|
+fn keyboard_anchor(element : @dom.Element) -> (Int, Int) {
+  let rect = if browser_selection().to_option() is Some(selection) &&
+    selection.count() > 0 {
+    let rect = selection.range(0).bounds()
+    if rect.get_width() > 0 || rect.get_height() > 0 {
+      rect
+    } else {
+      element.get_bounding_client_rect()
+    }
   } else {
-    None
+    element.get_bounding_client_rect()
   }
+  (
+    @math.round(rect.get_left()).to_int(),
+    @math.round(rect.get_bottom()).to_int(),
+  )
 }
 
 ///|
-fn context_target(value : @js.Value) -> Result[ContextTarget, Unit] {
-  if value.is_null() {
-    return Ok(NoTarget)
+fn element_context(element : @dom.Element) -> ContextTarget {
+  if element.closest("[data-context-file]") is Some(file) &&
+    file.get_attribute("data-context-file") is Some(path) {
+    return FileLink(path)
   }
-  if value.is_undefined() {
-    return Err(())
+  guard element.closest("a[href]") is Some(anchor) &&
+    !anchor.has_attribute("download") else {
+    return NoTarget
   }
-  guard context_string_field(value, "kind") is Some(kind) else {
-    return Err(())
-  }
-  match kind {
-    "web" =>
-      match context_string_field(value, "url") {
-        Some(url) => Ok(WebLink(url))
-        None => Err(())
+  match anchor_protocol(anchor).to_lower() {
+    "http:" | "https:" => WebLink(anchor_href(anchor))
+    "mailto:" => {
+      let href = anchor.get_attribute("href").unwrap_or(anchor_href(anchor))
+      let raw = href[7:].split("?").next().unwrap_or(href[7:]).to_owned()
+      let address = @js.Error_::wrap(() => {
+        @js.Value::cast_from(decode_uri_component(raw))
+      }) catch {
+        _ => raw
       }
-    "email" =>
-      match
-        (
-          context_string_field(value, "url"),
-          context_string_field(value, "address"),
-        ) {
-        (Some(url), Some(address)) => Ok(EmailLink(url~, address~))
-        _ => Err(())
-      }
-    "file" =>
-      match context_string_field(value, "path") {
-        Some(path) => Ok(FileLink(path))
-        None => Err(())
-      }
-    _ => Err(())
+      EmailLink(url=anchor_href(anchor), address~)
+    }
+    _ => NoTarget
   }
 }
 
 ///|
-fn optional_context_string(value : @js.Value) -> Result[String?, Unit] {
-  if value.is_null() {
-    Ok(None)
-  } else if value.is_string() {
-    Ok(Some(value.cast()))
-  } else {
-    Err(())
+fn discard_temporary_focus(element : @dom.Element?) -> Unit {
+  if element is Some(element) &&
+    element.get_attribute("id") is Some(id) &&
+    element.get_attribute(TemporaryFocusAttribute) == Some(id) {
+    element.remove_attribute(TemporaryFocusAttribute)
+    element.remove_attribute("id")
   }
 }
 
 ///|
-fn context_request(
-  target : @js.Value,
-  selected_text : @js.Value,
-) -> ContextRequest? {
-  match (context_target(target), optional_context_string(selected_text)) {
-    (Ok(target), Ok(selected_text)) => Some({ target, selected_text, })
-    _ => None
-  }
-}
-
-///|
-extern "js" fn install_context_menu_listener(
+fn install_context_menu_listener(
   close : () -> Unit,
-  open : (@js.Value, @js.Value, @js.Value, Int, Int) -> Unit,
-) -> @js.Value =
-  #| (close, open) => {
-  #|   let rememberedSelection = null;
-  #|   let temporaryFocus = null;
-  #|   let nextFocusId = 0;
-  #|
-  #|   const discardTemporaryFocus = () => {
-  #|     if (temporaryFocus &&
-  #|         temporaryFocus.getAttribute("data-action-menu-temporary-focus") === temporaryFocus.id) {
-  #|       temporaryFocus.removeAttribute("data-action-menu-temporary-focus");
-  #|       temporaryFocus.removeAttribute("id");
-  #|     }
-  #|     temporaryFocus = null;
-  #|   };
-  #|
-  #|   const rememberFocus = () => {
-  #|     discardTemporaryFocus();
-  #|     const active = document.activeElement;
-  #|     if (!(active instanceof HTMLElement) || active === document.body) return null;
-  #|     if (active.id) return active.id;
-  #|     const id = `app-context-focus:${++nextFocusId}`;
-  #|     active.id = id;
-  #|     active.setAttribute("data-action-menu-temporary-focus", id);
-  #|     temporaryFocus = active;
-  #|     return id;
-  #|   };
-  #|
-  #|   const eventElement = (event) => {
-  #|     const target = event.target;
-  #|     if (target instanceof Element) return target;
-  #|     return target?.parentElement ?? null;
-  #|   };
-  #|
-  #|   const editable = (element) => {
-  #|     const control = element?.closest?.("input, textarea, select, [contenteditable]");
-  #|     if (!control) return false;
-  #|     return control.getAttribute("contenteditable") !== "false";
-  #|   };
-  #|
-  #|   const selectedAt = (element, x, y, keyboard) => {
-  #|     const selection = document.getSelection?.();
-  #|     if (!selection || selection.isCollapsed || selection.rangeCount === 0) return null;
-  #|     const text = selection.toString();
-  #|     if (text.length === 0) return null;
-  #|     for (let index = 0; index < selection.rangeCount; index += 1) {
-  #|       const range = selection.getRangeAt(index);
-  #|       if (keyboard) {
-  #|         try {
-  #|           if (element && range.intersectsNode(element)) return text;
-  #|         } catch (_) {}
-  #|       }
-  #|       for (const rect of range.getClientRects()) {
-  #|         if (x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom) {
-  #|           return text;
-  #|         }
-  #|       }
-  #|     }
-  #|     return null;
-  #|   };
-  #|
-  #|   const onMouseDown = (event) => {
-  #|     if (event.button !== 2) return;
-  #|     const element = eventElement(event);
-  #|     rememberedSelection = {
-  #|       x: event.clientX,
-  #|       y: event.clientY,
-  #|       text: selectedAt(element, event.clientX, event.clientY, false),
-  #|     };
-  #|   };
-  #|
-  #|   // Closing in capture means an editor-owned menu that stops propagation
-  #|   // still dismisses this surface. An unhandled event reopens it in the
-  #|   // bubble listener below, after every more-specific owner had a chance.
-  #|   const onContextCapture = () => {
-  #|     discardTemporaryFocus();
-  #|     close();
-  #|   };
-  #|
-  #|   const onContextMenu = (event) => {
-  #|     if (event.defaultPrevented) return;
-  #|     const element = eventElement(event);
-  #|     if (!element || editable(element)) return;
-  #|
-  #|     event.preventDefault();
-  #|     const keyboard = event.clientX === 0 && event.clientY === 0;
-  #|     let selected = selectedAt(element, event.clientX, event.clientY, keyboard);
-  #|     if (!selected && rememberedSelection &&
-  #|         Math.abs(rememberedSelection.x - event.clientX) <= 2 &&
-  #|         Math.abs(rememberedSelection.y - event.clientY) <= 2) {
-  #|       selected = rememberedSelection.text;
-  #|     }
-  #|     rememberedSelection = null;
-  #|
-  #|     let target = null;
-  #|     const file = element.closest?.("[data-context-file]");
-  #|     if (file) {
-  #|       const path = file.getAttribute("data-context-file");
-  #|       if (path !== null) target = { kind: "file", path };
-  #|     } else {
-  #|       const anchor = element.closest?.("a[href]");
-  #|       if (anchor && !anchor.hasAttribute("download")) {
-  #|         const protocol = anchor.protocol.toLowerCase();
-  #|         if (protocol === "http:" || protocol === "https:") {
-  #|           target = { kind: "web", url: anchor.href };
-  #|         } else if (protocol === "mailto:") {
-  #|           const raw = anchor.getAttribute("href")?.slice(7).split("?")[0] ?? "";
-  #|           let address = raw;
-  #|           try { address = decodeURIComponent(raw); } catch (_) {}
-  #|           target = { kind: "email", url: anchor.href, address };
-  #|         }
-  #|       }
-  #|     }
-  #|
-  #|     let x = event.clientX;
-  #|     let y = event.clientY;
-  #|     if (keyboard) {
-  #|       const selection = document.getSelection?.();
-  #|       const rangeRect = selection && selection.rangeCount > 0
-  #|         ? selection.getRangeAt(0).getBoundingClientRect()
-  #|         : null;
-  #|       const rect = rangeRect && (rangeRect.width > 0 || rangeRect.height > 0)
-  #|         ? rangeRect
-  #|         : element.getBoundingClientRect();
-  #|       x = rect.left;
-  #|       y = rect.bottom;
-  #|     }
-  #|     open(
-  #|       target,
-  #|       selected,
-  #|       rememberFocus(),
-  #|       Math.round(x),
-  #|       Math.round(y),
-  #|     );
-  #|   };
-  #|
-  #|   document.addEventListener("mousedown", onMouseDown, true);
-  #|   document.addEventListener("contextmenu", onContextCapture, true);
-  #|   document.addEventListener("contextmenu", onContextMenu);
-  #|   return { onMouseDown, onContextCapture, onContextMenu, discardTemporaryFocus };
-  #| }
-
-///|
-extern "js" fn remove_context_menu_listener(listeners : @js.Value) -> Unit =
-  #| (listeners) => {
-  #|   document.removeEventListener("mousedown", listeners.onMouseDown, true);
-  #|   document.removeEventListener("contextmenu", listeners.onContextCapture, true);
-  #|   document.removeEventListener("contextmenu", listeners.onContextMenu);
-  #|   listeners.discardTemporaryFocus();
-  #| }
+  open : (ContextRequest, String?, Int, Int) -> Unit,
+) -> () -> Unit {
+  let document = @dom.document()
+  let mut remembered_selection : (Int, Int, String?)? = None
+  let mut temporary_focus : @dom.Element? = None
+  let mut next_focus_id = 0
+  let remember_focus = () => {
+    discard_temporary_focus(temporary_focus)
+    temporary_focus = None
+    guard document.get_active_element() is Some(active) &&
+      active.to_html_element() is Some(_) &&
+      !active.matches("body") else {
+      return None
+    }
+    if active.get_attribute("id") is Some(id) && !id.is_empty() {
+      return Some(id)
+    }
+    next_focus_id += 1
+    let id = "app-context-focus:\{next_focus_id}"
+    active.set_attribute("id", id)
+    active.set_attribute(TemporaryFocusAttribute, id)
+    temporary_focus = Some(active)
+    Some(id)
+  }
+  let on_mouse_down : @dom.Listener = event => {
+    guard event.to_mouse_event() is Some(mouse) &&
+      mouse.get_button() == 2 &&
+      event_element(event) is Some(element) else {
+      return
+    }
+    let x = mouse.get_client_x()
+    let y = mouse.get_client_y()
+    remembered_selection = Some((x, y, selected_at(element, x, y, false)))
+  }
+  // Capture closes the previous menu even when another owner stops bubbling.
+  let on_context_capture : @dom.Listener = _ => {
+    discard_temporary_focus(temporary_focus)
+    temporary_focus = None
+    close()
+  }
+  // Other owners get first refusal through ordinary DOM bubbling.
+  let on_context_menu : @dom.Listener = event => {
+    guard !event.get_default_prevented() &&
+      event_element(event) is Some(element) &&
+      event.to_mouse_event() is Some(mouse) else {
+      return
+    }
+    if element.closest("input, textarea, select, [contenteditable]")
+      is Some(control) &&
+      control.get_attribute("contenteditable") != Some("false") {
+      return
+    }
+    event.prevent_default()
+    let x = mouse.get_client_x()
+    let y = mouse.get_client_y()
+    let keyboard = x == 0 && y == 0
+    let mut selected_text = selected_at(element, x, y, keyboard)
+    if selected_text is None &&
+      remembered_selection is Some((old_x, old_y, text)) &&
+      (old_x.to_double() - x.to_double()).abs() <= 2 &&
+      (old_y.to_double() - y.to_double()).abs() <= 2 {
+      selected_text = text
+    }
+    remembered_selection = None
+    let (x, y) = if keyboard {
+      keyboard_anchor(element)
+    } else {
+      (@math.round(x.to_double()).to_int(), @math.round(y.to_double()).to_int())
+    }
+    open(
+      { target: element_context(element), selected_text, },
+      remember_focus(),
+      x,
+      y,
+    )
+  }
+  document.add_event_listener_with_options(
+    "mousedown",
+    on_mouse_down,
+    capture=true,
+  )
+  document.add_event_listener_with_options(
+    "contextmenu",
+    on_context_capture,
+    capture=true,
+  )
+  document.add_event_listener("contextmenu", on_context_menu)
+  () => {
+    document.remove_event_listener_with_options(
+      "mousedown",
+      on_mouse_down,
+      capture=true,
+    )
+    document.remove_event_listener_with_options(
+      "contextmenu",
+      on_context_capture,
+      capture=true,
+    )
+    document.remove_event_listener("contextmenu", on_context_menu)
+    discard_temporary_focus(temporary_focus)
+  }
+}
 
 ///|
 priv suberror ContextMenuSubscription {
@@ -300,22 +286,14 @@ fn context_menu_subscription(emit : @cmd.Emit[ContextMsg]) -> @sub.Sub {
   ) => {
     guard payload is ContextMenuSubscription(emit) else { return None }
     let mut emit = emit
-    let listeners = install_context_menu_listener(
+    let unload = install_context_menu_listener(
       () => scheduler.add(emit(CloseContext)),
-      (target, selected_text, restore_focus, x, y) => {
-        match
-          (
-            context_request(target, selected_text),
-            optional_context_string(restore_focus),
-          ) {
-          (Some(request), Ok(restore_focus_id)) =>
-            scheduler.add(emit(Requested(request, x, y, restore_focus_id)))
-          _ => ()
-        }
+      (request, restore, x, y) => {
+        scheduler.add(emit(Requested(request, x, y, restore)))
       },
     )
     Some({
-      unload: _ => remove_context_menu_listener(listeners),
+      unload: _ => unload(),
       update_tagger: payload => {
         guard payload is ContextMenuSubscription(next) else { return }
         emit = next

--- a/desktop/frontend/action_menu/moon.pkg
+++ b/desktop/frontend/action_menu/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "moonbitlang/core/math",
   "moonbit-community/rabbita",
   "moonbit-community/rabbita/clipboard",
   "moonbit-community/rabbita/cmd",


### PR DESCRIPTION
## Summary

- Move application context-menu event routing, listener lifetimes, selection hit testing, link classification, positioning decisions, and existing focus bookkeeping from JavaScript into MoonBit.
- Pass typed `ContextRequest` and `ContextTarget` values directly instead of constructing and decoding intermediate JavaScript objects. Return a cleanup closure from listener installation.
- Reuse existing Rabbita DOM bindings and limit the remaining FFI to 11 private, single-expression browser bindings in `browser_dom.mbt`.

This is a behavior-preserving refactor of the existing shell menu. It does not reintroduce text-input context menus, change focus policy, modify the desktop host, or update Rabbita dependencies. Inputs and editor-owned menus keep their existing handling.

## Validation

- `moon -C desktop check --target js`
- `moon -C desktop test frontend --target js` — 458 passed before and after the refactor
- `moon -C desktop run package/browser --target native`
- `npm --prefix desktop/e2e test` — 33 passed against the rebuilt browser bundle
- `moon -C desktop info --target js` and `moon -C desktop fmt`
- `git diff --check`
- Supplemental browser interaction probe: web/email/selection menus, malformed mailto decoding fallback, temporary focus restoration, menu replacement, propagation stopped by another menu owner, and native input/textarea/contenteditable menu handling. Clipboard transport was mocked; no native app runtime validation was performed.
