### PR TITLE
job_output: page retained output with `offset`

### DIFF
--- a/agent_tool/job_output/README.mbt.md
+++ b/agent_tool/job_output/README.mbt.md
@@ -27,6 +27,12 @@ Output first, one `<system>` footer line last (the `read` tool convention):
   `stopped killed_at_output_cap=true` (or `killed_at_time_cap=true` for the
   wall-clock reaper) so the model does not read it as a
   requested stop.
+- Output beyond the window is **retained** (the spill file for a large job),
+  and `offset` reads the window that starts at that character offset from
+  the start instead of the tail; the footer then carries `window_offset=N`.
+  A reader pages through all of `total_chars` with offsets 0, 12000, 24000,
+  … — the case is a workflow snippet that prints several scouts' reports,
+  which do not fit one window.
 - Status is `running`, `exit=<code>`, or `stopped`; non-zero exits and stops
   are tool errors, matching what the same snippet would report in the
   foreground.

--- a/agent_tool/job_output/job_output.mbt
+++ b/agent_tool/job_output/job_output.mbt
@@ -12,9 +12,11 @@ pub fn definition(
       #|a command moves to the background after its foreground grace period).
       #|Returns the most recent window of captured output (with truncation metadata naming
       #|the total size when output exceeds the window) and whether the job is still
-      #|running. If you need the job's result before you can continue and have no other
-      #|work to do, pass wait_ms to block until it finishes instead of checking
-      #|repeatedly.
+      #|running. Output beyond the window is retained: pass offset (a character offset
+      #|from the START) to read an earlier window instead — offsets 0, 12000, 24000, …
+      #|page through all of total_chars. If you need the job's result before you can
+      #|continue and have no other work to do, pass wait_ms to block until it finishes
+      #|instead of checking repeatedly.
     ),
     schema=JsonSchema({
       "type": "object",
@@ -26,6 +28,15 @@ pub fn definition(
             #|Wait up to this many milliseconds (capped at 120000) for the job to finish
             #|before reading. Use when you need the result now and have nothing else to
             #|do; never poll in a loop.
+          ),
+        },
+        "offset": {
+          "type": "number",
+          "description": (
+            #|Read the window that starts at this character offset from the START of the
+            #|captured output, instead of the most recent window. Use it to page through
+            #|output larger than one window: the footer's total_chars says how much there
+            #|is, so offsets 0, 12000, 24000, … cover all of it.
           ),
         },
       },
@@ -67,8 +78,20 @@ async fn execute(
   // Recent output, bounded to a window so a poll cannot flood the conversation
   // with a large job's full log. For output over the window, show the *tail*
   // (recent progress).
+  let page = match window_offset(arguments) {
+    Ok(page) => page
+    Err(message) => return @agent_tool.respond(message, is_error=true)
+  }
   let window = 12000
-  let raw_output = bg_runtime.read_output_tail(job_id, window).unwrap_or("")
+  // A page reads the retained log from the start — the spill file for a large
+  // job — so a result bigger than one window (a workflow's several reports)
+  // is reachable in full; the default stays the tail, which is what a poll on
+  // a running job wants.
+  let raw_output = match page {
+    Some(offset) =>
+      page_of(bg_runtime.read_output(job_id).unwrap_or(""), offset~, window~)
+    None => bg_runtime.read_output_tail(job_id, window).unwrap_or("")
+  }
   // Re-snapshot *after* the awaited read: the job may have appended more output
   // or exited while the read yielded, so size/status/binary/truncation in the
   // footer must reflect that post-read state, not a stale pre-read one — else a
@@ -135,7 +158,11 @@ async fn execute(
   } else {
     ""
   }
-  let footer = "<system>job=\{job_id} \{status_label}\{truncation}\{binary}</system>"
+  let paging = match page {
+    Some(offset) => " window_offset=\{offset}"
+    None => ""
+  }
+  let footer = "<system>job=\{job_id} \{status_label}\{truncation}\{paging}\{binary}</system>"
   // Assemble: output, then the source-write denial guidance (like the foreground
   // path), then the `<system>` footer LAST so it stays the trailing metadata line.
   let content = StringBuilder()
@@ -194,4 +221,43 @@ fn wait_ms(arguments : Json) -> Result[Int?, String] {
     { "wait_ms": _, .. } => Err("error: job_output wait_ms must be a number")
     _ => Ok(None)
   }
+}
+
+///|
+/// Decode the optional `offset` argument: a character offset from the start of
+/// the captured output, zero or more. Absent/null means the recent tail.
+fn window_offset(arguments : Json) -> Result[Int?, String] {
+  match arguments {
+    { "offset": Number(value, ..), .. } => {
+      let offset = value.to_int()
+      if offset < 0 {
+        Err("error: job_output offset must be zero or a positive number")
+      } else {
+        Ok(Some(offset))
+      }
+    }
+    { "offset": Null, .. } => Ok(None)
+    { "offset": _, .. } => Err("error: job_output offset must be a number")
+    _ => Ok(None)
+  }
+}
+
+///|
+/// The `window` characters of `text` starting at character `offset` — empty
+/// past the end. Counted in characters, the unit the footer's `total_chars`
+/// and `shown_chars` use, so the offsets a reader computes from them land
+/// where it expects.
+fn page_of(text : String, offset~ : Int, window~ : Int) -> String {
+  let out = StringBuilder()
+  let mut index = 0
+  for ch in text {
+    if index >= offset + window {
+      break
+    }
+    if index >= offset {
+      out.write_char(ch)
+    }
+    index += 1
+  }
+  out.to_string()
 }

--- a/agent_tool/job_output/job_output_test.mbt
+++ b/agent_tool/job_output/job_output_test.mbt
@@ -280,3 +280,41 @@ async test "a terminal job finds a policy refusal before the displayed tail" {
     }
   })
 }
+
+///|
+async test "offset pages through retained output from the start" {
+  @async.with_task_group(group => {
+    let dir = @fs.tmpdir(prefix="openseek-test-")
+    let bg = @bgjobs.BgJobRuntime(AgentTaskScope(group), spill_dir=dir)
+    let id = bg.start(
+      program="moonx",
+      args=[CLI_SEQ, "1", "20000"],
+      command="seq",
+      max_output_chars=100,
+    )
+    poll_bg_terminal(bg, id)
+    // The first page is the HEAD of the output, not the tail the default
+    // shows, and the footer says which window this is.
+    let head = run_job_output(bg, { "job_id": id, "offset": 0 })
+    assert_false(head.is_error)
+    assert_true(head.content.has_prefix("1\n2\n3\n"))
+    assert_true(head.content.contains("window_offset=0"))
+    assert_true(head.content.contains("truncated=true"))
+    assert_false(head.content.contains("\n20000\n"))
+    // The next page starts exactly where the first ended.
+    let next = run_job_output(bg, { "job_id": id, "offset": 12000 })
+    let full = bg.read_output(id).unwrap_or("")
+    let expected = full.view(start_offset=12000, end_offset=12040).to_owned()
+    assert_true(next.content.has_prefix(expected))
+    assert_true(next.content.contains("window_offset=12000"))
+    // Past the end: nothing but the footer. Negative: refused.
+    let past = run_job_output(bg, { "job_id": id, "offset": 10_000_000 })
+    assert_true(past.content.has_prefix("<system>"))
+    let bad = run_job_output(bg, { "job_id": id, "offset": -1 })
+    assert_true(bad.is_error)
+    // Without offset the tail is still what a poll gets.
+    let tail = run_job_output(bg, { "job_id": id })
+    assert_true(tail.content.contains("\n20000\n"))
+    assert_false(tail.content.contains("window_offset"))
+  })
+}


### PR DESCRIPTION
Found in the first GUI run of a workflow snippet (#1291 + #1293): the three scouts' reports came to 33,753 characters, `job_output` shows only the most recent 12,000, and the parent — correctly reading `truncated=true total_chars=33753 shown_chars=12000` — had no way to reach the first two reports and re-launched two scouts to get them again.

The output *is* retained in full (the spill file for a large job); only the read side was tail-only.

**Change:** `job_output` gains `offset`: read the window that starts at that character offset from the start instead of the tail. The footer then carries `window_offset=N`, so a reader pages through `total_chars` with `0, 12000, 24000, …`. The default is unchanged — a poll on a running job still gets the tail. Offsets are counted in characters, the unit the footer's `total_chars`/`shown_chars` already use, so offsets computed from the footer land where expected. Negative offsets are refused; an offset past the end returns just the footer.

Test: pages a 20,000-line job from the start, checks the second page begins exactly where the first ended, the past-the-end and negative cases, and that the default read is still the tail. 14/14 in the package on native; wasm check clean; README updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXBYcYo74F1DGSPZsYYAdc
