### PR TITLE
refactor: desktop/internal engine, host: share test fixtures

### DIFF
--- a/desktop/internal/engine/archive.mbt
+++ b/desktop/internal/engine/archive.mbt
@@ -81,16 +81,27 @@ priv struct SessionFamilyMove {
 }
 
 ///|
+/// Undo a family's holds in reverse acquisition order: engine claims first,
+/// then the record move guards.
+fn release_family_claims(
+  manager : EngineManager,
+  claims : Array[PendingClaim],
+  guards : Array[(String, SessionRecordGuard)],
+) -> Unit {
+  for claim in claims.rev_iter() {
+    claim.release(manager)
+  }
+  for entry in guards.rev_iter() {
+    let (record_key, record_state) = entry
+    manager.release_record_move(record_key, record_state)
+  }
+}
+
+///|
 fn SessionFamilyMove::release(self : SessionFamilyMove) -> Unit {
   guard self.active else { return }
   self.active = false
-  for claim in self.claims.rev_iter() {
-    claim.release(self.manager)
-  }
-  for entry in self.guards.rev_iter() {
-    let (record_key, record_state) = entry
-    self.manager.release_record_move(record_key, record_state)
-  }
+  release_family_claims(self.manager, self.claims, self.guards)
 }
 
 ///|
@@ -111,13 +122,7 @@ async fn EngineManager::claim_session_family_move(
   let mut handed_off = false
   defer {
     if !handed_off {
-      for claim in claims.rev_iter() {
-        claim.release(manager)
-      }
-      for entry in guards.rev_iter() {
-        let (record_key, record_state) = entry
-        manager.release_record_move(record_key, record_state)
-      }
+      release_family_claims(manager, claims, guards)
     }
     if placement_locked {
       manager.workspace_lifecycle_lock.release()

--- a/desktop/internal/engine/archive_lookup_wbtest.mbt
+++ b/desktop/internal/engine/archive_lookup_wbtest.mbt
@@ -5,6 +5,21 @@
 // refusal, and a failed attempt must leave no wedged host state behind.
 
 ///|
+/// The refusal `archive_session` answers with, or "no error" when it commits.
+/// Cancellation is never a refusal and stays observable.
+#cfg(not(platform="windows"))
+async fn archive_refusal(manager : EngineManager, session : String) -> String {
+  try {
+    ignore(archive_session(manager, session, (_, _) => ()))
+    "no error"
+  } catch {
+    EngineError(detail) => detail
+    error if @async.is_being_cancelled() => raise error
+    error => "\{error}"
+  }
+}
+
+///|
 #cfg(not(platform="windows"))
 async test "archive names the missing store after a workspace detach" {
   ambient_env_test_lock.acquire()
@@ -33,14 +48,7 @@ async test "archive names the missing store after a workspace detach" {
   // A stale sidebar can still offer the conversation; archiving it now
   // reports the record as unreachable instead of pretending it never
   // existed.
-  let detail = try {
-    ignore(archive_session(manager, "s-ws", (_, _) => ()))
-    "no error"
-  } catch {
-    EngineError(detail) => detail
-    error if @async.is_being_cancelled() => raise error
-    error => "\{error}"
-  }
+  let detail = archive_refusal(manager, "s-ws")
   debug_inspect(
     detail,
     content=(
@@ -54,14 +62,7 @@ async test "archive names the missing store after a workspace detach" {
   assert_true(manager.record_guards.get("s-ws") is None)
   guard manager.pump is Serving(sessions~) else { fail("pump stopped") }
   assert_true(sessions.get("s-ws") is None)
-  let second = try {
-    ignore(archive_session(manager, "s-ws", (_, _) => ()))
-    "no error"
-  } catch {
-    EngineError(detail) => detail
-    error if @async.is_being_cancelled() => raise error
-    error => "\{error}"
-  }
+  let second = archive_refusal(manager, "s-ws")
   debug_inspect(
     second,
     content=(
@@ -95,14 +96,7 @@ async test "archive reports a workspace record whose directory vanished" {
   // The workspace directory vanishes outside the app; the registry keeps
   // its dead entry addressable, so the sidebar still shows the workspace.
   @fs.rmdir(workspace, recursive=true)
-  let detail = try {
-    ignore(archive_session(manager, "s-ws", (_, _) => ()))
-    "no error"
-  } catch {
-    EngineError(detail) => detail
-    error if @async.is_being_cancelled() => raise error
-    error => "\{error}"
-  }
+  let detail = archive_refusal(manager, "s-ws")
   debug_inspect(
     detail,
     content=(
@@ -169,14 +163,7 @@ async test "archiving an already-archived conversation names that state" {
   @fsx.ensure_dir(Path(store + "/archived/sessions/s-done"))
   let manager = new_engine_manager("unused")
   manager.pump = Serving(sessions=Map([]))
-  let detail = try {
-    ignore(archive_session(manager, "s-done", (_, _) => ()))
-    "no error"
-  } catch {
-    EngineError(detail) => detail
-    error if @async.is_being_cancelled() => raise error
-    error => "\{error}"
-  }
+  let detail = archive_refusal(manager, "s-done")
   debug_inspect(
     detail,
     content=(

--- a/desktop/internal/engine/follower.mbt
+++ b/desktop/internal/engine/follower.mbt
@@ -677,6 +677,29 @@ fn follower_test_config(
 }
 
 ///|
+/// Install one test follower for `session` under `root`. The identity
+/// `ensure_follower` answers with is only present when this call installed a
+/// new follower; every test below reads the follower map instead.
+#cfg(not(platform="windows"))
+async fn[G] install_test_follower(
+  engine : String,
+  session : String,
+  root : @pathx.Absolute,
+  sink~ : EventSink,
+  group~ : @async.TaskGroup[G],
+  manager~ : EngineManager,
+) -> Unit {
+  ignore(
+    ensure_follower(
+      sink~,
+      group~,
+      manager~,
+      config=follower_test_config(engine, session, root),
+    ),
+  )
+}
+
+///|
 #cfg(not(platform="windows"))
 async test "a follower barrier broadcasts the durable tail before returning" {
   let dir = @fs.tmpdir(prefix="openseek-follower-barrier-")
@@ -689,14 +712,7 @@ async test "a follower barrier broadcasts the durable tail before returning" {
   let emitted : Array[EngineEvent] = []
   let sink = EventSink(fn(event) { emitted.push(event) })
   @async.with_task_group(group => {
-    ignore(
-      ensure_follower(
-        sink~,
-        group~,
-        manager~,
-        config=follower_test_config(engine, session, root),
-      ),
-    )
+    install_test_follower(engine, session, root, sink~, group~, manager~)
     guard manager.followers.get(session) is Some(follower) else {
       fail("expected follower")
     }
@@ -727,14 +743,7 @@ async test "an unreadable existing record refuses the spawn baseline" {
   @async.with_task_group(group => {
     // No record file: absence is proof, so the follower installs at the
     // proven-empty watermark and the first turn can run.
-    ignore(
-      ensure_follower(
-        sink~,
-        group~,
-        manager~,
-        config=follower_test_config(engine, "s-baseline", root),
-      ),
-    )
+    install_test_follower(engine, "s-baseline", root, sink~, group~, manager~)
     guard manager.followers.get("s-baseline") is Some(follower) else {
       fail("expected a follower for the record-less first turn")
     }
@@ -745,14 +754,7 @@ async test "an unreadable existing record refuses the spawn baseline" {
     // and leaves no follower installed.
     write_damaged_record(root, "s-baseline")
     let detail = try {
-      ignore(
-        ensure_follower(
-          sink~,
-          group~,
-          manager~,
-          config=follower_test_config(engine, "s-baseline", root),
-        ),
-      )
+      install_test_follower(engine, "s-baseline", root, sink~, group~, manager~)
       "no error"
     } catch {
       EngineError(detail) => detail
@@ -779,14 +781,7 @@ async test "failed final scan keeps the follower active and propagates" {
   let manager = new_engine_manager(engine)
   let sink = EventSink(fn(_) { () })
   @async.with_task_group(group => {
-    ignore(
-      ensure_follower(
-        sink~,
-        group~,
-        manager~,
-        config=follower_test_config(engine, "s-fail", root),
-      ),
-    )
+    install_test_follower(engine, "s-fail", root, sink~, group~, manager~)
     guard manager.followers.get("s-fail") is Some(follower) else {
       fail("expected follower")
     }
@@ -825,14 +820,7 @@ async test "an absent record retires as an empty drain" {
   let manager = new_engine_manager(engine)
   let sink = EventSink(fn(_) { () })
   @async.with_task_group(group => {
-    ignore(
-      ensure_follower(
-        sink~,
-        group~,
-        manager~,
-        config=follower_test_config(engine, session, root),
-      ),
-    )
+    install_test_follower(engine, session, root, sink~, group~, manager~)
     guard manager.followers.get(session) is Some(follower) else {
       fail("expected follower")
     }
@@ -856,14 +844,7 @@ async test "the drain that finally succeeds broadcasts what it could not read" {
   let emitted : Array[EngineEvent] = []
   let sink = EventSink(fn(event) { emitted.push(event) })
   @async.with_task_group(group => {
-    ignore(
-      ensure_follower(
-        sink~,
-        group~,
-        manager~,
-        config=follower_test_config(engine, session, root),
-      ),
-    )
+    install_test_follower(engine, session, root, sink~, group~, manager~)
     guard manager.followers.get(session) is Some(_) else {
       fail("expected follower")
     }
@@ -878,12 +859,9 @@ async test "the drain that finally succeeds broadcasts what it could not read" {
     // that succeeds is also the one that broadcasts it.
     write_session_record(root, session, [session_user_event(1, "done")])
     stop_follower(manager, session, writer_exited=true)
-    let relevant : Array[EngineEvent] = []
-    for event in emitted {
-      if event is SessionCommit(payload) && payload.session == session {
-        relevant.push(event)
-      }
-    }
+    let relevant = emitted.filter(event => {
+      event is SessionCommit(payload) && payload.session == session
+    })
     guard relevant is [SessionCommit({ sequence: 1, session_root, .. })] else {
       fail("expected exactly one rooted commit")
     }
@@ -908,13 +886,13 @@ async test "a committed terminal does not settle a run the stream never ended" {
   let emitted : Array[EngineEvent] = []
   let sink = EventSink(fn(event) { emitted.push(event) })
   @async.with_task_group(group => {
-    ignore(
-      ensure_follower(
-        sink~,
-        group~,
-        manager~,
-        config=follower_test_config(dir + "/engine.sh", session, root),
-      ),
+    install_test_follower(
+      dir + "/engine.sh",
+      session,
+      root,
+      sink~,
+      group~,
+      manager~,
     )
     guard manager.followers.get(session) is Some(follower) else {
       fail("expected follower")
@@ -982,14 +960,7 @@ async test "abrupt EOF leaves a failed drain for a later caller to retry" {
   let emitted : Array[EngineEvent] = []
   let sink = EventSink(fn(event) { emitted.push(event) })
   @async.with_task_group(group => {
-    ignore(
-      ensure_follower(
-        sink~,
-        group~,
-        manager~,
-        config=follower_test_config(engine_path, session, root),
-      ),
-    )
+    install_test_follower(engine_path, session, root, sink~, group~, manager~)
     guard manager.followers.get(session) is Some(follower) else {
       fail("expected follower")
     }
@@ -1071,14 +1042,7 @@ async test "workspace detach drains an orphaned pending follower before commit" 
   let emitted : Array[EngineEvent] = []
   let sink = EventSink(fn(event) { emitted.push(event) })
   @async.with_task_group(group => {
-    ignore(
-      ensure_follower(
-        sink~,
-        group~,
-        manager~,
-        config=follower_test_config(engine_path, session, root),
-      ),
-    )
+    install_test_follower(engine_path, session, root, sink~, group~, manager~)
     guard manager.followers.get(session) is Some(follower) else {
       fail("expected follower")
     }
@@ -1122,14 +1086,7 @@ async test "workspace detach refuses an idle engine whose follower cannot drain"
   let manager = new_engine_manager(engine_path)
   let sink = EventSink(fn(_) { () })
   @async.with_task_group(group => {
-    ignore(
-      ensure_follower(
-        sink~,
-        group~,
-        manager~,
-        config=follower_test_config(engine_path, session, root),
-      ),
-    )
+    install_test_follower(engine_path, session, root, sink~, group~, manager~)
     guard manager.followers.get(session) is Some(follower) else {
       fail("expected follower")
     }
@@ -1196,14 +1153,7 @@ async test "record stat failure is not mistaken for an empty final drain" {
   let manager = new_engine_manager(engine)
   let sink = EventSink(fn(_) { () })
   @async.with_task_group(group => {
-    ignore(
-      ensure_follower(
-        sink~,
-        group~,
-        manager~,
-        config=follower_test_config(engine, "s-stat", root),
-      ),
-    )
+    install_test_follower(engine, "s-stat", root, sink~, group~, manager~)
     guard manager.followers.get("s-stat") is Some(follower) else {
       fail("expected follower")
     }
@@ -1252,25 +1202,11 @@ async test "root change retires the old follower before installing another" {
   write_session_record(root_a, "s-root", [])
   write_session_record(root_b, "s-root", [])
   @async.with_task_group(group => {
-    ignore(
-      ensure_follower(
-        sink~,
-        group~,
-        manager~,
-        config=follower_test_config(engine, "s-root", root_a),
-      ),
-    )
+    install_test_follower(engine, "s-root", root_a, sink~, group~, manager~)
     guard manager.followers.get("s-root") is Some(first) else {
       fail("expected first follower")
     }
-    ignore(
-      ensure_follower(
-        sink~,
-        group~,
-        manager~,
-        config=follower_test_config(engine, "s-root", root_b),
-      ),
-    )
+    install_test_follower(engine, "s-root", root_b, sink~, group~, manager~)
     guard manager.followers.get("s-root") is Some(second) else {
       fail("expected replacement follower")
     }
@@ -1291,14 +1227,7 @@ async test "one Load control message answers a bounded request batch" {
   let manager = new_engine_manager(engine)
   let sink = EventSink(fn(_) { () })
   @async.with_task_group(group => {
-    ignore(
-      ensure_follower(
-        sink~,
-        group~,
-        manager~,
-        config=follower_test_config(engine, "s-load", root),
-      ),
-    )
+    install_test_follower(engine, "s-load", root, sink~, group~, manager~)
     guard manager.followers.get("s-load") is Some(follower) else {
       fail("expected follower")
     }
@@ -1421,14 +1350,7 @@ async test "cancelling follower baseline removes its startup identity" {
   let sink = EventSink(fn(_) { () })
   @async.with_task_group(group => {
     let startup = group.spawn(() => {
-      ignore(
-        ensure_follower(
-          sink~,
-          group~,
-          manager~,
-          config=follower_test_config(engine, "s-cancel", root),
-        ),
-      )
+      install_test_follower(engine, "s-cancel", root, sink~, group~, manager~)
     })
     while manager.followers.get("s-cancel") is None {
       @async.pause()

--- a/desktop/internal/engine/ops.mbt
+++ b/desktop/internal/engine/ops.mbt
@@ -931,6 +931,62 @@ async fn attach_run_workspace(root : @pathx.Path) -> String {
 }
 
 ///|
+/// Point the manager at a stub custom endpoint. Every run test needs a
+/// configured provider before `start_run` will spawn a child.
+#cfg(not(platform="windows"))
+async fn configure_custom_provider(manager : EngineManager) -> Unit {
+  ignore(
+    update_settings(manager, {
+      provider: Some("custom"),
+      custom_api_url: Some("https://example.invalid/chat/completions"),
+      deepseek_api_key: None,
+      glm_api_key: None,
+      custom_api_key: None,
+    }),
+  )
+}
+
+///|
+/// Serve `actor` in `group` and wait until its pump accepts commands: the
+/// first thing every run test does after building the manager.
+#cfg(not(platform="windows"))
+async fn[G] serve_until_pumping(
+  actor : EngineActor,
+  manager : EngineManager,
+  sink : EventSink,
+  group~ : @async.TaskGroup[G],
+) -> Unit {
+  group.spawn_bg(no_wait=true, allow_failure=true, () => {
+    actor.run(sink, fn(_) { () })
+  })
+  while manager.pump is Stopped {
+    @async.sleep(1)
+  }
+}
+
+///|
+/// The default `start.run` payload for these tests: only the task, the
+/// conversation and its workspace vary. The optional client knobs stay unset,
+/// so a run takes the host's own defaults.
+#cfg(not(platform="windows"))
+fn test_start_payload(
+  task : String,
+  session~ : String,
+  workspace~ : String,
+  submission_id? : String,
+) -> @protocol.StartPayload {
+  {
+    task,
+    submission_id,
+    model: None,
+    thinking: None,
+    max_steps: None,
+    session,
+    workspace: Some(workspace),
+  }
+}
+
+///|
 #cfg(not(platform="windows"))
 async test "start echoes the client submission id in Started" {
   let dir = @fs.tmpdir(prefix="openseek-start-submission-")
@@ -960,37 +1016,25 @@ async test "start echoes the client submission id in Started" {
   assert_eq(@process.run("chmod", ["+x", engine.to_string()]), 0)
   let actor = new_engine_actor(engine.to_string(), runtime_dir=runtime)
   let manager = actor.manager()
-  ignore(
-    update_settings(manager, {
-      provider: Some("custom"),
-      custom_api_url: Some("https://example.invalid/chat/completions"),
-      deepseek_api_key: None,
-      glm_api_key: None,
-      custom_api_key: None,
-    }),
-  )
+  configure_custom_provider(manager)
   let emitted : Array[EngineEvent] = []
   // Starts are durable now, so each test owns a fresh conversation record
   // instead of sharing a fixed id across test processes.
   let session = "s-" + mint_run_id()
   let sink = EventSink(fn(event) { emitted.push(event) })
   @async.with_task_group(group => {
-    group.spawn_bg(no_wait=true, allow_failure=true, () => {
-      actor.run(sink, fn(_) { () })
-    })
-    while manager.pump is Stopped {
-      @async.sleep(1)
-    }
+    serve_until_pumping(actor, manager, sink, group~)
     ignore(
-      start_run(sink, manager, {
-        task: "hello",
-        submission_id: Some("submission-start"),
-        model: None,
-        thinking: None,
-        max_steps: None,
-        session,
-        workspace: Some(workspace),
-      }),
+      start_run(
+        sink,
+        manager,
+        test_start_payload(
+          "hello",
+          session~,
+          workspace~,
+          submission_id="submission-start",
+        ),
+      ),
     )
     let mut echoed : String? = None
     for event in emitted {
@@ -1040,24 +1084,11 @@ async test "a goal is delivered only once its command is on the wire" {
   assert_eq(@process.run("chmod", ["+x", engine.to_string()]), 0)
   let actor = new_engine_actor(engine.to_string(), runtime_dir=runtime)
   let manager = actor.manager()
-  ignore(
-    update_settings(manager, {
-      provider: Some("custom"),
-      custom_api_url: Some("https://example.invalid/chat/completions"),
-      deepseek_api_key: None,
-      glm_api_key: None,
-      custom_api_key: None,
-    }),
-  )
+  configure_custom_provider(manager)
   let session = "s-" + mint_run_id()
   let sink = EventSink(fn(_) { () })
   @async.with_task_group(group => {
-    group.spawn_bg(no_wait=true, allow_failure=true, () => {
-      actor.run(sink, fn(_) { () })
-    })
-    while manager.pump is Stopped {
-      @async.sleep(1)
-    }
+    serve_until_pumping(actor, manager, sink, group~)
     let delivered = goal_run(manager, {
       session,
       text: Some("keep the build green"),
@@ -1166,34 +1197,17 @@ async test "setup failure retires the writer before an immediate next start" {
   assert_eq(@process.run("chmod", ["+x", engine.to_string()]), 0)
   let actor = new_engine_actor(engine.to_string(), runtime_dir=runtime)
   let manager = actor.manager()
-  ignore(
-    update_settings(manager, {
-      provider: Some("custom"),
-      custom_api_url: Some("https://example.invalid/chat/completions"),
-      deepseek_api_key: None,
-      glm_api_key: None,
-      custom_api_key: None,
-    }),
-  )
+  configure_custom_provider(manager)
   let emitted : Array[EngineEvent] = []
   let session = "s-" + mint_run_id()
   let sink = EventSink(fn(event) { emitted.push(event) })
   @async.with_task_group(group => {
-    group.spawn_bg(no_wait=true, allow_failure=true, () => {
-      actor.run(sink, fn(_) { () })
-    })
-    while manager.pump is Stopped {
-      @async.sleep(1)
-    }
-    let first = start_run(sink, manager, {
-        task: "first",
-        submission_id: None,
-        model: None,
-        thinking: None,
-        max_steps: None,
-        session,
-        workspace: Some(workspace),
-      }).run_id
+    serve_until_pumping(actor, manager, sink, group~)
+    let first = start_run(
+        sink,
+        manager,
+        test_start_payload("first", session~, workspace~),
+      ).run_id
     assert_true(
       @async.with_timeout_opt(3000, () => {
         while !has_finished_run(emitted, first) {
@@ -1209,15 +1223,11 @@ async test "setup failure retires the writer before an immediate next start" {
       assert_true(slot.live() is None)
     }
     assert_true(cancel_run(manager, { run_id: Some(first), }).run_id is None)
-    let second = start_run(sink, manager, {
-      task: "second",
-      submission_id: None,
-      model: None,
-      thinking: None,
-      max_steps: None,
-      session,
-      workspace: Some(workspace),
-    })
+    let second = start_run(
+      sink,
+      manager,
+      test_start_payload("second", session~, workspace~),
+    )
     assert_eq(second.status, "accepted")
     assert_true(@fsx.exists(old_done))
     assert_false(@fsx.exists(overlapped))
@@ -1281,15 +1291,7 @@ async test "a prompt bigger than the pipe still settles exactly once" {
   assert_eq(@process.run("chmod", ["+x", engine.to_string()]), 0)
   let actor = new_engine_actor(engine.to_string(), runtime_dir=runtime)
   let manager = actor.manager()
-  ignore(
-    update_settings(manager, {
-      provider: Some("custom"),
-      custom_api_url: Some("https://example.invalid/chat/completions"),
-      deepseek_api_key: None,
-      glm_api_key: None,
-      custom_api_key: None,
-    }),
-  )
+  configure_custom_provider(manager)
   let emitted : Array[EngineEvent] = []
   let session = "s-" + mint_run_id()
   let started : Ref[String?] = Ref(None)
@@ -1300,22 +1302,13 @@ async test "a prompt bigger than the pipe still settles exactly once" {
     emitted.push(event)
   })
   @async.with_task_group(group => {
-    group.spawn_bg(no_wait=true, allow_failure=true, () => {
-      actor.run(sink, fn(_) { () })
-    })
-    while manager.pump is Stopped {
-      @async.sleep(1)
-    }
+    serve_until_pumping(actor, manager, sink, group~)
     // Returns without waiting for the 4MB to reach the child.
-    let reply = start_run(sink, manager, {
-      task: "x".repeat(4_000_000),
-      submission_id: None,
-      model: None,
-      thinking: None,
-      max_steps: None,
-      session,
-      workspace: Some(workspace),
-    })
+    let reply = start_run(
+      sink,
+      manager,
+      test_start_payload("x".repeat(4_000_000), session~, workspace~),
+    )
     assert_eq(reply.status, "accepted")
     assert_eq(started.val, Some(reply.run_id))
     let run_id = reply.run_id
@@ -1380,15 +1373,7 @@ async test "named session retries after its first prompt creates no record" {
   assert_eq(@process.run("chmod", ["+x", engine.to_string()]), 0)
   let actor = new_engine_actor(engine.to_string(), runtime_dir=runtime)
   let manager = actor.manager()
-  ignore(
-    update_settings(manager, {
-      provider: Some("custom"),
-      custom_api_url: Some("https://example.invalid/chat/completions"),
-      deepseek_api_key: None,
-      glm_api_key: None,
-      custom_api_key: None,
-    }),
-  )
+  configure_custom_provider(manager)
   let emitted : Array[EngineEvent] = []
   let started : Ref[String?] = Ref(None)
   let sink = EventSink(fn(event) {
@@ -1398,21 +1383,12 @@ async test "named session retries after its first prompt creates no record" {
     emitted.push(event)
   })
   @async.with_task_group(group => {
-    group.spawn_bg(no_wait=true, allow_failure=true, () => {
-      actor.run(sink, fn(_) { () })
-    })
-    while manager.pump is Stopped {
-      @async.sleep(1)
-    }
-    let first = start_run(sink, manager, {
-      task: "x".repeat(4_000_000),
-      submission_id: None,
-      model: None,
-      thinking: None,
-      max_steps: None,
-      session,
-      workspace: Some(workspace),
-    })
+    serve_until_pumping(actor, manager, sink, group~)
+    let first = start_run(
+      sink,
+      manager,
+      test_start_payload("x".repeat(4_000_000), session~, workspace~),
+    )
     assert_eq(first.status, "accepted")
     assert_eq(started.val, Some(first.run_id))
     assert_true(
@@ -1445,15 +1421,11 @@ async test "named session retries after its first prompt creates no record" {
       is Some(_),
     )
 
-    let second = start_run(sink, manager, {
-      task: "retry",
-      submission_id: None,
-      model: None,
-      thinking: None,
-      max_steps: None,
-      session,
-      workspace: Some(workspace),
-    })
+    let second = start_run(
+      sink,
+      manager,
+      test_start_payload("retry", session~, workspace~),
+    )
     assert_eq(second.status, "accepted")
     let second_run_id = second.run_id
     assert_true(
@@ -1614,33 +1586,20 @@ async test "workspace detach refuses a running conversation without hiding it" {
   assert_eq(@process.run("chmod", ["+x", engine.to_string()]), 0)
   let actor = new_engine_actor(engine.to_string(), runtime_dir=runtime)
   let manager = actor.manager()
-  ignore(
-    update_settings(manager, {
-      provider: Some("custom"),
-      custom_api_url: Some("https://example.invalid/chat/completions"),
-      deepseek_api_key: None,
-      glm_api_key: None,
-      custom_api_key: None,
-    }),
-  )
+  configure_custom_provider(manager)
   let sink = EventSink(fn(_) { () })
   @async.with_task_group(group => {
-    group.spawn_bg(no_wait=true, allow_failure=true, () => {
-      actor.run(sink, fn(_) { () })
-    })
-    while manager.pump is Stopped {
-      @async.sleep(1)
-    }
+    serve_until_pumping(actor, manager, sink, group~)
     ignore(attach_workspace(workspace.to_string(), fn(_) { () }))
-    let reply = start_run(sink, manager, {
-      task: "keep running",
-      submission_id: None,
-      model: None,
-      thinking: None,
-      max_steps: None,
-      session: "s-detach-running",
-      workspace: Some(workspace.to_string()),
-    })
+    let reply = start_run(
+      sink,
+      manager,
+      test_start_payload(
+        "keep running",
+        session="s-detach-running",
+        workspace=workspace.to_string(),
+      ),
+    )
     assert_eq(reply.status, "accepted")
     let committed : Ref[Bool] = Ref(false)
     let detail = try {
@@ -1701,34 +1660,21 @@ async test "workspace detach drains an idle writer and its follower first" {
   assert_eq(@process.run("chmod", ["+x", engine.to_string()]), 0)
   let actor = new_engine_actor(engine.to_string(), runtime_dir=runtime)
   let manager = actor.manager()
-  ignore(
-    update_settings(manager, {
-      provider: Some("custom"),
-      custom_api_url: Some("https://example.invalid/chat/completions"),
-      deepseek_api_key: None,
-      glm_api_key: None,
-      custom_api_key: None,
-    }),
-  )
+  configure_custom_provider(manager)
   let events : Array[EngineEvent] = []
   let sink = EventSink(fn(event) { events.push(event) })
   @async.with_task_group(group => {
-    group.spawn_bg(no_wait=true, allow_failure=true, () => {
-      actor.run(sink, fn(_) { () })
-    })
-    while manager.pump is Stopped {
-      @async.sleep(1)
-    }
+    serve_until_pumping(actor, manager, sink, group~)
     ignore(attach_workspace(workspace.to_string(), fn(_) { () }))
-    let reply = start_run(sink, manager, {
-      task: "finish",
-      submission_id: None,
-      model: None,
-      thinking: None,
-      max_steps: None,
-      session: "s-detach-idle",
-      workspace: Some(workspace.to_string()),
-    })
+    let reply = start_run(
+      sink,
+      manager,
+      test_start_payload(
+        "finish",
+        session="s-detach-idle",
+        workspace=workspace.to_string(),
+      ),
+    )
     let run_id = reply.run_id
     assert_true(
       @async.with_timeout_opt(3000, () => {

--- a/desktop/internal/engine/worktree_seam_wbtest.mbt
+++ b/desktop/internal/engine/worktree_seam_wbtest.mbt
@@ -282,36 +282,23 @@ async test "worktree remove refuses a running conversation without unmapping it"
     runtime_dir=runtime.to_path(),
   )
   let manager = actor.manager()
-  ignore(
-    update_settings(manager, {
-      provider: Some("custom"),
-      custom_api_url: Some("https://example.invalid/chat/completions"),
-      deepseek_api_key: None,
-      glm_api_key: None,
-      custom_api_key: None,
-    }),
-  )
+  configure_custom_provider(manager)
   let sink = EventSink(fn(_) {  })
   @async.with_task_group(group => {
-    group.spawn_bg(no_wait=true, allow_failure=true, () => {
-      actor.run(sink, fn(_) {  })
-    })
-    while manager.pump is Stopped {
-      @async.sleep(1)
-    }
+    serve_until_pumping(actor, manager, sink, group~)
     ignore(@workspaces.add(ws.to_string(), fn(_) {  }))
     stage_worktree_placements(ws, [
       ("wt", "openseek/wt", Some("s-wt-run"), None),
     ])
-    let reply = start_run(sink, manager, {
-      task: "keep running",
-      submission_id: None,
-      model: None,
-      thinking: None,
-      max_steps: None,
-      session: "s-wt-run",
-      workspace: Some(ws.to_string()),
-    })
+    let reply = start_run(
+      sink,
+      manager,
+      test_start_payload(
+        "keep running",
+        session="s-wt-run",
+        workspace=ws.to_string(),
+      ),
+    )
     assert_eq(reply.status, "accepted")
     let committed : Ref[Bool] = Ref(false)
     let detail = try {

--- a/desktop/internal/host/git_ops.mbt
+++ b/desktop/internal/host/git_ops.mbt
@@ -454,13 +454,7 @@ fn parse_numstat(output : String) -> GitDiffStat {
 /// command that failed reads as None rather than an empty string, so a caller
 /// whose empty output means "nothing changed" can tell the two apart.
 async fn git_output_opt(dir : String, args : Array[String]) -> String? {
-  let (code, stdout, _) = @processx.collect_output_no_stdin(
-    "git",
-    args,
-    cwd=dir,
-    extra_env=git_environment(),
-    inherit_env=false,
-  ) catch {
+  let (code, stdout, _) = git_collect(dir, args) catch {
     error if @async.is_being_cancelled() => raise error
     _ => return None
   }
@@ -497,13 +491,7 @@ fn git_environment() -> Map[String, String] {
 
 ///|
 async fn git_output(dir : String, args : Array[String]) -> String {
-  let (code, stdout, _) = @processx.collect_output_no_stdin(
-    "git",
-    args,
-    cwd=dir,
-    extra_env=git_environment(),
-    inherit_env=false,
-  ) catch {
+  let (code, stdout, _) = git_collect(dir, args) catch {
     error if @async.is_being_cancelled() => raise error
     _ => return ""
   }
@@ -1900,6 +1888,16 @@ test "Git single-line output preserves significant path whitespace" {
 }
 
 ///|
+/// Best-effort removal of a test repository. Cancellation stays observable;
+/// any other rmdir failure is the test's own tmpdir and is ignored.
+async fn git_test_cleanup(dir : String) -> Unit {
+  @fs.rmdir(dir, recursive=true) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => ()
+  }
+}
+
+///|
 async fn git_test_run(dir : String, args : Array[String]) -> Unit {
   let (code, _, stderr) = git_collect(dir, args)
   guard code == 0 else {
@@ -1919,14 +1917,8 @@ async fn git_test_commit(dir : String, message : String) -> Unit {
 ///|
 async test "Git history pages stay pinned and commit changes use first parent" {
   let dir = @fs.tmpdir(prefix="openseek-git-history-")
-  async fn cleanup() {
-    @fs.rmdir(dir, recursive=true) catch {
-      error if @async.is_being_cancelled() => raise error
-      _ => ()
-    }
-  }
   let _ = {
-    defer cleanup()
+    defer git_test_cleanup(dir)
     git_test_run(dir, ["init", "--quiet"])
     @fs.write_file("\{dir}/old.mbt", "first\n", create_mode=CreateOrTruncate)
     git_test_run(dir, ["add", "old.mbt"])
@@ -2080,14 +2072,8 @@ async test "Git history pages stay pinned and commit changes use first parent" {
 ///|
 async test "Git history paginates fifty commits and describes detached HEAD" {
   let dir = @fs.tmpdir(prefix="openseek-git-history-page-")
-  async fn cleanup() {
-    @fs.rmdir(dir, recursive=true) catch {
-      error if @async.is_being_cancelled() => raise error
-      _ => ()
-    }
-  }
   let _ = {
-    defer cleanup()
+    defer git_test_cleanup(dir)
     git_test_run(dir, ["init", "--quiet"])
     let unborn = capture_git_history_snapshot(dir, None)
     assert_eq(unborn.head, None)
@@ -2119,13 +2105,7 @@ async test "Git history paginates fifty commits and describes detached HEAD" {
 ///|
 async test "Git recognizes only origin HEAD's branch as the default" {
   let dir = @fs.tmpdir(prefix="openseek-git-default-branch-")
-  async fn cleanup() {
-    @fs.rmdir(dir, recursive=true) catch {
-      error if @async.is_being_cancelled() => raise error
-      _ => ()
-    }
-  }
-  defer cleanup()
+  defer git_test_cleanup(dir)
   git_test_run(dir, ["init", "--quiet"])
   @fs.write_file("\{dir}/tracked.txt", "first\n", create_mode=CreateOrTruncate)
   git_test_run(dir, ["add", "tracked.txt"])
@@ -2147,13 +2127,7 @@ async test "Git recognizes only origin HEAD's branch as the default" {
 ///|
 async test "ordinary checkout reviews retain committed branch changes" {
   let dir = @fs.tmpdir(prefix="openseek-git-root-review-")
-  async fn cleanup() {
-    @fs.rmdir(dir, recursive=true) catch {
-      error if @async.is_being_cancelled() => raise error
-      _ => ()
-    }
-  }
-  defer cleanup()
+  defer git_test_cleanup(dir)
   git_test_run(dir, ["init", "--quiet"])
   @fs.write_file("\{dir}/review.txt", "first\n", create_mode=CreateOrTruncate)
   git_test_run(dir, ["add", "review.txt"])
@@ -2201,13 +2175,7 @@ async test "ordinary checkout reviews retain committed branch changes" {
 ///|
 async test "Git snapshots pair status with HEAD and supplied revisions stay pinned" {
   let dir = @fs.tmpdir(prefix="openseek-git-review-")
-  async fn cleanup() {
-    @fs.rmdir(dir, recursive=true) catch {
-      error if @async.is_being_cancelled() => raise error
-      _ => ()
-    }
-  }
-  defer cleanup()
+  defer git_test_cleanup(dir)
   git_test_run(dir, ["init", "--quiet"])
   assert_eq(git_revision_commit(dir, "HEAD"), None)
   @fs.mkdir("\{dir}/desktop", recursive=true)

--- a/desktop/internal/host/language_path.mbt
+++ b/desktop/internal/host/language_path.mbt
@@ -105,6 +105,24 @@ async fn LanguagePath::resolve(
 }
 
 ///|
+/// Whether `LanguagePath::resolve` refuses this root/path pair at all: the
+/// test only cares that the escape is rejected, not by which error.
+async fn resolve_rejected(
+  session : String,
+  root : String,
+  path : String,
+) -> Bool {
+  try {
+    ignore(LanguagePath::resolve(session, root, path))
+    false
+  } catch {
+    _ => true
+  } noraise {
+    rejected => rejected
+  }
+}
+
+///|
 async test "language paths accept frontend resource roots and reject escapes" {
   let root = @fs.tmpdir(prefix="openseek-language-root-")
   let outside = @fs.tmpdir(prefix="openseek-language-outside-")
@@ -127,38 +145,19 @@ async test "language paths accept frontend resource roots and reject escapes" {
     root_absolute.to_uri_path() is Some(root_resource) else {
     fail("test root could not be represented as a frontend resource")
   }
-  let unauthorized_rejected = try {
-    ignore(LanguagePath::resolve("unbound", root_resource, "src/main.mbt"))
-    false
-  } catch {
-    _ => true
-  } noraise {
-    rejected => rejected
-  }
+  let unauthorized_rejected = resolve_rejected(
+    "unbound", root_resource, "src/main.mbt",
+  )
   @work_dir.authorize_host_workspace("language-test", root)
   let resolved = LanguagePath::resolve(
     "language-test", root_resource, "src/main.mbt",
   )
-  let traversal_rejected = try {
-    ignore(
-      LanguagePath::resolve("language-test", root_resource, "../outside.mbt"),
-    )
-    false
-  } catch {
-    _ => true
-  } noraise {
-    rejected => rejected
-  }
-  let symlink_rejected = try {
-    ignore(
-      LanguagePath::resolve("language-test", root_resource, "src/link.mbt"),
-    )
-    false
-  } catch {
-    _ => true
-  } noraise {
-    rejected => rejected
-  }
+  let traversal_rejected = resolve_rejected(
+    "language-test", root_resource, "../outside.mbt",
+  )
+  let symlink_rejected = resolve_rejected(
+    "language-test", root_resource, "src/link.mbt",
+  )
   assert_eq(resolved.physical_relative, Relative("src/main.mbt"))
   assert_true(unauthorized_rejected)
   assert_true(traversal_rejected)

--- a/desktop/internal/host/text_search.mbt
+++ b/desktop/internal/host/text_search.mbt
@@ -264,14 +264,9 @@ async fn TextSearchService::run(self : TextSearchService) -> Unit {
 /// VS Code's Search view uses `splitGlobAware` rather than a glob parser: only
 /// commas outside brace alternatives and character classes split the input.
 fn split_text_search_globs(value : String) -> Array[String] {
-  let globs : Array[String] = []
-  for part in split_text_search_glob_aware(value, ',') {
-    let glob = part.trim().to_owned()
-    if !glob.is_empty() {
-      globs.push(glob)
-    }
-  }
-  globs
+  split_text_search_glob_aware(value, ',')
+  .map(part => part.trim().to_owned())
+  .filter(glob => !glob.is_empty())
 }
 
 ///|


### PR DESCRIPTION
A pure **simplification** pass: no feature, no fix, no behaviour change. Part of a project-wide sweep; each PR is one package family so it can be reviewed on its own.

Candidates came from a read-only survey of the whole repository. The author was told to drop any that would not compile or would change behaviour, so this branch carries fewer than were proposed: **11 applied, 0 dropped, net -191 lines.**

## Applied

- **desktop/internal/engine/follower.mbt** — 15 identical ensure_follower spawn blocks in follower tests collapse to one helper
  Applied to all 15 sites. Renamed the proposed helper spawn_test_follower -> install_test_follower: nothing is spawned, and follower_test_config's own doc comment says the engine path is never created. Signature kept as proposed (async fn[G], positional engine/session/root, labelled sink~/group~/manager~). The site at old line 749 sits inside a try/catch; the helper still raises, so the refusal capture is unchanged.
- **desktop/internal/engine/ops.mbt** — Seven byte-identical update_settings custom-provider blocks in ops tests
  Applied as configure_custom_provider. 7 sites in ops.mbt as the finding said, plus an 8th byte-identical copy in worktree_seam_wbtest.mbt (same package) so no verbatim copy is left behind.
- **desktop/internal/engine/ops.mbt** — Eight start_run payload literals differ only in task/session/workspace
  Applied as test_start_payload, 8 sites in ops.mbt plus the 9th in worktree_seam_wbtest.mbt that the finding's own evidence names. Deviation: session and workspace are LABELLED (session~ : String, workspace~ : String), not positional as proposed - three bare Strings in a row would let a caller silently transpose the conversation and its workspace. Punned call sites read test_start_payload("retry", session~, workspace~); the one site with a client id passes submission_id="submission-start".
- **desktop/internal/engine/ops.mbt** — Seven copies of "spawn the actor, wait for its pump" in ops run tests
  Applied as serve_until_pumping, 7 sites in ops.mbt plus the equivalent copy in worktree_seam_wbtest.mbt (which spelled the callback fn(_) {  } instead of fn(_) { () } - same thing). manager is passed explicitly rather than re-derived from actor.manager(), so the equivalence is visible without knowing what that accessor returns.
- **desktop/internal/host/git_ops.mbt** — Five identical local `async fn cleanup()` tmpdir removers in git_ops tests
  Applied as git_test_cleanup(dir), placed next to git_test_run. All five `defer cleanup()` became `defer git_test_cleanup(dir)`, including the two inside a `let _ = { ... }` block.
- **desktop/internal/engine/archive_lookup_wbtest.mbt** — Four identical archive_session refusal-capture blocks in one test file
  Applied as archive_refusal(manager, session), 4 sites. The fifth block (load_session at old line 141) was left alone as the finding said. Helper carries the same #cfg(not(platform="windows")) guard as all four tests.
- **desktop/internal/host/language_path.mbt** — Three identical LanguagePath::resolve rejection probes in one test
  Applied as resolve_rejected(session, root, path), 3 sites. Positional args kept here because they mirror LanguagePath::resolve's own argument order exactly. No cfg guard, matching the unguarded test.
- **desktop/internal/host/git_ops.mbt** — git_output_opt and git_output re-spell git_collect's spawn instead of calling it
  Applied to both functions. Equivalence rests on the error arms: git_collect re-raises cancellation (so both callers' `error if @async.is_being_cancelled() => raise error` arm still sees the original error) and turns anything else into HostError, which both callers already discard via `_ => return None` / `_ => return ""`. Success returns the identical tuple. This is the only production-code hot path in the commit.
- **desktop/internal/engine/archive.mbt** — Claim/guard reverse release written twice in archive.mbt
  Applied as release_family_claims(manager, claims, guards). Both sites (SessionFamilyMove::release and the rollback `defer` in claim_session_family_move) had byte-identical bodies modulo self. Parameter types are all distinct, so the positional call is unambiguous. Production code, on a rollback path.
- **desktop/internal/host/text_search.mbt** — split_text_search_globs is a map+filter over the glob-aware split
  Applied as proposed. The explanatory comment above the function (VS Code splitGlobAware) is kept verbatim - it describes the function, not the loop.
- **desktop/internal/engine/follower.mbt** — Manual push loop selecting this session's commits is Array::filter
  Applied. moon fmt settled on a block-bodied lambda: emitted.filter(event => { event is SessionCommit(payload) && payload.session == session }). The explicit Array[EngineEvent] annotation was dropped rather than carried over, since `unnecessary_annotation` is in this package's warning set.

## Verification

Both touched packages are native-only (supported_targets = "+native" in desktop/internal/engine/moon.pkg and desktop/internal/host/moon.pkg), so everything below ran on the default native target. No js or wasm target applies.

TESTS, before and after (identical):
- BEFORE `moon test desktop/internal/engine desktop/internal/host` -> "Total tests: 221, passed: 221, failed: 0."
- BEFORE `moon test desktop/internal/engine` -> 111 passed, 0 failed
- BEFORE `moon test desktop/internal/host`   -> 110 passed, 0 failed
- AFTER  `moon test desktop/internal/engine` -> 111 passed, 0 failed
- AFTER  `moon test desktop/internal/host`   -> 110 passed, 0 failed

ASSERTION / ROW COUNTS: not applicable to any finding here, and I want to be exact about why. Despite the "dedupe-test" category, none of these are table collapses: no test was deleted, no two tests were merged, and no assertion was removed, reworded or made anonymous. Every change lifted *fixture construction* (provider setup, actor/pump startup, payload literal, tmpdir cleanup, a refusal capture) out of tests that each keep their own body and their own assertions. Hence the test counts above are identical rather than reduced, and there is no "N assertions before, N rows after" to state. The one shape that could have hurt diagnosability - archive_refusal collapsing four capture blocks - keeps each caller's own debug_inspect on the returned string, so a failure still names its own test and its own expected refusal.

FORMAT:
- `moon fmt` (ran 1740 tasks), then `moon fmt --check` -> "Finished. moon: ran 1740 tasks, now up to date", clean.

CHECK, deny-warn:
- `moon check desktop/internal/engine desktop/internal/host --deny-warn` -> "Finished. moon: ran 106 tasks, now up to date". Clean on the first attempt; no warning had to be worked around.
- Additionally, because git_ops/archive changes are production code, I checked every package that imports engine or host: `moon check desktop desktop/internal/extension desktop/internal/api desktop/internal/remote --deny-warn` -> "Finished. moon: ran 119 tasks, now up to date", clean.

MOON INFO (scoped, never bare):
- `moon info desktop/internal/engine desktop/internal/host` -> "Finished. moon: ran 104 tasks". Both packages DO have tracked pkg.generated.mbti files, and `git status --short` immediately afterwards still listed exactly the same 8 modified .mbt files and nothing else - i.e. both desktop/internal/engine/pkg.generated.mbti and desktop/internal/host/pkg.generated.mbti came back byte-identical. No public interface moved, so nothing had to be reverted on that ground.

GIT:
- `git status --short` before starting: empty; branch confirmed simplify/de-engine.
- Staged by explicit path (8 files, no `git add -A`); `git status --short` showed only those 8.
- Commit 4dbe7518c, 266 insertions / 457 deletions.
- `git push -u origin simplify/de-engine` -> new branch created, tracking set. Working tree clean afterwards. No PR opened, no merge, no other branch touched.

WORKAROUND WORTH DISCLOSING: I applied the edits with a throwaway Python script (scratchpad/apply.py) that asserts an exact match count for every substitution and aborts otherwise. It aborted twice and I reset the worktree with `git checkout -- .` and re-ran from clean each time: (1) the first version inserted each shared helper before rewriting the call sites, so the helper's own body counted as a 16th duplicate; (2) the start_run payload regex missed 6 of 8 sites because those literals use field punning (`session,` not `session: session,`). Both were script bugs, not source ambiguities - the third run reported the exact expected counts for all 23 substitutions (15/7/7/8/1/1/1/4/5/5/3/2/... ) before writing anything.

## Worth a second look

Three things deserve a second look.

1. git_output / git_output_opt (desktop/internal/host/git_ops.mbt) is the only PRODUCTION hot path in this commit - every Git query in the desktop host goes through it. The equivalence is entirely in the error arms, so verify it directly rather than by eye on the happy path: git_collect re-raises cancellation unchanged, so each caller's `error if @async.is_being_cancelled() => raise error` arm still receives the original error and re-raises it (cancellation is now tested twice against the same ambient task state, which cannot disagree); every other spawn failure becomes HostError inside git_collect, which both callers then discard through the arms they already had (`_ => return None`, `_ => return ""`). Net effect: identical returns, one extra discarded string allocation on a path that was already failing.

2. release_family_claims (desktop/internal/engine/archive.mbt) is production code on a rollback path. The two former bodies were byte-identical modulo self, and release order (claims reversed, then guards reversed) is preserved exactly - that ordering is the thing that matters here, so confirm the helper's two loops are in the same order as the originals.

3. SCOPE: findings 2, 3 and 4 each named ops.mbt, but each pattern had one more verbatim copy in desktop/internal/engine/worktree_seam_wbtest.mbt (same package; finding 3's evidence names it explicitly). I converted those too, so worktree_seam_wbtest.mbt appears in the diff even though no finding lists it as its `file`. If you would rather the vetted list be applied literally, that file is the one to drop - it is 35 lines of the diff and nothing else depends on it.

Minor, cosmetic: at most start_run sites `moon fmt` re-wraps `start_run(sink, manager, test_start_payload(...))` onto five lines rather than one, so the saving there is 9 lines -> 5 rather than 9 -> 1. One site (former line 1188, the `.run_id` chain) keeps the odd 8-space continuation indent it already had; that is fmt's own output and `moon fmt --check` is clean on it.

No finding was dropped, which is worth a skeptical pass in itself: all eleven were mechanical extractions whose `current` snippets still matched the source exactly, and the compiler accepted every helper on the first attempt with deny-warn on. The single riskiest judgement call is the labelled-argument deviation in test_start_payload (finding 3, the one the surveyor rated medium) - I chose session~/workspace~ over the proposed positional Strings specifically so a transposed session/workspace pair cannot compile.

Reviewed by OpenSeek's own review subagent (DeepSeek Flash); its verdict is posted as a comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXBYcYo74F1DGSPZsYYAdc
