### PR TITLE
feat(desktop): toggle terminal with Command+J on macOS

### DIFF
--- a/desktop/frontend/boot.mbt
+++ b/desktop/frontend/boot.mbt
@@ -152,6 +152,7 @@ fn app_shortcut_message(keyboard : @dom.KeyboardEvent, is_apple : Bool) -> Msg? 
     ("KeyO", false) => Some(AddProjectRequested)
     ("KeyB", false) => Some(ToggleSidebar)
     ("KeyB", true) => Some(ToggleRightPanel)
+    ("KeyJ", false) if is_apple => Some(Terminal(@terminal.ToggleTerminal))
     ("KeyF", true) => Some(ExplorerRequested(ExplorerSearch))
     _ => None
   }


### PR DESCRIPTION
## Summary
- Add Command+J on macOS as an alias for the existing terminal visibility toggle.
- Preserve Control+Backquote and existing terminal lifecycle and focus behavior.
- Leave Control+J unchanged on Windows and Linux.

## Validation
- `moon check --target js --warn-list +73` passed with existing warnings.
- `moon test desktop/frontend/terminal --target js`: 10 passed.
- `moon info --target js` and `moon fmt` completed; no generated interface changes.
- `git diff --check` passed.
- The new shortcut has not yet been manually tested in the packaged macOS app.