### PR TITLE
mbtx: reserve and inject the coordinates a snippet's workflow needs

### DIFF
--- a/agent/moon.pkg
+++ b/agent/moon.pkg
@@ -13,6 +13,7 @@ import {
   "bobzhang/openseek/agent_tool/multi_edit",
   "bobzhang/openseek/agent_tool/plan",
   "bobzhang/openseek/agent_tool/mbtx",
+  "bobzhang/openseek/agent_subrun/host",
   "bobzhang/openseek/agent_tool/read",
   "bobzhang/openseek/agent_tool/remove",
   "bobzhang/openseek/agent_tool/write",

--- a/agent/pkg.generated.mbti
+++ b/agent/pkg.generated.mbti
@@ -4,12 +4,13 @@ package "bobzhang/openseek/agent"
 import {
   "bobzhang/openseek/agent_runtime",
   "bobzhang/openseek/agent_session",
+  "bobzhang/openseek/agent_subrun/host",
   "bobzhang/openseek/agent_tool",
   "bobzhang/openseek/deepseek",
 }
 
 // Values
-pub async fn[X] build_tools(@agent_runtime.AgentRuntime, @agent_runtime.AgentTaskScope[X], on_background_wake? : () -> Unit, extra_tools? : Array[@agent_tool.AgentToolDefinition]) -> @agent_tool.Tools
+pub async fn[X] build_tools(@agent_runtime.AgentRuntime, @agent_runtime.AgentTaskScope[X], on_background_wake? : () -> Unit, extra_tools? : Array[@agent_tool.AgentToolDefinition], mbtx_subrun? : @host.SubrunInjection) -> @agent_tool.Tools
 
 pub let plan_reminder_after_steps : Int
 

--- a/agent/tool_definition.mbt
+++ b/agent/tool_definition.mbt
@@ -51,6 +51,7 @@ pub async fn[X] build_tools(
   scope : @agent_runtime.AgentTaskScope[X],
   on_background_wake? : () -> Unit,
   extra_tools? : Array[@agent_tool.AgentToolDefinition] = [],
+  mbtx_subrun? : @host.SubrunInjection,
 ) -> @agent_tool.Tools {
   let workspace_root = runtime.workspace_root()
   // One session-scoped file-state map, shared by the file-writing tools so they
@@ -107,11 +108,17 @@ pub async fn[X] build_tools(
       // it is passed straight through rather than tested and rebuilt. What the
       // tool package receives is the channel and nothing else: it can ask, and
       // knows nothing about who answers.
+      // `mbtx_subrun`, when present, is what lets a snippet delegate to child
+      // agents that are VISIBLE: it carries the engine's own path plus the
+      // block of child session ids and journal paths this session reserved.
+      // Absent for a conversation with no durable session, where a child
+      // would have nowhere to leave a transcript.
       @mbtx.definition(
         workspace_root~,
         bg_runtime~,
         job_dir?=spill_dir,
         approval?=runtime.approval_channel(),
+        subrun?=mbtx_subrun,
       ),
       // Deliberately NOT told about escalation. It reports a job that already
       // ran — a policy refusal reaches it after minutes of real work — and the

--- a/agent_subrun/host/host.mbt
+++ b/agent_subrun/host/host.mbt
@@ -161,10 +161,12 @@ pub fn SubrunReservation::env(self : SubrunReservation) -> Map[String, String] {
 /// transcript viewer links to and the desktop's progress probe tails.
 pub fn SubrunInjection::reserve(self : SubrunInjection) -> SubrunReservation {
   let base = (self.reserve_ordinals)(block_size)
-  // The run's directory is a sibling of the child transcripts it describes, in
-  // the same store: `openseek sessions` and the viewer already walk this
-  // directory, and a run's ledger belongs beside the runs it accounts for
-  // rather than in a build directory that gets reclaimed.
+  // The run's directory lives in the session store's root, beside the store's
+  // own `sessions/` tree that holds the transcripts it accounts for — with the
+  // session data, not in a build directory that gets reclaimed. It is NOT
+  // inside the store's tree: this package is a leaf and does not know the
+  // store's private layout, and nothing enumerates the root itself, so the
+  // ledger is found only by the paths announced for it, never by walking.
   let dir = "\{self.session_root}/\{self.parent}-wf-\{base}"
   let journal_path = "\{dir}/journal.jsonl"
   let events_path = "\{dir}/events.jsonl"

--- a/agent_subrun/host/host.mbt
+++ b/agent_subrun/host/host.mbt
@@ -1,0 +1,209 @@
+// The openseek half of the host handoff: what a snippet is given so the
+// children it delegates to are visible to the rest of the engine.
+//
+// `moonbitlang/workflow` is a generic library. It spawns whatever its `Runner`
+// spawns and writes its journal wherever it was told, and it never learns
+// openseek exists — so nothing a snippet can say about itself would make its
+// children discoverable. The coordinates come from the host, chosen BEFORE the
+// snippet runs and written into its environment as the library's own handoff,
+// `WORKFLOW_HOST` (see `moonbitlang/workflow/hosted` and its
+// docs/host-handoff.md). Discovery is therefore not discovery: a reader is told
+// where to look, exactly as it is told that a sub-run started rather than
+// finding one.
+//
+// This package knows what the sandbox tool that injects the handoff must not:
+// the engine's own command line, the session store's layout, the child-session
+// grammar `<parent>-sr-N`. It is a LEAF — `agent_subrun` builds one of these
+// from a `ChildSession` and its shared allocator, and `mbtx` receives an
+// opaque reservation and a variable to set; neither side's dependencies flow
+// through here.
+
+///|
+/// How many child ordinals one snippet may mint.
+///
+/// It is a ceiling, not an estimate. A snippet is opaque to the parent — one
+/// tool call can loop — so nothing else bounds how many children a confused
+/// model can start from inside one, and goal runs execute unattended for
+/// hours. Generous enough that a real fan-out never notices; small enough that
+/// a runaway stops inside one call.
+pub let block_size : Int = 32
+
+///|
+/// What to spawn, where transcripts belong, and the counter that keeps two
+/// snippets from minting the same child id.
+///
+/// ABSTRACT: the layout is not the contract, and a caller has no business
+/// reading a coordinate it did not choose.
+struct SubrunInjection {
+  exe : String
+  session_root : String
+  parent : String
+  /// Where a child RUNS. Not the session store: an `explore` child reads the
+  /// workspace by paths relative to its cwd, exactly as `run_subrun` launches
+  /// it, and a store-rooted child would find nothing to read.
+  workspace_root : String
+  model : String?
+  api_url : String?
+  /// Reserve N consecutive child ordinals and return the first.
+  reserve_ordinals : (Int) -> Int
+}
+
+///|
+/// An injection over an explicit allocator.
+///
+/// `reserve_ordinals` must be the session's ONE child-ordinal allocator — the
+/// counter `run_subrun` mints `explore` children from — or a snippet's child
+/// and an `explore` child will be named alike and the second to append will
+/// die against the first's stale snapshot. `ChildSession::injection` in
+/// `agent_subrun` wires that counter; this package is a leaf and cannot name
+/// it. Tests pass a local counter so ordinals do not depend on what earlier
+/// tests in the process reserved.
+///
+/// `exe` must be absolute: a sandbox admits it by exact path, so parent and
+/// child are the same binary and the report's derived JSON codecs cannot
+/// drift — the guarantee `explore` gets by never resolving the engine through
+/// `PATH`.
+pub fn SubrunInjection::SubrunInjection(
+  exe~ : String,
+  session_root~ : String,
+  parent~ : String,
+  workspace_root~ : String,
+  reserve_ordinals~ : (Int) -> Int,
+  model? : String,
+  api_url? : String,
+) -> SubrunInjection {
+  {
+    exe,
+    session_root,
+    parent,
+    workspace_root,
+    model,
+    api_url,
+    reserve_ordinals,
+  }
+}
+
+///|
+/// The engine binary a snippet may spawn — what a sandbox policy admits, by
+/// exact path, for the one delegating verb.
+pub fn SubrunInjection::exe(self : SubrunInjection) -> String {
+  self.exe
+}
+
+///|
+/// One snippet's reserved coordinates: a disjoint block of child ordinals, the
+/// directory holding the two files a reader tails for this run, and the guest
+/// variable that carries them.
+struct SubrunReservation {
+  base : Int
+  limit : Int
+  dir : String
+  journal_path : String
+  events_path : String
+  env : Map[String, String]
+}
+
+///|
+/// The first child ordinal of the block.
+pub fn SubrunReservation::base(self : SubrunReservation) -> Int {
+  self.base
+}
+
+///|
+/// How many ordinals the block holds — also the run's launch ceiling.
+pub fn SubrunReservation::limit(self : SubrunReservation) -> Int {
+  self.limit
+}
+
+///|
+/// The run's OWN directory, and the one place in the session store a snippet
+/// may write. A sandbox binds the guest's writes to explicit roots; granting
+/// the whole store would let a snippet append to another session's
+/// transcript, so the ledger gets a directory of its own instead. The
+/// injecting tool creates it before naming it in a policy — moonrun refuses a
+/// root that does not exist.
+pub fn SubrunReservation::dir(self : SubrunReservation) -> String {
+  self.dir
+}
+
+///|
+/// The append-only ledger of RESOLVED calls: `<dir>/journal.jsonl`.
+pub fn SubrunReservation::journal_path(self : SubrunReservation) -> String {
+  self.journal_path
+}
+
+///|
+/// The sidecar that reports a launch when it STARTS: `<dir>/events.jsonl`.
+pub fn SubrunReservation::events_path(self : SubrunReservation) -> String {
+  self.events_path
+}
+
+///|
+/// The guest environment to set: `WORKFLOW_HOST` and nothing else.
+pub fn SubrunReservation::env(self : SubrunReservation) -> Map[String, String] {
+  self.env
+}
+
+///|
+/// Reserve a block for one snippet invocation.
+///
+/// Blocks never overlap, so the child session ids two snippets mint cannot
+/// collide — including a background snippet still running from an earlier
+/// turn, which is the case a per-call counter would get wrong. The block base
+/// also names the run's directory, so a caller that reserved a block knows the
+/// paths without a second allocation.
+///
+/// The handoff is the workflow library's OWN contract, not an openseek one:
+/// argv arrives as a template the library substitutes per call, so the
+/// library never learns this engine's command line, and any other host can
+/// write the same document. `attempt_id` in the resulting ledger is the
+/// rendered `child_id` — `<parent>-sr-N` — which is exactly the session id the
+/// transcript viewer links to and the desktop's progress probe tails.
+pub fn SubrunInjection::reserve(self : SubrunInjection) -> SubrunReservation {
+  let base = (self.reserve_ordinals)(block_size)
+  // The run's directory is a sibling of the child transcripts it describes, in
+  // the same store: `openseek sessions` and the viewer already walk this
+  // directory, and a run's ledger belongs beside the runs it accounts for
+  // rather than in a build directory that gets reclaimed.
+  let dir = "\{self.session_root}/\{self.parent}-wf-\{base}"
+  let journal_path = "\{dir}/journal.jsonl"
+  let events_path = "\{dir}/events.jsonl"
+  // The child argv, with the library's two placeholders. The API key NEVER
+  // rides argv — it reaches the child through the inherited environment.
+  // Per-call `max_steps` is not here either: it rides the request envelope,
+  // where the contract already carries it, and `subrun` reads it from there.
+  let child_args = ["subrun", "{kind}"]
+  if self.model is Some(model) {
+    child_args.push("--model")
+    child_args.push(model)
+  }
+  if self.api_url is Some(url) {
+    child_args.push("--api-url")
+    child_args.push(url)
+  }
+  child_args.push("--session")
+  child_args.push("{child}")
+  child_args.push("--session-root")
+  child_args.push(self.session_root)
+  let handoff : Json = {
+    "v": 1,
+    "exe": self.exe,
+    "child_args": Json(child_args.map(Json::string)),
+    "child_id": "\{self.parent}-sr-{n}",
+    "ids": [
+      Json::number(base.to_double()),
+      Json::number(block_size.to_double()),
+    ],
+    "journal": journal_path,
+    "events": events_path,
+    "cwd": self.workspace_root,
+  }
+  {
+    base,
+    limit: block_size,
+    dir,
+    journal_path,
+    events_path,
+    env: { "WORKFLOW_HOST": handoff.stringify() },
+  }
+}

--- a/agent_subrun/host/host_test.mbt
+++ b/agent_subrun/host/host_test.mbt
@@ -1,0 +1,86 @@
+///|
+/// An injection over a local counter, so ordinals are deterministic whatever
+/// earlier tests in this process reserved. `issued` stands in for the
+/// engine's counter; starting it above zero stands in for a resumed session
+/// whose floor an earlier process already pushed up.
+fn injection(issued : Ref[Int], model? : String) -> @host.SubrunInjection {
+  @host.SubrunInjection(
+    exe="/opt/openseek",
+    session_root="/store",
+    parent="run7",
+    workspace_root="/ws",
+    model?,
+    reserve_ordinals=count => {
+      let base = issued.val + 1
+      issued.val += count
+      base
+    },
+  )
+}
+
+///|
+test "blocks are disjoint and come from the allocator" {
+  let injection = injection(Ref(8))
+  let first = injection.reserve()
+  let second = injection.reserve()
+  // The floor is honoured: a resumed session never reissues an ordinal an
+  // earlier process already persisted.
+  assert_eq(first.base(), 9)
+  // And the next snippet starts past the whole of the first block, not past
+  // the ordinals it happened to use — a snippet that launched two children
+  // still holds its block, because the parent cannot see inside it.
+  assert_eq(second.base(), 9 + @host.block_size)
+  assert_eq(first.limit(), @host.block_size)
+  // Every run gets a directory of its own, named by its base, and its files
+  // live inside it — the directory is the unit of both write permission and
+  // discovery.
+  assert_eq(first.dir(), "/store/run7-wf-9")
+  assert_eq(first.journal_path(), "/store/run7-wf-9/journal.jsonl")
+  assert_eq(first.events_path(), "/store/run7-wf-9/events.jsonl")
+}
+
+///|
+test "what this host writes is what the library reads" {
+  // The round trip that matters: the document put in the guest environment
+  // must be one `moonbitlang/workflow/hosted` accepts, with the engine's own
+  // argv shape intact. A drift here would be silent — the snippet would see
+  // no handoff and quietly delegate to nothing.
+  let reservation = injection(Ref(0), model="deepseek-chat").reserve()
+  guard reservation.env().get("WORKFLOW_HOST") is Some(raw) else {
+    fail("the handoff variable must be set")
+  }
+  assert_eq(reservation.env().length(), 1)
+  let document = @json.parse(raw)
+  guard @hosted.parse(document) is Some(ctx) else {
+    fail("the library must accept what this host wrote")
+  }
+  assert_eq(ctx.child_capacity(), @host.block_size)
+  assert_eq(ctx.journal_path(), Some("/store/run7-wf-1/journal.jsonl"))
+  assert_eq(ctx.events_path(), Some("/store/run7-wf-1/events.jsonl"))
+  // The engine's own CLI shape, as data the library substitutes per call: the
+  // session flags are what make a child durable, and they name the library's
+  // placeholder rather than an ordinal this host would have had to guess. A
+  // child RUNS in the workspace, not the session store.
+  guard document
+    is {
+      "child_args": Array(args),
+      "child_id": String("run7-sr-{n}"),
+      "ids": [Number(1, ..), Number(32, ..)],
+      "cwd": String("/ws"),
+      ..
+    } else {
+    fail("handoff shape drifted: \{document.stringify()}")
+  }
+  let args = args.map(a => {
+    match a {
+      String(s) => s
+      _ => "?"
+    }
+  })
+  assert_eq(args, [
+    "subrun", "{kind}", "--model", "deepseek-chat", "--session", "{child}", "--session-root",
+    "/store",
+  ])
+  // No `--max-steps`: per-call ceilings ride the request envelope.
+  assert_false(args.contains("--max-steps"))
+}

--- a/agent_subrun/host/moon.pkg
+++ b/agent_subrun/host/moon.pkg
@@ -1,0 +1,10 @@
+import {
+  "moonbitlang/core/json",
+}
+
+import {
+  "moonbitlang/workflow/hosted",
+  "moonbitlang/core/json",
+} for "test"
+
+supported_targets = "+wasm+native"

--- a/agent_subrun/host/pkg.generated.mbti
+++ b/agent_subrun/host/pkg.generated.mbti
@@ -1,0 +1,25 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_subrun/host"
+
+// Values
+pub let block_size : Int
+
+// Errors
+
+// Types and methods
+type SubrunInjection
+pub fn SubrunInjection::SubrunInjection(exe~ : String, session_root~ : String, parent~ : String, workspace_root~ : String, reserve_ordinals~ : (Int) -> Int, model? : String, api_url? : String) -> Self
+pub fn SubrunInjection::exe(Self) -> String
+pub fn SubrunInjection::reserve(Self) -> SubrunReservation
+
+type SubrunReservation
+pub fn SubrunReservation::base(Self) -> Int
+pub fn SubrunReservation::dir(Self) -> String
+pub fn SubrunReservation::env(Self) -> Map[String, String]
+pub fn SubrunReservation::events_path(Self) -> String
+pub fn SubrunReservation::journal_path(Self) -> String
+pub fn SubrunReservation::limit(Self) -> Int
+
+// Type aliases
+
+// Traits

--- a/agent_subrun/injection.mbt
+++ b/agent_subrun/injection.mbt
@@ -1,0 +1,48 @@
+///|
+/// The host handoff for a snippet run under this durable session: what an
+/// `mbtx` snippet is given so the children it delegates to are visible.
+///
+/// Built HERE, beside `reserve_subrun_ordinals`, because the injection must
+/// draw from the session's one child-ordinal allocator — the same counter
+/// `run_subrun` mints `explore` children from, with this session's resumed
+/// floor. Two independent counters would hand `<parent>-sr-1` to both a
+/// snippet's child and an `explore` child, and the second to append would
+/// die against the first's stale snapshot. `agent_subrun/host` owns the
+/// document; it is a leaf and cannot name the allocator, so the wiring is
+/// this function's whole job.
+///
+/// `exe` must be absolute (the sandbox admits it by exact path);
+/// `workspace_root` is where a child RUNS, since an `explore` child reads code
+/// by paths relative to its cwd.
+pub fn ChildSession::injection(
+  self : ChildSession,
+  exe~ : String,
+  workspace_root~ : String,
+  model? : String,
+  api_url? : String,
+) -> @host.SubrunInjection {
+  let first_free = self.first_free
+  @host.SubrunInjection(
+    exe~,
+    session_root=self.root,
+    parent=self.parent,
+    workspace_root~,
+    model?,
+    api_url?,
+    reserve_ordinals=count => reserve_subrun_ordinals(count, first_free~),
+  )
+}
+
+///|
+test "a session's injection draws from the shared counter" {
+  // Ordinals depend on what this process has already reserved, so the test
+  // pins the invariants rather than the numbers: consecutive blocks, disjoint,
+  // never below the session's floor.
+  let session = ChildSession(root="/store", parent="run7", first_free=1)
+  let injection = session.injection(exe="/opt/openseek", workspace_root="/ws")
+  let first = injection.reserve()
+  let second = injection.reserve()
+  assert_true(first.base() >= 1)
+  assert_eq(second.base(), first.base() + @host.block_size)
+  assert_true(first.dir().has_prefix("/store/run7-wf-"))
+}

--- a/agent_subrun/moon.pkg
+++ b/agent_subrun/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "bobzhang/openseek/agent",
+  "bobzhang/openseek/agent_subrun/host",
   "moonbitlang/workflow/spawn",
   "bobzhang/openseek/agent_runtime",
   "bobzhang/openseek/agent_session",

--- a/agent_subrun/pkg.generated.mbti
+++ b/agent_subrun/pkg.generated.mbti
@@ -3,6 +3,7 @@ package "bobzhang/openseek/agent_subrun"
 
 import {
   "bobzhang/openseek/agent_session",
+  "bobzhang/openseek/agent_subrun/host",
   "bobzhang/openseek/agent_tool",
   "bobzhang/openseek/deepseek",
   "bobzhang/openseek_protocol",
@@ -17,6 +18,8 @@ pub async fn[T] execute_kind(session_id~ : String, system_prompt~ : String, task
 
 pub fn report_line(Json) -> String
 
+pub fn reserve_subrun_ordinals(Int, first_free? : Int) -> Int
+
 pub async fn[T] run_subrun(command~ : String, args~ : Array[String], input~ : Json, parse_report~ : (Json) -> Result[T, String], wall_deadline_ms~ : Int, kind~ : String, label~ : String, cwd? : String, child_session? : ChildSession, extra_env? : Map[String, String], emit_event? : (@openseek_protocol.Event) -> Unit) -> SubrunResult[T]
 
 pub fn[T] validated(Result[T, String], (T) -> Array[String]) -> Result[T, Array[String]]
@@ -29,6 +32,9 @@ pub struct ChildSession {
   // private fields
 }
 pub fn ChildSession::ChildSession(root~ : String, parent~ : String, first_free? : Int) -> Self
+pub fn ChildSession::first_free(Self) -> Int
+pub fn ChildSession::injection(Self, exe~ : String, workspace_root~ : String, model? : String, api_url? : String) -> @host.SubrunInjection
+pub fn ChildSession::root(Self) -> String
 
 type SubrunBudget
 pub fn SubrunBudget::SubrunBudget(max_calls_per_turn? : Int) -> Self

--- a/agent_subrun/runner.mbt
+++ b/agent_subrun/runner.mbt
@@ -208,6 +208,20 @@ pub struct ChildSession {
 }
 
 ///|
+/// The session store the child's transcript is written into.
+pub fn ChildSession::root(self : ChildSession) -> String {
+  self.root
+}
+
+///|
+/// The lowest child ordinal no earlier engine process has persisted for this
+/// parent — the floor a second allocator must also respect if it is minting
+/// child sessions under the same parent.
+pub fn ChildSession::first_free(self : ChildSession) -> Int {
+  self.first_free
+}
+
+///|
 /// See `ChildSession`.
 pub fn ChildSession::ChildSession(
   root~ : String,
@@ -226,6 +240,29 @@ let subrun_ids : Ref[Int] = { val: 0, }
 fn next_subrun_id() -> String {
   subrun_ids.val += 1
   "sr-\{subrun_ids.val}"
+}
+
+///|
+/// Reserve `count` consecutive child ordinals from THIS process's counter and
+/// return the first.
+///
+/// Child sessions are named `<parent>-sr-N`, and `run_subrun` is no longer the
+/// only thing that mints one: an mbtx snippet running a workflow allocates its
+/// own children. Both must draw from the same counter, or a snippet's `sr-1`
+/// and an `explore` call's `sr-1` name the same file and the second child dies
+/// on its first append against the first's snapshot.
+///
+/// `first_free` is the same floor `ChildSession` carries — the lowest ordinal
+/// no earlier engine process persisted for this parent — applied here so a
+/// block reserved right after a resume cannot reuse a persisted id either.
+/// Monotonic: this can skip ordinals, never reuse one.
+pub fn reserve_subrun_ordinals(count : Int, first_free? : Int = 1) -> Int {
+  if subrun_ids.val < first_free - 1 {
+    subrun_ids.val = first_free - 1
+  }
+  let base = subrun_ids.val + 1
+  subrun_ids.val += if count > 0 { count } else { 1 }
+  base
 }
 
 ///|

--- a/agent_tool/mbtx/README.mbt.md
+++ b/agent_tool/mbtx/README.mbt.md
@@ -309,3 +309,29 @@ fn main {
   println(classify('7'))
 }
 ```
+
+## Hosting a workflow
+
+Two decisions, made by two parties.
+
+The CLI says whether this session CAN host: `definition(…, subrun?)` takes a
+`SubrunInjection` from `agent_subrun/host` — the engine path, the session store, the parent id, and the
+session's one child-ordinal allocator — when the conversation has a durable
+session, and nothing when it does not (a `--no-session` run, a read-only
+child's own snippets). That is a capability, not a switch.
+
+The model says whether this snippet WILL delegate: the `subrun: true` argument.
+Only then does the tool reserve a block of 32 child ordinals, create a run
+directory in the session store, write a `WORKFLOW_HOST` handoff into the guest
+environment for `moonbitlang/workflow/hosted` to read, admit the engine to the
+spawn allowlist (by absolute path, `subrun` only), grant the run directory as
+the one writable store path, and announce the run with `workflow_started`.
+Every other snippet gets none of that — reserving children a script never
+starts would waste ids and announce a workflow that does not exist.
+
+Asked on a session that cannot host, the call is refused with a result that
+says why, rather than running the snippet without the coordinates it expects
+and letting its subagents vanish. And whether or not the flag is set,
+`WORKFLOW_HOST` is always DECIDED by the policy — the handoff, or nothing — so
+a child engine's snippet can never inherit its grandparent's handoff and mint
+child ids from a block that is not its own.

--- a/agent_tool/mbtx/internal/decode/decode.mbt
+++ b/agent_tool/mbtx/internal/decode/decode.mbt
@@ -16,6 +16,15 @@ pub struct MbtxInput {
   /// the field, but a model that sends it anyway must be told what happened,
   /// not silently run confined while believing otherwise.
   escalated : Bool
+  /// Whether the snippet declares that it will DELEGATE — run a
+  /// `moonbitlang/workflow` workflow whose children must be visible. Only
+  /// then does the tool reserve child ordinals and a run directory and hand
+  /// the snippet a `WORKFLOW_HOST`; every other snippet gets none, so the
+  /// announcement of a workflow means one was asked for. Decoded whatever the
+  /// tool was built with, for the same reason as `escalated`: a model that
+  /// asks on a session that cannot host must be told, not quietly run
+  /// without its children.
+  subrun : Bool
 } derive(Debug)
 
 ///|
@@ -78,7 +87,13 @@ pub fn decode(arguments : Json) -> MbtxInput raise {
         { "escalated": _, .. } => fail("arguments.escalated to be a boolean")
         _ => false
       }
-      { source, target, cwd, warning, escalated, }
+      let subrun = match arguments {
+        { "subrun": True, .. } => true
+        { "subrun": False, .. } | { "subrun": Null, .. } => false
+        { "subrun": _, .. } => fail("arguments.subrun to be a boolean")
+        _ => false
+      }
+      { source, target, cwd, warning, escalated, subrun, }
     }
     Object(_) => fail("arguments.source")
     _ => fail("object arguments")

--- a/agent_tool/mbtx/internal/decode/pkg.generated.mbti
+++ b/agent_tool/mbtx/internal/decode/pkg.generated.mbti
@@ -17,6 +17,7 @@ pub struct MbtxInput {
   cwd : String?
   warning : Bool
   escalated : Bool
+  subrun : Bool
 } derive(@debug.Debug)
 
 // Type aliases

--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -268,6 +268,26 @@ async fn execute(
   // targets never had `--wasm-policy` passed to them in the first place — they
   // cannot spawn or touch files at all — so asking here would spend a person's
   // attention on a grant that changes nothing about the run.
+  // Delegation lives in the sandbox policy — the handoff is a policy `env.set`,
+  // the engine a policy `process.allow` entry, the run directory a policy write
+  // root — so it exists only where the policy applies: the wasm target, with
+  // the policy in force. Refuse anything else BEFORE a block is reserved or a
+  // run announced; the alternative is a snippet that finds no handoff while
+  // the desktop shows a workflow that never existed.
+  if input.subrun && input.target != "wasm" {
+    return @agent_tool.respond(
+      "mbtx: `subrun` applies to the wasm target, which is the one the sandbox policy binds — the handoff, the engine's spawn rule and the run's write root all live in that policy; `\{input.target}` runs none. Drop `target` to use wasm, or drop `subrun`.",
+      is_error=true,
+      brief="mbtx (subrun needs wasm)",
+    )
+  }
+  if input.subrun && input.escalated {
+    return @agent_tool.respond(
+      "mbtx: `subrun` and `escalated` exclude each other — escalation runs the snippet with NO sandbox policy, and the delegation handoff is delivered through that policy. Use `subrun` alone to delegate; the allowed programs already include the engine.",
+      is_error=true,
+      brief="mbtx (subrun with escalated)",
+    )
+  }
   if input.escalated && input.target != "wasm" {
     return @agent_tool.respond(
       "mbtx: `escalated` applies to the wasm target, which is the one the sandbox policy binds; `\{input.target}` runs no policy to lift and cannot spawn or touch files anyway. Drop `escalated`, or drop `target` to use wasm.",

--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -120,6 +120,7 @@ pub fn definition(
   foreground_timeout_ms? : Int = ForegroundTimeoutMs,
   build_timeout_ms? : Int = BuildTimeoutMs,
   approval? : @agent_runtime.ApprovalChannel,
+  subrun? : @host.SubrunInjection,
 ) -> @agent_tool.AgentToolDefinition {
   // Background snippet directories are numbered inside the caller's scratch
   // dir rather than created as fresh system temp dirs: a detached job outlives
@@ -131,11 +132,14 @@ pub fn definition(
     description=description(
       background=bg_runtime is Some(_),
       escalation=approval is Some(_),
+      hosting=subrun is Some(_),
       auto_background_after_ms~,
       foreground_timeout_ms~,
       build_timeout_ms~,
     ),
-    schema=JsonSchema(schema(escalation=approval is Some(_))),
+    schema=JsonSchema(
+      schema(escalation=approval is Some(_), hosting=subrun is Some(_)),
+    ),
     execute=Async(arguments => {
       execute(
         workspace_root,
@@ -150,6 +154,7 @@ pub fn definition(
         build_timeout_ms~,
         next_background~,
         approval?,
+        subrun?,
       )
     }),
   )
@@ -208,6 +213,7 @@ async fn execute(
   build_timeout_ms~ : Int,
   next_background~ : Ref[Int],
   approval? : @agent_runtime.ApprovalChannel,
+  subrun? : @host.SubrunInjection,
 ) -> @agent_tool.ToolAction {
   let input = @decode.decode(arguments) catch {
     error =>
@@ -421,9 +427,48 @@ async fn execute(
   // `cwd` is deliberately NOT a write root: naming where a program runs should
   // not also grant writing there, and reads are open, so a snippet can still
   // work in a directory it may not modify.
+  // Reserve this snippet's child ordinals and journal BEFORE it runs. The
+  // coordinates reach it as guest environment variables, never as argv it
+  // wrote: only values mbtx chose resolve to anything the host watches, so a
+  // snippet cannot name a session that was not reserved for it.
+  let reservation = if input.subrun {
+    match subrun {
+      Some(injection) => Some(injection.reserve())
+      // Asked, and cannot be served: say so. A snippet that believed it had a
+      // handoff would spawn children with no transcript, and the model would
+      // learn nothing until its subagents failed to appear anywhere.
+      None =>
+        return @agent_tool.respond(
+          "mbtx: `subrun` was requested, but this conversation has no durable session, so a workflow's children would have nowhere to leave a transcript. Retry without `subrun` and do the work in this snippet directly.",
+          is_error=true,
+          brief="mbtx (subrun unavailable)",
+        )
+    }
+  } else {
+    None
+  }
+  // The run's own directory, and the ONE place in the session store the
+  // snippet may write. It must exist before the policy names it — moonrun
+  // canonicalizes every root when it loads the document and refuses the whole
+  // file otherwise. Granting the store itself would let a snippet append to
+  // another session's transcript; the ledger gets a directory instead.
+  if reservation is Some(r) {
+    @fs.mkdir(r.dir()) catch {
+      error if @async.is_being_cancelled() => raise error
+      _ => ()
+    }
+  }
   let policy = wasm_policy_document(
     tmp_dir=snippet_tmp,
-    extra_roots=[..scratch_dir.map(l => [l]).unwrap_or([])],
+    extra_roots=[
+      ..scratch_dir.map(l => [l]).unwrap_or([]),
+      ..reservation.map(r => [r.dir()]).unwrap_or([]),
+    ],
+    inject=reservation.map(r => r.env()).unwrap_or(Map([])),
+    spawnable=match (reservation, subrun) {
+      (Some(_), Some(injection)) => Some(injection.exe())
+      _ => None
+    },
   )
   @fs.write_file(policy_path, policy.stringify(), create_mode=CreateOrTruncate)
   // Wrap each phase's command in sandbox-exec for the roles that need a rule
@@ -1210,7 +1255,7 @@ async fn read_capped(path : String) -> String {
 /// The `mbtx` argument schema. `escalation` adds `escalated` only when an
 /// approval channel is wired; otherwise every use would come back refused, and
 /// the cheapest way not to waste a turn is for the argument not to exist.
-fn schema(escalation~ : Bool) -> Json {
+fn schema(escalation~ : Bool, hosting~ : Bool) -> Json {
   {
     "type": "object",
     "properties": Json(
@@ -1262,6 +1307,25 @@ fn schema(escalation~ : Bool) -> Json {
               ),
             ]
           },
+          ..if hosting {
+            [
+              (
+                "subrun",
+                Json({
+                  "type": "boolean",
+                  "description": (
+                    #|Set true when this snippet DELEGATES: runs a `moonbitlang/workflow`
+                    #|workflow whose children are subagents (`import "moonbitlang/workflow/hosted"`,
+                    #|then `@hosted.context()` and `ctx.run(wf => ...)`). Only then are child
+                    #|sessions reserved and handed to the snippet, so its subagents get their own
+                    #|transcripts and appear in the desktop. Leave it unset for every other
+                    #|snippet: reserving children a script never starts wastes ids and announces
+                    #|a workflow that does not exist. A snippet may start at most 32 children.
+                  ),
+                }),
+              ),
+            ]
+          },
         ],
       ),
     ),
@@ -1294,6 +1358,7 @@ fn schema(escalation~ : Bool) -> Json {
 fn description(
   background~ : Bool,
   escalation~ : Bool,
+  hosting~ : Bool,
   auto_background_after_ms~ : Int,
   foreground_timeout_ms~ : Int,
   build_timeout_ms~ : Int,
@@ -1429,6 +1494,27 @@ fn description(
       $|for up to \{foreground_bound}; at that deadline it is cancelled and reported as a timeout.
     )
   }
+  // Delegation is described only where it can be granted. A session with no
+  // durable store has no argument to advertise, and telling the model about
+  // one it cannot use costs it a refused call to find that out.
+  let delegation = if hosting {
+    (
+      #|
+      #|## Delegating to subagents
+      #|
+      #|Set `subrun: true` when this snippet runs a `moonbitlang/workflow` workflow whose
+      #|children are subagents — and only then. Import "moonbitlang/workflow" and
+      #|"moonbitlang/workflow/hosted", then `guard @hosted.context() is Some(ctx)` and
+      #|`ctx.run(wf => ...)`; inside, `wf.agent(prompt=..., kind="explore")` runs one
+      #|scout, and `@workflow.parallel([...])` with `@workflow.attempt` fans several out
+      #|concurrently. The children get their own transcripts and appear in the desktop.
+      #|A snippet may start at most 32 children. Without the flag no child sessions are
+      #|reserved and the engine is not on the spawn allowlist: a workflow written
+      #|without it runs with no handoff and its subagents are refused.
+    )
+  } else {
+    ""
+  }
   // The blank `$|` line is the paragraph break: without it the section heading
   // runs onto the base text's last line and stops reading as a heading.
   (
@@ -1446,5 +1532,6 @@ fn description(
     $|polling: keep working and act on the notice. Read recent output with job_output
     $|(use one bounded wait_ms call only when the result is needed now), and cancel it
     $|with job_stop.
+    $|\{delegation}
   )
 }

--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -472,8 +472,11 @@ async fn execute(
   // canonicalizes every root when it loads the document and refuses the whole
   // file otherwise. Granting the store itself would let a snippet append to
   // another session's transcript; the ledger gets a directory instead.
+  // Recursive, so the store root's own existence is not this call's problem:
+  // the store creates its directories lazily, and a policy naming a root that
+  // failed to appear would be refused whole, with nothing to say why.
   if reservation is Some(r) {
-    @fs.mkdir(r.dir()) catch {
+    @fs.mkdir(r.dir(), recursive=true) catch {
       error if @async.is_being_cancelled() => raise error
       _ => ()
     }

--- a/agent_tool/mbtx/mbtx_test.mbt
+++ b/agent_tool/mbtx/mbtx_test.mbt
@@ -1523,3 +1523,58 @@ async test "a hosted session reserves nothing unless the snippet asks" {
     })
   })
 }
+
+///|
+async fn run_hosted_with(
+  workspace_root : String,
+  store : String,
+  arguments : Json,
+) -> (@agent_tool.ToolOutput, Int) {
+  let issued = Ref(0)
+  let subrun = @host.SubrunInjection(
+    exe="/unused/openseek",
+    session_root=store,
+    parent="run7",
+    workspace_root~,
+    reserve_ordinals=count => {
+      let base = issued.val + 1
+      issued.val += count
+      base
+    },
+  )
+  let action = match @mbtx.definition(workspace_root~, subrun~).execute {
+    Async(execute) => execute(arguments)
+    Sync(_) => fail("mbtx should be async")
+  }
+  guard action is Respond(output) else { fail("expected Respond") }
+  (output, issued.val)
+}
+
+///|
+async test "delegation is refused off the wasm target, before anything is reserved" {
+  @vfs.with_tmpdir(prefix="mbtx-ws-", ws => {
+    @vfs.with_tmpdir(prefix="mbtx-store-", store => {
+      // The handoff lives in the wasm policy; a js run has none to carry it.
+      let (out, issued) = run_hosted_with(ws, store, {
+        "source": "fn main { println(1) }",
+        "target": "js",
+        "subrun": true,
+      })
+      assert_true(out.is_error)
+      assert_true(out.content.contains("applies to the wasm target"))
+      assert_eq(issued, 0)
+      // Escalation lifts the policy the handoff is delivered through.
+      let (out, issued) = run_hosted_with(ws, store, {
+        "source": "fn main { println(1) }",
+        "subrun": true,
+        "escalated": true,
+      })
+      assert_true(out.is_error)
+      assert_true(out.content.contains("exclude each other"))
+      assert_eq(issued, 0)
+      // Neither refusal created a run directory: the desktop must never be
+      // told about a workflow that was refused.
+      assert_false(@fs.exists("\{store}/run7-wf-1"))
+    })
+  })
+}

--- a/agent_tool/mbtx/mbtx_test.mbt
+++ b/agent_tool/mbtx/mbtx_test.mbt
@@ -1578,3 +1578,22 @@ async test "delegation is refused off the wasm target, before anything is reserv
     })
   })
 }
+
+///|
+async test "the run directory is created even when the store root is not there yet" {
+  @vfs.with_tmpdir(prefix="mbtx-ws-", ws => {
+    @vfs.with_tmpdir(prefix="mbtx-store-", store => {
+      // The store creates its directories lazily, so a reservation may be the
+      // first thing to touch the root. A policy naming a root that failed to
+      // appear is refused whole; the mkdir must not depend on the root.
+      let root = "\{store}/not-yet"
+      let (out, issued) = run_hosted_with(ws, root, {
+        "source": "fn main { println(\"hosted\") }",
+        "subrun": true,
+      })
+      assert_false(out.is_error, msg=out.content)
+      assert_eq(issued, @host.block_size)
+      assert_true(@fs.exists("\{root}/run7-wf-1"))
+    })
+  })
+}

--- a/agent_tool/mbtx/mbtx_test.mbt
+++ b/agent_tool/mbtx/mbtx_test.mbt
@@ -1343,3 +1343,183 @@ async test "an escalated run is not read as a policy refusal" {
   assert_false(out.content.contains("this tool's policy refusing"))
   assert_false(out.content.contains("escalated: true"))
 }
+
+///|
+/// Run `source` as a HOSTED snippet: one whose conversation has a durable
+/// session, so mbtx reserves child ordinals and a run directory and hands
+/// them to the guest as `WORKFLOW_HOST`. `store` stands in for the session
+/// store; ordinals come from a local counter, as the CLI's shared one would.
+async fn run_hosted(
+  workspace_root : String,
+  store : String,
+  source : String,
+) -> @agent_tool.ToolOutput {
+  let issued = Ref(0)
+  let subrun = @host.SubrunInjection(
+    exe="/unused/openseek",
+    session_root=store,
+    parent="run7",
+    workspace_root~,
+    reserve_ordinals=count => {
+      let base = issued.val + 1
+      issued.val += count
+      base
+    },
+  )
+  let action = match @mbtx.definition(workspace_root~, subrun~).execute {
+    Async(execute) => execute({ "source": source, "subrun": true })
+    Sync(_) => fail("mbtx should be async")
+  }
+  guard action is Respond(output) else { fail("expected Respond") }
+  output
+}
+
+///|
+async test "a hosted snippet may write its own run directory" {
+  @vfs.with_tmpdir(prefix="mbtx-ws-", ws => {
+    @vfs.with_tmpdir(prefix="mbtx-store-", store => {
+      // The guest reads the handoff the policy set and appends to the two
+      // paths it names. Under mbtx's REAL policy the session store is not a
+      // write root, so this passes only because the run's own directory was
+      // created before the policy named it and granted as one — the case a
+      // hand-written policy in an earlier end-to-end check silently hid.
+      let out = run_hosted(
+        ws,
+        store,
+        (
+          #|import { "moonbitlang/async", "moonbitlang/async/fs", "moonbitlang/core/env", "moonbitlang/core/json" }
+          #|
+          #|async fn main {
+          #|  guard @env.get_env_var("WORKFLOW_HOST") is Some(raw) else { println("NO HANDOFF"); return }
+          #|  guard @json.parse(raw) is { "journal": String(journal), "events": String(events), .. } else { println("BAD HANDOFF"); return }
+          #|  @fs.write_file(journal, "{\"e\":1}\n", append=true, create_mode=OpenOrCreate)
+          #|  @fs.write_file(events, "{\"event\":\"agent_started\"}\n", append=true, create_mode=OpenOrCreate)
+          #|  println("wrote")
+          #|}
+        ),
+      )
+      if out.is_error {
+        fail("hosted snippet failed:\n\{out.content}")
+      }
+      assert_true(out.content.contains("wrote"))
+      let journal = @fs.read_file("\{store}/run7-wf-1/journal.jsonl").text()
+      assert_true(journal.contains("{\"e\":1}"))
+      let events = @fs.read_file("\{store}/run7-wf-1/events.jsonl").text()
+      assert_true(events.contains("agent_started"))
+    })
+  })
+}
+
+///|
+async test "a hosted snippet may NOT write the rest of the session store" {
+  @vfs.with_tmpdir(prefix="mbtx-ws-", ws => {
+    @vfs.with_tmpdir(prefix="mbtx-store-", store => {
+      // Only the run's directory was granted. Writing beside another session's
+      // transcript in the store root is refused by the policy — and mbtx
+      // reports a refusal as an error, with its own advice, which is the
+      // contract this test also pins: a snippet that overreaches is TOLD so.
+      let out = run_hosted(
+        ws,
+        store,
+        (
+          #|import { "moonbitlang/async", "moonbitlang/async/fs", "moonbitlang/core/env", "moonbitlang/core/json" }
+          #|
+          #|async fn main {
+          #|  guard @env.get_env_var("WORKFLOW_HOST") is Some(raw) else { println("NO HANDOFF"); return }
+          #|  guard @json.parse(raw) is { "journal": String(journal), .. } else { println("BAD HANDOFF"); return }
+          #|  let dir = journal.rev_find("/").map(i => journal[:i].to_string()).unwrap_or("?")
+          #|  let store = dir.rev_find("/").map(i => dir[:i].to_string()).unwrap_or("?")
+          #|  @fs.write_file("\{store}/other-session.jsonl", "x", create_mode=OpenOrCreate) catch { _ => { println("store refused"); return } }
+          #|  println("STORE WRITABLE")
+          #|}
+        ),
+      )
+      assert_true(out.is_error)
+      assert_true(out.content.contains("store refused"))
+      assert_true(out.content.contains("Sandbox policy blocked"))
+      assert_false(out.content.contains("STORE WRITABLE"))
+      assert_false(@fs.exists("\{store}/other-session.jsonl"))
+    })
+  })
+}
+
+///|
+async test "an unhosted snippet sees no handoff, even one its host inherited" {
+  // The guest copies the host's environment, and this process may itself be
+  // a child of a hosted snippet. The policy therefore always DECIDES
+  // `WORKFLOW_HOST`: to the reservation when there is one, to nothing when
+  // there is not. A snippet with no durable session must never find a
+  // grandparent's handoff and mint child ids from a block that is not its own.
+  let out = run(
+    (
+      #|import { "moonbitlang/core/env" }
+      #|
+      #|fn main {
+      #|  match @env.get_env_var("WORKFLOW_HOST") {
+      #|    Some(v) if !v.is_empty() => println("LEAKED: \{v}")
+      #|    _ => println("clear")
+      #|  }
+      #|}
+    ),
+  )
+  assert_false(out.is_error)
+  assert_true(out.content.contains("clear"))
+  assert_false(out.content.contains("LEAKED"))
+}
+
+///|
+async test "asking to delegate on a session that cannot host is refused, and says why" {
+  // The capability is absent (no `subrun` injection); the model asks anyway.
+  // Running the snippet without the coordinates it expects would let its
+  // subagents vanish, so the answer is a refusal the model can act on.
+  let out = run_in(".", { "source": "fn main { println(1) }", "subrun": true })
+  assert_true(out.is_error)
+  assert_true(out.content.contains("no durable session"))
+  assert_true(out.content.contains("Retry without `subrun`"))
+}
+
+///|
+async test "a hosted session reserves nothing unless the snippet asks" {
+  @vfs.with_tmpdir(prefix="mbtx-ws-", ws => {
+    @vfs.with_tmpdir(prefix="mbtx-store-", store => {
+      // Same capability as `run_hosted`, but the snippet does not set the
+      // flag: no ordinals are reserved, no run directory is created, no
+      // handoff is written, and no engine enters the command vocabulary.
+      // Reserving children a script never starts would waste ids and announce
+      // a workflow that does not exist.
+      let issued = Ref(0)
+      let subrun = @host.SubrunInjection(
+        exe="/unused/openseek",
+        session_root=store,
+        parent="run7",
+        workspace_root=ws,
+        reserve_ordinals=count => {
+          let base = issued.val + 1
+          issued.val += count
+          base
+        },
+      )
+      let action = match @mbtx.definition(workspace_root=ws, subrun~).execute {
+        Async(execute) =>
+          execute({
+            "source": (
+              #|import { "moonbitlang/core/env" }
+              #|
+              #|fn main {
+              #|  match @env.get_env_var("WORKFLOW_HOST") {
+              #|    Some(v) if !v.is_empty() => println("HANDOFF PRESENT")
+              #|    _ => println("no handoff")
+              #|  }
+              #|}
+            ),
+          })
+        Sync(_) => fail("mbtx should be async")
+      }
+      guard action is Respond(out) else { fail("expected Respond") }
+      assert_false(out.is_error)
+      assert_true(out.content.contains("no handoff"))
+      assert_eq(issued.val, 0)
+      assert_false(@fs.exists("\{store}/run7-wf-1"))
+    })
+  })
+}

--- a/agent_tool/mbtx/moon.pkg
+++ b/agent_tool/mbtx/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/agent_subrun/host",
   "bobzhang/openseek/agent_tool/bgjobs",
   "bobzhang/openseek/agent_runtime",
   "bobzhang/openseek/agent_tool/mbtx/internal/decode",
@@ -19,6 +20,7 @@ supported_targets = "+wasm+native"
 
 import {
   "moonbitlang/async",
+  "bobzhang/openseek/agent_subrun/host",
   "bobzhang/openseek/testkit/filesystem" @vfs,
 } for "test"
 

--- a/agent_tool/mbtx/pkg.generated.mbti
+++ b/agent_tool/mbtx/pkg.generated.mbti
@@ -3,12 +3,13 @@ package "bobzhang/openseek/agent_tool/mbtx"
 
 import {
   "bobzhang/openseek/agent_runtime",
+  "bobzhang/openseek/agent_subrun/host",
   "bobzhang/openseek/agent_tool",
   "bobzhang/openseek/agent_tool/bgjobs",
 }
 
 // Values
-pub fn definition(workspace_root~ : String, read_only? : Bool, bg_runtime? : @bgjobs.BgJobRuntime, job_dir? : String, scratch_dir? : String, worker_sandbox? : WorkerSandbox, auto_background_after_ms? : Int, foreground_timeout_ms? : Int, build_timeout_ms? : Int, approval? : @agent_runtime.ApprovalChannel) -> @agent_tool.AgentToolDefinition
+pub fn definition(workspace_root~ : String, read_only? : Bool, bg_runtime? : @bgjobs.BgJobRuntime, job_dir? : String, scratch_dir? : String, worker_sandbox? : WorkerSandbox, auto_background_after_ms? : Int, foreground_timeout_ms? : Int, build_timeout_ms? : Int, approval? : @agent_runtime.ApprovalChannel, subrun? : @host.SubrunInjection) -> @agent_tool.AgentToolDefinition
 
 // Errors
 

--- a/agent_tool/mbtx/wasm_policy.mbt
+++ b/agent_tool/mbtx/wasm_policy.mbt
@@ -246,9 +246,21 @@ let spawnable_commands : Array[(String, Array[String])] = [
 /// which admits no shell, no interpreter, and no ad-hoc rewriter, and which
 /// refuses git's reconfiguring global options because they precede the
 /// subcommand.
+/// `inject` names variables written into the GUEST environment on top of the
+/// host's, and `spawnable` an extra program the snippet may start. Both exist
+/// for one caller: a snippet that runs a workflow needs the engine's own
+/// absolute path plus the coordinates mbtx reserved for it, and neither can
+/// come from the snippet — the whole point is that only values mbtx chose
+/// resolve to anything the host is watching. `spawnable` is an ABSOLUTE path
+/// for the same reason `explore` never resolves the engine through PATH:
+/// parent and child must be the same binary or the report's derived JSON
+/// codecs can drift. moonrun matches the entry exactly, so an absolute rule
+/// admits only that exact binary and no same-named one earlier in PATH.
 fn wasm_policy_document(
   tmp_dir~ : String,
   extra_roots~ : Array[String],
+  inject~ : Map[String, String],
+  spawnable~ : String?,
 ) -> Json {
   // A snippet writes NOTHING in the workspace. It does not need to: the file
   // tools make the edits, and the commands whose job is to rewrite source
@@ -277,6 +289,15 @@ fn wasm_policy_document(
     }
     allow.push(rule)
   }
+  // The engine itself, one verb only. `subrun` reads a JSON line and reports
+  // a child agent's result; the other verbs stay out, since a bare `openseek`
+  // starts an interactive agent. An admitted verb spawns children of its own
+  // — the sub-run IS an agent — which is the already-accepted `moon run`
+  // shape; what the prefix buys is that only the delegating FORM of this
+  // program exists in a snippet's vocabulary.
+  if spawnable is Some(exe) {
+    allow.push({ "program": exe, "args_prefix": json_strings(["subrun"]) })
+  }
   {
     // A policy run BUILDS the guest environment rather than inheriting one, so
     // an empty list means an empty environment — `moon` could not even be
@@ -296,7 +317,7 @@ fn wasm_policy_document(
     // run's files. A native child ignores it either way — moonbitlang/async's
     // `stub.c` hardcodes `/tmp` off Windows — but a child is outside this
     // policy, so its temp directory is not this policy's business.
-    "env": { "from_host": ["*"], "set": { "TMPDIR": tmp_dir } },
+    "env": { "from_host": ["*"], "set": Json(env_set(tmp_dir, inject)) },
     // `"*"` is moonrun's every-host-path wildcard — see the header for why
     // reads are open where writes are not.
     "fs": { "read": ["*"], "write": json_strings(write_roots) },
@@ -316,7 +337,125 @@ fn wasm_policy_document(
 }
 
 ///|
+/// The guest's `env.set` block: whatever the caller injects, then the two
+/// names whose values are POLICY DECISIONS rather than messages, written last
+/// so no injected variable can override them.
+///
+/// `TMPDIR` points the snippet's scratch space into the directory this run
+/// owns. `WORKFLOW_HOST` is always set — to the handoff when this run has one,
+/// and to NOTHING otherwise. The guest copies the host's environment
+/// (`from_host: ["*"]`), and this process may itself be a child of a hosted
+/// snippet, whose handoff it inherited: left alone, that handoff would reach
+/// this snippet, which would then mint child ids from a block that belongs to
+/// its grandparent and collide with the grandparent's own children. An empty
+/// value fails the library's reader closed, so the snippet sees no handoff
+/// rather than someone else's.
+fn env_set(tmp_dir : String, inject : Map[String, String]) -> Map[String, Json] {
+  let set : Map[String, Json] = Map([])
+  for name, value in inject {
+    set[name] = value.to_json()
+  }
+  if !set.contains(HostHandoffVar) {
+    set[HostHandoffVar] = "".to_json()
+  }
+  set["TMPDIR"] = tmp_dir.to_json()
+  set
+}
+
+///|
+/// The variable `moonbitlang/workflow/hosted` reads its handoff from.
+const HostHandoffVar = "WORKFLOW_HOST"
+
+///|
 /// A JSON array of strings, for the path lists the policy is mostly made of.
 fn json_strings(values : Array[String]) -> Json {
   Json([ for value in values => Json(value) ])
+}
+
+///|
+fn test_injection(issued : Ref[Int]) -> @host.SubrunInjection {
+  SubrunInjection(
+    exe="/opt/openseek",
+    session_root="/store",
+    parent="run7",
+    workspace_root="/ws",
+    reserve_ordinals=count => {
+      let base = issued.val + 1
+      issued.val += count
+      base
+    },
+  )
+}
+
+///|
+test "the reservation reaches the guest, and only its own directory is writable" {
+  let injection = test_injection(Ref(0))
+  let reservation = injection.reserve()
+  // A snippet that tried to redirect its own scratch space cannot: the policy
+  // writes TMPDIR last, so the one name here whose value is a policy decision
+  // rather than a message always wins.
+  let inject = reservation.env()
+  inject["TMPDIR"] = "/somewhere/else"
+  let policy = wasm_policy_document(
+    tmp_dir="/run/tmp",
+    extra_roots=[reservation.dir()],
+    inject~,
+    spawnable=Some(injection.exe()),
+  )
+  guard policy
+    is {
+      "env": { "set": Object(set), .. },
+      "fs": { "write": Array(write), .. },
+      "process": { "allow": Array(allow), .. },
+      ..
+    } else {
+    fail("policy lost its env, fs or process section")
+  }
+  assert_eq(set.get("TMPDIR"), Some(Json::string("/run/tmp")))
+  assert_true(set.get("WORKFLOW_HOST") is Some(String(_)))
+  // The run's directory is writable; the session store as a whole is not. A
+  // snippet can append its own ledger and nothing else's transcript.
+  assert_true(write.contains("/store/run7-wf-1"))
+  assert_false(write.contains("/store"))
+  // The engine is admitted by ABSOLUTE path and for one verb. moonrun matches
+  // the entry exactly, so this admits that binary and not a same-named one
+  // earlier in PATH — the same guarantee `explore` gets from never resolving
+  // the engine through PATH.
+  assert_true(
+    allow.contains({ "program": "/opt/openseek", "args_prefix": ["subrun"] }),
+  )
+}
+
+///|
+test "no injection clears any inherited handoff and admits no engine" {
+  let policy = wasm_policy_document(
+    tmp_dir="/run/tmp",
+    extra_roots=[],
+    inject=Map([]),
+    spawnable=None,
+  )
+  guard policy
+    is {
+      "env": { "set": Object(set), .. },
+      "process": { "allow": Array(allow), .. },
+      ..
+    } else {
+    fail("policy lost its env or process section")
+  }
+  // A conversation with no durable session gets no coordinates and no engine
+  // in its command vocabulary: there is nowhere to put a child transcript, so
+  // admitting the spawn would only produce invisible children.
+  //
+  // `WORKFLOW_HOST` is still SET — to nothing. The guest copies the host's
+  // environment, and this process may itself be a child of a hosted snippet,
+  // whose handoff it inherited. Left alone, that handoff would reach this
+  // snippet, which would mint child ids from a block that belongs to its
+  // grandparent. An empty value fails the library's reader closed.
+  assert_eq(set.length(), 2)
+  assert_true(set.get("TMPDIR") is Some(_))
+  assert_eq(set.get("WORKFLOW_HOST"), Some(Json::string("")))
+  for rule in allow {
+    guard rule is { "program": String(program), .. } else { continue }
+    assert_false(program.contains("openseek"))
+  }
 }

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -308,7 +308,13 @@ async fn run_task_turn(
       api_url?,
       child_session?,
     )
-    let tools = @agent.build_tools(runtime, scope, extra_tools~)
+    // A snippet's workflow delegates to children named from the SAME ordinal
+    // counter `run_subrun` uses, so a snippet's child and an `explore` child
+    // cannot collide on one transcript file.
+    let mbtx_subrun = child_session.map(spec => {
+      spec.injection(exe~, workspace_root~, model="\{model}", api_url?)
+    })
+    let tools = @agent.build_tools(runtime, scope, extra_tools~, mbtx_subrun?)
     let on_goal_met = if review_gate_enabled(matches) {
       Some(
         build_goal_met_gate(

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -686,6 +686,13 @@ async fn run_serve(
       }
       None => None
     }
+    // The same coordinates, in the shape an mbtx snippet needs: a workflow it
+    // runs delegates to children that must be named from the SAME ordinal
+    // counter `run_subrun` uses, or a snippet's child and an `explore` child
+    // collide on one transcript file.
+    let mbtx_subrun = child_session.map(spec => {
+      spec.injection(exe~, workspace_root~, model="\{model}", api_url?)
+    })
     // The callable review tool audits against the LIVE standing goal: the
     // closure reads the loop-updated session at call time, never a
     // snapshot.
@@ -731,6 +738,7 @@ async fn run_serve(
         ignore(steps.try_put(BackgroundNotice) catch { _ => false })
       },
       extra_tools~,
+      mbtx_subrun?,
     )
     group.spawn_bg(no_wait=true) <| () => {
       @jsonl.each(@stdio.stdin, json => {

--- a/cmd/openseek/subrun.mbt
+++ b/cmd/openseek/subrun.mbt
@@ -59,6 +59,16 @@ async fn run_subrun_command(matches : @argparse.Matches) -> Unit {
       }
       other => other
     }
+    // The envelope also carries the caller's step ceiling. That is where the
+    // workflow contract puts it — a hosted snippet's `wf.agent(max_steps=N)`
+    // arrives HERE, not on argv, because the library's argv is a template
+    // that cannot express an optional flag. The explicit `--max-steps` flag
+    // still wins when both are present: it is the operator's word.
+    let ceiling : Int? = match parsed {
+      { "workflow_contract": Number(1, ..), "max_steps": Number(steps, ..), .. } =>
+        Some(steps.to_int())
+      _ => None
+    }
     @async.with_task_group() <| group => {
       // Failures are caught INSIDE the task: a spawned task's failure
       // cancels the group body, so a catch around `work.wait()` observes
@@ -68,7 +78,7 @@ async fn run_subrun_command(matches : @argparse.Matches) -> Unit {
       // parent classifies on, and the task completes normally.
       let work = group.spawn(() => {
         dispatch_kind(
-          kind, input, matches, model, thinking, api_url, workspace_root,
+          kind, input, ceiling, matches, model, thinking, api_url, workspace_root,
         ) catch {
           error if @async.is_being_cancelled() ||
             @async.is_cancellation_error(error) => raise error
@@ -197,10 +207,27 @@ async fn remove_scratch_lab(dir : String) -> Unit {
 }
 
 ///|
+/// The step ceiling for one child, by precedence: the explicit `--max-steps`
+/// flag (the operator's word), else the request envelope's `max_steps` (where
+/// the workflow contract carries a caller's per-call ceiling), else the
+/// kind's own default.
+fn step_ceiling(
+  matches : @argparse.Matches,
+  envelope : Int?,
+  default : Int,
+) -> Int raise {
+  match max_steps(matches) {
+    Some(steps) => steps
+    None => envelope.unwrap_or(default)
+  }
+}
+
+///|
 /// Run one kind in this process and return its report, if any.
 async fn dispatch_kind(
   kind : String,
   input : Json,
+  ceiling : Int?,
   matches : @argparse.Matches,
   model : @deepseek.Model,
   thinking : @deepseek.ThinkingMode,
@@ -213,6 +240,22 @@ async fn dispatch_kind(
   // items append as the turn runs. Without the flags the transcript stays
   // in-memory, exactly as before.
   let durable = child_durable_session(matches, workspace_root~)
+  // A child spawned from a hosted snippet inherits that snippet's handoff
+  // in its environment. One that arrives with the handoff but WITHOUT a
+  // reserved session was launched around the library — a hand-rolled
+  // spawn, not `@hosted.run` — and would run to completion leaving no
+  // transcript, invisible to every viewer. Refuse up front, so the model
+  // learns the one path that is visible instead of silently losing a child.
+  if durable is None &&
+    @env.get_env_var("WORKFLOW_HOST") is Some(handoff) &&
+    !handoff.is_empty() {
+    @emit.emit(
+      CommandError(
+        error="subrun was launched from a hosted workflow without a reserved --session; delegate through @hosted.run so the child gets a transcript",
+      ),
+    )
+    return None
+  }
   let session_id = durable.map(pair => pair.0)
   let append_item = durable.map(pair => {
     let store = @store.SessionStore(pair.1)
@@ -233,8 +276,8 @@ async fn dispatch_kind(
         input,
         api_key~,
         model~,
-        max_steps=max_steps(matches).unwrap_or(
-          @agent_explore.default_explore_max_steps,
+        max_steps=step_ceiling(
+          matches, ceiling, @agent_explore.default_explore_max_steps,
         ),
         thinking~,
         api_url?,
@@ -267,8 +310,8 @@ async fn dispatch_kind(
         baseline~,
         api_key~,
         model~,
-        max_steps=max_steps(matches).unwrap_or(
-          @agent_review.default_audit_max_steps,
+        max_steps=step_ceiling(
+          matches, ceiling, @agent_review.default_audit_max_steps,
         ),
         thinking~,
         api_url?,
@@ -298,8 +341,8 @@ async fn dispatch_kind(
           input,
           api_key~,
           model~,
-          max_steps=max_steps(matches).unwrap_or(
-            @agent_worker.default_worker_max_steps,
+          max_steps=step_ceiling(
+            matches, ceiling, @agent_worker.default_worker_max_steps,
           ),
           thinking~,
           api_url?,
@@ -337,7 +380,7 @@ async fn dispatch_kind(
         instruction,
         api_key~,
         model~,
-        max_steps=max_steps(matches).unwrap_or(8),
+        max_steps=step_ceiling(matches, ceiling, 8),
         thinking~,
         api_url?,
         workspace_root~,

--- a/moon.mod
+++ b/moon.mod
@@ -9,7 +9,7 @@ import {
   "bobzhang/openseek_protocol@0.1.1",
   "moonbit-community/rabbita@0.15.4",
   "moonbitlang/editor@0.4.5",
-  "moonbitlang/workflow@0.6.0",
+  "moonbitlang/workflow@0.7.0",
 }
 
 readme = "README.mbt.md"


### PR DESCRIPTION
Now based on `main` (its former base, #1286, was merged in its 0.6.0 form). Two commits:

1. `deps: bump moonbitlang/workflow 0.6.0 -> 0.7.0` — one line. 0.7.0 adds the `hosted` sub-package (moonbitlang/workflow#21), which is what an `mbtx` snippet needs and which **cannot live in openseek**: a snippet's front-matter imports resolve `bobzhang/openseek/*` against the *published* module.
2. The mbtx change below.

## Two decisions, made by two parties

**The CLI says whether this session *can* host.** `definition(…, subrun? : SubrunInjection)` carries the engine path, the session store, the parent id and the session's one child-ordinal allocator when the conversation has a durable session — and nothing when it does not. That is a capability, not a switch.

**The model says whether this snippet *will* delegate.** `MbtxInput` gains a boolean `subrun`. Only a call that sets it reserves a block of 32 child ordinals, creates a run directory in the store, writes a `WORKFLOW_HOST` handoff for `moonbitlang/workflow/hosted`, admits the engine to the spawn allowlist (absolute path, `subrun` only), grants the run directory as the one writable store path, and announces the run with `workflow_started`. Every other snippet gets none of that — reserving children a script never starts would waste 32 ids per call, litter the store with empty run directories, and show every file-reading snippet in the desktop as a "workflow". Asked on a session that cannot host, the call is **refused with a result that says why**. The argument is advertised in the schema and described in the tool text only where it can be granted, exactly as `escalated` is.

## `agent_subrun/host`: the injection is its own package

It is the openseek half of the host handoff — the engine's argv shape, the `<store>/<parent>-wf-N/` layout, the `<parent>-sr-{n}` grammar, the block size — none of which is about the sandbox tool. It is a **leaf** (core/json only), because `agent_subrun` imports `agent` and `agent` imports `mbtx`: a package under `agent_subrun` that imported `agent_subrun` would close a cycle the moment `mbtx` imported it. So `agent_subrun` gains the one production constructor, `ChildSession::injection(exe~, workspace_root~, model?, api_url?)`, wiring the session's shared allocator — the CLI builds the injection from the session in one call — while the leaf keeps an explicit-allocator constructor for deterministic tests. `SubrunInjection` is **abstract** (`type SubrunInjection`), and its round-trip test through the published `@hosted.parse` lives with the document it checks. `mbtx` receives an opaque reservation through accessors and sets one variable.

## The handoff is the library's contract, not ours

The child argv goes across as a **template** the library substitutes per call (`{kind}`, `{child}`), so the library learns nothing of this engine's command line — and `attempt_id` in the resulting ledger is the rendered `<parent>-sr-N`, exactly the session id `viz`'s chip links to and `desktop/internal/subrun/probe.mbt` tails.

## One counter, not two

Two independent counters would hand `<parent>-sr-1` to both a snippet's child and an `explore` child, and the second to append would die against the first's stale snapshot. One counter (`agent_subrun.reserve_subrun_ordinals`), one resumed-session floor; the block doubles as the runaway backstop.

## `subrun` honors the envelope's `max_steps`

Explicit `--max-steps` wins, else the request envelope, else the kind's default. Before this, `wf.agent(max_steps=N)` from a snippet was silently dropped.

## Robustness pass — pinned by tests through `@mbtx.definition` itself

1. **The store is not a write root.** Each run gets `<store>/<parent>-wf-<base>/`, created before the policy names it and granted as the **one** writable store path.
2. **`WORKFLOW_HOST` is always decided by the policy** — the handoff, or empty — so a child engine's snippet cannot inherit its grandparent's handoff.
3. **A child's cwd is the workspace**, not the store.
4. **`subrun` (the child engine) refuses a child launched with the handoff in its environment but no `--session`.**
5. **`subrun` is refused off the wasm target, and together with `escalated`** — before a block is reserved or a run announced. The handoff, the engine's spawn rule and the run's write root are all facts of the sandbox *policy*; a js/native target runs none and escalation lifts it, so either combination would have burned 32 ids and told the desktop about a workflow no snippet could join. Same shape as the existing `escalated`-needs-wasm refusal.

## Verification

End to end with a snippet importing `hosted` from the **published** 0.7.0: three concurrent children into `run7-sr-5/6/7`, a journal whose `attempt_id`s are those session ids, a sidecar bracketing each launch. 70/70 mbtx (incl. refusal-without-capability, no-reservation-without-the-flag, and the two policy-less refusals above), 281/281 across host/agent_subrun/mbtx/agent/CLI, `moon check` / `--fmt` / interfaces clean workspace-wide, zero warnings.

Note on CI: the native job's `moon test` fails on **different** timing-sensitive tests on different cold runs (`auto_check`, `job_output`, the mbtx background-job tests); all pass warm and locally. That's the runner, not this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXBYcYo74F1DGSPZsYYAdc
