### PR TITLE
refactor: cmd/openseek, mcp: dedupe tests and share the subrun argv builder

### DIFF
--- a/cmd/openseek/approval.mbt
+++ b/cmd/openseek/approval.mbt
@@ -295,6 +295,19 @@ fn ApprovalDesk::standing(self : ApprovalDesk) -> String? {
 }
 
 ///|
+/// Test helper: block until the asker has registered its pending entry. It
+/// registers before it blocks, so wait for that rather than assuming the
+/// spawn already ran.
+async fn await_standing(desk : ApprovalDesk) -> Unit {
+  for _ in 0..<200 {
+    if desk.standing() is Some(_) {
+      break
+    }
+    @async.sleep(5)
+  }
+}
+
+///|
 async test "an answered question resolves to the controller's decision" {
   let desk = ApprovalDesk::ApprovalDesk(now_ms=0)
   @async.with_task_group(group => {
@@ -305,14 +318,7 @@ async test "an answered question resolves to the controller's decision" {
         body: Some("fn main { println(1) }"),
       })
     })
-    // The asker registers its pending entry before it blocks; wait for it
-    // rather than assuming the spawn already ran.
-    for _ in 0..<200 {
-      if desk.standing() is Some(_) {
-        break
-      }
-      @async.sleep(5)
-    }
+    await_standing(desk)
     guard desk.standing() is Some(id) else { fail("no question was announced") }
     desk.settle(id, true)
     assert_true(asked.wait() is AllowedOnce)
@@ -331,12 +337,7 @@ async test "a refused question resolves to rejected" {
         body: Some("fn main { println(1) }"),
       })
     })
-    for _ in 0..<200 {
-      if desk.standing() is Some(_) {
-        break
-      }
-      @async.sleep(5)
-    }
+    await_standing(desk)
     guard desk.standing() is Some(id) else { fail("no question was announced") }
     desk.settle(id, false)
     assert_true(asked.wait() is Rejected)
@@ -354,12 +355,7 @@ async test "a decision for a settled question is discarded" {
     let asking = group.spawn(() => {
       desk.ask({ tool_name: "mbtx", detail: "escalate", body: None, })
     })
-    for _ in 0..<200 {
-      if desk.pending.length() > 0 {
-        break
-      }
-      @async.sleep(5)
-    }
+    await_standing(desk)
     asking.cancel()
   })
   assert_eq(desk.pending.length(), 0)
@@ -398,12 +394,7 @@ async test "an interrupted wait still retires its question" {
         body: Some("fn main { println(1) }"),
       })
     })
-    for _ in 0..<200 {
-      if desk.pending.length() > 0 {
-        break
-      }
-      @async.sleep(5)
-    }
+    await_standing(desk)
     // The pending entry proves a tool is blocked here right now.
     assert_eq(desk.pending.length(), 1)
     asking.cancel()
@@ -426,12 +417,7 @@ async test "closing the command stream withdraws a standing question" {
     let asking = group.spawn(() => {
       desk.ask({ tool_name: "mbtx", detail: "escalate", body: None, })
     })
-    for _ in 0..<200 {
-      if desk.pending.length() > 0 {
-        break
-      }
-      @async.sleep(5)
-    }
+    await_standing(desk)
     desk.withdraw_all()
     assert_true(asking.wait() is Cancelled)
   })

--- a/cmd/openseek/gate.mbt
+++ b/cmd/openseek/gate.mbt
@@ -33,6 +33,20 @@ fn parse_audit_report(
 }
 
 ///|
+/// The input every `subrun review` child reads: the criteria to audit
+/// against, plus the baseline commit when the goal captured one.
+fn review_subrun_input(
+  goal : String,
+  baseline : @agent_session.GoalBaseline?,
+) -> Json {
+  match baseline {
+    Some(baseline) =>
+      { "goal": goal, "sha": baseline.sha, "dirty": baseline.dirty }
+    None => { "goal": goal }
+  }
+}
+
+///|
 /// Build the advisory goal-met gate: on a durably recorded met, spawn the
 /// `subrun review` child against the goal's baseline and return the bounded
 /// digest notice. Advisory by contract — every failure shape (no report,
@@ -55,23 +69,13 @@ fn build_goal_met_gate(
   child_session? : @agent_subrun.ChildSession,
 ) -> async (String, @agent_session.GoalBaseline?) -> String? {
   (goal, baseline) => {
-    let args = [
-      "subrun",
+    let args = subrun_args(
       "review",
-      "--model",
-      "\{model}",
-      "--max-steps",
-      "\{@agent_review.default_audit_max_steps}",
-    ]
-    if api_url is Some(url) {
-      args.push("--api-url")
-      args.push(url)
-    }
-    let input : Json = match baseline {
-      Some(baseline) =>
-        { "goal": goal, "sha": baseline.sha, "dirty": baseline.dirty }
-      None => { "goal": goal }
-    }
+      model~,
+      max_steps=@agent_review.default_audit_max_steps,
+      api_url~,
+    )
+    let input = review_subrun_input(goal, baseline)
     let result = @agent_subrun.run_subrun(
       command=self_exe,
       args~,

--- a/cmd/openseek/review_tool.mbt
+++ b/cmd/openseek/review_tool.mbt
@@ -90,23 +90,8 @@ async fn execute_review(
       brief="review (budget exhausted)",
     )
   }
-  let args = [
-    "subrun",
-    "review",
-    "--model",
-    "\{model}",
-    "--max-steps",
-    "\{granted_steps}",
-  ]
-  if api_url is Some(url) {
-    args.push("--api-url")
-    args.push(url)
-  }
-  let input : Json = match baseline {
-    Some(baseline) =>
-      { "goal": criteria, "sha": baseline.sha, "dirty": baseline.dirty }
-    None => { "goal": criteria }
-  }
+  let args = subrun_args("review", model~, max_steps=granted_steps, api_url~)
+  let input = review_subrun_input(criteria, baseline)
   let result = @agent_subrun.run_subrun(
     command=self_exe,
     args~,

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -471,78 +471,36 @@ test "an unblocked goal resumes auto-continuation at the boundary" {
 }
 
 ///|
+/// Test helper: `should_auto_continue` with every input defaulted to its
+/// continuing value, so a case reads as the one condition it flips.
+fn auto_continues(
+  auto? : Bool = true,
+  finished? : Bool = true,
+  idle? : Bool = true,
+  shutting_down? : Bool = false,
+  goal_standing? : Bool = true,
+  turns_remaining? : Int = 1,
+) -> Bool {
+  should_auto_continue(
+    auto~,
+    finished~,
+    idle~,
+    shutting_down~,
+    goal_standing~,
+    turns_remaining~,
+  )
+}
+
+///|
 test "auto-continue requires a finished idle serving turn with budget" {
-  assert_true(
-    should_auto_continue(
-      auto=true,
-      finished=true,
-      idle=true,
-      shutting_down=false,
-      goal_standing=true,
-      turns_remaining=1,
-    ),
-  )
+  assert_true(auto_continues())
   // Any single condition failing pauses for the controller.
-  assert_false(
-    should_auto_continue(
-      auto=false,
-      finished=true,
-      idle=true,
-      shutting_down=false,
-      goal_standing=true,
-      turns_remaining=1,
-    ),
-  )
-  assert_false(
-    should_auto_continue(
-      auto=true,
-      finished=false,
-      idle=true,
-      shutting_down=false,
-      goal_standing=true,
-      turns_remaining=1,
-    ),
-  )
-  assert_false(
-    should_auto_continue(
-      auto=true,
-      finished=true,
-      idle=false,
-      shutting_down=false,
-      goal_standing=true,
-      turns_remaining=1,
-    ),
-  )
-  assert_false(
-    should_auto_continue(
-      auto=true,
-      finished=true,
-      idle=true,
-      shutting_down=true,
-      goal_standing=true,
-      turns_remaining=1,
-    ),
-  )
-  assert_false(
-    should_auto_continue(
-      auto=true,
-      finished=true,
-      idle=true,
-      shutting_down=false,
-      goal_standing=false,
-      turns_remaining=1,
-    ),
-  )
-  assert_false(
-    should_auto_continue(
-      auto=true,
-      finished=true,
-      idle=true,
-      shutting_down=false,
-      goal_standing=true,
-      turns_remaining=0,
-    ),
-  )
+  assert_false(auto_continues(auto=false))
+  assert_false(auto_continues(finished=false))
+  assert_false(auto_continues(idle=false))
+  assert_false(auto_continues(shutting_down=true))
+  assert_false(auto_continues(goal_standing=false))
+  assert_false(auto_continues(turns_remaining=0))
 }
 
 ///|

--- a/cmd/openseek/subrun.mbt
+++ b/cmd/openseek/subrun.mbt
@@ -1,4 +1,30 @@
 ///|
+/// The child argv every subrun spawn shares — the parent half of the contract
+/// `run_subrun_command` below reads: the subcommand and its kind, the
+/// inherited model and step ceiling, plus `--api-url` only when one is
+/// configured (absent, the child falls back to its own default endpoint).
+fn subrun_args(
+  kind : String,
+  model~ : @deepseek.Model,
+  max_steps~ : Int,
+  api_url~ : String?,
+) -> Array[String] {
+  let args = [
+    "subrun",
+    kind,
+    "--model",
+    "\{model}",
+    "--max-steps",
+    "\{max_steps}",
+  ]
+  if api_url is Some(url) {
+    args.push("--api-url")
+    args.push(url)
+  }
+  args
+}
+
+///|
 /// `openseek subrun <kind>` — the INTERNAL child mode the engine spawns for
 /// one sub-run. Contract (see `agent_subrun`, and the normative text in the
 /// `moonbitlang/workflow` library's docs/child-contract.md — §7 records what

--- a/cmd/openseek/subtask_tool.mbt
+++ b/cmd/openseek/subtask_tool.mbt
@@ -458,18 +458,12 @@ async fn run_worker_slice(
         "base_oid": entry.base_oid,
       }
   }
-  let args = [
-    "subrun",
+  let args = subrun_args(
     "worker",
-    "--model",
-    "\{env.model}",
-    "--max-steps",
-    "\{granted_steps}",
-  ]
-  if env.api_url is Some(url) {
-    args.push("--api-url")
-    args.push(url)
-  }
+    model=env.model,
+    max_steps=granted_steps,
+    api_url=env.api_url,
+  )
   let result = @agent_subrun.run_subrun(
     command=env.self_exe,
     args~,

--- a/mcp/client_test.mbt
+++ b/mcp/client_test.mbt
@@ -115,20 +115,28 @@ fn[X] spawn_server(
 }
 
 ///|
+/// An MCP client wired to a fake server that answers with `reply`: the queue
+/// transport, the jsonrpc client with its message pump, and the server loop,
+/// all spawned on `group`.
+fn[X] fake_client(
+  group : @async.TaskGroup[X],
+  reply : (Json) -> Json?,
+) -> @mcp.McpClient {
+  let transport = new_transport()
+  let rpc = @jsonrpc.Client(transport)
+  spawn_client(group, rpc)
+  spawn_server(group, transport, reply)
+  @mcp.McpClient(rpc)
+}
+
+///|
 async test "initialize completes the handshake and returns server identity" {
   @async.with_task_group(group => {
-    let transport = new_transport()
-    let rpc = @jsonrpc.Client(transport)
-    spawn_client(group, rpc)
-    spawn_server(
+    let client = fake_client(
       group,
-      transport,
       stock_reply({ "tools": [] }, { "content": [] }),
     )
-    let init = @mcp.McpClient(rpc).initialize(
-      client_name="openseek",
-      client_version="0.1",
-    )
+    let init = client.initialize(client_name="openseek", client_version="0.1")
     assert_eq(init.protocol_version, "2025-11-25")
     assert_eq(init.server_name, "fake")
     assert_eq(init.server_version, "1.0")
@@ -138,9 +146,6 @@ async test "initialize completes the handshake and returns server identity" {
 ///|
 async test "initialize accepts a supported older protocol version" {
   @async.with_task_group(group => {
-    let transport = new_transport()
-    let rpc = @jsonrpc.Client(transport)
-    spawn_client(group, rpc)
     let reply = fn(request : Json) -> Json? {
       match method_of(request) {
         "initialize" =>
@@ -153,11 +158,8 @@ async test "initialize accepts a supported older protocol version" {
         _ => None
       }
     }
-    spawn_server(group, transport, reply)
-    let init = @mcp.McpClient(rpc).initialize(
-      client_name="openseek",
-      client_version="0.1",
-    )
+    let client = fake_client(group, reply)
+    let init = client.initialize(client_name="openseek", client_version="0.1")
     assert_eq(init.protocol_version, "2024-11-05")
   })
 }
@@ -165,9 +167,6 @@ async test "initialize accepts a supported older protocol version" {
 ///|
 async test "initialize rejects an unsupported negotiated protocol version" {
   @async.with_task_group(group => {
-    let transport = new_transport()
-    let rpc = @jsonrpc.Client(transport)
-    spawn_client(group, rpc)
     let reply = fn(request : Json) -> Json? {
       match method_of(request) {
         "initialize" =>
@@ -180,13 +179,9 @@ async test "initialize rejects an unsupported negotiated protocol version" {
         _ => None
       }
     }
-    spawn_server(group, transport, reply)
+    let client = fake_client(group, reply)
     let outcome = try {
-      @mcp.McpClient(rpc).initialize(
-        client_name="openseek",
-        client_version="0.1",
-      )
-      |> ignore
+      client.initialize(client_name="openseek", client_version="0.1") |> ignore
       "no error raised"
     } catch {
       @mcp.Protocol(_) => "protocol"
@@ -200,9 +195,6 @@ async test "initialize rejects an unsupported negotiated protocol version" {
 ///|
 async test "list_tools returns tools with pass-through schemas" {
   @async.with_task_group(group => {
-    let transport = new_transport()
-    let rpc = @jsonrpc.Client(transport)
-    spawn_client(group, rpc)
     let tools_result : Json = {
       "tools": [
         {
@@ -215,8 +207,11 @@ async test "list_tools returns tools with pass-through schemas" {
         },
       ],
     }
-    spawn_server(group, transport, stock_reply(tools_result, { "content": [] }))
-    let tools = @mcp.McpClient(rpc).list_tools()
+    let client = fake_client(
+      group,
+      stock_reply(tools_result, { "content": [] }),
+    )
+    let tools = client.list_tools()
     assert_eq(tools.length(), 1)
     assert_eq(tools[0].name, "echo")
     assert_eq(tools[0].description, "Echo text")
@@ -234,9 +229,6 @@ async test "list_tools returns tools with pass-through schemas" {
 ///|
 async test "list_tools follows nextCursor pagination" {
   @async.with_task_group(group => {
-    let transport = new_transport()
-    let rpc = @jsonrpc.Client(transport)
-    spawn_client(group, rpc)
     let calls : Ref[Int] = { val: 0, }
     let reply = fn(request : Json) -> Json? {
       match method_of(request) {
@@ -256,8 +248,8 @@ async test "list_tools follows nextCursor pagination" {
         _ => None
       }
     }
-    spawn_server(group, transport, reply)
-    let tools = @mcp.McpClient(rpc).list_tools()
+    let client = fake_client(group, reply)
+    let tools = client.list_tools()
     assert_eq(tools.length(), 2)
     assert_eq(tools[0].name, "a")
     assert_eq(tools[1].name, "b")
@@ -267,17 +259,12 @@ async test "list_tools follows nextCursor pagination" {
 ///|
 async test "call_tool returns text content and renders it" {
   @async.with_task_group(group => {
-    let transport = new_transport()
-    let rpc = @jsonrpc.Client(transport)
-    spawn_client(group, rpc)
     let call_result : Json = {
       "content": [{ "type": "text", "text": "hello world" }],
       "isError": false,
     }
-    spawn_server(group, transport, stock_reply({ "tools": [] }, call_result))
-    let result = @mcp.McpClient(rpc).call_tool(name="echo", arguments={
-      "text": "hi",
-    })
+    let client = fake_client(group, stock_reply({ "tools": [] }, call_result))
+    let result = client.call_tool(name="echo", arguments={ "text": "hi" })
     assert_false(result.is_error)
     assert_eq(result.render_text(), "hello world")
   })
@@ -286,15 +273,12 @@ async test "call_tool returns text content and renders it" {
 ///|
 async test "call_tool surfaces a tool-level error as is_error" {
   @async.with_task_group(group => {
-    let transport = new_transport()
-    let rpc = @jsonrpc.Client(transport)
-    spawn_client(group, rpc)
     let call_result : Json = {
       "content": [{ "type": "text", "text": "boom" }],
       "isError": true,
     }
-    spawn_server(group, transport, stock_reply({ "tools": [] }, call_result))
-    let result = @mcp.McpClient(rpc).call_tool(
+    let client = fake_client(group, stock_reply({ "tools": [] }, call_result))
+    let result = client.call_tool(
       name="explode",
       arguments=Json::empty_object(),
     )
@@ -306,22 +290,15 @@ async test "call_tool surfaces a tool-level error as is_error" {
 ///|
 async test "call_tool raises on a JSON-RPC error reply" {
   @async.with_task_group(group => {
-    let transport = new_transport()
-    let rpc = @jsonrpc.Client(transport)
-    spawn_client(group, rpc)
     let reply = fn(request : Json) -> Json? {
       match method_of(request) {
         "tools/call" => Some(failure(request, -32602, "unknown tool"))
         _ => None
       }
     }
-    spawn_server(group, transport, reply)
+    let client = fake_client(group, reply)
     let outcome = try {
-      @mcp.McpClient(rpc).call_tool(
-        name="ghost",
-        arguments=Json::empty_object(),
-      )
-      |> ignore
+      client.call_tool(name="ghost", arguments=Json::empty_object()) |> ignore
       "no error raised"
     } catch {
       @jsonrpc.Failed(code~, message~, data=_) => "failed \{code} \{message}"
@@ -335,18 +312,15 @@ async test "call_tool raises on a JSON-RPC error reply" {
 ///|
 async test "list_tools raises Protocol on a malformed result" {
   @async.with_task_group(group => {
-    let transport = new_transport()
-    let rpc = @jsonrpc.Client(transport)
-    spawn_client(group, rpc)
     let reply = fn(request : Json) -> Json? {
       match method_of(request) {
         "tools/list" => Some(success(request, Json::empty_object()))
         _ => None
       }
     }
-    spawn_server(group, transport, reply)
+    let client = fake_client(group, reply)
     let outcome = try {
-      @mcp.McpClient(rpc).list_tools() |> ignore
+      client.list_tools() |> ignore
       "no error raised"
     } catch {
       @mcp.Protocol(_) => "protocol"

--- a/mcp/tools/tools.mbt
+++ b/mcp/tools/tools.mbt
@@ -96,20 +96,16 @@ pub async fn[X] build(
   workspace_root? : String,
   discovery_timeout_ms? : Int = DefaultDiscoveryTimeoutMs,
 ) -> Array[@agent_tool.AgentToolDefinition] {
-  let tools = []
-  for
-    entry in build_grouped(
-      scope,
-      servers,
-      client_name~,
-      client_version~,
-      workspace_root?,
-      discovery_timeout_ms~,
-    ) {
-    let (_, contributed) = entry
-    tools.append(contributed)
-  }
-  tools
+  build_grouped(
+    scope,
+    servers,
+    client_name~,
+    client_version~,
+    workspace_root?,
+    discovery_timeout_ms~,
+  )
+  .map(group => group.1)
+  .flatten()
 }
 
 ///|

--- a/mcp/types.mbt
+++ b/mcp/types.mbt
@@ -126,13 +126,7 @@ fn decode_tool(entry : Json) -> McpTool raise {
 /// `isError` defaults to false.
 fn decode_call_result(result : Json) -> CallToolResult raise {
   let content = match result {
-    { "content": Array(blocks), .. } => {
-      let decoded = []
-      for block in blocks {
-        decoded.push(decode_content_block(block))
-      }
-      decoded
-    }
+    { "content": Array(blocks), .. } => blocks.map(decode_content_block)
     _ => []
   }
   let structured_content = match result {
@@ -173,25 +167,20 @@ fn decode_content_block(block : Json) -> ContentBlock raise {
 /// output is never lost). The caller applies any size budget and metadata
 /// footer. Empty content and no structured output yields "".
 pub fn CallToolResult::render_text(self : CallToolResult) -> String {
-  let out = StringBuilder()
-  let mut first = true
-  for block in self.content {
-    if !first {
-      out.write_string("\n")
-    }
-    first = false
-    match block {
-      Text(text) => out.write_string(text)
-      Image(mime_type~) => out.write_string("[image: \{mime_type}]")
-      Resource(uri~, text~) =>
-        match text {
-          Some(text) => out.write_string("[resource \{uri}]\n\{text}")
-          None => out.write_string("[resource: \{uri}]")
-        }
-      Other(kind~) => out.write_string("[unsupported content: \{kind}]")
-    }
-  }
-  let text = out.to_string()
+  let text = self.content
+    .map(block => {
+      match block {
+        Text(text) => text
+        Image(mime_type~) => "[image: \{mime_type}]"
+        Resource(uri~, text~) =>
+          match text {
+            Some(text) => "[resource \{uri}]\n\{text}"
+            None => "[resource: \{uri}]"
+          }
+        Other(kind~) => "[unsupported content: \{kind}]"
+      }
+    })
+    .join("\n")
   // Preserve structured output. A conformant server mirrors it into a text
   // block (then `text` already contains it — don't duplicate); when it does not
   // (empty content, or a bare status) append the serialized structure.


### PR DESCRIPTION
A pure **simplification** pass: no feature, no fix, no behaviour change. Part of a project-wide sweep; each PR is one package family so it can be reviewed on its own.

Candidates came from a read-only survey of the whole repository. The author was told to drop any that would not compile or would change behaviour, so this branch carries fewer than were proposed: **8 applied, 1 dropped, net -88 lines.**

## Applied

- **cmd/openseek/serve.mbt** — Seven near-identical should_auto_continue assertions collapse into one flip-one-flag table
  Applied, but NOT as the proposed tuple table. MoonBit local `fn` inside a test body does not support labelled/defaulted parameters — the proposed form failed to compile (19 errors: "This function has no parameter with label goal_standing~"). Instead added a top-level private helper `auto_continues` with every input defaulted to its continuing value, mirroring the existing test-helper precedent `ApprovalDesk::standing` in cmd/openseek/approval.mbt. Each case stays its own assert statement with its own source location, so a failure is still pinpointed by line — better diagnosability than the proposed for-loop table. 7 assertions before, 7 after; -50 lines.
- **mcp/client_test.mbt** — Nine MCP client tests repeat the same transport/pump/server wiring preamble
  Applied as proposed. `fake_client(group, reply)` added after `spawn_server`; all nine async tests rewritten, each keeping its own reply/fixture hoisted above the call. `spawn_client` still runs before `spawn_server` in the same order, and the reply closures are pure, so no side-effect order changed. Test count unchanged (23 in the package).
- **cmd/openseek/approval.mbt** — Five copies of the same spawn-registration spin-wait in ApprovalDesk tests
  Applied as proposed. `await_standing(desk)` added next to `ApprovalDesk::standing`; the load-bearing comment moved from the first copy onto the helper. Three of the five call sites spun on `desk.pending.length() > 0` and now spin on `desk.standing() is Some(_)` — same predicate, since `standing()` returns the first key of `pending` or None (its body is 10 lines above the helper).
- **cmd/openseek/subrun.mbt** — Three copies of the subrun argv builder, including the --api-url rule
  Helper added here rather than in tools.mbt as proposed: subrun.mbt's own doc comment already states the argv contract ("model, endpoint, and the step ceiling ride argv"), so the parent-side builder sits with the child-side reader. Call sites rewritten in gate.mbt, review_tool.mbt and subtask_tool.mbt.
- **cmd/openseek/gate.mbt** — The review subrun's input JSON is built identically in review_tool.mbt and gate.mbt
  Applied as proposed. `review_subrun_input` added beside `parse_audit_report`, the existing shared home for review-subrun helpers; both call sites rewritten. The explicit `: Json` annotation is dropped at the call sites because the helper's return type supplies it.
- **mcp/types.mbt** — render_text's first-flag StringBuilder loop is map + join("\n")
  Applied as proposed. `join` writes exactly `\n` between elements and "" for an empty array, matching the first-flag loop. Everything after `let text = ...` is untouched. moon fmt wrapped the match in a block body.
- **mcp/types.mbt** — decode_call_result's push loop is Array::map, the way decode_tools_page already writes it
  Applied as proposed. `Array::map` is error-polymorphic, so `decode_content_block`'s raise propagates exactly as the loop's did.
- **mcp/tools/tools.mbt** — build's regroup-and-append loop is map + Array::flatten
  Applied as proposed. `build_grouped`'s own doc comment already promises "Flattening the groups yields exactly `build`'s registry", so the new code says what the comment said.

## Dropped, and why

- **Four render_text/structuredContent tests differ only in content and expectation (mcp/types_wbtest.mbt:137)**
  Dropped on the brief's test-collapse rules. (1) The four test NAMES are the documentation of render_text's structuredContent contract — they mirror its doc comment clause by clause ("renders structuredContent when content is empty", "does not duplicate structuredContent already in content", "appends structuredContent distinct from a status message"); one table named for the whole contract loses three of those. (2) The proposed first row, "render_text is empty for empty content", is not about structuredContent at all — it is the empty-content pin, and it is precisely what makes the map+join rewrite in mcp/types.mbt safe. Folding the pin into a structuredContent table hides that relationship right when it started mattering. (3) A `for`-loop of `assert_eq` turns four precisely-located failures into one; `assert_eq` does take `msg?`, so a row label was possible, but the label would only restore what the four test names already gave for free. 18 lines is not worth that trade. The four tests are untouched.

## Verification

Toolchain: moon 0.1.20260827 (d0aaa07). All commands run in the worktree at .../scratchpad/wt/cli.

TESTS BEFORE (baseline on clean simplify/cli):
  moon test -p bobzhang/openseek/cmd/openseek  -> Total tests: 82, passed: 82, failed: 0
  moon test -p bobzhang/openseek/mcp           -> Total tests: 23, passed: 23, failed: 0
  moon test -p bobzhang/openseek/mcp/tools     -> Total tests:  7, passed:  7, failed: 0
  (combined run of the three: Total tests: 112, passed: 112, failed: 0)

TESTS AFTER (identical counts — no test was added or removed):
  cmd/openseek 82/82, mcp 23/23, mcp/tools 7/7.

ASSERTION COUNTS for the one test whose body changed
(cmd/openseek/serve.mbt "auto-continue requires a finished idle serving turn with budget"):
  before: 1 assert_true + 6 assert_false = 7 assertions across 73 lines.
  after:  1 assert_true + 6 assert_false = 7 assertions across 9 lines, plus a 17-line
  defaulted helper. Same six single-condition flips (auto, finished, idle, shutting_down,
  goal_standing, turns_remaining), same order, same expectations. NOT collapsed into a
  table row loop — each case stayed a separate assert statement, so failures keep their
  own source locations.

FORMAT:
  moon fmt -> "Finished. moon: ran 4 tasks, now up to date". git status --short after fmt
  listed only my own files; no unrelated file was reformatted.
  (An earlier repo-wide `moon fmt` also touched nothing outside my files — verified with
  git status immediately after.)

CHECK (--deny-warn, both targets; all three packages are supported_targets = "+wasm+native"):
  moon check -p ./cmd/openseek --target native --deny-warn -> Finished, 0 warnings/errors
  moon check -p ./mcp          --target native --deny-warn -> Finished
  moon check -p ./mcp/tools    --target native --deny-warn -> Finished
  moon check -p ./cmd/openseek --target wasm   --deny-warn -> Finished (107 tasks)
  moon check -p ./mcp          --target wasm   --deny-warn -> Finished
  moon check -p ./mcp/tools    --target wasm   --deny-warn -> Finished

BUILD (to confirm the new test-only top-level helpers are not dead-code warnings in a
non-test build):
  moon build ./cmd/openseek --target native --deny-warn -> Finished, 155 tasks.
  (One pre-existing, unrelated Xcode libtool warning about an empty
  moonbitlang/async/types archive; present on the clean baseline too.)

MOON INFO (scoped, never bare):
  moon info -p bobzhang/openseek/cmd/openseek -> Finished
  moon info -p bobzhang/openseek/mcp          -> Finished
  moon info -p bobzhang/openseek/mcp/tools    -> Finished
  git status --short afterwards showed the SAME nine .mbt files and no .mbti — the public
  interface of all three packages is unchanged.

WORKAROUNDS / FRICTION worth naming:
  - `moon check -p <full/package/name>` fails here ("Failed to canonicalize input filter
    directory"); check wants a relative path (./mcp). `moon test -p` and `moon info -p`
    want the full package name (bobzhang/openseek/mcp). `moon check` also rejects more
    than one -p, so I looped instead of batching.
  - The finding-1 proposal did not compile: a local `fn` inside a test body degrades to a
    positional lambda, so labelled defaults are rejected. Reworked to a top-level helper
    (see `applied`).

COMMIT/PUSH:
  git add <nine explicit paths>; git commit -> 4a27cf8f8, 9 files changed,
  160 insertions(+), 248 deletions(-). git push -u origin simplify/cli -> new branch
  created on origin. git status --short is clean. No PR opened, no merge, no other branch
  touched.

## Worth a second look

Three things deserve a second look.

1. cmd/openseek/approval.mbt — the only place I changed a predicate rather than just moving code. Three of the five spin-waits tested `desk.pending.length() > 0` and now test `desk.standing() is Some(_)` via the shared helper. These are the same predicate because `ApprovalDesk::standing` (10 lines above the new helper) returns the first key of `self.pending`, or None when it is empty. If you disagree that this is obvious enough at the call sites, the alternative is two helpers instead of one.

2. cmd/openseek/serve.mbt and cmd/openseek/approval.mbt each gain a top-level private `fn` used only from a `test` block in the same non-test file (`auto_continues`, `await_standing`). This follows the existing `ApprovalDesk::standing` precedent in the repo, and I confirmed it does not trip deny-warn on `moon check` (native + wasm) or on `moon build --target native`. Still, it is a pattern worth a deliberate nod rather than an accident.

3. cmd/openseek/subrun.mbt is a file about the CHILD subrun mode, and `subrun_args` is parent-side code. I put it there anyway because that file's doc comment is where the argv contract is written down ("model, endpoint, and the step ceiling ride argv"), so the producer now sits beside the spec its consumer implements. If the team would rather keep the file strictly child-side, moving the helper to tools.mbt (as the original finding proposed) is a one-block move with no other edits.

Minor: in mcp/tools/tools.mbt, `build` is now an expression body ending in `.flatten()` with no intermediate binding — check the `.map(group => group.1)` reads clearly enough versus the previous `let (_, contributed) = entry` destructuring.

Nothing here changes a public signature: `moon info` on all three packages left every .mbti byte-identical.

Reviewed by OpenSeek's own review subagent (DeepSeek Flash); its verdict is posted as a comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXBYcYo74F1DGSPZsYYAdc