### PR TITLE
refactor: agent_tool/mbtx, sandbox: reuse stdlib and collapse repeated tests

### DIFF
--- a/agent_tool/internal/auto_check/auto_check.mbt
+++ b/agent_tool/internal/auto_check/auto_check.mbt
@@ -158,6 +158,14 @@ async fn moon_check_cwd(path : String) -> String? {
 
 ///|
 fn is_relevant_moonbit_path(path : String) -> Bool {
+  // A path that ends in a separator names a DIRECTORY, never a manifest, and
+  // `path_basename` strips that separator before reporting the last component
+  // — so "pkg/moon.pkg/" would come back as "moon.pkg". Rule those out first
+  // to keep this predicate's domain exactly what it was when the manifest
+  // names were matched as whole final components.
+  if path.has_suffix("/") || path.has_suffix("\\") {
+    return false
+  }
   // `path_basename` treats backslashes as separators, so the manifest names
   // match on Windows too; the source suffixes below contain no separator and
   // so are unaffected by them.
@@ -182,6 +190,12 @@ fn containing_dir(path : String) -> String {
 
 ///|
 test "relevant path detection covers MoonBit source and manifests" {
+  // A trailing separator makes it a directory, not a manifest: the predicate
+  // must answer the same here as it did before `path_basename` (which strips
+  // that separator) was introduced.
+  assert_false(is_relevant_moonbit_path("x/moon.pkg/"))
+  assert_false(is_relevant_moonbit_path("moon.mod/"))
+  assert_false(is_relevant_moonbit_path("x\\moon.work\\"))
   assert_true(is_relevant_moonbit_path("moon.mod"))
   assert_true(is_relevant_moonbit_path("lib/moon.pkg"))
   assert_true(is_relevant_moonbit_path("moon.work"))

--- a/agent_tool/internal/auto_check/auto_check.mbt
+++ b/agent_tool/internal/auto_check/auto_check.mbt
@@ -158,13 +158,10 @@ async fn moon_check_cwd(path : String) -> String? {
 
 ///|
 fn is_relevant_moonbit_path(path : String) -> Bool {
-  let path = path.replace_all(old="\\", new="/")
-  path == "moon.mod" ||
-  path.has_suffix("/moon.mod") ||
-  path == "moon.pkg" ||
-  path.has_suffix("/moon.pkg") ||
-  path == "moon.work" ||
-  path.has_suffix("/moon.work") ||
+  // `path_basename` treats backslashes as separators, so the manifest names
+  // match on Windows too; the source suffixes below contain no separator and
+  // so are unaffected by them.
+  @workspace_path.path_basename(path) is ("moon.mod" | "moon.pkg" | "moon.work") ||
   is_moonbit_source_path(path)
 }
 
@@ -175,14 +172,12 @@ fn is_moonbit_source_path(path : String) -> Bool {
 
 ///|
 fn containing_dir(path : String) -> String {
-  let path = path.replace_all(old="\\", new="/")
-  // An empty part before the last slash means the slash was the leading one,
-  // so the containing directory is the root itself rather than "".
-  match path.rev_split_once("/") {
-    Some(([], _)) => "/"
-    Some((dir, _)) => dir.to_owned()
-    None => "."
-  }
+  // `parent_dir` already keeps a leading slash as the root rather than
+  // collapsing it to "", and normalizes backslashes. Its `None` cases ("",
+  // ".", "/", a bare drive) are unreachable here: the only caller has already
+  // passed `path` through `is_relevant_moonbit_path`, so it ends in a manifest
+  // name or a source suffix.
+  @workspace_path.parent_dir(path).unwrap_or(".")
 }
 
 ///|

--- a/agent_tool/internal/auto_check/moon.pkg
+++ b/agent_tool/internal/auto_check/moon.pkg
@@ -2,6 +2,7 @@ import {
   "bobzhang/openseek/agent_tool/internal/manifest_path",
   "bobzhang/openseek/agent_tool/internal/moon_check",
   "bobzhang/openseek/agent_tool/shell",
+  "bobzhang/openseek/internal/workspace_path",
   "moonbitlang/async",
   "moonbitlang/async/fs",
   "moonbitlang/core/json",

--- a/agent_tool/internal/auto_check/parse_gate.mbt
+++ b/agent_tool/internal/auto_check/parse_gate.mbt
@@ -455,17 +455,6 @@ test "format_parse_gate_errors caps at the display limit and handles bad locs" {
 }
 
 ///|
-test "loc_line_span reads spans, single points, and rejects junk" {
-  assert_true(loc_line_span("7:1-9:2") is Some((7, 9)))
-  assert_true(loc_line_span("7:1") is Some((7, 7)))
-  assert_true(loc_line_span("7") is Some((7, 7)))
-  // A reversed span clamps to the start line rather than going negative.
-  assert_true(loc_line_span("9:1-7:2") is Some((9, 9)))
-  assert_true(loc_line_span("") is None)
-  assert_true(loc_line_span("abc:1") is None)
-}
-
-///|
 /// Real-moonc round trips: unlike `moon check`, the standalone gate can run
 /// inside `moon test` safely (no project build lock is involved).
 async test "content_parse_errors gates real content through moonc" {
@@ -593,7 +582,9 @@ test "loc_line_span accepts every lenient loc form" {
   debug_inspect(loc_line_span("7:1-x"), content="Some((7, 7))")
   debug_inspect(loc_line_span("7:1-"), content="Some((7, 7))")
   debug_inspect(loc_line_span("9:2-7:1"), content="Some((9, 9))")
+  debug_inspect(loc_line_span("9:1-7:2"), content="Some((9, 9))")
   debug_inspect(loc_line_span("x"), content="None")
+  debug_inspect(loc_line_span("abc:1"), content="None")
   debug_inspect(loc_line_span(""), content="None")
   debug_inspect(loc_line_span(":1"), content="None")
 }

--- a/agent_tool/internal/sandbox/worker_profile.mbt
+++ b/agent_tool/internal/sandbox/worker_profile.mbt
@@ -76,16 +76,13 @@ fn worker_write_profile_data(
     $|(version 1)
     $|(allow default)
     $|
-  let denial_subjects : Array[String] = []
+  // Same path-then-basename subjects the source-write profile names, in the
+  // same order; the `.git` literal below still appends after them.
+  let denial_subjects = source_write_denial_subjects(deny_roots)
   for root in deny_roots {
     profile <+
       $|(deny file-write* (subpath "\{sbpl_string_escape(root)}"))
       $|
-    denial_subjects.push(root)
-    let base = @workspace_path.path_basename(root)
-    if base != root {
-      denial_subjects.push(base)
-    }
   }
   profile <+
     $|(allow file-write* (subpath "\{sbpl_string_escape(worker_root)}"))

--- a/agent_tool/internal/source_write_policy/source_write_policy.mbt
+++ b/agent_tool/internal/source_write_policy/source_write_policy.mbt
@@ -78,14 +78,18 @@ pub fn is_protected_source_path(path : String) -> Bool {
   path.has_suffix(".mbt.md") ||
   path.has_suffix(".mbt") ||
   path.has_suffix(".mbti") ||
-  path == "moon.mod" ||
-  path.has_suffix("/moon.mod") ||
-  path == "moon.pkg" ||
-  path.has_suffix("/moon.pkg") ||
-  path == "moon.mod.json" ||
-  path.has_suffix("/moon.mod.json") ||
-  path == "moon.pkg.json" ||
-  path.has_suffix("/moon.pkg.json") ||
-  path == "moon.work" ||
-  path.has_suffix("/moon.work")
+  // A bare basename and a full path are both accepted, so each manifest name
+  // is matched either whole or as the last component. Deliberately NOT via
+  // `path_basename`: that strips a trailing slash, and callers hand this raw
+  // shell arguments where `pkg/moon.pkg/` names a directory, not the manifest.
+  protected_manifest_names.any(name => {
+    path == name || path.has_suffix("/\{name}")
+  })
 }
+
+///|
+/// The manifest filenames `is_protected_source_path` guards, current and
+/// legacy-JSON spellings alike.
+let protected_manifest_names : Array[String] = [
+  "moon.mod", "moon.pkg", "moon.work", "moon.mod.json", "moon.pkg.json",
+]

--- a/agent_tool/internal/source_write_policy/source_write_policy_test.mbt
+++ b/agent_tool/internal/source_write_policy/source_write_policy_test.mbt
@@ -1,30 +1,19 @@
 ///|
 test "protected workspace source policy" {
-  assert_true(
-    @source_write_policy.is_protected_workspace_source_path(
-      "/workspace", "/workspace/moon.mod",
-    ),
-  )
-  assert_true(
-    @source_write_policy.is_protected_workspace_source_path(
-      "/workspace", "/workspace/pkg/moon.pkg",
-    ),
-  )
-  assert_true(
-    @source_write_policy.is_protected_workspace_source_path(
-      "/workspace", "/workspace/pkg/main.mbt",
-    ),
-  )
-  assert_true(
-    @source_write_policy.is_protected_workspace_source_path(
-      "/workspace", "/workspace/pkg/_build.mbt",
-    ),
-  )
-  assert_true(
-    @source_write_policy.is_protected_workspace_source_path(
-      "/workspace", "/workspace/.mooncakes.mbt",
-    ),
-  )
+  // The last two are files whose names merely START with a generated
+  // directory's: only a whole path COMPONENT is treated as moon-managed.
+  for
+    guarded in [
+      "/workspace/moon.mod", "/workspace/pkg/moon.pkg", "/workspace/pkg/main.mbt",
+      "/workspace/pkg/_build.mbt", "/workspace/.mooncakes.mbt",
+    ] {
+    assert_true(
+      @source_write_policy.is_protected_workspace_source_path(
+        "/workspace", guarded,
+      ),
+      msg=guarded,
+    )
+  }
   assert_false(
     @source_write_policy.is_protected_workspace_source_path(
       "/workspace", "/workspace/backup-moon.mod",

--- a/agent_tool/mbtx/internal/decode/decode.mbt
+++ b/agent_tool/mbtx/internal/decode/decode.mbt
@@ -155,58 +155,28 @@ test "decode defaults warning to off and reads on/off" {
 }
 
 ///|
-test "decode rejects an unknown warning value" {
-  let failed = try {
-    decode({ "source": "x", "warning": "loud" }) |> ignore
-    false
-  } catch {
-    _ => true
+/// Argument shapes `decode` must refuse. Only the refusal itself is pinned
+/// here; the two tests above stay separate because they also pin the wording
+/// the model is supposed to read.
+test "decode rejects malformed arguments" {
+  let malformed : Array[Json] = [
+    // An unknown warning value, a non-string cwd, an unknown target, a
+    // missing source, and arguments that are not an object at all.
+    { "source": "x", "warning": "loud" },
+    { "source": "x", "cwd": 3 },
+    { "source": "x", "target": "banana" },
+    { "code": "x" },
+    Json("x"),
+  ]
+  for arguments in malformed {
+    let failed = try {
+      decode(arguments) |> ignore
+      false
+    } catch {
+      _ => true
+    }
+    assert_true(failed, msg="accepted \{arguments.stringify()}")
   }
-  assert_true(failed)
-}
-
-///|
-test "decode rejects a non-string cwd" {
-  let failed = try {
-    decode({ "source": "x", "cwd": 3 }) |> ignore
-    false
-  } catch {
-    _ => true
-  }
-  assert_true(failed)
-}
-
-///|
-test "decode rejects an unknown target" {
-  let failed = try {
-    decode({ "source": "x", "target": "banana" }) |> ignore
-    false
-  } catch {
-    _ => true
-  }
-  assert_true(failed)
-}
-
-///|
-test "decode rejects a missing source" {
-  let failed = try {
-    decode({ "code": "x" }) |> ignore
-    false
-  } catch {
-    _ => true
-  }
-  assert_true(failed)
-}
-
-///|
-test "decode rejects non-object arguments" {
-  let failed = try {
-    decode(Json("x")) |> ignore
-    false
-  } catch {
-    _ => true
-  }
-  assert_true(failed)
 }
 
 ///|

--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -779,11 +779,7 @@ async fn execute(
     } else {
       body
     }
-    let body = if sandbox_denied is Some(guidance) {
-      "\{body}\n\n\{guidance}"
-    } else {
-      body
-    }
+    let body = with_denial_guidance(body, sandbox_denied)
     return @agent_tool.respond(
       body,
       is_error=exit_code != 0 ||
@@ -829,11 +825,7 @@ async fn execute(
         build_notes,
         finished_body(text, exit_code, staged~),
       )
-      let body = if sandbox_denied is Some(guidance) {
-        "\{body}\n\n\{guidance}"
-      } else {
-        body
-      }
+      let body = with_denial_guidance(body, sandbox_denied)
       @agent_tool.respond(
         body,
         is_error=exit_code != 0 || sandbox_denied is Some(_),
@@ -852,11 +844,7 @@ async fn execute(
       } else {
         "\{head}\n[partial output before the timeout]\n\{partial}"
       }
-      let body = if sandbox_denied is Some(guidance) {
-        "\{body}\n\n\{guidance}"
-      } else {
-        body
-      }
+      let body = with_denial_guidance(body, sandbox_denied)
       // Requested compiler warnings live only in the build phase's capture, so
       // a run that never finished must still carry them out.
       @agent_tool.respond(
@@ -1080,6 +1068,19 @@ fn timeout_head(foreground_timeout_ms : Int, staged~ : Bool) -> String {
     "mbtx: timed out after \{bound} and was cancelled — the build had already succeeded, so it is the PROGRAM that did not finish (an infinite loop, or waiting on something that never arrived)."
   } else {
     "mbtx: timed out after \{bound} and was cancelled — the program did not finish (an infinite loop, or a build that never completed)."
+  }
+}
+
+///|
+/// Append a confinement refusal's guidance to a report, when there is one. All
+/// three exit paths that can carry a denial — the background handoff, a
+/// finished run, and a timeout — append it the same way, after the body the
+/// run itself produced.
+fn with_denial_guidance(body : String, guidance : String?) -> String {
+  if guidance is Some(text) {
+    "\{body}\n\n\{text}"
+  } else {
+    body
   }
 }
 

--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -1072,10 +1072,12 @@ fn timeout_head(foreground_timeout_ms : Int, staged~ : Bool) -> String {
 }
 
 ///|
-/// Append a confinement refusal's guidance to a report, when there is one. All
-/// three exit paths that can carry a denial — the background handoff, a
-/// finished run, and a timeout — append it the same way, after the body the
-/// run itself produced.
+/// Append a confinement refusal's guidance to a report, when there is one. The
+/// three exit paths that report on a run's output — a run that finished inside
+/// the handoff grace on a job runtime, a finished foreground run, and a
+/// foreground timeout — append it the same way, after the body the run itself
+/// produced. The background handoff carries none: its program is still
+/// running, so there is no output to scan for a refusal yet.
 fn with_denial_guidance(body : String, guidance : String?) -> String {
   if guidance is Some(text) {
     "\{body}\n\n\{text}"

--- a/agent_tool/mbtx/mbtx_test.mbt
+++ b/agent_tool/mbtx/mbtx_test.mbt
@@ -6,18 +6,29 @@ async fn run(source : String) -> @agent_tool.ToolOutput {
 }
 
 ///|
+/// Dispatch `arguments` through a built definition and take the response it
+/// must produce. Every test here drives the tool this way; the two `fail`s
+/// name which half of that contract broke when one does not.
+async fn dispatch(
+  definition : @agent_tool.AgentToolDefinition,
+  arguments : Json,
+) -> @agent_tool.ToolOutput {
+  let action = match definition.execute {
+    Async(execute) => execute(arguments)
+    Sync(_) => fail("mbtx should be async")
+  }
+  guard action is Respond(output) else { fail("expected Respond") }
+  output
+}
+
+///|
 /// Run with an explicit `workspace_root` and raw arguments (for cwd / target /
 /// decode-failure cases).
 async fn run_in(
   workspace_root : String,
   arguments : Json,
 ) -> @agent_tool.ToolOutput {
-  let action = match @mbtx.definition(workspace_root~).execute {
-    Async(execute) => execute(arguments)
-    Sync(_) => fail("mbtx should be async")
-  }
-  guard action is Respond(output) else { fail("expected Respond") }
-  output
+  dispatch(@mbtx.definition(workspace_root~), arguments)
 }
 
 ///|
@@ -74,11 +85,7 @@ async test "diagnostic-shaped output with a clean exit stays unlabeled" {
 async test "a build that outlives its bound is reported as the build's" {
   @vfs.with_tmpdir(prefix="mbtx-build-bound-", ws => {
     let definition = @mbtx.definition(workspace_root=ws, build_timeout_ms=1)
-    let action = match definition.execute {
-      Async(execute) => execute({ "source": "fn main { println(1) }" })
-      Sync(_) => fail("mbtx should be async")
-    }
-    guard action is Respond(output) else { fail("expected Respond") }
+    let output = dispatch(definition, { "source": "fn main { println(1) }" })
     assert_true(output.is_error)
     assert_true(output.content.contains("BUILD did not finish"))
     assert_true(output.content.contains("never ran"))
@@ -104,11 +111,7 @@ async test "a run timeout carries build warnings and blames only the program" {
       #|  let unused = 1
       #|  @async.sleep(60_000)
       #|}
-    let action = match definition.execute {
-      Async(execute) => execute({ "source": source, "warning": "on" })
-      Sync(_) => fail("mbtx should be async")
-    }
-    guard action is Respond(output) else { fail("expected Respond") }
+    let output = dispatch(definition, { "source": source, "warning": "on" })
     assert_true(output.is_error)
     assert_true(output.content.contains("timed out"))
     assert_true(output.content.contains("the PROGRAM that did not finish"))
@@ -512,24 +515,19 @@ async test "read_only denies source writes with no scratch lab wired" {
       create_mode=CreateOrTruncate,
     )
     let definition = @mbtx.definition(workspace_root=ws, read_only=true)
-    let action = match definition.execute {
-      Async(execute) =>
-        execute({
-          "source": (
-            #|import { "moonbitlang/async", "moonbitlang/async/fs", "moonbitlang/async/stdio" }
-            #|
-            #|async fn main {
-            #|  let wrote = try {
-            #|    @fs.write_file("keep.mbt", "// CORRUPTED\n", create_mode=CreateOrTruncate)
-            #|    true
-            #|  } catch { _ => false }
-            #|  @stdio.stdout.write("workspace=\{wrote}\n")
-            #|}
-          ),
-        })
-      Sync(_) => fail("mbtx should be async")
-    }
-    guard action is Respond(output) else { fail("expected Respond") }
+    let output = dispatch(definition, {
+      "source": (
+        #|import { "moonbitlang/async", "moonbitlang/async/fs", "moonbitlang/async/stdio" }
+        #|
+        #|async fn main {
+        #|  let wrote = try {
+        #|    @fs.write_file("keep.mbt", "// CORRUPTED\n", create_mode=CreateOrTruncate)
+        #|    true
+        #|  } catch { _ => false }
+        #|  @stdio.stdout.write("workspace=\{wrote}\n")
+        #|}
+      ),
+    })
     assert_true(output.content.contains("workspace=false"))
     assert_true(@fs.read_file("\{ws}/keep.mbt").text().contains("fn main {  }"))
   })
@@ -571,11 +569,7 @@ async test "a scratch lab is writable while workspace source stays denied" {
         #|  @stdio.stdout.write("lab=\{in_lab} workspace=\{in_workspace}\n")
         #|}
       ).replace_all(old="LAB_DIR", new=lab)
-      let action = match definition.execute {
-        Async(execute) => execute({ "source": source })
-        Sync(_) => fail("mbtx should be async")
-      }
-      guard action is Respond(output) else { fail("expected Respond") }
+      let output = dispatch(definition, { "source": source })
       assert_true(output.content.contains("lab=true"))
       assert_true(output.content.contains("workspace=false"))
       assert_true(
@@ -639,11 +633,7 @@ async test "a worker's snippet writes neither its own tree nor a sibling's" {
       #|  @stdio.stdout.write("mine=\{mine} theirs=\{theirs}\n")
       #|}
     ).replace_all(old="SIBLING", new=sibling)
-    let action = match definition.execute {
-      Async(execute) => execute({ "source": source })
-      Sync(_) => fail("mbtx should be async")
-    }
-    guard action is Respond(output) else { fail("expected Respond") }
+    let output = dispatch(definition, { "source": source })
     assert_true(output.content.contains("mine=false"))
     assert_true(output.content.contains("theirs=false"))
     // Untouched on disk, not merely reported as denied — both trees.
@@ -1044,11 +1034,7 @@ async test "a runtime-less run uses its foreground timeout, not the handoff grac
       #|  @async.sleep(100)
       #|  println("finished inline")
       #|}
-    let action = match definition.execute {
-      Async(execute) => execute({ "source": source })
-      Sync(_) => fail("mbtx should be async")
-    }
-    guard action is Respond(output) else { fail("expected Respond") }
+    let output = dispatch(definition, { "source": source })
     assert_false(output.is_error)
     assert_true(output.content.contains("finished inline"))
     assert_false(output.content.contains("moved to the background"))
@@ -1071,12 +1057,7 @@ async fn run_escalating(
         answer
       }),
     )
-    let action = match definition.execute {
-      Async(execute) => execute({ "source": source, "escalated": true })
-      Sync(_) => fail("mbtx should be async")
-    }
-    guard action is Respond(output) else { fail("expected Respond") }
-    output
+    dispatch(definition, { "source": source, "escalated": true })
   })
 }
 
@@ -1196,11 +1177,7 @@ async test "an ordinary call never asks for approval" {
         AllowedOnce
       }),
     )
-    let action = match definition.execute {
-      Async(execute) => execute({ "source": "fn main { println(6 * 7) }" })
-      Sync(_) => fail("mbtx should be async")
-    }
-    guard action is Respond(output) else { fail("expected Respond") }
+    let output = dispatch(definition, { "source": "fn main { println(6 * 7) }" })
     assert_true(output.content.contains("42"))
   })
   assert_eq(asked.length(), 0)
@@ -1224,12 +1201,7 @@ async test "a refusal names escalation when a channel is wired" {
       workspace_root=ws,
       approval=ApprovalChannel(_ => Rejected),
     )
-    let action = match definition.execute {
-      Async(execute) => execute({ "source": source })
-      Sync(_) => fail("mbtx should be async")
-    }
-    guard action is Respond(output) else { fail("expected Respond") }
-    output
+    dispatch(definition, { "source": source })
   })
   assert_true(asking.is_error)
   assert_true(asking.content.contains("spawn allowlist"))
@@ -1280,17 +1252,11 @@ async test "escalation is refused on a target that carries no policy" {
         AllowedOnce
       }),
     )
-    let action = match definition.execute {
-      Async(execute) =>
-        execute({
-          "source": "fn main { println(1) }",
-          "target": "js",
-          "escalated": true,
-        })
-      Sync(_) => fail("mbtx should be async")
-    }
-    guard action is Respond(output) else { fail("expected Respond") }
-    output
+    dispatch(definition, {
+      "source": "fn main { println(1) }",
+      "target": "js",
+      "escalated": true,
+    })
   })
   assert_true(out.is_error)
   assert_true(out.content.contains("applies to the wasm target"))
@@ -1326,12 +1292,7 @@ async test "an escalated run is not read as a policy refusal" {
       #|  } catch { error => "\{error}" }
       #|  println("child: \{refused}")
       #|}
-    let action = match definition.execute {
-      Async(execute) => execute({ "source": source, "escalated": true })
-      Sync(_) => fail("mbtx should be async")
-    }
-    guard action is Respond(output) else { fail("expected Respond") }
-    output
+    dispatch(definition, { "source": source, "escalated": true })
   })
   // Whatever the child did, this tool must not claim its own sandbox refused
   // something, nor tell the model to escalate again.
@@ -1366,12 +1327,10 @@ async fn run_hosted(
       base
     },
   )
-  let action = match @mbtx.definition(workspace_root~, subrun~).execute {
-    Async(execute) => execute({ "source": source, "subrun": true })
-    Sync(_) => fail("mbtx should be async")
-  }
-  guard action is Respond(output) else { fail("expected Respond") }
-  output
+  dispatch(@mbtx.definition(workspace_root~, subrun~), {
+    "source": source,
+    "subrun": true,
+  })
 }
 
 ///|
@@ -1499,23 +1458,18 @@ async test "a hosted session reserves nothing unless the snippet asks" {
           base
         },
       )
-      let action = match @mbtx.definition(workspace_root=ws, subrun~).execute {
-        Async(execute) =>
-          execute({
-            "source": (
-              #|import { "moonbitlang/core/env" }
-              #|
-              #|fn main {
-              #|  match @env.get_env_var("WORKFLOW_HOST") {
-              #|    Some(v) if !v.is_empty() => println("HANDOFF PRESENT")
-              #|    _ => println("no handoff")
-              #|  }
-              #|}
-            ),
-          })
-        Sync(_) => fail("mbtx should be async")
-      }
-      guard action is Respond(out) else { fail("expected Respond") }
+      let out = dispatch(@mbtx.definition(workspace_root=ws, subrun~), {
+        "source": (
+          #|import { "moonbitlang/core/env" }
+          #|
+          #|fn main {
+          #|  match @env.get_env_var("WORKFLOW_HOST") {
+          #|    Some(v) if !v.is_empty() => println("HANDOFF PRESENT")
+          #|    _ => println("no handoff")
+          #|  }
+          #|}
+        ),
+      })
       assert_false(out.is_error)
       assert_true(out.content.contains("no handoff"))
       assert_eq(issued.val, 0)
@@ -1557,11 +1511,7 @@ async fn run_hosted_with(
   first? : Int = 1,
 ) -> (@agent_tool.ToolOutput, Int) {
   let (subrun, issued) = hosted_injection(store, workspace_root, first~)
-  let action = match @mbtx.definition(workspace_root~, subrun~).execute {
-    Async(execute) => execute(arguments)
-    Sync(_) => fail("mbtx should be async")
-  }
-  guard action is Respond(output) else { fail("expected Respond") }
+  let output = dispatch(@mbtx.definition(workspace_root~, subrun~), arguments)
   (output, issued.val - (first - 1))
 }
 
@@ -1700,11 +1650,7 @@ async test "a hosted run is announced before it runs and closed on every exit" {
           #|  @async.sleep(400)
           #|  println("late")
           #|}
-        let action = match definition.execute {
-          Async(execute) => execute({ "source": source, "subrun": true })
-          Sync(_) => fail("mbtx should be async")
-        }
-        guard action is Respond(output) else { fail("expected Respond") }
+        let output = dispatch(definition, { "source": source, "subrun": true })
         assert_false(output.is_error, msg=output.content)
         assert_true(output.content.contains("moved to the background"))
         guard workflow_lines("wf-900")

--- a/agent_tool/mbtx/mbtx_wbtest.mbt
+++ b/agent_tool/mbtx/mbtx_wbtest.mbt
@@ -105,17 +105,20 @@ test "finished_body and timeout_head are stage-aware only when staged" {
 }
 
 ///|
+/// The argument prefixes the spawn allowlist admits for `program`, in the
+/// order `spawnable_commands` lists them.
+fn spawn_prefixes(program : String) -> Array[Array[String]] {
+  [
+    for entry in spawnable_commands if entry.0 == program => entry.1
+  ]
+}
+
+///|
 /// Proton CLI is admitted one subcommand at a time. In particular, there is no
 /// bare rule and no global working-directory prefix: callers set the child
 /// process cwd instead of letting the command redirect itself elsewhere.
 test "the spawn policy admits Proton subcommands but not global cwd options" {
-  let proton_prefixes : Array[Array[String]] = []
-  for entry in spawnable_commands {
-    let (program, args_prefix) = entry
-    if program == "proton_cli" {
-      proton_prefixes.push(args_prefix)
-    }
-  }
+  let proton_prefixes = spawn_prefixes("proton_cli")
   assert_eq(proton_prefixes.length(), 9)
   for
     args_prefix in [
@@ -146,13 +149,7 @@ test "the spawn policy admits Proton subcommands but not global cwd options" {
 /// bare rule and no verb that runs or installs an agent (`exec`, `install`),
 /// so the prefix gating keeps the agentic binary's surface to review.
 test "the spawn policy admits only the codex review verb" {
-  let codex_prefixes : Array[Array[String]] = []
-  for entry in spawnable_commands {
-    let (program, args_prefix) = entry
-    if program == "codex" {
-      codex_prefixes.push(args_prefix)
-    }
-  }
+  let codex_prefixes = spawn_prefixes("codex")
   assert_eq(codex_prefixes.length(), 1)
   assert_eq(codex_prefixes[0], ["review"])
   assert_false(codex_prefixes.contains([]))

--- a/agent_tool/mbtx/wasm_policy.mbt
+++ b/agent_tool/mbtx/wasm_policy.mbt
@@ -351,10 +351,8 @@ fn wasm_policy_document(
 /// value fails the library's reader closed, so the snippet sees no handoff
 /// rather than someone else's.
 fn env_set(tmp_dir : String, inject : Map[String, String]) -> Map[String, Json] {
-  let set : Map[String, Json] = Map([])
-  for name, value in inject {
-    set[name] = value.to_json()
-  }
+  // A fresh map, so the policy writes below cannot leak back into `inject`.
+  let set = inject.map((_, value) => value.to_json())
   if !set.contains(HostHandoffVar) {
     set[HostHandoffVar] = "".to_json()
   }


### PR DESCRIPTION
A pure **simplification** pass: no feature, no fix, no behaviour change. Part of a project-wide sweep; each PR is one package family so it can be reviewed on its own.

Candidates came from a read-only survey of the whole repository. The author was told to drop any that would not compile or would change behaviour, so this branch carries fewer than were proposed: **11 applied, 0 dropped, net -111 lines.**

## Applied

- **agent_tool/mbtx/mbtx_test.mbt** — 16 tests repeat the same execute-dispatch block that `run_in` already contains
  Helper named `dispatch(definition, arguments)` rather than `respond_of`; `run_in` now delegates to it. All 16 sites confirmed identical in shape (3 of them wrapped the args across lines) and rewritten mechanically. Went one step further than the finding: 5 sites whose block tail was a bare `output` after the new `let output = dispatch(...)` had the redundant binding collapsed into a tail expression.
- **agent_tool/mbtx/internal/decode/decode.mbt** — Five `decode rejects ...` tests have byte-identical bodies; collapse to one table
  Same five Json inputs, same order, same try/catch/assert_true body. Added `msg="accepted \{arguments.stringify()}"` so a failing row is identifiable — plain `\{arguments}` tripped deny-warn (deprecated Show-for-debugging), hence `.stringify()`. The two reject tests that also pin message wording were left separate, and a comment now says why.
- **agent_tool/internal/source_write_policy/source_write_policy_test.mbt** — Five identical is_protected_workspace_source_path assertions fit the loop this test already uses
  Loop variable is `guarded`, not `protected`: `protected` is a MoonBit reserved keyword and failed to compile. Added `msg=guarded` for row identifiability, and a comment preserving the point that `_build.mbt` / `.mooncakes.mbt` are protected because only a whole path COMPONENT counts as generated.
- **agent_tool/internal/auto_check/parse_gate.mbt** — `loc_line_span reads spans...` is a subset of the lenient-form table 130 lines below
  Deleted the duplicate test; its two inputs not already present in some spelling ("9:1-7:2", "abc:1") moved into the surviving table beside their equivalents. The deleted inline comment about reversed spans clamping is already stated in the surviving test's doc comment.
- **agent_tool/internal/source_write_policy/source_write_policy.mbt** — is_protected_source_path hand-rolls basename matching that @workspace_path.path_basename does
  DEVIATED from the proposal. `path_basename` strips trailing slashes, so it would flip `pkg/moon.pkg/` from unprotected to protected — and two of the six callers (agent_tool/shell/sandbox.mbt:3578 and :3955-3956) pass raw shell arguments, where a trailing slash is ordinary. Instead collapsed the ten `== name || has_suffix("/name")` lines into one `.any` over a new private `protected_manifest_names` list. Byte-identical behaviour for every input; a comment records why path_basename was rejected.
- **agent_tool/mbtx/mbtx_wbtest.mbt** — Two allowlist tests hand-roll the same filter loop over spawnable_commands
  Added `spawn_prefixes(program)` using the guarded array comprehension `[for entry in spawnable_commands if entry.0 == program => entry.1]`. Test-only file, so no interface surface.
- **agent_tool/internal/auto_check/auto_check.mbt** — containing_dir is a copy of @workspace_path.parent_dir, comment included
  Now `@workspace_path.parent_dir(path).unwrap_or(".")`. The two differ for "", "/", a bare drive, and trailing-slash inputs; none is reachable, because the sole caller `moon_check_cwd` gates on `is_relevant_moonbit_path` first. Private fn, single caller. Added the moon.pkg import. The old comment about the leading slash was replaced with one explaining why the `None` fallback is safe, not deleted.
- **agent_tool/internal/auto_check/auto_check.mbt** — is_relevant_moonbit_path re-implements manifest basename matching available as path_basename
  Same private-fn / single-caller argument as containing_dir. All 7 existing assertions re-verified by hand and by the suite. `is_moonbit_source_path` now sees the unnormalized path, which is fine: it only tests `.mbt` / `.mbt.md` suffixes.
- **agent_tool/mbtx/mbtx.mbt** — The denial-guidance append is written three times; it deserves a helper like with_build_notes
  Added `with_denial_guidance`, placed immediately before `with_build_notes` whose shape it mirrors. All three sites replaced; the surrounding `is_error=` conditions were left untouched.
- **agent_tool/internal/sandbox/worker_profile.mbt** — worker_write_profile_data re-derives denial subjects that source_write_denial_subjects already builds
  Same package-private helper, same [root, base-if-different] order; the later `.git` literal still appends last. `@workspace_path` is still imported for `is_under_workspace_root` above, so no unused import.
- **agent_tool/mbtx/wasm_policy.mbt** — env_set's copy loop is Map::map
  `inject.map((_, value) => value.to_json())`. Confirmed in core (builtin/linked_hash_map.mbt:878) that Map::map copies the linked structure, so insertion order — which is what the emitted policy JSON's key order depends on — is preserved, and the returned map is fresh so the two policy writes after it still cannot reach `inject`.

## Verification

All commands run from the worktree root /private/tmp/.../scratchpad/wt/mbtx with moon 0.1.20260827.

BASELINE (before any edit)
- `moon test agent_tool/internal/source_write_policy agent_tool/internal/auto_check agent_tool/internal/sandbox agent_tool/mbtx/internal/decode` -> "Total tests: 75, passed: 75, failed: 0."
- `moon test agent_tool/mbtx` (run detached, ~several minutes; it compiles real snippets) -> exit 0, "Total tests: 72, passed: 72, failed: 0."

AFTER
- `moon fmt` then `moon fmt --check` -> exit 0, no reformatting pending.
- `moon check agent_tool/mbtx agent_tool/mbtx/internal/decode agent_tool/internal/auto_check agent_tool/internal/sandbox agent_tool/internal/source_write_policy agent_tool/shell --deny-warn` -> "Finished. moon: ran 8 tasks, now up to date" (clean). agent_tool/shell was added on purpose: it is the only external caller of the source_write_policy function I touched.
- Same package list with `--target wasm --deny-warn` -> clean. All five touched packages declare supported_targets = "+wasm+native"; none is under desktop/, so no js run was needed.
- `moon test agent_tool/internal/source_write_policy agent_tool/internal/auto_check agent_tool/internal/sandbox agent_tool/mbtx/internal/decode` -> "Total tests: 70, passed: 70, failed: 0." 75 -> 70 is exactly the intended collapse: decode 5 tests -> 1, parse_gate 1 test -> 0. No test lost coverage.
- `moon test agent_tool/mbtx` -> "Total tests: 72, passed: 72, failed: 0." Unchanged, as expected: the mbtx_test/mbtx_wbtest work removed duplication inside test bodies, not tests.
- `moon info agent_tool/mbtx agent_tool/mbtx/internal/decode agent_tool/internal/auto_check agent_tool/internal/sandbox agent_tool/internal/source_write_policy` (SCOPED, never bare) -> ran clean and rewrote NO .mbti. `git status --short` after it listed only the 11 files I edited, so no public interface moved.

TEST-DEDUPE COUNTS (per the brief)
- decode.mbt: 5 assertions before (5 separate tests, one assert_true each) -> 5 rows after, each carrying its Json input in msg=.
- source_write_policy_test.mbt: 5 assertions before -> 5 rows after, each carrying its path in msg=.
- parse_gate.mbt: the deleted test's 6 assertions were all already pinned in the surviving table except two spellings ("9:1-7:2", "abc:1"); the table went from 12 rows to 14, so 6 assertions before -> 6 facts still covered, 2 of them newly written out.

WORKAROUNDS / FAILURES HIT
- First `moon check` after the test edits failed with 4 deny-warn errors, all fixed rather than worked around: `protected` is a MoonBit reserved keyword (renamed the loop variable to `guarded`), and `"\\{arguments}"` on a Json triggered the deprecated Show-for-debugging warning (switched to `arguments.stringify()`).
- The first scripted pass over mbtx_test.mbt matched only 13 of the 16 dispatch sites (three write `Async(execute) =>` with the call on the next line); the script asserted the count and wrote nothing, and was rerun with a tolerant pattern that got all 16. The resulting diff was read line by line before committing.

## Worth a second look

Three things worth a second look.

1. `is_protected_source_path` (source_write_policy.mbt) is where I deliberately did NOT do what the finding proposed. Using `@workspace_path.path_basename` there would strip trailing slashes and so newly classify `pkg/moon.pkg/` as protected. That predicate is a write-policy gate, and two of its six callers (agent_tool/shell/sandbox.mbt:3578 and :3955-3956) feed it raw shell arguments, where a trailing slash is completely ordinary — so the change would have been a real behaviour change in a security check, even though it errs toward denying. I kept the existing normalization and only collapsed the repetition into `.any` over a named list. Verify that the `.any` predicate `path == name || path.has_suffix("/\{name}")` really is the same test the ten deleted lines performed, for all five names.

2. The same trailing-slash argument does NOT apply to `is_relevant_moonbit_path` and `containing_dir` in auto_check.mbt, and that is why I did use `path_basename` / `parent_dir` there. Both are private, both have exactly one caller (`moon_check_cwd`), and the path reaching them is a file that was just written, filtered through `is_relevant_moonbit_path` first. If you disagree that those inputs are unreachable, these two hunks are the ones to revert — they are self-contained, and reverting them also makes the new `workspace_path` line in auto_check/moon.pkg unnecessary.

3. `worker_write_profile_data` now calls `source_write_denial_subjects`, whose name says "source_write_" at a worker call site. The behaviour is identical (same order, same basename-if-different rule) but the name now reads oddly; renaming it to something neutral would touch its other caller in source_write_profile.mbt, so I left it and put a comment at the call site instead. Worth deciding whether you'd rather have the rename.

Minor: `agent_tool/internal/auto_check/moon.pkg` gained one import line. workspace_path depends only on moonbitlang/x/path, so there is no cycle, and both targets check clean.

Reviewed by OpenSeek's own review subagent (DeepSeek Flash); its verdict is posted as a comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXBYcYo74F1DGSPZsYYAdc