### PR TITLE
refactor: desktop/internal services: reuse stdlib and share decode helpers

### DIFF
--- a/desktop/internal/api/api.mbt
+++ b/desktop/internal/api/api.mbt
@@ -176,10 +176,7 @@ fn CodexWorktreeCatalog::annotate_thread(
     is Some(binding) else {
     return value
   }
-  let annotated : Map[String, Json] = Map([])
-  for key, field in thread {
-    annotated[key] = field
-  }
+  let annotated = thread.copy()
   // The registry retains the owning project even after its checkout is gone;
   // Git cannot recover that relationship from a deleted cwd.
   annotated["projectRoot"] = Json(binding.workspace)
@@ -193,16 +190,11 @@ fn CodexWorktreeCatalog::annotate(
   reply : Json,
 ) -> Json {
   guard reply is Object(fields) else { return reply }
-  let annotated : Map[String, Json] = Map([])
-  for key, field in fields {
-    annotated[key] = field
-  }
+  let annotated = fields.copy()
   if fields.get("data") is Some(Array(threads)) {
-    let data : Array[Json] = []
-    for thread in threads {
-      data.push(self.annotate_thread(thread))
-    }
-    annotated["data"] = Json(data)
+    annotated["data"] = Json(
+      threads.map(thread => self.annotate_thread(thread)),
+    )
   }
   if fields.get("thread") is Some(thread) {
     annotated["thread"] = self.annotate_thread(thread)
@@ -805,15 +797,9 @@ async fn ApiState::codex_thread_history(
       _ => break
     }
   }
-  let thread : Map[String, Json] = Map([])
-  for key, value in thread_fields {
-    thread[key] = value
-  }
+  let thread = thread_fields.copy()
   thread["turns"] = Json(turns)
-  let reply : Map[String, Json] = Map([])
-  for key, value in reply_fields {
-    reply[key] = value
-  }
+  let reply = reply_fields.copy()
   reply["thread"] = Json(thread)
   @json.from_json(Json(reply))
 }
@@ -1086,10 +1072,7 @@ async fn ApiState::codex_request(
     // Preserve the caller's source filter (or Codex's interactive default)
     // instead of hiding threads that OpenSeek itself just created.
     ("codex.thread.list", Object(fields)) => {
-      let scoped : Map[String, Json] = Map([])
-      for key, value in fields {
-        scoped[key] = value
-      }
+      let scoped = fields.copy()
       // JSONL scan-and-repair can exceed the Proton request deadline on a
       // long-lived Codex home. The Desktop catalog is an interactive state
       // query, so read the app-server state database without that repair pass.
@@ -1100,10 +1083,7 @@ async fn ApiState::codex_request(
     // The dedicated thread/start endpoint has already reduced this object to
     // cwd, model, and Desktop's fixed service name.
     ("codex.thread.start", Object(fields)) => {
-      let scoped : Map[String, Json] = Map([])
-      for key, value in fields {
-        scoped[key] = value
-      }
+      let scoped = fields.copy()
       scoped["serviceName"] = "openseek_desktop"
       Json(scoped)
     }

--- a/desktop/internal/api/hub.mbt
+++ b/desktop/internal/api/hub.mbt
@@ -174,15 +174,9 @@ fn Hub::track_approval(
 ///|
 /// Drop every question belonging to `run_id`.
 fn Hub::forget_run_approvals(self : Hub, run_id : String) -> Unit {
-  let doomed : Array[String] = []
-  for session, approval in self.pending_approvals {
-    if approval.run_id is Some(owner) && owner == run_id {
-      doomed.push(session)
-    }
-  }
-  for session in doomed {
-    self.pending_approvals.remove(session)
-  }
+  self.pending_approvals.retain((_, approval) => {
+    !(approval.run_id is Some(owner) && owner == run_id)
+  })
 }
 
 ///|
@@ -204,10 +198,7 @@ fn Hub::runs(
   self : Hub,
   known? : Array[KnownRunPayload],
 ) -> @protocol.RunsReply {
-  let runs : Array[@protocol.StartedPayload] = []
-  for _, payload in self.active_starts {
-    runs.push(payload)
-  }
+  let runs = self.active_starts.values().to_array()
   let settled : Array[@protocol.RunSettlementPayload] = []
   if known is Some(selectors) {
     for _, settlement in self.settlements {
@@ -220,10 +211,7 @@ fn Hub::runs(
   // client only wants for runs it owns, while a standing question is a turn
   // stopped RIGHT NOW that anyone looking at that session should be able to
   // answer.
-  let approvals : Array[@protocol.PendingApprovalPayload] = []
-  for _, approval in self.pending_approvals {
-    approvals.push(approval)
-  }
+  let approvals = self.pending_approvals.values().to_array()
   { runs, settled, approvals, }
 }
 

--- a/desktop/internal/auth/auth_wbtest.mbt
+++ b/desktop/internal/auth/auth_wbtest.mbt
@@ -3,6 +3,20 @@
 // signin.mbt is built from.
 
 ///|
+/// The one signed-in session every codec and store test below uses. The avatar
+/// is the only field any of them varies, so it stays an explicit argument.
+fn sample_session(avatar~ : String) -> AuthSession {
+  {
+    server_url: "https://relay.example",
+    device_token: "odt_secret",
+    device_id: "d_abc",
+    device_name: "My Mac",
+    user_login: "octocat",
+    user_avatar_url: avatar,
+  }
+}
+
+///|
 test "pkce challenge is the verifier's unpadded base64url sha256" {
   // Cross-checked against RFC 7636 S256 (python:
   // urlsafe_b64encode(sha256(b"test-verifier")).rstrip("=")) — and against
@@ -86,14 +100,7 @@ test "url derivations" {
 
 ///|
 test "auth.json codec round-trips and reads corruption as signed out" {
-  let session : AuthSession = {
-    server_url: "https://relay.example",
-    device_token: "odt_secret",
-    device_id: "d_abc",
-    device_name: "My Mac",
-    user_login: "octocat",
-    user_avatar_url: "https://avatars.example/1",
-  }
+  let session = sample_session(avatar="https://avatars.example/1")
   let json = session_to_json(session)
   guard session_from_json(json) is Some(reloaded) else {
     fail("round-trip lost the session")
@@ -108,14 +115,7 @@ test "auth.json codec round-trips and reads corruption as signed out" {
 async test "auth.json persists 0600 and deletes cleanly" {
   let dir : @pathx.Path = Path(@fs.tmpdir(prefix="openseek-auth-"))
   let body = async fn() {
-    let session : AuthSession = {
-      server_url: "https://relay.example",
-      device_token: "odt_secret",
-      device_id: "d_abc",
-      device_name: "My Mac",
-      user_login: "octocat",
-      user_avatar_url: "",
-    }
+    let session = sample_session(avatar="")
     save_session_file(dir, session)
     guard load_session_file(dir) is Some(reloaded) else {
       fail("persisted session did not load")
@@ -130,14 +130,7 @@ async test "auth.json persists 0600 and deletes cleanly" {
 
 ///|
 async test "session commit persists before memory and wakes each local transition" {
-  let session : AuthSession = {
-    server_url: "https://relay.example",
-    device_token: "odt_secret",
-    device_id: "d_abc",
-    device_name: "My Mac",
-    user_login: "octocat",
-    user_avatar_url: "",
-  }
+  let session = sample_session(avatar="")
   let store = AuthStore::empty()
   store.commit_session(session)
   assert_true(store.session_server() is Some("https://relay.example"))
@@ -178,14 +171,7 @@ test "store transitions dedup their auth.changed edges" {
   let store = AuthStore::empty()
   assert_true(store.desired_connector() is None)
   // Signed-in session drives the connector config.
-  store.session = Some({
-    server_url: "https://relay.example",
-    device_token: "odt_secret",
-    device_id: "d_abc",
-    device_name: "My Mac",
-    user_login: "octocat",
-    user_avatar_url: "",
-  })
+  store.session = Some(sample_session(avatar=""))
   guard store.desired_connector() is Some(config) else {
     fail("signed-in store offered no connector config")
   }
@@ -200,14 +186,7 @@ test "store transitions dedup their auth.changed edges" {
 ///|
 async test "a terminal refusal clears a session but only parks an override" {
   let store = AuthStore::empty()
-  store.session = Some({
-    server_url: "https://relay.example",
-    device_token: "odt_secret",
-    device_id: "d_abc",
-    device_name: "My Mac",
-    user_login: "octocat",
-    user_avatar_url: "",
-  })
+  store.session = Some(sample_session(avatar=""))
   store.connected = true
   store.handle_refusal()
   assert_true(store.session is None)
@@ -246,14 +225,7 @@ test "status shapes" {
   let configured = store.status(server_url="https://relay.example")
   assert_false(configured.connected)
   assert_eq(configured.server_url, Some("https://relay.example"))
-  store.session = Some({
-    server_url: "https://relay.example",
-    device_token: "odt_secret",
-    device_id: "d_abc",
-    device_name: "My Mac",
-    user_login: "octocat",
-    user_avatar_url: "https://avatars.example/1",
-  })
+  store.session = Some(sample_session(avatar="https://avatars.example/1"))
   store.connected = true
   let status = store.status()
   assert_true(status.connected)

--- a/desktop/internal/codex/project_catalog.mbt
+++ b/desktop/internal/codex/project_catalog.mbt
@@ -109,10 +109,7 @@ async fn ProjectCatalog::annotate_thread(
   value : Json,
 ) -> Json {
   guard value is Object(thread) else { return value }
-  let annotated : Map[String, Json] = Map([])
-  for key, field in thread {
-    annotated[key] = field
-  }
+  let annotated = thread.copy()
   if thread.get("cwd") is Some(String(cwd)) &&
     !cwd.trim().is_empty() &&
     self.resolve(cwd) is Some(project) {
@@ -132,10 +129,7 @@ pub async fn ProjectCatalog::annotate(
   reply : Json,
 ) -> Json {
   guard reply is Object(fields) else { return reply }
-  let annotated : Map[String, Json] = Map([])
-  for key, field in fields {
-    annotated[key] = field
-  }
+  let annotated = fields.copy()
   if fields.get("data") is Some(Array(threads)) {
     let data : Array[Json] = []
     for thread in threads {

--- a/desktop/internal/extension/external_link.mbt
+++ b/desktop/internal/extension/external_link.mbt
@@ -19,15 +19,9 @@ impl Show for OpenExternalError with fn output(self, logger) {
 /// lowercase allowlist is both sufficient and intentionally rejects every
 /// local, app-owned, executable, or otherwise unknown scheme.
 fn allowed_external_url(url : String) -> Bool {
-  if url.strip_prefix("https://") is Some(rest) {
-    !rest.is_empty()
-  } else if url.strip_prefix("http://") is Some(rest) {
-    !rest.is_empty()
-  } else if url.strip_prefix("mailto:") is Some(rest) {
-    !rest.is_empty()
-  } else {
-    false
-  }
+  ["https://", "http://", "mailto:"].any(scheme => {
+    url.strip_prefix(scheme) is Some(rest) && !rest.is_empty()
+  })
 }
 
 ///|

--- a/desktop/internal/moonbit/moonbit_toolchain.mbt
+++ b/desktop/internal/moonbit/moonbit_toolchain.mbt
@@ -212,9 +212,6 @@ async test "prepared payload dir accepts existing toolchain root" {
     seed_dir=runtime.join("seed").join("macos-arm64").resolve(),
     runtime_dir=runtime,
   )
-  let actual = match result {
-    Some(path) => path.to_string()
-    None => "<none>"
-  }
+  let actual = result.map(path => path.to_string()).unwrap_or("<none>")
   assert_eq(actual, expected)
 }

--- a/desktop/internal/pathx/pathx_test.mbt
+++ b/desktop/internal/pathx/pathx_test.mbt
@@ -1,26 +1,26 @@
 ///|
+/// A host-absolute fixture spelling, failing the test when this host does not
+/// classify it as absolute. `loc` is autofilled so the report names the call
+/// site rather than this helper.
+#callsite(autofill(loc))
+fn absolute_fixture(text : String, loc~ : SourceLoc) -> @pathx.Absolute raise {
+  guard @pathx.Path(text).to_absolute() is Some(absolute) else {
+    fail("test fixture \{text} was not absolute", loc~)
+  }
+  absolute
+}
+
+///|
 #cfg(not(platform="windows"))
 test "contains normalizes POSIX paths before comparing them" {
-  guard @pathx.Path("/ws/proj").to_absolute() is Some(root) else {
-    fail("test root was not absolute")
-  }
-  guard @pathx.Path("/ws/proj/tmp/../src/a.mbt").to_absolute() is Some(file) else {
-    fail("test file was not absolute")
-  }
-  guard @pathx.Path("/ws/project/a.mbt").to_absolute() is Some(sibling) else {
-    fail("test sibling was not absolute")
-  }
+  let root = absolute_fixture("/ws/proj")
+  let file = absolute_fixture("/ws/proj/tmp/../src/a.mbt")
+  let sibling = absolute_fixture("/ws/project/a.mbt")
   assert_true(root.contains(file))
   assert_true(root.contains(root))
   assert_false(root.contains(sibling))
-  guard @pathx.Path("/ws/proj/dir\\name/a.mbt").to_absolute()
-    is Some(backslash_name) else {
-    fail("test backslash filename was not absolute")
-  }
-  guard @pathx.Path("/ws/proj/dir/name/a.mbt").to_absolute()
-    is Some(nested_name) else {
-    fail("test nested name was not absolute")
-  }
+  let backslash_name = absolute_fixture("/ws/proj/dir\\name/a.mbt")
+  let nested_name = absolute_fixture("/ws/proj/dir/name/a.mbt")
   assert_true(root.contains(backslash_name))
   assert_false(backslash_name.contains(nested_name))
 }
@@ -28,16 +28,9 @@ test "contains normalizes POSIX paths before comparing them" {
 ///|
 #cfg(platform="windows")
 test "contains normalizes Windows paths before comparing them" {
-  guard @pathx.Path("C:\\ws\\proj").to_absolute() is Some(root) else {
-    fail("test root was not absolute")
-  }
-  guard @pathx.Path("C:\\ws\\proj\\tmp\\..\\src\\a.mbt").to_absolute()
-    is Some(file) else {
-    fail("test file was not absolute")
-  }
-  guard @pathx.Path("C:/ws/project/a.mbt").to_absolute() is Some(sibling) else {
-    fail("test sibling was not absolute")
-  }
+  let root = absolute_fixture("C:\\ws\\proj")
+  let file = absolute_fixture("C:\\ws\\proj\\tmp\\..\\src\\a.mbt")
+  let sibling = absolute_fixture("C:/ws/project/a.mbt")
   assert_true(root.contains(file))
   assert_true(root.contains(root))
   assert_false(root.contains(sibling))
@@ -106,9 +99,7 @@ test "Path::resolve returns a host-absolute path" {
 ///|
 #cfg(not(platform="windows"))
 test "Absolute::relative_to normalizes POSIX paths" {
-  guard @pathx.Path("/ws").to_absolute() is Some(root) else {
-    fail("test root was not absolute")
-  }
+  let root = absolute_fixture("/ws")
   assert_true(
     @pathx.Path("/ws/tmp/../src/a.mbt").to_absolute() is Some(path) &&
     path.relative_to(root~) == Some(Relative("src/a.mbt")),
@@ -128,9 +119,7 @@ test "Absolute::relative_to normalizes POSIX paths" {
     path.relative_to(root~) is None,
   )
   // A trailing slash on the root reads the same as none.
-  guard @pathx.Path("/ws/").to_absolute() is Some(root_with_slash) else {
-    fail("test root with slash was not absolute")
-  }
+  let root_with_slash = absolute_fixture("/ws/")
   assert_true(
     @pathx.Path("/ws/a.mbt").to_absolute() is Some(path) &&
     path.relative_to(root=root_with_slash) == Some(Relative("a.mbt")),
@@ -140,9 +129,7 @@ test "Absolute::relative_to normalizes POSIX paths" {
 ///|
 #cfg(platform="windows")
 test "Absolute::relative_to normalizes Windows paths" {
-  guard @pathx.Path("C:\\ws").to_absolute() is Some(root) else {
-    fail("test root was not absolute")
-  }
+  let root = absolute_fixture("C:\\ws")
   assert_true(
     @pathx.Path("C:\\ws\\tmp\\..\\src\\a.mbt").to_absolute() is Some(path) &&
     path.relative_to(root~) == Some(Relative("src/a.mbt")),
@@ -192,13 +179,9 @@ test "normalize uses POSIX host rules" {
     @pathx.Relative("dir\\name/./file").normalize() ==
     Relative("dir\\name/file"),
   )
-  guard @pathx.Path("/a/./b/../c").to_absolute() is Some(absolute) else {
-    fail("test path was not absolute")
-  }
+  let absolute = absolute_fixture("/a/./b/../c")
   assert_true(absolute.normalize() is Absolute("/a/c"))
-  guard @pathx.Path("/dir\\name/./file").to_absolute() is Some(backslash_name) else {
-    fail("test backslash filename was not absolute")
-  }
+  let backslash_name = absolute_fixture("/dir\\name/./file")
   assert_true(backslash_name.normalize() is Absolute("/dir\\name/file"))
 }
 
@@ -210,9 +193,7 @@ test "normalize uses Windows host rules and typed paths use forward slashes" {
     @pathx.Relative("src\\tmp\\..\\main.mbt").normalize() ==
     Relative("src/main.mbt"),
   )
-  guard @pathx.Path("C:\\a\\.\\b\\..\\c").to_absolute() is Some(absolute) else {
-    fail("test path was not absolute")
-  }
+  let absolute = absolute_fixture("C:\\a\\.\\b\\..\\c")
   assert_true(absolute.normalize() is Absolute("C:/a/c"))
 }
 
@@ -220,9 +201,7 @@ test "normalize uses Windows host rules and typed paths use forward slashes" {
 #cfg(not(platform="windows"))
 test "other host path operations keep POSIX spellings" {
   assert_eq(@pathx.Path("a").join(Relative("b")).0, "a/b")
-  guard @pathx.Path("/a").to_absolute() is Some(root) else {
-    fail("test root was not absolute")
-  }
+  let root = absolute_fixture("/a")
   assert_true(root.join(Relative("b/../c")) is Absolute("/a/c"))
   assert_eq(@pathx.Path("a/b.txt").dirname().0, "a")
   assert_eq(@pathx.Path("a/b.txt").basename().to_owned(), "b.txt")
@@ -233,9 +212,7 @@ test "other host path operations keep POSIX spellings" {
 #cfg(platform="windows")
 test "other host path operations keep Windows spellings" {
   assert_eq(@pathx.Path("a").join(Relative("b")).0, "a\\b")
-  guard @pathx.Path("C:\\a").to_absolute() is Some(root) else {
-    fail("test root was not absolute")
-  }
+  let root = absolute_fixture("C:\\a")
   assert_true(root.join(Relative("b/../c")) is Absolute("C:\\a\\c"))
   assert_eq(@pathx.Path("a\\b.txt").dirname().0, "a")
   assert_eq(@pathx.Path("a\\b.txt").basename().to_owned(), "b.txt")
@@ -245,9 +222,7 @@ test "other host path operations keep Windows spellings" {
 ///|
 #cfg(not(platform="windows"))
 test "POSIX absolute paths round-trip through URI paths" {
-  guard @pathx.Path("/work/a b/#file.mbt").to_absolute() is Some(absolute) else {
-    fail("expected an absolute POSIX fixture")
-  }
+  let absolute = absolute_fixture("/work/a b/#file.mbt")
   assert_eq(absolute.to_uri_path(), Some("/work/a b/#file.mbt"))
   assert_eq(
     @pathx.Absolute::from_uri_path("/work/a b/#file.mbt"),
@@ -258,9 +233,7 @@ test "POSIX absolute paths round-trip through URI paths" {
 ///|
 #cfg(not(platform="windows"))
 test "resource URI conversion rejects double-rooted POSIX paths" {
-  guard @pathx.Path("//server/share/a.mbt").to_absolute() is Some(absolute) else {
-    fail("expected an absolute POSIX fixture")
-  }
+  let absolute = absolute_fixture("//server/share/a.mbt")
   assert_true(absolute.to_uri_path() is None)
   assert_true(@pathx.Absolute::from_uri_path("//server/share/a.mbt") is None)
 }
@@ -268,9 +241,7 @@ test "resource URI conversion rejects double-rooted POSIX paths" {
 ///|
 #cfg(platform="windows")
 test "Windows drive paths round-trip through URI paths" {
-  guard @pathx.Path("C:\\work\\a b\\#file.mbt").to_absolute() is Some(absolute) else {
-    fail("expected an absolute Windows fixture")
-  }
+  let absolute = absolute_fixture("C:\\work\\a b\\#file.mbt")
   assert_eq(absolute.to_uri_path(), Some("/C:/work/a b/#file.mbt"))
   assert_true(
     @pathx.Absolute::from_uri_path("/C:/work/a b/#file.mbt") is Some(decoded) &&
@@ -282,10 +253,7 @@ test "Windows drive paths round-trip through URI paths" {
 #cfg(platform="windows")
 test "resource URI conversion rejects UNC and root-relative Windows paths" {
   for path in ["\\\\server\\share\\a.mbt", "\\rooted\\a.mbt"] {
-    guard @pathx.Path(path).to_absolute() is Some(absolute) else {
-      fail("expected an absolute Windows fixture")
-    }
-    assert_true(absolute.to_uri_path() is None)
+    assert_true(absolute_fixture(path).to_uri_path() is None)
   }
   assert_true(@pathx.Absolute::from_uri_path("//server/share/a.mbt") is None)
   assert_true(@pathx.Absolute::from_uri_path("/rooted/a.mbt") is None)

--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -986,22 +986,10 @@ pub impl FromJson for AgentErrorPayload with fn from_json(json, path) {
     raise JsonDecodeError((path, "expected agent error payload"))
   }
   {
-    run_id: match fields.get("run_id") {
-      Some(String(value)) => Some(value)
-      _ => None
-    },
-    message: match fields.get("message") {
-      Some(String(value)) => Some(value)
-      _ => None
-    },
-    exit_code: match fields.get("exit_code") {
-      Some(Number(value, ..)) => Some(value.to_int())
-      _ => None
-    },
-    diagnostics: match fields.get("diagnostics") {
-      Some(String(value)) => Some(value)
-      _ => None
-    },
+    run_id: lenient_string(fields, "run_id"),
+    message: lenient_string(fields, "message"),
+    exit_code: lenient_int(fields, "exit_code"),
+    diagnostics: lenient_string(fields, "diagnostics"),
   }
 }
 
@@ -1046,14 +1034,8 @@ pub impl FromJson for FinishedPayload with fn from_json(json, path) {
   {
     run_id,
     status,
-    answer: match fields.get("answer") {
-      Some(String(value)) => Some(value)
-      _ => None
-    },
-    exit_code: match fields.get("exit_code") {
-      Some(Number(value, ..)) => Some(value.to_int())
-      _ => None
-    },
+    answer: lenient_string(fields, "answer"),
+    exit_code: lenient_int(fields, "exit_code"),
   }
 }
 

--- a/desktop/internal/protocol/desktop_replies.mbt
+++ b/desktop/internal/protocol/desktop_replies.mbt
@@ -192,14 +192,8 @@ pub impl FromJson for RunSettlementPayload with fn from_json(json, path) {
     run_id,
     session,
     status,
-    submission_id: match fields.get("submission_id") {
-      Some(String(value)) => Some(value)
-      _ => None
-    },
-    exit_code: match fields.get("exit_code") {
-      Some(Number(value, ..)) => Some(value.to_int())
-      _ => None
-    },
+    submission_id: lenient_string(fields, "submission_id"),
+    exit_code: lenient_int(fields, "exit_code"),
   }
 }
 
@@ -1513,12 +1507,7 @@ pub impl ToJson for StatFilesReply with fn to_json(self) {
 ///|
 pub impl FromJson for StatFilesReply with fn from_json(json, path) {
   let object = JsonObject::decode(json, path, "stat files reply")
-  let stats : Array[FileStat] = []
-  for index, raw in object.required_array("stats") {
-    stats.push(
-      @json.from_json(raw, path=path.add_key("stats").add_index(index)),
-    )
-  }
+  let stats : Array[FileStat] = object.required_array_of("stats")
   { stats, }
 }
 

--- a/desktop/internal/protocol/desktop_replies_test.mbt
+++ b/desktop/internal/protocol/desktop_replies_test.mbt
@@ -1,4 +1,16 @@
 ///|
+/// True when `decode` refuses its input. Every rejection assertion below is
+/// this shape; only the payload type and the JSON literal differ, so the
+/// try/catch/noraise scaffold lives here once.
+fn refused(decode : () -> Unit raise) -> Bool {
+  try decode() catch {
+    _ => true
+  } noraise {
+    _ => false
+  }
+}
+
+///|
 test "session list rows decode activity stamps and tolerate the engine's null" {
   let rows = @protocol.SessionListEntry::array_from_wire([
     { "id": "desktop-a", "title": "stamped", "updated_at_ms": 1500.0 },
@@ -440,38 +452,26 @@ test "worktree creation accepts exactly representable owner namespaces" {
     "futureMetadata": true,
   })
   assert_eq(nullable, codex)
-  let both_rejected = try {
+  let both_rejected = refused(() => {
     let _ : @protocol.WorktreeCreatePayload = @json.from_json({
       "workspace": "/work/project",
       "session": "session-1",
       "codex_thread": "thread-1",
     })
-  } catch {
-    _ => true
-  } noraise {
-    _ => false
-  }
+  })
   assert_true(both_rejected)
-  let missing_rejected = try {
+  let missing_rejected = refused(() => {
     let _ : @protocol.WorktreeCreatePayload = @json.from_json({
       "workspace": "/work/project",
     })
-  } catch {
-    _ => true
-  } noraise {
-    _ => false
-  }
+  })
   assert_true(missing_rejected)
-  let wrong_type_rejected = try {
+  let wrong_type_rejected = refused(() => {
     let _ : @protocol.WorktreeCreatePayload = @json.from_json({
       "workspace": "/work/project",
       "session": 7,
     })
-  } catch {
-    _ => true
-  } noraise {
-    _ => false
-  }
+  })
   assert_true(wrong_type_rejected)
 }
 
@@ -632,7 +632,7 @@ test "text search payload and UTF-16 reply round-trip at the JSON boundary" {
 
 ///|
 test "text search payload rejects missing and invalid required fields" {
-  let missing_rejected = try {
+  let missing_rejected = refused(() => {
     let _ : @protocol.SearchTextPayload = @json.from_json({
       "root": "/work/project",
       "query": "moon",
@@ -644,24 +644,16 @@ test "text search payload rejects missing and invalid required fields" {
       "generation": 1,
       "max_results": 20000,
     })
-  } catch {
-    _ => true
-  } noraise {
-    _ => false
-  }
+  })
   assert_true(missing_rejected)
-  let invalid_rejected = try {
+  let invalid_rejected = refused(() => {
     let _ : @protocol.CancelSearchTextPayload = @json.from_json({
       "session_key": 7,
       "generation": 1,
     })
-  } catch {
-    _ => true
-  } noraise {
-    _ => false
-  }
+  })
   assert_true(invalid_rejected)
-  let null_rejected = try {
+  let null_rejected = refused(() => {
     let _ : @protocol.SearchTextPayload = @json.from_json({
       "root": Json::null(),
       "query": "moon",
@@ -674,13 +666,9 @@ test "text search payload rejects missing and invalid required fields" {
       "generation": 1,
       "max_results": 20000,
     })
-  } catch {
-    _ => true
-  } noraise {
-    _ => false
-  }
+  })
   assert_true(null_rejected)
-  let half_error_rejected = try {
+  let half_error_rejected = refused(() => {
     let _ : @protocol.SearchTextReply = @json.from_json({
       "root": "/work/project",
       "generation": 1,
@@ -691,13 +679,9 @@ test "text search payload rejects missing and invalid required fields" {
       "cancelled": false,
       "error_code": "search_failed",
     })
-  } catch {
-    _ => true
-  } noraise {
-    _ => false
-  }
+  })
   assert_true(half_error_rejected)
-  let empty_error_sentinel_rejected = try {
+  let empty_error_sentinel_rejected = refused(() => {
     let _ : @protocol.SearchTextReply = @json.from_json({
       "root": "/work/project",
       "generation": 1,
@@ -709,11 +693,7 @@ test "text search payload rejects missing and invalid required fields" {
       "error_code": "",
       "error_message": "",
     })
-  } catch {
-    _ => true
-  } noraise {
-    _ => false
-  }
+  })
   assert_true(empty_error_sentinel_rejected)
 }
 
@@ -1452,13 +1432,9 @@ test "terminal input encodes and decodes exactly one data field" {
         { "id": "terminal-9", "data": null, "data_base64": null },
         { "id": "terminal-9", "data": "x", "data_base64": "eA==" },
       ] : Array[Json]) {
-    let rejected = try {
+    let rejected = refused(() => {
       let _ : @protocol.TerminalInputPayload = @json.from_json(invalid)
-    } catch {
-      _ => true
-    } noraise {
-      _ => false
-    }
+    })
     assert_true(rejected)
   }
 }

--- a/desktop/internal/protocol/git_protocol_codec.mbt
+++ b/desktop/internal/protocol/git_protocol_codec.mbt
@@ -74,10 +74,7 @@ pub impl ToJson for GitHistoryRef with fn to_json(self) {
 ///|
 pub impl FromJson for GitHistorySnapshot with fn from_json(json, path) {
   let object = JsonObject::decode(json, path, "Git history snapshot")
-  let refs : Array[GitHistoryRef] = []
-  for index, raw in object.required_array("refs") {
-    refs.push(@json.from_json(raw, path=path.add_key("refs").add_index(index)))
-  }
+  let refs : Array[GitHistoryRef] = object.required_array_of("refs")
   {
     head: object.optional_string("head"),
     branch: object.optional_string("branch"),
@@ -131,12 +128,7 @@ pub impl FromJson for GitHistoryReply with fn from_json(json, path) {
     object.required_json("snapshot"),
     path=path.add_key("snapshot"),
   )
-  let commits : Array[GitHistoryCommit] = []
-  for index, raw in object.required_array("commits") {
-    commits.push(
-      @json.from_json(raw, path=path.add_key("commits").add_index(index)),
-    )
-  }
+  let commits : Array[GitHistoryCommit] = object.required_array_of("commits")
   {
     repository: object.required_bool("repository"),
     snapshot,
@@ -182,12 +174,7 @@ pub impl ToJson for GitHistoricalChange with fn to_json(self) {
 ///|
 pub impl FromJson for GitCommitChangesReply with fn from_json(json, path) {
   let object = JsonObject::decode(json, path, "Git commit-changes reply")
-  let changes : Array[GitHistoricalChange] = []
-  for index, raw in object.required_array("changes") {
-    changes.push(
-      @json.from_json(raw, path=path.add_key("changes").add_index(index)),
-    )
-  }
+  let changes : Array[GitHistoricalChange] = object.required_array_of("changes")
   {
     commit: object.required_string("commit"),
     parent: object.optional_string("parent"),

--- a/desktop/internal/protocol/json_object.mbt
+++ b/desktop/internal/protocol/json_object.mbt
@@ -42,6 +42,25 @@ fn JsonObject::of(
 }
 
 ///|
+/// A tolerant optional read: a wrong-typed value reads as absent instead of
+/// refusing the whole payload, which is what the lifecycle readers want — a
+/// report must not disappear because one display field is malformed. The
+/// `JsonObject` readers below deliberately do the opposite and raise, so these
+/// two stay separate rather than becoming an option on them.
+fn lenient_string(fields : Map[String, Json], name : String) -> String? {
+  guard fields.get(name) is Some(String(value)) else { return None }
+  Some(value)
+}
+
+///|
+/// `lenient_string` for a JSON number, truncated the way the raising integer
+/// readers truncate.
+fn lenient_int(fields : Map[String, Json], name : String) -> Int? {
+  guard fields.get(name) is Some(Number(value, ..)) else { return None }
+  Some(value.to_int())
+}
+
+///|
 fn JsonObject::required_json(
   self : JsonObject,
   name : String,
@@ -139,6 +158,22 @@ fn JsonObject::required_array(
     raise JsonDecodeError((self.path.add_key(name), "expected array"))
   }
   values
+}
+
+///|
+/// Decode every element of the array at `name`, naming the failing index in
+/// the path — what every list-bearing Desktop reply used to spell out with its
+/// own indexed loop.
+fn[T : @json.FromJson] JsonObject::required_array_of(
+  self : JsonObject,
+  name : String,
+) -> Array[T] raise @json.JsonDecodeError {
+  let at = self.path.add_key(name)
+  let decoded : Array[T] = []
+  for index, raw in self.required_array(name) {
+    decoded.push(@json.from_json(raw, path=at.add_index(index)))
+  }
+  decoded
 }
 
 ///|

--- a/desktop/internal/protocol/pattern_repair_codec.mbt
+++ b/desktop/internal/protocol/pattern_repair_codec.mbt
@@ -1,12 +1,23 @@
 ///|
-pub impl FromJson for PatternRepairPayload with fn from_json(json, path) {
-  let object = JsonObject::decode(json, path, "pattern-repair payload")
+/// A pattern-repair generation counts forward only; both the payload and the
+/// reply refuse a negative one with the same message.
+fn required_generation(
+  object : JsonObject,
+  path : @json.JsonPath,
+) -> Int raise @json.JsonDecodeError {
   let generation = object.required_int("generation")
   if generation < 0 {
     raise JsonDecodeError(
       (path.add_key("generation"), "expected non-negative generation"),
     )
   }
+  generation
+}
+
+///|
+pub impl FromJson for PatternRepairPayload with fn from_json(json, path) {
+  let object = JsonObject::decode(json, path, "pattern-repair payload")
+  let generation = required_generation(object, path)
   {
     root: object.required_string("root"),
     pattern: object.required_string("pattern"),
@@ -34,12 +45,7 @@ pub extend PatternRepairPayload with ToJson::{to_json}
 ///|
 pub impl FromJson for PatternRepairReply with fn from_json(json, path) {
   let object = JsonObject::decode(json, path, "pattern-repair reply")
-  let generation = object.required_int("generation")
-  if generation < 0 {
-    raise JsonDecodeError(
-      (path.add_key("generation"), "expected non-negative generation"),
-    )
-  }
+  let generation = required_generation(object, path)
   {
     root: object.required_string("root"),
     generation,

--- a/desktop/internal/protocol/semantic_search_codec.mbt
+++ b/desktop/internal/protocol/semantic_search_codec.mbt
@@ -141,12 +141,9 @@ pub impl FromJson for SemanticSearchHit with fn from_json(json, path) {
     (end_line == start_line && end_column < start_column) {
     raise JsonDecodeError((path, "semantic-search hit range must be forward"))
   }
-  let context : Array[SemanticContextLine] = []
-  for index, raw in object.required_array("source_context") {
-    context.push(
-      @json.from_json(raw, path=path.add_key("source_context").add_index(index)),
-    )
-  }
+  let context : Array[SemanticContextLine] = object.required_array_of(
+    "source_context",
+  )
   let description = match object.fields.get("description") {
     Some(String(value)) => Some(value)
     Some(Null) | None => None
@@ -231,12 +228,7 @@ pub impl FromJson for SearchSemanticReply with fn from_json(json, path) {
     object.required_int("file_count"),
     path.add_key("file_count"),
   )
-  let hits : Array[SemanticSearchHit] = []
-  for index, raw in object.required_array("matches") {
-    hits.push(
-      @json.from_json(raw, path=path.add_key("matches").add_index(index)),
-    )
-  }
+  let hits : Array[SemanticSearchHit] = object.required_array_of("matches")
   let error_code = object.optional_string("error_code")
   let error_message = object.optional_string("error_message")
   let error = match (error_code, error_message) {
@@ -302,12 +294,7 @@ pub impl FromJson for SemanticSearchProgressPayload with fn from_json(
   let object = JsonObject::decode(
     json, path, "semantic-search progress payload",
   )
-  let matches : Array[SemanticSearchHit] = []
-  for index, raw in object.required_array("matches") {
-    matches.push(
-      @json.from_json(raw, path=path.add_key("matches").add_index(index)),
-    )
-  }
+  let matches : Array[SemanticSearchHit] = object.required_array_of("matches")
   {
     root: object.required_string("root"),
     session_key: object.required_string("session_key"),

--- a/desktop/internal/protocol/text_search_codec.mbt
+++ b/desktop/internal/protocol/text_search_codec.mbt
@@ -111,12 +111,7 @@ pub impl FromJson for TextSearchMatch with fn from_json(json, path) {
       (path.add_key("preview_start_column"), "expected one-based column"),
     )
   }
-  let ranges : Array[TextSearchRange] = []
-  for index, raw in object.required_array("ranges") {
-    ranges.push(
-      @json.from_json(raw, path=path.add_key("ranges").add_index(index)),
-    )
-  }
+  let ranges : Array[TextSearchRange] = object.required_array_of("ranges")
   if ranges.is_empty() {
     raise JsonDecodeError(
       (path.add_key("ranges"), "expected at least one match range"),
@@ -157,12 +152,7 @@ pub impl FromJson for SearchTextReply with fn from_json(json, path) {
     object.required_int("file_count"),
     path.add_key("file_count"),
   )
-  let matches : Array[TextSearchMatch] = []
-  for index, raw in object.required_array("matches") {
-    matches.push(
-      @json.from_json(raw, path=path.add_key("matches").add_index(index)),
-    )
-  }
+  let matches : Array[TextSearchMatch] = object.required_array_of("matches")
   let error_code = object.optional_string("error_code")
   let error_message = object.optional_string("error_message")
   let error = match (error_code, error_message) {

--- a/desktop/internal/remote/serve.mbt
+++ b/desktop/internal/remote/serve.mbt
@@ -547,6 +547,18 @@ fn expect_notification(
 }
 
 ///|
+/// One run-scoped agent event as `notification_for_client` sees it.
+fn client_frame(event : @wire.Event) -> @protocol.Notification? {
+  notification_for_client(
+    AgentEvent({
+      run_id: None,
+      session: "session-1",
+      event: { event, submission_id: None, },
+    }),
+  )
+}
+
+///|
 test "remote delivery omits only canonical transcript duplicates" {
   let events : Array[@wire.Event] = [
     ToolResult(
@@ -561,16 +573,7 @@ test "remote delivery omits only canonical transcript duplicates" {
     ContextYield(to_sequence=2, answer="answer"),
   ]
   for event in events {
-    assert_true(
-      notification_for_client(
-        AgentEvent({
-          run_id: None,
-          session: "session-1",
-          event: { event, submission_id: None, },
-        }),
-      )
-      is None,
-    )
+    assert_true(client_frame(event) is None)
   }
 }
 
@@ -604,16 +607,7 @@ test "remote delivery retains streaming runtime and error events" {
     CompactionFailed(error="compact failed"),
   ]
   for event in events {
-    assert_true(
-      notification_for_client(
-        AgentEvent({
-          run_id: None,
-          session: "session-1",
-          event: { event, submission_id: None, },
-        }),
-      )
-      is Some(_),
-    )
+    assert_true(client_frame(event) is Some(_))
   }
   assert_true(
     notification_for_client(
@@ -664,19 +658,12 @@ test "remote lifecycle frames keep state without transcript text" {
     "answer": "large answer",
   })
   let compacted = expect_notification(
-    notification_for_client(
-      AgentEvent({
-        run_id: None,
-        session: "session-1",
-        event: {
-          event: CompactionFinished(
-            from_sequence=1,
-            to_sequence=2,
-            summary="large summary",
-          ),
-          submission_id: None,
-        },
-      }),
+    client_frame(
+      CompactionFinished(
+        from_sequence=1,
+        to_sequence=2,
+        summary="large summary",
+      ),
     ),
   )
   assert_eq(compacted.params(), {
@@ -693,15 +680,7 @@ test "remote lifecycle frames keep state without transcript text" {
     AssistantMessage(content="large content"),
   ]
   for event in settled_events {
-    let settled = expect_notification(
-      notification_for_client(
-        AgentEvent({
-          run_id: None,
-          session: "session-1",
-          event: { event, submission_id: None, },
-        }),
-      ),
-    )
+    let settled = expect_notification(client_frame(event))
     let event_name = match event {
       ReasoningMessage(..) => "reasoning_message"
       AssistantMessage(..) => "assistant_message"

--- a/desktop/internal/session_record/moon.pkg
+++ b/desktop/internal/session_record/moon.pkg
@@ -5,6 +5,7 @@ import {
   "moonbitlang/async/fs",
   "moonbitlang/async/os_error",
   "moonbitlang/core/buffer",
+  "moonbitlang/core/cmp",
   "moonbitlang/core/debug",
   "moonbitlang/core/encoding/utf8",
   "moonbitlang/core/json",

--- a/desktop/internal/session_record/record.mbt
+++ b/desktop/internal/session_record/record.mbt
@@ -263,11 +263,7 @@ async fn Tail::read_forward(self : Tail) -> Array[@protocol.SessionEvent] {
   let fresh : Array[@protocol.SessionEvent] = []
   while self.offset < size {
     let remaining = size - self.offset
-    let take = if remaining > record_chunk_bytes {
-      record_chunk_bytes
-    } else {
-      remaining
-    }
+    let take = @cmp.minimum(remaining, record_chunk_bytes)
     let chunk = file.read_exactly_at(take.to_int(), position=self.offset) catch {
       error if @async.is_being_cancelled() => raise error
       error => raise Unreadable("cannot read the session record: \{error}")

--- a/desktop/internal/session_store/store.mbt
+++ b/desktop/internal/session_store/store.mbt
@@ -53,11 +53,9 @@ pub fn deleting_root(root : @pathx.Absolute) -> @pathx.Absolute {
 /// hints are optional and cannot be trusted to identify where an existing
 /// record lives.
 pub async fn known_roots() -> Array[@pathx.Absolute] {
-  let roots : Array[@pathx.Absolute] = []
-  for path in @workspaces.registered() {
-    roots.push(@workspaces.store_root(path))
-  }
-  roots
+  [
+    for path in @workspaces.registered() => @workspaces.store_root(path)
+  ]
 }
 
 ///|

--- a/desktop/internal/skillmarket/skillmarket_test.mbt
+++ b/desktop/internal/skillmarket/skillmarket_test.mbt
@@ -563,79 +563,49 @@ async test "a non-skill module is refused" {
 }
 
 ///|
-async test "a skill without archive coordinates is not installable" {
+/// Every bad registry fixture is refused with the phrase its own message
+/// carries, and a refusal leaves no directory behind in the library. Each row
+/// still names the scenario it stands for — that label rides the assertion, so
+/// a failure says which refusal broke rather than only which line.
+async test "install refuses every bad fixture and leaves no library directory" {
   @async.with_task_group() <| group => {
     guard fake_registry(group) is Some(base) else { return }
-    let lib = @fs.tmpdir(prefix="skillmarket-")
-    let message = install_failure(base, lib, "acme/bare")
-    assert_true(message.contains("does not publish a skill archive"))
-    assert_false(@fs.exists("\{lib}/acme-bare"))
-  }
-}
-
-///|
-async test "malformed archive coordinates are a registry error, not absence" {
-  @async.with_task_group() <| group => {
-    guard fake_registry(group) is Some(base) else { return }
-    let lib = @fs.tmpdir(prefix="skillmarket-")
-    let message = install_failure(base, lib, "acme/malformed")
-    assert_true(message.contains("malformed"))
-    assert_false(@fs.exists("\{lib}/acme-malformed"))
-  }
-}
-
-///|
-async test "a skill whose archive is missing reports it plainly" {
-  @async.with_task_group() <| group => {
-    guard fake_registry(group) is Some(base) else { return }
-    let lib = @fs.tmpdir(prefix="skillmarket-")
-    let message = install_failure(base, lib, "acme/noarchive")
-    assert_true(message.contains("missing from the registry"))
-    assert_false(@fs.exists("\{lib}/acme-noarchive"))
-  }
-}
-
-///|
-async test "an archive that fails its digest check is refused" {
-  @async.with_task_group() <| group => {
-    guard fake_registry(group) is Some(base) else { return }
-    let lib = @fs.tmpdir(prefix="skillmarket-")
-    let message = install_failure(base, lib, "acme/badsum")
-    assert_true(message.contains("does not match its published digest"))
-    assert_false(@fs.exists("\{lib}/acme-badsum"))
-  }
-}
-
-///|
-async test "an archive without a SKILL.md is refused at install" {
-  @async.with_task_group() <| group => {
-    guard fake_registry(group) is Some(base) else { return }
-    let lib = @fs.tmpdir(prefix="skillmarket-")
-    let message = install_failure(base, lib, "acme/nomd")
-    assert_true(message.contains("does not contain a SKILL.md"))
-    assert_false(@fs.exists("\{lib}/acme-nomd"))
-  }
-}
-
-///|
-async test "an archive whose SKILL.md is not text is refused" {
-  @async.with_task_group() <| group => {
-    guard fake_registry(group) is Some(base) else { return }
-    let lib = @fs.tmpdir(prefix="skillmarket-")
-    let message = install_failure(base, lib, "acme/binary")
-    assert_true(message.contains("unreadable SKILL.md"))
-    assert_false(@fs.exists("\{lib}/acme-binary"))
-  }
-}
-
-///|
-async test "a path-escaping archive is refused" {
-  @async.with_task_group() <| group => {
-    guard fake_registry(group) is Some(base) else { return }
-    let lib = @fs.tmpdir(prefix="skillmarket-")
-    let message = install_failure(base, lib, "acme/slip")
-    assert_true(message.contains("unsafe path"))
-    assert_false(@fs.exists("\{lib}/acme-slip"))
+    for
+      row in [
+        (
+          "a skill without archive coordinates is not installable", "acme/bare",
+          "does not publish a skill archive", "acme-bare",
+        ),
+        (
+          "malformed archive coordinates are a registry error, not absence", "acme/malformed",
+          "malformed", "acme-malformed",
+        ),
+        (
+          "a skill whose archive is missing reports it plainly", "acme/noarchive",
+          "missing from the registry", "acme-noarchive",
+        ),
+        (
+          "an archive that fails its digest check is refused", "acme/badsum", "does not match its published digest",
+          "acme-badsum",
+        ),
+        (
+          "an archive without a SKILL.md is refused at install", "acme/nomd", "does not contain a SKILL.md",
+          "acme-nomd",
+        ),
+        (
+          "an archive whose SKILL.md is not text is refused", "acme/binary", "unreadable SKILL.md",
+          "acme-binary",
+        ),
+        (
+          "a path-escaping archive is refused", "acme/slip", "unsafe path", "acme-slip",
+        ),
+      ] {
+      let (scenario, module_name, reason, directory) = row
+      let lib = @fs.tmpdir(prefix="skillmarket-")
+      let message = install_failure(base, lib, module_name)
+      assert_true(message.contains(reason), msg="case: \{scenario}")
+      assert_false(@fs.exists("\{lib}/\{directory}"), msg="case: \{scenario}")
+    }
   }
 }
 

--- a/desktop/internal/subrun/moon.pkg
+++ b/desktop/internal/subrun/moon.pkg
@@ -4,6 +4,7 @@ import {
   "openseek_desktop/internal/session_record",
   "moonbitlang/async",
   "moonbitlang/async/fs",
+  "moonbitlang/core/cmp",
   "moonbitlang/core/json",
   "moonbitlang/core/encoding/utf8",
 }

--- a/desktop/internal/subrun/probe.mbt
+++ b/desktop/internal/subrun/probe.mbt
@@ -104,11 +104,7 @@ async fn SubrunProbeState::poll(self : SubrunProbeState) -> Bool {
     return false
   }
   let want = size - self.offset
-  let take = if want > subrun_probe_max_chunk {
-    subrun_probe_max_chunk
-  } else {
-    want
-  }
+  let take = @cmp.minimum(want, subrun_probe_max_chunk)
   let chunk = file.read_exactly_at(take.to_int(), position=self.offset) catch {
     _ => return false
   }

--- a/desktop/internal/update/update.mbt
+++ b/desktop/internal/update/update.mbt
@@ -199,11 +199,7 @@ fn normalized_sha256(text : String) -> String? {
   }
   let hex = text.to_lower()
   guard hex.length() == 64 else { return None }
-  for ch in hex {
-    if !(ch is ('0'..='9' | 'a'..='f')) {
-      return None
-    }
-  }
+  guard hex.iter().all(ch => ch is ('0'..='9' | 'a'..='f')) else { return None }
   Some(hex)
 }
 

--- a/desktop/internal/workflow/moon.pkg
+++ b/desktop/internal/workflow/moon.pkg
@@ -2,6 +2,7 @@ import {
   "openseek_desktop/internal/protocol",
   "moonbitlang/async",
   "moonbitlang/async/fs",
+  "moonbitlang/core/cmp",
   "moonbitlang/core/json",
   "moonbitlang/core/encoding/utf8",
 }

--- a/desktop/internal/workflow/tail.mbt
+++ b/desktop/internal/workflow/tail.mbt
@@ -93,11 +93,7 @@ async fn FileTail::poll(self : FileTail) -> Array[String] {
     return []
   }
   let want = size - self.offset
-  let take = if want > workflow_tail_max_chunk {
-    workflow_tail_max_chunk
-  } else {
-    want
-  }
+  let take = @cmp.minimum(want, workflow_tail_max_chunk)
   let chunk = file.read_exactly_at(take.to_int(), position=self.offset) catch {
     _ => return []
   }

--- a/desktop/internal/worktree/submodules.mbt
+++ b/desktop/internal/worktree/submodules.mbt
@@ -48,18 +48,12 @@ async fn provision_initialized_submodules(
   // never relax the default on the app's own authority.
   if @gitx.probe(origin, ["config", "--get", "protocol.file.allow"])
     is Some("always") {
-    args.push("-c")
-    args.push("protocol.file.allow=always")
+    args.append(["-c", "protocol.file.allow=always"])
   }
-  args.push("submodule")
-  args.push("update")
-  args.push("--init")
-  args.push("--checkout")
-  args.push("--recursive")
-  args.push("--")
-  for path in initialized {
-    args.push(path)
-  }
+  args.append([
+    "submodule", "update", "--init", "--checkout", "--recursive", "--",
+  ])
+  args.append(initialized)
   guard @async.with_timeout_opt(timeout_seconds * 1_000, () => {
       @gitx.run(checkout, args)
     })

--- a/desktop/internal/worktree/worktree.mbt
+++ b/desktop/internal/worktree/worktree.mbt
@@ -209,6 +209,16 @@ fn valid_worktree_name(name : String) -> Bool {
 }
 
 ///|
+/// A registry row's optional owner id: present, a JSON string, and non-empty.
+/// A blank id names no conversation, so it reads as an unbound row.
+fn owner_field(fields : Map[String, Json], key : String) -> String? {
+  guard fields.get(key) is Some(String(id)) && !id.is_empty() else {
+    return None
+  }
+  Some(id)
+}
+
+///|
 /// The registered worktrees of `workspace`, dropping anything malformed: an
 /// entry without a valid name, branch, and base string self-heals to absent
 /// rather than poisoning every later operation. A missing or unreadable
@@ -238,19 +248,8 @@ async fn read_worktrees_unlocked(
       continue
     }
     guard fields.get("base") is Some(String(base)) else { continue }
-    let session : String? = if fields.get("session") is Some(String(id)) &&
-      !id.is_empty() {
-      Some(id)
-    } else {
-      None
-    }
-    let codex_thread : String? = if fields.get("codex_thread")
-      is Some(String(id)) &&
-      !id.is_empty() {
-      Some(id)
-    } else {
-      None
-    }
+    let session = owner_field(fields, "session")
+    let codex_thread = owner_field(fields, "codex_thread")
     // A row cannot be owned by both products. Drop a malformed ambiguous row
     // instead of letting whichever lookup happens first claim its checkout.
     guard session is None || codex_thread is None else { continue }
@@ -588,10 +587,7 @@ fn archive_dirty_path_preview(status : String) -> (Array[String], Int) {
     if paths.length() < ArchiveDirtyPathPreviewLimit {
       paths.push(path)
     }
-    if index_status == "R" ||
-      worktree_status == "R" ||
-      index_status == "C" ||
-      worktree_status == "C" {
+    if index_status is ("R" | "C") || worktree_status is ("R" | "C") {
       index += 1
     }
     index += 1
@@ -1209,11 +1205,7 @@ fn test_host(
   {
     lifecycle_lock: Mutex(),
     session_is_live: session => live.contains(session),
-    drain_sessions: sessions => {
-      for session in sessions {
-        drained.push(session)
-      }
-    },
+    drain_sessions: sessions => drained.append(sessions),
   }
 }
 


### PR DESCRIPTION
A pure **simplification** pass: no feature, no fix, no behaviour change. Part of a project-wide sweep; each PR is one package family so it can be reviewed on its own.

Candidates came from a read-only survey of the whole repository. The author was told to drop any that would not compile or would change behaviour, so this branch carries fewer than were proposed: **22 applied, 0 dropped, net -235 lines.**

## Applied

- **desktop/internal/skillmarket/skillmarket_test.mbt** — Seven install-refusal tests differ only in fixture slug, message phrase, and directory name
  Applied with an adjustment. The proposed 3-column table would have dropped seven descriptive test names, one of which ('malformed archive coordinates are a registry error, not absence') states a distinction the row data does not carry. I used a 4-column row (scenario, module, phrase, directory) and put the scenario in msg= on BOTH assertions, so a failing row still names the refusal. 14 assertions before (7 tests x 2), 7 rows x 2 = 14 assertions after; same inputs, same phrases, same directory-absence checks, fresh @fs.tmpdir per row. Test count 38 -> 32, which is exactly 7 tests collapsing into 1.
- **desktop/internal/protocol/desktop_replies_test.mbt** — 8 decode-rejection assertions repeat the same try/catch/noraise scaffold; extract a `refused` helper
  Applied to 9 sites (the 8 named plus the nested one at the TerminalInputPayload loop). Adjusted: kept the existing named bindings (both_rejected, empty_error_sentinel_rejected, ...) rather than inlining into assert_true, because those names are the only label each case carries. The helper body is the original try/catch/noraise verbatim, so refusal semantics are byte-identical. Left the one site whose noraise arm calls fail("expected malformed directory creation payload to fail") alone -- different shape, and the finding excluded it.
- **desktop/internal/auth/auth_wbtest.mbt** — The same six-field AuthSession literal is spelled out six times; extract sample_session
  Applied to all 6 sites. Adjusted: the avatar is a required LABELLED argument (sample_session(avatar="")) rather than positional, so every call site still states the varying field. Dropped the now-redundant ': AuthSession' annotations (this package has +unnecessary_annotation). The seventh, similar-looking literal (https://old.example / d_old / Old Mac) is a deliberately DIFFERENT session and was left untouched.
- **desktop/internal/api/api.mbt** — Eight sites copy a Map with a for/assign loop; Map::copy (and Array::map) already do it
  Applied to all 8 sites: 6 in api.mbt (annotate_thread, annotate, the turn-history thread/reply pair, and the two codex.thread scoped-params arms) and 2 in codex/project_catalog.mbt. Array::map used only in the non-async annotate; project_catalog keeps its for loop for the data array because ProjectCatalog::annotate_thread is async.
- **desktop/internal/protocol/json_object.mbt** — 9 codecs hand-roll the same indexed array decode; add JsonObject::required_array_of
  Helper added beside required_string_array; all 9 call sites rewritten (git_protocol_codec x3, text_search_codec x2, semantic_search_codec x3, desktop_replies x1). Verified every one of the 9 builds its object with JsonObject::decode(json, path, ..), so self.path == path and the emitted JsonPath is unchanged.
- **desktop/internal/pathx/pathx_test.mbt** — 16 identical `guard ...to_absolute() is Some(x) else { fail(...) }` fixture blocks collapse to one helper
  Applied, and extended from the finding's 16 sites to all 20 -- the other 4 spell the same guard with the message 'expected an absolute POSIX/Windows fixture'. Leaving 4 hand-rolled copies beside 16 helper calls would have been worse. #callsite(autofill(loc)) + loc~ keeps the reported failure line at the call site. Their four failure messages change to 'test fixture <text> was not absolute', which names the exact fixture and is strictly more informative.
- **desktop/internal/remote/serve.mbt** — Three delivery tests rebuild the same AgentEvent notification inline
  Applied to 4 sites: the 3 named plus the CompactionFinished construction in the same test, which is the identical run_id=None / session="session-1" shape. client_frame sits beside the existing expect_notification helper.
- **desktop/internal/protocol/desktop_messages.mbt** — Eight lenient optional reads repeat the same 4-line match; extract lenient_string/lenient_int
  Applied to all 8 sites (AgentErrorPayload x4, FinishedPayload x2, RunSettlementPayload x2 in desktop_replies.mbt). The helpers live in json_object.mbt with a doc comment saying why they cannot reuse JsonObject::optional_string/optional_int -- those raise on a wrong type, these deliberately read it as absent. semantic_search_codec's description reader stays as-is; it raises.
- **desktop/internal/extension/external_link.mbt** — The scheme allowlist is a 3-branch if/else-if chain that is literally a list plus `any`
  Applied. The three prefixes are mutually exclusive ('https://' does not start with 'http://'), so scanning all three gives the same answer as short-circuiting on the first match. The 'strict lowercase allowlist' doc comment is kept and now names an actual list. The existing 7-case test still passes.
- **desktop/internal/api/hub.mbt** — forget_run_approvals hand-rolls collect-then-remove; Map::retain does it in one call
  Applied with a fix: the proposed `not(...)` is deprecated in this toolchain (moon check error [0020] 'Use !expr instead'), so the predicate is `!(approval.run_id is Some(owner) && owner == run_id)`. The 'Drop every question belonging to run_id' comment is unchanged.
- **desktop/internal/api/hub.mbt** — Two push-every-value loops in Hub::runs are Map::values().to_array()
  Both sites applied. Order is load-bearing here (hub.mbt documents 'in run-start order (the map preserves insertion order)'); Map::values walks head->next, the same order `for _, v in map` yields.
- **desktop/internal/protocol/pattern_repair_codec.mbt** — The non-negative generation guard is written twice in one file
  Applied as proposed. The message 'expected non-negative generation' is carried through unchanged -- it differs from text_search_codec's require_text_search_non_negative ('expected non-negative integer'), which is why that helper cannot be reused.
- **desktop/internal/worktree/submodules.mbt** — 11 sequential `args.push(...)` calls are three `Array::append` calls
  Applied. Argument order unchanged, so the generated git argv is byte-identical. The 'git submodule does not forward repository-local protocol policy' comment is untouched.
- **desktop/internal/update/update.mbt** — Hand-rolled hex-digit scan is `hex.iter().all(...)`
  Applied as a guard so the early `return None` is preserved. String::iter yields Char, the same as `for ch in hex`.
- **desktop/internal/session_store/store.mbt** — `known_roots` accumulator loop is a one-line array comprehension
  Applied. @workspaces.registered() is async and @workspaces.store_root is a pure non-async mapping, so the comprehension compiles and preserves order. moon fmt reflowed it onto three lines.
- **desktop/internal/worktree/worktree.mbt** — Test host's drain loop is `drained.append(sessions)`
  Applied as proposed; both sides are Array[String] and append preserves order exactly as the push loop did.
- **desktop/internal/workflow/tail.mbt** — Manual chunk clamp is `@cmp.minimum`
  Applied; needed one added import line, "moonbitlang/core/cmp", in desktop/internal/workflow/moon.pkg. Both operands are Int64.
- **desktop/internal/session_record/record.mbt** — Manual chunk clamp is `@cmp.minimum`
  Applied; one added import line in desktop/internal/session_record/moon.pkg.
- **desktop/internal/subrun/probe.mbt** — Manual chunk clamp is `@cmp.minimum`
  Applied; one added import line in desktop/internal/subrun/moon.pkg.
- **desktop/internal/worktree/worktree.mbt** — Four-way `==` chain on porcelain status letters is two `is ("R" | "C")` tests
  Applied. Both operands are String; the repo already uses string or-patterns with `is` this way in shellenv.mbt. Same truth table, same short-circuit order over the two distinct subjects, so the extra `index += 1` for rename/copy records fires on exactly the same inputs.
- **desktop/internal/moonbit/moonbit_toolchain.mbt** — Test's `match Option` render is `.map(...).unwrap_or(...)`
  Applied as proposed.
- **desktop/internal/worktree/worktree.mbt** — Two copies of the "present, non-empty JSON string" decode share one helper
  Applied as proposed; owner_field sits directly above read_worktrees_unlocked with the finding's doc comment. The 'A row cannot be owned by both products' comment below is untouched.

## Verification

All commands run from the worktree's desktop/ directory unless noted. moon 0.1.20260827 (d0aaa07), macOS, native target (desktop/internal/** is native-only; no frontend files touched).

FORMAT: `moon fmt` after each edit batch, then `moon fmt --check` at the end -> "Finished. moon: ran 1740 tasks, now up to date" (clean, no reformat pending). moon fmt reflowed several of my edits and I accepted its output: the known_roots comprehension onto 3 lines, the external_link closure into a block body, the skillmarket table rows, and the `refused` helper into `try decode() catch {..} noraise {..}`.

CHECK: `moon check --deny-warn` over the WHOLE desktop module (native) -> "Finished. moon: ran 731 tasks, now up to date" (0 errors, 0 warnings). Ran module-wide rather than only the 15 packages, to catch downstream breakage from the api/protocol/session_store edits. `moon check --target js --deny-warn` -> "Finished. moon: ran 158 tasks, now up to date" (desktop/frontend is js-only and imports internal/protocol, so the codec edits had to hold on js too). Per-package `moon check <pkg> --deny-warn` was also run after each batch.

ONE FAILURE, FIXED: the first Map::retain attempt used the finding's `not(...)`, which this toolchain rejects: "Error [0020] ... Error Warning (deprecated): Use !expr instead" at hub.mbt:178. Rewritten as `!(approval.run_id is Some(owner) && owner == run_id)`; re-checked clean. No other command failed and there were no other workarounds.

TESTS, before -> after (`moon test internal/<pkg>`, run once on the untouched tree and once after all edits):
skillmarket 38 -> 32 (INTENDED: 7 install-refusal tests collapsed into 1; 14 assertions before, 7 table rows x 2 assertions = 14 after, each row labelled with its old test name in msg=)
protocol 67 -> 67; api 22 -> 22; codex 12 -> 12; auth 12 -> 12; pathx 12 -> 12; remote 9 -> 9; extension 8 -> 8; worktree 14 -> 14; update 11 -> 11; session_store 3 -> 3; workflow 6 -> 6; session_record 15 -> 15; subrun 8 -> 8; moonbit 10 -> 10. All passed, 0 failures, in both runs.
Note: the codex baseline was captured after the fact -- I copied my edited project_catalog.mbt aside, `git checkout --` the original, ran `moon test internal/codex` (12 passed), then restored my copy and confirmed `git status` still showed only that one modification.

MBTI: `moon info internal/skillmarket internal/auth internal/api internal/codex internal/pathx internal/remote internal/extension internal/worktree internal/update internal/session_store internal/workflow internal/session_record internal/subrun internal/moonbit internal/protocol` (SCOPED, never bare) -> "Finished. moon: ran 127 tasks". `git status --short` immediately afterwards listed exactly the same 27 files as before it -- NO .mbti changed, so no public interface moved.

GIT: `git status --short` showed only the 27 intended files; staged by explicit path (no `git add -A`); committed as 8633c93af "refactor(desktop/internal): reuse stdlib and share decode helpers" with the Co-Authored-By and Claude-Session footers; `git push -u origin simplify/de-rest` created the branch on origin. Working tree clean after push. No PR opened, no merge, no other branch touched. Diffstat: 27 files, 261 insertions, 496 deletions (net -235).

## Worth a second look

Four places where I went beyond or against the literal proposal, all called out in the per-finding notes but worth a second look:

1. skillmarket_test.mbt is the one medium-risk change and the only test-count change (38 -> 32). Seven separately named tests became one table. I judged the seven names to be load-bearing documentation, so each row carries its old test name as a 4th column and that name appears in msg= on both assertions -- verify you agree the collapse is worth it, and that the shared fake_registry (one HTTP server now serves all seven sequential installs instead of one server per test) is acceptable. Filesystem isolation is preserved: still a fresh @fs.tmpdir per row.

2. pathx_test.mbt: I converted 20 fixture guards, not the 16 the finding named. The extra 4 had the message "expected an absolute POSIX/Windows fixture", which now reads "test fixture <text> was not absolute". Failure messages in an impossible branch, but they did change.

3. Twelve of the twenty pathx guards and several other pathx/worktree lines sit inside `#cfg(platform="windows")` blocks that this macOS host does NOT compile. Their POSIX twins are compile-verified and the transformation is line-for-line identical, but nothing here type-checked the Windows arms.

4. serve.mbt got a 4th client_frame call site (the CompactionFinished construction) that the finding did not list; it is the identical AgentEvent shape.

Also worth a look: `Map::copy` and `Map::values().to_array()` both depend on MoonBit's Map preserving insertion order, which hub.mbt:193 and project_catalog.mbt explicitly document relying on. I checked core's linked_hash_map implementation (copy walks tail->prev, values walks head->next) but this is the one semantic assumption the whole api/hub group rests on. And three moon.pkg files gained a `"moonbitlang/core/cmp"` import for a single @cmp.minimum call each -- a fair trade for removing 12 lines, but it is 3 new package dependencies.

Reviewed by OpenSeek's own review subagent (DeepSeek Flash); its verdict is posted as a comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXBYcYo74F1DGSPZsYYAdc
