### PR TITLE
desktop: live visualization of a snippet's workflow and its subagents

### DIFF
--- a/desktop/frontend/boot.mbt
+++ b/desktop/frontend/boot.mbt
@@ -528,6 +528,8 @@ pub fn boot() -> Unit {
       search: emit(ExplorerRequested(ExplorerSearch)),
       files: emit(ExplorerRequested(ExplorerFiles)),
       review: emit(ExplorerRequested(ExplorerChanges)),
+      workflows: emit(WorkflowsRequested),
+      open_child: child => emit(OpenSessionHere(child)),
       browser_input: emit.map(value => BrowserAddressEdited(value)),
       browser_submit: emit(BrowserNavigateSubmitted),
       browser_back: emit(BrowserBack),

--- a/desktop/frontend/bridge.mbt
+++ b/desktop/frontend/bridge.mbt
@@ -196,6 +196,24 @@ fn device_msg(
           activity=payload.activity,
         ),
       )
+    WorkflowEntry(payload) =>
+      Some(
+        WorkflowEntryArrived(channel, {
+          workflow: payload.workflow,
+          session: payload.session,
+          child: payload.child,
+          kind: payload.kind,
+          label: payload.label,
+          phase: payload.phase,
+          status: payload.status,
+          steps: payload.steps,
+          prompt_tokens: payload.prompt_tokens,
+          completion_tokens: payload.completion_tokens,
+          cost_usd: payload.cost_usd,
+          started_at: payload.started_at,
+          finished_at: payload.finished_at,
+        }),
+      )
     SessionChanged(payload) => session_changed_msg(channel, payload)
     WorkspaceChanged(payload) => {
       let paths : Array[@common.Uri] = []

--- a/desktop/frontend/component_right_panel.mbt
+++ b/desktop/frontend/component_right_panel.mbt
@@ -9,5 +9,9 @@ fn Model::right_panel_input(self : Model) -> @right_panel.Input {
     is_desktop=self.is_desktop,
     menu_open=self.right_panel_menu_open,
     expanded=self.right_panel_expanded,
+    workflows=self
+      .active_conversation()
+      .map(conv => conv.workflows)
+      .unwrap_or([]),
   )
 }

--- a/desktop/frontend/dock/state.mbt
+++ b/desktop/frontend/dock/state.mbt
@@ -34,6 +34,10 @@ pub(all) enum DockTab {
   // The transient open-a-file tab (at most one): the file view's tree with
   // a pick-a-file placeholder. Picking a file replaces it in place.
   FilePicker
+  // The subagent viewer this enum's comment anticipated: every workflow the
+  // conversation's snippets announced, one row per subagent, each a click
+  // from that child's own transcript. At most one lives in the strip.
+  Workflows
 } derive(Eq)
 
 ///|

--- a/desktop/frontend/dock/update.mbt
+++ b/desktop/frontend/dock/update.mbt
@@ -108,6 +108,20 @@ pub fn open_picker(state : State) -> State {
 }
 
 ///|
+/// Open the workflows tab, re-activating the existing one — at most one
+/// lives in the strip.
+pub fn open_workflows(state : State) -> State {
+  let tabs = if tab_index(state, Workflows) is Some(_) {
+    state.tabs
+  } else {
+    let tabs = state.tabs.copy()
+    tabs.push(Workflows)
+    tabs
+  }
+  { ..state, tabs, active: Some(Workflows), }
+}
+
+///|
 /// A file was picked while the picker tab is in the strip: the picker is
 /// replaced in place by that file's tab — unless the file is already open,
 /// in which case its existing tab activates and the picker closes. Without

--- a/desktop/frontend/dock/view.mbt
+++ b/desktop/frontend/dock/view.mbt
@@ -111,6 +111,25 @@ fn icon_review() -> @html.Html {
 }
 
 ///|
+/// One node fanning out to three: the launcher's Workflows row.
+fn icon_workflows() -> @html.Html {
+  @svg.svg(
+    width=16,
+    height=16,
+    view_box="0 0 16 16",
+    attrs=@svg.Attrs::build()
+      .fill("none")
+      .stroke("currentColor")
+      .stroke_linecap("round"),
+    [
+      @svg.path(d="M2.5 8h4"),
+      @svg.path(d="M6.5 8c2 0 2-4.5 4-4.5M6.5 8c2 0 2 4.5 4 4.5M6.5 8h4"),
+      @svg.path(d="M10.5 3.5h3M10.5 8h3M10.5 12.5h3"),
+    ],
+  )
+}
+
+///|
 /// An icon in a fixed-size span. Icons are functions, not shared constants:
 /// each render site gets its own virtual-DOM value, so no Props instance is
 /// ever aliased between two mounted elements.
@@ -142,6 +161,7 @@ pub(all) struct LauncherActions {
   search : @cmd.Cmd
   files : @cmd.Cmd
   review : @cmd.Cmd
+  workflows : @cmd.Cmd
 }
 
 ///|
@@ -177,6 +197,16 @@ fn launcher_rows(actions : LauncherActions) -> Array[@html.Html] {
       icon(icon_review),
       @html.span(class="dock-launcher-name", "Review"),
       @html.span(class="dock-launcher-hint", "Review changed files and diffs"),
+    ]),
+  )
+  rows.push(
+    @html.button(class="dock-launcher-row", on_click=actions.workflows, [
+      icon(icon_workflows),
+      @html.span(class="dock-launcher-name", "Workflows"),
+      @html.span(
+        class="dock-launcher-hint",
+        "Subagents this conversation delegated to",
+      ),
     ]),
   )
   rows

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -811,6 +811,11 @@ priv struct Conversation {
   // engine events arrive stamped with this id once the run phase is already
   // back to `NoRun`; routing them needs the retained id.
   last_run_id : String?
+  // Workflows this conversation's snippets announced, one row per subagent.
+  // Live-only, like the lanes: the run's journal and the children's own
+  // transcripts in the store are the record, and a reload rebuilds nothing
+  // here until the next bracket or entry arrives.
+  workflows : Array[@workflow.Run]
   // Where this conversation's compaction stands; see `CompactionPhase`.
   compaction : CompactionPhase
   // A run finished while this conversation was off screen and the user has
@@ -2052,6 +2057,8 @@ priv enum Msg {
   // menu; all inventories share this one shell transition.
   BrowserTabRequested
   ExplorerRequested(@fileeditor.ExplorerMode)
+  // Open the Workflows tab in the right panel.
+  WorkflowsRequested
   // The browser toolbar, acting on whatever Browser tab is active — the
   // messages carry no id so a stale click cannot outlive a tab switch.
   BrowserAddressEdited(String)
@@ -2229,6 +2236,10 @@ priv enum DeviceMsg {
     steps~ : Int,
     activity~ : String
   )
+  // The host's `workflow.entry` broadcast: one resolved call of a workflow a
+  // snippet is running, read from the run's journal. Routed to the parent
+  // conversation by the entry's own session, like sub-run progress.
+  WorkflowEntryArrived(@interop.ChannelId, @workflow.Entry)
   // The registered projects — the reply to `workspace.list`. Both
   // generations are required: reconnect rejects a dead socket, while request
   // generation rejects an older reply from the current connection.
@@ -2495,6 +2506,7 @@ fn empty_conversation(
     task: "",
     mentions: [],
     composer_draft_present: false,
+    workflows: [],
     run: NoRun(ended=None),
     last_run_id: None,
     compaction: NotCompacting,

--- a/desktop/frontend/moon.pkg
+++ b/desktop/frontend/moon.pkg
@@ -36,6 +36,7 @@ import {
   "openseek_desktop/frontend/interop",
   "openseek_desktop/frontend/mention_context",
   "openseek_desktop/frontend/subrun",
+  "openseek_desktop/frontend/workflow",
   "openseek_desktop/frontend/project_picker",
   "openseek_desktop/frontend/preview",
   "openseek_desktop/frontend/resource",

--- a/desktop/frontend/right_panel/component.mbt
+++ b/desktop/frontend/right_panel/component.mbt
@@ -9,6 +9,9 @@ struct Input {
   is_desktop : Bool
   menu_open : Bool
   expanded : Bool
+  // The workflows the active conversation's snippets announced, for the
+  // Workflows tab. Live-only state projected from the root's conversation.
+  workflows : Array[@workflow.Run]
 } derive(Eq)
 
 ///|
@@ -20,8 +23,18 @@ pub fn Input::Input(
   is_desktop~ : Bool,
   menu_open~ : Bool,
   expanded~ : Bool,
+  workflows~ : Array[@workflow.Run],
 ) -> Input {
-  { dock, file_panel, preview, file_ctx, is_desktop, menu_open, expanded, }
+  {
+    dock,
+    file_panel,
+    preview,
+    file_ctx,
+    is_desktop,
+    menu_open,
+    expanded,
+    workflows,
+  }
 }
 
 ///|
@@ -34,6 +47,10 @@ pub(all) struct Actions {
   search : @cmd.Cmd
   files : @cmd.Cmd
   review : @cmd.Cmd
+  workflows : @cmd.Cmd
+  // Open one subagent's transcript: the child's session id, as its row
+  // carries it.
+  open_child : (String) -> @cmd.Cmd
   browser_input : @cmd.Emit[String]
   browser_submit : @cmd.Cmd
   browser_back : @cmd.Cmd

--- a/desktop/frontend/right_panel/moon.pkg
+++ b/desktop/frontend/right_panel/moon.pkg
@@ -3,6 +3,7 @@ import {
   "moonbit-community/rabbita/cmd",
   "moonbit-community/rabbita/html",
   "openseek_desktop/frontend/dock",
+  "openseek_desktop/frontend/workflow",
   "openseek_desktop/frontend/fileeditor",
   "openseek_desktop/frontend/preview",
 }

--- a/desktop/frontend/right_panel/view.mbt
+++ b/desktop/frontend/right_panel/view.mbt
@@ -39,6 +39,13 @@ fn panel_view(
         }
         { tab, label, title, missing: false, }
       }
+      Workflows =>
+        {
+          tab,
+          label: "Workflows",
+          title: "Subagents this conversation delegated to",
+          missing: false,
+        }
       FilePicker =>
         match input.file_panel.explorer_mode {
           ExplorerChanges =>
@@ -75,6 +82,7 @@ fn panel_view(
     search: @cmd.batch([actions.search, actions.close_menu]),
     files: @cmd.batch([actions.files, actions.close_menu]),
     review: @cmd.batch([actions.review, actions.close_menu]),
+    workflows: @cmd.batch([actions.workflows, actions.close_menu]),
   }
   // Every body remains mounted and CSS selects the active kind. This preserves
   // the imperative Viewer and native browser attachment points.
@@ -88,6 +96,7 @@ fn panel_view(
     Some(FilePicker) => "mode-picker"
     Some(File(_)) => "mode-file"
     Some(GitDiff(_)) => "mode-history"
+    Some(Workflows) => "mode-workflows"
   }
   let active_page : @preview.PageState = match
     @dock.active_browser(input.dock) {
@@ -142,6 +151,7 @@ fn panel_view(
           ([] : Array[@html.Html]),
         ),
       ]),
+      @workflow.panel(input.workflows, { open_child: actions.open_child, }),
       @dock.launcher_pane(launcher),
     ],
   )

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -831,7 +831,8 @@ fn reveal_local_directory(
 ) -> (@cmd.Cmd, Model) {
   let dock = match model.dock.active {
     Some(File(_)) | Some(FilePicker) => model.dock
-    None | Some(Browser(_)) | Some(GitDiff(_)) => @dock.open_picker(model.dock)
+    None | Some(Browser(_)) | Some(GitDiff(_)) | Some(Workflows) =>
+      @dock.open_picker(model.dock)
   }
   let model = {
     ..model,
@@ -1173,13 +1174,27 @@ fn apply_engine_event(
     // id (a reconnect replaying the bracket) refreshes rather than doubles.
     // The lane docks above the composer, so opening one does not grow the
     // transcript and must not drag a pinned conversation down.
-    // A workflow's brackets. Nothing renders for them YET: what a workflow
-    // needs is a tail of its journal and sidecar on the host side, feeding
-    // the same lane dock the sub-run brackets feed, and a panel for its
-    // phases and ledger on top. Both are the next change. Until then the
-    // brackets are consumed here deliberately, so that a snippet running a
-    // workflow neither breaks this reducer nor leaves a stray notice.
-    WorkflowOpened(..) | WorkflowClosed(..) => (None, conv)
+    // A workflow's brackets. The run is recorded for the Workflows tab; its
+    // children arrive through the sub-run brackets the host synthesizes from
+    // the run's sidecar (below), and resolve through `WorkflowEntryArrived`.
+    // Nothing is dropped on close: a finished run is exactly what a reader
+    // looks back over.
+    WorkflowOpened(id~, first_child~, child_count~, ..) =>
+      (
+        None,
+        {
+          ..conv,
+          workflows: @workflow.opened(
+            conv.workflows,
+            id~,
+            session=conv.session_id,
+            first_child~,
+            child_count~,
+          ),
+        },
+      )
+    WorkflowClosed(id~) =>
+      (None, { ..conv, workflows: @workflow.closed(conv.workflows, id~), })
     SubrunOpened(id~, kind~, label~) => {
       let subruns = conv.turn.subruns.filter(lane => lane.id != id)
       subruns.push({
@@ -1190,7 +1205,16 @@ fn apply_engine_event(
         activity: "",
         run: event_run_id,
       })
-      (None, { ..conv, turn: { ..conv.turn, subruns, }, })
+      (
+        None,
+        {
+          ..conv,
+          turn: { ..conv.turn, subruns, },
+          // A child of a known workflow gets its row here, from the same
+          // bracket that opened its lane.
+          workflows: @workflow.child_opened(conv.workflows, id~, kind~, label~),
+        },
+      )
     }
     // Closed: always drop the lane. A captured sub-run already settles as the
     // durable tool brief, so repeating its status here would leave two
@@ -1207,6 +1231,13 @@ fn apply_engine_event(
           ..conv.turn,
           subruns: conv.turn.subruns.filter(lane => lane.id != id),
         },
+        workflows: @workflow.child_closed(
+          conv.workflows,
+          id~,
+          status~,
+          steps~,
+          tokens~,
+        ),
       }
       if status == "captured" {
         (None, conv)
@@ -1376,7 +1407,7 @@ fn file_ctx(model : Model) -> @fileeditor.Ctx {
   }
   let file_body_visible = match model.dock.active {
     Some(File(_)) | Some(GitDiff(_)) | Some(FilePicker) => true
-    None | Some(Browser(_)) => false
+    None | Some(Browser(_)) | Some(Workflows) => false
   }
   {
     // Keep the real identity even while placement is unresolved or missing.
@@ -4883,7 +4914,9 @@ fn update_msg(
                   (@cmd.batch(cmds), model)
                 }
               }
-              FilePicker =>
+              // Neither tab owns a document: closing one while active hands
+              // focus to a neighbouring file or diff, and otherwise nothing.
+              FilePicker | Workflows =>
                 if was_active && next_file is Some(path) {
                   let (cmd, panel) = @fileeditor.activate(
                     femit,
@@ -4945,6 +4978,18 @@ fn update_msg(
       )
     }
     ExplorerRequested(mode) => open_explorer(dispatch, model, mode)
+    // The Workflows tab: opened like the explorer inventories, keeping the
+    // right panel on screen with its launcher menu closed.
+    WorkflowsRequested =>
+      (
+        @cmd.none,
+        {
+          ..model,
+          dock: @dock.open_workflows(model.dock),
+          right_panel_open: true,
+          right_panel_menu_open: false,
+        },
+      )
     BrowserAddressEdited(value) =>
       match @dock.active_browser(model.dock) {
         Some(id) =>
@@ -5400,6 +5445,20 @@ fn update_device_msg(
     // whose parent conversation is gone must not suppress the refresh of a
     // child on screen, and a child nobody is viewing must not suppress the
     // lane.
+    // A resolved call of a workflow: refines the row its brackets created, or
+    // creates one when they were missed. Routed like sub-run progress, by the
+    // parent session the entry names; a conversation that is gone drops it.
+    WorkflowEntryArrived(channel, entry) => {
+      let model = match model.find_conversation(channel, entry.session) {
+        Some(conv) =>
+          model.replace_conversation({
+            ..conv,
+            workflows: @workflow.entry(conv.workflows, entry),
+          })
+        None => model
+      }
+      (@cmd.none, model)
+    }
     SubrunProgressed(id~, session~, steps~, activity~) => {
       // Route by the CHILD session id, not by the sub-run id: `sr-N` is only
       // unique within its parent engine, so two conversations can both have
@@ -19739,4 +19798,119 @@ test "a sub-run's finish refreshes the child transcript one last time" {
   guard subrun_child_of(next).sync is Reloading(..) else {
     fail("expected the finish to catch the child transcript up")
   }
+}
+
+///|
+/// A workflow's brackets record the run, and the sub-run brackets the host
+/// synthesizes from its sidecar give the run its rows — the SAME bracket that
+/// opens a child's lane. A sub-run outside the run's reserved block is an
+/// ordinary child and touches no row.
+test "a workflow's brackets and its children's brackets build the run's rows" {
+  let conv = { ..test_conversation(), run: Open(run_id="r1", stage=Opened), }
+  let (_, opened) = apply_engine_event(
+    conv,
+    WorkflowOpened(
+      id="wf-5",
+      journal="/store/run-wf-5/journal.jsonl",
+      events="/store/run-wf-5/events.jsonl",
+      first_child=5,
+      child_count=32,
+    ),
+    Some("r1"),
+  )
+  inspect(opened.workflows.length(), content="1")
+  let (_, child) = apply_engine_event(
+    opened,
+    SubrunOpened(id="sr-5", kind="explore", label="scout:x"),
+    Some("r1"),
+  )
+  inspect(child.visible_subruns().length(), content="1")
+  inspect(child.workflows[0].rows.length(), content="1")
+  inspect(child.workflows[0].running(), content="1")
+  let (_, other) = apply_engine_event(
+    child,
+    SubrunOpened(id="sr-2", kind="explore", label="elsewhere"),
+    Some("r1"),
+  )
+  inspect(other.visible_subruns().length(), content="2")
+  inspect(other.workflows[0].rows.length(), content="1")
+  let (_, closed) = apply_engine_event(
+    other,
+    SubrunClosed(id="sr-5", status="captured", steps=12, tokens=3400),
+    Some("r1"),
+  )
+  inspect(closed.workflows[0].running(), content="0")
+  inspect(closed.workflows[0].rows[0].steps, content="12")
+  // The lane is gone, as for any captured sub-run; the row stays.
+  inspect(closed.visible_subruns().length(), content="1")
+  let (_, done) = apply_engine_event(
+    closed,
+    WorkflowClosed(id="wf-5"),
+    Some("r1"),
+  )
+  inspect(done.workflows[0].closed, content="true")
+  inspect(done.workflows[0].rows.length(), content="1")
+}
+
+///|
+/// A resolved call reaches the run through the parent session the entry
+/// names. A conversation this page does not hold gets nothing: only a bracket
+/// knows a run exists, and an entry is never a reason to invent one.
+test "a workflow entry refines the parent conversation's run" {
+  let base = running_conversation()
+  let parent = {
+    ..base,
+    workflows: @workflow.opened(
+      [],
+      id="wf-5",
+      session=base.session_id,
+      first_child=5,
+      child_count=32,
+    ),
+  }
+  let model = test_model().replace_conversation(parent)
+  let entry : @workflow.Entry = {
+    workflow: "wf-5",
+    session: base.session_id,
+    child: "\{base.session_id}-sr-5",
+    kind: "explore",
+    label: "scout:x",
+    phase: Some("survey"),
+    status: "captured",
+    steps: 12,
+    prompt_tokens: 3000,
+    completion_tokens: 400,
+    cost_usd: Some(0.01),
+    started_at: Some(1788535817640.0),
+    finished_at: Some(1788535817648.0),
+  }
+  let (_, next) = update_dev(
+    test_dispatch(),
+    WorkflowEntryArrived(@interop.ChannelId::Local, entry),
+    model,
+  )
+  guard next.find_conversation(@interop.ChannelId::Local, base.session_id)
+    is Some(conv) else {
+    fail("expected the parent conversation")
+  }
+  inspect(conv.workflows[0].rows.length(), content="1")
+  inspect(conv.workflows[0].rows[0].ordinal, content="5")
+  debug_inspect(conv.workflows[0].rows[0].phase, content="Some(\"survey\")")
+  debug_inspect(conv.workflows[0].cost_usd(), content="Some(0.01)")
+  let (_, same) = update_dev(
+    test_dispatch(),
+    WorkflowEntryArrived(@interop.ChannelId::Local, {
+      ..entry,
+      session: "elsewhere",
+    }),
+    next,
+  )
+  assert_true(
+    same.find_conversation(@interop.ChannelId::Local, "elsewhere") is None,
+  )
+  guard same.find_conversation(@interop.ChannelId::Local, base.session_id)
+    is Some(untouched) else {
+    fail("expected the parent conversation")
+  }
+  inspect(untouched.workflows[0].rows.length(), content="1")
 }

--- a/desktop/frontend/workflow/moon.pkg
+++ b/desktop/frontend/workflow/moon.pkg
@@ -1,0 +1,8 @@
+import {
+  "moonbit-community/rabbita/cmd",
+  "moonbit-community/rabbita/html",
+  "openseek_desktop/frontend/labels",
+  "moonbitlang/core/debug",
+}
+
+supported_targets = "js"

--- a/desktop/frontend/workflow/state.mbt
+++ b/desktop/frontend/workflow/state.mbt
@@ -174,7 +174,10 @@ pub fn child_opened(
     let child = "\{run.session}-\{id}"
     match run.rows.search_by(row => row.child == child) {
       // Seen already (an entry outran the bracket, or a replay): keep what
-      // is known, just make sure it reads as running again if it was not.
+      // is known. The bracket is authoritative for the child's kind and
+      // label; its status is not touched — an entry that arrived first
+      // means the child has already resolved, and a replayed open must not
+      // make it look live again.
       Some(index) => {
         let rows = run.rows.copy()
         rows[index] = { ..rows[index], kind, label, }

--- a/desktop/frontend/workflow/state.mbt
+++ b/desktop/frontend/workflow/state.mbt
@@ -109,6 +109,14 @@ fn ordinal_of(id : String) -> Int? {
 
 ///|
 /// Whether `ordinal` is one this run reserved.
+///
+/// Attribution by RANGE is the one place a reader keys on ordinals rather
+/// than an explicit id, and it is sound only because of two invariants the
+/// engine holds: blocks are allocated parent-side from one counter (so two
+/// runs never overlap) and the host refuses sidecar children outside the
+/// announced block (so nothing outside a run ever wears its ordinals). The
+/// synthesized bracket carries `sr-N` and no run id; carrying one would let
+/// this be explicit, and is the natural next protocol change.
 fn Run::owns(self : Run, ordinal : Int) -> Bool {
   ordinal >= self.first_child && ordinal < self.first_child + self.child_count
 }
@@ -343,4 +351,22 @@ pub fn Run::cost_usd(self : Run) -> Double? {
     }
   }
   total
+}
+
+///|
+/// What a row's status cell says, and the class that styles it. A row still
+/// running after its run CLOSED never got its finish — the snippet died, or
+/// the finish was lost — and is shown as unresolved rather than pulsing
+/// forever; a run's close is the last word its brackets will say.
+pub fn row_status(row : Row, closed~ : Bool) -> (String, String) {
+  match row.status {
+    None =>
+      if closed {
+        ("unresolved", "failed")
+      } else {
+        ("running", "running")
+      }
+    Some("captured") => ("done", "done")
+    Some(other) => (other.replace_all(old="_", new=" "), "failed")
+  }
 }

--- a/desktop/frontend/workflow/state.mbt
+++ b/desktop/frontend/workflow/state.mbt
@@ -1,0 +1,346 @@
+// A workflow a snippet is running, as this client can see it: the run the
+// engine announced, and one row per subagent, assembled from three sources
+// that tick at different moments.
+//
+// The engine's `workflow_started` bracket says a run exists and which child
+// ordinals it may use. The sub-run brackets the host synthesizes from the
+// run's sidecar say a child STARTED (with its kind and label) and ENDED (with
+// its status and spend). The `workflow.entry` push, read from the run's
+// journal, says how a call RESOLVED — phase, timings, cost — and it lands
+// only at completion. A row is therefore born from a bracket and refined by
+// an entry; either can arrive without the other (a snippet that died leaves
+// started rows with no entry; a client that connected late may see entries
+// for rows it never saw start), so every update is keyed by the child's
+// session id and tolerates missing halves.
+//
+// Nothing here is durable. The journal and the transcripts in the session
+// store are the record; this is what the client knows right now, and it is
+// dropped with the conversation it belongs to.
+
+///|
+/// One resolved call, as the host read it from the journal. Mirrors the
+/// `workflow.entry` payload field for field; the bridge converts.
+pub(all) struct Entry {
+  workflow : String
+  session : String
+  child : String
+  kind : String
+  label : String
+  phase : String?
+  status : String
+  steps : Int
+  prompt_tokens : Int
+  completion_tokens : Int
+  cost_usd : Double?
+  /// Milliseconds since the epoch.
+  started_at : Double?
+  finished_at : Double?
+} derive(Eq, @debug.Debug)
+
+///|
+pub extend Entry with Eq::{equal, not_equal}
+
+///|
+pub extend Entry with @debug.Debug::{to_repr}
+
+///|
+/// One subagent of a run. `status` is `None` while the child is running.
+pub(all) struct Row {
+  /// The child's session id, `<parent>-sr-N`: what the sidebar folds under
+  /// the parent and what a click opens.
+  child : String
+  ordinal : Int
+  kind : String
+  label : String
+  phase : String?
+  status : String?
+  steps : Int
+  tokens : Int
+  cost_usd : Double?
+  /// Milliseconds since the epoch.
+  started_at : Double?
+  finished_at : Double?
+} derive(Eq, @debug.Debug)
+
+///|
+pub extend Row with Eq::{equal, not_equal}
+
+///|
+pub extend Row with @debug.Debug::{to_repr}
+
+///|
+/// One run. `closed` flips at `workflow_finished`; rows are kept, because a
+/// finished run is exactly what a reader wants to look back over.
+pub(all) struct Run {
+  id : String
+  session : String
+  first_child : Int
+  child_count : Int
+  closed : Bool
+  rows : Array[Row]
+} derive(Eq, @debug.Debug)
+
+///|
+pub extend Run with Eq::{equal, not_equal}
+
+///|
+pub extend Run with @debug.Debug::{to_repr}
+
+///|
+/// The ordinal in a sub-run id (`sr-7` → 7), or `None` for any other shape.
+fn ordinal_of(id : String) -> Int? {
+  guard id.has_prefix("sr-") else { return None }
+  let digits = id.view(start_offset=3)
+  // Bounded as `@protocol.split_child_session_id` bounds it: nine digits,
+  // so a pathological id cannot overflow, and beyond that it is simply not
+  // a sub-run id.
+  guard !digits.is_empty() &&
+    digits.length() <= 9 &&
+    digits.iter().all(c => c.is_ascii_digit()) else {
+    return None
+  }
+  let ordinal = for c in digits; ordinal = 0 {
+    continue ordinal * 10 + (c.to_int() - '0'.to_int())
+  } nobreak {
+    ordinal
+  }
+  Some(ordinal)
+}
+
+///|
+/// Whether `ordinal` is one this run reserved.
+fn Run::owns(self : Run, ordinal : Int) -> Bool {
+  ordinal >= self.first_child && ordinal < self.first_child + self.child_count
+}
+
+///|
+/// The engine announced a run. A repeated id (a reconnect replaying the
+/// bracket) refreshes the announcement without dropping the rows already
+/// known.
+pub fn opened(
+  runs : Array[Run],
+  id~ : String,
+  session~ : String,
+  first_child~ : Int,
+  child_count~ : Int,
+) -> Array[Run] {
+  match runs.search_by(run => run.id == id) {
+    Some(index) => {
+      let updated = runs.copy()
+      updated[index] = {
+        ..runs[index],
+        first_child,
+        child_count,
+        closed: false,
+      }
+      updated
+    }
+    None =>
+      [
+        ..runs,
+        { id, session, first_child, child_count, closed: false, rows: [], },
+      ]
+  }
+}
+
+///|
+/// The engine closed a run. Rows stay; only the state flips, so a run that
+/// ended abnormally still shows every child it started.
+pub fn closed(runs : Array[Run], id~ : String) -> Array[Run] {
+  runs.map(run => if run.id == id { { ..run, closed: true, } } else { run })
+}
+
+///|
+/// A sub-run started. When its ordinal belongs to a run this client knows,
+/// it is that run's child and gets a row; otherwise it is an ordinary
+/// `explore`/`review` sub-run and none of this package's business.
+pub fn child_opened(
+  runs : Array[Run],
+  id~ : String,
+  kind~ : String,
+  label~ : String,
+) -> Array[Run] {
+  guard ordinal_of(id) is Some(ordinal) else { return runs }
+  runs.map(run => {
+    guard run.owns(ordinal) else { return run }
+    let child = "\{run.session}-\{id}"
+    match run.rows.search_by(row => row.child == child) {
+      // Seen already (an entry outran the bracket, or a replay): keep what
+      // is known, just make sure it reads as running again if it was not.
+      Some(index) => {
+        let rows = run.rows.copy()
+        rows[index] = { ..rows[index], kind, label, }
+        { ..run, rows, }
+      }
+      None =>
+        {
+          ..run,
+          rows: [
+            ..run.rows,
+            {
+              child,
+              ordinal,
+              kind,
+              label,
+              phase: None,
+              status: None,
+              steps: 0,
+              tokens: 0,
+              cost_usd: None,
+              started_at: None,
+              finished_at: None,
+            },
+          ],
+        }
+    }
+  })
+}
+
+///|
+/// A sub-run ended. The bracket carries the terminal and the spend; the
+/// journal's entry, when it lands, adds phase, timings and cost.
+pub fn child_closed(
+  runs : Array[Run],
+  id~ : String,
+  status~ : String,
+  steps~ : Int,
+  tokens~ : Int,
+) -> Array[Run] {
+  guard ordinal_of(id) is Some(ordinal) else { return runs }
+  runs.map(run => {
+    guard run.owns(ordinal) else { return run }
+    let child = "\{run.session}-\{id}"
+    match run.rows.search_by(row => row.child == child) {
+      Some(index) => {
+        let rows = run.rows.copy()
+        rows[index] = { ..rows[index], status: Some(status), steps, tokens, }
+        { ..run, rows, }
+      }
+      // A finish for a child whose start this client never saw: still a
+      // fact about the run. Recorded with what the bracket says.
+      None =>
+        {
+          ..run,
+          rows: [
+            ..run.rows,
+            {
+              child,
+              ordinal,
+              kind: "",
+              label: "",
+              phase: None,
+              status: Some(status),
+              steps,
+              tokens,
+              cost_usd: None,
+              started_at: None,
+              finished_at: None,
+            },
+          ],
+        }
+    }
+  })
+}
+
+///|
+/// A call resolved in the journal. Keyed by the child's session id: refines
+/// the row a bracket created, or creates one when the brackets were missed.
+/// The bracket's status and the entry's agree by construction (both come
+/// from the same contract terminal), so the entry's may overwrite.
+pub fn entry(runs : Array[Run], entry : Entry) -> Array[Run] {
+  runs.map(run => {
+    guard run.id == entry.workflow && run.session == entry.session else {
+      return run
+    }
+    let refined = fn(row : Row) -> Row {
+      {
+        ..row,
+        kind: if row.kind.is_empty() {
+          entry.kind
+        } else {
+          row.kind
+        },
+        label: if row.label.is_empty() {
+          entry.label
+        } else {
+          row.label
+        },
+        phase: entry.phase,
+        status: Some(entry.status),
+        steps: entry.steps,
+        tokens: entry.prompt_tokens + entry.completion_tokens,
+        cost_usd: entry.cost_usd,
+        started_at: entry.started_at,
+        finished_at: entry.finished_at,
+      }
+    }
+    match run.rows.search_by(row => row.child == entry.child) {
+      Some(index) => {
+        let rows = run.rows.copy()
+        rows[index] = refined(rows[index])
+        { ..run, rows, }
+      }
+      None => {
+        let ordinal = match entry.child.rev_find("-sr-") {
+          Some(at) =>
+            ordinal_of(entry.child.view(start_offset=at + 1).to_owned()).unwrap_or(
+              0,
+            )
+          None => 0
+        }
+        {
+          ..run,
+          rows: [
+            ..run.rows,
+            refined({
+              child: entry.child,
+              ordinal,
+              kind: "",
+              label: "",
+              phase: None,
+              status: None,
+              steps: 0,
+              tokens: 0,
+              cost_usd: None,
+              started_at: None,
+              finished_at: None,
+            }),
+          ],
+        }
+      }
+    }
+  })
+}
+
+///|
+/// The rows of a run, oldest child first — the order they were launched,
+/// which is the order a reader follows.
+pub fn Run::ordered_rows(self : Run) -> Array[Row] {
+  let rows = self.rows.copy()
+  rows.sort_by(fn(a, b) { a.ordinal - b.ordinal })
+  rows
+}
+
+///|
+/// How many of a run's children are still running.
+pub fn Run::running(self : Run) -> Int {
+  self.rows.filter(row => row.status is None).length()
+}
+
+///|
+/// Total tokens across the run's resolved children.
+pub fn Run::tokens(self : Run) -> Int {
+  self.rows.fold(init=0, (sum, row) => sum + row.tokens)
+}
+
+///|
+/// Total cost across children that reported one; `None` when none did.
+pub fn Run::cost_usd(self : Run) -> Double? {
+  let mut total : Double? = None
+  for row in self.rows {
+    if row.cost_usd is Some(cost) {
+      total = Some(total.unwrap_or(0.0) + cost)
+    }
+  }
+  total
+}

--- a/desktop/frontend/workflow/state_test.mbt
+++ b/desktop/frontend/workflow/state_test.mbt
@@ -140,3 +140,44 @@ test "rows read in launch order and a closed run keeps them" {
   inspect(runs[0].closed, content="true")
   inspect(runs[0].rows.length(), content="3")
 }
+
+///|
+test "a row still running after the run closed reads as unresolved" {
+  let runs = @workflow.child_opened(
+    announced(),
+    id="sr-5",
+    kind="explore",
+    label="a",
+  )
+  let row = runs[0].rows[0]
+  debug_inspect(
+    @workflow.row_status(row, closed=false),
+    content="(\"running\", \"running\")",
+  )
+  debug_inspect(
+    @workflow.row_status(row, closed=true),
+    content="(\"unresolved\", \"failed\")",
+  )
+  let done = @workflow.child_closed(
+    runs,
+    id="sr-5",
+    status="captured",
+    steps=1,
+    tokens=1,
+  )
+  debug_inspect(
+    @workflow.row_status(done[0].rows[0], closed=true),
+    content="(\"done\", \"done\")",
+  )
+  let timed = @workflow.child_closed(
+    runs,
+    id="sr-5",
+    status="timed_out",
+    steps=1,
+    tokens=1,
+  )
+  debug_inspect(
+    @workflow.row_status(timed[0].rows[0], closed=true),
+    content="(\"timed out\", \"failed\")",
+  )
+}

--- a/desktop/frontend/workflow/state_test.mbt
+++ b/desktop/frontend/workflow/state_test.mbt
@@ -1,0 +1,142 @@
+///|
+fn announced() -> Array[@workflow.Run] {
+  @workflow.opened([], id="wf-5", session="run7", first_child=5, child_count=32)
+}
+
+///|
+test "a run is announced once and a replayed bracket does not drop its rows" {
+  let runs = announced()
+  inspect(runs.length(), content="1")
+  let with_child = @workflow.child_opened(
+    runs,
+    id="sr-5",
+    kind="explore",
+    label="scout:x",
+  )
+  // A reconnect replays `workflow_started`: the run keeps what it knows.
+  let replayed = @workflow.opened(
+    with_child,
+    id="wf-5",
+    session="run7",
+    first_child=5,
+    child_count=32,
+  )
+  inspect(replayed.length(), content="1")
+  inspect(replayed[0].rows.length(), content="1")
+  inspect(replayed[0].closed, content="false")
+}
+
+///|
+test "a sub-run bracket makes a row only for a child in the run's block" {
+  let runs = announced()
+  // Ordinal 5 is the run's; ordinal 2 is an ordinary explore child of the
+  // same conversation, and none of this package's business.
+  let runs = @workflow.child_opened(
+    runs,
+    id="sr-5",
+    kind="explore",
+    label="scout:x",
+  )
+  let runs = @workflow.child_opened(
+    runs,
+    id="sr-2",
+    kind="explore",
+    label="elsewhere",
+  )
+  inspect(runs[0].rows.length(), content="1")
+  let row = runs[0].rows[0]
+  inspect(row.child, content="run7-sr-5")
+  inspect(row.ordinal, content="5")
+  debug_inspect(row.status, content="None")
+  inspect(runs[0].running(), content="1")
+  // The finish bracket carries the terminal and the spend.
+  let runs = @workflow.child_closed(
+    runs,
+    id="sr-5",
+    status="captured",
+    steps=12,
+    tokens=3400,
+  )
+  debug_inspect(runs[0].rows[0].status, content="Some(\"captured\")")
+  inspect(runs[0].rows[0].steps, content="12")
+  inspect(runs[0].running(), content="0")
+  inspect(runs[0].tokens(), content="3400")
+}
+
+///|
+fn entry_for(child : String, phase : String?) -> @workflow.Entry {
+  {
+    workflow: "wf-5",
+    session: "run7",
+    child,
+    kind: "explore",
+    label: "scout:x",
+    phase,
+    status: "captured",
+    steps: 12,
+    prompt_tokens: 3000,
+    completion_tokens: 400,
+    cost_usd: Some(0.01),
+    started_at: Some(1788535817640.0),
+    finished_at: Some(1788535817648.0),
+  }
+}
+
+///|
+test "a journal entry refines the row its brackets created" {
+  let runs = @workflow.child_opened(
+    announced(),
+    id="sr-5",
+    kind="explore",
+    label="scout:x",
+  )
+  let runs = @workflow.child_closed(
+    runs,
+    id="sr-5",
+    status="captured",
+    steps=12,
+    tokens=3400,
+  )
+  let runs = @workflow.entry(runs, entry_for("run7-sr-5", Some("survey")))
+  inspect(runs[0].rows.length(), content="1")
+  let row = runs[0].rows[0]
+  debug_inspect(row.phase, content="Some(\"survey\")")
+  debug_inspect(row.cost_usd, content="Some(0.01)")
+  debug_inspect(row.started_at, content="Some(1788535817640)")
+  debug_inspect(runs[0].cost_usd(), content="Some(0.01)")
+}
+
+///|
+test "an entry whose brackets were missed still becomes a row" {
+  // A client that connected mid-run sees the journal's entries without ever
+  // having seen the launches. The entry is a fact about the run: it gets a
+  // row, keyed and ordered by the child it names.
+  let runs = @workflow.entry(announced(), entry_for("run7-sr-7", None))
+  inspect(runs[0].rows.length(), content="1")
+  inspect(runs[0].rows[0].ordinal, content="7")
+  inspect(runs[0].rows[0].kind, content="explore")
+  debug_inspect(runs[0].rows[0].status, content="Some(\"captured\")")
+  // And an entry for a run this client does not know is dropped, not
+  // resurrected: only a bracket knows a run exists.
+  let other = { ..entry_for("run7-sr-9", None), workflow: "wf-99", }
+  inspect(@workflow.entry(runs, other)[0].rows.length(), content="1")
+}
+
+///|
+test "rows read in launch order and a closed run keeps them" {
+  let runs = @workflow.child_opened(
+    announced(),
+    id="sr-7",
+    kind="explore",
+    label="c",
+  )
+  let runs = @workflow.child_opened(runs, id="sr-5", kind="explore", label="a")
+  let runs = @workflow.child_opened(runs, id="sr-6", kind="explore", label="b")
+  debug_inspect(
+    runs[0].ordered_rows().map(row => row.label),
+    content="[\"a\", \"b\", \"c\"]",
+  )
+  let runs = @workflow.closed(runs, id="wf-5")
+  inspect(runs[0].closed, content="true")
+  inspect(runs[0].rows.length(), content="3")
+}

--- a/desktop/frontend/workflow/view.mbt
+++ b/desktop/frontend/workflow/view.mbt
@@ -66,17 +66,16 @@ fn run_view(run : Run, actions : Actions) -> @html.Html {
   }
   @html.section(class="workflow-run workflow-run-\{state}", [
     @html.header(class="workflow-run-head", summary),
-    @html.div(class="workflow-rows", rows.map(row => row_view(row, actions))),
+    @html.div(
+      class="workflow-rows",
+      rows.map(row => row_view(row, closed=run.closed, actions)),
+    ),
   ])
 }
 
 ///|
-fn row_view(row : Row, actions : Actions) -> @html.Html {
-  let (status, status_class) = match row.status {
-    None => ("running", "running")
-    Some("captured") => ("done", "done")
-    Some(other) => (other.replace_all(old="_", new=" "), "failed")
-  }
+fn row_view(row : Row, closed~ : Bool, actions : Actions) -> @html.Html {
+  let (status, status_class) = row_status(row, closed~)
   let detail : Array[@html.Html] = []
   if row.phase is Some(phase) {
     detail.push(@html.span(class="workflow-row-phase", phase))

--- a/desktop/frontend/workflow/view.mbt
+++ b/desktop/frontend/workflow/view.mbt
@@ -1,0 +1,155 @@
+// The workflows panel: every run this conversation announced, each with one
+// row per subagent, the way a reader follows a fan-out — launch order, what
+// each child is, whether it is still running, what it cost, and a click that
+// opens the child's own transcript.
+//
+// It is a dock tab, not a dock lane. The lane dock above the composer is the
+// glance surface for what is running RIGHT NOW and drops a lane the moment
+// its child ends; a run is something to look back over, so its rows stay
+// until the conversation is dropped. Both are fed by the same brackets, and a
+// row here and a lane there for the same child agree by construction.
+
+///|
+/// What the panel can do: open a child's transcript. Root-owned, since
+/// switching sessions allocates state in other packages.
+pub(all) struct Actions {
+  open_child : (String) -> @cmd.Cmd
+}
+
+///|
+/// The panel body. Always rendered — CSS shows it only while its tab is
+/// active — so the right panel's child order stays structural.
+pub fn panel(runs : Array[Run], actions : Actions) -> @html.Html {
+  if runs.is_empty() {
+    return @html.div(class="workflow-panel workflow-panel-empty", [
+      @html.p(
+        class="workflow-empty",
+        "No workflows in this conversation yet. A snippet that sets `subrun: true` and runs a workflow will appear here, with a row per subagent.",
+      ),
+    ])
+  }
+  // Newest run first: the one a reader is most likely watching.
+  let ordered = runs.copy()
+  ordered.rev_in_place()
+  @html.div(class="workflow-panel", ordered.map(run => run_view(run, actions)))
+}
+
+///|
+fn run_view(run : Run, actions : Actions) -> @html.Html {
+  let rows = run.ordered_rows()
+  let running = run.running()
+  let state = if run.closed {
+    "finished"
+  } else if running > 0 {
+    "running"
+  } else {
+    "open"
+  }
+  let summary : Array[@html.Html] = [
+    @html.span(class="workflow-run-id", run.id),
+    @html.span(class="workflow-run-state workflow-run-state-\{state}", state),
+    @html.span(
+      class="workflow-run-count",
+      "\{rows.length()} of \{run.child_count} subagent\{plural(rows.length())}",
+    ),
+  ]
+  if run.tokens() > 0 {
+    summary.push(
+      @html.span(
+        class="workflow-run-tokens",
+        "\{@labels.compact_count(run.tokens())} tok",
+      ),
+    )
+  }
+  if run.cost_usd() is Some(cost) {
+    summary.push(@html.span(class="workflow-run-cost", money(cost)))
+  }
+  @html.section(class="workflow-run workflow-run-\{state}", [
+    @html.header(class="workflow-run-head", summary),
+    @html.div(class="workflow-rows", rows.map(row => row_view(row, actions))),
+  ])
+}
+
+///|
+fn row_view(row : Row, actions : Actions) -> @html.Html {
+  let (status, status_class) = match row.status {
+    None => ("running", "running")
+    Some("captured") => ("done", "done")
+    Some(other) => (other.replace_all(old="_", new=" "), "failed")
+  }
+  let detail : Array[@html.Html] = []
+  if row.phase is Some(phase) {
+    detail.push(@html.span(class="workflow-row-phase", phase))
+  }
+  if row.steps > 0 {
+    detail.push(
+      @html.span(
+        class="workflow-row-steps",
+        "\{row.steps} step\{plural(row.steps)}",
+      ),
+    )
+  }
+  if row.tokens > 0 {
+    detail.push(
+      @html.span(
+        class="workflow-row-tokens",
+        "\{@labels.compact_count(row.tokens)} tok",
+      ),
+    )
+  }
+  if row.cost_usd is Some(cost) {
+    detail.push(@html.span(class="workflow-row-cost", money(cost)))
+  }
+  if row.started_at is Some(started) && row.finished_at is Some(finished) {
+    detail.push(
+      @html.span(class="workflow-row-duration", duration(finished - started)),
+    )
+  }
+  let label = if row.label.is_empty() { row.child } else { row.label }
+  @html.button(
+    class="workflow-row workflow-row-\{status_class}",
+    title="Open \{row.child}",
+    on_click=(actions.open_child)(row.child),
+    [
+      @html.span(class="workflow-row-mark", ""),
+      @html.span(class="workflow-row-kind", row.kind),
+      @html.span(class="workflow-row-label", label),
+      @html.span(class="workflow-row-status", status),
+      @html.span(class="workflow-row-detail", detail),
+    ],
+  )
+}
+
+///|
+fn plural(n : Int) -> String {
+  if n == 1 {
+    ""
+  } else {
+    "s"
+  }
+}
+
+///|
+/// Dollars to the cent, the way a cost line reads; a fraction of a cent is
+/// still shown as one, never as zero.
+fn money(cost : Double) -> String {
+  let cents = (cost * 100.0 + 0.5).to_int()
+  let cents = if cost > 0.0 && cents == 0 { 1 } else { cents }
+  let dollars = cents / 100
+  let rest = cents % 100
+  let rest = if rest < 10 { "0\{rest}" } else { "\{rest}" }
+  "$\{dollars}.\{rest}"
+}
+
+///|
+/// A wall-clock span in the unit a reader thinks in.
+fn duration(ms : Double) -> String {
+  let seconds = (ms / 1000.0).to_int()
+  if seconds < 60 {
+    "\{seconds}s"
+  } else if seconds < 3600 {
+    "\{seconds / 60}m \{seconds % 60}s"
+  } else {
+    "\{seconds / 3600}h \{seconds % 3600 / 60}m"
+  }
+}

--- a/desktop/internal/api/hub.mbt
+++ b/desktop/internal/api/hub.mbt
@@ -289,6 +289,9 @@ fn Hub::sink(
       // a client that arrives late simply learns nothing about a child's
       // progress until its next advance.
       SubrunProgress(payload) => self.publish(SubrunProgress(payload))
+      // A workflow's ledger row. Like sub-run progress, nothing downstream
+      // persists it: the journal in the session store is the record.
+      WorkflowEntry(payload) => self.publish(WorkflowEntry(payload))
       // A failed command may have settled lifecycle before its process was
       // reapable. This later durable boundary is not a second finish: it must
       // not post another system notification or mutate the live-runs table.

--- a/desktop/internal/engine/api.mbt
+++ b/desktop/internal/engine/api.mbt
@@ -122,6 +122,11 @@ pub(all) enum EngineEvent {
   /// brackets on the raw stream own the sub-run's start and end, and this
   /// only refreshes what it is doing in between.
   SubrunProgress(@protocol.SubrunProgressPayload)
+  /// One resolved call of a workflow a snippet is running, read from the
+  /// run's journal. Not lifecycle and not durable here: the journal is the
+  /// record, and the `workflow_started`/`workflow_finished` brackets on the
+  /// raw stream own the run's start and end.
+  WorkflowEntry(@protocol.WorkflowEntryPayload)
 }
 
 ///|

--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -1745,6 +1745,12 @@ async fn ServeEngine::consume(
   // never arrives cannot outlive the engine that launched it.
   @async.with_task_group() <| group => {
     let probes : Map[String, @async.Task[Unit]] = Map([])
+    // Workflow tails likewise: one per run a snippet announced, spawned at
+    // its `workflow_started` bracket and cancelled at the finish. A tail
+    // turns the run's sidecar into the SAME sub-run brackets an `explore`
+    // child gets — so the lane dock and the child's own probe need no new
+    // path — and its journal into `workflow.entry` pushes.
+    let tails : Map[String, @async.Task[Unit]] = Map([])
     for ;; {
       guard reader.read_until("\n") is Some(line) else { break }
       for json in @jsonl.parse(line) {
@@ -1772,6 +1778,99 @@ async fn ServeEngine::consume(
             if probes.get(id) is Some(probe) {
               probes.remove(id)
               probe.cancel()
+            }
+          Some(WorkflowStarted(id~, journal~, events~, ..)) =>
+            if engine.session_root is Some(root) && tails.get(id) is None {
+              tails[id] = group.spawn(no_wait=true, allow_failure=true, () => {
+                @workflow.follow_run(
+                  workflow=id,
+                  session=engine.session_key,
+                  journal~,
+                  events~,
+                  on_child_started=started => {
+                    // The child's session id is `<parent>-sr-N`; its bracket
+                    // id is the `sr-N` suffix, exactly as `run_subrun` names
+                    // the children it launches itself.
+                    guard @wire.split_child_session_id(started.child)
+                      is Some((_, ordinal)) else {
+                      return
+                    }
+                    let sr = "sr-\{ordinal}"
+                    let event : @wire.Event = SubrunStarted(
+                      id=sr,
+                      kind=started.kind,
+                      label=@workflow.display_label(started.label),
+                    )
+                    let (run_id, submission_id) = engine.steer_runs.route_event(
+                      Some(event),
+                      engine.phase.latest_run(),
+                    )
+                    emit(
+                      sink,
+                      StreamEvent({
+                        run_id,
+                        session: engine.session_key,
+                        event: { event, submission_id, },
+                      }),
+                    )
+                    if probes.get(sr) is None {
+                      probes[sr] = group.spawn(
+                        no_wait=true,
+                        allow_failure=true,
+                        () => {
+                          @subrun.follow_progress(
+                            root~,
+                            parent_session=engine.session_key,
+                            id=sr,
+                            publish=payload => {
+                              emit(sink, SubrunProgress(payload))
+                            },
+                          )
+                        },
+                      )
+                    }
+                  },
+                  on_child_finished=finished => {
+                    guard @wire.split_child_session_id(finished.child)
+                      is Some((_, ordinal)) else {
+                      return
+                    }
+                    let sr = "sr-\{ordinal}"
+                    // The sidecar reports the spend as one figure; the
+                    // bracket wants it split, and the lane only ever shows
+                    // the sum.
+                    let event : @wire.Event = SubrunFinished(
+                      id=sr,
+                      status=finished.status,
+                      steps=finished.steps,
+                      prompt_tokens=finished.tokens,
+                      completion_tokens=0,
+                    )
+                    let (run_id, submission_id) = engine.steer_runs.route_event(
+                      Some(event),
+                      engine.phase.latest_run(),
+                    )
+                    emit(
+                      sink,
+                      StreamEvent({
+                        run_id,
+                        session: engine.session_key,
+                        event: { event, submission_id, },
+                      }),
+                    )
+                    if probes.get(sr) is Some(probe) {
+                      probes.remove(sr)
+                      probe.cancel()
+                    }
+                  },
+                  on_entry=entry => emit(sink, WorkflowEntry(entry)),
+                )
+              })
+            }
+          Some(WorkflowFinished(id~)) =>
+            if tails.get(id) is Some(tail) {
+              tails.remove(id)
+              tail.cancel()
             }
           _ => ()
         }

--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -1782,7 +1782,11 @@ async fn ServeEngine::consume(
           Some(
             WorkflowStarted(id~, journal~, events~, first_child~, child_count~)
           ) =>
-            if engine.session_root is Some(root) && tails.get(id) is None {
+            // The bracket names both files by absolute path, so the tail
+            // needs no store root; only the per-child PROBE does (it locates
+            // the child's transcript under the store), and an engine without
+            // one still gets its lanes and ledger rows, just no live activity.
+            if tails.get(id) is None {
               tails[id] = group.spawn(no_wait=true, allow_failure=true, () => {
                 @workflow.follow_run(
                   workflow=id,
@@ -1820,7 +1824,8 @@ async fn ServeEngine::consume(
                         event: { event, submission_id, },
                       }),
                     )
-                    if probes.get(sr) is None {
+                    if engine.session_root is Some(root) &&
+                      probes.get(sr) is None {
                       probes[sr] = group.spawn(
                         no_wait=true,
                         allow_failure=true,

--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -1779,7 +1779,9 @@ async fn ServeEngine::consume(
               probes.remove(id)
               probe.cancel()
             }
-          Some(WorkflowStarted(id~, journal~, events~, ..)) =>
+          Some(
+            WorkflowStarted(id~, journal~, events~, first_child~, child_count~)
+          ) =>
             if engine.session_root is Some(root) && tails.get(id) is None {
               tails[id] = group.spawn(no_wait=true, allow_failure=true, () => {
                 @workflow.follow_run(
@@ -1791,8 +1793,13 @@ async fn ServeEngine::consume(
                     // The child's session id is `<parent>-sr-N`; its bracket
                     // id is the `sr-N` suffix, exactly as `run_subrun` names
                     // the children it launches itself.
+                    // Only a child inside the announced block is this run's:
+                    // the sidecar is the snippet's own writing, and a line
+                    // naming an `explore` child's id must not open a second
+                    // lane for it.
                     guard @wire.split_child_session_id(started.child)
-                      is Some((_, ordinal)) else {
+                      is Some((_, ordinal)) &&
+                      @workflow.in_block(ordinal, first_child~, child_count~) else {
                       return
                     }
                     let sr = "sr-\{ordinal}"
@@ -1832,7 +1839,8 @@ async fn ServeEngine::consume(
                   },
                   on_child_finished=finished => {
                     guard @wire.split_child_session_id(finished.child)
-                      is Some((_, ordinal)) else {
+                      is Some((_, ordinal)) &&
+                      @workflow.in_block(ordinal, first_child~, child_count~) else {
                       return
                     }
                     let sr = "sr-\{ordinal}"
@@ -1870,7 +1878,16 @@ async fn ServeEngine::consume(
           Some(WorkflowFinished(id~)) =>
             if tails.get(id) is Some(tail) {
               tails.remove(id)
-              tail.cancel()
+              // Not cancelled on the bracket: the snippet wrote its last
+              // sidecar lines and journal entries just before exiting, and
+              // the tail's next poll may be a whole interval away. The grace
+              // guarantees one full poll over the final files, so a child
+              // that finished is never left showing as running.
+              group.spawn(no_wait=true, allow_failure=true, () => {
+                @async.sleep(@workflow.drain_grace_ms)
+                tail.cancel()
+              })
+              |> ignore
             }
           _ => ()
         }

--- a/desktop/internal/engine/moon.pkg
+++ b/desktop/internal/engine/moon.pkg
@@ -14,6 +14,7 @@ import {
   "openseek_desktop/internal/session_record",
   "openseek_desktop/internal/session_store",
   "openseek_desktop/internal/subrun",
+  "openseek_desktop/internal/workflow",
   "openseek_desktop/internal/uuid",
   "openseek_desktop/internal/worktree",
   "openseek_desktop/internal/workspaces",

--- a/desktop/internal/engine/pkg.generated.mbti
+++ b/desktop/internal/engine/pkg.generated.mbti
@@ -80,6 +80,7 @@ pub(all) enum EngineEvent {
   Finished(@protocol.FinishedPayload)
   SessionCommit(@protocol.SessionCommitPayload)
   SubrunProgress(@protocol.SubrunProgressPayload)
+  WorkflowEntry(@protocol.WorkflowEntryPayload)
 }
 
 type EngineManager

--- a/desktop/internal/extension/extension.mbt
+++ b/desktop/internal/extension/extension.mbt
@@ -45,6 +45,11 @@ let subrun_progress : @proton_contract.Event[@protocol.SubrunProgressPayload] = 
 )
 
 ///|
+let workflow_entry : @proton_contract.Event[@protocol.WorkflowEntryPayload] = @commands.extension_contract.event(
+  @protocol.NotificationKind::WorkflowEntry.wire_name(),
+)
+
+///|
 let session_changed_event : @proton_contract.Event[
   @protocol.SessionChangedPayload,
 ] = @commands.extension_contract.event(
@@ -213,6 +218,7 @@ async fn PageEventTarget::emit(
     Hub(AgentFinished(payload)) => self.events.emit(finished_event, payload)
     Hub(SessionEvent(payload)) => self.events.emit(session_event, payload)
     Hub(SubrunProgress(payload)) => self.events.emit(subrun_progress, payload)
+    Hub(WorkflowEntry(payload)) => self.events.emit(workflow_entry, payload)
     Hub(SessionChanged(payload)) =>
       self.events.emit(session_changed_event, payload)
     Hub(WorkspaceChanged(payload)) =>

--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -1083,6 +1083,35 @@ pub(all) struct SubrunProgressPayload {
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
+/// One resolved call of a workflow a snippet is running, read by the host from
+/// the run's journal and broadcast as `workflow.entry`. Nothing downstream
+/// persists it: the journal itself is the record, and a client that arrives
+/// late rebuilds its view from the next entries it sees. `child` is the
+/// subagent's own session id (`<parent>-sr-N`), the same string its transcript
+/// is named by — a reader can open it directly. `phase`, `cost_usd` and the
+/// timestamps are absent when the journal did not carry them.
+pub(all) struct WorkflowEntryPayload {
+  /// The run, as `workflow_started` named it (`wf-N`).
+  workflow : String
+  /// The parent session the run belongs to.
+  session : String
+  child : String
+  kind : String
+  label : String
+  phase : String?
+  /// The contract's snake_case terminal: `captured`, `no_report`,
+  /// `max_steps`, `context_yield`, `timed_out`, `skipped`, `failed`.
+  status : String
+  steps : Int
+  prompt_tokens : Int
+  completion_tokens : Int
+  cost_usd : Double?
+  /// Milliseconds since the epoch, as plain JSON numbers.
+  started_at : Double?
+  finished_at : Double?
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
 /// One exact store-qualified session changed placement or display metadata.
 /// Current change values are `archived`, `unarchived`, `deleted`, and
 /// `renamed`; clients still treat unknown values as list invalidations.
@@ -2002,6 +2031,18 @@ pub extend SubrunProgressPayload with Eq::{equal, not_equal}
 
 ///|
 pub extend SubrunProgressPayload with ToJson::{to_json}
+
+///|
+pub extend WorkflowEntryPayload with Debug::{to_repr}
+
+///|
+pub extend WorkflowEntryPayload with FromJson::{from_json}
+
+///|
+pub extend WorkflowEntryPayload with Eq::{equal, not_equal}
+
+///|
+pub extend WorkflowEntryPayload with ToJson::{to_json}
 
 ///|
 pub extend TerminalAckPayload with Debug::{to_repr}

--- a/desktop/internal/protocol/desktop_transport.mbt
+++ b/desktop/internal/protocol/desktop_transport.mbt
@@ -13,6 +13,7 @@ pub(all) enum NotificationKind {
   AgentFinished
   SessionEvent
   SubrunProgress
+  WorkflowEntry
   SessionChanged
   WorkspaceChanged
   WorkspaceSettingsChanged
@@ -45,6 +46,7 @@ pub fn NotificationKind::wire_name(self : NotificationKind) -> String {
     AgentFinished => "agent.finished"
     SessionEvent => "session.event"
     SubrunProgress => "subrun.progress"
+    WorkflowEntry => "workflow.entry"
     SessionChanged => "session.changed"
     WorkspaceChanged => "workspace.changed"
     WorkspaceSettingsChanged => "workspace.settings_changed"
@@ -78,6 +80,7 @@ pub fn NotificationKind::all() -> Array[NotificationKind] {
     AgentFinished,
     SessionEvent,
     SubrunProgress,
+    WorkflowEntry,
     SessionChanged,
     WorkspaceChanged,
     WorkspaceSettingsChanged,
@@ -112,6 +115,7 @@ pub(all) enum Notification {
   AgentFinished(FinishedPayload)
   SessionEvent(SessionCommitPayload)
   SubrunProgress(SubrunProgressPayload)
+  WorkflowEntry(WorkflowEntryPayload)
   SessionChanged(SessionChangedPayload)
   WorkspaceChanged(WorkspacesChangedPayload)
   WorkspaceSettingsChanged(WorkspaceSettingsPayload)
@@ -157,6 +161,8 @@ pub fn Notification::from_wire(name : String, params : Json) -> Notification? {
       Some(SessionEvent(@json.from_json(params) catch { _ => return None }))
     "subrun.progress" =>
       Some(SubrunProgress(@json.from_json(params) catch { _ => return None }))
+    "workflow.entry" =>
+      Some(WorkflowEntry(@json.from_json(params) catch { _ => return None }))
     "session.changed" =>
       Some(SessionChanged(@json.from_json(params) catch { _ => return None }))
     "workspace.changed" =>
@@ -226,6 +232,7 @@ pub fn Notification::kind(self : Notification) -> NotificationKind {
     AgentFinished(_) => AgentFinished
     SessionEvent(_) => SessionEvent
     SubrunProgress(_) => SubrunProgress
+    WorkflowEntry(_) => WorkflowEntry
     SessionChanged(_) => SessionChanged
     WorkspaceChanged(_) => WorkspaceChanged
     WorkspaceSettingsChanged(_) => WorkspaceSettingsChanged
@@ -265,6 +272,7 @@ pub fn Notification::params(self : Notification) -> Json {
     AgentFinished(payload) => ToJson::to_json(payload)
     SessionEvent(payload) => ToJson::to_json(payload)
     SubrunProgress(payload) => ToJson::to_json(payload)
+    WorkflowEntry(payload) => ToJson::to_json(payload)
     SessionChanged(payload) => ToJson::to_json(payload)
     WorkspaceChanged(payload) => ToJson::to_json(payload)
     WorkspaceSettingsChanged(payload) => ToJson::to_json(payload)
@@ -377,3 +385,35 @@ pub extend NotificationKind with Eq::{equal, not_equal}
 
 ///|
 pub extend NotificationKind with Hash::{hash, hash_combine}
+
+///|
+test "a workflow entry round-trips at the wire edge" {
+  let params : Json = {
+    "workflow": "wf-5",
+    "session": "run7",
+    "child": "run7-sr-5",
+    "kind": "explore",
+    "label": "scout:x",
+    "phase": "survey",
+    "status": "captured",
+    "steps": 12,
+    "prompt_tokens": 3000,
+    "completion_tokens": 400,
+    "started_at": 1788535817640,
+    "finished_at": 1788535817648,
+  }
+  // `cost_usd` is absent, not null: an optional field that is not there
+  // decodes as None, and encodes back to nothing — the round trip below
+  // pins that the params come back exactly as sent.
+  guard Notification::from_wire("workflow.entry", params) is Some(event) else {
+    fail("known notification was rejected")
+  }
+  assert_eq(event.wire_name(), "workflow.entry")
+  assert_eq(event.kind(), WorkflowEntry)
+  guard event is WorkflowEntry(payload) else { fail("wrong case") }
+  assert_eq(payload.child, "run7-sr-5")
+  assert_eq(payload.phase, Some("survey"))
+  assert_eq(payload.cost_usd, None)
+  assert_eq(payload.finished_at, Some(1788535817648.0))
+  assert_eq(event.params(), params)
+}

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -1426,6 +1426,7 @@ pub(all) enum Notification {
   AgentFinished(FinishedPayload)
   SessionEvent(SessionCommitPayload)
   SubrunProgress(SubrunProgressPayload)
+  WorkflowEntry(WorkflowEntryPayload)
   SessionChanged(SessionChangedPayload)
   WorkspaceChanged(WorkspacesChangedPayload)
   WorkspaceSettingsChanged(WorkspaceSettingsPayload)
@@ -1462,6 +1463,7 @@ pub(all) enum NotificationKind {
   AgentFinished
   SessionEvent
   SubrunProgress
+  WorkflowEntry
   SessionChanged
   WorkspaceChanged
   WorkspaceSettingsChanged
@@ -2480,6 +2482,27 @@ pub fn WatchWorkspacePayload::from_json(Json, @json.JsonPath) -> Self raise @jso
 pub fn WatchWorkspacePayload::not_equal(Self, Self) -> Bool
 pub fn WatchWorkspacePayload::to_json(Self) -> Json
 pub fn WatchWorkspacePayload::to_repr(Self) -> @debug.Repr
+
+pub(all) struct WorkflowEntryPayload {
+  workflow : String
+  session : String
+  child : String
+  kind : String
+  label : String
+  phase : String?
+  status : String
+  steps : Int
+  prompt_tokens : Int
+  completion_tokens : Int
+  cost_usd : Double?
+  started_at : Double?
+  finished_at : Double?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn WorkflowEntryPayload::equal(Self, Self) -> Bool
+pub fn WorkflowEntryPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn WorkflowEntryPayload::not_equal(Self, Self) -> Bool
+pub fn WorkflowEntryPayload::to_json(Self) -> Json
+pub fn WorkflowEntryPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct WorkspacePayload {
   path : String

--- a/desktop/internal/workflow/moon.pkg
+++ b/desktop/internal/workflow/moon.pkg
@@ -1,0 +1,11 @@
+import {
+  "openseek_desktop/internal/protocol",
+  "moonbitlang/async",
+  "moonbitlang/async/fs",
+  "moonbitlang/core/json",
+  "moonbitlang/core/encoding/utf8",
+}
+
+warnings = "+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"
+
+supported_targets = "+native"

--- a/desktop/internal/workflow/pkg.generated.mbti
+++ b/desktop/internal/workflow/pkg.generated.mbti
@@ -9,7 +9,11 @@ import {
 // Values
 pub fn display_label(String) -> String
 
+pub let drain_grace_ms : Int
+
 pub async fn follow_run(workflow~ : String, session~ : String, journal~ : String, events~ : String, on_child_started~ : async (ChildStarted) -> Unit, on_child_finished~ : async (ChildFinished) -> Unit, on_entry~ : async (@protocol.WorkflowEntryPayload) -> Unit) -> Unit
+
+pub fn in_block(Int, first_child~ : Int, child_count~ : Int) -> Bool
 
 // Errors
 

--- a/desktop/internal/workflow/pkg.generated.mbti
+++ b/desktop/internal/workflow/pkg.generated.mbti
@@ -1,0 +1,38 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "openseek_desktop/internal/workflow"
+
+import {
+  "moonbitlang/core/debug",
+  "openseek_desktop/internal/protocol",
+}
+
+// Values
+pub fn display_label(String) -> String
+
+pub async fn follow_run(workflow~ : String, session~ : String, journal~ : String, events~ : String, on_child_started~ : async (ChildStarted) -> Unit, on_child_finished~ : async (ChildFinished) -> Unit, on_entry~ : async (@protocol.WorkflowEntryPayload) -> Unit) -> Unit
+
+// Errors
+
+// Types and methods
+pub(all) struct ChildFinished {
+  child : String
+  status : String
+  steps : Int
+  tokens : Int
+} derive(Eq, @debug.Debug)
+pub fn ChildFinished::equal(Self, Self) -> Bool
+pub fn ChildFinished::not_equal(Self, Self) -> Bool
+pub fn ChildFinished::to_repr(Self) -> @debug.Repr
+
+pub(all) struct ChildStarted {
+  child : String
+  kind : String
+  label : String
+} derive(Eq, @debug.Debug)
+pub fn ChildStarted::equal(Self, Self) -> Bool
+pub fn ChildStarted::not_equal(Self, Self) -> Bool
+pub fn ChildStarted::to_repr(Self) -> @debug.Repr
+
+// Type aliases
+
+// Traits

--- a/desktop/internal/workflow/tail.mbt
+++ b/desktop/internal/workflow/tail.mbt
@@ -32,6 +32,25 @@
 // treated as a fresh file and re-read from the head.
 
 ///|
+/// How long a tail is kept alive after the run's finish bracket. The snippet
+/// writes its last sidecar lines and journal entries just before it exits,
+/// and the bracket can arrive up to a whole interval before the next poll —
+/// cancelling on the bracket would lose exactly those lines, leaving a child
+/// that finished showing as running. Two intervals guarantee one full poll
+/// over the final state of both files.
+pub let drain_grace_ms : Int = 2 * WorkflowTailIntervalMs
+
+///|
+/// Whether `ordinal` is one the run was announced with. The host synthesizes
+/// a sub-run bracket for every child the sidecar names, and the sidecar is
+/// written by the snippet — a buggy or hostile one could name an ordinary
+/// `explore` child's id and collide with a real lane. The announced block is
+/// the host's own knowledge; a child outside it is not this run's.
+pub fn in_block(ordinal : Int, first_child~ : Int, child_count~ : Int) -> Bool {
+  ordinal >= first_child && ordinal < first_child + child_count
+}
+
+///|
 /// How often the tail re-checks its files. Nothing kicks it: a snippet's
 /// appends do not reach this process as events, so this interval IS the
 /// update rate. The same cadence as the sub-run probe, for the same reason.

--- a/desktop/internal/workflow/tail.mbt
+++ b/desktop/internal/workflow/tail.mbt
@@ -1,0 +1,316 @@
+// Live view of a workflow a snippet is running, read from the two files the
+// engine told this host about.
+//
+// A workflow written in an `mbtx` snippet runs inside a sandbox the host does
+// not manage, and delegates to child engines the host never launched. All the
+// host is TOLD is the `workflow_started` bracket — which names a journal, a
+// sidecar, and the child ordinals the run may use — and, eventually,
+// `workflow_finished`. In between, nothing about the run reaches this process
+// as an event: the library that runs it is generic and never learns openseek
+// exists (`moonbitlang/workflow`), and the snippet's own output is captured by
+// the tool call that owns it.
+//
+// What the run DOES leave where the host can reach it is those two files, in
+// the session store:
+//
+// - the SIDECAR (`events.jsonl`) reports a child the moment it is launched and
+//   again when it ends, each line carrying the child's session id — the
+//   earliest a reader can learn a subagent exists;
+// - the JOURNAL (`journal.jsonl`) is the library's ledger of RESOLVED calls:
+//   phase, timings, spend, and the child's session id as `attempt_id`. An
+//   entry carries an outcome, so it lands only at completion; a reader with
+//   only the journal learns of a child no earlier than its finish.
+//
+// This tail follows both, remembering a byte offset per file and reading only
+// what was appended since, and hands each line to the caller as a typed
+// callback. It decides nothing about the run's lifetime: the caller starts it
+// at `workflow_started` and cancels it at `workflow_finished`.
+//
+// Deliberately simpler than `subrun/probe.mbt`. Both files are append-only by
+// contract and never rewritten in place, so there is no torn-tail repair to
+// detect and no watermark to keep — a truncation (size below the offset) is
+// treated as a fresh file and re-read from the head.
+
+///|
+/// How often the tail re-checks its files. Nothing kicks it: a snippet's
+/// appends do not reach this process as events, so this interval IS the
+/// update rate. The same cadence as the sub-run probe, for the same reason.
+const WorkflowTailIntervalMs = 1500
+
+///|
+/// The most one poll reads from one file. A burst of completions yields its
+/// tail on the next pass instead of one large allocation; a line arriving a
+/// poll late costs nothing a ledger cares about.
+let workflow_tail_max_chunk : Int64 = 128 * 1024
+
+///|
+/// One file's tail: where the last poll stopped, and the partial line it
+/// stopped inside. Bytes, not text, so a chunk boundary inside a multi-byte
+/// character cannot corrupt the line it belongs to.
+priv struct FileTail {
+  path : String
+  mut offset : Int64
+  mut carry : Bytes
+}
+
+///|
+/// Read whatever was appended since the last poll and return the complete
+/// lines it contains, decoded. Every failure is silent and non-fatal: the file
+/// may not exist yet (the snippet has not launched a child), may be mid-write,
+/// or may be gone (a run directory reclaimed after the bracket). A line is
+/// worth exactly as much as the next successful poll.
+async fn FileTail::poll(self : FileTail) -> Array[String] {
+  let file = @fs.open(self.path, mode=ReadOnly) catch { _ => return [] }
+  defer file.close()
+  let size = file.size() catch { _ => return [] }
+  if size < self.offset {
+    // Shorter than what was read: not the file that was read. Both files are
+    // append-only, so this is a replacement, and the head is the only honest
+    // place to resume from.
+    self.offset = 0
+    self.carry = b""
+  }
+  if size <= self.offset {
+    return []
+  }
+  let want = size - self.offset
+  let take = if want > workflow_tail_max_chunk {
+    workflow_tail_max_chunk
+  } else {
+    want
+  }
+  let chunk = file.read_exactly_at(take.to_int(), position=self.offset) catch {
+    _ => return []
+  }
+  self.offset += take
+  let pending = self.carry + chunk
+  let lines : Array[String] = []
+  let mut line_start = 0
+  for index in 0..<pending.length() {
+    if pending[index] != b'\n' {
+      continue
+    }
+    let text = @utf8.decode_lossy(pending[line_start:index].to_owned())
+      .trim(chars="\r\n \t")
+      .to_owned()
+    if !text.is_empty() {
+      lines.push(text)
+    }
+    line_start = index + 1
+  }
+  self.carry = pending[line_start:].to_owned()
+  lines
+}
+
+///|
+/// A child the sidecar reported launched.
+pub(all) struct ChildStarted {
+  /// The child's session id, `<parent>-sr-N` — the same string its own record
+  /// is named by and the journal's `attempt_id` will carry.
+  child : String
+  kind : String
+  label : String
+} derive(Eq, Debug)
+
+///|
+pub extend ChildStarted with Eq::{equal, not_equal}
+
+///|
+pub extend ChildStarted with Debug::{to_repr}
+
+///|
+/// A child the sidecar reported ended.
+pub(all) struct ChildFinished {
+  child : String
+  /// The contract's own vocabulary: `captured`, `no_report`, `max_steps`,
+  /// `context_yield`, `timed_out`, `skipped`, `failed`.
+  status : String
+  steps : Int
+  /// Prompt and completion tokens together; the sidecar does not split them.
+  tokens : Int
+} derive(Eq, Debug)
+
+///|
+pub extend ChildFinished with Eq::{equal, not_equal}
+
+///|
+pub extend ChildFinished with Debug::{to_repr}
+
+///|
+/// One sidecar line, or `None` for a line this build does not read.
+fn parse_sidecar(text : String) -> Result[ChildStarted, ChildFinished]? {
+  let json = @json.parse(text) catch { _ => return None }
+  match json {
+    {
+      "event": "agent_started",
+      "child": String(child),
+      "kind": String(kind),
+      "label": String(label),
+      ..
+    } => Some(Ok({ child, kind, label, }))
+    {
+      "event": "agent_finished",
+      "child": String(child),
+      "status": String(status),
+      "steps": Number(steps, ..),
+      "tokens": Number(tokens, ..),
+      ..
+    } =>
+      Some(
+        Err({ child, status, steps: steps.to_int(), tokens: tokens.to_int(), }),
+      )
+    _ => None
+  }
+}
+
+///|
+/// One journal line as the ledger row a reader wants, or `None` for a line
+/// this build does not read.
+///
+/// The journal is `moonbitlang/workflow`'s own format: `{"v":1,"e":ENTRY}`
+/// where ENTRY carries the call (kind, label), the outcome as a tagged array
+/// — `["Finished", {value, attempt}]` or `["DidNotFinish", {failure,
+/// attempt}]` — and the attribution the host renders: phase and the two
+/// timestamps. Only the fields named here are read; anything else on the
+/// line is ignored, so an added field upstream changes nothing.
+fn parse_journal(
+  text : String,
+  workflow~ : String,
+  session~ : String,
+) -> @protocol.WorkflowEntryPayload? {
+  let json = @json.parse(text) catch { _ => return None }
+  guard json is { "v": Number(1, ..), "e": Object(entry), .. } else {
+    return None
+  }
+  guard entry.get("call") is Some(Object(call)) &&
+    call.get("kind") is Some(String(kind)) &&
+    call.get("label") is Some(String(label)) else {
+    return None
+  }
+  guard entry.get("outcome") is Some(Array([String(tag), Object(body)])) else {
+    return None
+  }
+  let attempt = match body.get("attempt") {
+    Some(Object(attempt)) => Some(attempt)
+    _ => None
+  }
+  guard attempt is Some(attempt) &&
+    attempt.get("attempt_id") is Some(String(child)) else {
+    // A call that never launched (a refused or skipped one) has no child and
+    // nothing for a per-subagent view to point at; the sidecar did not report
+    // it either.
+    return None
+  }
+  let status = match tag {
+    "Finished" => "captured"
+    _ =>
+      match body.get("failure") {
+        Some(Array([String(name), ..])) => failure_status(name)
+        Some(String(name)) => failure_status(name)
+        _ => "failed"
+      }
+  }
+  let int_at = fn(fields : Map[String, Json], name : String) -> Int {
+    match fields.get(name) {
+      Some(Number(n, ..)) => n.to_int()
+      _ => 0
+    }
+  }
+  // Milliseconds since the epoch, as the plain JSON numbers the journal
+  // writes them as. `Double` carries them exactly and crosses the wire as a
+  // number; core's `Int64` codec would want a string.
+  let time_at = fn(fields : Map[String, Json], name : String) -> Double? {
+    match fields.get(name) {
+      Some(Number(n, ..)) => Some(n)
+      _ => None
+    }
+  }
+  Some({
+    workflow,
+    session,
+    child,
+    kind,
+    label,
+    phase: match entry.get("phase") {
+      Some(String(phase)) => Some(phase)
+      _ => None
+    },
+    status,
+    steps: int_at(attempt, "steps_used"),
+    prompt_tokens: int_at(attempt, "prompt_tokens"),
+    completion_tokens: int_at(attempt, "completion_tokens"),
+    cost_usd: match attempt.get("cost_usd") {
+      Some(Number(cost, ..)) => Some(cost)
+      _ => None
+    },
+    started_at: time_at(entry, "started_at"),
+    finished_at: time_at(entry, "finished_at"),
+  })
+}
+
+///|
+/// The contract's snake_case status for a library failure name — the same
+/// vocabulary the `subrun_finished` bracket uses, so a reader learns one.
+fn failure_status(name : String) -> String {
+  match name {
+    "TimedOut" => "timed_out"
+    "NoReport" => "no_report"
+    "MaxSteps" => "max_steps"
+    "ContextYield" => "context_yield"
+    "Skipped" => "skipped"
+    _ => "failed"
+  }
+}
+
+///|
+/// Tail one workflow's sidecar and journal until the task is cancelled,
+/// reporting each line through the matching callback.
+///
+/// The caller owns the lifetime: it starts this at the `workflow_started`
+/// bracket and cancels it at `workflow_finished`. Nothing here decides when a
+/// run is over — the brackets already say so, and a tail that guessed from
+/// the files could only guess late. The sidecar is polled before the journal
+/// on every pass, so a child's `started` line is always seen before the entry
+/// that resolves it.
+pub async fn follow_run(
+  workflow~ : String,
+  session~ : String,
+  journal~ : String,
+  events~ : String,
+  on_child_started~ : async (ChildStarted) -> Unit,
+  on_child_finished~ : async (ChildFinished) -> Unit,
+  on_entry~ : async (@protocol.WorkflowEntryPayload) -> Unit,
+) -> Unit {
+  let sidecar : FileTail = { path: events, offset: 0, carry: b"", }
+  let ledger : FileTail = { path: journal, offset: 0, carry: b"", }
+  for ;; {
+    @async.sleep(WorkflowTailIntervalMs)
+    for line in sidecar.poll() {
+      match parse_sidecar(line) {
+        Some(Ok(started)) => on_child_started(started)
+        Some(Err(finished)) => on_child_finished(finished)
+        None => ()
+      }
+    }
+    for line in ledger.poll() {
+      if parse_journal(line, workflow~, session~) is Some(entry) {
+        on_entry(entry)
+      }
+    }
+  }
+}
+
+///|
+/// A label fit for a lane. The sidecar's label is whatever the snippet's
+/// author passed to `wf.agent(label=...)` — model-written and unbounded —
+/// while a bracket's label is display-bounded by contract, so the same bound
+/// `run_subrun` applies (72 characters) is applied here before one is
+/// synthesized.
+pub fn display_label(label : String) -> String {
+  let flat = label.replace_all(old="\n", new=" ").trim(chars=" \t").to_owned()
+  if flat.length() <= 72 {
+    flat
+  } else {
+    flat.view(end_offset=71).to_owned() + "…"
+  }
+}

--- a/desktop/internal/workflow/tail_wbtest.mbt
+++ b/desktop/internal/workflow/tail_wbtest.mbt
@@ -137,3 +137,19 @@ async test "follow_run reports launches, finishes and ledger rows in file order"
     "started run7-sr-6", "finished run7-sr-6 captured", "entry run7-sr-6 captured",
   ])
 }
+
+///|
+test "only ordinals inside the announced block are the run's children" {
+  assert_true(in_block(5, first_child=5, child_count=32))
+  assert_true(in_block(36, first_child=5, child_count=32))
+  assert_false(in_block(37, first_child=5, child_count=32))
+  assert_false(in_block(4, first_child=5, child_count=32))
+  // An explore child of the same conversation, named by a sidecar line: not
+  // this run's, whatever the line says.
+  assert_false(in_block(1, first_child=5, child_count=32))
+}
+
+///|
+test "the drain grace covers at least one full poll after the bracket" {
+  assert_true(drain_grace_ms >= 2 * WorkflowTailIntervalMs)
+}

--- a/desktop/internal/workflow/tail_wbtest.mbt
+++ b/desktop/internal/workflow/tail_wbtest.mbt
@@ -1,0 +1,139 @@
+///|
+/// A journal line exactly as `moonbitlang/workflow` 0.7.0 writes one for a
+/// call that finished: the entry under `e`, the outcome as a tagged array,
+/// and the child's session id as `attempt_id`.
+let finished_line : String =
+  #|{"v":1,"e":{"call":{"kind":"explore","input":{"query":"who calls Y?"},"label":"scout:y","scope":""},"outcome":["Finished",{"value":{"answer":"..."},"attempt":{"attempt_id":"run7-sr-6","steps_used":7,"prompt_tokens":11,"completion_tokens":5}}],"phase":"survey","started_at":1788535817640,"finished_at":1788535817648}}
+
+///|
+/// A call that timed out: `DidNotFinish` with a unit failure and the attempt
+/// it still cost.
+let timed_out_line : String =
+  #|{"v":1,"e":{"call":{"kind":"worker","input":{},"label":"edit:a","scope":""},"outcome":["DidNotFinish",{"failure":["TimedOut"],"attempt":{"attempt_id":"run7-sr-7","steps_used":40,"prompt_tokens":900,"completion_tokens":100,"cost_usd":0.02}}],"phase":"apply"}}
+
+///|
+/// A call refused before launch: no attempt, no child, nothing to point at.
+let skipped_line : String =
+  #|{"v":1,"e":{"call":{"kind":"explore","input":{},"label":"scout:z","scope":""},"outcome":["DidNotFinish",{"failure":["Skipped"],"attempt":null}],"phase":"survey"}}
+
+///|
+test "journal lines become ledger rows keyed by the child's session" {
+  guard parse_journal(finished_line, workflow="wf-5", session="run7")
+    is Some(row) else {
+    fail("a finished entry must parse")
+  }
+  assert_eq(row.child, "run7-sr-6")
+  assert_eq(row.kind, "explore")
+  assert_eq(row.label, "scout:y")
+  assert_eq(row.phase, Some("survey"))
+  assert_eq(row.status, "captured")
+  assert_eq(row.steps, 7)
+  assert_eq(row.prompt_tokens, 11)
+  assert_eq(row.completion_tokens, 5)
+  assert_eq(row.cost_usd, None)
+  assert_eq(row.started_at, Some(1788535817640.0))
+  assert_eq(row.finished_at, Some(1788535817648.0))
+  // A failure keeps the contract's snake_case vocabulary, and its spend.
+  guard parse_journal(timed_out_line, workflow="wf-5", session="run7")
+    is Some(row) else {
+    fail("a timed-out entry must parse")
+  }
+  assert_eq(row.status, "timed_out")
+  assert_eq(row.steps, 40)
+  assert_eq(row.cost_usd, Some(0.02))
+  assert_eq(row.started_at, None)
+  // A refused call launched nothing: there is no child for a per-subagent
+  // view to point at, and the sidecar never reported one.
+  assert_true(
+    parse_journal(skipped_line, workflow="wf-5", session="run7") is None,
+  )
+  // Unknown lines are not rows.
+  assert_true(
+    parse_journal("{\"v\":2}", workflow="wf-5", session="run7") is None,
+  )
+  assert_true(
+    parse_journal("not json", workflow="wf-5", session="run7") is None,
+  )
+}
+
+///|
+test "sidecar lines are launches and finishes, carrying the child's session" {
+  let started_line : String =
+    #|{"event":"agent_started","child":"run7-sr-5","kind":"explore","label":"scout:x"}
+  guard parse_sidecar(started_line) is Some(Ok(started)) else {
+    fail("a started line must parse")
+  }
+  assert_eq(started, { child: "run7-sr-5", kind: "explore", label: "scout:x", })
+  let finished_line : String =
+    #|{"event":"agent_finished","child":"run7-sr-5","status":"captured","steps":12,"tokens":3400}
+  guard parse_sidecar(finished_line) is Some(Err(finished)) else {
+    fail("a finished line must parse")
+  }
+  assert_eq(finished, {
+    child: "run7-sr-5",
+    status: "captured",
+    steps: 12,
+    tokens: 3400,
+  })
+  assert_true(parse_sidecar("{\"event\":\"phase\"}") is None)
+}
+
+///|
+/// The tail reads only what was appended, survives a poll landing mid-line,
+/// and starts over when the file it was reading is replaced by a shorter one.
+async test "a file tail reads appended lines exactly once" {
+  let dir = @fs.tmpdir(prefix="workflow-tail-")
+  defer (@fs.rmdir(dir, recursive=true) catch { _ => () })
+  let path = "\{dir}/events.jsonl"
+  let tail : FileTail = { path, offset: 0, carry: b"", }
+  // Nothing yet: not an error, just nothing.
+  assert_eq(tail.poll(), [])
+  @fs.write_file(path, "one\ntwo\n", create_mode=CreateOrTruncate)
+  assert_eq(tail.poll(), ["one", "two"])
+  assert_eq(tail.poll(), [])
+  // A partial line waits for its newline.
+  @fs.write_file(path, "thr", append=true, create_mode=OpenOrCreate)
+  assert_eq(tail.poll(), [])
+  @fs.write_file(path, "ee\n", append=true, create_mode=OpenOrCreate)
+  assert_eq(tail.poll(), ["three"])
+  // Replaced by something shorter: re-read from the head.
+  @fs.write_file(path, "new\n", create_mode=CreateOrTruncate)
+  assert_eq(tail.poll(), ["new"])
+}
+
+///|
+async test "follow_run reports launches, finishes and ledger rows in file order" {
+  let dir = @fs.tmpdir(prefix="workflow-follow-")
+  defer (@fs.rmdir(dir, recursive=true) catch { _ => () })
+  let events = "\{dir}/events.jsonl"
+  let journal = "\{dir}/journal.jsonl"
+  let seen : Array[String] = []
+  @async.with_task_group() <| group => {
+    let tail = group.spawn(no_wait=true, allow_failure=true, () => {
+      follow_run(
+        workflow="wf-5",
+        session="run7",
+        journal~,
+        events~,
+        on_child_started=started => seen.push("started \{started.child}"),
+        on_child_finished=finished => {
+          seen.push("finished \{finished.child} \{finished.status}")
+        },
+        on_entry=entry => seen.push("entry \{entry.child} \{entry.status}"),
+      )
+    })
+    let started : String =
+      #|{"event":"agent_started","child":"run7-sr-6","kind":"explore","label":"scout:y"}
+    @fs.write_file(events, started + "\n", create_mode=CreateOrTruncate)
+    @async.sleep(2200)
+    let ended : String =
+      #|{"event":"agent_finished","child":"run7-sr-6","status":"captured","steps":7,"tokens":16}
+    @fs.write_file(events, ended + "\n", append=true, create_mode=OpenOrCreate)
+    @fs.write_file(journal, finished_line + "\n", create_mode=CreateOrTruncate)
+    @async.sleep(2200)
+    tail.cancel()
+  }
+  assert_eq(seen, [
+    "started run7-sr-6", "finished run7-sr-6 captured", "entry run7-sr-6 captured",
+  ])
+}

--- a/desktop/styles/file_panel.css
+++ b/desktop/styles/file_panel.css
@@ -625,7 +625,7 @@ html.is-resizing * {
   border-radius: var(--radius-xs);
 }
 .search-semantic-hit:hover {
-  background: var(--color-bg-hover);
+  background: var(--color-bg-hover, var(--color-bg-surface));
 }
 .search-semantic-meta {
   display: flex;
@@ -1769,7 +1769,7 @@ button.git-history-file.selected {
 
 .history-commit-crumb {
   color: var(--color-text-secondary);
-  font-family: var(--font-mono);
+  font-family: var(--font-mono, ui-monospace, monospace);
 }
 
 .file-panel-empty {
@@ -2642,4 +2642,132 @@ button.git-history-file.selected {
 .semantic-review-host .semantic-diff-editor-host .scrollbar.vertical,
 .semantic-review-host .semantic-diff-editor-host .scrollbar.horizontal {
   display: none !important;
+}
+
+/* The workflows tab. Like the browser and launcher modes, the file chrome is
+   hidden while it is active and its own body is shown; the body is always
+   mounted, so the panel's child order stays structural. */
+.editor .workflow-panel {
+  display: none;
+}
+.editor.mode-workflows .viewer-breadcrumb,
+.editor.mode-workflows .editor-body,
+.editor.mode-workflows .browser-chrome {
+  display: none;
+}
+.editor.mode-workflows .workflow-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-height: 0;
+  overflow: auto;
+  padding: 12px 14px;
+}
+.workflow-empty {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  line-height: 1.5;
+}
+.workflow-run {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.workflow-run-head {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 0 2px 4px;
+  border-bottom: 1px solid var(--color-border);
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+}
+.workflow-run-id {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  color: var(--color-text);
+}
+.workflow-run-state {
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: var(--font-size-xs);
+}
+.workflow-run-state-running {
+  color: var(--color-accent);
+}
+.workflow-run-tokens,
+.workflow-run-cost,
+.workflow-run-count {
+  color: var(--color-text-muted);
+}
+.workflow-rows {
+  display: flex;
+  flex-direction: column;
+}
+/* A row is a button: clicking it opens the child's transcript. It shares the
+   lane dock's baseline grid so a child reads the same way in both places. */
+.workflow-row {
+  display: grid;
+  grid-template-columns: 6px auto 1fr auto;
+  align-items: baseline;
+  gap: 8px;
+  width: 100%;
+  min-width: 0;
+  padding: 5px 2px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--color-text-muted);
+  font: inherit;
+  font-size: var(--font-size-sm);
+  text-align: left;
+  cursor: pointer;
+}
+.workflow-row:hover,
+.workflow-row:focus-visible {
+  background: var(--color-bg-hover, var(--color-bg-surface));
+  outline: none;
+}
+.workflow-row-mark {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--color-text-secondary);
+}
+.workflow-row-running .workflow-row-mark {
+  animation: lane-pulse 1.6s ease-in-out infinite;
+}
+.workflow-row-done .workflow-row-mark {
+  background: var(--color-success, var(--color-text-secondary));
+  animation: none;
+}
+.workflow-row-failed .workflow-row-mark {
+  background: var(--color-danger, var(--color-text-secondary));
+  animation: none;
+}
+.workflow-row-kind {
+  color: var(--color-text-secondary);
+  font-weight: 600;
+}
+.workflow-row-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--color-text);
+}
+.workflow-row-status {
+  color: var(--color-text-muted);
+}
+.workflow-row-detail {
+  grid-column: 2 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+.workflow-row-detail:empty {
+  display: none;
 }


### PR DESCRIPTION
Rebased onto `main` now that #1288 and #1289 have landed; the base is `main` and the diff is this change alone (30 files, +1.9k, of which ~half is tests).

## How it works

The host already knew where to look — `workflow_started` names the run's journal and sidecar — but did nothing with them. Now, beside the existing per-child probe map in `ServeEngine::consume`, a **workflow tail** (`desktop/internal/workflow`) follows both files by byte offset, exactly as `subrun/probe.mbt` does for a child's record (simpler: both files are append-only by contract, so no torn-tail repair, no watermark).

- Each sidecar `agent_started` line becomes **the same `subrun_started` bracket an `explore` child gets**, emitted into the same stream with the same run routing, and the same per-child probe is started on that child's transcript. Each `agent_finished` becomes `subrun_finished` and cancels the probe. Result: a snippet's children appear in the **existing lane dock**, live, with per-child progress — no new frontend path.
- Each journal line becomes one **`workflow.entry`** push — a new notification carried through transport, hub, extension and bridge exactly like `subrun.progress` — with phase, timings, split tokens, cost, and the child's session id.

## What you see

A **Workflows** dock tab in the right panel (the "subagent viewer" the dock's own design note anticipated). Every run the conversation announced, one row per child in launch order: kind, label, running/done/failed, steps, tokens, cost, duration — and clicking a row opens that child's transcript.

Rows are built from three sources that tick at different moments — a bracket opens a row, a bracket closes it, the journal's entry refines it — keyed by the child's session id, so either half can arrive without the other (a snippet that died leaves started rows without entries; a client that connected late sees entries for launches it never saw). A run is **not dropped on close**: a finished run is what a reader looks back over. The lane dock keeps its existing rule (drop on close, so a captured sub-run's tool brief stays the single completion row) — it's the glance surface; the tab is the inspection surface.

Not durable, like the lanes: the journal and the children's transcripts in the store are the record.

## Verification

- `desktop/internal/workflow`: journal lines as 0.7.0 writes them (finished / timed out / skipped-without-attempt), sidecar lines, the file tail (append, mid-line, replacement), and `follow_run` end to end over real files.
- Transport: `workflow.entry` wire round trip, pinning the absent-means-`None` rule for optional fields (`null` is rejected by the derived decoder; `to_json` omits `None`).
- Frontend `workflow` state: the three update paths, ordering, and the missed-bracket cases.
- Reducer: a full bracket sequence (open → child in block → child outside block → close → workflow close) through `apply_engine_event`; model-level routing of an entry to the parent conversation, and dropping one for a conversation not held.
- Gates: `moon check --target {js,native,wasm} --deny-warn` clean, `--fmt` clean, bare `moon info` yields exactly the three intended interface files. Host packages 212/212, frontend 462/462.

The engine-level wiring in `consume` mirrors the probe wiring line for line and, like it, has no engine-level test — a scripted-engine test for both would be a worthwhile follow-up.

## Review pass (second commit)

Three things a cold read of the path turned up, each with a test:

- **Sidecar child ids are validated against the announced block.** The sidecar is written by a process the snippet drives, so a line's `child` must be in this session and inside `[first_child, first_child + child_count)` (`in_block`) before it becomes a lane and a probe; anything else is dropped, never synthesized into a `subrun_started`.
- **The tail drains before it is cancelled.** The library writes a run's last journal lines *after* the snippet's final child returns, so cancelling on `workflow_finished` could miss the last entry on a fast close. The follower now gets `drain_grace_ms` (two poll intervals) and is cancelled by a task.
- **A closed run's rows with no result render as "unresolved"** (`row_status`) rather than looking live forever — what a snippet that died mid-run leaves behind.

`Run::owns` (attributing a bracket that carries no workflow id by ordinal range) is documented as resting on two invariants — blocks do not overlap, a session's ordinals are monotone — with a `workflow` field on the synthesized bracket noted as the follow-up that would make it exact.

## Re-review after the rebase (third commit)

Cold read of the diff against `main`; `moon check --deny-warn` on native, js and wasm (workspace-wide where the target allows), fmt, and a bare `moon info` with no drift; host packages 184/184, frontend 462/462.

- **The tail no longer needs a store root.** It was gated on `engine.session_root`, which only the per-child *probe* needs (to find the child's transcript). The bracket names both files by absolute path, so the tail now runs regardless and the probe alone stays gated.
- A comment on a replayed `child_opened` claimed it makes a row read as running again; it does not and must not (an entry that arrived first means the child already resolved). Comment corrected; behaviour was already right and is pinned by the state tests.
- Drive-by: two existing rules in `file_panel.css` referenced `--color-bg-hover` and `--font-mono`, which are defined nowhere; they now carry fallbacks. Unrelated to workflows, but the new rules needed the same fallbacks and it was one line each.

## End-to-end evidence

Run with the real engine and a real model (`openseek serve --session … --system-prompt-addendum-file` carrying the prompt section from #1293), in a clean clone of this branch, given three independent questions about this repository:

- The model chose the workflow path unprompted, its snippet built on the first try, and it ran three workflows in one session as it adjusted scout ceilings — blocks `1..32`, `33..64`, `65..96`, allocated in order, each announced by `workflow_started` with the right journal/sidecar paths and closed by `workflow_finished` from the background job's terminal.
- Seven children in total ran under their own transcripts (`e2e2-sr-1…3`, `33…35`, `65`); the second workflow's three scouts all reached `captured` and the parent's final message synthesized their answers with file:line citations.
- The sidecar and journal the library wrote were fed through this PR's parsers (`parse_sidecar`, `parse_journal`, `FileTail`) unchanged: every line parsed, opens matched closes matched rows for all three runs, and the rows carry phase, status (`max_steps` / `captured`), steps, tokens and duration — exactly what the Workflows tab renders.

What this does not cover: the GUI itself (the wiring in `consume` and the rendering), which is the manual plan below. One thing it exposed that is not this PR's: in the maintainer's own checkout (15 GB `.worktrees/`), child engines' read-only `sandbox-exec` profile is 768 KB against macOS's 64 KB cap, so every child's `mbtx` call fails and scouts time out; a clean clone measures 56 KB. That breaks `explore` the same way and needs its own fix in `agent_tool/internal/sandbox`.

## How to test it

Automated: `moon test desktop/internal/workflow desktop/internal/protocol desktop/internal/engine` (native) and `moon test desktop/frontend --target js`. The engine-level wiring in `consume` has no test (see above), so the real proof is the desktop:

1. `just desktop-dev` on this branch and open a project. A desktop engine always runs `serve --session=… --session-root=<project>/.openseek`, so the session can host.
2. Ask the agent to run this snippet through `mbtx` with `subrun: true` (or let it write its own — the tool text tells it how):

   ```
   import { "moonbitlang/async", "moonbitlang/workflow", "moonbitlang/workflow/hosted" }

   async fn main {
     guard @hosted.context() is Some(ctx) else { println("NO HANDOFF"); return }
     ctx.run(max_concurrent=3, wf => {
       wf.phase("survey")
       let found = @workflow.parallel([
         () => @workflow.attempt(() => wf.agent(prompt="which packages import agent_tool/mbtx?", kind="explore", label="scout:mbtx")),
         () => @workflow.attempt(() => wf.agent(prompt="where is WorkflowStarted emitted?", kind="explore", label="scout:protocol")),
         () => @workflow.attempt(() => wf.agent(prompt="how does the desktop tail a run's journal?", kind="explore", label="scout:tail", max_steps=7)),
       ])
       for answer in @workflow.collect_ok(found) { println(answer.stringify()) }
       println("calls=\{wf.calls_made()} tokens=\{wf.tokens_spent()}")
     })
   }
   ```
3. **While it runs:** three lanes appear in the dock above the composer with live activity, exactly as `explore` children do. Right panel → launcher → **Workflows**: a run `wf-N` marked *running*, "3 of 32 subagents", one pulsing row per child.
4. **As children finish:** rows turn *done* with steps, tokens, cost and duration (from the journal); lanes drop as they do for any captured sub-run; the run reads *finished* once the snippet returns. Click a row → that child's transcript opens.
5. **On disk:** `<project>/.openseek/<session>-wf-<N>/{events.jsonl,journal.jsonl}` and the children under `<project>/.openseek/sessions/<session>-sr-<N>/`; the sidebar folds them under the parent.
6. **Negatives:** the same snippet without `subrun: true` prints `NO HANDOFF` and nothing appears in Workflows. A row whose child died shows *unresolved* once the run closes rather than pulsing forever.
7. **Late join:** reload the page mid-run — the rows rebuild from the entries that arrive after the reload (brackets missed, journal not).

## Not in this PR

Per-kind child deadlines in `hosted` (one `deadline_ms` per handoff; `worker` children need longer than `explore`'s 10 min), and child engines hosting nested workflows. Both are library/engine follow-ups, not desktop ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXBYcYo74F1DGSPZsYYAdc