### PR TITLE
prompt: show how to fan out scouts through an mbtx workflow and conclude

### DIFF
--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -469,6 +469,62 @@ stderr warning while exit stays 0 — treat skipped blocks as a blind spot.
   one `moon ide doc` query or one focused file read can settle it. The scouts
   cannot edit, and their shared per-turn budget is bounded, so spot-check the
   returned citations and do not delegate overlapping questions.
+- Concurrent exploration through `mbtx`: when the `mbtx` tool offers a
+  `subrun` argument (it does only in a durable session), ONE snippet can fan
+  out several read-only scouts as one workflow and conclude over their answers
+  in code. The scouts get their own transcripts and appear in the desktop; you
+  see one tool result. Prefer this over separate `explore` calls when the
+  fan-out is wider than three, when a second wave of questions depends on the
+  first wave's answers, or when the conclusion is mechanical (compare, count,
+  cross-check). Set `subrun: true` on that one call and on no other: a snippet
+  without the flag gets no handoff, and `@hosted.context()` is `None`.
+
+    ```mbtx
+    import {
+      "moonbitlang/async",
+      "moonbitlang/workflow",
+      "moonbitlang/workflow/hosted",
+    }
+
+    async fn main {
+      guard @hosted.context() is Some(ctx) else {
+        println("no subagent handoff: call mbtx with subrun=true")
+        return
+      }
+      ctx.run(max_concurrent=3, wf => {
+        wf.phase("survey")
+        let found = @workflow.parallel([
+          () => @workflow.attempt(() => wf.agent(
+            prompt="Where is X constructed, and by whom? Cite file:line.",
+            kind="explore", label="scout:x")),
+          () => @workflow.attempt(() => wf.agent(
+            prompt="Who calls Y, and what do the callers pass? Cite file:line.",
+            kind="explore", label="scout:y")),
+          () => @workflow.attempt(() => wf.agent(
+            prompt="How does Z reach the network? Cite file:line.",
+            kind="explore", label="scout:z")),
+        ])
+        wf.phase("conclude")
+        // Each answer is that scout's report as JSON. Conclude in code when
+        // the conclusion is mechanical; otherwise print the reports and
+        // conclude yourself from the tool result.
+        for answer in @workflow.collect_ok(found, min_ok=2) {
+          println(answer.stringify())
+        }
+        println("scouts=\{wf.calls_made()} tokens=\{wf.tokens_spent()}")
+      })
+    }
+    ```
+
+  Each `wf.agent` call is one scout with ONE self-contained question
+  (`kind="explore"`, hints in the prompt). `@workflow.parallel` runs the calls
+  concurrently, `@workflow.attempt` turns a failed scout into an `Err` instead
+  of aborting the run, and `collect_ok` keeps the answers that arrived (it
+  raises if fewer than `min_ok` did). Leave `max_steps` unset: a scout
+  reads files and runs probes, and a real question takes it 20-60 steps —
+  a ceiling of 10 ends every scout in `max_steps` with no answer. A snippet
+  may start at most 32 scouts, and the same rule as `explore` applies: no
+  overlapping questions, and spot-check the citations.
 - `subtask` tool: parallelize LARGE partitionable work — three or more
   independent slices that each need real edit+verify cycles (fixing warnings
   by category, per-package sweeps, migration chunks). Each launch names a

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -474,6 +474,62 @@ fn default_prompt() -> String {
     #|  one `moon ide doc` query or one focused file read can settle it. The scouts
     #|  cannot edit, and their shared per-turn budget is bounded, so spot-check the
     #|  returned citations and do not delegate overlapping questions.
+    #|- Concurrent exploration through `mbtx`: when the `mbtx` tool offers a
+    #|  `subrun` argument (it does only in a durable session), ONE snippet can fan
+    #|  out several read-only scouts as one workflow and conclude over their answers
+    #|  in code. The scouts get their own transcripts and appear in the desktop; you
+    #|  see one tool result. Prefer this over separate `explore` calls when the
+    #|  fan-out is wider than three, when a second wave of questions depends on the
+    #|  first wave's answers, or when the conclusion is mechanical (compare, count,
+    #|  cross-check). Set `subrun: true` on that one call and on no other: a snippet
+    #|  without the flag gets no handoff, and `@hosted.context()` is `None`.
+    #|
+    #|    ```mbtx
+    #|    import {
+    #|      "moonbitlang/async",
+    #|      "moonbitlang/workflow",
+    #|      "moonbitlang/workflow/hosted",
+    #|    }
+    #|
+    #|    async fn main {
+    #|      guard @hosted.context() is Some(ctx) else {
+    #|        println("no subagent handoff: call mbtx with subrun=true")
+    #|        return
+    #|      }
+    #|      ctx.run(max_concurrent=3, wf => {
+    #|        wf.phase("survey")
+    #|        let found = @workflow.parallel([
+    #|          () => @workflow.attempt(() => wf.agent(
+    #|            prompt="Where is X constructed, and by whom? Cite file:line.",
+    #|            kind="explore", label="scout:x")),
+    #|          () => @workflow.attempt(() => wf.agent(
+    #|            prompt="Who calls Y, and what do the callers pass? Cite file:line.",
+    #|            kind="explore", label="scout:y")),
+    #|          () => @workflow.attempt(() => wf.agent(
+    #|            prompt="How does Z reach the network? Cite file:line.",
+    #|            kind="explore", label="scout:z")),
+    #|        ])
+    #|        wf.phase("conclude")
+    #|        // Each answer is that scout's report as JSON. Conclude in code when
+    #|        // the conclusion is mechanical; otherwise print the reports and
+    #|        // conclude yourself from the tool result.
+    #|        for answer in @workflow.collect_ok(found, min_ok=2) {
+    #|          println(answer.stringify())
+    #|        }
+    #|        println("scouts=\{wf.calls_made()} tokens=\{wf.tokens_spent()}")
+    #|      })
+    #|    }
+    #|    ```
+    #|
+    #|  Each `wf.agent` call is one scout with ONE self-contained question
+    #|  (`kind="explore"`, hints in the prompt). `@workflow.parallel` runs the calls
+    #|  concurrently, `@workflow.attempt` turns a failed scout into an `Err` instead
+    #|  of aborting the run, and `collect_ok` keeps the answers that arrived (it
+    #|  raises if fewer than `min_ok` did). Leave `max_steps` unset: a scout
+    #|  reads files and runs probes, and a real question takes it 20-60 steps —
+    #|  a ceiling of 10 ends every scout in `max_steps` with no answer. A snippet
+    #|  may start at most 32 scouts, and the same rule as `explore` applies: no
+    #|  overlapping questions, and spot-check the citations.
     #|- `subtask` tool: parallelize LARGE partitionable work — three or more
     #|  independent slices that each need real edit+verify cycles (fixing warnings
     #|  by category, per-package sweeps, migration chunks). Each launch names a


### PR DESCRIPTION
Adds a worked example to the system prompt, next to the `explore` guidance: one `mbtx` snippet that delegates three read-only scouts as a `moonbitlang/workflow` run under `subrun: true` and concludes over their answers. It says when to prefer this over separate `explore` calls (fan-out wider than three, a second wave that depends on the first, a mechanical conclusion), what the flag does and does not do, and — from the end-to-end run below — to leave `max_steps` unset on scouts.

Depends on the delegation path from #1288/#1289 (both on `main`); the desktop side (#1291) is what makes the scouts visible.

## Verified end to end, twice, with the real engine and a real model

`openseek serve --session … --system-prompt-addendum-file <this section>` given three independent questions about this repository and told to delegate.

- The model chose the workflow path **unprompted** in both runs, wrote a snippet from the example that built on the first try, and set `subrun: true` on that one call.
- Three children launched concurrently under their own transcripts (`<session>-sr-1/2/3`); the run announced itself (`workflow_started`, correct journal/sidecar paths, block `1..32`), moved to the background after 5 s, and `workflow_finished` came from the job's terminal — the path the lifecycle test pins. A second run in the same session correctly took the next block (`first_child: 33`).
- The sidecar and journal the library wrote parse through the desktop tail's own functions into exactly the lanes and rows the Workflows tab would show (3 opens, 3 closes, 3 entries; phase, status, steps, tokens, duration).

Two findings, one fixed here and one filed separately:

1. The example originally carried `max_steps=7` on one scout. The model generalized it to `max_steps=10` on all three, and every scout ended in `max_steps` with no answer (a real question takes a scout 20-60 steps). The example now leaves the ceiling unset and says why.
2. In the maintainer's checkout — not a clean clone — every child's own `mbtx` call failed: the read-only `sandbox-exec` profile that child engines run under enumerates one literal rule per source directory and comes to **768 KB / 6,381 rules** there (the 15 GB `.worktrees/` tree), against macOS's 64 KB cap; a clean clone measures 56 KB / 316 rules, barely under. The scan also runs inside `mbtx`'s 10 s build budget. That breaks the existing `explore` tool the same way and is independent of this change; it deserves its own fix in `agent_tool/internal/sandbox`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXBYcYo74F1DGSPZsYYAdc
