### PR TITLE
refactor: eval, scripts: reuse stdlib and dedupe tests

### DIFF
--- a/eval/file_edit/harness/harness.mbt
+++ b/eval/file_edit/harness/harness.mbt
@@ -239,11 +239,7 @@ async fn evaluate_trial(
     write_successes: @metrics.count_occurrences(log_text, "ok: wrote "),
     validation_passed,
     marker_present: marker_ok,
-    warnings: if warnings.length() == 0 {
-      ""
-    } else {
-      warnings.join("; ")
-    },
+    warnings: warnings.join("; "),
   }
 }
 

--- a/eval/prompt_task/harness/analyzer.mbt
+++ b/eval/prompt_task/harness/analyzer.mbt
@@ -381,36 +381,31 @@ fn eval_session_with_context(
     @metrics.count_occurrences(text, "Err("),
     try_mentions: @metrics.count_occurrences(text, "try?") +
     @metrics.count_occurrences(text, "try!"),
-    warnings: if warnings.length() == 0 {
-      ""
-    } else {
-      warnings.join("; ")
-    },
+    warnings: warnings.join("; "),
   }
 }
 
 ///|
+/// Locate this trial's session events. A recorded `events_path` counts only
+/// while it stays inside the trial workspace; when it does not name a file
+/// that exists, the same workspace scan `discover_session_events` runs for a
+/// fresh trial decides, with the recorded path — or the default session file
+/// location — as the last resort.
 async fn resolve_events_path(trial : TrialArtifact) -> String {
-  if trial.events_path != "" &&
-    path_under_dir(trial.events_path, trial.workspace) &&
-    @fs.exists(trial.events_path) {
+  let recorded_under_workspace = trial.events_path != "" &&
+    path_under_dir(trial.events_path, trial.workspace)
+  if recorded_under_workspace && @fs.exists(trial.events_path) {
     return trial.events_path
   }
-  let matches : Array[String] = []
-  collect_session_events(trial.workspace, trial.session_id, matches)
-  if matches is [first, ..] {
-    first
-  } else if trial.events_path != "" &&
-    path_under_dir(trial.events_path, trial.workspace) {
-    trial.events_path
-  } else {
-    trial.workspace +
-    "/.openseek/sessions/" +
-    trial.session_id +
-    "/openseek_session-" +
-    trial.session_id +
-    ".jsonl"
-  }
+  discover_session_events(
+    trial.workspace,
+    trial.session_id,
+    fallback=if recorded_under_workspace {
+      trial.events_path
+    } else {
+      "\{trial.workspace}/.openseek/sessions/\{trial.session_id}/openseek_session-\{trial.session_id}.jsonl"
+    },
+  )
 }
 
 ///|
@@ -573,12 +568,11 @@ fn validation_passed_by_name(
   results : Array[ProbeResult],
   name : String,
 ) -> Bool {
-  for result in results {
-    if result.name == name {
-      return result.passed
-    }
-  }
-  false
+  // `find_first` keeps the loop's first-match semantics for duplicate names.
+  results
+  .iter()
+  .find_first(result => result.name == name)
+  .map_or(false, result => result.passed)
 }
 
 ///|

--- a/eval/prompt_task/harness/analyzer_wbtest.mbt
+++ b/eval/prompt_task/harness/analyzer_wbtest.mbt
@@ -74,14 +74,18 @@ fn eval_session_for_test(session : @agent_session.Session) -> EvalResult {
 }
 
 ///|
-test "session summary counts typed events" {
+/// The analyzed sample session shared by the counter and rendering tests:
+/// both replay `sample_events()` through the log parser before analyzing.
+fn sample_eval_result() -> EvalResult {
   let parsed = @session_log.parse_events(sample_events())
-  let session = @session_log.session_from_parse(
-    parsed,
-    id="trial-01",
-    system_prompt="",
+  eval_session_for_test(
+    @session_log.session_from_parse(parsed, id="trial-01", system_prompt=""),
   )
-  let result = eval_session_for_test(session)
+}
+
+///|
+test "session summary counts typed events" {
+  let result = sample_eval_result()
   assert_true(result.finished)
   assert_eq(result.steps, 2)
   assert_eq(result.tool_results, 1)
@@ -93,13 +97,7 @@ test "session summary counts typed events" {
 
 ///|
 test "eval session produces standalone result" {
-  let parsed = @session_log.parse_events(sample_events())
-  let session = @session_log.session_from_parse(
-    parsed,
-    id="trial-01",
-    system_prompt="",
-  )
-  let result = eval_session_for_test(session)
+  let result = sample_eval_result()
   assert_true(result.success)
   assert_eq(result.session_id, "trial-01")
   assert_eq(result.steps, 2)

--- a/eval/prompt_task/harness/harness_wbtest.mbt
+++ b/eval/prompt_task/harness/harness_wbtest.mbt
@@ -1,12 +1,21 @@
 ///|
-test "trial environment configures model and isolated skills" {
-  let config = Config(
-    api_key="key",
-    model=Deepseek(V4Flash),
-    problem_id="toml_parser_cli",
+/// Config for the trial_extra_env tests. `trial_extra_env` reads only
+/// `api_key`, `model` and `max_steps`, so the remaining fields are fixed
+/// here; `problem_id` and `min_successes` stay overridable to keep each
+/// test's original literal intact.
+fn env_test_config(
+  api_key~ : String,
+  model~ : @deepseek.Model,
+  problem_id? : String = "toml_parser_cli",
+  min_successes? : Int = 1,
+) -> Config {
+  Config(
+    api_key~,
+    model~,
+    problem_id~,
     runs=1,
     concurrency=1,
-    min_successes=1,
+    min_successes~,
     max_steps=12,
     out_dir="out",
     repo_root=".",
@@ -16,6 +25,11 @@ test "trial environment configures model and isolated skills" {
     system_prompt_file="",
     system_prompt_addendum_file="",
   )
+}
+
+///|
+test "trial environment configures model and isolated skills" {
+  let config = env_test_config(api_key="key", model=Deepseek(V4Flash))
   let env = trial_extra_env(config, "/tmp/workspace")
   assert_true(env.get("DEEPSEEK") == Some("key"))
   assert_true(env.get("KIMI") is None)
@@ -43,21 +57,11 @@ test "empty api key leaves provider keys to the inherited environment" {
   // A cross-provider suite runs with an empty key so each trial inherits its
   // own DEEPSEEK/KIMI/GLM from the parent env; the harness must not pin a
   // variable to an empty string, which would shadow the inherited key.
-  let config = Config(
+  let config = env_test_config(
     api_key="",
     model=Deepseek(V4Pro),
     problem_id="expr_eval",
-    runs=1,
-    concurrency=1,
     min_successes=0,
-    max_steps=12,
-    out_dir="out",
-    repo_root=".",
-    prompt_label="label",
-    task_file="task.md",
-    validation_probes=default_toml_validation_probes(),
-    system_prompt_file="",
-    system_prompt_addendum_file="",
   )
   let env = trial_extra_env(config, "/tmp/workspace")
   assert_true(env.get("DEEPSEEK") is None)

--- a/eval/prompt_task/harness/suite.mbt
+++ b/eval/prompt_task/harness/suite.mbt
@@ -847,14 +847,10 @@ fn validation_summary(report : EvalReport) -> String {
 ///|
 fn suite_combo_warnings(report : EvalReport) -> String {
   let warnings : Array[String] = []
-  let mut parse_errors = 0
-  let mut partial_tails = 0
-  for result in report.results {
-    parse_errors += result.parse_errors
-    if result.partial_tail {
-      partial_tails += 1
-    }
-  }
+  let parse_errors = report.results.fold(init=0, (total, result) => {
+    total + result.parse_errors
+  })
+  let partial_tails = report.results.count_if(result => result.partial_tail)
   if parse_errors > 0 {
     warnings.push("events decode errors \{parse_errors}")
   }

--- a/eval/report/report.mbt
+++ b/eval/report/report.mbt
@@ -310,12 +310,11 @@ fn ReportRow::markdown_row(
 
 ///|
 fn ReportRow::metric_value(self : ReportRow, column : String) -> String {
-  for metric in self.metrics {
-    if metric.name == column {
-      return metric.value
-    }
-  }
-  ""
+  // `find_first` keeps the loop's first-match semantics for duplicate names.
+  self.metrics
+  .iter()
+  .find_first(metric => metric.name == column)
+  .map_or("", metric => metric.value)
 }
 
 ///|
@@ -355,12 +354,7 @@ fn detail_section_lines(rows : Array[ReportRow]) -> Array[String] {
 
 ///|
 fn has_detail_section(rows : Array[ReportRow]) -> Bool {
-  for row in rows {
-    if row.has_details() {
-      return true
-    }
-  }
-  false
+  rows.any(row => row.has_details())
 }
 
 ///|

--- a/eval/session_analyzer/analyzer_test.mbt
+++ b/eval/session_analyzer/analyzer_test.mbt
@@ -171,14 +171,18 @@ test "session analyzer counts typed events" {
 }
 
 ///|
+/// A final assistant/terminal pair, with or without reasoning content: the
+/// two shapes differ only in whether the assistant message carries reasoning.
+fn final_pair_session(reasoning_content? : String) -> @agent_session.Session {
+  @agent_session.Session(SessionId("reasoning-final"), system_prompt="")
+  .append(User(UserMessage("question")))
+  .append(Assistant(AssistantMessage("unique-answer", reasoning_content?)))
+  .append(Terminal(Finished("unique-answer")))
+}
+
+///|
 test "assistant final pair counts and indexes the answer once" {
-  let session = @agent_session.Session(
-      SessionId("reasoning-final"),
-      system_prompt="",
-    )
-    .append(User(UserMessage("question")))
-    .append(Assistant(AssistantMessage("unique-answer")))
-    .append(Terminal(Finished("unique-answer")))
+  let session = final_pair_session()
   let result = @session_analyzer.analyze_session(session)
   assert_eq(result.steps, 1)
   let transcript = @session_analyzer.transcript_text(session)
@@ -187,17 +191,7 @@ test "assistant final pair counts and indexes the answer once" {
 
 ///|
 test "reasoning-bearing final pair still counts and indexes the answer once" {
-  let session = @agent_session.Session(
-      SessionId("reasoning-final"),
-      system_prompt="",
-    )
-    .append(User(UserMessage("question")))
-    .append(
-      Assistant(
-        AssistantMessage("unique-answer", reasoning_content="unique-thought"),
-      ),
-    )
-    .append(Terminal(Finished("unique-answer")))
+  let session = final_pair_session(reasoning_content="unique-thought")
   let result = @session_analyzer.analyze_session(session)
   assert_eq(result.steps, 1)
   let transcript = @session_analyzer.transcript_text(session)

--- a/scripts/internal/markdown_comments/markdown_comments.mbt
+++ b/scripts/internal/markdown_comments/markdown_comments.mbt
@@ -8,7 +8,7 @@ priv struct SourceRange {
 pub fn without_comments(markdown : String) -> String {
   let ranges = comment_ranges(markdown)
   guard !ranges.is_empty() else { markdown }
-  ranges.sort_by(fn(left, right) { left.first.compare(right.first) })
+  ranges.sort_by_key(range => range.first)
   remove_source_ranges(markdown, ranges)
 }
 


### PR DESCRIPTION
A pure **simplification** pass: no feature, no fix, no behaviour change. Part of a project-wide sweep; each PR is one package family so it can be reviewed on its own.

Candidates came from a read-only survey of the whole repository. The author was told to drop any that would not compile or would change behaviour, so this branch carries fewer than were proposed: **11 applied, 0 dropped, net -24 lines.**

## Applied

- **eval/session_analyzer/analyzer_test.mbt** — Two final-pair tests differ only by reasoning_content; share one session builder
  Applied with the proposal's `final_pair_session(reasoning_content? : String)` helper and its optional-argument punning `AssistantMessage("unique-answer", reasoning_content?)`. Kept the two tests' original `let result` / `let transcript` bindings rather than the proposal's inlined one-liners, so the diff is only the setup. 2 tests before and after, 4 assert_eq before and after.
- **eval/prompt_task/harness/analyzer_wbtest.mbt** — Two tests repeat the same 7-line sample-session prologue verbatim
  Extracted `sample_eval_result()`; both tests keep every assertion unchanged. Compiles as a plain non-raising `fn` as the finding predicted. 2 tests before and after, 13 assertions before and after (7 + 6).
- **eval/prompt_task/harness/harness_wbtest.mbt** — Both trial_extra_env tests build a 16-line Config literal that differs in 4 unread fields
  APPLIED IN MODIFIED FORM. The proposal pinned problem_id and min_successes to the first test's values, which would have silently changed the second test's inputs ("expr_eval"/0). Instead `env_test_config` takes them as defaulted labelled args, so the second test passes its original values explicitly and the inputs of both tests are byte-for-byte what they were. Saves ~5 lines instead of 9, but the equivalence is checkable field by field. 2 tests before and after, 13 assertions before and after (9 + 4).
- **eval/prompt_task/harness/analyzer.mbt** — resolve_events_path re-implements discover_session_events (same package)
  Applied as proposed. Short-circuiting is preserved: `@fs.exists` is still skipped when the recorded path is empty or outside the workspace. The eager fallback string is a pure interpolation of the same path the old `else` branch concatenated. Added a doc comment (the function had none) because the fallback chain now lives in an argument position.
- **eval/prompt_task/harness/suite.mbt** — suite_combo_warnings accumulates with two `let mut` counters instead of fold/count_if
  Applied as proposed; `moon fmt` reformatted the fold closure to a block body, matching `average_result_metric` 25 lines above.
- **eval/report/report.mbt** — has_detail_section is a manual any-loop; Array::any exists
  Applied as proposed. `Array::any` short-circuits like the loop's early `return true`.
- **eval/prompt_task/harness/analyzer.mbt** — Empty-check before join is redundant: Array::join on an empty array returns ""
  Applied. Verified in core: builtin/arrayview.mbt:1493-1494 matches `[] => ""` first, and builtin/array.mbt:2183-2188 `Array::join` delegates to it.
- **eval/file_edit/harness/harness.mbt** — Same redundant empty-check before join in the file_edit harness
  Applied. Only the `warnings:` field changed; the sibling `reason:` field 35 lines above keeps its conditional because its empty case yields "ok", not "" — confirmed by reading it before editing.
- **eval/prompt_task/harness/analyzer.mbt** — validation_passed_by_name is a hand-rolled find; use iter().find_first + map_or
  Applied as proposed, plus a one-line comment recording that `find_first` is what preserves the loop's first-match behaviour on duplicate names. Signature unchanged.
- **eval/report/report.mbt** — ReportRow::metric_value is a hand-rolled find with a "" default
  Applied as proposed, with the same first-match comment. The `""` default is a literal, so making it eager in `map_or` has no effect.
- **scripts/internal/markdown_comments/markdown_comments.mbt** — sort_by with a compare-on-one-field closure is exactly sort_by_key
  Applied. Verified in core that the permutation is identical, not merely equivalent: builtin/array_sort.mbt:206-211 `Array::sort_by_key` -> :85-95 `MutArrayView::sort_by_key` builds comparator `(a, b) => map(a).compare(map(b))` and calls `fixed_quick_sort_by` with the same limit that :227-229 / :31-33 `sort_by` uses with the supplied closure.

## Verification

All commands run in the worktree /private/tmp/claude-501/-Users-hongbozhang-git-openseek/ee773eb3-cd66-4ac0-a331-789265556fad/scratchpad/wt/eval. Every touched package declares supported_targets = "+native", so native (the default) is the correct and only target; nothing under desktop/ was touched, so no js or wasm run was needed.

PRE-CHANGE BASELINE
- `moon test eval/session_analyzer eval/prompt_task/harness eval/report eval/file_edit/harness` -> "Total tests: 37, passed: 37, failed: 0."
- (in scripts/, a separate module `bobzhang/openseek-scripts` not listed in moon.work) `moon test internal/markdown_comments` -> "Total tests: 18, passed: 18, failed: 0."

POST-CHANGE
- `moon fmt` (root) -> "ran 1740 tasks"; it rewrote nothing outside my eight files (verified with `git status --short`). It did normalise my `problem_id~ : String = "..."` defaults to the canonical `problem_id? : String = "..."` form in harness_wbtest.mbt.
- `moon fmt` (scripts/) -> "ran 6 tasks"; no extra files touched.
- `moon check eval/prompt_task/harness eval/report eval/file_edit/harness eval/session_analyzer --deny-warn` -> clean, no warnings. Notable because the module sets warnings = "+missing_doc...+unused_default_value...": the two new defaults in env_test_config are both exercised, so `unused_default_value` does not fire.
- `moon check internal/markdown_comments --deny-warn` (scripts/) -> clean.
- `moon test eval/session_analyzer eval/prompt_task/harness eval/report eval/file_edit/harness` -> "Total tests: 37, passed: 37, failed: 0." Identical to baseline.
- `moon test internal/markdown_comments` (scripts/) -> "Total tests: 18, passed: 18, failed: 0." Identical to baseline.
- `moon info eval/prompt_task/harness eval/report eval/file_edit/harness eval/session_analyzer` and, in scripts/, `moon info internal/markdown_comments` — both SCOPED, never bare. All five packages have a pkg.generated.mbti and NONE changed: `git status --short` listed the same eight .mbt files before and after. No public interface moved, consistent with every edit being to a private fn or a test file.

TEST-DEDUPE COUNTS (these are shared-fixture extractions, not table collapses, so no rows were introduced and each case still fails under its own test name)
- eval/session_analyzer/analyzer_test.mbt: 2 tests / 4 assertions before, 2 tests / 4 assertions after.
- eval/prompt_task/harness/analyzer_wbtest.mbt: 2 tests / 13 assertions before, 2 tests / 13 after.
- eval/prompt_task/harness/harness_wbtest.mbt: 2 tests / 13 assertions before, 2 tests / 13 after.
- Total across the three: 30 assertions before, 30 after.

GIT
- Staged by explicit path (eight files, no `git add -A`); `git status --short` showed only those eight both before staging and after commit. The repo's untracked desktop/ build artifacts were never in this worktree's status.
- Commit 58c7ec3a9, message `refactor(eval,scripts): reuse stdlib and dedupe tests` with the brief's Co-Authored-By and Claude-Session footer.
- `git push -u origin simplify/eval` -> "* [new branch] simplify/eval -> simplify/eval", tracking set. No PR opened, no merge, no other branch touched.

Nothing failed and no workaround was needed. One environment note: `moon test <pkg>` rejects the fully-qualified package name (`bobzhang/openseek/eval/session_analyzer` -> "Failed to canonicalize input filter directory"); it wants the directory path, so all scoping used paths.

## Worth a second look

Three things worth a second look.

1. harness_wbtest.mbt is the one place I deviated from the vetted proposal, and it is the one to read closely. The finding wanted a helper that pins problem_id="toml_parser_cli" and min_successes=1 for both tests, on the reasoning that trial_extra_env never reads either field. That reasoning is correct (harness.mbt:107-126 reads only config.model, config.max_steps and config.api_key, which I confirmed by reading it), but it would still have rewritten the second test's inputs from "expr_eval"/0 to "toml_parser_cli"/1 — a change the brief's "same inputs" rule forbids, and one that would quietly matter if anyone ever widens trial_extra_env. I made those two parameters defaulted instead, so the second test passes its own original values. Worth confirming you agree with the trade: it saves ~5 lines rather than 9.

2. resolve_events_path in eval/prompt_task/harness/analyzer.mbt is the only non-test production change with real control flow in it. The old three-way tail (`matches` / recorded path / default path) became `discover_session_events(..., fallback=if recorded_under_workspace { ... } else { ... })`. Two things to check by eye: the `path_under_dir` test is now computed once into `recorded_under_workspace` and reused in both places it was previously spelled out, and the fallback string is now built eagerly on every call instead of only in the old `else` branch. It is a pure interpolation of the same path shape harness.mbt:94 builds, so this is a wasted allocation at worst, never a behaviour change. This function has no test of its own in the package, so it rests on reading rather than on the 37 passing tests.

3. The two `warnings: warnings.join("; ")` simplifications turn on Array::join returning "" for an empty array. I verified that in core rather than trusting the finding (arrayview.mbt:1493 matches `[] => ""` as its first arm; array.mbt:2187 delegates to it). The trap nearby is eval/file_edit/harness/harness.mbt:206-210, a `reason:` field with the same shape whose empty case yields "ok" — that one must keep its conditional and I left it alone. If anyone scans for more instances of this pattern elsewhere in the repo, check the default before deleting the guard.

Reviewed by OpenSeek's own review subagent (DeepSeek Flash); its verdict is posted as a comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXBYcYo74F1DGSPZsYYAdc