### PR TITLE
refactor: desktop/frontend packages: comprehensions, stdlib reuse, shared helpers

### DIFF
--- a/desktop/frontend/action_menu/action_menu.mbt
+++ b/desktop/frontend/action_menu/action_menu.mbt
@@ -231,17 +231,6 @@ fn set_style(element : @dom.Element, key : String, value : String) -> Unit {
 }
 
 ///|
-fn clamp(value : Double, low : Double, high : Double) -> Double {
-  if value < low {
-    low
-  } else if value > high {
-    high
-  } else {
-    value
-  }
-}
-
-///|
 fn position(target : String, anchor : Anchor) -> @cmd.Cmd {
   @cmd.custom_cmd(
     _ => {
@@ -285,26 +274,14 @@ fn position(target : String, anchor : Anchor) -> @cmd.Cmd {
         }
       }
       let margin = 4.0
+      let min_left = viewport_left + margin
+      let min_top = viewport_top + margin
       let max_left = viewport_left + viewport_width - menu_width - margin
       let max_top = viewport_top + viewport_height - menu_height - margin
-      let left = clamp(
-        wanted_left,
-        viewport_left + margin,
-        if max_left < viewport_left + margin {
-          viewport_left + margin
-        } else {
-          max_left
-        },
-      )
-      let top = clamp(
-        wanted_top,
-        viewport_top + margin,
-        if max_top < viewport_top + margin {
-          viewport_top + margin
-        } else {
-          max_top
-        },
-      )
+      // A menu taller or wider than the viewport pins to the near edge: the
+      // `.max(min_*)` keeps the clamp window non-empty.
+      let left = wanted_left.clamp(min=min_left, max=max_left.max(min_left))
+      let top = wanted_top.clamp(min=min_top, max=max_top.max(min_top))
       set_style(menu, "left", "\{left.to_int()}px")
       set_style(menu, "top", "\{top.to_int()}px")
       menu.set_attribute("data-positioned", "true")
@@ -326,12 +303,7 @@ fn Definition::enabled_indices(self : Definition) -> Array[Int] {
 
 ///|
 fn enabled_position(indices : Array[Int], index : Int) -> Int? {
-  for position, candidate in indices {
-    if candidate == index {
-      return Some(position)
-    }
-  }
-  None
+  indices.search(index)
 }
 
 ///|

--- a/desktop/frontend/codex/activity_wbtest.mbt
+++ b/desktop/frontend/codex/activity_wbtest.mbt
@@ -30,27 +30,36 @@ test "Codex activity accepts idle catalog evidence without a run mark" {
 }
 
 ///|
-test "Codex activity rejects active snapshot older than completion" {
+/// Take a frontier, let `mutate` record newer evidence on the ledger, then
+/// reconcile a one-thread snapshot carrying `status` against that now-stale
+/// frontier — the shared shape of the four fencing tests below.
+fn stale_snapshot_mark(
+  mutate : (CodexActivityLedger) -> CodexActivityLedger,
+  status : CodexThreadRuntime,
+) -> @conversation.RunMark {
   let activity = CodexActivityLedger::empty()
   let frontier = activity.frontier()
-  let completed = activity.started("thread-1").completed("thread-1")
-  let reconciled = completed.reconcile_snapshot(
-    [("thread-1", Some(ThreadActive))],
-    frontier,
+  mutate(activity)
+  .reconcile_snapshot([("thread-1", Some(status))], frontier)
+  .presentation("thread-1")
+}
+
+///|
+test "Codex activity rejects active snapshot older than completion" {
+  let mark = stale_snapshot_mark(
+    activity => activity.started("thread-1").completed("thread-1"),
+    ThreadActive,
   )
-  assert_true(reconciled.presentation("thread-1") is @conversation.NoRunMark)
+  assert_true(mark is @conversation.NoRunMark)
 }
 
 ///|
 test "Codex activity rejects active snapshot older than idle notification" {
-  let activity = CodexActivityLedger::empty()
-  let frontier = activity.frontier()
-  let idle = activity.status_changed("thread-1", Some(ThreadInactive))
-  let reconciled = idle.reconcile_snapshot(
-    [("thread-1", Some(ThreadActive))],
-    frontier,
+  let mark = stale_snapshot_mark(
+    activity => activity.status_changed("thread-1", Some(ThreadInactive)),
+    ThreadActive,
   )
-  assert_true(reconciled.presentation("thread-1") is @conversation.NoRunMark)
+  assert_true(mark is @conversation.NoRunMark)
 }
 
 ///|
@@ -99,24 +108,18 @@ test "failed newer Codex snapshot does not fence older catalog evidence" {
 
 ///|
 test "Codex activity rejects idle snapshot older than start" {
-  let activity = CodexActivityLedger::empty()
-  let frontier = activity.frontier()
-  let running = activity.started("thread-1")
-  let reconciled = running.reconcile_snapshot(
-    [("thread-1", Some(ThreadInactive))],
-    frontier,
+  let mark = stale_snapshot_mark(
+    activity => activity.started("thread-1"),
+    ThreadInactive,
   )
-  assert_true(reconciled.presentation("thread-1") is @conversation.RunningMark)
+  assert_true(mark is @conversation.RunningMark)
 }
 
 ///|
 test "Codex activity rejects snapshots from an earlier connection" {
-  let activity = CodexActivityLedger::empty()
-  let frontier = activity.frontier()
-  let reconnected = activity.disconnected()
-  let reconciled = reconnected.reconcile_snapshot(
-    [("thread-1", Some(ThreadActive))],
-    frontier,
+  let mark = stale_snapshot_mark(
+    activity => activity.disconnected(),
+    ThreadActive,
   )
-  assert_true(reconciled.presentation("thread-1") is @conversation.NoRunMark)
+  assert_true(mark is @conversation.NoRunMark)
 }

--- a/desktop/frontend/composer/codex_request.mbt
+++ b/desktop/frontend/composer/codex_request.mbt
@@ -7,6 +7,14 @@ priv struct CodexRequestQuestion {
 }
 
 ///|
+/// The string members of a JSON array; every other value is ignored.
+fn json_string_parts(values : Array[Json]) -> Array[String] {
+  [
+    for value in values if value is String(part) => part
+  ]
+}
+
+///|
 /// Render only the approval facts needed for a decision. The complete payload
 /// remains available below for diagnostics and fields this client does not yet
 /// understand.
@@ -75,12 +83,7 @@ fn CodexRequestInput::approval_details(
     )
   }
   if fields.get("proposedExecpolicyAmendment") is Some(Array(values)) {
-    let parts : Array[String] = []
-    for value in values {
-      if value is String(part) {
-        parts.push(part)
-      }
-    }
+    let parts = json_string_parts(values)
     if !parts.is_empty() {
       details.push(
         @html.div(class="codex-request-detail", [
@@ -140,25 +143,17 @@ fn CodexRequestInput::execpolicy_label(
   self : CodexRequestInput,
   decision : Json,
 ) -> String {
-  let parts : Array[String] = []
+  let mut parts : Array[String] = []
   if decision is Object(decision_fields) &&
     decision_fields.get("acceptWithExecpolicyAmendment")
     is Some(Object(amendment)) &&
     amendment.get("execpolicy_amendment") is Some(Array(values)) {
-    for value in values {
-      if value is String(part) {
-        parts.push(part)
-      }
-    }
+    parts = json_string_parts(values)
   }
   if parts.is_empty() &&
     self.params is Object(fields) &&
     fields.get("proposedExecpolicyAmendment") is Some(Array(values)) {
-    for value in values {
-      if value is String(part) {
-        parts.push(part)
-      }
-    }
+    parts = json_string_parts(values)
   }
   if parts.is_empty() {
     "Allow by rule"

--- a/desktop/frontend/dock/state.mbt
+++ b/desktop/frontend/dock/state.mbt
@@ -74,13 +74,13 @@ pub fn State::empty() -> State {
 /// The strip's file paths, in strip order — the projection the root update
 /// hands to fileeditor's `Ctx` for its stat/watch/reload sweeps.
 pub fn file_paths(state : State) -> Array[@pathx.Relative] {
-  let paths : Array[@pathx.Relative] = []
-  for tab in state.tabs {
+  state.tabs.filter_map(tab => {
     if tab is File(path~) {
-      paths.push(path)
+      Some(path)
+    } else {
+      None
     }
-  }
-  paths
+  })
 }
 
 ///|
@@ -94,13 +94,13 @@ pub fn active_file(state : State) -> @pathx.Relative? {
 
 ///|
 pub fn history_diffs(state : State) -> Array[GitHistoryDiff] {
-  let diffs : Array[GitHistoryDiff] = []
-  for tab in state.tabs {
+  state.tabs.filter_map(tab => {
     if tab is GitDiff(diff~) {
-      diffs.push(diff)
+      Some(diff)
+    } else {
+      None
     }
-  }
-  diffs
+  })
 }
 
 ///|

--- a/desktop/frontend/dock/update.mbt
+++ b/desktop/frontend/dock/update.mbt
@@ -48,10 +48,9 @@ pub fn update(msg : Msg, state : State) -> State {
 }
 
 ///|
-/// Open `path`'s file tab (appending one if it is not in the strip yet) and
-/// make it active — the strip half of a tree click or a chip jump.
-pub fn open_file(state : State, path : @pathx.Relative) -> State {
-  let tab = DockTab::File(path~)
+/// Append `tab` unless the strip already holds it, then make it active — the
+/// shared body of the `open_*` entry points below.
+fn open_tab(state : State, tab : DockTab) -> State {
   let tabs = if tab_index(state, tab) is Some(_) {
     state.tabs
   } else {
@@ -63,18 +62,17 @@ pub fn open_file(state : State, path : @pathx.Relative) -> State {
 }
 
 ///|
+/// Open `path`'s file tab (appending one if it is not in the strip yet) and
+/// make it active — the strip half of a tree click or a chip jump.
+pub fn open_file(state : State, path : @pathx.Relative) -> State {
+  open_tab(state, DockTab::File(path~))
+}
+
+///|
 /// Open one immutable historical comparison. Equality includes the commit, so
 /// the same path at two revisions stays independently inspectable.
 pub fn open_history_diff(state : State, diff : GitHistoryDiff) -> State {
-  let tab = DockTab::GitDiff(diff~)
-  let tabs = if tab_index(state, tab) is Some(_) {
-    state.tabs
-  } else {
-    let tabs = state.tabs.copy()
-    tabs.push(tab)
-    tabs
-  }
-  { ..state, tabs, active: Some(tab), }
+  open_tab(state, DockTab::GitDiff(diff~))
 }
 
 ///|
@@ -82,43 +80,21 @@ pub fn open_history_diff(state : State, diff : GitHistoryDiff) -> State {
 /// yet) and make it active. The caller owns the id: allocating the page and
 /// asking the host for its native view are the browser subsystem's business.
 pub fn open_browser(state : State, id : Int) -> State {
-  let tab = DockTab::Browser(id~)
-  let tabs = if tab_index(state, tab) is Some(_) {
-    state.tabs
-  } else {
-    let tabs = state.tabs.copy()
-    tabs.push(tab)
-    tabs
-  }
-  { ..state, tabs, active: Some(tab), }
+  open_tab(state, DockTab::Browser(id~))
 }
 
 ///|
 /// Open the transient file-picker tab, re-activating the existing one — at
 /// most one lives in the strip.
 pub fn open_picker(state : State) -> State {
-  let tabs = if tab_index(state, FilePicker) is Some(_) {
-    state.tabs
-  } else {
-    let tabs = state.tabs.copy()
-    tabs.push(FilePicker)
-    tabs
-  }
-  { ..state, tabs, active: Some(FilePicker), }
+  open_tab(state, FilePicker)
 }
 
 ///|
 /// Open the workflows tab, re-activating the existing one — at most one
 /// lives in the strip.
 pub fn open_workflows(state : State) -> State {
-  let tabs = if tab_index(state, Workflows) is Some(_) {
-    state.tabs
-  } else {
-    let tabs = state.tabs.copy()
-    tabs.push(Workflows)
-    tabs
-  }
-  { ..state, tabs, active: Some(Workflows), }
+  open_tab(state, Workflows)
 }
 
 ///|

--- a/desktop/frontend/dock/view.mbt
+++ b/desktop/frontend/dock/view.mbt
@@ -5,17 +5,6 @@
 // reads document tables.
 
 ///|
-/// The sidebar-right codicon for the panel toggle, from Microsoft's
-/// vscode-codicons (CC BY 4.0); the path data is unmodified, transcribed
-/// into `@svg` builders (an innerHTML-bearing element cannot be safely
-/// morphed by the positional child diff).
-fn icon_layout_sidebar_right() -> @html.Html {
-  @icons.codicon(
-    "M12.5 1C13.881 1 15 2.119 15 3.5V12.5C15 13.881 13.881 15 12.5 15H3.5C2.119 15 1 13.881 1 12.5V3.5C1 2.119 2.119 1 3.5 1H12.5ZM9 14V2H3.5C2.672 2 2 2.672 2 3.5V12.5C2 13.328 2.672 14 3.5 14H9Z",
-  )
-}
-
-///|
 /// Four outward-facing corners for expanding the panel into the whole content
 /// area. The inverse glyph below points inward when the next action restores
 /// the split view.
@@ -43,30 +32,6 @@ fn icon_restore_panel() -> @html.Html {
       .stroke("currentColor")
       .stroke_linecap("round"),
     [@svg.path(d="M2.5 6H6V2.5M13.5 6H10V2.5M13.5 10H10v3.5M2.5 10H6v3.5")],
-  )
-}
-
-///|
-/// The add codicon (CC BY 4.0): the strip's new-tab button.
-fn icon_add() -> @html.Html {
-  @icons.codicon(
-    "M8 1.5C8 1.22386 7.77614 1 7.5 1C7.22386 1 7 1.22386 7 1.5V7H1.5C1.22386 7 1 7.22386 1 7.5C1 7.77614 1.22386 8 1.5 8H7V13.5C7 13.7761 7.22386 14 7.5 14C7.77614 14 8 13.7761 8 13.5V8H13.5C13.7761 8 14 7.77614 14 7.5C14 7.22386 13.7761 7 13.5 7H8V1.5Z",
-  )
-}
-
-///|
-/// The folder codicon (CC BY 4.0): the launcher's Files row.
-fn icon_folder() -> @html.Html {
-  @icons.codicon(
-    "M2 4.5V6H5.58579C5.71839 6 5.84557 5.94732 5.93934 5.85355L7.29289 4.5L5.93934 3.14645C5.84557 3.05268 5.71839 3 5.58579 3H3.5C2.67157 3 2 3.67157 2 4.5ZM1 4.5C1 3.11929 2.11929 2 3.5 2H5.58579C5.98361 2 6.36514 2.15804 6.64645 2.43934L8.20711 4H12.5C13.8807 4 15 5.11929 15 6.5V11.5C15 12.8807 13.8807 14 12.5 14H3.5C2.11929 14 1 12.8807 1 11.5V4.5ZM2 7V11.5C2 12.3284 2.67157 13 3.5 13H12.5C13.3284 13 14 12.3284 14 11.5V6.5C14 5.67157 13.3284 5 12.5 5H8.20711L6.64645 6.56066C6.36514 6.84197 5.98361 7 5.58579 7H2Z",
-  )
-}
-
-///|
-/// The search codicon (CC BY 4.0): the launcher's workspace Search row.
-fn icon_search() -> @html.Html {
-  @icons.codicon(
-    "M10.0195 10.7266C9.06578 11.5217 7.83875 12 6.5 12C3.46243 12 1 9.53757 1 6.5C1 3.46243 3.46243 1 6.5 1C9.53757 1 12 3.46243 12 6.5C12 7.83875 11.5217 9.06578 10.7266 10.0195L13.8535 13.1464C14.0488 13.3417 14.0488 13.6583 13.8535 13.8536C13.6583 14.0488 13.3417 14.0488 13.1464 13.8536L10.0195 10.7266ZM11 6.5C11 4.01472 8.98528 2 6.5 2C4.01472 2 2 4.01472 2 6.5C2 8.98528 4.01472 11 6.5 11C8.98528 11 11 8.98528 11 6.5Z",
   )
 }
 
@@ -130,16 +95,6 @@ fn icon_workflows() -> @html.Html {
 }
 
 ///|
-/// An icon in a fixed-size span. Icons are functions, not shared constants:
-/// each render site gets its own virtual-DOM value, so no Props instance is
-/// ever aliased between two mounted elements.
-fn icon(image : () -> @html.Html) -> @html.Html {
-  @html.span(class="icon", attrs=@html.Attrs::build().aria_hidden("true"), [
-    image(),
-  ])
-}
-
-///|
 /// One strip entry as the root view presents it: the tab's identity plus the
 /// decorations only the owning subsystem knows — the label text, the hover
 /// title, and whether the tab's backing content is missing (a deleted file),
@@ -172,7 +127,7 @@ fn launcher_rows(actions : LauncherActions) -> Array[@html.Html] {
   if actions.browser is Some(open_browser) {
     rows.push(
       @html.button(class="dock-launcher-row", on_click=open_browser, [
-        icon(icon_globe),
+        @icons.icon(icon_globe),
         @html.span(class="dock-launcher-name", "Browse"),
         @html.span(class="dock-launcher-hint", "Open a page in a tab"),
       ]),
@@ -180,28 +135,28 @@ fn launcher_rows(actions : LauncherActions) -> Array[@html.Html] {
   }
   rows.push(
     @html.button(class="dock-launcher-row", on_click=actions.search, [
-      icon(icon_search),
+      @icons.icon(@icons.icon_search),
       @html.span(class="dock-launcher-name", "Search"),
       @html.span(class="dock-launcher-hint", "Search text across the workspace"),
     ]),
   )
   rows.push(
     @html.button(class="dock-launcher-row", on_click=actions.files, [
-      icon(icon_folder),
+      @icons.icon(@icons.icon_folder),
       @html.span(class="dock-launcher-name", "Files"),
       @html.span(class="dock-launcher-hint", "Open a file from the workspace"),
     ]),
   )
   rows.push(
     @html.button(class="dock-launcher-row", on_click=actions.review, [
-      icon(icon_review),
+      @icons.icon(icon_review),
       @html.span(class="dock-launcher-name", "Review"),
       @html.span(class="dock-launcher-hint", "Review changed files and diffs"),
     ]),
   )
   rows.push(
     @html.button(class="dock-launcher-row", on_click=actions.workflows, [
-      icon(icon_workflows),
+      @icons.icon(icon_workflows),
       @html.span(class="dock-launcher-name", "Workflows"),
       @html.span(
         class="dock-launcher-hint",
@@ -283,7 +238,7 @@ pub fn tabs_bar(
         .aria_label("Close all tabs")
         .disabled(close_all_tabs_disabled)
         .on_click(_ => close_all_tabs),
-      icon(@icons.icon_close_all),
+      @icons.icon(@icons.icon_close_all),
     ),
     @html.button(
       class=if chips.is_empty() {
@@ -293,7 +248,7 @@ pub fn tabs_bar(
       },
       title="New tab",
       on_click=toggle_menu,
-      icon(icon_add),
+      @icons.icon(@icons.icon_add),
     ),
     @html.button(
       class="panel-toggle panel-expand",
@@ -302,13 +257,13 @@ pub fn tabs_bar(
         .aria_label(if expanded { "Restore panel" } else { "Expand panel" })
         .aria_pressed(expanded.to_string())
         .on_click(_ => toggle_expanded),
-      icon(if expanded { icon_restore_panel } else { icon_expand_panel }),
+      @icons.icon(if expanded { icon_restore_panel } else { icon_expand_panel }),
     ),
     @html.button(
       class="panel-toggle",
       title="Hide panel",
       on_click=toggle_panel,
-      icon(icon_layout_sidebar_right),
+      @icons.icon(@icons.icon_layout_sidebar_right),
     ),
   ]
   if menu_open {

--- a/desktop/frontend/fileeditor/editor_resize.mbt
+++ b/desktop/frontend/fileeditor/editor_resize.mbt
@@ -112,14 +112,7 @@ fn on_resize_move(event : @dom.Event) -> Unit {
 /// On a very narrow window the floor wins, even past the ceiling.
 fn drag_size(raw : Double, floor~ : Double, max~ : Double) -> Int {
   let ceiling = if max > floor { max } else { floor }
-  let size = if raw < floor {
-    floor
-  } else if raw > ceiling {
-    ceiling
-  } else {
-    raw
-  }
-  size.to_int()
+  raw.clamp(min=floor, max=ceiling).to_int()
 }
 
 ///|
@@ -152,24 +145,19 @@ let tree_width : Ref[Int?] = Ref(None)
 fn sync_root_style() -> Unit {
   guard document_element() is Some(root) else { return }
   let style : @js.Value = @js.Value::cast_from(root).get_with_string("style")
-  if editor_width.val is Some(width) {
-    let _ : @js.Value = style.apply_with_string("setProperty", [
-      @js.Value::cast_from("--editor-width"),
-      @js.Value::cast_from("\{width}px"),
-    ])
+  // One `style` handle, one `setProperty` per set size, in the same order.
+  fn set_px(name : String, size : Int?) -> Unit {
+    if size is Some(px) {
+      let _ : @js.Value = style.apply_with_string("setProperty", [
+        @js.Value::cast_from(name),
+        @js.Value::cast_from("\{px}px"),
+      ])
+    }
   }
-  if tree_height.val is Some(height) {
-    let _ : @js.Value = style.apply_with_string("setProperty", [
-      @js.Value::cast_from("--tree-height"),
-      @js.Value::cast_from("\{height}px"),
-    ])
-  }
-  if tree_width.val is Some(width) {
-    let _ : @js.Value = style.apply_with_string("setProperty", [
-      @js.Value::cast_from("--tree-width"),
-      @js.Value::cast_from("\{width}px"),
-    ])
-  }
+
+  set_px("--editor-width", editor_width.val)
+  set_px("--tree-height", tree_height.val)
+  set_px("--tree-width", tree_width.val)
 }
 
 ///|

--- a/desktop/frontend/fileeditor/feedback/service.mbt
+++ b/desktop/frontend/fileeditor/feedback/service.mbt
@@ -125,14 +125,7 @@ fn DesktopFeedbackService::items_for(
   self : DesktopFeedbackService,
   resource : @common.Uri,
 ) -> Array[@agent_feedback_api.AgentFeedback] {
-  let key = resource.to_string()
-  if self.items_by_resource.get(key) is Some(items) {
-    items
-  } else {
-    let created : Array[@agent_feedback_api.AgentFeedback] = []
-    self.items_by_resource.set(key, created)
-    created
-  }
+  self.items_by_resource.get_or_init(resource.to_string(), () => [])
 }
 
 ///|

--- a/desktop/frontend/fileeditor/files.mbt
+++ b/desktop/frontend/fileeditor/files.mbt
@@ -40,12 +40,9 @@ fn read_directory(
           return
         }
       }
-      let entries : Array[FileEntry] = []
-      for entry in reply.entries {
-        if FileEntry::from_reply(entry, path) is Some(entry) {
-          entries.push(entry)
-        }
-      }
+      let entries = reply.entries.filter_map(entry => {
+        FileEntry::from_reply(entry, path)
+      })
       scheduler.add(dispatch(DirLoaded(owner~, epoch~, path~, entries~)))
     })
   })

--- a/desktop/frontend/fileeditor/git_history.mbt
+++ b/desktop/frontend/fileeditor/git_history.mbt
@@ -506,12 +506,7 @@ fn graph_ref_color(
 
 ///|
 fn find_graph_lane(lanes : Array[GraphLane], id : String) -> Int? {
-  for index in 0..<lanes.length() {
-    if lanes[index].id == id {
-      return Some(index)
-    }
-  }
-  None
+  lanes.search_by(lane => lane.id == id)
 }
 
 ///|
@@ -549,18 +544,12 @@ fn graph_rows(
     let first_unprocessed_parent = if first_parent_added { 1 } else { 0 }
     for parent_index in first_unprocessed_parent..<commit.parent_ids.length() {
       let parent = commit.parent_ids[parent_index]
-      let mut semantic_color = if parent_index == 0 {
+      let semantic_color = if parent_index == 0 {
         graph_ref_color(snapshot, commit.id)
+      } else if commits.any(item => item.id == parent) {
+        graph_ref_color(snapshot, parent)
       } else {
         None
-      }
-      if parent_index > 0 {
-        for item in commits {
-          if item.id == parent {
-            semantic_color = graph_ref_color(snapshot, parent)
-            break
-          }
-        }
       }
       let color = match semantic_color {
         Some(color) => color

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -1587,12 +1587,7 @@ fn reviewable_changes(state : State) -> Array[ChangedFile] {
 ///|
 fn change_row_index(state : State, selected : ChangedFile) -> Int? {
   guard state.changes is ChangeListReady(files~, ..) else { return None }
-  for index in 0..<files.length() {
-    if files[index] == selected {
-      return Some(index)
-    }
-  }
-  None
+  files.search_by(change => change == selected)
 }
 
 ///|
@@ -1604,16 +1599,10 @@ fn review_neighbor(
   delta : Int,
 ) -> ChangedFile? {
   let changes = reviewable_changes(state)
-  for index in 0..<changes.length() {
-    if changes[index] == selected {
-      let destination = index + delta
-      if destination >= 0 && destination < changes.length() {
-        return Some(changes[destination])
-      }
-      return None
-    }
+  guard changes.search_by(change => change == selected) is Some(index) else {
+    return None
   }
-  None
+  changes.get(index + delta)
 }
 
 ///|
@@ -1639,12 +1628,9 @@ fn active_review_position(state : State, ctx : Ctx) -> (ChangedFile, Int, Int)? 
     return None
   }
   let changes = reviewable_changes(state)
-  for index in 0..<changes.length() {
-    if changes[index] == review.selected {
-      return Some((review.selected, index, changes.length()))
-    }
-  }
-  None
+  changes
+  .search_by(change => change == review.selected)
+  .map(index => (review.selected, index, changes.length()))
 }
 
 ///|
@@ -1668,18 +1654,11 @@ fn ChangedFile::is_selected(
 /// Split a relative path into its non-empty segments, e.g.
 /// `"cef/runtime.mbt"` → `["cef", "runtime.mbt"]`.
 fn path_segments(path : @pathx.Relative) -> Array[String] {
-  let segments : Array[String] = []
-  let mut rest = path.0
-  while rest.split_once("/") is Some((head, tail)) {
-    if !head.is_empty() {
-      segments.push(head.to_owned())
+  [
+    for segment in path.0.split("/") if !segment.is_empty() => {
+      segment.to_owned()
     }
-    rest = tail.to_owned()
-  }
-  if !rest.is_empty() {
-    segments.push(rest)
-  }
-  segments
+  ]
 }
 
 ///|

--- a/desktop/frontend/files/request.mbt
+++ b/desktop/frontend/files/request.mbt
@@ -94,13 +94,9 @@ pub fn Request::run(
           scheduler.add(failed())
           return
         }
-        let paths = reply.files.filter_map(path => {
-          if path.is_empty() {
-            None
-          } else {
-            Some(@pathx.Relative(path))
-          }
-        })
+        let paths = [
+          for path in reply.files if !path.is_empty() => @pathx.Relative(path)
+        ]
         scheduler.add(loaded(paths, reply.limit_hit))
       }) catch {
         _ => scheduler.add(failed())
@@ -205,13 +201,9 @@ fn searching_loader(
           if reply.cancelled {
             return
           }
-          let paths = reply.files.filter_map(path => {
-            if path.is_empty() {
-              None
-            } else {
-              Some(@pathx.Relative(path))
-            }
-          })
+          let paths = [
+            for path in reply.files if !path.is_empty() => @pathx.Relative(path)
+          ]
           if active {
             scheduler.add(loaded(paths, reply.limit_hit))
           }

--- a/desktop/frontend/grep_search/view.mbt
+++ b/desktop/frontend/grep_search/view.mbt
@@ -64,11 +64,7 @@ fn visible_file_groups(page : Page) -> Array[FileGroup] {
   let mut remaining = page.visible_lines.max(0)
   for group in grouped_matches(page.text.matches) {
     guard remaining > 0 else { break }
-    let rows : Array[@protocol.TextSearchMatch] = []
-    for result in group.matches {
-      guard rows.length() < remaining else { break }
-      rows.push(result)
-    }
+    let rows = group.matches.iter().take(remaining).to_array()
     visible.push({ ..group, matches: rows, })
     remaining -= rows.length()
   }
@@ -661,11 +657,7 @@ fn visible_semantic_file_groups(page : Page) -> Array[SemanticFileGroup] {
   let mut remaining = page.visible_lines.max(0)
   for group in semantic_grouped_hits(page.semantic.hits) {
     guard remaining > 0 else { break }
-    let rows : Array[@protocol.SemanticSearchHit] = []
-    for hit in group.hits {
-      guard rows.length() < remaining else { break }
-      rows.push(hit)
-    }
+    let rows = group.hits.iter().take(remaining).to_array()
     visible.push({ ..group, hits: rows, })
     remaining -= rows.length()
   }

--- a/desktop/frontend/markdown/markdown.mbt
+++ b/desktop/frontend/markdown/markdown.mbt
@@ -106,16 +106,7 @@ fn MarkdownRender::heading(
 
 ///|
 fn lines_text(lines : @cmark.Seq[@cmark.Node[String]]) -> String {
-  let buf = StringBuilder()
-  let mut first = true
-  for line in lines.iter() {
-    if !first {
-      buf.write_char('\n')
-    }
-    buf.write_string(line.v)
-    first = false
-  }
-  buf.to_string()
+  lines.iter().map(line => line.v).join("\n")
 }
 
 ///|

--- a/desktop/frontend/mention_context/mention_context.mbt
+++ b/desktop/frontend/mention_context/mention_context.mbt
@@ -347,12 +347,6 @@ fn parse_mention_block(lines : ArrayView[String]) -> Array[MentionRef]? {
       index += 1
       continue
     }
-    if file_pattern.execute(line) is Some(matched) {
-      guard matched.named_group("path") is Some(path) else { return None }
-      mentions.push(File(path=path.to_owned()))
-      index += 1
-      continue
-    }
     if symbol_pattern.execute(line) is Some(matched) {
       guard matched.named_group("name") is Some(name) else { return None }
       let (file, line_number) = if matched.named_group("file") is Some(file) &&

--- a/desktop/frontend/preview/state.mbt
+++ b/desktop/frontend/preview/state.mbt
@@ -111,11 +111,7 @@ pub fn page_label(page : PageState) -> String {
     return page.title
   }
   match page.url {
-    Some(url) =>
-      match host_of(url) {
-        Some(host) => host
-        None => url
-      }
+    Some(url) => host_of(url).unwrap_or(url)
     None => "New Tab"
   }
 }

--- a/desktop/frontend/preview/url.mbt
+++ b/desktop/frontend/preview/url.mbt
@@ -125,14 +125,7 @@ pub fn is_loopback(url : String) -> Bool {
 /// Whether the text is one or more digits — the shape that distinguishes a
 /// `localhost:5173` port from a `mailto:someone` scheme.
 fn all_digits(text : StringView) -> Bool {
-  let mut seen_digit = false
-  for ch in text {
-    if ch < '0' || ch > '9' {
-      return false
-    }
-    seen_digit = true
-  }
-  seen_digit
+  !text.is_empty() && text.all(ch => ch.is_ascii_digit())
 }
 
 ///|

--- a/desktop/frontend/project_picker/path_input.mbt
+++ b/desktop/frontend/project_picker/path_input.mbt
@@ -73,10 +73,7 @@ fn State::visible_entries(self : State) -> Array[String] {
       contains.push(name)
     }
   }
-  for name in contains {
-    prefixes.push(name)
-  }
-  prefixes
+  [..prefixes, ..contains]
 }
 
 ///|

--- a/desktop/frontend/quick_open/state.mbt
+++ b/desktop/frontend/quick_open/state.mbt
@@ -437,12 +437,7 @@ fn State::apply_symbol_result(
     open.phase is Loading else {
     return self
   }
-  let openable : Array[@symbols.Symbol] = []
-  for item in items {
-    if !item.path.is_empty() {
-      openable.push(item)
-    }
-  }
+  let openable = items.filter(item => !item.path.is_empty())
   {
     ..self,
     open: Some({

--- a/desktop/frontend/skills/document.mbt
+++ b/desktop/frontend/skills/document.mbt
@@ -21,11 +21,7 @@ fn parse_skill_document(source : String) -> SkillDocument {
   } else {
     first
   }
-  let rest_array : Array[String] = []
-  for line in rest {
-    rest_array.push(line)
-  }
-  let rest = rest_array
+  let rest = rest.to_owned()
   guard first == "---" else { return { metadata: [], body: source, } }
   let closing = find_frontmatter_close(rest)
   guard closing is Some(index) else { return { metadata: [], body: source, } }
@@ -38,11 +34,7 @@ fn parse_skill_document(source : String) -> SkillDocument {
     guard !key.is_empty() else { continue }
     metadata.push((key, line[colon + 1:].trim().to_owned()))
   }
-  let body_lines : Array[String] = []
-  for body_line in rest[index + 1:] {
-    body_lines.push(body_line)
-  }
-  { metadata, body: lines_to_string(body_lines), }
+  { metadata, body: rest[index + 1:].join("\n"), }
 }
 
 ///|
@@ -54,18 +46,6 @@ fn find_frontmatter_close(lines : Array[String]) -> Int? {
     }
   }
   None
-}
-
-///|
-fn lines_to_string(lines : Array[String]) -> String {
-  let out = StringBuilder()
-  for index, line in lines {
-    if index > 0 {
-      out.write_char('\n')
-    }
-    out.write_string(line)
-  }
-  out.to_string()
 }
 
 ///|

--- a/desktop/frontend/terminal/host.mbt
+++ b/desktop/frontend/terminal/host.mbt
@@ -483,15 +483,7 @@ fn TermHost::clear_pending(
     term_host.opening_channels = term_host.opening_channels.filter(existing => {
       existing != channel
     })
-    let pending_ids : Array[String] = []
-    for id, pending in self.pending {
-      if pending.0 == channel {
-        pending_ids.push(id)
-      }
-    }
-    for id in pending_ids {
-      self.pending.remove(id)
-    }
+    self.pending.retain((_, pending) => pending.0 != channel)
   })
 }
 

--- a/desktop/frontend/terminal/resize.mbt
+++ b/desktop/frontend/terminal/resize.mbt
@@ -97,15 +97,9 @@ fn TerminalResizer::track(self : TerminalResizer, event : @dom.Event) -> Unit {
   let rect = content.get_bounding_client_rect()
   let floor = MinTerminalHeight.to_double()
   let max = rect.get_height() - MinConversationHeight.to_double()
-  let ceiling = if max > floor { max } else { floor }
+  let ceiling = max.max(floor)
   let raw = rect.get_bottom() - mouse.get_client_y().to_double()
-  let height = if raw < floor {
-    floor
-  } else if raw > ceiling {
-    ceiling
-  } else {
-    raw
-  }
+  let height = raw.clamp(min=floor, max=ceiling)
   guard @dom.document().query_selector("html").to_option() is Some(root) else {
     return
   }

--- a/desktop/frontend/transcript/component/component.mbt
+++ b/desktop/frontend/transcript/component/component.mbt
@@ -727,8 +727,10 @@ fn TranscriptObservers::disconnect(self : Self) -> Unit {
 }
 
 ///|
-test "local pinned transitions are pure" {
-  let input = Input(
+/// The neutral local-OpenSeek input the component tests below start from;
+/// each test names only the fields it varies, with struct update.
+fn base_input() -> Input {
+  Input(
     source=OpenSeek,
     focused=Local,
     active_session="desktop-test",
@@ -743,7 +745,12 @@ test "local pinned transitions are pure" {
     streaming_response=None,
     streaming_identity="idle",
   )
-  let state : Model = {
+}
+
+///|
+/// The mounted, pinned model matching `base_input()`.
+fn pinned_model(input : Input) -> Model {
+  {
     pinned: true,
     overview: @transcript_overview.State::empty(),
     source: OpenSeek,
@@ -754,6 +761,12 @@ test "local pinned transitions are pure" {
     submission_generation: 0,
     mounted: true,
   }
+}
+
+///|
+test "local pinned transitions are pure" {
+  let input = base_input()
+  let state = pinned_model(input)
   let emit : @cmd.Emit[Msg] = @cmd.Emit(_ => @cmd.none)
   let (first, _) = state.update(input, Pinned(false), emit)
   let (second, _) = state.update(input, Pinned(false), emit)
@@ -794,32 +807,8 @@ test "local pinned transitions are pure" {
 ///|
 test "an overview click unpins and highlights inside the component" {
   let key = @transcript_overview.Durable(3)
-  let input = Input(
-    source=OpenSeek,
-    focused=Local,
-    active_session="desktop-test",
-    current_project=None,
-    projects=[],
-    can_choose_project=false,
-    project_menu_open=false,
-    project_query="",
-    root=None,
-    submission_generation=0,
-    items=[],
-    streaming_response=None,
-    streaming_identity="idle",
-  )
-  let state : Model = {
-    pinned: true,
-    overview: @transcript_overview.State::empty(),
-    source: OpenSeek,
-    focused: Local,
-    active_session: "desktop-test",
-    image_owner: input.image_owner(),
-    images: ImageCache::empty(),
-    submission_generation: 0,
-    mounted: true,
-  }
+  let input = base_input()
+  let state = pinned_model(input)
   let emit : @cmd.Emit[Msg] = @cmd.Emit(_ => @cmd.none)
   let (next, _) = state.update(input, Overview(Clicked(key)), emit)
   assert_false(next.pinned)
@@ -828,22 +817,9 @@ test "an overview click unpins and highlights inside the component" {
 
 ///|
 test "a conversation switch clears component-owned overview state" {
-  let input = Input(
-    source=OpenSeek,
-    focused=Local,
-    active_session="desktop-test",
-    current_project=None,
-    projects=[],
-    can_choose_project=false,
-    project_menu_open=false,
-    project_query="",
-    root=None,
-    submission_generation=0,
-    items=[],
-    streaming_response=None,
-    streaming_identity="idle",
-  )
-  let state : Model = {
+  let input = base_input()
+  let state = {
+    ..pinned_model(input),
     pinned: false,
     overview: {
       hover: Some({
@@ -853,13 +829,6 @@ test "a conversation switch clears component-owned overview state" {
       }),
       active: Some(@transcript_overview.Durable(3)),
     },
-    source: OpenSeek,
-    focused: Local,
-    active_session: "desktop-test",
-    image_owner: input.image_owner(),
-    images: ImageCache::empty(),
-    submission_generation: 0,
-    mounted: true,
   }
   let emit : @cmd.Emit[Msg] = @cmd.Emit(_ => @cmd.none)
   let (next, _) = state.update(

--- a/desktop/frontend/transcript/component/rendering.mbt
+++ b/desktop/frontend/transcript/component/rendering.mbt
@@ -141,12 +141,7 @@ fn EmptyProjectControl::render(
     ),
   ]
   if self.open {
-    let visible : Array[ProjectChoice] = []
-    for project in projects {
-      if project.matches(self.query) {
-        visible.push(project)
-      }
-    }
+    let visible = projects.filter(project => project.matches(self.query))
     let rows : Array[@html.Html] = []
     for project in visible {
       let selected = project.root == current

--- a/desktop/frontend/transcript/sessions.mbt
+++ b/desktop/frontend/transcript/sessions.mbt
@@ -218,11 +218,7 @@ pub fn subrun_child_sessions(
 /// differ, then by depth, so `sr-2` precedes `sr-10` and a child precedes
 /// its own grandchildren.
 fn compare_subrun_path(left : Array[Int], right : Array[Int]) -> Int {
-  let shared = if left.length() < right.length() {
-    left.length()
-  } else {
-    right.length()
-  }
+  let shared = left.length().min(right.length())
   for index in 0..<shared {
     if left[index] < right[index] {
       return -1


### PR DESCRIPTION
A pure **simplification** pass: no feature, no fix, no behaviour change. Part of a project-wide sweep; each PR is one package family so it can be reviewed on its own.

Candidates came from a read-only survey of the whole repository. The author was told to drop any that would not compile or would change behaviour, so this branch carries fewer than were proposed: **35 applied, 1 dropped, net -277 lines.**

## Applied

- **desktop/frontend/transcript/component/component.mbt** — Three tests rebuild the same 14-line `Input` and the same 11-line `Model` literal
  Added package-private `base_input()` / `pinned_model(input)` fixtures; the third test keeps its distinct model as `{ ..pinned_model(input), pinned: false, overview: {...} }`. Scoped to component.mbt only — I did NOT touch the near-identical literal in view_tests.mbt (see reviewer_notes). All three test names, inputs and assertions unchanged.
- **desktop/frontend/dock/update.mbt** — Five `open_*` functions repeat the same append-unless-present-then-activate body
  Extracted private `open_tab(state, tab)`; each of open_file / open_history_diff / open_browser / open_picker / open_workflows keeps its own doc comment and public signature.
- **desktop/frontend/dock/view.mbt** — dock/view.mbt re-declares four codicons byte-identically to `@icons.icon_*`
  Deleted icon_layout_sidebar_right, icon_add, icon_folder, icon_search; call sites now use @icons.*. Bodies were byte-identical modulo the `@icons.` qualifier on `codicon`; the CC BY 4.0 attribution and the innerHTML/morph rationale live verbatim in the icons package header.
- **desktop/frontend/dock/view.mbt** — dock/view.mbt's private `icon` wrapper duplicates `@icons.icon`, comment and all
  Deleted; nine call sites now call @icons.icon. The doc comment was byte-identical to the one on @icons.icon, so nothing explanatory was lost.
- **desktop/frontend/skills/document.mbt** — `lines_to_string` is a hand-rolled `join("\n")`; the copy loop feeding it is also unneeded
  `rest[index + 1:].join("\n")`; helper deleted (single caller).
- **desktop/frontend/skills/document.mbt** — Copying an ArrayView into an Array by push loop; `ArrayView::to_owned` does it
  `let rest = rest.to_owned()`; still an Array[String] because find_frontmatter_close takes one.
- **desktop/frontend/action_menu/action_menu.mbt** — Menu positioning re-implements clamp/max inline; core has Double::clamp and Double::max
  `wanted_left.clamp(min=min_left, max=max_left.max(min_left))` and the same for top. Added a two-line comment naming why `.max(min_*)` is there (it keeps core's `guard! min <= max` satisfied when the menu is larger than the viewport).
- **desktop/frontend/action_menu/action_menu.mbt** — Delete the private clamp helper — it is a verbatim copy of core's Double::clamp
  Deleted; both callers were rewritten by the finding above.
- **desktop/frontend/action_menu/action_menu.mbt** — enabled_position is Array::search
  `indices.search(index)`. Kept the wrapper (the finding's optional extra step of inlining it at the two call sites was not taken).
- **desktop/frontend/fileeditor/view.mbt** — path_segments hand-rolls split-on-"/"; one comprehension over String::split does it
  `[for segment in path.0.split("/") if !segment.is_empty() => segment.to_owned()]`; doc comment kept verbatim.
- **desktop/frontend/fileeditor/view.mbt** — change_row_index is Array::search_by
  Also applied to the two sibling scans the finding's evidence names: review_neighbor (now `search_by` + `changes.get(index + delta)` — Array::get is literally the `>= 0 && < length` check it replaces) and active_review_position.
- **desktop/frontend/fileeditor/view.mbt** — active_review_position's index scan is search_by + Option::map
  `changes.search_by(...).map(index => (review.selected, index, changes.length()))`.
- **desktop/frontend/fileeditor/editor_resize.mbt** — drag_size open-codes Double::clamp, which has the identical body in core
  `raw.clamp(min=floor, max=ceiling).to_int()`; the `ceiling` line is retained, so both core's guard and the doc comment's "floor wins past the ceiling" still hold.
- **desktop/frontend/fileeditor/editor_resize.mbt** — sync_root_style repeats the same setProperty block three times; a local helper collapses it
  Local `fn set_px(name, size)` capturing the single `style` handle; same three properties in the same order, one DOM lookup as before. Four-line doc comment kept verbatim.
- **desktop/frontend/fileeditor/feedback/service.mbt** — items_for hand-rolls Map::get_or_init
  `self.items_by_resource.get_or_init(resource.to_string(), () => [])`; doc comment ("creating it on first mutation") stays accurate.
- **desktop/frontend/fileeditor/files.mbt** — read_directory's entries accumulator is Array::filter_map
  `reply.entries.filter_map(entry => FileEntry::from_reply(entry, path))`.
- **desktop/frontend/fileeditor/git_history.mbt** — find_graph_lane is Array::search_by
  `lanes.search_by(lane => lane.id == id)`.
- **desktop/frontend/fileeditor/git_history.mbt** — The parent-lookup break loop and its mut accumulator are one if/else-if with Array::any
  `else if commits.any(item => item.id == parent)`; the `mut` is gone. `parent_index == 0` still short-circuits before any scan.
- **desktop/frontend/files/request.mbt** — The same 6-line filter_map lambda over reply.files appears twice; both are one comprehension
  Both sites (Request::run and searching_loader) now `[for path in reply.files if !path.is_empty() => @pathx.Relative(path)]`.
- **desktop/frontend/dock/state.mbt** — `file_paths` / `history_diffs` are push loops that are exactly `filter_map`
  filter_map preserves order, which both doc comments depend on.
- **desktop/frontend/codex/activity_wbtest.mbt** — Four ledger tests share one body that differs only in the mutation, status and mark
  Added `stale_snapshot_mark(mutate, status) -> @conversation.RunMark` with a doc comment describing the stale-frontier scenario. All four test names, mutations, statuses and expected marks preserved; each test keeps its own assert, so a failure still names the exact case.
- **desktop/frontend/markdown/markdown.mbt** — `lines_text` hand-rolls a first-flag StringBuilder join over an Iter
  `lines.iter().map(line => line.v).join("\n")`.
- **desktop/frontend/terminal/host.mbt** — Collect-then-remove over a Map is Map::retain
  `self.pending.retain((_, pending) => pending.0 != channel)`. retain is the reason the two-phase form existed — it removes while walking the entry list.
- **desktop/frontend/terminal/resize.mbt** — Hand-written max and three-branch clamp in the resize tracker
  `max.max(floor)` then `raw.clamp(min=floor, max=ceiling)`; the doc comment's "matching the CSS `clamp`" now names the mechanism literally.
- **desktop/frontend/preview/url.mbt** — all_digits is a seen_digit accumulator loop; StringView::all + Char::is_ascii_digit says it directly
  `!text.is_empty() && text.all(ch => ch.is_ascii_digit())`; `seen_digit` was exactly `!is_empty()`.
- **desktop/frontend/preview/state.mbt** — page_label's nested match on host_of is Option::unwrap_or
  Outer `match page.url` kept so the "New Tab" arm stays explicit.
- **desktop/frontend/mention_context/mention_context.mbt** — An unreachable second copy of the file-mention arm sits behind the first
  Dead-code deletion: identical condition on the same unchanged `line`, and the first arm always `continue`s. I verified I removed the SECOND copy (the one missing `MentionAttribute::decode`), leaving the live decoded arm untouched.
- **desktop/frontend/composer/codex_request.mbt** — execpolicy_label repeats the JSON string-array loop twice; extract one helper
  Added `json_string_parts(values : Array[Json]) -> Array[String]` near the top of the file; execpolicy_label now assigns to `let mut parts` twice. Equivalent because the first block previously appended into an empty array and the second still runs only when `parts.is_empty()`.
- **desktop/frontend/composer/codex_request.mbt** — Third copy of "collect the String members of a JSON array" in this file
  approval_details now calls json_string_parts too.
- **desktop/frontend/quick_open/state.mbt** — Manual accumulator that is exactly Array::filter
  `items.filter(item => !item.path.is_empty())`; filter preserves order, which rank_symbols' source-index tiebreak depends on.
- **desktop/frontend/transcript/component/rendering.mbt** — A push loop selecting matching projects is exactly `Array::filter`
  `projects.filter(project => project.matches(self.query))`.
- **desktop/frontend/grep_search/view.mbt** — Bounded take loop in visible_file_groups is iter().take(n)
  `group.matches.iter().take(remaining).to_array()`; `remaining > 0` already guaranteed by the guard on the line above, and `remaining -= rows.length()` is unaffected.
- **desktop/frontend/grep_search/view.mbt** — Same bounded take loop in visible_semantic_file_groups
  Same edit on `group.hits`.
- **desktop/frontend/transcript/sessions.mbt** — Hand-written minimum of two lengths; `Int::min` exists and is used elsewhere here
  `left.length().min(right.length())`.
- **desktop/frontend/project_picker/path_input.mbt** — Appending the contains bucket with a push loop where an array spread reads it
  `[..prefixes, ..contains]`; both are function-local arrays, so returning a fresh concatenation is observationally identical and keeps the bucket order the doc comment describes.

## Dropped, and why

- **enabled_indices is a filtered index comprehension (desktop/frontend/action_menu/action_menu.mbt:317)**
  `moon fmt` is not idempotent on this shape and its second pass produces code that would not compile. I wrote the finding's form (`[for index, entry in self.entries if entry is Action(item) && item.enabled => index]`); it compiled and passed `moon check --target js --deny-warn`, but `moon fmt` rewrote the bare-identifier body into a block `=> { index }`, and `moon fmt --check` then demanded `=> { { index, } }` — i.e. the formatter reinterprets the block as a struct literal, which is not an Int. CI runs `moon fmt --check`, so any form the formatter cannot round-trip is a landmine. Reverted the hunk to the original push loop; the finding was only worth 2 lines. Note this is a formatter bug, not a MoonBit-semantics problem: every other comprehension I added has a non-identifier body (`segment.to_owned()`, `@pathx.Relative(path)`, `part`) and survives `moon fmt --check` unchanged.

## Verification

All commands run from the worktree at .../scratchpad/wt/fe-pkgs (branch simplify/fe-pkgs, clean at start, based on origin/main).

BASELINE (before any edit)
- `cd desktop && moon check --target js --deny-warn` → "Finished. moon: ran 589 tasks, now up to date" (clean).
- `moon test --target js` over the 17 packages I was about to touch (openseek_desktop/frontend/{transcript/component, transcript, dock, skills, action_menu, fileeditor, fileeditor/feedback, files, codex, markdown, terminal, preview, mention_context, composer, quick_open, grep_search, project_picker}) → "Total tests: 419, passed: 419, failed: 0."

PER-PACKAGE during work
- `moon check --target js --deny-warn frontend/<pkg>` after each batch of edits; all clean. Note: `-p openseek_desktop/frontend/dock` does NOT work for `moon check` on this toolchain (it canonicalizes the package name as a filesystem path and fails); the working form is a path relative to cwd, e.g. `moon check --target js --deny-warn frontend/dock`. `-p <full-package-name>` does work for `moon test`.
- One real failure, fixed: `moon check` rejected the first `enabled_indices` comprehension with "Parse error, unexpected token `{`, you may expect `=>`" (2 errors) plus an `unused_value` on `index`. I rewrote it in `=>` form, which then compiled clean — and later dropped it entirely for the fmt reason below.

FINAL GATE (all from desktop/)
- `moon fmt --check` → "Finished. moon: ran 25 tasks, now up to date" (clean). It FAILED twice before that, both times on action_menu.mbt's `enabled_indices`; I confirmed by diffing the file against `_build/wasm-gc/release/format/.../action_menu.mbt` that the formatter wanted `=> { { index, } }`, i.e. its own output re-read as a struct literal. Reverted that hunk; fmt --check then passed. (Separately: `moon fmt --check`'s failure output includes "failed to execute `git --no-pager diff --color=always --no-index ...`" because this repo routes git diff through an external differ — that message is noise, the format diff itself is real. I used plain `diff -u` against the _build copy to read it.)
- `moon check --target js --deny-warn` → "Finished. moon: ran 434 tasks, now up to date" (clean; js is the frontend's only supported target).
- `moon check --deny-warn` (native, the module's preferred target) → "Finished. moon: ran 423 tasks, now up to date" (clean).
- `moon test --target js` over the same 17 packages → "Total tests: 419, passed: 419, failed: 0." Identical to baseline: 419 before, 419 after.

TEST DEDUPE COUNTS
- codex/activity_wbtest.mbt: 4 tests before → 4 tests after; 4 assert_true before → 4 after; all four test names, mutations, statuses and expected marks preserved. Each keeps its own `test` block, so a failure still names the case.
- transcript/component/component.mbt: 3 tests before → 3 after; assertion count unchanged (7 + 2 + 6 = 15 before and after); no inputs or expectations altered, only the shared literals hoisted.
- Package-level confirmation: `moon test --target js -p openseek_desktop/frontend/codex` → 70/70 both before and after the dedupe.

MBTI / PUBLIC INTERFACE
- `moon info frontend/<17 packages>` (SCOPED, never bare) → "Finished. moon: ran 4 tasks"; git status showed NO .mbti change. I then verified this was not a false negative: I appended a probe line to desktop/frontend/dock/pkg.generated.mbti and re-ran `moon info frontend/dock`, which printed "Warning: Skipping package `openseek_desktop/frontend/dock` for `moon info`: it does not support target backend `native`" and left the probe in place. So plain `moon info` genuinely cannot regenerate js-only packages on this toolchain (matching the brief's note). Probe reverted with `git checkout --`.
- Because of that I verified the interfaces a second way: captured `moon info --target js` (report mode; it does not write) over the same 17 packages AFTER my changes, then `git stash push -- desktop/frontend`, captured the same report on the pristine tree, then `git stash pop`. `diff -u info-before.txt info-after.txt` → a single differing line, moon's own "ran 35 tasks" vs "ran 43 tasks" progress line. The 2023 lines of interface report are byte-identical. No public signature changed.

GIT
- `git status --short` before staging listed exactly the 25 files I edited and nothing else (no build artifacts, no stray .mbti).
- Staged by explicit path (25 paths, no `git add -A`), committed as 3a8ba70f4 "refactor(desktop/frontend): reach for core APIs and shared helpers" with the Co-Authored-By and Claude-Session footer from the brief. 25 files changed, 155 insertions(+), 432 deletions(-).
- `git push -u origin simplify/fe-pkgs` → "* [new branch] simplify/fe-pkgs -> simplify/fe-pkgs", tracking set. No PR opened, no merge, no other branch touched. Working tree clean afterwards.

## Worth a second look

Four things worth a second look.

1. dock/view.mbt icon deletions cost some prose. The four deleted codicon wrappers carried per-call-site notes ("the strip's new-tab button", "the launcher's Files row", "the launcher's workspace Search row", "for the panel toggle"). The load-bearing part of those comments — the CC BY 4.0 attribution and the "an innerHTML-bearing element cannot be safely morphed by the positional child diff" rationale — is stated verbatim in the icons package header (icons/icons.mbt:1-9), so nothing explaining WHY was lost; the what/where notes were. If you'd rather keep them, this is the one finding to revert. The `icon` wrapper deletion loses nothing at all (its doc comment was byte-identical to the one on @icons.icon). Aesthetic side effect: `@icons.icon(@icons.icon_close_all)` at view.mbt:241 reads a bit heavy.

2. Double::max vs `if a > b`. terminal/resize.mbt and action_menu now use `Double::max`, which differs from the hand-written comparison only when an operand is NaN. Every operand comes from getBoundingClientRect / clientY / window.innerWidth, all finite. Same for core's `Double::clamp` debug `guard! min <= max`: I kept the `ceiling` / `.max(min_*)` lines specifically so that guard cannot trip.

3. mention_context.mbt is a real dead-code deletion, not just a rewrite. The removed arm had a different payload (`path.to_owned()` without `MentionAttribute::decode`) but was unreachable behind an identical condition on an unchanged `line` whose first arm always `continue`s. Deleting it leaves observable behaviour exactly as it runs today, but if the intent was ever that the two arms test *different* patterns, this deletion buries that bug instead of fixing it. Worth a glance from whoever wrote it.

4. Test dedupe scope. For the transcript component fixture I deliberately stopped at component.mbt. The finding's evidence also points at view_tests.mbt:189-203 (same Input literal modulo `focused=@interop.ChannelId::Local`) and two more literals there that differ in several fields; folding those into `{ ..base_input(), ... }` would have been a larger, less obviously-equivalent edit for little gain. `base_input()` / `pinned_model()` are package-private, so a follow-up can pick them up from view_tests.mbt whenever someone wants to.

Also note: `moon fmt` reformatted two of my comprehensions into brace-body form (fileeditor/view.mbt path_segments, fileeditor/files.mbt filter_map). That is the formatter's own output and `moon fmt --check` is clean on it — but see the `dropped` entry for the case where that same rewrite produces non-compiling code.

Reviewed by OpenSeek's own review subagent (DeepSeek Flash); its verdict is posted as a comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXBYcYo74F1DGSPZsYYAdc