### PR TITLE
docs: fix documentation that the code no longer supports

### DIFF
--- a/agent/README.mbt.md
+++ b/agent/README.mbt.md
@@ -318,8 +318,10 @@ improving:
   another explicit validation command.
 - Use `mbtx` for exact end-to-end MoonBit command validation beyond
   compiler feedback, especially `moon test`, `moon run`, and README command
-  checks. Source-writing commands (`moon fmt`, `moon info`) are denied by the
-  snippet sandbox and belong to the caller, not the agent.
+  checks. Source-writing commands (`moon fmt`, `moon info`, `git checkout`) run
+  normally inside snippets — the sandbox bounds which commands exist, not
+  whether they write source. Only a `read_only` subrun takes a profile that
+  denies source writes.
 - For snapshot updates, run plain `moon test` first and only run
   `moon test --update` after deciding the failure is a stale snapshot or
   intentional output change, not a behavior bug.

--- a/agent_review/README.mbt.md
+++ b/agent_review/README.mbt.md
@@ -106,7 +106,8 @@ report a calibrated confidence signal that one pass cannot.
 
 | file | role |
 | --- | --- |
-| `types.mbt` | `ReviewReport` / `Finding` / `ReviewScope` / `ReviewStats`, JSON, `validate` |
+| `types.mbt` | `ReviewReport` / `Finding` / `ReviewScope` / `ReviewStats`, JSON derive, `to_json_string` |
+| `exports.mbt` | `ReviewReport::parse` and `ReviewReport::validate` |
 | `submit.mbt` | the `submit_review` structured-output tool |
 | `prompt.mbt` | the review system prompt and task |
 | `engine.mbt` | `run_review` — the engine, and `ReviewError` |

--- a/agent_session/README.mbt.md
+++ b/agent_session/README.mbt.md
@@ -203,8 +203,11 @@ compaction rules are applied:
 - `Assistant` events preserve visible content, reasoning content, and native
   tool calls.
 - `Tool` events are emitted only when they answer a pending assistant tool call.
-- `Terminal(Finished(...))` becomes a final assistant message when non-empty;
-  failed, aborted, and interrupted terminals become assistant-status messages.
+- `Terminal(Finished(...))` becomes a final assistant message when non-empty,
+  unless it is a context-yield notice (carrying `ContextYieldAnswerPrefix`) or
+  repeats the immediately preceding Assistant message — either is dropped from
+  the model-facing projection. Failed, aborted, and interrupted terminals
+  become assistant-status messages.
 - A dangling assistant tool call is closed with a synthetic tool error before
   the next non-tool event, keeping the protocol-valid replay shape.
 

--- a/agent_session/store/README.mbt.md
+++ b/agent_session/store/README.mbt.md
@@ -16,6 +16,7 @@ Each session lives under:
 <root>/sessions/<session-id>/
   openseek_session-<session-id>.jsonl
   session.lock
+  session-title            (only once a user title is set)
 ```
 
 `openseek_session-<session-id>.jsonl` is the whole durable session: its first
@@ -290,9 +291,9 @@ them up. `latest` uses loadability as the resume gate.
 
 ## File Path Helpers
 
-`session_file` exposes the absolute path of a session's file for read-only
-tooling such as the visualizer server. It still validates the session id before
-constructing the path.
+`session_file` exposes the path of a session's file for read-only tooling such
+as the visualizer server — root-joined, so it is relative whenever the store
+root is. It still validates the session id before constructing the path.
 
 ```mbt nocheck
 ///|
@@ -301,8 +302,9 @@ let path = store.session_file(@agent_session.SessionId("demo"))
 
 ## Failure Model
 
-The whole session is one file, so there is no cross-file consistency to
-maintain:
+The whole transcript is one file, so there is no cross-file consistency to
+maintain (the optional `session-title` sidecar is replaced atomically under the
+same lock):
 
 - `append` is a single `O_APPEND` write of one event line. The first durable
   write for a session (no file yet) writes the header line and the first event

--- a/agent_tool/bgjobs/README.mbt.md
+++ b/agent_tool/bgjobs/README.mbt.md
@@ -7,17 +7,18 @@ ids, session-visible metadata, spill-file placement, exit watchers, and
 push-completion hooks — it adds no second execution or output pipeline.
 
 One `BgJobRuntime` is created per session (by `@agent.build_tools`) and shared
-by the `shell` (`run_in_background`), `shell_output`, and `shell_stop` tools, so
-a job started in one turn is visible in every later turn of the session.
+by `mbtx` (auto-adopted after its foreground grace period) and the `job_output`
+and `job_stop` tools, so a job started in one turn is visible in every later
+turn of the session. The registry carries no shell tool family.
 
 ## Lifecycle
 
 ```mermaid
 flowchart LR
-  rib["shell run_in_background"] -->|"start()"| job["BgJob (id bg-N)"]
+  rib["mbtx (auto-adopt)"] -->|"start()"| job["BgJob (id bg-N)"]
   timeout["foreground timeout"] -->|"background() + adopt()"| job
-  job -->|"snapshot()/read_output_tail()"| out["shell_output"]
-  job -->|"stop()"| stop["shell_stop"]
+  job -->|"snapshot()/read_output_tail()"| out["job_output"]
+  job -->|"stop()"| stop["job_stop"]
   job -->|"natural exit / watchdog kill"| watcher["exit watcher"]
   watcher -->|"on_job_exit(snapshot)"| notice["completion notice\n(SteerInput::Notice + idle wake)"]
 ```
@@ -26,7 +27,7 @@ flowchart LR
   its spill file never diverge).
 - `adopt` registers an *already running* execution — this is detach-on-timeout:
   a foreground command that outlived its `timeout_ms` is flipped to
-  `Backgrounded` and adopted, so `shell_output`/`shell_stop` and the completion
+  `Backgrounded` and adopted, so `job_output`/`job_stop` and the completion
   notice see it like any explicitly backgrounded job. The launch's sandbox
   metadata rides along so a source-write denial is still detected when the
   job's output is read later.
@@ -37,7 +38,7 @@ flowchart LR
 ## Output retention
 
 Jobs use the sink's file-backed model: an inline preview up to the budget
-(`max_output_chars`, matching the shell tool's foreground default so a command
+(`max_output_chars`, matching the foreground default so a command
 reads the same either way), full output in a per-job spill file under the
 session's spill directory, a thirty-minute wall-clock lifetime cap (a reaped
 job reports `killed_by_time_limit`, measured from process start so adopted
@@ -52,7 +53,7 @@ memory-only jobs (bounded preview, rest dropped).
 The per-job watcher awaits the execution and calls `on_job_exit` exactly once
 when the job ends *on its own* — a natural exit, the output watchdog, or the
 wall-clock reaper. A
-requested stop (`shell_stop`, session teardown) fires nothing: it is already
+requested stop (`job_stop`, session teardown) fires nothing: it is already
 user-visible. The `agent` package wires `on_job_exit` to queue a
 `SteerInput::Notice` (lossless) and poke the serve loop, which is what makes
 job completion *push* into the conversation instead of requiring the model to
@@ -62,8 +63,9 @@ exactly that workflow.
 ## Snapshots
 
 Consumers only ever see `BgJobSnapshot`, an immutable view carrying the status
-(`Running`/`Exited(code)`/`Stopped`), the inline output preview, size and
-sequence counters for change detection, and the error-semantics flags
+(`Running`/`Exited(code)`/`Stopped`), the inline output preview, the `size`
+counter for change detection, and the error-semantics flags
 (`had_invalid_utf8`, sandbox metadata, `killed_by_output_limit`) that let
-`shell_output` report a background job with exactly the foreground path's error
-behavior.
+`job_output` report a background job with exactly the foreground path's error
+behavior. The sink's own sequence number stays private and is not copied into
+the snapshot.

--- a/agent_tool/edit/internal/decode/README.mbt.md
+++ b/agent_tool/edit/internal/decode/README.mbt.md
@@ -12,7 +12,8 @@ package.
 
 ## API Shape
 
-- `EditInput(path, old_string, new_string, replace_all, start_line, end_line)`:
+- `EditInput(path, old_string, new_string, replace_all, replace_all_preview,
+  start_line, end_line, revert_on_parse_errors)`:
   the normalized edit request.
 - `decode(arguments)`: accepts a JSON object and returns `EditInput`, or raises
   when required fields are missing or have invalid types.
@@ -27,8 +28,10 @@ package.
 | `replace_all` | boolean | no | Legacy field. Defaults to `false`; `true` is rejected by `agent_tool/edit` with guidance to use `multi_edit`. |
 | `start_line` | integer | yes | Required positive 1-based inclusive search start. |
 | `end_line` | integer | no | Optional positive 1-based inclusive range end; when present, it must be greater than or equal to `start_line`. |
+| `replace_all_preview` | boolean | no | Defaults to `false`. When `true`, `agent_tool/edit` reports every match in the line range as a reviewable `multi_edit` array instead of applying the edit. |
+| `revert_on_parse_errors` | boolean | no | Defaults to `true`. Honored by `agent_tool/edit` as the parse gate on the written result. |
 
-Extra fields are ignored. Non-object JSON values raise `object arguments`.
+Unrecognized keys are ignored. Non-object JSON values raise `object arguments`.
 
 The decoder does not reject empty `old_string`, identical replacements,
 `replace_all=true`, missing files, missing matches, or manifest edits. Those


### PR DESCRIPTION
Nine documentation claims that the code no longer supports, found by a
drift sweep and each re-checked by hand against the code it cites.

The sweep used `moonbitlang/workflow`'s `examples/doc-audit.mbtx`
(`--engine explore`, deepseek-v4-flash) over 24 tracked docs — 27 slices,
372 claims checked. Eleven findings came back; **two did not survive
verification** and are written up at the bottom, because how they failed
is the more useful half of the report.

## Fixed here

| file | said | code says |
| --- | --- | --- |
| `agent/README.mbt.md` | source-writing commands (`moon fmt`, `moon info`) are denied by the snippet sandbox | `mbtx.mbt` says the opposite in as many words — "Note what is deliberately NOT denied: source writes as such"; a `read_only` subrun is the one role taking a profile that denies them |
| `agent_review/README.mbt.md` | Layout table credits `types.mbt` with `validate` | `ReviewReport::parse`/`validate` live in `exports.mbt`, which the table did not list at all |
| `agent_session/README.mbt.md` | a non-empty `Finished` becomes a final assistant message | two more cases are dropped from the model-facing projection: a context-yield notice, and an answer repeating the preceding Assistant message (`projection.mbt:32`) |
| `agent_session/store/README.mbt.md` | `session_file` exposes the **absolute** path | it is root-joined, so relative whenever the root is — the README's own example uses `SessionStore(".openseek")` |
| `agent_session/store/README.mbt.md` | layout block lists two per-session files | the store writes three: `session-title` appears once a user title is set (`store.mbt:22`) |
| `agent_tool/bgjobs/README.mbt.md` | the runtime is shared by `shell` / `shell_output` / `shell_stop` | none are in the registry — there is a test named *"the registry has no shell tool family"* asserting exactly that. It is `mbtx` (auto-adopt), `job_output`, `job_stop` |
| `agent_tool/bgjobs/README.mbt.md` | `BgJobSnapshot` carries sequence counters | the sink's `seq` is private and never copied into the snapshot, which carries `size` |
| `agent_tool/edit/internal/decode/README.mbt.md` | `EditInput` has six fields | it has eight — `replace_all_preview` and `revert_on_parse_errors` are missing from the documented shape |
| `agent_tool/edit/internal/decode/README.mbt.md` | "Extra fields are ignored" | those same two arguments are decoded and acted on (preview short-circuits the write; the parse gate is honored) |

## Two findings that did not survive verification

Both are worth recording, because both looked solid and cited real code.

**The `agent_runtime` event bus (reported `high`).** The sweep claimed
`README.mbt.md` and `exports.mbt` describe the wrong overflow policy: the
docs say a full bus ignores the incoming event, while the bus is built as
`Queue(kind=DiscardOldest(...))` (`runtime.mbt:84`), which by its name
evicts the oldest. The async queue does offer both `DiscardOldest` and
`DiscardLatest`, so the argument was tight, and I wrote the "fix" —
including new expected values for the README's flood example.

`moon test -p agent_runtime` rejected it: the actual drained values are
`["event 0", "event 31"]`, exactly what the README already said. The
documented behaviour is the real behaviour, and `try_put` on that queue
does not evict. Reverted; the docs are untouched.

**The `agent_review` audit prompt.** The sweep claimed
`audit_system_prompt.mbt.md` describes a worktree-auditing mode
(`git status --porcelain`, `scope.head = "WORKTREE"`) that the engine
does not implement, citing `engine.mbt` — where `run_review` really does
diff only `base...HEAD`. But that prompt belongs to `run_audit` in
`audit.mbt`, a different runner, which genuinely audits the worktree and
sets `scope.head = "WORKTREE"` (`audit.mbt:51,62`). Real code, correctly
quoted, wrong runner.

## Checks

Docs only — no `.mbt` sources changed. `moon check` is clean, and the
packages these files document pass (`agent_runtime`, `agent_session`,
`agent_session/store`: 105/105). This tree has 24 native failures in
`agent_tool/internal/sandbox/`, `agent_tool/shell/` and
`eval/tool_harness/`; I confirmed the identical 24 on pristine
`origin/main`, so they predate this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXAZSnNythUMZG5HVV4ozb
