### PR TITLE
protocol: announce a snippet's workflow so a reader can find it

### DIFF
--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -481,6 +481,32 @@ async fn execute(
       _ => ()
     }
   }
+  // Announce the run before it can produce anything. A reader is TOLD where
+  // the ledger and its sidecar are, and which child ordinals belong to this
+  // run, because nothing about a snippet is otherwise visible: the parent
+  // sees one opaque tool call however many children it starts. The finish
+  // bracket is closed on every exit below, cancellation included, so nothing
+  // shows a workflow as running forever.
+  if reservation is Some(r) {
+    @emit.emit(
+      WorkflowStarted(
+        id="wf-\{r.base()}",
+        journal=r.journal_path(),
+        events=r.events_path(),
+        first_child=r.base(),
+        child_count=r.limit(),
+      ),
+    )
+  }
+  // Closed here only while this call still owns the run. A background
+  // handoff returns from this function with the snippet STILL RUNNING — the
+  // job then owns its lifecycle, and closes the bracket at terminal status
+  // instead (see `terminal_cleanup`), the same split `cleanup()` makes for
+  // the temp directory. Closing it here regardless would report a workflow
+  // finished the moment it was adopted.
+  defer (if reservation is Some(r) && !job_owns_cleanup {
+    @emit.emit(WorkflowFinished(id="wf-\{r.base()}"))
+  })
   let policy = wasm_policy_document(
     tmp_dir=snippet_tmp,
     extra_roots=[
@@ -679,6 +705,11 @@ async fn execute(
         dir
       }
       let terminal_cleanup : async () -> Unit = () => {
+        // The workflow bracket closes when the JOB ends — not when this call
+        // returned at adoption, which was while the run was still going.
+        if reservation is Some(r) {
+          @emit.emit(WorkflowFinished(id="wf-\{r.base()}"))
+        }
         @async.protect_from_cancel(() => {
           @fs.rmdir(terminal_cleanup_path, recursive=true) catch {
             _ => ()

--- a/agent_tool/mbtx/mbtx_test.mbt
+++ b/agent_tool/mbtx/mbtx_test.mbt
@@ -1525,13 +1525,17 @@ async test "a hosted session reserves nothing unless the snippet asks" {
 }
 
 ///|
-async fn run_hosted_with(
-  workspace_root : String,
+/// An injection over a local counter that starts at `first`, so a test can
+/// pick the ordinal block — and therefore the run id, `wf-<first>` — its
+/// lines will carry. The protocol sink is shared by every test in the
+/// process, so a test that reads it must be able to tell its own run apart.
+fn hosted_injection(
   store : String,
-  arguments : Json,
-) -> (@agent_tool.ToolOutput, Int) {
-  let issued = Ref(0)
-  let subrun = @host.SubrunInjection(
+  workspace_root : String,
+  first~ : Int,
+) -> (@host.SubrunInjection, Ref[Int]) {
+  let issued = Ref(first - 1)
+  let injection = @host.SubrunInjection(
     exe="/unused/openseek",
     session_root=store,
     parent="run7",
@@ -1542,12 +1546,23 @@ async fn run_hosted_with(
       base
     },
   )
+  (injection, issued)
+}
+
+///|
+async fn run_hosted_with(
+  workspace_root : String,
+  store : String,
+  arguments : Json,
+  first? : Int = 1,
+) -> (@agent_tool.ToolOutput, Int) {
+  let (subrun, issued) = hosted_injection(store, workspace_root, first~)
   let action = match @mbtx.definition(workspace_root~, subrun~).execute {
     Async(execute) => execute(arguments)
     Sync(_) => fail("mbtx should be async")
   }
   guard action is Respond(output) else { fail("expected Respond") }
-  (output, issued.val)
+  (output, issued.val - (first - 1))
 }
 
 ///|
@@ -1594,6 +1609,128 @@ async test "the run directory is created even when the store root is not there y
       assert_false(out.is_error, msg=out.content)
       assert_eq(issued, @host.block_size)
       assert_true(@fs.exists("\{root}/run7-wf-1"))
+    })
+  })
+}
+
+///|
+/// The workflow bracket lines for run `id` that the in-process protocol sink
+/// is holding, in order. Everything else queued is discarded: other tests'
+/// hosted runs announce runs of their own into the same sink.
+fn workflow_lines(id : String) -> Array[Json] raise {
+  let lines = []
+  while @emit.poll_line() is Some(line) {
+    let entry = @json.parse(line)
+    if entry is { "event": String(event), "id": String(entry_id), .. } &&
+      event.has_prefix("workflow_") &&
+      entry_id == id {
+      lines.push(entry)
+    }
+  }
+  lines
+}
+
+///|
+/// One test, not four: the protocol sink is process-global and a drain takes
+/// every queued line, so two tests reading it concurrently would steal each
+/// other's brackets. The sink is opened and left open — closing it while
+/// another test's hosted run is announcing would drop that run's lines.
+async test "a hosted run is announced before it runs and closed on every exit" {
+  @vfs.with_tmpdir(prefix="mbtx-ws-", ws => {
+    @vfs.with_tmpdir(prefix="mbtx-store-", store => {
+      @emit.open()
+      ignore(workflow_lines(""))
+      // A run that completes: one open, one close, the coordinates a reader
+      // needs — where to tail, and which child ordinals are this run's.
+      let (out, _) = run_hosted_with(
+        ws,
+        store,
+        { "source": "fn main { println(\"hosted\") }", "subrun": true },
+        first=700,
+      )
+      assert_false(out.is_error, msg=out.content)
+      guard workflow_lines("wf-700")
+        is [
+          {
+            "event": String("workflow_started"),
+            "journal": String(journal),
+            "events": String(events),
+            "first_child": Number(700, ..),
+            "child_count": Number(32, ..),
+            ..
+          },
+          { "event": String("workflow_finished"), .. },
+        ] else {
+        fail("expected one open and one close for wf-700")
+      }
+      assert_eq(journal, "\{store}/run7-wf-700/journal.jsonl")
+      assert_eq(events, "\{store}/run7-wf-700/events.jsonl")
+      // A run that never starts — the build fails — still closes its bracket,
+      // or a reader would show a workflow running forever.
+      let (out, _) = run_hosted_with(
+        ws,
+        store,
+        { "source": "fn main { let _x : Int = \"nope\" }", "subrun": true },
+        first=800,
+      )
+      assert_true(out.is_error)
+      guard workflow_lines("wf-800")
+        is [
+          { "event": String("workflow_started"), .. },
+          { "event": String("workflow_finished"), .. },
+        ] else {
+        fail("a failed build must still close wf-800")
+      }
+      // A run adopted into the background returns from the call while the
+      // snippet is STILL RUNNING. Its bracket must stay open until the job
+      // ends, not close at adoption.
+      @async.with_task_group() <| group => {
+        let bg = @bgjobs.BgJobRuntime(AgentTaskScope(group))
+        let (subrun, _) = hosted_injection(store, ws, first=900)
+        let definition = @mbtx.definition(
+          workspace_root=ws,
+          bg_runtime=bg,
+          auto_background_after_ms=1,
+          subrun~,
+        )
+        let source =
+          #|import { "moonbitlang/async" }
+          #|
+          #|async fn main {
+          #|  @async.sleep(400)
+          #|  println("late")
+          #|}
+        let action = match definition.execute {
+          Async(execute) => execute({ "source": source, "subrun": true })
+          Sync(_) => fail("mbtx should be async")
+        }
+        guard action is Respond(output) else { fail("expected Respond") }
+        assert_false(output.is_error, msg=output.content)
+        assert_true(output.content.contains("moved to the background"))
+        guard workflow_lines("wf-900")
+          is [{ "event": String("workflow_started"), .. }] else {
+          fail("at adoption the run is announced and still open")
+        }
+        let mut closed = false
+        for _ in 0..<200 {
+          if workflow_lines("wf-900")
+            is [{ "event": String("workflow_finished"), .. }] {
+            closed = true
+            break
+          }
+          @async.sleep(50)
+        }
+        assert_true(closed, msg="the job's terminal must close wf-900")
+      }
+      // A run that does not delegate announces nothing.
+      let (out, _) = run_hosted_with(
+        ws,
+        store,
+        { "source": "fn main { println(1) }" },
+        first=950,
+      )
+      assert_false(out.is_error)
+      assert_eq(workflow_lines("wf-950").length(), 0)
     })
   })
 }

--- a/agent_tool/mbtx/moon.pkg
+++ b/agent_tool/mbtx/moon.pkg
@@ -22,8 +22,12 @@ supported_targets = "+wasm+native"
 
 import {
   "moonbitlang/async",
+  "moonbitlang/core/json",
+  "bobzhang/openseek/agent_runtime",
   "bobzhang/openseek/agent_subrun/host",
+  "bobzhang/openseek/agent_tool/bgjobs",
   "bobzhang/openseek/testkit/filesystem" @vfs,
+  "bobzhang/openseek_protocol/emit",
 } for "test"
 
 import {

--- a/agent_tool/mbtx/moon.pkg
+++ b/agent_tool/mbtx/moon.pkg
@@ -12,6 +12,8 @@ import {
   "moonbitlang/async/process",
   "moonbitlang/core/json",
   "moonbitlang/core/encoding/utf8",
+  "bobzhang/openseek_protocol",
+  "bobzhang/openseek_protocol/emit",
 }
 
 warnings = "+unnecessary_annotation"

--- a/desktop/frontend/transcript/engine_event.mbt
+++ b/desktop/frontend/transcript/engine_event.mbt
@@ -27,6 +27,22 @@ pub(all) enum EngineEvent {
   // finish reports what it cost — the only place those numbers appear.
   SubrunOpened(id~ : String, kind~ : String, label~ : String)
   SubrunClosed(id~ : String, status~ : String, steps~ : Int, tokens~ : Int)
+  // A workflow's lifecycle brackets. A workflow is a run inside an `mbtx`
+  // snippet that delegates to child agents of its own; the engine has to
+  // announce it because the workflow library is generic and the parent sees
+  // only one opaque tool call, however many children it starts.
+  //
+  // `journal` and `events` are files the host tails: the ledger of resolved
+  // calls, and the sidecar that reports a launch when it starts. The ordinal
+  // range says which `<parent>-sr-N` transcripts belong to this run.
+  WorkflowOpened(
+    id~ : String,
+    journal~ : String,
+    events~ : String,
+    first_child~ : Int,
+    child_count~ : Int
+  )
+  WorkflowClosed(id~ : String)
   AgentFinished(String)
   // The current turn stopped at the model's context ceiling after attempting
   // an automatic checkpoint. It is run-terminal, but not task success.
@@ -138,6 +154,11 @@ pub fn decode_engine_event(
           tokens=prompt_tokens + completion_tokens,
         ),
       )
+    // A workflow's brackets, carried through unchanged: the host needs the
+    // paths to tail and the ordinal range to know whose children these are.
+    WorkflowStarted(id~, journal~, events~, first_child~, child_count~) =>
+      Some(WorkflowOpened(id~, journal~, events~, first_child~, child_count~))
+    WorkflowFinished(id~) => Some(WorkflowClosed(id~))
     // Not shown, and now each one a recorded decision rather than a line the
     // view drops unnoticed. `plan_reminder` and the goal reminders/checks are
     // model-directed text, not news for the user (the TUI drops them too);

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1173,6 +1173,13 @@ fn apply_engine_event(
     // id (a reconnect replaying the bracket) refreshes rather than doubles.
     // The lane docks above the composer, so opening one does not grow the
     // transcript and must not drag a pinned conversation down.
+    // A workflow's brackets. Nothing renders for them YET: what a workflow
+    // needs is a tail of its journal and sidecar on the host side, feeding
+    // the same lane dock the sub-run brackets feed, and a panel for its
+    // phases and ledger on top. Both are the next change. Until then the
+    // brackets are consumed here deliberately, so that a snippet running a
+    // workflow neither breaks this reducer nor leaves a stray notice.
+    WorkflowOpened(..) | WorkflowClosed(..) => (None, conv)
     SubrunOpened(id~, kind~, label~) => {
       let subruns = conv.turn.subruns.filter(lane => lane.id != id)
       subruns.push({

--- a/protocol/event.mbt
+++ b/protocol/event.mbt
@@ -131,6 +131,39 @@ pub(all) enum Event {
     completion_tokens~ : Int
   )
 
+  // ── workflow ───────────────────────────────────────────────────────────
+  /// A `mbtx` snippet started a workflow: a run that delegates to child
+  /// agents of its own, through `moonbitlang/workflow`.
+  ///
+  /// The engine emits this because nothing else can. The workflow library is
+  /// generic — it never learns openseek exists — so a run inside a snippet
+  /// would otherwise be invisible: the parent sees one opaque `mbtx` tool
+  /// call, however many children it starts. What mbtx knows, and says here,
+  /// is where it told the run to write and which child ordinals it reserved
+  /// for it. Discovery is therefore not discovery; a reader is told where to
+  /// look, exactly as `SubrunStarted` tells it a sub-run began.
+  ///
+  /// `journal` is an append-only JSONL ledger of RESOLVED calls (phase,
+  /// timings, spend); `events` is the sidecar that reports a launch when it
+  /// STARTS, which the journal cannot — an entry carries an outcome, so it
+  /// lands only at completion. Both are absolute paths a reader tails.
+  ///
+  /// `first_child`/`child_count` bound the reserved ordinals: the child
+  /// sessions of this run are exactly `<parent>-sr-N` for N in
+  /// `[first_child, first_child + child_count)`, which is how a reader knows
+  /// which transcripts belong to it.
+  WorkflowStarted(
+    id~ : String,
+    journal~ : String,
+    events~ : String,
+    first_child~ : Int,
+    child_count~ : Int
+  )
+  /// The paired completion, emitted on every exit of the snippet that owns
+  /// the run — success, failure, and cancellation — so a reader never shows
+  /// a workflow as running forever.
+  WorkflowFinished(id~ : String)
+
   // ── session / workspace ────────────────────────────────────────────────
   /// `workspace_root` is optional because it postdates the event: engines
   /// between d11e04c2 (which added `session_started`) and d5d0b208 (which

--- a/protocol/parse.mbt
+++ b/protocol/parse.mbt
@@ -195,6 +195,20 @@ pub fn parse(line : Json) -> Event? {
         SubrunFinished(id~, status~, steps~, prompt_tokens~, completion_tokens~),
       )
     }
+    "workflow_started" => {
+      guard text(fields, "id") is Some(id) &&
+        text(fields, "journal") is Some(journal) &&
+        text(fields, "events") is Some(events) &&
+        int(fields, "first_child") is Some(first_child) &&
+        int(fields, "child_count") is Some(child_count) else {
+        return None
+      }
+      Some(WorkflowStarted(id~, journal~, events~, first_child~, child_count~))
+    }
+    "workflow_finished" => {
+      guard text(fields, "id") is Some(id) else { return None }
+      Some(WorkflowFinished(id~))
+    }
     "auto_compaction_started" => {
       guard sequences(fields) is Some((from_sequence, to_sequence)) else {
         return None

--- a/protocol/parse_test.mbt
+++ b/protocol/parse_test.mbt
@@ -210,3 +210,52 @@ test "unknown and malformed lines are ignored" {
     None,
   )
 }
+
+///|
+test "decodes a workflow's lifecycle brackets" {
+  // A workflow announces where it will write and which child ordinals it
+  // reserved: the reader is told, because a run inside an opaque `mbtx` call
+  // cannot be found by looking.
+  debug_inspect(
+    decode(
+      (
+        #|{"event":"workflow_started","id":"wf-5","journal":"/s/run7-wf-5.jsonl","events":"/s/run7-wf-5.events.jsonl","first_child":5,"child_count":32}
+      ),
+    ),
+    content=(
+      #|Some(
+      #|  WorkflowStarted(
+      #|    id="wf-5",
+      #|    journal="/s/run7-wf-5.jsonl",
+      #|    events="/s/run7-wf-5.events.jsonl",
+      #|    first_child=5,
+      #|    child_count=32,
+      #|  ),
+      #|)
+    ),
+  )
+  debug_inspect(
+    decode(
+      (
+        #|{"event":"workflow_finished","id":"wf-5"}
+      ),
+    ),
+    content=(
+      #|Some(WorkflowFinished(id="wf-5"))
+    ),
+  )
+}
+
+///|
+test "a workflow line missing any coordinate is not an event" {
+  // Fail closed: a half-read bracket would point a reader at a path that is
+  // not there, or at an ordinal range that is not this run's.
+  assert_eq(
+    decode(
+      (
+        #|{"event":"workflow_started","id":"wf-5","journal":"/s/j.jsonl","events":"/s/e.jsonl","first_child":5}
+      ),
+    ),
+    None,
+  )
+}

--- a/protocol/parse_test.mbt
+++ b/protocol/parse_test.mbt
@@ -259,3 +259,20 @@ test "a workflow line missing any coordinate is not an event" {
     None,
   )
 }
+
+///|
+test "a workflow's brackets survive the wire unchanged" {
+  // `to_json` is the one encoder and `parse` the one decoder; a field the
+  // encoder writes under a name the decoder does not read would make an
+  // announced run unfindable, silently.
+  let started : @openseek_protocol.Event = WorkflowStarted(
+    id="wf-5",
+    journal="/s/run7-wf-5/journal.jsonl",
+    events="/s/run7-wf-5/events.jsonl",
+    first_child=5,
+    child_count=32,
+  )
+  assert_eq(@openseek_protocol.parse(started.to_json()), Some(started))
+  let finished : @openseek_protocol.Event = WorkflowFinished(id="wf-5")
+  assert_eq(@openseek_protocol.parse(finished.to_json()), Some(finished))
+}

--- a/protocol/pkg.generated.mbti
+++ b/protocol/pkg.generated.mbti
@@ -65,6 +65,8 @@ pub(all) enum Event {
   ContextYield(to_sequence~ : Int, answer~ : String)
   SubrunStarted(id~ : String, kind~ : String, label~ : String)
   SubrunFinished(id~ : String, status~ : String, steps~ : Int, prompt_tokens~ : Int, completion_tokens~ : Int)
+  WorkflowStarted(id~ : String, journal~ : String, events~ : String, first_child~ : Int, child_count~ : Int)
+  WorkflowFinished(id~ : String)
   SessionStarted(session~ : String, session_root~ : String, workspace_root~ : String?)
   SessionError(error~ : String)
   WorkspaceCreated(dir~ : String)

--- a/protocol/to_json.mbt
+++ b/protocol/to_json.mbt
@@ -108,6 +108,16 @@ pub fn Event::to_json(self : Event) -> Json {
         "prompt_tokens": prompt_tokens,
         "completion_tokens": completion_tokens,
       }
+    WorkflowStarted(id~, journal~, events~, first_child~, child_count~) =>
+      {
+        "event": "workflow_started",
+        "id": id,
+        "journal": journal,
+        "events": events,
+        "first_child": first_child,
+        "child_count": child_count,
+      }
+    WorkflowFinished(id~) => { "event": "workflow_finished", "id": id }
     AutoCompactionStarted(from_sequence~, to_sequence~) =>
       {
         "event": "auto_compaction_started",


### PR DESCRIPTION
Rebased onto `main` now that #1288 has landed; the base is `main` and the diff is this change alone (9 files, +169). The re-review after the rebase is in the last section.


Answers the question this whole stack turns on: *the workflow library is generic, so how does the desktop know which run to visualize?*

It doesn't find one. It is **told**. The parent sees one opaque `mbtx` tool call however many children it starts, and nothing in the snippet can fix that — only the component that chose the coordinates can say what they are.

## The events

`workflow_started` carries the two files a reader tails plus the ordinal range that says whose children these are:

- `journal` — the append-only JSONL ledger of **resolved** calls (phase, timings, spend).
- `events` — the sidecar that reports a launch when it **starts**, which the journal cannot: an entry carries an outcome, so it lands only at completion. Each line carries the child's session id, which is the field a reader keys on — never arithmetic on the ordinal range.
- `first_child` / `child_count` — the reserved range, for capacity display.

`workflow_finished` closes the bracket on every exit, cancellation included.

**Closing at the right moment.** A background handoff returns from `execute` with the snippet still running, so a plain `defer` reported every adopted workflow finished at the instant it was adopted. Now the inline path closes the bracket only while the call still owns the run, and an adopted job closes it from its own terminal hook — the same split `cleanup()` already makes for the temp directory.

Parsing **fails closed** on a partial line. The desktop transcript maps both through as `WorkflowOpened`/`WorkflowClosed`, and this PR's reducer consumes them as explicit no-ops — **#1291, stacked on this one, is where they turn into a live view** (host tail, synthesized sub-run brackets, the `workflow.entry` push, and the Workflows tab).

## Verification

21/21 protocol tests including round-trip and fail-closed cases; 460/460 desktop frontend tests on js; `moon check` clean across the workspace.

## Re-review after the rebase

A cold read of the diff against `main`, plus `moon check --deny-warn` on native/wasm/js for the touched packages and a workspace-wide native check, fmt, and interface drift: all clean. Every consumer that matches on `Event` either handles the two new variants (the desktop transcript) or has a catch-all (host engine, sub-run runner), so nothing downstream changes shape.

One gap, closed in a second commit: the **bracket lifecycle had no test**, and it is the subtle part — opened after the reservation, closed by `defer` on every foreground exit, and for a run adopted into the background (where `execute` returns while the snippet is still going) closed by the job's terminal instead. One mbtx test now drives all four cases through `@mbtx.definition` and reads the in-process protocol sink: completing run (both lines, with the paths and ordinal range), failed build (still closed), background adoption (open at adoption, closed when the job ends), undelegating run (nothing announced). Stable across repeated local runs. `protocol` also gains a `parse(to_json(e)) == e` round trip for both events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXBYcYo74F1DGSPZsYYAdc