### PR TITLE
agent_workflow/snippet: the seam that makes a snippet's workflow visible

### DIFF
--- a/agent_workflow/snippet/injected.mbt
+++ b/agent_workflow/snippet/injected.mbt
@@ -1,0 +1,163 @@
+// The engine-side coordinates an `mbtx` snippet needs to run a workflow whose
+// children are visible to the rest of openseek.
+//
+// `moonbitlang/workflow` is a generic library: it spawns whatever its `Runner`
+// spawns and writes its journal wherever it was told, and it never learns
+// openseek exists. So nothing IN the snippet can make a run discoverable —
+// the coordinates have to come from outside, from the one component that
+// knows both the session and the snippet: the `mbtx` tool that launched it.
+//
+// mbtx picks them BEFORE the snippet starts (a reserved block of child
+// ordinals, a journal path, a sidecar path) and injects them into the guest
+// environment through the wasm policy's `env.set`. Discovery is therefore not
+// discovery at all: the host already knows where to look, the same way it
+// already knows a sub-run started because the engine told it.
+//
+// A snippet reads them through `injected()` and hands the result to `run`.
+// The model never types a session id, a path, or an ordinal — it cannot, since
+// only the values mbtx reserved will resolve to anything the host watches.
+
+///|
+/// The names mbtx writes into the guest environment. Read here and nowhere
+/// else: a snippet that spelled one itself would be inventing a coordinate
+/// rather than receiving one.
+const ExeVar = "OPENSEEK_MBTX_EXE"
+
+///|
+const SessionRootVar = "OPENSEEK_MBTX_SESSION_ROOT"
+
+///|
+const ParentVar = "OPENSEEK_MBTX_PARENT_SESSION"
+
+///|
+const BaseVar = "OPENSEEK_MBTX_SUBRUN_BASE"
+
+///|
+const LimitVar = "OPENSEEK_MBTX_SUBRUN_LIMIT"
+
+///|
+const JournalVar = "OPENSEEK_MBTX_JOURNAL"
+
+///|
+const EventsVar = "OPENSEEK_MBTX_EVENTS"
+
+///|
+const ModelVar = "OPENSEEK_MBTX_MODEL"
+
+///|
+const ApiUrlVar = "OPENSEEK_MBTX_API_URL"
+
+///|
+/// What mbtx reserved for one snippet: the engine to spawn, where child
+/// transcripts belong, the block of child ordinals this snippet may mint, and
+/// the two files the host tails.
+///
+/// Fields are private. A snippet passes this value along; it has no business
+/// reading a path it did not choose, and every field is a coordinate whose
+/// only correct value is the one that arrived.
+pub struct Injected {
+  priv exe : String
+  priv session_root : String
+  priv parent : String
+  /// The first child ordinal this snippet owns. Blocks are allocated
+  /// parent-side and never overlap, so two snippets — including one still
+  /// running in the background — cannot mint the same child session id.
+  priv base : Int
+  /// How many ordinals the block holds. It doubles as the launch ceiling:
+  /// a snippet cannot start more children than it was given room for.
+  priv limit : Int
+  priv journal_path : String
+  priv events_path : String
+  priv model : String?
+  priv api_url : String?
+}
+
+///|
+/// The coordinates mbtx injected, or `None` when this snippet was not
+/// launched with any.
+///
+/// `None` is a normal state, not an error: a snippet run against a
+/// conversation with no durable session has nowhere to put child
+/// transcripts, so mbtx injects nothing and there is nothing to visualize.
+/// Such a snippet can still do ordinary work — it just cannot delegate
+/// through `run`.
+pub fn injected() -> Injected? {
+  guard @env.get_env_var(ExeVar) is Some(exe) &&
+    @env.get_env_var(SessionRootVar) is Some(session_root) &&
+    @env.get_env_var(ParentVar) is Some(parent) &&
+    @env.get_env_var(JournalVar) is Some(journal_path) &&
+    @env.get_env_var(EventsVar) is Some(events_path) &&
+    positive_int(@env.get_env_var(BaseVar)) is Some(base) &&
+    positive_int(@env.get_env_var(LimitVar)) is Some(limit) else {
+    return None
+  }
+  Some({
+    exe,
+    session_root,
+    parent,
+    base,
+    limit,
+    journal_path,
+    events_path,
+    model: @env.get_env_var(ModelVar),
+    api_url: @env.get_env_var(ApiUrlVar),
+  })
+}
+
+///|
+/// Coordinates built directly rather than read from the environment.
+///
+/// The environment is how they arrive in a real snippet, and `injected()` is
+/// the only reader of it. This constructor exists for the two callers that
+/// already hold the values: tests, and any in-process caller that reserved a
+/// block itself instead of going through mbtx.
+pub fn Injected::Injected(
+  exe~ : String,
+  session_root~ : String,
+  parent~ : String,
+  base~ : Int,
+  limit~ : Int,
+  journal_path~ : String,
+  events_path~ : String,
+  model? : String,
+  api_url? : String,
+) -> Injected {
+  {
+    exe,
+    session_root,
+    parent,
+    base,
+    limit,
+    journal_path,
+    events_path,
+    model,
+    api_url,
+  }
+}
+
+///|
+/// A positive integer from an injected variable. Anything else — absent,
+/// unparseable, zero, negative — fails the whole read: a block of unknown
+/// size is not a block, and guessing one would let a snippet mint ordinals
+/// that belong to another.
+fn positive_int(raw : String?) -> Int? {
+  guard raw is Some(raw) else { return None }
+  let value = @string.parse_int(raw) catch { _ => return None }
+  if value > 0 {
+    Some(value)
+  } else {
+    None
+  }
+}
+
+///|
+test "a complete environment reads, and any missing coordinate refuses" {
+  // The parser is exercised through `positive_int`, which is what decides
+  // whether a block is usable; the env read itself is a straight lookup.
+  assert_eq(positive_int(Some("7")), Some(7))
+  assert_eq(positive_int(Some("0")), None)
+  assert_eq(positive_int(Some("-3")), None)
+  assert_eq(positive_int(Some("sr-1")), None)
+  assert_eq(positive_int(Some("")), None)
+  assert_eq(positive_int(None), None)
+}

--- a/agent_workflow/snippet/moon.pkg
+++ b/agent_workflow/snippet/moon.pkg
@@ -1,0 +1,18 @@
+import {
+  "moonbitlang/workflow",
+  "moonbitlang/workflow/spawn",
+  "moonbitlang/async/fs",
+  "moonbitlang/core/env",
+  "moonbitlang/core/json",
+  "moonbitlang/core/string",
+}
+
+import {
+  "moonbitlang/workflow",
+  "moonbitlang/workflow/spawn",
+  "moonbitlang/async",
+  "moonbitlang/async/fs",
+  "moonbitlang/core/json",
+} for "test"
+
+supported_targets = "native+wasm"

--- a/agent_workflow/snippet/pkg.generated.mbti
+++ b/agent_workflow/snippet/pkg.generated.mbti
@@ -1,0 +1,28 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_workflow/snippet"
+
+import {
+  "moonbitlang/core/ref",
+  "moonbitlang/workflow",
+  "moonbitlang/workflow/spawn",
+}
+
+// Values
+pub fn injected() -> Injected?
+
+pub async fn[T] run(Injected, async (@workflow.Workflow) -> T, max_concurrent? : Int) -> T
+
+pub fn runner(Injected, phase~ : @ref.Ref[String?], emit_line? : async (String, Json) -> Unit, map_launch? : (@spawn.LaunchSpec, @workflow.AgentCall) -> @spawn.LaunchSpec) -> @workflow.Runner
+
+// Errors
+
+// Types and methods
+pub struct Injected {
+  // private fields
+}
+pub fn Injected::Injected(exe~ : String, session_root~ : String, parent~ : String, base~ : Int, limit~ : Int, journal_path~ : String, events_path~ : String, model? : String, api_url? : String) -> Self
+pub fn Injected::journal_path(Self) -> String
+
+// Type aliases
+
+// Traits

--- a/agent_workflow/snippet/run.mbt
+++ b/agent_workflow/snippet/run.mbt
@@ -1,0 +1,55 @@
+// The one entry point a snippet calls.
+//
+// Everything the desktop needs is a SIDE EFFECT of running here: children get
+// durable sessions, completions append to the journal, and lifecycle lines
+// stream to the sidecar. The snippet author writes the shape of the work and
+// nothing else — no session ids, no paths, no ordinals, no budget.
+//
+// That is deliberate. The alternative — teaching the model to pass these
+// itself — would put the coordinates that make a run visible into the same
+// text that decides what the run does, where a plausible-looking wrong value
+// silently produces an invisible workflow.
+
+///|
+/// Run `body` with a workflow wired to the injected coordinates.
+///
+/// `max_concurrent` bounds how many children run at once. The LIFETIME launch
+/// cap is not a parameter: it is the reserved block, which the runner enforces
+/// by refusing calls past its end. A snippet cannot widen it, because it
+/// cannot mint an ordinal it was not given.
+///
+/// The journal is file-backed and append-only, so a reader tailing it sees
+/// each completion as it lands. `phase` is tracked here rather than read from
+/// the journal because `Workflow::phase` is a live setting that the sidecar's
+/// `started` lines need before any entry exists to carry it.
+pub async fn[T] run(
+  spec : Injected,
+  body : async (@workflow.Workflow) -> T,
+  max_concurrent? : Int = 4,
+) -> T {
+  let phase : Ref[String?] = Ref(None)
+  let journal = @workflow.Journal::load(spec.journal_path)
+  let wf = @workflow.Workflow(
+    runner=runner(spec, phase~),
+    max_concurrent~,
+    journal~,
+    on_event=event => {
+      match event {
+        // The only event whose information is not already in the journal or
+        // the sidecar: a phase is declared BEFORE the calls it groups, and
+        // nothing else records it until one of them finishes.
+        PhaseStarted(title) => phase.val = Some(title)
+        _ => ()
+      }
+    },
+  )
+  body(wf)
+}
+
+///|
+/// The journal this snippet writes, for a caller that wants to read its own
+/// ledger back (a summary line, a cost figure) rather than leave it to the
+/// viewer.
+pub fn Injected::journal_path(self : Injected) -> String {
+  self.journal_path
+}

--- a/agent_workflow/snippet/runner.mbt
+++ b/agent_workflow/snippet/runner.mbt
@@ -1,0 +1,211 @@
+// The `Runner` a snippet's workflow spawns through, and the sidecar that makes
+// its launches visible while they are still running.
+//
+// This is the openseek half of the seam. `moonbitlang/workflow` supplies the
+// concurrency gate, the launch allowance, the journal and the combinators; it
+// asks only for a function from a call to an outcome. Everything openseek
+// needs a child to have — a durable transcript at `<parent>-sr-N`, an ordinal
+// from the block mbtx reserved, an `attempt_id` the journal can be joined on —
+// is added here, where the coordinates are known.
+
+///|
+/// The wall deadline a kind gets. Sized like the engine's own ceilings: a
+/// scout that has not answered in ten minutes is lost rather than thorough,
+/// while a worker slice is allowed real work and killing it at explore's
+/// deadline would throw away everything it had done.
+fn deadline_for(kind : String) -> Int {
+  match kind {
+    "explore" => 600_000
+    "review" => 900_000
+    "worker" => 2_700_000
+    _ => 600_000
+  }
+}
+
+///|
+/// The child argv for one call. The step ceiling rides argv per the subrun
+/// contract, the input line carries the question, and the API key NEVER rides
+/// argv — it reaches the child through the inherited environment, where `ps`
+/// cannot read it.
+///
+/// `--session`/`--session-root` are what make the child durable, and they are
+/// appended HERE rather than by the caller: the ordinal exists only after this
+/// runner allocates it.
+fn child_args(
+  spec : Injected,
+  call : @workflow.AgentCall,
+  session_id : String,
+) -> Array[String] {
+  let args = ["subrun", call.kind]
+  if spec.model is Some(model) {
+    args.push("--model")
+    args.push(model)
+  }
+  if call.max_steps is Some(steps) {
+    args.push("--max-steps")
+    args.push("\{steps}")
+  }
+  if spec.api_url is Some(url) {
+    args.push("--api-url")
+    args.push(url)
+  }
+  args.push("--session")
+  args.push(session_id)
+  args.push("--session-root")
+  args.push(spec.session_root)
+  args
+}
+
+///|
+/// Map a contract terminal into the lossless outcome envelope, so even a
+/// timed-out child's spend survives into the journal and the ledger.
+///
+/// `attempt_id` is the child's session SUFFIX (`sr-N`), not an opaque id: a
+/// journal entry therefore names `<parent>-sr-N` given the parent, which is
+/// the same string the transcript viewer links to and the desktop's progress
+/// probe tails. That is the whole join between the ledger and the per-subagent
+/// view, and it costs nothing because the runner had to mint the ordinal
+/// anyway.
+fn outcome_of(
+  subrun_id : String,
+  result : @spawn.ContractResult,
+) -> @workflow.AgentOutcome {
+  let attempt : @workflow.AgentAttempt = {
+    attempt_id: subrun_id,
+    steps_used: result.steps_used,
+    prompt_tokens: result.prompt_tokens,
+    completion_tokens: result.completion_tokens,
+    cost_usd: result.cost_usd,
+  }
+  match result.terminal {
+    Captured =>
+      match result.report {
+        Some(value) => Finished(value~, attempt~)
+        // Unreachable by the contract: refuse to dress an invariant
+        // violation up as a clean no-report terminal.
+        None =>
+          DidNotFinish(
+            failure=Failed("captured terminal without a report value"),
+            attempt=Some(attempt),
+          )
+      }
+    NoReport => DidNotFinish(failure=NoReport, attempt=Some(attempt))
+    MaxSteps => DidNotFinish(failure=MaxSteps, attempt=Some(attempt))
+    ContextYield => DidNotFinish(failure=ContextYield, attempt=Some(attempt))
+    TimedOut => DidNotFinish(failure=TimedOut, attempt=Some(attempt))
+    Failed(reason) =>
+      DidNotFinish(failure=Failed(reason), attempt=Some(attempt))
+  }
+}
+
+///|
+/// The status word for a finished child, matching the engine's own wire
+/// vocabulary so a reader does not have to learn two.
+fn status_of(outcome : @workflow.AgentOutcome) -> String {
+  match outcome {
+    Finished(..) => "captured"
+    DidNotFinish(failure=NoReport, ..) => "no_report"
+    DidNotFinish(failure=MaxSteps, ..) => "max_steps"
+    DidNotFinish(failure=ContextYield, ..) => "context_yield"
+    DidNotFinish(failure=TimedOut, ..) => "timed_out"
+    DidNotFinish(failure=Skipped, ..) => "skipped"
+    DidNotFinish(failure=Failed(_), ..) => "failed"
+  }
+}
+
+///|
+/// Append one line to the sidecar the host tails.
+///
+/// Deliberately best-effort: a sidecar is a view, and a snippet whose work
+/// succeeded must not fail because a progress line could not be written. The
+/// journal is the record, and it has its own durability.
+async fn note(path : String, line : Json) -> Unit {
+  @fs.write_file(
+    path,
+    line.stringify() + "\n",
+    append=true,
+    create_mode=OpenOrCreate,
+  ) catch {
+    _ => ()
+  }
+}
+
+///|
+/// A `Runner` that spawns `openseek subrun <kind>` children, giving each the
+/// durable child session mbtx reserved for it.
+///
+/// Ordinals come from the injected block and are handed out in order. The
+/// block is also the ceiling: a call past its end is refused as `Skipped`
+/// rather than launched without a session, because a child with no transcript
+/// is exactly the thing this package exists to prevent.
+///
+/// Two sidecar lines bracket every launch. They exist because the journal
+/// cannot: a `JournalEntry` carries an outcome, so it is written when a call
+/// RESOLVES, and a reader with only the journal learns about a child no
+/// earlier than its completion. The `started` line is what makes a running
+/// child visible, and it carries the session id so the host can begin tailing
+/// the child's own record immediately.
+/// `map_launch` is the spawn seam, the same one `subrun_runner` carries: it
+/// receives the CANONICAL `LaunchSpec` this runner computed plus the call and
+/// returns what to actually launch, so a test can redirect to a scripted child
+/// with the real argv — including the reserved `--session` — still in hand.
+pub fn runner(
+  spec : Injected,
+  phase~ : Ref[String?],
+  emit_line? : async (String, Json) -> Unit = note,
+  map_launch? : (@spawn.LaunchSpec, @workflow.AgentCall) -> @spawn.LaunchSpec,
+) -> @workflow.Runner {
+  let next = Ref(spec.base)
+  @workflow.Runner(call => {
+    guard next.val < spec.base + spec.limit else {
+      return DidNotFinish(failure=Skipped, attempt=None)
+    }
+    let subrun_id = "sr-\{next.val}"
+    next.val += 1
+    let session_id = "\{spec.parent}-\{subrun_id}"
+    emit_line(spec.events_path, {
+      "event": "agent_started",
+      "id": subrun_id,
+      "session": session_id,
+      "kind": call.kind,
+      "label": call.label,
+      "phase": match phase.val {
+        Some(phase) => Json::string(phase)
+        None => Json::null()
+      },
+    })
+    let canonical : @spawn.LaunchSpec = {
+      command: spec.exe,
+      args: child_args(spec, call, session_id),
+      cwd: Some(spec.session_root),
+      extra_env: None,
+      deadline_ms: Some(deadline_for(call.kind)),
+    }
+    let launch = match map_launch {
+      Some(map_launch) => map_launch(canonical, call)
+      None => canonical
+    }
+    let result = @spawn.contract_run(
+      command=launch.command,
+      args=launch.args,
+      input=call.input,
+      kind=call.kind,
+      id=subrun_id,
+      max_steps?=call.max_steps,
+      schema?=call.schema,
+      wall_deadline_ms=launch.deadline_ms.unwrap_or(deadline_for(call.kind)),
+      cwd?=launch.cwd,
+      extra_env?=launch.extra_env,
+    )
+    let outcome = outcome_of(subrun_id, result)
+    emit_line(spec.events_path, {
+      "event": "agent_finished",
+      "id": subrun_id,
+      "session": session_id,
+      "status": status_of(outcome),
+      "steps": result.steps_used,
+      "tokens": result.prompt_tokens + result.completion_tokens,
+    })
+    outcome
+  })
+}

--- a/agent_workflow/snippet/runner_test.mbt
+++ b/agent_workflow/snippet/runner_test.mbt
@@ -1,0 +1,176 @@
+///|
+/// A child speaking the contract: one accounted usage line, then the report.
+/// The same shape `openseek subrun` writes, so a test exercises the real
+/// drain path rather than a stub.
+let scripted_child : String =
+  #|read line
+  #|printf '{"event":"usage","usage":{"prompt_tokens":7,"completion_tokens":3,"total_tokens":10,"prompt_cache_hit_tokens":0,"prompt_cache_miss_tokens":7}}\n'
+  #|printf '{"subrun_report": {"answer": "forty-two"}}\n'
+
+///|
+/// Coordinates for a test: a block of `limit` ordinals starting at `base`,
+/// with paths under a scratch directory the caller owns.
+fn spec_at(
+  dir : String,
+  base? : Int = 1,
+  limit? : Int = 4,
+) -> @snippet.Injected {
+  @snippet.Injected(
+    exe="/unused/openseek",
+    session_root=dir,
+    parent="run7",
+    base~,
+    limit~,
+    journal_path="\{dir}/journal.jsonl",
+    events_path="\{dir}/events.jsonl",
+    model="test-model",
+  )
+}
+
+///|
+/// Every launch this runner made, as `(command, args)` — what a spawn seam
+/// sees, which is where the reserved session has to appear if the child is
+/// going to leave a transcript at all.
+fn recording_runner(
+  spec : @snippet.Injected,
+  into : Array[Array[String]],
+  lines : Array[Json],
+) -> @workflow.Runner {
+  @snippet.runner(
+    spec,
+    phase=Ref(None),
+    emit_line=(_path, line) => lines.push(line),
+    map_launch=(launch, _call) => {
+      into.push(launch.args)
+      { ..launch, command: "sh", args: ["-c", scripted_child], }
+    },
+  )
+}
+
+///|
+async test "each child is launched into the session its ordinal names" {
+  let dir = @fs.tmpdir(prefix="snippet-runner-")
+  defer (@fs.rmdir(dir, recursive=true) catch { _ => () })
+  let launches : Array[Array[String]] = []
+  let lines : Array[Json] = []
+  let wf = @workflow.Workflow(
+    runner=recording_runner(spec_at(dir, base=5), launches, lines),
+  )
+  let _ = wf.agent(prompt="where is X?", kind="explore")
+  let _ = wf.agent(prompt="where is Y?", kind="explore")
+
+  // Ordinals come from the reserved block, in order, and each one becomes
+  // `<parent>-sr-N` — the id the transcript viewer links to and the desktop
+  // probe tails. A runner that skipped this would produce a workflow whose
+  // children left nothing behind.
+  guard launches is [first, second] else {
+    fail("expected two launches, got \{launches.length()}")
+  }
+  assert_true(session_arg(first) is Some("run7-sr-5"))
+  assert_true(session_arg(second) is Some("run7-sr-6"))
+  // The engine settings ride argv; the step ceiling is absent because this
+  // call set none.
+  assert_eq(first[0], "subrun")
+  assert_eq(first[1], "explore")
+  assert_true(first.contains("--model"))
+  assert_false(first.contains("--max-steps"))
+}
+
+///|
+/// The `--session` value from a recorded argv.
+fn session_arg(args : Array[String]) -> String? {
+  for index, arg in args {
+    if arg == "--session" {
+      return args.get(index + 1)
+    }
+  }
+  None
+}
+
+///|
+async test "the reserved block is the launch ceiling" {
+  let dir = @fs.tmpdir(prefix="snippet-block-")
+  defer (@fs.rmdir(dir, recursive=true) catch { _ => () })
+  let launches : Array[Array[String]] = []
+  let lines : Array[Json] = []
+  let wf = @workflow.Workflow(
+    runner=recording_runner(spec_at(dir, base=1, limit=2), launches, lines),
+  )
+  let _ = wf.agent(prompt="one", kind="explore")
+  let _ = wf.agent(prompt="two", kind="explore")
+  // The third call has no ordinal left. It is REFUSED rather than launched
+  // without a session: a child with no transcript is precisely what this
+  // package exists to prevent, so an unnumbered launch is worse than none.
+  let third = @workflow.attempt(() => wf.agent(prompt="three", kind="explore"))
+  assert_true(third is Err(_))
+  assert_eq(launches.length(), 2)
+}
+
+///|
+async test "a launch is bracketed by sidecar lines naming its session" {
+  let dir = @fs.tmpdir(prefix="snippet-sidecar-")
+  defer (@fs.rmdir(dir, recursive=true) catch { _ => () })
+  let launches : Array[Array[String]] = []
+  let lines : Array[Json] = []
+  let phase = Ref(Some("survey"))
+  let wf = @workflow.Workflow(
+    runner=@snippet.runner(
+      spec_at(dir),
+      phase~,
+      emit_line=(_path, line) => lines.push(line),
+      map_launch=(launch, _call) => {
+        launches.push(launch.args)
+        { ..launch, command: "sh", args: ["-c", scripted_child], }
+      },
+    ),
+  )
+  let _ = wf.agent(prompt="where is X?", kind="explore", label="scout:x")
+
+  // The `started` line is the whole reason the sidecar exists: a journal
+  // entry carries an outcome, so it lands only when the call RESOLVES, and a
+  // reader with only the journal would learn about a running child no earlier
+  // than its completion.
+  guard lines is [started, finished] else {
+    fail("expected a started/finished pair, got \{lines.length()} line(s)")
+  }
+  assert_eq(started, {
+    "event": "agent_started",
+    "id": "sr-1",
+    "session": "run7-sr-1",
+    "kind": "explore",
+    "label": "scout:x",
+    "phase": "survey",
+  })
+  assert_eq(finished, {
+    "event": "agent_finished",
+    "id": "sr-1",
+    "session": "run7-sr-1",
+    "status": "captured",
+    "steps": 0,
+    "tokens": 10,
+  })
+}
+
+///|
+async test "completions land in the journal with the session as attempt id" {
+  let dir = @fs.tmpdir(prefix="snippet-journal-")
+  defer (@fs.rmdir(dir, recursive=true) catch { _ => () })
+  let spec = spec_at(dir)
+  let launches : Array[Array[String]] = []
+  let lines : Array[Json] = []
+  let wf = @workflow.Workflow(
+    runner=recording_runner(spec, launches, lines),
+    journal=@workflow.Journal::load(spec.journal_path()),
+  )
+  wf.phase("survey")
+  let _ = wf.agent(prompt="where is X?", kind="explore")
+
+  // `attempt_id` is the child's session SUFFIX, not an opaque id: with the
+  // parent in hand a reader rebuilds `run7-sr-1` and follows the ledger row
+  // into that child's own transcript. That join is the entire link between
+  // the workflow view and the per-subagent view.
+  let text = @fs.read_file(spec.journal_path()).text()
+  assert_true(text.contains("attempt_id"))
+  assert_true(text.contains("sr-1"))
+  assert_true(text.contains("survey"))
+}


### PR DESCRIPTION
Stacked on #1286.

`moonbitlang/workflow` is generic: it spawns whatever its `Runner` spawns, writes its journal wherever it was told, and never learns openseek exists. So **nothing inside a snippet can make its own run discoverable** — a snippet that hand-rolled `@shell.Cmd(openseek, ["subrun", ...])` produces children with no transcript and no ledger, invisible to every viewer.

This package is the openseek half. It reads coordinates mbtx reserved *before* the snippet started (a block of child ordinals, a journal path, a sidecar path) out of the guest environment, and turns them into a `Runner` that gives every child the durable session `<parent>-sr-N`.

## Three load-bearing properties

**`attempt_id` is the child's session suffix, not an opaque id.** A journal row therefore names `<parent>-sr-N` given the parent — the same string `viz`'s chip links to and `desktop/internal/subrun/probe.mbt` tails. That single field is the whole join between the workflow view and the per-subagent view, and it costs nothing because the runner had to mint the ordinal anyway. (Contrast `@spawn.contract_runner`, which mints `cr-N` and cannot be joined to anything.)

**The reserved block is the launch ceiling.** A call past its end is refused as `Skipped` rather than launched unnumbered: a child with no transcript is exactly what this package exists to prevent.

**Sidecar lines bracket every launch.** The journal cannot do this — a `JournalEntry` carries an outcome, so it is written when a call *resolves*, and a reader with only the journal learns about a child no earlier than its completion.

`run` is the only entry point a snippet calls, so the author writes the shape of the work and nothing else. Teaching the model to pass these itself would put the coordinates that make a run visible into the same text that decides what the run does, where a plausible-looking wrong value silently produces an invisible workflow.

## Verification

5/5 new tests, covering ordinal allocation from the block, `--session` injection, block-as-ceiling refusal, sidecar bracket contents, and `attempt_id` in a real file-backed journal.

## Known constraint

`.mbtx` front-matter imports resolve `bobzhang/openseek/...` against the **published** module in the registry cache, not the local working tree — so this package is not importable from a snippet until openseek is released. See the stack description for the two options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXBYcYo74F1DGSPZsYYAdc