### PR TITLE
fix(desktop): restore sidebar toggle placement

### DIFF
--- a/desktop/e2e/tests/rabbita_dom.spec.js
+++ b/desktop/e2e/tests/rabbita_dom.spec.js
@@ -1016,6 +1016,41 @@ test('new chat materializes on send, and archive and restore update the sidebar'
   expect(app.pageErrors).toEqual([]);
 });
 
+test('sidebar toggle returns to its header while the sidebar is open', async ({ page }) => {
+  const app = new DesktopBrowserHarness(page);
+  await app.install();
+  await app.goto();
+
+  const sidebar = page.locator('aside');
+  const headerToggle = page.locator('.sidebar-header')
+    .getByRole('button', { name: 'Hide sidebar' });
+  const topbar = page.locator('.topbar');
+
+  await expect(headerToggle).toBeVisible();
+  await expect(
+    topbar.getByRole('button', { name: 'Hide sidebar' }),
+  ).toHaveCount(0);
+  const [sidebarBounds, toggleBounds] = await Promise.all([
+    sidebar.boundingBox(),
+    headerToggle.boundingBox(),
+  ]);
+  expect(sidebarBounds).not.toBeNull();
+  expect(toggleBounds).not.toBeNull();
+  expect(toggleBounds.x).toBeGreaterThanOrEqual(sidebarBounds.x);
+  expect(toggleBounds.x + toggleBounds.width)
+    .toBeLessThanOrEqual(sidebarBounds.x + sidebarBounds.width);
+
+  await headerToggle.click();
+  const reopenToggle = topbar.getByRole('button', { name: 'Show sidebar' });
+  await expect(reopenToggle).toBeVisible();
+  await expect(headerToggle).not.toBeVisible();
+
+  await reopenToggle.click();
+  await expect(headerToggle).toBeVisible();
+  await expect(reopenToggle).toHaveCount(0);
+  expect(app.pageErrors).toEqual([]);
+});
+
 test('new-chat project title filters and switches registered projects', async ({ page }) => {
   const app = new DesktopBrowserHarness(page);
   app.workspaces.push('/other');

--- a/desktop/frontend/boot.mbt
+++ b/desktop/frontend/boot.mbt
@@ -361,6 +361,7 @@ fn SidebarDispatcher::actions(self : SidebarDispatcher) -> @sidebar.Actions {
     conversation,
   }
   {
+    toggle: self.emit(ToggleSidebar),
     update: self.emit(UpdateClicked),
     open_skills: self.emit(OpenSkills),
     open_settings: self.emit(OpenSetup),

--- a/desktop/frontend/codex/view.mbt
+++ b/desktop/frontend/codex/view.mbt
@@ -423,20 +423,19 @@ pub fn State::page(
   // Account actions (sign in/out, the pending sign-in page) live in the
   // Settings page's Codex group; the topbar keeps only the status label.
   let topbar : Array[@html.Html] = []
-  let sidebar_toggle_label = if sidebar_open {
-    "Hide sidebar"
-  } else {
-    "Show sidebar"
+  // The sidebar header owns the close action while visible; Codex only needs
+  // to supply the reopen action after the sidebar has collapsed.
+  if !sidebar_open {
+    topbar.push(
+      @html.button(
+        class="topbar-toggle",
+        title="Show sidebar",
+        on_click=actions.toggle_sidebar,
+        attrs=@html.Attrs::build().aria_label("Show sidebar"),
+        icon(icon_layout_sidebar_left),
+      ),
+    )
   }
-  topbar.push(
-    @html.button(
-      class="topbar-toggle sidebar-boundary-toggle",
-      title=sidebar_toggle_label,
-      on_click=actions.toggle_sidebar,
-      attrs=@html.Attrs::build().aria_label(sidebar_toggle_label),
-      icon(icon_layout_sidebar_left),
-    ),
-  )
   let title = match self.selection {
     CodexDraftTask(_) => "New chat"
     CodexStoredTask(thread) => thread.title

--- a/desktop/frontend/sidebar/pkg.generated.mbti
+++ b/desktop/frontend/sidebar/pkg.generated.mbti
@@ -28,6 +28,7 @@ pub fn Account::not_equal(Self, Self) -> Bool
 pub fn Account::to_repr(Self) -> @debug.Repr
 
 pub(all) struct Actions {
+  toggle : @cmd.Cmd
   update : @cmd.Cmd
   open_skills : @cmd.Cmd
   open_settings : @cmd.Cmd

--- a/desktop/frontend/sidebar/sidebar.mbt
+++ b/desktop/frontend/sidebar/sidebar.mbt
@@ -28,6 +28,7 @@ pub(all) struct Input {
 
 ///|
 pub(all) struct Actions {
+  toggle : @cmd.Cmd
   update : @cmd.Cmd
   open_skills : @cmd.Cmd
   open_settings : @cmd.Cmd
@@ -225,10 +226,17 @@ pub fn component(
       }
     }
     @html.aside([
-      // Navigation actions live with the hierarchy they affect. This empty
-      // strip exists only under the macOS overlay titlebar, where it protects
-      // the traffic-light controls and remains a native drag region.
-      @html.div(class="sidebar-header", @html.nothing),
+      // While the sidebar is visible, its own header owns the close action.
+      // The collapsed main topbar supplies the corresponding reopen action.
+      @html.div(class="sidebar-header", [
+        @html.button(
+          class="topbar-toggle",
+          title="Hide sidebar",
+          on_click=actions.toggle,
+          attrs=@html.Attrs::build().aria_label("Hide sidebar"),
+          @icons.icon(@icons.icon_layout_sidebar_left),
+        ),
+      ]),
       @html.div(class="sidebar-main", [
         @html.div(class="sidebar-section sessions", rows),
       ]),

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -1349,22 +1349,19 @@ fn topbar_view(
   conv : Conversation,
 ) -> @html.Html {
   let items : Array[@html.Html] = []
-  // The layout action sits at the boundary it controls: beside the sidebar
-  // while open, and at the window edge while collapsed.
-  let sidebar_toggle_label = if model.sidebar_open {
-    "Hide sidebar"
-  } else {
-    "Show sidebar"
+  // The visible sidebar owns its close action. Once collapsed, the topbar
+  // supplies the reopen action at the window's leading edge.
+  if !model.sidebar_open {
+    items.push(
+      @html.button(
+        class="topbar-toggle",
+        title="Show sidebar",
+        on_click=dispatch(ToggleSidebar),
+        attrs=@html.Attrs::build().aria_label("Show sidebar"),
+        icon(icon_layout_sidebar_left),
+      ),
+    )
   }
-  items.push(
-    @html.button(
-      class="topbar-toggle sidebar-boundary-toggle",
-      title=sidebar_toggle_label,
-      on_click=dispatch(ToggleSidebar),
-      attrs=@html.Attrs::build().aria_label(sidebar_toggle_label),
-      icon(icon_layout_sidebar_left),
-    ),
-  )
   items.push(
     @html.span(
       class="topbar-title",
@@ -1475,28 +1472,27 @@ fn onboarding_view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
 }
 
 ///|
-/// Skills and Settings have no topbar, so they float the layout control at the
-/// same sidebar boundary used by conversation topbars.
+/// Skills and Settings have no topbar, so while the sidebar is collapsed they
+/// float the reopen action at the window's leading edge.
 fn page_with_toggle(
   dispatch : @cmd.Emit[Msg],
   model : Model,
   page : @html.Html,
 ) -> Array[@html.Html] {
-  let sidebar_toggle_label = if model.sidebar_open {
-    "Hide sidebar"
+  if model.sidebar_open {
+    [page]
   } else {
-    "Show sidebar"
+    [
+      @html.button(
+        class="topbar-toggle page-sidebar-toggle",
+        title="Show sidebar",
+        on_click=dispatch(ToggleSidebar),
+        attrs=@html.Attrs::build().aria_label("Show sidebar"),
+        icon(icon_layout_sidebar_left),
+      ),
+      page,
+    ]
   }
-  [
-    @html.button(
-      class="topbar-toggle page-sidebar-toggle sidebar-boundary-toggle",
-      title=sidebar_toggle_label,
-      on_click=dispatch(ToggleSidebar),
-      attrs=@html.Attrs::build().aria_label(sidebar_toggle_label),
-      icon(icon_layout_sidebar_left),
-    ),
-    page,
-  ]
 }
 
 ///|

--- a/desktop/styles/base.css
+++ b/desktop/styles/base.css
@@ -297,7 +297,6 @@ html {
   --resize-handle-height: 6px;
   --sidebar-column-width: clamp(220px, var(--sidebar-width, 264px), 480px);
   --sidebar-drawer-width: min(320px, 86vw);
-  --sidebar-boundary-width: var(--sidebar-column-width);
   --sidebar-toggle-size: 28px;
   --topbar-inline-padding: 18px;
   --topbar-leading-toggle-offset: -4px;
@@ -305,10 +304,6 @@ html {
     var(--topbar-inline-padding) + var(--topbar-leading-toggle-offset)
   );
   --sidebar-toggle-trailing-gap: 12px;
-  --sidebar-toggle-inline-start: min(
-    calc(var(--sidebar-boundary-width) + var(--sidebar-toggle-inline-inset)),
-    calc(100vw - var(--sidebar-toggle-size))
-  );
   --sidebar-toggle-reserved-width: calc(
     var(--sidebar-toggle-inline-inset) + var(--sidebar-toggle-size) +
       var(--sidebar-toggle-trailing-gap)
@@ -381,15 +376,15 @@ html {
   height: 46px;
 }
 
-/* macOS keeps its traffic-light controls in the top-left corner. The open
-   sidebar reserves them with its empty titlebar strip; once collapsed, the
-   main column reaches that corner and its visible chrome takes the inset. */
+/* macOS keeps its traffic-light controls in the top-left corner. Whichever
+   header owns the sidebar toggle reserves that native hit area. */
 .app.native-apple-titlebar {
   --native-titlebar-leading-inset: 88px;
 }
 .app.native-apple-titlebar.sidebar-collapsed {
   --sidebar-toggle-inline-inset: var(--native-titlebar-leading-inset);
 }
+.app.native-apple-titlebar .sidebar-header,
 .app.native-apple-titlebar.sidebar-collapsed .topbar {
   padding-inline-start: var(--native-titlebar-leading-inset);
 }
@@ -470,18 +465,21 @@ html {
   grid-template-columns: 0 minmax(0, 1fr);
 }
 
-/* Expanded hides the zero-width conversation column behind the editor. Float
-   its sidebar control back to the boundary it owns and reserve matching room
-   in the tab strip so open tabs never sit underneath it. */
-.content.panel-expanded :where(.topbar > .sidebar-boundary-toggle) {
+/* With both the sidebar collapsed and the editor expanded, the reopen action
+   would otherwise stay inside the main column's zero-width track. Float that
+   one fallback above the editor and reserve matching tab-strip room. */
+.app.sidebar-collapsed
+  .content.panel-expanded
+  .topbar
+  > .topbar-toggle {
   position: fixed;
   inset-block-start: calc(
     (var(--topbar-height) - var(--sidebar-toggle-size)) / 2
   );
-  inset-inline-start: var(--sidebar-toggle-inline-start);
+  inset-inline-start: var(--sidebar-toggle-inline-inset);
   z-index: var(--z-editor-overlay-control);
   margin-inline-start: 0;
 }
-.content.panel-expanded .editor-tabsbar {
+.app.sidebar-collapsed .content.panel-expanded .editor-tabsbar {
   padding-inline-start: var(--sidebar-toggle-reserved-width);
 }

--- a/desktop/styles/main_header.css
+++ b/desktop/styles/main_header.css
@@ -54,13 +54,13 @@ main {
   color: var(--color-text-primary);
 }
 
-/* Pages without a topbar float the same control at the live sidebar boundary. */
+/* Pages without a topbar float the reopen action at the window's leading edge. */
 .page-sidebar-toggle {
   position: fixed;
   inset-block-start: calc(
     (var(--topbar-height) - var(--sidebar-toggle-size)) / 2
   );
-  inset-inline-start: var(--sidebar-toggle-inline-start);
+  inset-inline-start: var(--sidebar-toggle-inline-inset);
   z-index: var(--z-titlebar-control);
   margin-inline-start: 0;
 }

--- a/desktop/styles/responsive.css
+++ b/desktop/styles/responsive.css
@@ -49,17 +49,11 @@
      content column always has the full width. */
   .app {
     --sidebar-column-width: 0px;
-    --sidebar-boundary-width: 0px;
     --sidebar-toggle-size: 44px;
-    --topbar-inline-padding: 12px;
     grid-template-columns: minmax(0, 1fr);
   }
   .app.sidebar-collapsed {
     grid-template-columns: minmax(0, 1fr);
-  }
-  .app:not(.sidebar-collapsed) {
-    --sidebar-boundary-width: var(--sidebar-drawer-width);
-    --sidebar-toggle-inline-inset: 0px;
   }
   .app > aside {
     position: fixed;
@@ -167,20 +161,15 @@
   .editor-tabsbar {
     height: 52px;
   }
+  /* The fallback on pages without a topbar keeps the pre-drawer phone inset. */
+  .page-sidebar-toggle {
+    inset-block-start: 4px;
+    inset-inline-start: 8px;
+  }
+  .topbar-toggle,
   .panel-toggle {
     min-width: 44px;
     min-height: 44px;
-  }
-  /* The drawer overlays the main column, so its layout control leaves normal
-     flow and sits on the drawer boundary above the dimmed backdrop. */
-  .app:not(.sidebar-collapsed) .sidebar-boundary-toggle {
-    position: fixed;
-    inset-block-start: calc(
-      (var(--topbar-height) - var(--sidebar-toggle-size)) / 2
-    );
-    inset-inline-start: var(--sidebar-toggle-inline-start);
-    z-index: var(--z-sidebar-drawer-control);
-    margin-inline-start: 0;
   }
   /* A narrow Windows desktop window still shares its first row with native
      caption buttons. Keep that row compact instead of applying phone touch
@@ -196,6 +185,7 @@
   .app.native-windows-titlebar .editor-tabsbar {
     height: var(--native-titlebar-height);
   }
+  .app.native-windows-titlebar .topbar-toggle,
   .app.native-windows-titlebar .panel-toggle {
     min-width: 32px;
     min-height: 32px;

--- a/desktop/styles/sidebar.css
+++ b/desktop/styles/sidebar.css
@@ -43,16 +43,16 @@ html.is-resizing .sidebar-resize-handle {
   background: var(--color-accent-soft);
 }
 
-/* The hierarchy starts at the top of the sidebar. macOS alone keeps an empty
-   native-titlebar strip so project controls never sit beneath the traffic
-   lights; the main-column toggle owns the visible layout action. */
+/* The sidebar's own header owns its close action while the sidebar is visible.
+   Its height matches the main topbar so collapsing swaps the control between
+   columns without changing its vertical position. */
 .sidebar-header {
-  display: none;
+  display: flex;
+  align-items: center;
   height: 46px;
+  padding-block: 0;
+  padding-inline: var(--topbar-inline-padding);
   border-bottom: 1px solid var(--color-separator);
-}
-.app.native-apple-titlebar .sidebar-header {
-  display: block;
 }
 
 .sidebar-main {

--- a/desktop/styles/tokens.css
+++ b/desktop/styles/tokens.css
@@ -161,7 +161,6 @@
   --z-editor-overlay-control: 46;
   --z-sidebar-backdrop: 51;
   --z-sidebar-drawer: 52;
-  --z-sidebar-drawer-control: 53;
   --z-notification: 55;
   --z-modal: 60;
   --z-quick-open: 70;


### PR DESCRIPTION
## Summary

- return the sidebar toggle to the sidebar header while the sidebar is open
- show the reopen control in the main topbar only after the sidebar is collapsed
- preserve the project and chat action hierarchy introduced by #1251
- add a browser regression test for both toggle positions

## Testing

- moon info && moon fmt
- just check
- just test
- just build
- just desktop-test-browser (40 passed)