### PR TITLE
refactor: desktop/frontend: replace accumulator loops with map/filter

### DIFF
--- a/desktop/frontend/agent_model.mbt
+++ b/desktop/frontend/agent_model.mbt
@@ -137,13 +137,10 @@ fn openseek_model_group(
     Glm => [Glm53, Glm53Flash]
     Custom => [DsPro, DsFlash, Glm53, Glm53Flash]
   }
-  let options : Array[@composer.ModelOption] = []
-  for model in listed {
-    options.push({
-      value: ModelChoice::OpenSeekModel(model).wire(),
-      label: model.label(),
-    })
-  }
+  let options = listed.map(model => @composer.ModelOption::{
+    value: ModelChoice::OpenSeekModel(model).wire(),
+    label: model.label(),
+  })
   if !listed.contains(selected) {
     options.push({
       value: ModelChoice::OpenSeekModel(selected).wire(),
@@ -179,13 +176,10 @@ test "the model group follows the configured provider" {
 fn Model::codex_model_group(self : Model) -> @composer.ModelGroup {
   match self.codex.model_listing() {
     CodexModels(options, selected=_) => {
-      let prefixed : Array[@composer.ModelOption] = []
-      for option in options {
-        prefixed.push({
-          value: ModelChoice::CodexModel(option.value).wire(),
-          label: option.label,
-        })
-      }
+      let prefixed = options.map(option => @composer.ModelOption::{
+        value: ModelChoice::CodexModel(option.value).wire(),
+        label: option.label,
+      })
       { label: "Codex", options: prefixed, }
     }
     CodexModelsUnavailable(label) =>

--- a/desktop/frontend/bridge.mbt
+++ b/desktop/frontend/bridge.mbt
@@ -35,27 +35,21 @@ fn notification_msg(
       let changes : Array[@fileeditor.FileChange]? = if payload.baseline {
         None
       } else {
-        let decoded : Array[@fileeditor.FileChange] = []
-        for item in payload.events {
+        let decoded = payload.events.filter_map(item => {
           match item.kind_ {
-            "modify" =>
-              decoded.push(@fileeditor.Modified(@pathx.Relative(item.path)))
-            "create" =>
-              decoded.push(@fileeditor.Created(@pathx.Relative(item.path)))
-            "remove" =>
-              decoded.push(@fileeditor.Removed(@pathx.Relative(item.path)))
+            "modify" => Some(@fileeditor.Modified(@pathx.Relative(item.path)))
+            "create" => Some(@fileeditor.Created(@pathx.Relative(item.path)))
+            "remove" => Some(@fileeditor.Removed(@pathx.Relative(item.path)))
             "rename" =>
-              if item.old_path is Some(old) {
-                decoded.push(
-                  @fileeditor.Renamed(
-                    old=@pathx.Relative(old),
-                    new=@pathx.Relative(item.path),
-                  ),
+              item.old_path.map(old => {
+                @fileeditor.Renamed(
+                  old=@pathx.Relative(old),
+                  new=@pathx.Relative(item.path),
                 )
-              }
-            _ => ()
+              })
+            _ => None
           }
-        }
+        })
         Some(decoded)
       }
       Some(
@@ -578,20 +572,13 @@ fn fetch_runs(
       ) catch {
         _ => return
       }
-      let live : Array[String] = []
-      let recovered : Array[RecoveredRun] = []
-      for item in reply.runs {
-        live.push(item.run_id)
-        if RecoveredRun::from_started(channel, item) is Some(run) {
-          recovered.push(run)
-        }
-      }
-      let recovered_settlements : Array[RecoveredSettlement] = []
-      for item in reply.settled {
-        if RecoveredSettlement::from_reply(item) is Some(settlement) {
-          recovered_settlements.push(settlement)
-        }
-      }
+      let live = reply.runs.map(item => item.run_id)
+      let recovered = reply.runs.filter_map(item => {
+        RecoveredRun::from_started(channel, item)
+      })
+      let recovered_settlements = reply.settled.filter_map(
+        RecoveredSettlement::from_reply,
+      )
       // Standing questions come back unfiltered: unlike a settlement, which is
       // history only its owner wants, a blocked turn is stopped right now and
       // whoever is looking at that session should be able to unblock it.

--- a/desktop/frontend/composer_files.mbt
+++ b/desktop/frontend/composer_files.mbt
@@ -3,14 +3,10 @@
 /// bookmark in the editor strip, but neither Quick Open nor a composer mention
 /// may offer it as a destination.
 fn Model::live_editor_files(self : Model) -> Array[@pathx.Relative] {
-  let paths : Array[@pathx.Relative] = []
-  for path in @dock.file_paths(self.dock) {
-    match self.file_panel.docs.get(path) {
-      Some(doc) if doc.state is @fileeditor.TabDeleted => ()
-      _ => paths.push(path)
-    }
-  }
-  paths
+  @dock.file_paths(self.dock).filter(path => {
+    !(self.file_panel.docs.get(path) is Some(doc) &&
+    doc.state is @fileeditor.TabDeleted)
+  })
 }
 
 ///|

--- a/desktop/frontend/console.mbt
+++ b/desktop/frontend/console.mbt
@@ -224,17 +224,11 @@ fn apply_roster(
   // roster no longer grants, drops its state and conversations and disposes
   // its PTYs. Removing the device also removes its root subscription, whose
   // unload closes the socket before update's commands run.
-  let devices : Array[DeviceState] = []
-  for dev in model.devices {
-    let granted = if dev.channel is Remote(id) {
-      metas.iter().any(meta => meta.id == id)
-    } else {
-      false
-    }
-    if Some(dev.channel) == page_channel && granted {
-      devices.push(dev)
-    }
-  }
+  let devices = model.devices.filter(dev => {
+    Some(dev.channel) == page_channel &&
+    dev.channel is Remote(id) &&
+    metas.iter().any(meta => meta.id == id)
+  })
   let conversations = model.conversations.filter(conv => {
     devices.iter().any(dev => dev.channel == conv.device)
   })

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -242,12 +242,9 @@ fn Model::push_group_component_inputs(
       ),
     )
   }
-  let durable : Array[@transcript.SessionListItem] = []
-  for item in dev.sessions {
-    if item.workspace == workspace && !archived(item.id) {
-      durable.push(item)
-    }
-  }
+  let durable = dev.sessions.filter(item => {
+    item.workspace == workspace && !archived(item.id)
+  })
   // Sub-run transcripts fold under the conversation that launched them: they
   // are that turn's evidence, not conversations of their own. They ride the
   // parent's component input, so their disclosure state lives in the
@@ -346,10 +343,7 @@ fn RowStamp::rank(self : RowStamp) -> Int {
 fn ordered_by_recency(
   rows : Array[(RowStamp, @conversation.Input)],
 ) -> Array[@conversation.Input] {
-  let keyed : Array[(Int, RowStamp, @conversation.Input)] = []
-  for index, row in rows {
-    keyed.push((index, row.0, row.1))
-  }
+  let keyed = rows.mapi((index, row) => (index, row.0, row.1))
   keyed.sort_by((a, b) => {
     let (a_index, a_stamp, _) = a
     let (b_index, b_stamp, _) = b
@@ -398,12 +392,9 @@ fn Model::sidebar_component_sections(
   // root. Codex state mirrors the focused device only, so other devices'
   // rows are OpenSeek's alone.
   let codex_context : @codex.SidebarContext? = if dev.channel == self.focused {
-    let registered_projects : Array[String] = []
-    for project in dev.projects {
-      if @resource.path_for(project, dev.channel) is Some(path) {
-        registered_projects.push(path)
-      }
-    }
+    let registered_projects = dev.projects.filter_map(project => {
+      @resource.path_for(project, dev.channel)
+    })
     Some({
       channel: dev.channel,
       selected: self.screen is Codex,

--- a/desktop/frontend/window_titlebar_wbtest.mbt
+++ b/desktop/frontend/window_titlebar_wbtest.mbt
@@ -17,6 +17,9 @@ extern "js" fn titlebar_test_element(
 
 ///|
 test "window zoom gesture accepts chrome and excludes controls and popups" {
+  // The chrome selector group includes `.window-titlebar-drag-strip`, so this
+  // accepting case also covers the explicit drag strip blank native pages
+  // provide.
   assert_true(
     is_window_titlebar_double_click_target(titlebar_test_element(true, false)),
   )
@@ -26,12 +29,6 @@ test "window zoom gesture accepts chrome and excludes controls and popups" {
   assert_false(
     is_window_titlebar_double_click_target(titlebar_test_element(false, false)),
   )
-}
-
-///|
-test "the explicit blank-page drag strip is titlebar chrome" {
-  let strip = titlebar_test_element(true, false)
-  assert_true(is_window_titlebar_double_click_target(strip))
 }
 
 ///|


### PR DESCRIPTION
A pure **simplification** pass: no feature, no fix, no behaviour change. Part of a project-wide sweep; each PR is one package family so it can be reviewed on its own.

Candidates came from a read-only survey of the whole repository. The author was told to drop any that would not compile or would change behaviour, so this branch carries fewer than were proposed: **10 applied, 0 dropped, net -41 lines.**

## Applied

- **desktop/frontend/console.mbt** — apply_roster's retire loop is one `filter` with an `is` guard in the `&&` chain
  Applied, but with the conjuncts in the ORIGINAL order (`Some(dev.channel) == page_channel && dev.channel is Remote(id) && metas.iter().any(...)`) rather than the finding's reordered form, so the chain still reads in the order the comment above it describes. All three conjuncts are pure, so the short-circuit is observationally identical.
- **desktop/frontend/bridge.mbt** — Three accumulator loops over the agent.runs reply are map/filter_map (fetch_runs, line ~572)
  Applied as proposed. Now two passes over `reply.runs` instead of one; verified `RecoveredRun::from_started` (bridge.mbt:703) and `RecoveredSettlement::from_reply` (bridge.mbt:737) are pure projections with no dispatch or mutation, so the extra pass is invisible. Point-free `filter_map(RecoveredSettlement::from_reply)` compiles.
- **desktop/frontend/window_titlebar_wbtest.mbt** — "blank-page drag strip is titlebar chrome" duplicates an assertion in the test above it
  Applied, but the intent was moved as a plain `//` comment INSIDE the surviving test body, immediately above the assertion it describes, not as a `///` doc comment on the `test` block as the finding proposed — a normal comment is guaranteed to compile and sits next to the assertion it justifies. Assertion accounting: 7 assertions / 3 tests before, 6 assertions / 2 tests after; the removed assertion was byte-identical to window_titlebar_wbtest.mbt:20-22.
- **desktop/frontend/composer_files.mbt** — live_editor_files is a `filter` on the negated deleted-tab test
  Applied as proposed; `moon fmt` settled it into a braced lambda body.
- **desktop/frontend/view.mbt** — The durable-session accumulator loop is `dev.sessions.filter(...)` (line ~245)
  Applied as proposed.
- **desktop/frontend/bridge.mbt** — FsChanged event decoding is `payload.events.filter_map(...)` over the same match (line ~38)
  Applied with two adjustments. (1) The finding's `if item.old_path is Some(old) { Some(...) } else { None }` for the "rename" arm is `item.old_path.map(old => ...)`, which is what I used. (2) The finding's explicit `let decoded : Array[@fileeditor.FileChange] =` annotation is NOT needed — the `Some(...)` arms fix the element type — and keeping it pushed the line past the fmt width, producing a badly-indented result. Dropping it lets `moon fmt` lay the block out cleanly.
- **desktop/frontend/agent_model.mbt** — openseek_model_group's option loop is `listed.map(...)` (line ~140)
  Applied, but the finding's bare record literal DOES NOT COMPILE here: error [4033] "There is no record definition with the fields: value, label". The cited precedent (composer/view.mbt:49-52) only works because an enclosing record field supplies the expected type; a bare `let` does not. Fixed with the qualified literal `@composer.ModelOption::{ ... }` (repo precedent: branch.mbt:353). The later `options.push({...})` for the carried selection then resolves from the array's element type and was left untouched.
- **desktop/frontend/agent_model.mbt** — codex_model_group's prefixing loop is `options.map(...)` (line ~179)
  Same [4033] failure and same fix as above: `@composer.ModelOption::{ ... }`.
- **desktop/frontend/view.mbt** — ordered_by_recency's index-tagging loop is `Array::mapi` (line ~343)
  Applied as proposed, one line. `mapi` returns a fresh array so the following `keyed.sort_by` still mutates a copy; the stable-tiebreak comment above it is untouched and still accurate.
- **desktop/frontend/view.mbt** — registered_projects is `dev.projects.filter_map(@resource.path_for)` (line ~392)
  Applied as proposed; kept the explicit lambda (rather than point-free) because `path_for` takes two arguments.

## Verification

Everything below was run from the worktree at .../scratchpad/wt/fe-root. NOTE: `moon` rejects the package-name form here (`moon check openseek_desktop/frontend` fails with "Failed to canonicalize input filter directory"); the scope must be given as a DIRECTORY path relative to the module, so all commands were run from `<wt>/desktop` with the scope `./frontend`. desktop/ is its own module (`openseek_desktop`) and a moon.work member.

BEFORE (baseline, clean tree):
  cd <wt>/desktop && moon check ./frontend --target js --deny-warn
    -> "Finished. moon: ran 326 tasks, now up to date" — 0 warnings, 0 errors.
  cd <wt>/desktop && moon test ./frontend --target js
    -> "Total tests: 462, passed: 462, failed: 0."

AFTER (all 10 findings applied):
  moon fmt  -> ran clean; re-running it a second time produced no further file changes (idempotent), so `moon fmt --check` in CI will pass.
  moon check ./frontend --target js --deny-warn  -> "Finished. moon: ran 3 tasks, now up to date" — 0 warnings, 0 errors.
  moon test ./frontend --target js  -> "Total tests: 461, passed: 461, failed: 0."

TEST COUNT DELTA EXPLAINED: 462 -> 461 is exactly the one deliberately deleted duplicate test ("the explicit blank-page drag strip is titlebar chrome"). No other test count moved and nothing failed at any point.

DEDUPE ACCOUNTING (window_titlebar_wbtest.mbt): 3 tests / 7 assertions before; 2 tests / 6 assertions after. The single removed assertion was byte-identical to the first assertion of the test above it (lines 20-22), so coverage is unchanged; its title's intent was preserved as a comment on the surviving assertion.

MBTI / PUBLIC INTERFACE:
  moon info ./frontend --target js  -> printed the regenerated interface; `git status --short` afterwards listed ONLY my 6 .mbt files, and `desktop/frontend/pkg.generated.mbti` was NOT among them, i.e. it is byte-identical to the committed version (still just `pub fn boot()` and `pub fn request_sidebar_resize_mount()`). No public interface changed, so no finding had to be reverted on that ground. No other .mbti anywhere in the repo was touched — `moon info` was scoped, never run bare.

FAILURE ENCOUNTERED AND FIXED (not worked around): the first `moon check` after applying the findings failed with three [4033] errors in agent_model.mbt ("There is no record definition with the fields: value, label") — the surveyor's bare record literals inside `.map` lambdas. Fixed properly by qualifying them as `@composer.ModelOption::{ ... }`, then re-ran the full gate above from scratch. Separately, the first fmt pass of the bridge.mbt FsChanged rewrite produced badly-indented output because of the finding's redundant type annotation; removing the annotation (type still inferred from the `Some(...)` arms) let fmt produce clean output. No gate step was skipped, softened, or worked around.

GIT: `git status --short` before staging listed exactly the 6 intended files and nothing else (no build artifacts, no stray .mbti). Staged by explicit path (no `git add -A`), committed as 9ae78ded6, pushed with `git push -u origin simplify/fe-root` -> "* [new branch] simplify/fe-root -> simplify/fe-root". Working tree clean afterwards. No PR opened, no merge, no other branch touched. Diffstat: 6 files changed, 45 insertions(+), 86 deletions(-).

## Worth a second look

Three things worth a second look.

1. `bridge.mbt` fetch_runs now walks `reply.runs` TWICE (once for `live`, once for `recovered`) where the loop walked it once. I checked `RecoveredRun::from_started` (bridge.mbt:703) — it is pure parsing/guarding with no dispatch or mutation — so this is a cost question, not a correctness one, on a list that is one host reply's worth of runs. If a reviewer objects on principle, that single finding can be reverted in isolation.

2. `console.mbt` apply_roster now short-circuits: when `Some(dev.channel) != page_channel` it no longer evaluates `metas.iter().any(...)`. The old code computed `granted` unconditionally. `any` over a plain `Array[DeviceMeta]` comparing `meta.id == id` is pure, so this is invisible — but it is the only place where a computation that used to always run now sometimes does not.

3. `agent_model.mbt` carries the one syntactic thing the surveyor got wrong: a bare `{ value: ..., label: ... }` literal inside a `.map` lambda bound to a plain `let` does not typecheck (error [4033]). I used `@composer.ModelOption::{ ... }`. A reviewer who prefers the unqualified form would have to annotate the `let` instead; the qualified literal is existing repo style (branch.mbt:353).

Also note the brief said desktop/frontend has no `.mbti`; it does — `desktop/frontend/pkg.generated.mbti` — so `moon info` was genuinely meaningful here rather than a no-op, and it confirmed no interface drift.

Reviewed by OpenSeek's own review subagent (DeepSeek Flash); its verdict is posted as a comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXBYcYo74F1DGSPZsYYAdc