### PR TITLE
Refactor titlebar layout around Proton geometry and fix sidebar toggle position

### DIFF
--- a/desktop/e2e/tests/close_shortcut.spec.js
+++ b/desktop/e2e/tests/close_shortcut.spec.js
@@ -25,8 +25,9 @@ async function installDesktop(page) {
     window.desktopEvent = (name, payload) => {
       for (const callback of listeners.get(name) || []) callback({ payload });
     };
+    window.titlebarArea = null;
     window.__MoonBit__ = {
-      getTitlebarArea: async () => null,
+      getTitlebarArea: async () => window.titlebarArea,
       app: events,
       events,
       openseek: new Proxy({}, {
@@ -49,6 +50,57 @@ async function closeFocused(page) {
     command_id: 'app.close_focused',
   }));
 }
+
+test('fixed sidebar toggle respects native geometry across pages and fullscreen', async ({ page }) => {
+  const app = await installDesktop(page);
+  const toggle = page.getByRole('button', { name: /^(Hide|Show) sidebar$/ });
+  await page.evaluate(() => {
+    window.titlebarArea = { x: 88, y: 0, width: innerWidth - 88, height: 46 };
+    window.desktopEvent('openseek.window.chrome_changed', {});
+  });
+  await expect.poll(async () => (await toggle.boundingBox()).x).toBe(88);
+  const original = await toggle.elementHandle();
+  for (const name of ['Hide sidebar', 'Show sidebar']) {
+    await expect(toggle).toHaveAccessibleName(name);
+    const frames = await toggle.evaluate(button => new Promise(resolve => {
+      const positions = [button.getBoundingClientRect().x];
+      const start = performance.now();
+      button.click();
+      const sample = now => {
+        positions.push(button.getBoundingClientRect().x);
+        if (now - start < 250) requestAnimationFrame(sample);
+        else resolve(positions);
+      };
+      requestAnimationFrame(sample);
+    }));
+    expect(frames.every(x => x === 88)).toBe(true);
+  }
+  await page.getByRole('button', { name: 'Show panel', exact: true }).click();
+  await page.getByRole('button', { name: 'Expand panel', exact: true }).click();
+  await expect(toggle).toBeVisible();
+  await toggle.click();
+  await expect(toggle).toHaveAccessibleName('Show sidebar');
+  await expect.poll(async () => (await toggle.boundingBox()).x).toBe(88);
+  await page.getByRole('button', { name: 'Hide panel', exact: true }).click();
+  await toggle.click();
+  await page.getByRole('button', { name: 'Settings', exact: true }).click();
+  await expect(page.getByRole('heading', { name: 'Settings', exact: true })).toBeVisible();
+  await expect(toggle).toHaveCount(1);
+  expect(await original.evaluate(button => button.isConnected)).toBe(true);
+  await page.setViewportSize({ width: 640, height: 850 });
+  await expect.poll(async () => (await toggle.boundingBox()).x).toBe(88);
+  await page.evaluate(() => {
+    window.titlebarArea = null;
+    window.desktopEvent('openseek.window.chrome_changed', {});
+  });
+  await expect.poll(async () => (await toggle.boundingBox()).x).toBe(8);
+  // A real click must reach the fixed control above the narrow drawer.
+  await toggle.click();
+  await expect(toggle).toHaveAccessibleName('Hide sidebar');
+  await toggle.click();
+  await expect(toggle).toHaveAccessibleName('Show sidebar');
+  expect(app.pageErrors).toEqual([]);
+});
 
 test('Launcher tabs receive focus and Close never closes the window', async ({ page }) => {
   const app = await installDesktop(page);

--- a/desktop/e2e/tests/close_shortcut.spec.js
+++ b/desktop/e2e/tests/close_shortcut.spec.js
@@ -26,6 +26,7 @@ async function installDesktop(page) {
       for (const callback of listeners.get(name) || []) callback({ payload });
     };
     window.__MoonBit__ = {
+      getTitlebarArea: async () => null,
       app: events,
       events,
       openseek: new Proxy({}, {

--- a/desktop/e2e/tests/rabbita_dom.spec.js
+++ b/desktop/e2e/tests/rabbita_dom.spec.js
@@ -1016,37 +1016,34 @@ test('new chat materializes on send, and archive and restore update the sidebar'
   expect(app.pageErrors).toEqual([]);
 });
 
-test('sidebar toggle returns to its header while the sidebar is open', async ({ page }) => {
+test('sidebar toggle follows the sidebar boundary in the main header', async ({ page }) => {
   const app = new DesktopBrowserHarness(page);
   await app.install();
   await app.goto();
 
   const sidebar = page.locator('aside');
-  const headerToggle = page.locator('.sidebar-header')
-    .getByRole('button', { name: 'Hide sidebar' });
   const topbar = page.locator('.topbar');
+  const closeToggle = topbar.getByRole('button', { name: 'Hide sidebar' });
 
-  await expect(headerToggle).toBeVisible();
-  await expect(
-    topbar.getByRole('button', { name: 'Hide sidebar' }),
-  ).toHaveCount(0);
+  await expect(closeToggle).toBeVisible();
+  await expect(page.locator('.sidebar-header')).not.toBeVisible();
   const [sidebarBounds, toggleBounds] = await Promise.all([
     sidebar.boundingBox(),
-    headerToggle.boundingBox(),
+    closeToggle.boundingBox(),
   ]);
   expect(sidebarBounds).not.toBeNull();
   expect(toggleBounds).not.toBeNull();
-  expect(toggleBounds.x).toBeGreaterThanOrEqual(sidebarBounds.x);
-  expect(toggleBounds.x + toggleBounds.width)
-    .toBeLessThanOrEqual(sidebarBounds.x + sidebarBounds.width);
+  expect(toggleBounds.x).toBeGreaterThanOrEqual(sidebarBounds.x + sidebarBounds.width);
+  expect(toggleBounds.x - sidebarBounds.x - sidebarBounds.width).toBeLessThan(32);
 
-  await headerToggle.click();
+  await closeToggle.click();
   const reopenToggle = topbar.getByRole('button', { name: 'Show sidebar' });
   await expect(reopenToggle).toBeVisible();
-  await expect(headerToggle).not.toBeVisible();
+  await expect(sidebar).not.toBeVisible();
+  await expect.poll(async () => (await reopenToggle.boundingBox()).x).toBeLessThan(32);
 
   await reopenToggle.click();
-  await expect(headerToggle).toBeVisible();
+  await expect(closeToggle).toBeVisible();
   await expect(reopenToggle).toHaveCount(0);
   expect(app.pageErrors).toEqual([]);
 });

--- a/desktop/e2e/tests/rabbita_dom.spec.js
+++ b/desktop/e2e/tests/rabbita_dom.spec.js
@@ -1016,35 +1016,31 @@ test('new chat materializes on send, and archive and restore update the sidebar'
   expect(app.pageErrors).toEqual([]);
 });
 
-test('sidebar toggle follows the sidebar boundary in the main header', async ({ page }) => {
+test('sidebar toggle stays fixed throughout the sidebar animation', async ({ page }) => {
   const app = new DesktopBrowserHarness(page);
   await app.install();
   await app.goto();
 
-  const sidebar = page.locator('aside');
-  const topbar = page.locator('.topbar');
-  const closeToggle = topbar.getByRole('button', { name: 'Hide sidebar' });
-
-  await expect(closeToggle).toBeVisible();
-  await expect(page.locator('.sidebar-header')).not.toBeVisible();
-  const [sidebarBounds, toggleBounds] = await Promise.all([
-    sidebar.boundingBox(),
-    closeToggle.boundingBox(),
-  ]);
-  expect(sidebarBounds).not.toBeNull();
-  expect(toggleBounds).not.toBeNull();
-  expect(toggleBounds.x).toBeGreaterThanOrEqual(sidebarBounds.x + sidebarBounds.width);
-  expect(toggleBounds.x - sidebarBounds.x - sidebarBounds.width).toBeLessThan(32);
-
-  await closeToggle.click();
-  const reopenToggle = topbar.getByRole('button', { name: 'Show sidebar' });
-  await expect(reopenToggle).toBeVisible();
-  await expect(sidebar).not.toBeVisible();
-  await expect.poll(async () => (await reopenToggle.boundingBox()).x).toBeLessThan(32);
-
-  await reopenToggle.click();
-  await expect(closeToggle).toBeVisible();
-  await expect(reopenToggle).toHaveCount(0);
+  for (const name of ['Hide sidebar', 'Show sidebar']) {
+    const toggle = page.getByRole('button', { name, exact: true });
+    const frames = await toggle.evaluate(button => new Promise(resolve => {
+      const start = performance.now();
+      const positions = [button.getBoundingClientRect().x];
+      button.click();
+      const sample = now => {
+        positions.push(button.getBoundingClientRect().x);
+        if (now - start < 250) requestAnimationFrame(sample);
+        else resolve({ positions, connected: button.isConnected });
+      };
+      requestAnimationFrame(sample);
+    }));
+    expect(frames.connected).toBe(true);
+    expect(Math.max(...frames.positions) - Math.min(...frames.positions)).toBeLessThan(0.5);
+    await expect(page.getByRole('button', {
+      name: name === 'Hide sidebar' ? 'Show sidebar' : 'Hide sidebar',
+      exact: true,
+    })).toBeVisible();
+  }
   expect(app.pageErrors).toEqual([]);
 });
 

--- a/desktop/frontend/boot.mbt
+++ b/desktop/frontend/boot.mbt
@@ -361,7 +361,6 @@ fn SidebarDispatcher::actions(self : SidebarDispatcher) -> @sidebar.Actions {
     conversation,
   }
   {
-    toggle: self.emit(ToggleSidebar),
     update: self.emit(UpdateClicked),
     open_skills: self.emit(OpenSkills),
     open_settings: self.emit(OpenSetup),
@@ -463,15 +462,11 @@ pub fn boot() -> Unit {
               emit.map(focused => WindowFocusChanged(focused)),
             ),
           )
-          // Only overlay titlebars turn the page's top chrome into native
-          // window chrome; Linux keeps its separate system titlebar.
-          if window_titlebar_overlay_supported() {
-            subs.push(
-              window_titlebar_subscription(
-                emit.map((_ : Unit) => AppToggleMaximizedRequested),
-              ),
-            )
-          }
+          subs.push(
+            window_titlebar_subscription(
+              emit.map((_ : Unit) => AppToggleMaximizedRequested),
+            ),
+          )
           // Rabbita captures its own `@html.a` nodes. The embedded Viewer owns
           // foreign DOM below `.viewer-host`, so its anchors need the adjacent
           // document subscription to reach the same root URL policy.

--- a/desktop/frontend/codex/icon_imports.mbt
+++ b/desktop/frontend/codex/icon_imports.mbt
@@ -2,10 +2,4 @@
 // importing the shell package or duplicating SVG markup.
 
 ///|
-using @icons {
-  icon,
-  icon_folder,
-  icon_layout_sidebar_left,
-  icon_layout_sidebar_right,
-  icon_terminal,
-}
+using @icons {icon, icon_folder, icon_layout_sidebar_right, icon_terminal}

--- a/desktop/frontend/codex/pkg.generated.mbti
+++ b/desktop/frontend/codex/pkg.generated.mbti
@@ -60,7 +60,6 @@ pub fn Msg::unarchive_thread(String) -> Self
 pub fn Msg::worktree_changed(String, String, String, String, Bool) -> Self
 
 pub(all) struct PageActions {
-  toggle_sidebar : @cmd.Cmd
   toggle_terminal : @cmd.Cmd
   toggle_files : @cmd.Cmd
   workspace_label : (@common.Uri) -> String
@@ -95,7 +94,7 @@ pub fn State::loose_entries(Self, SidebarContext) -> Array[@section.Entry]
 pub fn State::model_listing(Self) -> CodexModelListing
 pub fn State::new_thread_cwd(Self) -> String
 pub fn State::not_equal(Self, Self) -> Bool
-pub fn State::page(Self, @cmd.Emit[Msg], @interop.ChannelId, Bool, Bool, Bool, PageActions) -> Array[@html.Html]
+pub fn State::page(Self, @cmd.Emit[Msg], @interop.ChannelId, Bool, Bool, PageActions) -> Array[@html.Html]
 pub fn State::pending_auth_url(Self) -> String?
 pub fn State::project_activation(Self, SidebarContext, String) -> String?
 pub fn State::project_conversations(Self, SidebarContext, String) -> Array[CodexProjectRow]

--- a/desktop/frontend/codex/view.mbt
+++ b/desktop/frontend/codex/view.mbt
@@ -423,19 +423,20 @@ pub fn State::page(
   // Account actions (sign in/out, the pending sign-in page) live in the
   // Settings page's Codex group; the topbar keeps only the status label.
   let topbar : Array[@html.Html] = []
-  // The sidebar header owns the close action while visible; Codex only needs
-  // to supply the reopen action after the sidebar has collapsed.
-  if !sidebar_open {
-    topbar.push(
-      @html.button(
-        class="topbar-toggle",
-        title="Show sidebar",
-        on_click=actions.toggle_sidebar,
-        attrs=@html.Attrs::build().aria_label("Show sidebar"),
-        icon(icon_layout_sidebar_left),
-      ),
-    )
+  let sidebar_toggle_label = if sidebar_open {
+    "Hide sidebar"
+  } else {
+    "Show sidebar"
   }
+  topbar.push(
+    @html.button(
+      class="topbar-toggle sidebar-boundary-toggle",
+      title=sidebar_toggle_label,
+      on_click=actions.toggle_sidebar,
+      attrs=@html.Attrs::build().aria_label(sidebar_toggle_label),
+      icon(icon_layout_sidebar_left),
+    ),
+  )
   let title = match self.selection {
     CodexDraftTask(_) => "New chat"
     CodexStoredTask(thread) => thread.title

--- a/desktop/frontend/codex/view.mbt
+++ b/desktop/frontend/codex/view.mbt
@@ -393,9 +393,8 @@ fn CodexGitStatus::presentation(
 
 ///|
 /// Shell-owned controls embedded in the Codex topbar. Passing commands keeps
-/// terminal, file-editor, sidebar, and external-link policy in the root shell.
+/// terminal, file-editor, and external-link policy in the root shell.
 pub(all) struct PageActions {
-  toggle_sidebar : @cmd.Cmd
   toggle_terminal : @cmd.Cmd
   toggle_files : @cmd.Cmd
   workspace_label : (@common.Uri) -> String
@@ -415,7 +414,6 @@ pub fn State::page(
   self : State,
   dispatch : @cmd.Emit[Msg],
   channel : @interop.ChannelId,
-  sidebar_open : Bool,
   terminal_open : Bool,
   file_panel_open : Bool,
   actions : PageActions,
@@ -423,20 +421,6 @@ pub fn State::page(
   // Account actions (sign in/out, the pending sign-in page) live in the
   // Settings page's Codex group; the topbar keeps only the status label.
   let topbar : Array[@html.Html] = []
-  let sidebar_toggle_label = if sidebar_open {
-    "Hide sidebar"
-  } else {
-    "Show sidebar"
-  }
-  topbar.push(
-    @html.button(
-      class="topbar-toggle sidebar-boundary-toggle",
-      title=sidebar_toggle_label,
-      on_click=actions.toggle_sidebar,
-      attrs=@html.Attrs::build().aria_label(sidebar_toggle_label),
-      icon(icon_layout_sidebar_left),
-    ),
-  )
   let title = match self.selection {
     CodexDraftTask(_) => "New chat"
     CodexStoredTask(thread) => thread.title

--- a/desktop/frontend/sidebar/pkg.generated.mbti
+++ b/desktop/frontend/sidebar/pkg.generated.mbti
@@ -28,7 +28,6 @@ pub fn Account::not_equal(Self, Self) -> Bool
 pub fn Account::to_repr(Self) -> @debug.Repr
 
 pub(all) struct Actions {
-  toggle : @cmd.Cmd
   update : @cmd.Cmd
   open_skills : @cmd.Cmd
   open_settings : @cmd.Cmd

--- a/desktop/frontend/sidebar/sidebar.mbt
+++ b/desktop/frontend/sidebar/sidebar.mbt
@@ -28,7 +28,6 @@ pub(all) struct Input {
 
 ///|
 pub(all) struct Actions {
-  toggle : @cmd.Cmd
   update : @cmd.Cmd
   open_skills : @cmd.Cmd
   open_settings : @cmd.Cmd
@@ -226,17 +225,10 @@ pub fn component(
       }
     }
     @html.aside([
-      // While the sidebar is visible, its own header owns the close action.
-      // The collapsed main topbar supplies the corresponding reopen action.
-      @html.div(class="sidebar-header", [
-        @html.button(
-          class="topbar-toggle",
-          title="Hide sidebar",
-          on_click=actions.toggle,
-          attrs=@html.Attrs::build().aria_label("Hide sidebar"),
-          @icons.icon(@icons.icon_layout_sidebar_left),
-        ),
-      ]),
+      // Navigation actions live with the hierarchy they affect. This empty
+      // strip exists only under the macOS overlay titlebar, where it protects
+      // the traffic-light controls and remains a native drag region.
+      @html.div(class="sidebar-header", @html.nothing),
       @html.div(class="sidebar-main", [
         @html.div(class="sidebar-section sessions", rows),
       ]),

--- a/desktop/frontend/sidebar/sidebar.mbt
+++ b/desktop/frontend/sidebar/sidebar.mbt
@@ -225,9 +225,7 @@ pub fn component(
       }
     }
     @html.aside([
-      // Navigation actions live with the hierarchy they affect. This empty
-      // strip exists only under the macOS overlay titlebar, where it protects
-      // the traffic-light controls and remains a native drag region.
+      // Reserve chrome for the shell-owned fixed toggle and native controls.
       @html.div(class="sidebar-header", @html.nothing),
       @html.div(class="sidebar-main", [
         @html.div(class="sidebar-section sessions", rows),

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -1372,19 +1372,22 @@ fn topbar_view(
   conv : Conversation,
 ) -> @html.Html {
   let items : Array[@html.Html] = []
-  // The visible sidebar owns its close action. Once collapsed, the topbar
-  // supplies the reopen action at the window's leading edge.
-  if !model.sidebar_open {
-    items.push(
-      @html.button(
-        class="topbar-toggle",
-        title="Show sidebar",
-        on_click=dispatch(ToggleSidebar),
-        attrs=@html.Attrs::build().aria_label("Show sidebar"),
-        icon(icon_layout_sidebar_left),
-      ),
-    )
+  // The layout action sits at the boundary it controls: beside the sidebar
+  // while open, and at the window edge while collapsed.
+  let sidebar_toggle_label = if model.sidebar_open {
+    "Hide sidebar"
+  } else {
+    "Show sidebar"
   }
+  items.push(
+    @html.button(
+      class="topbar-toggle sidebar-boundary-toggle",
+      title=sidebar_toggle_label,
+      on_click=dispatch(ToggleSidebar),
+      attrs=@html.Attrs::build().aria_label(sidebar_toggle_label),
+      icon(icon_layout_sidebar_left),
+    ),
+  )
   items.push(
     @html.span(
       class="topbar-title",
@@ -1495,27 +1498,28 @@ fn onboarding_view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
 }
 
 ///|
-/// Skills and Settings have no topbar, so while the sidebar is collapsed they
-/// float the reopen action at the window's leading edge.
+/// Skills and Settings have no topbar, so they float the layout control at the
+/// same sidebar boundary used by conversation topbars.
 fn page_with_toggle(
   dispatch : @cmd.Emit[Msg],
   model : Model,
   page : @html.Html,
 ) -> Array[@html.Html] {
-  if model.sidebar_open {
-    [page]
+  let sidebar_toggle_label = if model.sidebar_open {
+    "Hide sidebar"
   } else {
-    [
-      @html.button(
-        class="topbar-toggle page-sidebar-toggle",
-        title="Show sidebar",
-        on_click=dispatch(ToggleSidebar),
-        attrs=@html.Attrs::build().aria_label("Show sidebar"),
-        icon(icon_layout_sidebar_left),
-      ),
-      page,
-    ]
+    "Show sidebar"
   }
+  [
+    @html.button(
+      class="topbar-toggle page-sidebar-toggle sidebar-boundary-toggle",
+      title=sidebar_toggle_label,
+      on_click=dispatch(ToggleSidebar),
+      attrs=@html.Attrs::build().aria_label(sidebar_toggle_label),
+      icon(icon_layout_sidebar_left),
+    ),
+    page,
+  ]
 }
 
 ///|
@@ -1643,25 +1647,12 @@ fn console_gate_view(
 }
 
 ///|
-/// Root shell classes keep platform chrome geometry explicit in CSS. Browser
-/// pages and Linux retain ordinary header geometry; native Apple and Windows
-/// windows expose the distinct control reserves their overlays require.
-fn app_shell_class(
-  sidebar_open : Bool,
-  is_desktop : Bool,
-  platform : String,
-  is_windows? : Bool = @common.platform_is_win32(),
-) -> String {
+/// Native chrome geometry is owned by the window subscription, independently
+/// of the application view's sidebar state.
+fn app_shell_class(sidebar_open : Bool) -> String {
   let classes : Array[String] = ["app"]
   if !sidebar_open {
     classes.push("sidebar-collapsed")
-  }
-  if is_desktop && browser_platform_is_apple(platform) {
-    classes.push("native-titlebar-overlay")
-    classes.push("native-apple-titlebar")
-  } else if is_desktop && is_windows {
-    classes.push("native-titlebar-overlay")
-    classes.push("native-windows-titlebar")
   }
   classes.join(" ")
 }
@@ -1774,7 +1765,6 @@ fn view(
   let window_titlebar_drag_strip = window_titlebar_drag_strip_visible(
     window_titlebar_page,
     model.is_desktop,
-    app_shortcut_browser_platform(),
   )
   let content = match model.screen {
     // The one fork that decides what the conversation column is. A chat needs
@@ -1930,14 +1920,7 @@ fn view(
   if model.is_desktop && model.bridge_state() is BridgeLost(message) {
     children.push(bridge_lost_overlay(message))
   }
-  @html.div(
-    class=app_shell_class(
-      model.sidebar_open,
-      model.is_desktop,
-      app_shortcut_browser_platform(),
-    ),
-    children,
-  )
+  @html.div(class=app_shell_class(model.sidebar_open), children)
 }
 
 ///|

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -1372,22 +1372,6 @@ fn topbar_view(
   conv : Conversation,
 ) -> @html.Html {
   let items : Array[@html.Html] = []
-  // The layout action sits at the boundary it controls: beside the sidebar
-  // while open, and at the window edge while collapsed.
-  let sidebar_toggle_label = if model.sidebar_open {
-    "Hide sidebar"
-  } else {
-    "Show sidebar"
-  }
-  items.push(
-    @html.button(
-      class="topbar-toggle sidebar-boundary-toggle",
-      title=sidebar_toggle_label,
-      on_click=dispatch(ToggleSidebar),
-      attrs=@html.Attrs::build().aria_label(sidebar_toggle_label),
-      icon(icon_layout_sidebar_left),
-    ),
-  )
   items.push(
     @html.span(
       class="topbar-title",
@@ -1495,31 +1479,6 @@ fn onboarding_view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
     _ => card.push(@html.p("Connecting to this device…"))
   }
   @html.section(class="onboarding", [@html.div(class="onboarding-card", card)])
-}
-
-///|
-/// Skills and Settings have no topbar, so they float the layout control at the
-/// same sidebar boundary used by conversation topbars.
-fn page_with_toggle(
-  dispatch : @cmd.Emit[Msg],
-  model : Model,
-  page : @html.Html,
-) -> Array[@html.Html] {
-  let sidebar_toggle_label = if model.sidebar_open {
-    "Hide sidebar"
-  } else {
-    "Show sidebar"
-  }
-  [
-    @html.button(
-      class="topbar-toggle page-sidebar-toggle sidebar-boundary-toggle",
-      title=sidebar_toggle_label,
-      on_click=dispatch(ToggleSidebar),
-      attrs=@html.Attrs::build().aria_label(sidebar_toggle_label),
-      icon(icon_layout_sidebar_left),
-    ),
-    page,
-  ]
 }
 
 ///|
@@ -1775,17 +1734,12 @@ fn view(
     Chat =>
       if model.conversation_load_failure is Some(failure) &&
         model.selected_conversation == Some(failure.target) {
-        page_with_toggle(
-          dispatch,
-          model,
-          conversation_load_failed_view(dispatch, failure.message),
-        )
+        [conversation_load_failed_view(dispatch, failure.message)]
       } else if !model.selected_conversation_loaded() {
-        page_with_toggle(dispatch, model, conversation_loading_view())
+        [conversation_loading_view()]
       } else {
         match model.active_conversation() {
-          None =>
-            page_with_toggle(dispatch, model, onboarding_view(dispatch, model))
+          None => [onboarding_view(dispatch, model)]
           Some(conv) =>
             [
               topbar_view(
@@ -1804,11 +1758,9 @@ fn view(
       model.codex.page(
         dispatch.map(msg => Codex(channel=model.focused, msg)),
         model.focused,
-        model.sidebar_open,
         terminal_panel_visible,
         file_panel_visible,
         @codex.PageActions::{
-          toggle_sidebar: dispatch(ToggleSidebar),
           toggle_terminal,
           toggle_files: toggle_right_panel,
           workspace_label: workspace => @resource.label(workspace),
@@ -1816,11 +1768,9 @@ fn view(
           composer: codex_composer_html,
         },
       )
-    Skills => page_with_toggle(dispatch, model, skills_html)
-    Settings =>
-      page_with_toggle(dispatch, model, settings_page(dispatch, model))
-    WorkspaceSettings(..) =>
-      page_with_toggle(dispatch, model, workspace_settings_html)
+    Skills => [skills_html]
+    Settings => [settings_page(dispatch, model)]
+    WorkspaceSettings(..) => [workspace_settings_html]
   }
   // The app is `sidebar | content`; `content` itself splits into the
   // conversation (left) and the editor (right) as two independent parts, so
@@ -1844,6 +1794,11 @@ fn view(
   } else {
     content
   }
+  let sidebar_toggle_label = if model.sidebar_open {
+    "Hide sidebar"
+  } else {
+    "Show sidebar"
+  }
   let children : Array[@html.Html] = [
     sidebar_html,
     @html.div(class=content_class, [
@@ -1858,6 +1813,14 @@ fn view(
       right_panel_html,
       terminal_html,
     ]),
+    // One shell-owned control remains outside all animated content tracks.
+    @html.button(
+      class="sidebar-toggle",
+      title=sidebar_toggle_label,
+      on_click=dispatch(ToggleSidebar),
+      attrs=@html.Attrs::build().aria_label(sidebar_toggle_label),
+      icon(icon_layout_sidebar_left),
+    ),
   ]
   // On the narrow layout the sidebar's stable backdrop fades with the drawer;
   // keeping it mounted lets the closing transition finish before it becomes

--- a/desktop/frontend/view_wbtest.mbt
+++ b/desktop/frontend/view_wbtest.mbt
@@ -1,22 +1,7 @@
 ///|
-test "native overlay shell classes stay desktop and platform specific" {
-  assert_eq(app_shell_class(true, false, "MacIntel", is_windows=false), "app")
-  assert_eq(
-    app_shell_class(false, false, "Win32", is_windows=true),
-    "app sidebar-collapsed",
-  )
-  assert_eq(
-    app_shell_class(true, true, "MacIntel", is_windows=false),
-    "app native-titlebar-overlay native-apple-titlebar",
-  )
-  assert_eq(
-    app_shell_class(false, true, "Windows", is_windows=true),
-    "app sidebar-collapsed native-titlebar-overlay native-windows-titlebar",
-  )
-  assert_eq(
-    app_shell_class(true, true, "Linux x86_64", is_windows=false),
-    "app",
-  )
+test "shell classes leave native geometry to the window subscription" {
+  assert_eq(app_shell_class(true), "app")
+  assert_eq(app_shell_class(false), "app sidebar-collapsed")
 }
 
 ///|

--- a/desktop/frontend/window_titlebar.mbt
+++ b/desktop/frontend/window_titlebar.mbt
@@ -59,7 +59,6 @@ extern "js" fn install_window_titlebar_geometry() -> @js.Value =
   #|       area.x < 0 || area.y < 0 || area.width <= 0 || area.height <= 0
   #|     )) throw new Error("Invalid Proton titlebar area");
   #|     html.classList.toggle("native-titlebar-overlay", area !== null);
-  #|     html.classList.toggle("native-titlebar-leading-controls", area !== null && area.x > 0);
   #|     if (area === null) {
   #|       for (const name of ["left", "right", "height"]) {
   #|         html.style.removeProperty(`--native-titlebar-${name}`);

--- a/desktop/frontend/window_titlebar.mbt
+++ b/desktop/frontend/window_titlebar.mbt
@@ -1,7 +1,5 @@
-// The native overlay titlebar is painted by the page, so its web content has
-// to recreate the operating system's double-click-to-zoom convention. Keep
-// the gesture at the document boundary: the visible top chrome is split
-// between the left sidebar, conversation topbar, and expanded editor strip.
+// Proton owns native control geometry; this window-local subscription mirrors
+// its available titlebar area into CSS and manages the page's drag regions.
 
 ///|
 const WindowTitlebarSelector = ".sidebar-header, .topbar, .editor-tabsbar, .window-titlebar-drag-strip"
@@ -10,28 +8,11 @@ const WindowTitlebarSelector = ".sidebar-header, .topbar, .editor-tabsbar, .wind
 const WindowTitlebarExcludedSelector = "button, a, input, textarea, select, [role=button], [contenteditable=true], .editor-tab, .dock-menu"
 
 ///|
-fn window_titlebar_platform_supports_overlay(
-  platform : String,
-  is_windows? : Bool = @common.platform_is_win32(),
-) -> Bool {
-  browser_platform_is_apple(platform) || is_windows
-}
-
-///|
-fn window_titlebar_overlay_supported() -> Bool {
-  window_titlebar_platform_supports_overlay(app_shortcut_browser_platform())
-}
-
-///|
 fn window_titlebar_drag_strip_visible(
   page_without_topbar : Bool,
   is_desktop : Bool,
-  platform : String,
-  is_windows? : Bool = @common.platform_is_win32(),
 ) -> Bool {
-  page_without_topbar &&
-  is_desktop &&
-  window_titlebar_platform_supports_overlay(platform, is_windows~)
+  page_without_topbar && is_desktop
 }
 
 ///|
@@ -43,23 +24,105 @@ fn is_window_titlebar_double_click_target(element : @dom.Element) -> Bool {
 }
 
 ///|
-/// CEF needs the initial drag region assigned after the DOM exists. Repeating
-/// this during subscription reconciliation also covers a topbar replaced by a
-/// page transition; CSS remains the steady-state declaration.
-extern "js" fn install_window_titlebar_drag_regions() -> Unit =
+/// Geometry is transient renderer state, not a session or host preference.
+/// Native state events cover OS fullscreen transitions (which are not DOM
+/// fullscreen events); resize also covers page zoom. Only the latest query may
+/// publish geometry. Subscription reconciliation republishes CEF drag regions
+/// for new DOM without issuing another native query.
+extern "js" fn install_window_titlebar_geometry() -> @js.Value =
   #| () => {
-  #|   const roots = document.querySelectorAll(
-  #|     ".sidebar-header, .topbar, .editor-tabsbar, .window-titlebar-drag-strip",
-  #|   );
+  #|   const html = document.documentElement;
+  #|   const selector = ".sidebar-header, .topbar, .editor-tabsbar, .window-titlebar-drag-strip";
   #|   const excluded =
   #|     "button, a, input, textarea, select, [role=button], [contenteditable=true], .editor-tab, .dock-menu";
-  #|   for (const root of roots) {
-  #|     root.style.webkitAppRegion = "drag";
-  #|     for (const control of root.querySelectorAll(excluded)) {
-  #|       control.style.webkitAppRegion = "no-drag";
+  #|   let active = true;
+  #|   let revision = 0;
+  #|   let inFlight = false;
+  #|   let frame = null;
+  #|   let retry = null;
+  #|   let unsubscribe = null;
+  #|   const refreshDom = () => {
+  #|     const drag = html.classList.contains("native-titlebar-overlay");
+  #|     for (const root of document.querySelectorAll(selector)) {
+  #|       root.style.webkitAppRegion = drag ? "drag" : "no-drag";
+  #|       for (const control of root.querySelectorAll(excluded)) {
+  #|         control.style.webkitAppRegion = "no-drag";
+  #|       }
   #|     }
-  #|   }
+  #|   };
+  #|   const publish = (area) => {
+  #|     // null means no overlay (including native fullscreen). A rejected or
+  #|     // malformed query must not be mistaken for that successful answer.
+  #|     if (area !== null && (
+  #|       typeof area !== "object" ||
+  #|       ![area.x, area.y, area.width, area.height].every(Number.isFinite) ||
+  #|       area.x < 0 || area.y < 0 || area.width <= 0 || area.height <= 0
+  #|     )) throw new Error("Invalid Proton titlebar area");
+  #|     html.classList.toggle("native-titlebar-overlay", area !== null);
+  #|     html.classList.toggle("native-titlebar-leading-controls", area !== null && area.x > 0);
+  #|     if (area === null) {
+  #|       for (const name of ["left", "right", "height"]) {
+  #|         html.style.removeProperty(`--native-titlebar-${name}`);
+  #|       }
+  #|     } else {
+  #|       html.style.setProperty("--native-titlebar-left", `${area.x}px`);
+  #|       html.style.setProperty("--native-titlebar-right", `${Math.max(0, window.innerWidth - area.x - area.width)}px`);
+  #|       html.style.setProperty("--native-titlebar-height", `${area.y + area.height}px`);
+  #|     }
+  #|     refreshDom();
+  #|   };
+  #|   const schedule = () => {
+  #|     if (active && !inFlight && frame === null) frame = requestAnimationFrame(read);
+  #|   };
+  #|   const read = async () => {
+  #|     frame = null;
+  #|     const requested = revision;
+  #|     inFlight = true;
+  #|     try {
+  #|       const area = await globalThis.__MoonBit__.getTitlebarArea();
+  #|       if (active && requested === revision) publish(area);
+  #|     } catch (error) {
+  #|       if (active && requested === revision) console.error("Titlebar geometry query failed", error);
+  #|     } finally {
+  #|       inFlight = false;
+  #|       if (requested !== revision) schedule();
+  #|     }
+  #|   };
+  #|   const refresh = () => { revision++; schedule(); };
+  #|   const connect = (attempt) => {
+  #|     if (!active) return;
+  #|     const bridge = globalThis.__MoonBit__;
+  #|     // Wait for injection, not for compatibility with an older host.
+  #|     if (!bridge?.getTitlebarArea || !bridge?.events?.on) {
+  #|       if (attempt < 120) retry = setTimeout(() => connect(attempt + 1), 25);
+  #|       else console.error("Proton titlebar bridge unavailable");
+  #|       return;
+  #|     }
+  #|     unsubscribe = bridge.events.on("openseek.window.chrome_changed", refresh);
+  #|     window.addEventListener("resize", refresh);
+  #|     window.addEventListener("focus", refresh);
+  #|     document.addEventListener("visibilitychange", refresh);
+  #|     refresh();
+  #|   };
+  #|   connect(0);
+  #|   return {
+  #|     refreshDom,
+  #|     dispose() {
+  #|       active = false;
+  #|       clearTimeout(retry);
+  #|       if (frame !== null) cancelAnimationFrame(frame);
+  #|       if (unsubscribe !== null) unsubscribe();
+  #|       window.removeEventListener("resize", refresh);
+  #|       window.removeEventListener("focus", refresh);
+  #|       document.removeEventListener("visibilitychange", refresh);
+  #|       publish(null);
+  #|     }
+  #|   };
   #| }
+
+///|
+extern "js" fn window_titlebar_overlay_visible() -> Bool =
+  #| () => document.documentElement.classList.contains("native-titlebar-overlay")
 
 ///|
 priv suberror WindowTitlebarSubscription {
@@ -75,9 +138,10 @@ fn window_titlebar_sub_loader(
     WindowTitlebarSubscription(emit) => {
       let mut emit = emit
       let target = @dom.document().as_event_target()
-      install_window_titlebar_drag_regions()
+      let geometry = install_window_titlebar_geometry()
       let listener : @dom.Listener = event => {
-        guard event.to_mouse_event() is Some(mouse) &&
+        guard window_titlebar_overlay_visible() &&
+          event.to_mouse_event() is Some(mouse) &&
           mouse.get_button() == 0 &&
           event.target().to_element() is Some(element) &&
           is_window_titlebar_double_click_target(element) else {
@@ -91,6 +155,10 @@ fn window_titlebar_sub_loader(
       target.add_event_listener_with_options("dblclick", listener, capture=true)
       Some({
         unload: _ => {
+          let _ : @js.Value = geometry.apply_with_string(
+            "dispose",
+            ([] : Array[@js.Value]),
+          )
           target.remove_event_listener_with_options(
             "dblclick",
             listener,
@@ -100,7 +168,10 @@ fn window_titlebar_sub_loader(
         update_tagger: payload => {
           guard payload is WindowTitlebarSubscription(next) else { return }
           emit = next
-          install_window_titlebar_drag_regions()
+          let _ : @js.Value = geometry.apply_with_string(
+            "refreshDom",
+            ([] : Array[@js.Value]),
+          )
         },
       })
     }
@@ -109,8 +180,8 @@ fn window_titlebar_sub_loader(
 }
 
 ///|
-/// Install only after the caller has established that this is a desktop page
-/// on a platform where Proton overlays web content into the native titlebar.
+/// Install only in the native desktop page. Proton decides whether the current
+/// window has an overlay; browser clients never query native window geometry.
 fn window_titlebar_subscription(emit : @cmd.Emit[Unit]) -> @sub.Sub {
   @sub.custom_sub(
     "window-titlebar-double-click",

--- a/desktop/frontend/window_titlebar_wbtest.mbt
+++ b/desktop/frontend/window_titlebar_wbtest.mbt
@@ -35,41 +35,8 @@ test "the explicit blank-page drag strip is titlebar chrome" {
 }
 
 ///|
-test "window titlebar gesture follows Proton overlay platforms" {
-  assert_true(
-    window_titlebar_platform_supports_overlay("MacIntel", is_windows=false),
-  )
-  assert_true(
-    window_titlebar_platform_supports_overlay("Windows", is_windows=true),
-  )
-  assert_true(
-    window_titlebar_platform_supports_overlay("Win32", is_windows=true),
-  )
-  assert_false(
-    window_titlebar_platform_supports_overlay("Linux x86_64", is_windows=false),
-  )
-}
-
-///|
-test "blank-page drag strip exists only in a native overlay window" {
-  assert_true(
-    window_titlebar_drag_strip_visible(true, true, "Windows", is_windows=true),
-  )
-  assert_true(
-    window_titlebar_drag_strip_visible(true, true, "MacIntel", is_windows=false),
-  )
-  assert_false(
-    window_titlebar_drag_strip_visible(false, true, "Windows", is_windows=true),
-  )
-  assert_false(
-    window_titlebar_drag_strip_visible(true, false, "Windows", is_windows=true),
-  )
-  assert_false(
-    window_titlebar_drag_strip_visible(
-      true,
-      true,
-      "Linux x86_64",
-      is_windows=false,
-    ),
-  )
+test "blank native pages provide a drag target whose visibility follows geometry" {
+  assert_true(window_titlebar_drag_strip_visible(true, true))
+  assert_false(window_titlebar_drag_strip_visible(false, true))
+  assert_false(window_titlebar_drag_strip_visible(true, false))
 }

--- a/desktop/internal/extension/extension.mbt
+++ b/desktop/internal/extension/extension.mbt
@@ -162,13 +162,20 @@ let semantic_search_progress_event : @proton_contract.Event[
 )
 
 ///|
-/// The one window-local event: native browser view events (navigation,
+/// Window-local native browser view events (navigation,
 /// title, load state), pumped in by `App::on_view_event` through
 /// `DesktopBridgeActor::notify_browser_event`. It deliberately has no
 /// `NotificationKind` — the shared wire catalog must never carry it to a
 /// relay client, which has no native views.
 let browser_event : @proton_contract.Event[Json] = @commands.extension_contract.event(
   "browser.event",
+)
+
+///|
+/// A window-local invalidation, not shared host state. The renderer queries
+/// Proton's current titlebar area; no native coordinates enter the relay.
+let window_chrome_changed : @proton_contract.Event[@protocol.EmptyPayload] = @commands.extension_contract.event(
+  "window.chrome_changed",
 )
 
 ///|
@@ -182,6 +189,7 @@ priv enum BridgeControl {
   PageConnected(@proton.CommandContext, @async.Queue[Unit])
   WindowReady(@proton.WindowEventEmitter)
   WindowClosed
+  WindowChromeChanged
 }
 
 ///|
@@ -191,6 +199,7 @@ priv enum BridgeControl {
 priv enum PageNotification {
   Hub(@protocol.Notification)
   BrowserEvent(Json)
+  WindowChromeChanged
 }
 
 ///|
@@ -247,6 +256,7 @@ async fn PageEventTarget::emit(
     Hub(SemanticSearchProgress(payload)) =>
       self.events.emit(semantic_search_progress_event, payload)
     BrowserEvent(payload) => self.events.emit(browser_event, payload)
+    WindowChromeChanged => self.events.emit(window_chrome_changed, NoPayload)
   }
 }
 
@@ -305,6 +315,13 @@ pub async fn DesktopBridgeActor::notify_browser_event(
   params : Json,
 ) -> Unit {
   self.browser_events.put(params)
+}
+
+///|
+pub async fn DesktopBridgeActor::notify_window_chrome_changed(
+  self : DesktopBridgeActor,
+) -> Unit {
+  self.controls.put(WindowChromeChanged)
 }
 
 ///|
@@ -484,6 +501,8 @@ pub async fn DesktopBridgeActor::run(self : DesktopBridgeActor) -> Unit {
               target = None
               pending.clear()
             }
+            WindowChromeChanged =>
+              deliver_to_page(connected, target, pending, WindowChromeChanged)
           }
         Deliver(notification) =>
           deliver_to_page(connected, target, pending, notification)

--- a/desktop/internal/extension/pkg.generated.mbti
+++ b/desktop/internal/extension/pkg.generated.mbti
@@ -27,6 +27,7 @@ pub fn BrowserViews::window_ready(Self, @proton.WindowHandle) -> Unit
 type DesktopBridgeActor
 pub fn DesktopBridgeActor::DesktopBridgeActor(@api.ApiState) -> Self
 pub async fn DesktopBridgeActor::notify_browser_event(Self, Json) -> Unit
+pub async fn DesktopBridgeActor::notify_window_chrome_changed(Self) -> Unit
 pub async fn DesktopBridgeActor::run(Self) -> Unit
 pub async fn DesktopBridgeActor::window_closed(Self) -> Unit
 pub async fn DesktopBridgeActor::window_ready(Self, @proton.WindowEventEmitter) -> Unit

--- a/desktop/main.mbt
+++ b/desktop/main.mbt
@@ -210,6 +210,16 @@ async fn main {
         bridge.window_closed()
       },
     )
+    // Geometry can change without a DOM fullscreen event (native fullscreen,
+    // display scaling, or page zoom). Only this window's page is notified.
+    .on_window_event(async fn(_, event) noraise {
+      if event is StateChanged(_) {
+        bridge.notify_window_chrome_changed() catch {
+          // Cancellation during shutdown leaves no page to notify.
+          _ => ()
+        }
+      }
+    })
     // Browser view events reach the page as `browser.event` notifications;
     // views that are not browser tabs are not the frontend's business.
     .on_view_event(async fn(view, event) noraise {

--- a/desktop/styles/base.css
+++ b/desktop/styles/base.css
@@ -297,24 +297,22 @@ html {
   --resize-handle-height: 6px;
   --sidebar-column-width: clamp(220px, var(--sidebar-width, 264px), 480px);
   --sidebar-drawer-width: min(320px, 86vw);
-  --sidebar-boundary-width: var(--sidebar-column-width);
   --sidebar-toggle-size: 28px;
   --topbar-inline-padding: 18px;
   --app-header-height: 46px;
   --topbar-height: max(var(--app-header-height), var(--native-titlebar-height, 0px));
-  --topbar-leading-toggle-offset: -4px;
   --sidebar-toggle-inline-inset: max(
-    calc(var(--topbar-inline-padding) + var(--topbar-leading-toggle-offset)),
-    calc(var(--native-titlebar-left, 0px) - var(--sidebar-boundary-width))
+    calc(var(--topbar-inline-padding) - 4px),
+    var(--native-titlebar-left, 0px)
   );
   --sidebar-toggle-trailing-gap: 12px;
-  --sidebar-toggle-inline-start: min(
-    calc(var(--sidebar-boundary-width) + var(--sidebar-toggle-inline-inset)),
-    calc(100vw - var(--sidebar-toggle-size))
-  );
   --sidebar-toggle-reserved-width: calc(
     var(--sidebar-toggle-inline-inset) + var(--sidebar-toggle-size) +
       var(--sidebar-toggle-trailing-gap)
+  );
+  --main-titlebar-leading-inset: max(
+    var(--topbar-inline-padding),
+    calc(var(--sidebar-toggle-reserved-width) - var(--sidebar-column-width))
   );
   display: grid;
   /* The sidebar track reads `--sidebar-width`, set as the user drags the
@@ -385,15 +383,8 @@ html.native-titlebar-overlay .app
   height: var(--topbar-height);
 }
 
-/* Proton reports the safe titlebar rectangle in CSS pixels. The sidebar
-   already protects part of the left edge; only the remaining inset belongs
-   to the main column. Right controls belong to the rightmost visible header. */
-html.native-titlebar-overlay .app .topbar {
-  padding-left: max(
-    var(--topbar-inline-padding),
-    calc(var(--native-titlebar-left, 0px) - var(--sidebar-column-width) - var(--topbar-leading-toggle-offset))
-  );
-}
+/* Native right controls belong to the rightmost visible header. The fixed
+   sidebar toggle reserves its own leading space on every platform. */
 html.native-titlebar-overlay .app .content:not(.panel-open) .topbar,
 html.native-titlebar-overlay .app .content.panel-open .editor-tabsbar {
   padding-right: max(var(--topbar-inline-padding), var(--native-titlebar-right, 0px));
@@ -452,18 +443,7 @@ html.native-titlebar-overlay .app .window-titlebar-drag-strip {
   grid-template-columns: 0 minmax(0, 1fr);
 }
 
-/* Expanded hides the zero-width conversation column behind the editor. Float
-   its sidebar control back to the boundary it owns and reserve matching room
-   in the tab strip so open tabs never sit underneath it. */
-.content.panel-expanded :where(.topbar > .sidebar-boundary-toggle) {
-  position: fixed;
-  inset-block-start: calc(
-    (var(--topbar-height) - var(--sidebar-toggle-size)) / 2
-  );
-  inset-inline-start: var(--sidebar-toggle-inline-start);
-  z-index: var(--z-editor-overlay-control);
-  margin-inline-start: 0;
-}
+/* The expanded editor occupies the main column and inherits its reservation. */
 .content.panel-expanded .editor-tabsbar {
-  padding-inline-start: var(--sidebar-toggle-reserved-width);
+  padding-inline-start: var(--main-titlebar-leading-inset);
 }

--- a/desktop/styles/base.css
+++ b/desktop/styles/base.css
@@ -297,13 +297,21 @@ html {
   --resize-handle-height: 6px;
   --sidebar-column-width: clamp(220px, var(--sidebar-width, 264px), 480px);
   --sidebar-drawer-width: min(320px, 86vw);
+  --sidebar-boundary-width: var(--sidebar-column-width);
   --sidebar-toggle-size: 28px;
   --topbar-inline-padding: 18px;
+  --app-header-height: 46px;
+  --topbar-height: max(var(--app-header-height), var(--native-titlebar-height, 0px));
   --topbar-leading-toggle-offset: -4px;
-  --sidebar-toggle-inline-inset: calc(
-    var(--topbar-inline-padding) + var(--topbar-leading-toggle-offset)
+  --sidebar-toggle-inline-inset: max(
+    calc(var(--topbar-inline-padding) + var(--topbar-leading-toggle-offset)),
+    calc(var(--native-titlebar-left, 0px) - var(--sidebar-boundary-width))
   );
   --sidebar-toggle-trailing-gap: 12px;
+  --sidebar-toggle-inline-start: min(
+    calc(var(--sidebar-boundary-width) + var(--sidebar-toggle-inline-inset)),
+    calc(100vw - var(--sidebar-toggle-size))
+  );
   --sidebar-toggle-reserved-width: calc(
     var(--sidebar-toggle-inline-inset) + var(--sidebar-toggle-size) +
       var(--sidebar-toggle-trailing-gap)
@@ -340,14 +348,14 @@ html {
    Empty chrome drags the native window; every interactive descendant opts
    back out. The inline mirror in window_titlebar.mbt makes CEF publish the
    initial regions after DOM creation. */
-.app.native-titlebar-overlay .sidebar-header,
-.app.native-titlebar-overlay .topbar,
-.app.native-titlebar-overlay .editor-tabsbar,
-.app.native-titlebar-overlay .window-titlebar-drag-strip {
+html.native-titlebar-overlay .app .sidebar-header,
+html.native-titlebar-overlay .app .topbar,
+html.native-titlebar-overlay .app .editor-tabsbar,
+html.native-titlebar-overlay .app .window-titlebar-drag-strip {
   -webkit-app-region: drag;
   user-select: none;
 }
-.app.native-titlebar-overlay
+html.native-titlebar-overlay .app
   :is(.sidebar-header, .topbar, .editor-tabsbar)
   :is(
     button,
@@ -370,50 +378,29 @@ html {
   position: relative;
 }
 .window-titlebar-drag-strip {
+  display: none;
   position: absolute;
   inset: 0 0 auto 0;
   z-index: 2;
-  height: 46px;
+  height: var(--topbar-height);
 }
 
-/* macOS keeps its traffic-light controls in the top-left corner. Whichever
-   header owns the sidebar toggle reserves that native hit area. */
-.app.native-apple-titlebar {
-  --native-titlebar-leading-inset: 88px;
+/* Proton reports the safe titlebar rectangle in CSS pixels. The sidebar
+   already protects part of the left edge; only the remaining inset belongs
+   to the main column. Right controls belong to the rightmost visible header. */
+html.native-titlebar-overlay .app .topbar {
+  padding-left: max(
+    var(--topbar-inline-padding),
+    calc(var(--native-titlebar-left, 0px) - var(--sidebar-column-width) - var(--topbar-leading-toggle-offset))
+  );
 }
-.app.native-apple-titlebar.sidebar-collapsed {
-  --sidebar-toggle-inline-inset: var(--native-titlebar-leading-inset);
+html.native-titlebar-overlay .app .content:not(.panel-open) .topbar,
+html.native-titlebar-overlay .app .content.panel-open .editor-tabsbar {
+  padding-right: max(var(--topbar-inline-padding), var(--native-titlebar-right, 0px));
 }
-.app.native-apple-titlebar .sidebar-header,
-.app.native-apple-titlebar.sidebar-collapsed .topbar {
-  padding-inline-start: var(--native-titlebar-leading-inset);
-}
-
-/* Windows keeps its real minimize/maximize/close cluster in the top-right.
-   Compact all app header variants to one 40px row and reserve the live
-   caption-button width on whichever column reaches the window edge. 150px is
-   Proton's Windows overlay reserve at 100% scale; CSS pixels and native
-   logical coordinates scale together at higher DPI. */
-.app.native-windows-titlebar {
-  --native-titlebar-height: 40px;
-  --native-titlebar-caption-inset: 150px;
-}
-.app.native-windows-titlebar main {
-  --topbar-height: var(--native-titlebar-height);
-}
-.app.native-windows-titlebar .sidebar-header,
-.app.native-windows-titlebar .editor-tabsbar {
-  height: var(--native-titlebar-height);
-}
-.app.native-windows-titlebar .content:not(.panel-open) .topbar {
-  padding-right: var(--native-titlebar-caption-inset);
-}
-.app.native-windows-titlebar .content.panel-open .editor-tabsbar {
-  padding-right: var(--native-titlebar-caption-inset);
-}
-.app.native-windows-titlebar .window-titlebar-drag-strip {
-  right: var(--native-titlebar-caption-inset);
-  height: var(--native-titlebar-height);
+html.native-titlebar-overlay .app .window-titlebar-drag-strip {
+  display: block;
+  right: var(--native-titlebar-right, 0px);
 }
 /* The conversation (left) and the editor (right) live side by side as two
    independent parts. The editor track is zero-width until the panel
@@ -465,21 +452,18 @@ html {
   grid-template-columns: 0 minmax(0, 1fr);
 }
 
-/* With both the sidebar collapsed and the editor expanded, the reopen action
-   would otherwise stay inside the main column's zero-width track. Float that
-   one fallback above the editor and reserve matching tab-strip room. */
-.app.sidebar-collapsed
-  .content.panel-expanded
-  .topbar
-  > .topbar-toggle {
+/* Expanded hides the zero-width conversation column behind the editor. Float
+   its sidebar control back to the boundary it owns and reserve matching room
+   in the tab strip so open tabs never sit underneath it. */
+.content.panel-expanded :where(.topbar > .sidebar-boundary-toggle) {
   position: fixed;
   inset-block-start: calc(
     (var(--topbar-height) - var(--sidebar-toggle-size)) / 2
   );
-  inset-inline-start: var(--sidebar-toggle-inline-inset);
+  inset-inline-start: var(--sidebar-toggle-inline-start);
   z-index: var(--z-editor-overlay-control);
   margin-inline-start: 0;
 }
-.app.sidebar-collapsed .content.panel-expanded .editor-tabsbar {
+.content.panel-expanded .editor-tabsbar {
   padding-inline-start: var(--sidebar-toggle-reserved-width);
 }

--- a/desktop/styles/codex.css
+++ b/desktop/styles/codex.css
@@ -67,7 +67,7 @@
   );
 }
 
-.codex-topbar > button:not(.topbar-toggle):not(.panel-toggle) {
+.codex-topbar > button:not(.panel-toggle) {
   flex: 0 0 auto;
   padding: 5px 9px;
   border-color: transparent;

--- a/desktop/styles/file_panel.css
+++ b/desktop/styles/file_panel.css
@@ -63,7 +63,7 @@ button.panel-toggle:not(:disabled):hover {
   align-items: center;
   gap: 10px;
   flex: 0 0 auto;
-  height: 46px;
+  height: var(--topbar-height);
   padding: 0 18px 0 12px;
   border-bottom: 1px solid var(--color-separator);
   background: var(--color-bg-surface);

--- a/desktop/styles/file_panel.css
+++ b/desktop/styles/file_panel.css
@@ -59,6 +59,7 @@ button.panel-toggle:not(:disabled):hover {
    opens/closes). Always rendered — the editor's child order is
    structural (see panel_view). */
 .editor-tabsbar {
+  transition: padding-inline-start var(--drawer-duration) var(--drawer-easing);
   display: flex;
   align-items: center;
   gap: 10px;

--- a/desktop/styles/main_header.css
+++ b/desktop/styles/main_header.css
@@ -28,17 +28,24 @@ main {
   height: var(--topbar-height);
   padding-block: 0;
   padding-inline: var(--topbar-inline-padding);
+  padding-inline-start: var(--main-titlebar-leading-inset);
+  transition: padding-inline-start var(--drawer-duration) var(--drawer-easing);
   border-bottom: 1px solid var(--color-separator);
   background: var(--color-bg-surface);
 }
 
-.topbar-toggle {
-  flex: none;
+.sidebar-toggle {
+  position: fixed;
+  inset-block-start: calc(
+    (var(--topbar-height) - var(--sidebar-toggle-size)) / 2
+  );
+  inset-inline-start: var(--sidebar-toggle-inline-inset);
+  z-index: var(--z-titlebar-control);
+  -webkit-app-region: no-drag;
   display: grid;
   place-items: center;
   inline-size: var(--sidebar-toggle-size);
   block-size: var(--sidebar-toggle-size);
-  margin-inline-start: var(--topbar-leading-toggle-offset);
   border: 0;
   border-radius: var(--radius-sm);
   background: transparent;
@@ -47,20 +54,9 @@ main {
   line-height: var(--line-height-tight);
   cursor: pointer;
 }
-.topbar-toggle:hover {
+.sidebar-toggle:hover {
   background: var(--color-bg-subtle);
   color: var(--color-text-primary);
-}
-
-/* Pages without a topbar float the same control at the live sidebar boundary. */
-.page-sidebar-toggle {
-  position: fixed;
-  inset-block-start: calc(
-    (var(--topbar-height) - var(--sidebar-toggle-size)) / 2
-  );
-  inset-inline-start: var(--sidebar-toggle-inline-start);
-  z-index: var(--z-titlebar-control);
-  margin-inline-start: 0;
 }
 
 .topbar-title {

--- a/desktop/styles/main_header.css
+++ b/desktop/styles/main_header.css
@@ -2,8 +2,6 @@
 
 /* ---------- main column ---------- */
 main {
-  --topbar-height: 46px;
-
   display: grid;
   grid-template-rows: auto minmax(0, 1fr) auto;
   /* Constrain the single column too: without this it defaults to `auto`
@@ -54,13 +52,13 @@ main {
   color: var(--color-text-primary);
 }
 
-/* Pages without a topbar float the reopen action at the window's leading edge. */
+/* Pages without a topbar float the same control at the live sidebar boundary. */
 .page-sidebar-toggle {
   position: fixed;
   inset-block-start: calc(
     (var(--topbar-height) - var(--sidebar-toggle-size)) / 2
   );
-  inset-inline-start: var(--sidebar-toggle-inline-inset);
+  inset-inline-start: var(--sidebar-toggle-inline-start);
   z-index: var(--z-titlebar-control);
   margin-inline-start: 0;
 }

--- a/desktop/styles/pages.css
+++ b/desktop/styles/pages.css
@@ -118,7 +118,7 @@ a:where(.setting-link) {
   grid-row: 1 / -1;
   min-height: 0;
   overflow: auto;
-  padding: 40px 28px 28px;
+  padding: calc(var(--topbar-height) + 24px) 28px 28px;
 }
 
 .settings-page-inner {
@@ -366,7 +366,7 @@ h2 {
   grid-row: 1 / -1;
   min-height: 0;
   overflow: auto;
-  padding: 40px 28px 28px;
+  padding: calc(var(--topbar-height) + 24px) 28px 28px;
 }
 
 .skills-page-inner {

--- a/desktop/styles/responsive.css
+++ b/desktop/styles/responsive.css
@@ -26,8 +26,8 @@
 }
 
 @media (max-width: 760px) {
-  main {
-    --topbar-height: 52px;
+  .app {
+    --app-header-height: 52px;
   }
 
   .quick-open-backdrop {
@@ -49,11 +49,17 @@
      content column always has the full width. */
   .app {
     --sidebar-column-width: 0px;
+    --sidebar-boundary-width: 0px;
     --sidebar-toggle-size: 44px;
+    --topbar-inline-padding: 12px;
     grid-template-columns: minmax(0, 1fr);
   }
   .app.sidebar-collapsed {
     grid-template-columns: minmax(0, 1fr);
+  }
+  .app:not(.sidebar-collapsed) {
+    --sidebar-boundary-width: var(--sidebar-drawer-width);
+    --sidebar-toggle-inline-inset: 0px;
   }
   .app > aside {
     position: fixed;
@@ -159,36 +165,22 @@
   .topbar,
   .sidebar-header,
   .editor-tabsbar {
-    height: 52px;
+    height: var(--topbar-height);
   }
-  /* The fallback on pages without a topbar keeps the pre-drawer phone inset. */
-  .page-sidebar-toggle {
-    inset-block-start: 4px;
-    inset-inline-start: 8px;
-  }
-  .topbar-toggle,
   .panel-toggle {
     min-width: 44px;
     min-height: 44px;
   }
-  /* A narrow Windows desktop window still shares its first row with native
-     caption buttons. Keep that row compact instead of applying phone touch
-     geometry that would make native and web chrome diverge. */
-  .app.native-windows-titlebar {
-    --sidebar-toggle-size: 32px;
-  }
-  .app.native-windows-titlebar main {
-    --topbar-height: var(--native-titlebar-height);
-  }
-  .app.native-windows-titlebar .topbar,
-  .app.native-windows-titlebar .sidebar-header,
-  .app.native-windows-titlebar .editor-tabsbar {
-    height: var(--native-titlebar-height);
-  }
-  .app.native-windows-titlebar .topbar-toggle,
-  .app.native-windows-titlebar .panel-toggle {
-    min-width: 32px;
-    min-height: 32px;
+  /* The drawer overlays the main column, so its layout control leaves normal
+     flow and sits on the drawer boundary above the dimmed backdrop. */
+  .app:not(.sidebar-collapsed) .sidebar-boundary-toggle {
+    position: fixed;
+    inset-block-start: calc(
+      (var(--topbar-height) - var(--sidebar-toggle-size)) / 2
+    );
+    inset-inline-start: var(--sidebar-toggle-inline-start);
+    z-index: var(--z-sidebar-drawer-control);
+    margin-inline-start: 0;
   }
   .button,
   .portal-button-link {

--- a/desktop/styles/responsive.css
+++ b/desktop/styles/responsive.css
@@ -49,17 +49,12 @@
      content column always has the full width. */
   .app {
     --sidebar-column-width: 0px;
-    --sidebar-boundary-width: 0px;
     --sidebar-toggle-size: 44px;
     --topbar-inline-padding: 12px;
     grid-template-columns: minmax(0, 1fr);
   }
   .app.sidebar-collapsed {
     grid-template-columns: minmax(0, 1fr);
-  }
-  .app:not(.sidebar-collapsed) {
-    --sidebar-boundary-width: var(--sidebar-drawer-width);
-    --sidebar-toggle-inline-inset: 0px;
   }
   .app > aside {
     position: fixed;
@@ -114,6 +109,9 @@
     transform: translateX(0);
     transition-delay: 0s;
   }
+  .content.panel-open .editor-tabsbar {
+    padding-inline-start: var(--sidebar-toggle-reserved-width);
+  }
   /* Drill-down: exactly one of tree/viewer shows. Opening a file
      closes the tree (the fileeditor's narrow Ctx flag); the
      breadcrumb's toggle brings the tree back. */
@@ -150,7 +148,7 @@
   }
   .settings-page,
   .skills-page {
-    padding: 24px 16px;
+    padding: calc(var(--topbar-height) + 24px) 16px 24px;
   }
 
   /* Touch targets at 44px and 16px fields — a smaller font makes iOS
@@ -170,17 +168,6 @@
   .panel-toggle {
     min-width: 44px;
     min-height: 44px;
-  }
-  /* The drawer overlays the main column, so its layout control leaves normal
-     flow and sits on the drawer boundary above the dimmed backdrop. */
-  .app:not(.sidebar-collapsed) .sidebar-boundary-toggle {
-    position: fixed;
-    inset-block-start: calc(
-      (var(--topbar-height) - var(--sidebar-toggle-size)) / 2
-    );
-    inset-inline-start: var(--sidebar-toggle-inline-start);
-    z-index: var(--z-sidebar-drawer-control);
-    margin-inline-start: 0;
   }
   .button,
   .portal-button-link {

--- a/desktop/styles/sidebar.css
+++ b/desktop/styles/sidebar.css
@@ -9,7 +9,7 @@ aside {
      The header keeps its own, wider inset for the icon buttons. */
   --sidebar-inset: 12px;
   display: grid;
-  grid-template-rows: auto minmax(0, 1fr) auto;
+  grid-template-rows: minmax(0, 1fr) auto;
   gap: 14px;
   min-width: 0;
   min-height: 0;
@@ -43,16 +43,18 @@ html.is-resizing .sidebar-resize-handle {
   background: var(--color-accent-soft);
 }
 
-/* The sidebar's own header owns its close action while the sidebar is visible.
-   Its height matches the main topbar so collapsing swaps the control between
-   columns without changing its vertical position. */
+/* Reserve a strip only while native controls actually occupy the left edge.
+   Fullscreen and right-side controls leave the hierarchy at the top. */
 .sidebar-header {
-  display: flex;
-  align-items: center;
-  height: 46px;
-  padding-block: 0;
-  padding-inline: var(--topbar-inline-padding);
+  display: none;
+  height: var(--topbar-height);
   border-bottom: 1px solid var(--color-separator);
+}
+html.native-titlebar-leading-controls .app .sidebar-header {
+  display: block;
+}
+html.native-titlebar-leading-controls .app aside {
+  grid-template-rows: auto minmax(0, 1fr) auto;
 }
 
 .sidebar-main {
@@ -74,7 +76,7 @@ html.is-resizing .sidebar-resize-handle {
   padding-right: max(0px, var(--sidebar-inset) - var(--scrollbar-lane));
   scrollbar-gutter: stable;
 }
-.app.native-apple-titlebar .sidebar-main {
+html.native-titlebar-leading-controls .app .sidebar-main {
   /* The titlebar strip already contributes the sidebar's leading rhythm. */
   padding-top: 0;
 }

--- a/desktop/styles/sidebar.css
+++ b/desktop/styles/sidebar.css
@@ -9,7 +9,7 @@ aside {
      The header keeps its own, wider inset for the icon buttons. */
   --sidebar-inset: 12px;
   display: grid;
-  grid-template-rows: minmax(0, 1fr) auto;
+  grid-template-rows: auto minmax(0, 1fr) auto;
   gap: 14px;
   min-width: 0;
   min-height: 0;
@@ -43,18 +43,10 @@ html.is-resizing .sidebar-resize-handle {
   background: var(--color-accent-soft);
 }
 
-/* Reserve a strip only while native controls actually occupy the left edge.
-   Fullscreen and right-side controls leave the hierarchy at the top. */
+/* The fixed shell toggle needs a header even without native titlebar controls. */
 .sidebar-header {
-  display: none;
   height: var(--topbar-height);
   border-bottom: 1px solid var(--color-separator);
-}
-html.native-titlebar-leading-controls .app .sidebar-header {
-  display: block;
-}
-html.native-titlebar-leading-controls .app aside {
-  grid-template-rows: auto minmax(0, 1fr) auto;
 }
 
 .sidebar-main {
@@ -72,15 +64,10 @@ html.native-titlebar-leading-controls .app aside {
      off the edge on its own; an overlay bar (macOS) floats above the content
      and reserves nothing, so there the whole inset has to be real padding.
      `--scrollbar-lane` is the measured width of the gutter the bar claims. */
-  padding-top: 12px;
+  padding-top: 0;
   padding-right: max(0px, var(--sidebar-inset) - var(--scrollbar-lane));
   scrollbar-gutter: stable;
 }
-html.native-titlebar-leading-controls .app .sidebar-main {
-  /* The titlebar strip already contributes the sidebar's leading rhythm. */
-  padding-top: 0;
-}
-
 .sidebar-section {
   display: grid;
   gap: 4px;

--- a/desktop/styles/tokens.css
+++ b/desktop/styles/tokens.css
@@ -155,13 +155,11 @@
      context stay local because they do not compete with these surfaces.
      Controls that escape an overlay sit on the named layer immediately above
      the surface they control. */
-  --z-titlebar-control: 5;
   --z-menu: 31;
   --z-editor-overlay: 45;
-  --z-editor-overlay-control: 46;
   --z-sidebar-backdrop: 51;
   --z-sidebar-drawer: 52;
-  --z-sidebar-drawer-control: 53;
+  --z-titlebar-control: 53;
   --z-notification: 55;
   --z-modal: 60;
   --z-quick-open: 70;

--- a/desktop/styles/tokens.css
+++ b/desktop/styles/tokens.css
@@ -161,6 +161,7 @@
   --z-editor-overlay-control: 46;
   --z-sidebar-backdrop: 51;
   --z-sidebar-drawer: 52;
+  --z-sidebar-drawer-control: 53;
   --z-notification: 55;
   --z-modal: 60;
   --z-quick-open: 70;


### PR DESCRIPTION
## Summary

- Derive native titlebar safe areas from Proton geometry instead of hard-coded platform padding, and refresh them when window chrome changes.
- Keep geometry and chrome notifications local to the desktop window; browser clients retain the normal application layout without native reservations.
- Render one shell-owned sidebar toggle at a fixed native-safe position across sidebar animations, page changes, and expanded editors.
- Update header spacing and narrow-screen layouts, and cover toggle stability and geometry changes in browser tests.

## Validation

- `just check`
- `moon test desktop/frontend --target js` — 459 passed
- `just build`
- `npm --prefix desktop/e2e test` — 41 passed
- Playwright checks for per-frame toggle stability, page/editor transitions, narrow layouts, and mocked native/fullscreen geometry
- Packaged the macOS arm64 Release app and passed deep, strict code-signature verification; the packaged app was not automatically launched

Windows behavior has been inspected in source but has not been validated on a Windows machine.