### PR TITLE
release: publish openseek 0.3.1 and openseek_protocol 0.1.1 for wasm

### DIFF
--- a/README.mbt.md
+++ b/README.mbt.md
@@ -9,6 +9,23 @@ For a picture of how the pieces fit together — module architecture, the core
 data model, and the life of one agent turn — see
 [`docs/architecture.md`](docs/architecture.md).
 
+## Running without a checkout
+
+`cmd/openseek` builds on both native and wasm, and mooncakes.io hosts a
+prebuilt wasm binary for every published version. `moonx` fetches and caches it,
+so the engine runs with no clone and no build:
+
+```sh
+moonx bobzhang/openseek/cmd/openseek --help
+DEEPSEEK=sk-... moonx bobzhang/openseek/cmd/openseek run --no-session 'summarize this repo'
+```
+
+The coordinate is the package path, not the module: `bobzhang/openseek` alone
+resolves to the root package, which is not an executable. Pin a release with
+`bobzhang/openseek/cmd/openseek@0.3.1`, or take the newest with `@latest`.
+Subprocesses, the filesystem, and HTTPS all work under `moonrun`, so the wasm
+binary drives the same tools as the native one.
+
 ## Monorepo development
 
 The root [`moon.work`](moon.work) develops OpenSeek, the desktop app, and the
@@ -56,8 +73,8 @@ git submodule update --init editor/vscode     # opt-in performance suite
 | --- | --- | --- |
 | `bobzhang/openseek` | Root package and module overview. | `README.mbt.md` |
 | `bobzhang/openseek/deepseek` | Pure chat data, provider-aware JSON encoding, and response decoding. | `deepseek/README.mbt.md` |
-| `bobzhang/openseek/deepseek/client` | Native-only HTTP transport for supported chat-completions providers. | `deepseek/client/README.mbt.md` |
-| `bobzhang/openseek/agent_runtime` | Native-only agent task-group and extensible runtime event queue. | `agent_runtime/README.mbt.md` |
+| `bobzhang/openseek/deepseek/client` | HTTP transport (native or wasm) for supported chat-completions providers. | `deepseek/client/README.mbt.md` |
+| `bobzhang/openseek/agent_runtime` | Agent task-group (native or wasm) and extensible runtime event queue. | `agent_runtime/README.mbt.md` |
 | `bobzhang/openseek/agent_session` | Typed durable conversation state and DeepSeek message projection. | `agent_session/README.mbt.md` |
 | `bobzhang/openseek/agent_session/store` | Native filesystem-backed append-only session store. | `agent_session/store/README.mbt.md` |
 | `bobzhang/openseek/agent_session/log` | Lenient session-file reader: header plus events, with per-line error capture. | — |
@@ -68,10 +85,10 @@ git submodule update --init editor/vscode     # opt-in performance suite
 | `bobzhang/openseek/mcp` (+ `config`, `stdio`, `streamhttp`, `tools`) | MCP client: `mcp.json` decoding, stdio and Streamable HTTP transports, and the bridge that namespaces server tools into the registry. | — |
 | `bobzhang/openseek/prompt` | Built-in system prompt text (generated from Markdown) and prompt-selection policy. | `prompt/README.mbt.md` |
 | `bobzhang/openseek_protocol` | Typed engine event stream (own module): the `openseek run`/`serve` stdout wire contract, decodable on every backend. | `protocol/README.mbt.md` |
-| `bobzhang/openseek_protocol/emit` | Native-only writer for that stream: owns each event's log level. | `protocol/emit/README.mbt.md` |
-| `bobzhang/openseek/agent` | Native-only OpenSeek agent loop and local tool dispatch. | `agent/README.mbt.md` |
+| `bobzhang/openseek_protocol/emit` | Writer for that stream (native or wasm): owns each event's log level. | `protocol/emit/README.mbt.md` |
+| `bobzhang/openseek/agent` | OpenSeek agent loop (native or wasm) and local tool dispatch. | `agent/README.mbt.md` |
 | `bobzhang/openseek/agent_review` | Read-only, compiler-grounded code-review engine behind `openseek review`. | `agent_review/README.mbt.md` |
-| `bobzhang/openseek/cmd/openseek` | Native-only headless automation CLI (`openseek`). | `cmd/openseek/README.md` |
+| `bobzhang/openseek/cmd/openseek` | Headless automation CLI (`openseek`), built for native or wasm. | `cmd/openseek/README.md` |
 | `bobzhang/openseek/cli` | Shared command-main helpers: the agent options (`--api-key`, `--model`, …) and failure-text sanitizer used by `openseek` and the out-of-tree `openseek_tui`. | — |
 | `bobzhang/openseek/viz` | Browser viewer for durable session logs (JS). | `viz/README.md` |
 | `bobzhang/inspect` (in `inspect/`, own module) | HTTP server (native or wasm) that serves the visualizer over recorded sessions. | `inspect/README.md` |
@@ -103,7 +120,7 @@ The `deepseek/client` subpackage exposes the HTTP client:
 - `Client(api_key~, model?, api_url?)`
 - `Client::chat(messages, tools?)`
 
-It depends on `moonbitlang/async/http` and is native-only.
+It depends on `moonbitlang/async/http` and builds on both native and wasm.
 
 The `agent_tool` package exposes the local tool registry and typed executor
 boundary. Tool executors return `ToolAction`: normal tools use

--- a/desktop/moon.mod
+++ b/desktop/moon.mod
@@ -4,7 +4,7 @@ version = "0.1.5"
 
 import {
   "moonbitlang/jsonl@0.2.0",
-  "bobzhang/openseek_protocol@0.1.0",
+  "bobzhang/openseek_protocol@0.1.1",
   "moonbit-community/cmark@0.4.5",
   "moonbit-community/pty@0.4.1",
   "moonbit-community/fuzzy_match@0.2.6",

--- a/moon.mod
+++ b/moon.mod
@@ -1,12 +1,12 @@
 name = "bobzhang/openseek"
 
-version = "0.3.0"
+version = "0.3.1"
 
 import {
   "moonbitlang/async@0.21.1",
   "moonbitlang/x@0.4.50",
   "moonbitlang/jsonl@0.2.0",
-  "bobzhang/openseek_protocol@0.1.0",
+  "bobzhang/openseek_protocol@0.1.1",
   "moonbit-community/rabbita@0.15.4",
   "moonbitlang/editor@0.4.5",
   "moonbitlang/workflow@0.6.0",

--- a/protocol/moon.mod
+++ b/protocol/moon.mod
@@ -1,6 +1,6 @@
 name = "bobzhang/openseek_protocol"
 
-version = "0.1.0"
+version = "0.1.1"
 
 import {
   "moonbitlang/async@0.21.2",


### PR DESCRIPTION
Both versions are **already published to mooncakes.io** — this PR brings the manifests in the repo in line with what is on the registry.

## Why

`moonx bobzhang/openseek/cmd/openseek` failed with `Prebuilt wasm asset does not exist`: 0.3.0 predates #1282, so mooncakes never built a wasm binary for it.

Republishing openseek alone would not have fixed it. `protocol/` had drifted from the published `bobzhang/openseek_protocol@0.1.0` without a version bump — that release still declares `emit` as `+native` and still imports the since-removed `tonyfettes/xlog`. Inside the workspace `moon.work` hides this; from the registry it does not. Building the real publish tarball with `moon.work` and `protocol/` deleted:

```
Selected backend 'wasm' is incompatible with the dependency graph.
'bobzhang/openseek/cmd/openseek' requires 'bobzhang/openseek/agent' which supports [native].
Dependency path: bobzhang/openseek/cmd/openseek -> bobzhang/openseek/agent
```

So `openseek_protocol` goes to 0.1.1 first, both importers follow, and `openseek` goes to 0.3.1 on top of it.

## Changes

| File | Change |
| --- | --- |
| `protocol/moon.mod` | `0.1.0` → `0.1.1` |
| `moon.mod` | `0.3.0` → `0.3.1`; dep → `openseek_protocol@0.1.1` |
| `desktop/moon.mod` | dep → `openseek_protocol@0.1.1` |
| `README.mbt.md` | drop five stale `Native-only` labels; document the moonx coordinate |

`deepseek/client`, `agent_runtime`, `protocol/emit`, `agent`, and `cmd/openseek` all declare `+wasm+native` after #1282, but the README still called them native-only. `eval/file_edit/cmd/main` keeps its label — it really is native-only.

## Verification

Local wasm, before publishing:

- `moon check --target wasm` and `moon build --target wasm` clean across the workspace.
- A live `run` under `moonrun` read a file and answered from it.
- A second run spawned `rg` as a subprocess, captured its output, and wrote a file — env vars, HTTPS, process spawn, and filesystem all work on wasm.

Registry-side build, before publishing openseek:

- Packaged 0.3.1, unpacked it outside the workspace with `moon.work` and `protocol/` removed so `openseek_protocol@0.1.1` resolved from mooncakes, then `moon build --target wasm ./cmd/openseek` — passed.

After publishing:

```
$ moonx bobzhang/openseek/cmd/openseek run --no-session --max-steps 8 \
    'Read secret.txt, then create answer.md ...'
{"event":"tool_result","tool_name":"read","is_error":false,...}
{"event":"tool_result","tool_name":"write","is_error":false,...}
{"event":"agent_finished","answer":"Read secret.txt (launch code ZULU-8813) and created answer.md ..."}
```

`moon check` and `moon fmt --check` are clean.

## Note

`moonx bobzhang/openseek` (module only) does **not** work — moonx looks for the root package's asset, and the root package is not an executable. The working coordinate is `bobzhang/openseek/cmd/openseek`. Making the short form work would mean moving the CLI to the module root; not attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xp3xk2xvGLmknC4eCFW3yX
