### PR TITLE
desktop: open a sub-run child through its parent before the store lists it

### DIFF
--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -3127,7 +3127,20 @@ fn Model::session_project(
       return Some(item.workspace)
     }
   }
-  self.find_conversation(channel, session_id).map(conv => conv.project())
+  match self.find_conversation(channel, session_id) {
+    Some(conv) => Some(conv.project())
+    // A sub-run's child (`<parent>-sr-N`) lives in its parent's store by
+    // construction, and it is usually NOT listed while it runs: the inventory
+    // is refreshed at connect, archive and unarchive, not when a child record
+    // appears mid-run. A click on a workflow row must still open it, so it is
+    // placed where its parent is; the host reads the record by id, and the
+    // sub-run probe keeps it moving on screen.
+    None =>
+      match @transcript.subrun_parent(session_id) {
+        Some(parent) => self.session_project(channel, parent)
+        None => None
+      }
+  }
 }
 
 ///|

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -9820,6 +9820,44 @@ test "open session is a no-op for the current session" {
 }
 
 ///|
+test "a sub-run child opens through its parent before the store lists it" {
+  // The Workflows tab offers a click into a child the sidebar has not listed
+  // yet (the inventory refreshes at connect, archive and unarchive, not when
+  // a child appears mid-run). The child's session lives in its parent's
+  // store, so the parent's placement is its own.
+  let dispatch = test_dispatch()
+  let model = test_model()
+  assert_true(
+    model.session_project(@interop.ChannelId::Local, "desktop-test-sr-2")
+    is Some(_),
+  )
+  let (_, next) = update(dispatch, OpenSessionHere("desktop-test-sr-2"), model)
+  // The click selects the child and starts its first load; the view switches
+  // when the snapshot lands, as for any session opened from the sidebar.
+  guard next.selected_conversation is Some(selection) else {
+    fail("expected the child to be selected")
+  }
+  inspect(selection.session, content="desktop-test-sr-2")
+  assert_eq(selection.workspace, @interop.ChannelId::Local.test_project())
+  assert_true(
+    next.loading_conversation
+    is Some({ channel: Local, session: "desktop-test-sr-2", }),
+  )
+  guard next.find_conversation(@interop.ChannelId::Local, "desktop-test-sr-2")
+    is Some(child) else {
+    fail("expected the child conversation to exist, loading")
+  }
+  assert_true(child.sync is Reloading(..))
+  inspect(
+    next.transcript_request_generation,
+    content="\{model.transcript_request_generation + 1}",
+  )
+  // A child of a parent this page knows nothing about is still unplaceable.
+  let (_, same) = update(dispatch, OpenSessionHere("elsewhere-sr-2"), model)
+  inspect(same.active_session, content="desktop-test")
+}
+
+///|
 test "open session keeps live state on screen while re-reading the store" {
   let dispatch = test_dispatch()
   let background = {


### PR DESCRIPTION
Found in the first GUI run of the Workflows tab (#1291): a row click did nothing.

The row sends `OpenSessionHere(<parent>-sr-N)`, and `OpenSession` drops any id the session inventory cannot place. That inventory is refreshed at connect, archive and unarchive — never when a child record appears mid-run — so a running scout was unplaceable and the click was silently dropped. `explore` children have the same gap; nothing offered a click into an unlisted child before this tab did.

**Fix:** a child lives in its parent's store by construction, so `Model::session_project` falls back to the parent's placement for a `-sr-N` id it cannot list. The open then proceeds like any unlisted-but-placeable session: the child is selected, an empty conversation begins its first load, the host reads the record by id, and the existing sub-run probe keeps the transcript moving while the scout runs. A child of a parent this page knows nothing about stays unplaceable.

One test: the click selects the child and starts its load without the inventory listing it; an unknown parent's child is still dropped. Frontend 462/462 on js, deny-warn clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXBYcYo74F1DGSPZsYYAdc
