### PR TITLE
refactor: agent, agent_session: share test fixtures and use iterator forms

### DIFF
--- a/agent/goal_check_test.mbt
+++ b/agent/goal_check_test.mbt
@@ -6,12 +6,9 @@ async fn goal_check_test_server(
   bodies : Array[String],
   responses : Array[String],
 ) -> String? {
-  let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
-    error if "\{error}".contains("Operation not permitted") => {
-      println("local TCP bind unavailable; skipping goal check test")
-      return None
-    }
-    error => raise error
+  guard bind_test_server("local TCP bind unavailable; skipping goal check test")
+    is Some(server) else {
+    return None
   }
   group.spawn_bg(no_wait=true) <| () => {
     server.run_forever(
@@ -39,12 +36,9 @@ async fn goal_ceiling_test_server(
   checkpoint_bodies : Array[String],
   responses : Array[String],
 ) -> String? {
-  let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
-    error if "\{error}".contains("Operation not permitted") => {
-      println("local TCP bind unavailable; skipping goal check test")
-      return None
-    }
-    error => raise error
+  guard bind_test_server("local TCP bind unavailable; skipping goal check test")
+    is Some(server) else {
+    return None
   }
   group.spawn_bg(no_wait=true) <| () => {
     server.run_forever(

--- a/agent/goal_reminder_test.mbt
+++ b/agent/goal_reminder_test.mbt
@@ -9,12 +9,11 @@ async fn goal_test_server(
   bodies : Array[String],
   probe_calls~ : Int,
 ) -> String? {
-  let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
-    error if "\{error}".contains("Operation not permitted") => {
-      println("local TCP bind unavailable; skipping goal reminder test")
-      return None
-    }
-    error => raise error
+  guard bind_test_server(
+      "local TCP bind unavailable; skipping goal reminder test",
+    )
+    is Some(server) else {
+    return None
   }
   group.spawn_bg(no_wait=true) <| () => {
     server.run_forever(
@@ -59,13 +58,7 @@ fn goal_set_marker(text : String) -> @agent_session.SessionItem {
 
 ///|
 fn count_reminders(body : String) -> Int {
-  let mut count = 0
-  let mut view = body[:]
-  while view.find("[goal reminder]") is Some(offset) {
-    count += 1
-    view = view[offset + 1:]
-  }
-  count
+  body.split("[goal reminder]").count() - 1
 }
 
 ///|

--- a/agent/tool_definition.mbt
+++ b/agent/tool_definition.mbt
@@ -133,6 +133,41 @@ pub async fn[X] build_tools(
 }
 
 ///|
+/// The mbtx fixture these tests share: a session temp dir, a job runtime that
+/// spills into it, and an mbtx bound to both. The handoff bound is injected so
+/// a test does not have to outwait the real one.
+async fn[X] mbtx_fixture(
+  group : @async.TaskGroup[X],
+  prefix~ : String,
+  auto_background_after_ms~ : Int,
+  approval? : @agent_runtime.ApprovalChannel,
+) -> (String, @bgjobs.BgJobRuntime, @agent_tool.AgentToolDefinition) {
+  let spill_dir = @fs.tmpdir(prefix~)
+  let bg_runtime = @bgjobs.BgJobRuntime(AgentTaskScope(group), spill_dir~)
+  let mbtx = @mbtx.definition(
+    workspace_root=".",
+    bg_runtime~,
+    job_dir=spill_dir,
+    auto_background_after_ms~,
+    approval?,
+  )
+  (spill_dir, bg_runtime, mbtx)
+}
+
+///|
+/// Run a tool definition's async executor, failing the test when the tool was
+/// registered with a synchronous one.
+async fn run_async_tool(
+  tool : @agent_tool.AgentToolDefinition,
+  arguments : Json,
+) -> @agent_tool.ToolAction {
+  match tool.execute {
+    Async(execute) => execute(arguments)
+    Sync(_) => fail("\{tool.name} should be async")
+  }
+}
+
+///|
 async test "agent registers the expected tool names" {
   @async.with_task_group() <| group => {
     let tools = build_tools(AgentRuntime(), AgentTaskScope(group))
@@ -188,22 +223,14 @@ async test "the registry has no shell tool family" {
 /// the throwaway path rewritten to `source:LINE:COL`.
 async test "a compile error reached inside the grace reports inline" {
   @async.with_task_group(group => {
-    let spill_dir = @fs.tmpdir(prefix="openseek-compile-inline-")
-    let bg_runtime = @bgjobs.BgJobRuntime::BgJobRuntime(
-      AgentTaskScope(group),
-      spill_dir~,
-    )
-    let mbtx = @mbtx.definition(
-      workspace_root=".",
-      bg_runtime~,
-      job_dir=spill_dir,
+    let (spill_dir, _, mbtx) = mbtx_fixture(
+      group,
+      prefix="openseek-compile-inline-",
       auto_background_after_ms=60_000,
     )
-    let action = match mbtx.execute {
-      Async(execute) =>
-        execute({ "source": "fn main { let _x : Int = \"nope\" }" })
-      Sync(_) => fail("mbtx should be async")
-    }
+    let action = run_async_tool(mbtx, {
+      "source": "fn main { let _x : Int = \"nope\" }",
+    })
     guard action is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_false(output.content.contains("moved to the background"))
@@ -223,12 +250,9 @@ async test "a compile error reached inside the grace reports inline" {
 /// later nonzero exit reads as the program's own.
 async test "a handoff carries build warnings and the build-ok label" {
   @async.with_task_group(group => {
-    let spill_dir = @fs.tmpdir(prefix="openseek-handoff-warn-")
-    let bg_runtime = @bgjobs.BgJobRuntime(AgentTaskScope(group), spill_dir~)
-    let mbtx = @mbtx.definition(
-      workspace_root=".",
-      bg_runtime~,
-      job_dir=spill_dir,
+    let (spill_dir, bg_runtime, mbtx) = mbtx_fixture(
+      group,
+      prefix="openseek-handoff-warn-",
       auto_background_after_ms=1500,
     )
     let source =
@@ -238,10 +262,7 @@ async test "a handoff carries build warnings and the build-ok label" {
       #|  let unused = 1
       #|  @async.sleep(60_000)
       #|}
-    let action = match mbtx.execute {
-      Async(execute) => execute({ "source": source, "warning": "on" })
-      Sync(_) => fail("mbtx should be async")
-    }
+    let action = run_async_tool(mbtx, { "source": source, "warning": "on" })
     guard action is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
     assert_true(output.content.contains("moved to the background"))
@@ -266,22 +287,14 @@ async test "a handoff carries build warnings and the build-ok label" {
 /// adopts is always a running program.
 async test "a compile error never becomes a job, whatever the grace" {
   @async.with_task_group(group => {
-    let spill_dir = @fs.tmpdir(prefix="openseek-compile-job-")
-    let bg_runtime = @bgjobs.BgJobRuntime::BgJobRuntime(
-      AgentTaskScope(group),
-      spill_dir~,
-    )
-    let mbtx = @mbtx.definition(
-      workspace_root=".",
-      bg_runtime~,
-      job_dir=spill_dir,
+    let (spill_dir, bg_runtime, mbtx) = mbtx_fixture(
+      group,
+      prefix="openseek-compile-job-",
       auto_background_after_ms=1,
     )
-    let action = match mbtx.execute {
-      Async(execute) =>
-        execute({ "source": "fn main { let _x : Int = \"nope\" }" })
-      Sync(_) => fail("mbtx should be async")
-    }
+    let action = run_async_tool(mbtx, {
+      "source": "fn main { let _x : Int = \"nope\" }",
+    })
     guard action is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_false(output.content.contains("moved to the background"))
@@ -302,12 +315,9 @@ async test "a compile error never becomes a job, whatever the grace" {
 /// deleting that result before the completion notice can be acted on.
 async test "a handed-off job cleans builds but keeps result files until teardown" {
   @async.with_task_group(group => {
-    let spill_dir = @fs.tmpdir(prefix="openseek-job-result-")
-    let bg_runtime = @bgjobs.BgJobRuntime(AgentTaskScope(group), spill_dir~)
-    let mbtx = @mbtx.definition(
-      workspace_root=".",
-      bg_runtime~,
-      job_dir=spill_dir,
+    let (spill_dir, bg_runtime, mbtx) = mbtx_fixture(
+      group,
+      prefix="openseek-job-result-",
       auto_background_after_ms=1,
     )
     let result_path = "\{spill_dir}/snippet-0/tmp/report.txt"
@@ -319,17 +329,14 @@ async test "a handed-off job cleans builds but keeps result files until teardown
       #|  println("RESULT_PATH")
       #|}
     ).replace_all(old="RESULT_PATH", new=result_path)
-    let action = match mbtx.execute {
-      Async(execute) => execute({ "source": source })
-      Sync(_) => fail("mbtx should be async")
-    }
+    let action = run_async_tool(mbtx, { "source": source })
     guard action is Respond(output) else { fail("expected Respond") }
     assert_true(output.content.contains("moved to the background"))
     guard bg_runtime.list() is [job, ..] else { fail("no job registered") }
-    let read = match @job_output.definition(bg_runtime).execute {
-      Async(execute) => execute({ "job_id": job.id, "wait_ms": 120_000 })
-      Sync(_) => fail("job_output should be async")
-    }
+    let read = run_async_tool(@job_output.definition(bg_runtime), {
+      "job_id": job.id,
+      "wait_ms": 120_000,
+    })
     guard read is Respond(result) else { fail("expected Respond") }
     assert_false(result.is_error)
     assert_eq(@fs.read_file(result_path).text(), "kept")
@@ -358,15 +365,9 @@ async test "a handed-off job cleans builds but keeps result files until teardown
 /// as a refusal from a policy that was not present.
 async test "an escalated handed-off job does not invent a policy refusal" {
   @async.with_task_group(group => {
-    let spill_dir = @fs.tmpdir(prefix="openseek-escalated-job-")
-    let bg_runtime = @bgjobs.BgJobRuntime::BgJobRuntime(
-      AgentTaskScope(group),
-      spill_dir~,
-    )
-    let mbtx = @mbtx.definition(
-      workspace_root=".",
-      bg_runtime~,
-      job_dir=spill_dir,
+    let (spill_dir, bg_runtime, mbtx) = mbtx_fixture(
+      group,
+      prefix="openseek-escalated-job-",
       auto_background_after_ms=1,
       approval=ApprovalChannel(_ => AllowedOnce),
     )
@@ -377,17 +378,14 @@ async test "an escalated handed-off job does not invent a policy refusal" {
       #|  @async.sleep(100)
       #|  println("Sandbox policy blocked file write: example")
       #|}
-    let action = match mbtx.execute {
-      Async(execute) => execute({ "source": source, "escalated": true })
-      Sync(_) => fail("mbtx should be async")
-    }
+    let action = run_async_tool(mbtx, { "source": source, "escalated": true })
     guard action is Respond(output) else { fail("expected Respond") }
     assert_true(output.content.contains("moved to the background"))
     guard bg_runtime.list() is [job, ..] else { fail("no job registered") }
-    let read = match @job_output.definition(bg_runtime).execute {
-      Async(execute) => execute({ "job_id": job.id, "wait_ms": 30_000 })
-      Sync(_) => fail("job_output should be async")
-    }
+    let read = run_async_tool(@job_output.definition(bg_runtime), {
+      "job_id": job.id,
+      "wait_ms": 30_000,
+    })
     guard read is Respond(result) else { fail("expected Respond") }
     assert_false(result.is_error)
     assert_true(result.content.contains("Sandbox policy blocked"))
@@ -404,32 +402,23 @@ async test "an escalated handed-off job does not invent a policy refusal" {
 /// of a policy that was never active.
 async test "a non-wasm handed-off job does not invent a policy refusal" {
   @async.with_task_group(group => {
-    let spill_dir = @fs.tmpdir(prefix="openseek-js-job-")
-    let bg_runtime = @bgjobs.BgJobRuntime::BgJobRuntime(
-      AgentTaskScope(group),
-      spill_dir~,
-    )
-    let mbtx = @mbtx.definition(
-      workspace_root=".",
-      bg_runtime~,
-      job_dir=spill_dir,
+    let (spill_dir, bg_runtime, mbtx) = mbtx_fixture(
+      group,
+      prefix="openseek-js-job-",
       auto_background_after_ms=1,
     )
     let source =
       #|fn main {
       #|  println("Sandbox policy blocked file write: example")
       #|}
-    let action = match mbtx.execute {
-      Async(execute) => execute({ "source": source, "target": "js" })
-      Sync(_) => fail("mbtx should be async")
-    }
+    let action = run_async_tool(mbtx, { "source": source, "target": "js" })
     guard action is Respond(output) else { fail("expected Respond") }
     assert_true(output.content.contains("moved to the background"))
     guard bg_runtime.list() is [job, ..] else { fail("no job registered") }
-    let read = match @job_output.definition(bg_runtime).execute {
-      Async(execute) => execute({ "job_id": job.id, "wait_ms": 30_000 })
-      Sync(_) => fail("job_output should be async")
-    }
+    let read = run_async_tool(@job_output.definition(bg_runtime), {
+      "job_id": job.id,
+      "wait_ms": 30_000,
+    })
     guard read is Respond(result) else { fail("expected Respond") }
     assert_false(result.is_error)
     assert_true(result.content.contains("Sandbox policy blocked"))
@@ -446,23 +435,16 @@ async test "a non-wasm handed-off job does not invent a policy refusal" {
 /// classified.
 async test "a non-wasm inline run does not invent a policy refusal" {
   @async.with_task_group(group => {
-    let spill_dir = @fs.tmpdir(prefix="openseek-js-inline-")
-    let bg_runtime = @bgjobs.BgJobRuntime(AgentTaskScope(group), spill_dir~)
-    let mbtx = @mbtx.definition(
-      workspace_root=".",
-      bg_runtime~,
-      job_dir=spill_dir,
+    let (spill_dir, _, mbtx) = mbtx_fixture(
+      group,
+      prefix="openseek-js-inline-",
       auto_background_after_ms=60_000,
     )
     assert_true(mbtx.description.contains("up to 60s"))
-    let action = match mbtx.execute {
-      Async(execute) =>
-        execute({
-          "source": "fn main { println(\"Sandbox policy blocked file write: example\") }",
-          "target": "js",
-        })
-      Sync(_) => fail("mbtx should be async")
-    }
+    let action = run_async_tool(mbtx, {
+      "source": "fn main { println(\"Sandbox policy blocked file write: example\") }",
+      "target": "js",
+    })
     guard action is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
     assert_false(output.content.contains("moved to the background"))
@@ -480,15 +462,9 @@ async test "a non-wasm inline run does not invent a policy refusal" {
 /// before continuing as a job.
 async test "an automatically handed-off snippet reads EOF on stdin" {
   @async.with_task_group(group => {
-    let spill_dir = @fs.tmpdir(prefix="openseek-jobs-stdin-")
-    let bg_runtime = @bgjobs.BgJobRuntime::BgJobRuntime(
-      AgentTaskScope(group),
-      spill_dir~,
-    )
-    let mbtx = @mbtx.definition(
-      workspace_root=".",
-      bg_runtime~,
-      job_dir=spill_dir,
+    let (spill_dir, bg_runtime, mbtx) = mbtx_fixture(
+      group,
+      prefix="openseek-jobs-stdin-",
       auto_background_after_ms=1500,
     )
     let source =
@@ -499,10 +475,7 @@ async test "an automatically handed-off snippet reads EOF on stdin" {
       #|  @stdio.stdout.write("got=\{line is Some(_)}\n")
       #|  @async.sleep(60_000)
       #|}
-    let action = match mbtx.execute {
-      Async(execute) => execute({ "source": source })
-      Sync(_) => fail("mbtx should be async")
-    }
+    let action = run_async_tool(mbtx, { "source": source })
     guard action is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
     assert_true(output.content.contains("moved to the background"))
@@ -520,10 +493,9 @@ async test "an automatically handed-off snippet reads EOF on stdin" {
       @async.sleep(25)
     }
     assert_true(saw_eof)
-    let read = match @job_output.definition(bg_runtime).execute {
-      Async(execute) => execute({ "job_id": job.id })
-      Sync(_) => fail("job_output should be async")
-    }
+    let read = run_async_tool(@job_output.definition(bg_runtime), {
+      "job_id": job.id,
+    })
     guard read is Respond(job) else { fail("expected Respond") }
     assert_true(job.content.contains("got=false"))
     let _ = bg_runtime.stop(bg_runtime.list()[0].id)
@@ -540,13 +512,9 @@ async test "an automatically handed-off snippet reads EOF on stdin" {
 /// so the test does not have to outwait the real one.
 async test "a foreground run past its deadline becomes a job instead of dying" {
   @async.with_task_group(group => {
-    let scope = @agent_runtime.AgentTaskScope(group)
-    let spill_dir = @fs.tmpdir(prefix="openseek-jobs-test-")
-    let bg_runtime = @bgjobs.BgJobRuntime(scope, spill_dir~)
-    let mbtx = @mbtx.definition(
-      workspace_root=".",
-      bg_runtime~,
-      job_dir=spill_dir,
+    let (spill_dir, bg_runtime, mbtx) = mbtx_fixture(
+      group,
+      prefix="openseek-jobs-test-",
       auto_background_after_ms=1500,
     )
     let source =
@@ -556,10 +524,7 @@ async test "a foreground run past its deadline becomes a job instead of dying" {
       #|  println("started")
       #|  @async.sleep(60_000)
       #|}
-    let action = match mbtx.execute {
-      Async(execute) => execute({ "source": source })
-      Sync(_) => fail("mbtx should be async")
-    }
+    let action = run_async_tool(mbtx, { "source": source })
     guard action is Respond(output) else { fail("expected Respond") }
     // Not an error, and not a corpse: it is a job the model can still watch.
     assert_false(output.is_error)
@@ -581,14 +546,11 @@ async test "a foreground run past its deadline becomes a job instead of dying" {
 /// tool waits out the real exit and says the rendering was lossy.
 async test "binary output waits for the real exit instead of abandoning it" {
   @async.with_task_group(group => {
-    let spill_dir = @fs.tmpdir(prefix="openseek-binary-inline-")
-    let bg_runtime = @bgjobs.BgJobRuntime(AgentTaskScope(group), spill_dir~)
     // This test is about waiting for the real exit, not the production 5s
     // handoff threshold. Keep cold dependency builds safely inside its premise.
-    let mbtx = @mbtx.definition(
-      workspace_root=".",
-      bg_runtime~,
-      job_dir=spill_dir,
+    let (spill_dir, _, mbtx) = mbtx_fixture(
+      group,
+      prefix="openseek-binary-inline-",
       auto_background_after_ms=60_000,
     )
     // Emit an invalid UTF-8 byte, then keep working briefly before exiting 3.
@@ -601,10 +563,7 @@ async test "binary output waits for the real exit instead of abandoning it" {
       #|  println("done")
       #|  @sys.exit(3)
       #|}
-    let action = match mbtx.execute {
-      Async(execute) => execute({ "source": source })
-      Sync(_) => fail("mbtx should be async")
-    }
+    let action = run_async_tool(mbtx, { "source": source })
     guard action is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     // The real exit code, not the -1 an abandoned execution would report.
@@ -623,21 +582,14 @@ async test "binary output waits for the real exit instead of abandoning it" {
 /// the recovery must also say to read the reduced result inside that snippet.
 async test "the inline output cap gives actionable retry guidance" {
   @async.with_task_group(group => {
-    let spill_dir = @fs.tmpdir(prefix="openseek-inline-cap-")
-    let bg_runtime = @bgjobs.BgJobRuntime(AgentTaskScope(group), spill_dir~)
-    let mbtx = @mbtx.definition(
-      workspace_root=".",
-      bg_runtime~,
-      job_dir=spill_dir,
+    let (spill_dir, _, mbtx) = mbtx_fixture(
+      group,
+      prefix="openseek-inline-cap-",
       auto_background_after_ms=60_000,
     )
-    let action = match mbtx.execute {
-      Async(execute) =>
-        execute({
-          "source": "fn main { for _ in 0..<50_000 { println(\"x\") } }",
-        })
-      Sync(_) => fail("mbtx should be async")
-    }
+    let action = run_async_tool(mbtx, {
+      "source": "fn main { for _ in 0..<50_000 { println(\"x\") } }",
+    })
     guard action is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_true(output.content.contains("fixed 48000-byte inline limit"))
@@ -658,13 +610,9 @@ async test "the inline output cap gives actionable retry guidance" {
 /// expiry detaches like any other long run.
 async test "binary output does not escape the deadline" {
   @async.with_task_group(group => {
-    let scope = @agent_runtime.AgentTaskScope(group)
-    let spill_dir = @fs.tmpdir(prefix="openseek-jobs-binary-")
-    let bg_runtime = @bgjobs.BgJobRuntime(scope, spill_dir~)
-    let mbtx = @mbtx.definition(
-      workspace_root=".",
-      bg_runtime~,
-      job_dir=spill_dir,
+    let (spill_dir, bg_runtime, mbtx) = mbtx_fixture(
+      group,
+      prefix="openseek-jobs-binary-",
       auto_background_after_ms=1500,
     )
     let source =
@@ -674,10 +622,7 @@ async test "binary output does not escape the deadline" {
       #|  @stdio.stdout.write(b"\xff\xfe")
       #|  @async.sleep(60_000)
       #|}
-    let action = match mbtx.execute {
-      Async(execute) => execute({ "source": source })
-      Sync(_) => fail("mbtx should be async")
-    }
+    let action = run_async_tool(mbtx, { "source": source })
     guard action is Respond(output) else { fail("expected Respond") }
     assert_true(output.content.contains("moved to the background as job"))
     guard bg_runtime.list() is [job, ..] else { fail("no job was registered") }
@@ -709,10 +654,7 @@ async test "a finished background job queues a notice and wakes the controller" 
       #|  @async.sleep(5_500)
       #|  println(1)
       #|}
-    let action = match mbtx.execute {
-      Async(execute) => execute({ "source": source })
-      Sync(_) => fail("mbtx should be async")
-    }
+    let action = run_async_tool(mbtx, { "source": source })
     guard action is Respond(output) else {
       fail("expected the run to hand off")
     }

--- a/agent/turn_loop.mbt
+++ b/agent/turn_loop.mbt
@@ -543,9 +543,7 @@ async fn AgentLoop::handle_tool_calls(
       ContinueToolBatch(next) => {
         // Account the result actually recorded for this call (the loop
         // clamp bounds it at max_tool_result_chars).
-        if next.events().peek() is Some(event) && event.item() is Tool(result) {
-          spent_result_chars += result.content().length().to_int64()
-        }
+        spent_result_chars += recorded_result_chars(next)
         continue next
       }
       ContinueAgentLoop(next) => return StepContinue(next)
@@ -906,15 +904,8 @@ async fn AgentLoop::salvage_control_calls_at_ceiling(
             // like an executed prefix's, or a LATER sealing control would
             // size its compact-on-finish decision against stale usage
             // while the reserved checkpoint headroom is already spent.
-            ContinueToolBatch(next) => {
-              let growth = if next.events().peek() is Some(event) &&
-                event.item() is Tool(result) {
-                result.content().length().to_int64()
-              } else {
-                0
-              }
-              continue index + 1, next, spent + growth
-            }
+            ContinueToolBatch(next) =>
+              continue index + 1, next, spent + recorded_result_chars(next)
             // The control already closed the batch remainder and prepared a
             // continuation (e.g. a control finish converted into a goal
             // check): re-scanning the same calls would duplicate results
@@ -963,6 +954,17 @@ let max_tool_result_chars : Int = 60_000
 
 ///|
 let tool_result_truncation_marker : String = "\n[truncated: result exceeded the 60000-char cap]"
+
+///|
+/// Chars recorded by the tool result the last append added, or 0 when the
+/// last event is not one — the batch budget's accounting unit.
+fn recorded_result_chars(session : @agent_session.Session) -> Int64 {
+  if session.events().peek() is Some(event) && event.item() is Tool(result) {
+    result.content().length().to_int64()
+  } else {
+    0
+  }
+}
 
 ///|
 /// Clamp an oversized tool result to `max_tool_result_chars`, never

--- a/agent_session/projection.mbt
+++ b/agent_session/projection.mbt
@@ -107,12 +107,9 @@ fn is_covered_by_later_summary(
   event : SessionEvent,
   events : @vector.Vector[SessionEvent],
 ) -> Bool {
-  for candidate in events {
-    if summary_covers_event(candidate, event.sequence()) {
-      return true
-    }
-  }
-  false
+  events
+  .iter()
+  .any(candidate => summary_covers_event(candidate, event.sequence()))
 }
 
 ///|

--- a/agent_session/store/store_test.mbt
+++ b/agent_session/store/store_test.mbt
@@ -10,6 +10,23 @@ fn session_file(store : @store.SessionStore, id : String) -> String {
 }
 
 ///|
+/// Append raw bytes to a session's durable file the way a torn write or a
+/// foreign writer would: no header rewrite, no lock, and no trailing newline
+/// unless `text` carries one.
+async fn append_raw(
+  store : @store.SessionStore,
+  id : String,
+  text : String,
+) -> Unit {
+  @fs.write_file(
+    session_file(store, id),
+    text,
+    create_mode=OpenOrCreate,
+    append=true,
+  )
+}
+
+///|
 async test "store creates and loads a session from one session file" {
   let store = new_store()
   defer @fs.rmdir(store.root(), recursive=true)
@@ -598,12 +615,7 @@ async test "load drops a torn trailing record without mutating the file" {
   store.create(session)
   // A crash mid-append leaves a half-written last line. The uncommitted tail
   // is dropped so the session stays resumable, and load itself is read-only.
-  @fs.write_file(
-    session_file(store, "s1"),
-    "{\"sequence\":2,\"ts\":0,\"item\":{\"kind\":\"assi",
-    create_mode=OpenOrCreate,
-    append=true,
-  )
+  append_raw(store, "s1", "{\"sequence\":2,\"ts\":0,\"item\":{\"kind\":\"assi")
   let text_before = @fs.read_file(session_file(store, "s1")).text()
   let loaded = store.load(SessionId("s1"))
   assert_eq(loaded.events().length(), 1)
@@ -619,12 +631,7 @@ async test "load keeps a complete final record that lost only its newline" {
   let (_, event) = session.append_event(User(UserMessage("first")))
   store.create(session)
   // The append was torn exactly at the newline boundary: the record is whole.
-  @fs.write_file(
-    session_file(store, "s1"),
-    ToJson::to_json(event).stringify(),
-    create_mode=OpenOrCreate,
-    append=true,
-  )
+  append_raw(store, "s1", ToJson::to_json(event).stringify())
   let loaded = store.load(SessionId("s1"))
   assert_eq(loaded.events().length(), 1)
   guard loaded.events()[0].item() is User(message) else {
@@ -641,12 +648,7 @@ async test "append repairs a torn tail before persisting the next event" {
     User(UserMessage("first")),
   )
   store.create(session)
-  @fs.write_file(
-    session_file(store, "s1"),
-    "{\"sequence\":2,\"ts\":0,\"item\":{\"kind\":\"assi",
-    create_mode=OpenOrCreate,
-    append=true,
-  )
+  append_raw(store, "s1", "{\"sequence\":2,\"ts\":0,\"item\":{\"kind\":\"assi")
   let resumed = store.load(SessionId("s1"))
   let next = store.append(resumed, Runtime(RuntimeNotice("recovered")))
   assert_eq(next.events().length(), 2)
@@ -667,12 +669,7 @@ async test "append repairs and keeps a complete unterminated final event" {
   let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
   let (_, event) = session.append_event(User(UserMessage("first")))
   store.create(session)
-  @fs.write_file(
-    session_file(store, "s1"),
-    ToJson::to_json(event).stringify(),
-    create_mode=OpenOrCreate,
-    append=true,
-  )
+  append_raw(store, "s1", ToJson::to_json(event).stringify())
   let resumed = store.load(SessionId("s1"))
   assert_eq(resumed.events().length(), 1)
   let next = store.append(resumed, Runtime(RuntimeNotice("second")))
@@ -697,12 +694,7 @@ async test "append rejects a stale snapshot against an unterminated durable even
   // Another writer committed an event; only its newline is missing. The
   // pre-commit empty snapshot is stale, and tail repair must not become a
   // path that discards that writer's data.
-  @fs.write_file(
-    session_file(store, "s1"),
-    ToJson::to_json(event).stringify(),
-    create_mode=OpenOrCreate,
-    append=true,
-  )
+  append_raw(store, "s1", ToJson::to_json(event).stringify())
   try store.append(session, Runtime(RuntimeNotice("stale"))) catch {
     error => {
       assert_true("\{error}".contains("stale session snapshot"))
@@ -725,12 +717,7 @@ async test "load tolerates unterminated tails in every torn shape" {
   // Valid JSON that is not a valid event: torn exactly inside the payload in
   // a way that still balances braces.
   store.create(Session(SessionId("json"), system_prompt="system"))
-  @fs.write_file(
-    session_file(store, "json"),
-    "{\"not\":\"an event\"}",
-    create_mode=OpenOrCreate,
-    append=true,
-  )
+  append_raw(store, "json", "{\"not\":\"an event\"}")
   assert_eq(store.load(SessionId("json")).events().length(), 0)
   // Whitespace-only unterminated tail.
   let one_event = @agent_session.Session(
@@ -738,21 +725,11 @@ async test "load tolerates unterminated tails in every torn shape" {
     system_prompt="system",
   ).append(User(UserMessage("hello")))
   store.create(one_event)
-  @fs.write_file(
-    session_file(store, "blank"),
-    "   ",
-    create_mode=OpenOrCreate,
-    append=true,
-  )
+  append_raw(store, "blank", "   ")
   assert_eq(store.load(SessionId("blank")).events().length(), 1)
   // Torn garbage after zero events.
   store.create(Session(SessionId("zero"), system_prompt="system"))
-  @fs.write_file(
-    session_file(store, "zero"),
-    "{\"seq",
-    create_mode=OpenOrCreate,
-    append=true,
-  )
+  append_raw(store, "zero", "{\"seq")
   assert_eq(store.load(SessionId("zero")).events().length(), 0)
 }
 
@@ -786,12 +763,7 @@ async test "compact repairs a torn tail before persisting the summary" {
     .append(User(UserMessage("first")))
     .append(Assistant(AssistantMessage("second")))
   store.create(session)
-  @fs.write_file(
-    session_file(store, "s1"),
-    "{\"sequence\":3,\"ts\":0,\"item\":{\"kind\":\"runt",
-    create_mode=OpenOrCreate,
-    append=true,
-  )
+  append_raw(store, "s1", "{\"sequence\":3,\"ts\":0,\"item\":{\"kind\":\"runt")
   let resumed = store.load(SessionId("s1"))
   let compacted = store.compact(
     resumed,
@@ -817,11 +789,8 @@ async test "latest can resume a session whose newest write was torn" {
     system_prompt="system",
   ).append(User(UserMessage("hello")))
   store.create(newest)
-  @fs.write_file(
-    session_file(store, "newest"),
-    "{\"sequence\":2,\"ts\":0,\"item\":{\"kind\":\"assi",
-    create_mode=OpenOrCreate,
-    append=true,
+  append_raw(
+    store, "newest", "{\"sequence\":2,\"ts\":0,\"item\":{\"kind\":\"assi",
   )
   guard store.latest() is Some(id) else { fail("expected a latest session") }
   assert_eq(id.value(), "newest")
@@ -837,23 +806,13 @@ async test "load still fails on corruption that is not a torn tail" {
   store.create(session)
   // Terminated garbage is interior-style corruption, not an interrupted
   // append: something after the bad line committed a newline.
-  @fs.write_file(
-    session_file(store, "s1"),
-    "not an event\n",
-    create_mode=OpenOrCreate,
-    append=true,
-  )
+  append_raw(store, "s1", "not an event\n")
   try store.load(SessionId("s1")) catch {
     error => {
       assert_true("\{error}" != "")
       // A bad line with valid lines after it fails the same way.
       let (_, event) = session.append_event(Runtime(RuntimeNotice("later")))
-      @fs.write_file(
-        session_file(store, "s1"),
-        ToJson::to_json(event).stringify() + "\n",
-        create_mode=OpenOrCreate,
-        append=true,
-      )
+      append_raw(store, "s1", ToJson::to_json(event).stringify() + "\n")
       try store.load(SessionId("s1")) catch {
         error => assert_true("\{error}" != "")
       } noraise {


### PR DESCRIPTION
A pure **simplification** pass: no feature, no fix, no behaviour change. Part of a project-wide sweep; each PR is one package family so it can be reviewed on its own.

Candidates came from a read-only survey of the whole repository. The author was told to drop any that would not compile or would change behaviour, so this branch carries fewer than were proposed: **7 applied, 0 dropped, net -113 lines.**

## Applied

- **agent_session/store/store_test.mbt** — 12 tests hand-roll the same 6-line raw append to a session file; one helper collapses each to a line
  Added `async fn append_raw(store, id, text)` next to `session_file` and rewrote all 12 `@fs.write_file(session_file(store, ...), <text>, create_mode=OpenOrCreate, append=true)` blocks as one-line calls. Every argument is preserved verbatim; the 13th write in the file (`create_mode=CreateOrTruncate`, no append) was deliberately left alone. Test count 43 -> 43, assertions 158 -> 158.
- **agent/tool_definition.mbt** — Ten mbtx tests repeat the same tmpdir + BgJobRuntime + mbtx.definition fixture block
  12 sites, not 10. Added `async fn[X] mbtx_fixture(group, prefix~, auto_background_after_ms~, approval?)` returning `(String, BgJobRuntime, AgentToolDefinition)`. Two sites bound `let scope = AgentTaskScope(group)` first; folded in (the constructor is a pure wrapper, so moving it after `tmpdir` is inert). Four sites never use the runtime, so they destructure `let (spill_dir, _, mbtx)` -- without that, deny-warn fails with `unused_value`. The comment explaining the 60_000 bound in "binary output waits for the real exit" was carried to sit directly above the fixture call it explains.
- **agent/tool_definition.mbt** — 16 sites repeat the same `match tool.execute { Async .. Sync => fail }` unwrap of a tool executor
  17 sites (13 mbtx + 4 job_output). Added `async fn run_async_tool(tool, arguments)`; the message is built from `tool.name`, and the two tool names are literally "mbtx" and "job_output" (agent_tool/mbtx/mbtx.mbt:131, agent_tool/job_output/job_output.mbt:9), so both failure texts are byte-identical. `moon fmt` dropped the `raise` I wrote on the signature as redundant.
- **agent/goal_reminder_test.mbt** — count_reminders hand-rolls substring counting that the sibling test file already does with split().count()
  Now `body.split("[goal reminder]").count() - 1`. I did NOT copy the sibling's doc comment across -- the original had none and the one-liner does not need one. Marker cannot self-overlap, so the old `offset + 1` advance and `split` count the same occurrences.
- **agent/turn_loop.mbt** — The batch budget's "chars the last append recorded" test is written twice in turn_loop.mbt
  Added `fn recorded_result_chars(session)` beside `clamp_tool_result_content`. Signature takes `@agent_session.Session` rather than the vector, so the `agent` package does not need a new `@vector` import. Both call sites keep their explanatory comments in place; the mutating-`if` site folds in because `+= 0` is a no-op.
- **agent_session/projection.mbt** — is_covered_by_later_summary is an early-return search loop that Iter::any expresses directly
  `events.iter().any(candidate => summary_covers_event(candidate, event.sequence()))`. `Iter::any` short-circuits, matching the early `return true`.
- **agent/goal_check_test.mbt** — Three test servers re-implement the sandbox-tolerant bind that bind_test_server already provides
  The finding pointed at agent/goal_reminder_test.mbt:12 but its evidence named all three copies, so I did all three: goal_reminder_test.mbt (1 site) and goal_check_test.mbt (2 sites). Both skip messages preserved verbatim ("...skipping goal reminder test" / "...skipping goal check test"). Also touches agent/goal_reminder_test.mbt.

## Verification

All commands run in the worktree /private/tmp/.../scratchpad/wt/agent-core on branch simplify/agent-core. Target: all three touched packages are root packages with `supported_targets = "+wasm+native"`, and moon.mod sets `preferred_target = "native"`, so bare commands are native.

BEFORE (baseline, clean tree at a227f6aae):
- `moon test agent`               -> Total tests: 99, passed: 99, failed: 0.
- `moon test agent_session`       -> Total tests: 38, passed: 38, failed: 0.
- `moon test agent_session/store` -> Total tests: 48, passed: 48, failed: 0.

AFTER (all seven findings applied):
- `moon fmt` then `moon fmt --check` -> exit 0, no diff.
- `moon check agent agent_session agent_session/store --deny-warn` -> Finished, 0 warnings, 0 errors.
- `moon check agent agent_session agent_session/store --target wasm --deny-warn` -> Finished, 0 warnings, 0 errors.
- `moon check --deny-warn` (whole workspace, native) -> Finished, 816 tasks, no errors.
- `moon test agent`               -> 99, passed: 99, failed: 0.  (unchanged)
- `moon test agent_session`       -> 38, passed: 38, failed: 0.  (unchanged)
- `moon test agent_session/store` -> 48, passed: 48, failed: 0.  (unchanged)
- `moon info agent agent_session agent_session/store` (SCOPED, never bare) -> ran 87 tasks; `git status --short` afterwards listed only the six source files I edited. No `.mbti` was modified, so no public interface changed.

TEST DEDUPE ACCOUNTING (no test cases were merged; these are fixture extractions, so coverage is identical by construction):
- agent_session/store/store_test.mbt: 43 tests before -> 43 after; 158 assertion/fail lines before -> 158 after; 12 raw-append blocks before -> 12 `append_raw` call sites after.
- agent/tool_definition.mbt: 16 tests before -> 16 after; 12 fixture blocks -> 12 `mbtx_fixture` calls; 17 executor unwraps -> 17 `run_async_tool` calls. Assertion/fail lines 126 -> 110, accounted for entirely by the 17 removed `Sync(_) => fail(...)` guards minus the 1 inside the new helper.
- agent/goal_reminder_test.mbt: 5 tests, 21 assertions, unchanged. agent/goal_check_test.mbt: 7 tests, 53 assertions, unchanged.

ONE FAILURE AND ITS WORKAROUND: `git push -u origin simplify/agent-core` was REJECTED (non-fast-forward) because a stale remote branch of that name already existed from merged PR #431 (tip 366a5964e, 2026-07-09). Verified via `gh pr list --head simplify/agent-core --state all` that PR #431 is MERGED and the branch was simply never deleted. Re-pushed with `git push -u --force-with-lease=simplify/agent-core:366a5964e5e30626f1c1fffb9bc184bfffdbac71 origin simplify/agent-core` -> `+ 366a5964e...0db12de7a simplify/agent-core -> simplify/agent-core (forced update)`. No PR was opened, nothing was merged, no other branch was touched. Final `git status --short` is clean; `origin/simplify/agent-core` is at 0db12de7a.

Commit: 0db12de7a, 6 files changed, 167 insertions(+), 280 deletions(-).

## Worth a second look

1. THE PUSH WAS A FORCE-PUSH. `origin/simplify/agent-core` already existed: it was the leftover branch of PR #431 ("refactor(agent): local simplification + dedupe sweep"), MERGED 2026-07-09, tip 366a5964e, never deleted after the squash-merge, and no longer an ancestor of main. A plain push was rejected non-fast-forward. I overwrote it with `git push --force-with-lease=simplify/agent-core:366a5964e5e30626f1c1fffb9bc184bfffdbac71`, so it could only land if the remote was still exactly that stale merged tip. Nothing unmerged was lost and the old SHA is recoverable from PR #431, but flag it if the parent expected a virgin branch name.

2. `agent/tool_definition.mbt` is a SOURCE file, not a `_test.mbt`, so the two new helpers (`mbtx_fixture`, `run_async_tool`) live beside production `build_tools` and are used only by the inline tests. `moon check --deny-warn` on native and wasm is clean, so the compiler does not consider them dead, but it is a placement worth a second look.

3. The four `let (spill_dir, _, mbtx) = mbtx_fixture(...)` destructures read less obviously than the named form. The `_` is load-bearing: binding it as `bg_runtime` trips `unused_value` under deny-warn in exactly those four tests.

4. `fail(...)` moved inside `run_async_tool`, so a failure there would report the helper's source location rather than the test's. The message text is unchanged and the test name is still reported by the runner; this branch only fires if a tool were registered `Sync`, which cannot happen for mbtx/job_output.

5. `agent/tool_definition.mbt` assertion-ish line count went 126 -> 110. That is exactly the 17 removed `Sync(_) => fail("... should be async")` guards minus the 1 added inside the helper; no behavioural assertion was removed. Every other touched test file is unchanged at 158/21/53.

6. In `salvage_control_calls_at_ceiling`, the `ContinueToolBatch` arm lost its braces (block -> single `continue` expression). The four-line comment above it is untouched.

Reviewed by OpenSeek's own review subagent (DeepSeek Flash); its verdict is posted as a comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXBYcYo74F1DGSPZsYYAdc