### PR TITLE
refactor: agent_tool/shell: collapse repeated test assertions and fold a duplicated git parser

### DIFF
--- a/agent_tool/shell/internal/git_policy/git_policy.mbt
+++ b/agent_tool/shell/internal/git_policy/git_policy.mbt
@@ -18,32 +18,10 @@ pub struct Invocation {
 /// to a value option, or an unrecognized `-option` (fail closed). Aliases are not
 /// resolved, so e.g. `git co` reports subcommand `co`.
 pub fn parse(argv : Array[String], arg_start : Int) -> Invocation? {
-  let mut index = arg_start
-  while index < argv.length() {
-    let arg = argv[index]
-    if arg == "--" || arg == "--help" || arg == "-h" {
-      return None
-    }
-    if arg == "-C" || arg == "--work-tree" || global_option_consumes_next(arg) {
-      if index + 1 >= argv.length() {
-        return None
-      }
-      index += 2
-      continue
-    }
-    if attached_cwd_option(arg) is Some(_) ||
-      attached_work_tree_option(arg) is Some(_) ||
-      global_option_with_attached_value(arg) ||
-      global_no_arg_option(arg) {
-      index += 1
-      continue
-    }
-    if arg.has_prefix("-") && arg != "-" {
-      return None
-    }
-    return Some({ subcommand: arg, subcommand_index: index, })
+  guard text_subcommand_index(argv, arg_start, argv.length()) is Some(index) else {
+    return None
   }
-  None
+  Some({ subcommand: argv[index], subcommand_index: index, })
 }
 
 ///|
@@ -541,8 +519,11 @@ fn clean_arg_is_exclude(arg : String) -> Bool {
 }
 
 ///|
-/// Find the git subcommand's index in a flat `words` list (the TooComplex text
-/// path), scanning `[start, end)` and skipping global options. Mirrors `parse`.
+/// Find the git subcommand's index in a flat `words` list, scanning
+/// `[start, end)` and skipping global options. The scanner behind both the
+/// TooComplex text path and `parse`. An explicit `--` is rejected by the
+/// trailing unrecognized-option arm, and a value option with no argument runs
+/// `index` past `end` and so falls out as `None`.
 fn text_subcommand_index(words : Array[String], start : Int, end : Int) -> Int? {
   let mut index = start
   while index < end {

--- a/agent_tool/shell/internal/shell_parse/parser.mbt
+++ b/agent_tool/shell/internal/shell_parse/parser.mbt
@@ -152,17 +152,11 @@ fn render_source(
   argv : Array[String],
   redirects : Array[Redirect],
 ) -> String {
-  let parts : Array[String] = []
-  for assignment in env {
-    parts.push("\{assignment.name}=\{assignment.value}")
-  }
-  for arg in argv {
-    parts.push(arg)
-  }
-  for redirect in redirects {
-    parts.push("\{redirect.op} \{redirect.target}")
-  }
-  parts.join(" ")
+  [
+    ..env.map(assignment => "\{assignment.name}=\{assignment.value}"),
+    ..argv,
+    ..redirects.map(redirect => "\{redirect.op} \{redirect.target}"),
+  ].join(" ")
 }
 
 ///|

--- a/agent_tool/shell/moon_auto_check.mbt
+++ b/agent_tool/shell/moon_auto_check.mbt
@@ -48,13 +48,7 @@ fn insert_before_system_footer(content : String, block : String) -> String {
 ///|
 fn moon_check_output_budget(content : String, max_output_chars : Int) -> Int {
   let remaining = max_output_chars - content.char_length() - 1
-  if remaining <= 0 {
-    0
-  } else if remaining < @moon_check.MaxOutputChars {
-    remaining
-  } else {
-    @moon_check.MaxOutputChars
-  }
+  remaining.clamp(min=0, max=@moon_check.MaxOutputChars)
 }
 
 ///|
@@ -609,158 +603,68 @@ test "do not trigger follow-up check for read-only moon commands or data" {
 ///|
 #cfg(not(platform="windows"))
 test "detect moon command check cwd from -C option" {
+  fn cwd_for(cmd : String, base : String) -> String? {
+    moon_auto_check_start_cwd(cmd, Some(base))
+  }
+
+  assert_true(cwd_for("moon fmt", "/repo") is Some("/repo"))
+  assert_true(cwd_for("moon -C pkg fmt", "/repo") is Some("/repo/pkg"))
+  assert_true(cwd_for("moon -Cpkg fmt", "/repo") is Some("/repo/pkg"))
+  assert_true(cwd_for("moon -C=pkg fmt", "/repo") is Some("/repo/pkg"))
   assert_true(
-    moon_auto_check_start_cwd("moon fmt", Some("/repo")) is Some("/repo"),
+    cwd_for("moon -C ../other info", "/repo/pkg") is Some("/repo/other"),
+  )
+  assert_true(cwd_for("moon -C /tmp/mod fmt", "/repo") is Some("/tmp/mod"))
+  assert_true(
+    cwd_for("moon --target-dir=/tmp/moonbuild fmt", "/repo") is Some("/repo"),
+  )
+  assert_true(cwd_for("cd project && moon fmt", "/repo") is None)
+  assert_true(
+    cwd_for("cd ./project && moon fmt", "/repo") is Some("/repo/project"),
   )
   assert_true(
-    moon_auto_check_start_cwd("moon -C pkg fmt", Some("/repo"))
-    is Some("/repo/pkg"),
+    cwd_for("cd ./project &&\nmoon fmt", "/repo") is Some("/repo/project"),
   )
+  assert_true(cwd_for("env cd ./project && moon fmt", "/repo") is Some("/repo"))
   assert_true(
-    moon_auto_check_start_cwd("moon -Cpkg fmt", Some("/repo"))
-    is Some("/repo/pkg"),
+    cwd_for("env -i cd ./project && moon fmt", "/repo") is Some("/repo"),
   )
+  assert_true(cwd_for("cd -- project && moon fmt", "/repo") is None)
   assert_true(
-    moon_auto_check_start_cwd("moon -C=pkg fmt", Some("/repo"))
-    is Some("/repo/pkg"),
+    cwd_for("cd -- ./project && moon fmt", "/repo") is Some("/repo/project"),
   )
+  assert_true(cwd_for("command cd project && moon fmt", "/repo") is None)
   assert_true(
-    moon_auto_check_start_cwd("moon -C ../other info", Some("/repo/pkg"))
-    is Some("/repo/other"),
-  )
-  assert_true(
-    moon_auto_check_start_cwd("moon -C /tmp/mod fmt", Some("/repo"))
-    is Some("/tmp/mod"),
-  )
-  assert_true(
-    moon_auto_check_start_cwd(
-      "moon --target-dir=/tmp/moonbuild fmt",
-      Some("/repo"),
-    )
-    is Some("/repo"),
-  )
-  assert_true(
-    moon_auto_check_start_cwd("cd project && moon fmt", Some("/repo")) is None,
-  )
-  assert_true(
-    moon_auto_check_start_cwd("cd ./project && moon fmt", Some("/repo"))
+    cwd_for("command cd ./project && moon fmt", "/repo")
     is Some("/repo/project"),
   )
+  assert_true(cwd_for("command -- cd project && moon fmt", "/repo") is None)
   assert_true(
-    moon_auto_check_start_cwd("cd ./project &&\nmoon fmt", Some("/repo"))
+    cwd_for("command -- cd ./project && moon fmt", "/repo")
     is Some("/repo/project"),
   )
+  assert_true(cwd_for("builtin cd project && moon fmt", "/repo") is None)
   assert_true(
-    moon_auto_check_start_cwd("env cd ./project && moon fmt", Some("/repo"))
-    is Some("/repo"),
-  )
-  assert_true(
-    moon_auto_check_start_cwd("env -i cd ./project && moon fmt", Some("/repo"))
-    is Some("/repo"),
-  )
-  assert_true(
-    moon_auto_check_start_cwd("cd -- project && moon fmt", Some("/repo"))
-    is None,
-  )
-  assert_true(
-    moon_auto_check_start_cwd("cd -- ./project && moon fmt", Some("/repo"))
+    cwd_for("builtin cd ./project && moon fmt", "/repo")
     is Some("/repo/project"),
   )
+  assert_true(cwd_for("cd && moon fmt", "/repo") is None)
+  assert_true(cwd_for("cd - && moon fmt", "/repo") is None)
+  assert_true(cwd_for("cd -P project && moon fmt", "/repo") is None)
+  assert_true(cwd_for("pushd project && moon fmt", "/repo") is None)
+  assert_true(cwd_for("cd project && moon -C nested info", "/repo") is None)
   assert_true(
-    moon_auto_check_start_cwd("command cd project && moon fmt", Some("/repo"))
-    is None,
-  )
-  assert_true(
-    moon_auto_check_start_cwd("command cd ./project && moon fmt", Some("/repo"))
-    is Some("/repo/project"),
-  )
-  assert_true(
-    moon_auto_check_start_cwd(
-      "command -- cd project && moon fmt",
-      Some("/repo"),
-    )
-    is None,
-  )
-  assert_true(
-    moon_auto_check_start_cwd(
-      "command -- cd ./project && moon fmt",
-      Some("/repo"),
-    )
-    is Some("/repo/project"),
-  )
-  assert_true(
-    moon_auto_check_start_cwd("builtin cd project && moon fmt", Some("/repo"))
-    is None,
-  )
-  assert_true(
-    moon_auto_check_start_cwd("builtin cd ./project && moon fmt", Some("/repo"))
-    is Some("/repo/project"),
-  )
-  assert_true(
-    moon_auto_check_start_cwd("cd && moon fmt", Some("/repo")) is None,
-  )
-  assert_true(
-    moon_auto_check_start_cwd("cd - && moon fmt", Some("/repo")) is None,
-  )
-  assert_true(
-    moon_auto_check_start_cwd("cd -P project && moon fmt", Some("/repo"))
-    is None,
-  )
-  assert_true(
-    moon_auto_check_start_cwd("pushd project && moon fmt", Some("/repo"))
-    is None,
-  )
-  assert_true(
-    moon_auto_check_start_cwd(
-      "cd project && moon -C nested info",
-      Some("/repo"),
-    )
-    is None,
-  )
-  assert_true(
-    moon_auto_check_start_cwd(
-      "cd ./project && moon -C nested info",
-      Some("/repo"),
-    )
+    cwd_for("cd ./project && moon -C nested info", "/repo")
     is Some("/repo/project/nested"),
   )
+  assert_true(cwd_for("moon check && cd project && moon fmt", "/repo") is None)
   assert_true(
-    moon_auto_check_start_cwd(
-      "moon check && cd project && moon fmt",
-      Some("/repo"),
-    )
-    is None,
-  )
-  assert_true(
-    moon_auto_check_start_cwd(
-      "moon check && cd ./project && moon fmt",
-      Some("/repo"),
-    )
+    cwd_for("moon check && cd ./project && moon fmt", "/repo")
     is Some("/repo/project"),
   )
-  assert_true(
-    moon_auto_check_start_cwd(
-      "moon check && cd project; moon fmt",
-      Some("/repo"),
-    )
-    is None,
-  )
-  assert_true(
-    moon_auto_check_start_cwd(
-      "cd missing; cd project && moon fmt",
-      Some("/repo"),
-    )
-    is None,
-  )
-  assert_true(
-    moon_auto_check_start_cwd("moon check; moon fmt", Some("/repo"))
-    is Some("/repo"),
-  )
-  assert_true(
-    moon_auto_check_start_cwd("moon fmt; true", Some("/repo")) is None,
-  )
-  assert_true(
-    moon_auto_check_start_cwd("echo ok; moon fmt", Some("/repo"))
-    is Some("/repo"),
-  )
+  assert_true(cwd_for("moon check && cd project; moon fmt", "/repo") is None)
+  assert_true(cwd_for("cd missing; cd project && moon fmt", "/repo") is None)
+  assert_true(cwd_for("moon check; moon fmt", "/repo") is Some("/repo"))
+  assert_true(cwd_for("moon fmt; true", "/repo") is None)
+  assert_true(cwd_for("echo ok; moon fmt", "/repo") is Some("/repo"))
 }

--- a/agent_tool/shell/review_guard.mbt
+++ b/agent_tool/shell/review_guard.mbt
@@ -131,115 +131,33 @@ fn mutating_moon_blocked(
 
 ///|
 test "read-only guard blocks mutating moon anywhere; allows read-only commands" {
+  fn blocks(cmd : String) -> Bool {
+    review_read_only_blocks(
+      @shell_parse.parse_for_policy(cmd),
+      base_cwd=".",
+      scratch_dir=None,
+    )
+  }
+
   // mutating moon — plain, chained either way, and env-prefixed (all bypasses)
-  assert_true(
-    review_read_only_blocks(
-      @shell_parse.parse_for_policy("moon fmt"),
-      base_cwd=".",
-      scratch_dir=None,
-    ),
-  )
-  assert_true(
-    review_read_only_blocks(
-      @shell_parse.parse_for_policy("moon new app"),
-      base_cwd=".",
-      scratch_dir=None,
-    ),
-  )
-  assert_true(
-    review_read_only_blocks(
-      @shell_parse.parse_for_policy("moon new -- --help"),
-      base_cwd=".",
-      scratch_dir=None,
-    ),
-  )
-  assert_true(
-    review_read_only_blocks(
-      @shell_parse.parse_for_policy("moon info"),
-      base_cwd=".",
-      scratch_dir=None,
-    ),
-  )
-  assert_true(
-    review_read_only_blocks(
-      @shell_parse.parse_for_policy("moon fmt && git diff"),
-      base_cwd=".",
-      scratch_dir=None,
-    ),
-  )
-  assert_true(
-    review_read_only_blocks(
-      @shell_parse.parse_for_policy("git diff && moon fmt"),
-      base_cwd=".",
-      scratch_dir=None,
-    ),
-  )
-  assert_true(
-    review_read_only_blocks(
-      @shell_parse.parse_for_policy("moon test --update; true"),
-      base_cwd=".",
-      scratch_dir=None,
-    ),
-  )
-  assert_true(
-    review_read_only_blocks(
-      @shell_parse.parse_for_policy("FOO=bar moon fmt"),
-      base_cwd=".",
-      scratch_dir=None,
-    ),
-  )
+  assert_true(blocks("moon fmt"))
+  assert_true(blocks("moon new app"))
+  assert_true(blocks("moon new -- --help"))
+  assert_true(blocks("moon info"))
+  assert_true(blocks("moon fmt && git diff"))
+  assert_true(blocks("git diff && moon fmt"))
+  assert_true(blocks("moon test --update; true"))
+  assert_true(blocks("FOO=bar moon fmt"))
   // a pipe segment that mutates is still caught (pipes parse as Simple)
-  assert_true(
-    review_read_only_blocks(
-      @shell_parse.parse_for_policy("moon fmt | tee out"),
-      base_cwd=".",
-      scratch_dir=None,
-    ),
-  )
+  assert_true(blocks("moon fmt | tee out"))
   // a read-only pipe is allowed (no mutating segment)
-  assert_false(
-    review_read_only_blocks(
-      @shell_parse.parse_for_policy("git diff | head"),
-      base_cwd=".",
-      scratch_dir=None,
-    ),
-  )
+  assert_false(blocks("git diff | head"))
   // read-only commands — allowed
-  assert_false(
-    review_read_only_blocks(
-      @shell_parse.parse_for_policy("moon check"),
-      base_cwd=".",
-      scratch_dir=None,
-    ),
-  )
-  assert_false(
-    review_read_only_blocks(
-      @shell_parse.parse_for_policy("moon check --target all"),
-      base_cwd=".",
-      scratch_dir=None,
-    ),
-  )
-  assert_false(
-    review_read_only_blocks(
-      @shell_parse.parse_for_policy("moon test"),
-      base_cwd=".",
-      scratch_dir=None,
-    ),
-  )
-  assert_false(
-    review_read_only_blocks(
-      @shell_parse.parse_for_policy("moon fmt --check"),
-      base_cwd=".",
-      scratch_dir=None,
-    ),
-  )
-  assert_false(
-    review_read_only_blocks(
-      @shell_parse.parse_for_policy("git diff origin/main"),
-      base_cwd=".",
-      scratch_dir=None,
-    ),
-  )
+  assert_false(blocks("moon check"))
+  assert_false(blocks("moon check --target all"))
+  assert_false(blocks("moon test"))
+  assert_false(blocks("moon fmt --check"))
+  assert_false(blocks("git diff origin/main"))
 }
 
 ///|

--- a/agent_tool/shell/sandbox_wbtest.mbt
+++ b/agent_tool/shell/sandbox_wbtest.mbt
@@ -347,218 +347,65 @@ async test "sandbox preblocks common source-writing commands" {
     let main_path = "\{real_root}/main.mbt"
     let src_pkg_path = "\{real_root}/src/pkg"
     let backup_path = "\{real_root}/backup.mbt"
+
+    // The four detector shapes this fixture exercises, all against the
+    // fixture root with the cwd at that root. They return the Bool so each
+    // case keeps its own `assert_true` line.
+    async fn blocks(cmd : String, expected : String) -> Bool {
+      is_some_path(tree_target(cmd, real_root, Some(real_root)), expected)
+    }
+
+    async fn allows(cmd : String) -> Bool {
+      tree_target(cmd, real_root, Some(real_root)) is None
+    }
+
+    async fn dyn_blocks(cmd : String, expected : String) -> Bool {
+      is_some_path(dyn_tree_target(cmd, real_root, Some(real_root)), expected)
+    }
+
+    async fn dyn_allows(cmd : String) -> Bool {
+      dyn_tree_target(cmd, real_root, Some(real_root)) is None
+    }
+
     assert_true(
-      is_some_path(
-        tree_target(
-          "cp replacement.txt main.mbt 2>/dev/null || true",
-          real_root,
-          Some(real_root),
-        ),
-        main_path,
-      ),
+      blocks("cp replacement.txt main.mbt 2>/dev/null || true", main_path),
     )
     assert_true(
-      is_some_path(
-        tree_target(
-          "cp replacement.txt out.log 2>/dev/null || true",
-          real_root,
-          Some(real_root),
-        ),
-        main_path,
-      ),
+      blocks("cp replacement.txt out.log 2>/dev/null || true", main_path),
     )
+    assert_true(blocks("touch main.mbt", main_path))
+    assert_true(blocks("touch out.log 2>/dev/null || true", main_path))
+    assert_true(allows("touch -h out.log"))
+    assert_true(allows("touch --no-dereference out.log"))
+    assert_true(blocks("touch --no-dereference main.mbt", main_path))
+    assert_true(blocks("printf x | tee main.mbt >/dev/null", main_path))
+    assert_true(blocks("printf x | tee out.log >/dev/null", main_path))
+    assert_true(blocks("install replacement.txt out.log", main_path))
+    assert_true(blocks("install replacement.txt main.mbt", main_path))
+    assert_true(blocks("install -Dm644 replacement.txt main.mbt", main_path))
+    assert_true(blocks("install -Dm 644 replacement.txt main.mbt", main_path))
+    assert_true(blocks("Set-Content main.mbt value", main_path))
+    assert_true(blocks("Add-Content -Path out.log -Value value", main_path))
+    assert_true(blocks("Out-File -FilePath main.mbt", main_path))
+    assert_true(blocks("Tee-Object -FilePath out.log", main_path))
+    assert_true(blocks("Copy-Item replacement.txt out.log", main_path))
     assert_true(
-      is_some_path(
-        tree_target("touch main.mbt", real_root, Some(real_root)),
-        main_path,
-      ),
-    )
-    assert_true(
-      is_some_path(
-        tree_target(
-          "touch out.log 2>/dev/null || true",
-          real_root,
-          Some(real_root),
-        ),
-        main_path,
-      ),
-    )
-    assert_true(
-      tree_target("touch -h out.log", real_root, Some(real_root)) is None,
-    )
-    assert_true(
-      tree_target("touch --no-dereference out.log", real_root, Some(real_root))
-      is None,
-    )
-    assert_true(
-      is_some_path(
-        tree_target(
-          "touch --no-dereference main.mbt",
-          real_root,
-          Some(real_root),
-        ),
-        main_path,
-      ),
-    )
-    assert_true(
-      is_some_path(
-        tree_target(
-          "printf x | tee main.mbt >/dev/null",
-          real_root,
-          Some(real_root),
-        ),
-        main_path,
-      ),
-    )
-    assert_true(
-      is_some_path(
-        tree_target(
-          "printf x | tee out.log >/dev/null",
-          real_root,
-          Some(real_root),
-        ),
-        main_path,
-      ),
-    )
-    assert_true(
-      is_some_path(
-        tree_target(
-          "install replacement.txt out.log",
-          real_root,
-          Some(real_root),
-        ),
-        main_path,
-      ),
-    )
-    assert_true(
-      is_some_path(
-        tree_target(
-          "install replacement.txt main.mbt",
-          real_root,
-          Some(real_root),
-        ),
-        main_path,
-      ),
-    )
-    assert_true(
-      is_some_path(
-        tree_target(
-          "install -Dm644 replacement.txt main.mbt",
-          real_root,
-          Some(real_root),
-        ),
-        main_path,
-      ),
-    )
-    assert_true(
-      is_some_path(
-        tree_target(
-          "install -Dm 644 replacement.txt main.mbt",
-          real_root,
-          Some(real_root),
-        ),
-        main_path,
-      ),
-    )
-    assert_true(
-      is_some_path(
-        tree_target("Set-Content main.mbt value", real_root, Some(real_root)),
-        main_path,
-      ),
-    )
-    assert_true(
-      is_some_path(
-        tree_target(
-          "Add-Content -Path out.log -Value value",
-          real_root,
-          Some(real_root),
-        ),
-        main_path,
-      ),
-    )
-    assert_true(
-      is_some_path(
-        tree_target("Out-File -FilePath main.mbt", real_root, Some(real_root)),
-        main_path,
-      ),
-    )
-    assert_true(
-      is_some_path(
-        tree_target("Tee-Object -FilePath out.log", real_root, Some(real_root)),
-        main_path,
-      ),
-    )
-    assert_true(
-      is_some_path(
-        tree_target(
-          "Copy-Item replacement.txt out.log",
-          real_root,
-          Some(real_root),
-        ),
-        main_path,
-      ),
-    )
-    assert_true(
-      is_some_path(
-        tree_target(
-          "Copy-Item _build/main.mbt src/main.mbt -ErrorAction SilentlyContinue",
-          real_root,
-          Some(real_root),
-        ),
+      blocks(
+        "Copy-Item _build/main.mbt src/main.mbt -ErrorAction SilentlyContinue",
         "\{real_root}/src/main.mbt",
       ),
     )
-    assert_true(
-      is_some_path(
-        tree_target("Move-Item main.mbt backup", real_root, Some(real_root)),
-        main_path,
-      ),
-    )
-    assert_true(
-      is_some_path(
-        tree_target("Remove-Item main.mbt", real_root, Some(real_root)),
-        main_path,
-      ),
-    )
-    assert_true(
-      is_some_path(
-        tree_target(
-          "Rename-Item main.mbt backup.mbt",
-          real_root,
-          Some(real_root),
-        ),
-        main_path,
-      ),
-    )
-    assert_true(
-      is_some_path(
-        tree_target(
-          "New-Item -Path main.mbt -ItemType File",
-          real_root,
-          Some(real_root),
-        ),
-        main_path,
-      ),
-    )
+    assert_true(blocks("Move-Item main.mbt backup", main_path))
+    assert_true(blocks("Remove-Item main.mbt", main_path))
+    assert_true(blocks("Rename-Item main.mbt backup.mbt", main_path))
+    assert_true(blocks("New-Item -Path main.mbt -ItemType File", main_path))
     // `-Name` is the leaf created under `-Path`, so the target is `./main.mbt`,
     // not the `.` directory.
     assert_true(
-      is_some_path(
-        tree_target(
-          "New-Item -Path . -Name main.mbt -ItemType File",
-          real_root,
-          Some(real_root),
-        ),
-        main_path,
-      ),
+      blocks("New-Item -Path . -Name main.mbt -ItemType File", main_path),
     )
     let powershell_remove_glob = "Remove-Item *.mbt"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(powershell_remove_glob, real_root, Some(real_root)),
-        real_root,
-      ),
-    )
+    assert_true(dyn_blocks(powershell_remove_glob, real_root))
     // Conservatively pre-blocked git: store feeders (external patch + plumbing),
     // mv, non-dry-run clean, reconfigured writers (-c filter / -C / --work-tree /
     // custom env), and checkout/restore forms that can clobber untracked source.
@@ -580,12 +427,7 @@ async test "sandbox preblocks common source-writing commands" {
         "git submodule update --force", "git submodule deinit --force path", "git -c filter.f.smudge=cmd submodule update --init",
         "GIT_DIR=/tmp/x git submodule update --init",
       ] {
-      assert_true(
-        is_some_path(
-          tree_target(blocked_git, real_root, Some(real_root)),
-          real_root,
-        ),
-      )
+      assert_true(blocks(blocked_git, real_root))
     }
     // A store feeder is blocked unconditionally — not conditioned on the resolved
     // cwd — so it cannot slip through with a cwd outside the workspace (e.g. a
@@ -600,12 +442,7 @@ async test "sandbox preblocks common source-writing commands" {
     )
     // git apply is also caught in the TooComplex text path (e.g. globbed patches).
     let git_apply_glob = "git apply *.patch"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(git_apply_glob, real_root, Some(real_root)),
-        real_root,
-      ),
-    )
+    assert_true(dyn_blocks(git_apply_glob, real_root))
     // A custom-env worktree writer is caught in the TooComplex text path too,
     // even though the env assignment precedes the `git` word.
     let git_env_glob = "GIT_DIR=/tmp/x git checkout -- *.mbt"
@@ -629,352 +466,108 @@ async test "sandbox preblocks common source-writing commands" {
         // bare submodule is implicit status; foreach --help bypasses preblock.
          "git submodule", "git submodule --quiet", "git submodule foreach --help",
       ] {
-      assert_true(tree_target(allowed_git, real_root, Some(real_root)) is None)
+      assert_true(allows(allowed_git))
     }
     let find_sed_source = "find \{real_root} -name '*.mbt' -exec sed -i '' 's/42/43/' {} +"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(find_sed_source, real_root, Some(real_root)),
-        real_root,
-      ),
-    )
+    assert_true(dyn_blocks(find_sed_source, real_root))
     let find_env_sed_source = "find \{real_root} -name '*.mbt' -exec env FOO=bar sed -i '' 's/42/43/' {} + 2>/dev/null || true"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(find_env_sed_source, real_root, Some(real_root)),
-        real_root,
-      ),
-    )
+    assert_true(dyn_blocks(find_env_sed_source, real_root))
     let find_sed_source_case_insensitive = "find \{real_root} -iname '*.MBT' -exec sed -i '' 's/42/43/' {} +"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(
-          find_sed_source_case_insensitive,
-          real_root,
-          Some(real_root),
-        ),
-        real_root,
-      ),
-    )
+    assert_true(dyn_blocks(find_sed_source_case_insensitive, real_root))
     let find_sed_readme_glob = "find \{real_root} -name README.* -exec sed -i '' 's/42/43/' '{}' +"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(find_sed_readme_glob, real_root, Some(real_root)),
-        real_root,
-      ),
-    )
+    assert_true(dyn_blocks(find_sed_readme_glob, real_root))
     // `xargs sed -i` runs sed as the xargs utility, so an in-place edit reached
     // that way must be blocked even though sed is not in shell command position.
     // (These shapes parse as TooComplex via the unquoted glob; the simple
     // `find ... | xargs sed -i` form parses as Simple and is caught by the
     // source-write sandbox instead.)
     let xargs_sed_source = "echo *.mbt | xargs sed -i '' 's/42/43/g'"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(xargs_sed_source, real_root, Some(real_root)),
-        real_root,
-      ),
-    )
+    assert_true(dyn_blocks(xargs_sed_source, real_root))
     let xargs_replace_sed = "echo *.mbt | xargs -I{} sed -i '' 's/42/43/g' {}"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(xargs_replace_sed, real_root, Some(real_root)),
-        real_root,
-      ),
-    )
+    assert_true(dyn_blocks(xargs_replace_sed, real_root))
     let xargs_n1_sed = "echo *.mbt | xargs -n 1 sed -i '' 's/42/43/g'"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(xargs_n1_sed, real_root, Some(real_root)),
-        real_root,
-      ),
-    )
+    assert_true(dyn_blocks(xargs_n1_sed, real_root))
     // BSD/macOS `-J replstr` consumes its operand before the utility.
     let xargs_bsd_replace_sed = "echo *.mbt | xargs -J {} sed -i '' 's/42/43/g' {}"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(xargs_bsd_replace_sed, real_root, Some(real_root)),
-        real_root,
-      ),
-    )
+    assert_true(dyn_blocks(xargs_bsd_replace_sed, real_root))
     // The same xargs-utility gap still applies to `git apply` (the one blocked
     // git op); recognized porcelain is trusted or not pre-blocked.
     let xargs_git_apply = "echo *.patch | xargs git apply"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(xargs_git_apply, real_root, Some(real_root)),
-        real_root,
-      ),
-    )
+    assert_true(dyn_blocks(xargs_git_apply, real_root))
     // Read-only xargs pipelines (sed is not the xargs utility, no in-place edit)
     // must not be blocked, so analysis loops keep working.
     let xargs_grep_readonly = "echo *.mbt | xargs grep -l 'sed -i'"
-    assert_true(
-      dyn_tree_target(xargs_grep_readonly, real_root, Some(real_root)) is None,
-    )
+    assert_true(dyn_allows(xargs_grep_readonly))
     let safe_find_then_sed = "find \{real_root} -name '*.txt' -print; sed -i '' 's/42/43/' *.mbt"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(safe_find_then_sed, real_root, Some(real_root)),
-        real_root,
-      ),
-    )
+    assert_true(dyn_blocks(safe_find_then_sed, real_root))
     let env_wrapped_sed = "env FOO=bar sed -i '' 's/42/43/' *.mbt"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(env_wrapped_sed, real_root, Some(real_root)),
-        real_root,
-      ),
-    )
+    assert_true(dyn_blocks(env_wrapped_sed, real_root))
     let env_assignment_sed = "FOO=bar sed -i '' 's/42/43/' *.mbt"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(env_assignment_sed, real_root, Some(real_root)),
-        real_root,
-      ),
-    )
+    assert_true(dyn_blocks(env_assignment_sed, real_root))
     let env_unset_wrapped_sed = "env -u FOO sed -i '' 's/42/43/' *.mbt"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(env_unset_wrapped_sed, real_root, Some(real_root)),
-        real_root,
-      ),
-    )
+    assert_true(dyn_blocks(env_unset_wrapped_sed, real_root))
     let env_long_unset_wrapped_sed = "env --unset FOO sed -i '' 's/42/43/' *.mbt"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(env_long_unset_wrapped_sed, real_root, Some(real_root)),
-        real_root,
-      ),
-    )
+    assert_true(dyn_blocks(env_long_unset_wrapped_sed, real_root))
     let command_wrapped_sed = "command sed -i '' 's/42/43/' *.mbt"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(command_wrapped_sed, real_root, Some(real_root)),
-        real_root,
-      ),
-    )
+    assert_true(dyn_blocks(command_wrapped_sed, real_root))
     let find_sed_text = "find \{real_root} -name '*.txt' -exec sed -i '' 's/42/43/' {} +"
-    assert_true(tree_target(find_sed_text, real_root, Some(real_root)) is None)
-    assert_true(
-      dyn_tree_target(find_sed_text, real_root, Some(real_root)) is None,
-    )
+    assert_true(allows(find_sed_text))
+    assert_true(dyn_allows(find_sed_text))
     let find_sed_text_quoted = "find \{real_root} -name '*.txt' -exec sed -i '' 's/42/43/' '{}' +"
-    assert_true(
-      tree_target(find_sed_text_quoted, real_root, Some(real_root)) is None,
-    )
-    assert_true(
-      dyn_tree_target(find_sed_text_quoted, real_root, Some(real_root)) is None,
-    )
+    assert_true(allows(find_sed_text_quoted))
+    assert_true(dyn_allows(find_sed_text_quoted))
     let find_sed_filter_after_exec = "find \{real_root} -exec sed -i '' 's/42/43/' '{}' + -name '*.txt'"
-    assert_true(
-      is_some_path(
-        tree_target(find_sed_filter_after_exec, real_root, Some(real_root)),
-        real_root,
-      ),
-    )
+    assert_true(blocks(find_sed_filter_after_exec, real_root))
     let broad_find_sed_text = "find \{real_root} -name '*' -exec sed -i '' 's/42/43/' '{}' +"
-    assert_true(
-      is_some_path(
-        tree_target(broad_find_sed_text, real_root, Some(real_root)),
-        real_root,
-      ),
-    )
+    assert_true(blocks(broad_find_sed_text, real_root))
     let find_sed_literal_source = "find \{real_root} -name '*.txt' -exec sed -i '' 's/42/43/' main.mbt ';'"
-    assert_true(
-      is_some_path(
-        tree_target(find_sed_literal_source, real_root, Some(real_root)),
-        real_root,
-      ),
-    )
+    assert_true(blocks(find_sed_literal_source, real_root))
     let find_sed_comma_quoted = "find \{real_root} -name '*.txt' -exec sed -i '' 's/42/43/' '{}' + , -exec sed -i '' 's/42/43/' '{}' +"
-    assert_true(
-      is_some_path(
-        tree_target(find_sed_comma_quoted, real_root, Some(real_root)),
-        real_root,
-      ),
-    )
+    assert_true(blocks(find_sed_comma_quoted, real_root))
     let readonly_sed_pipeline = "sed -n '1,5p' *.mbt | grep -i answer"
-    assert_true(
-      dyn_tree_target(readonly_sed_pipeline, real_root, Some(real_root)) is None,
-    )
+    assert_true(dyn_allows(readonly_sed_pipeline))
     let readonly_sed_file_named_i = "while true; do sed -f -i *.mbt\ndone"
-    assert_true(
-      dyn_tree_target(readonly_sed_file_named_i, real_root, Some(real_root))
-      is None,
-    )
+    assert_true(dyn_allows(readonly_sed_file_named_i))
     let multiline_sed = "while true; do printf ok\nsed -i '' 's/42/43/' *.mbt\ndone"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(multiline_sed, real_root, Some(real_root)),
-        real_root,
-      ),
-    )
+    assert_true(dyn_blocks(multiline_sed, real_root))
     let background_sed = "sleep 1 & sed -i '' 's/42/43/' *.mbt"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(background_sed, real_root, Some(real_root)),
-        real_root,
-      ),
-    )
+    assert_true(dyn_blocks(background_sed, real_root))
     let nested_shell_sed = "sh -c \"sed -i '' 's/42/43/' *.mbt\""
-    assert_true(
-      is_some_path(
-        tree_target(nested_shell_sed, real_root, Some(real_root)),
-        real_root,
-      ),
-    )
+    assert_true(blocks(nested_shell_sed, real_root))
     let quoted_sed_text = "grep 'foo|sed -i' *.mbt"
-    assert_true(
-      dyn_tree_target(quoted_sed_text, real_root, Some(real_root)) is None,
-    )
+    assert_true(dyn_allows(quoted_sed_text))
     let generated_script_with_sed = "cat > script.sh <<EOF\nsed -i 's/42/43/' f\nEOF"
-    assert_true(
-      dyn_tree_target(generated_script_with_sed, real_root, Some(real_root))
-      is None,
-    )
+    assert_true(dyn_allows(generated_script_with_sed))
     let backslash_quoted_heredoc_then_copy = "cat <<\\EOF\nignored\nEOF\ncp main.mbt backup.mbt"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(
-          backslash_quoted_heredoc_then_copy,
-          real_root,
-          Some(real_root),
-        ),
-        real_root,
-      ),
-    )
+    assert_true(dyn_blocks(backslash_quoted_heredoc_then_copy, real_root))
     let generated_script_then_executed = "cat > script.sh <<EOF\ncp main.mbt backup.mbt\nEOF\nsh script.sh"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(
-          generated_script_then_executed,
-          real_root,
-          Some(real_root),
-        ),
-        real_root,
-      ),
-    )
+    assert_true(dyn_blocks(generated_script_then_executed, real_root))
     let tee_generated_script_then_executed = "tee script.sh <<EOF >/dev/null\ncp main.mbt backup.mbt\nEOF\nsh script.sh"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(
-          tee_generated_script_then_executed,
-          real_root,
-          Some(real_root),
-        ),
-        real_root,
-      ),
-    )
+    assert_true(dyn_blocks(tee_generated_script_then_executed, real_root))
     let pipe_tee_generated_script_then_executed = "cat <<EOF | tee script.sh >/dev/null\ncp main.mbt backup.mbt\nEOF\nsh script.sh"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(
-          pipe_tee_generated_script_then_executed,
-          real_root,
-          Some(real_root),
-        ),
-        real_root,
-      ),
-    )
+    assert_true(dyn_blocks(pipe_tee_generated_script_then_executed, real_root))
     let generated_script_then_bash_with_option = "cat > script.sh <<EOF\ncp main.mbt backup.mbt\nEOF\nbash -o pipefail script.sh"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(
-          generated_script_then_bash_with_option,
-          real_root,
-          Some(real_root),
-        ),
-        real_root,
-      ),
-    )
+    assert_true(dyn_blocks(generated_script_then_bash_with_option, real_root))
     let generated_script_then_dot_sourced = "cat > script.sh <<EOF\ncp main.mbt backup.mbt\nEOF\n. script.sh"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(
-          generated_script_then_dot_sourced,
-          real_root,
-          Some(real_root),
-        ),
-        real_root,
-      ),
-    )
+    assert_true(dyn_blocks(generated_script_then_dot_sourced, real_root))
     let generated_script_then_source_sourced = "cat > script.sh <<EOF\ncp main.mbt backup.mbt\nEOF\nsource script.sh"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(
-          generated_script_then_source_sourced,
-          real_root,
-          Some(real_root),
-        ),
-        real_root,
-      ),
-    )
+    assert_true(dyn_blocks(generated_script_then_source_sourced, real_root))
     let generated_script_then_shell_c_sourced = "cat > script.sh <<EOF\nmkdir -p _build/gen\ncp main.mbt _build/gen/main.mbt\nmv _build/gen pkg\nEOF\nsh -c '. ./script.sh'"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(
-          generated_script_then_shell_c_sourced,
-          real_root,
-          Some(real_root),
-        ),
-        real_root,
-      ),
-    )
+    assert_true(dyn_blocks(generated_script_then_shell_c_sourced, real_root))
     let shell_heredoc_with_sed = "sh <<EOF\nsed -i '' 's/42/43/' *.mbt\nEOF"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(shell_heredoc_with_sed, real_root, Some(real_root)),
-        real_root,
-      ),
-    )
+    assert_true(dyn_blocks(shell_heredoc_with_sed, real_root))
     let python_heredoc_generated_move = "python3 <<EOF\nimport shutil\nshutil.move('_build/pkg', 'pkg')\nEOF"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(
-          python_heredoc_generated_move,
-          real_root,
-          Some(real_root),
-        ),
-        real_root,
-      ),
-    )
+    assert_true(dyn_blocks(python_heredoc_generated_move, real_root))
     let heredoc_source_redirect = "cat 2>/dev/null > main.mbt <<'EOF' || true\npub fn answer() -> Int { 43 }\nEOF"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(heredoc_source_redirect, real_root, Some(real_root)),
-        real_root,
-      ),
-    )
+    assert_true(dyn_blocks(heredoc_source_redirect, real_root))
     let fd_duplicate_source_redirect = "printf x >& main.mbt *.txt 2>/dev/null || true"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(
-          fd_duplicate_source_redirect,
-          real_root,
-          Some(real_root),
-        ),
-        real_root,
-      ),
-    )
+    assert_true(dyn_blocks(fd_duplicate_source_redirect, real_root))
     let rm_glob_source = "rm *.mbt 2>/dev/null || true"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(rm_glob_source, real_root, Some(real_root)),
-        real_root,
-      ),
-    )
+    assert_true(dyn_blocks(rm_glob_source, real_root))
     let grep_mv_source = "grep mv *.mbt"
-    assert_true(
-      dyn_tree_target(grep_mv_source, real_root, Some(real_root)) is None,
-    )
+    assert_true(dyn_allows(grep_mv_source))
     let python_heredoc_source_write = "python3 - <<'PY'\nopen('main.mbt', 'w').write('pub fn answer() -> Int { 43 }\\n')\nPY"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(python_heredoc_source_write, real_root, Some(real_root)),
-        main_path,
-      ),
-    )
+    assert_true(dyn_blocks(python_heredoc_source_write, main_path))
     let outside_python_heredoc_source_write = "python3 - <<'PY'\nopen('/tmp/probe.mbt', 'w').write('x')\nPY"
     assert_true(
       dyn_tree_target(
@@ -985,14 +578,9 @@ async test "sandbox preblocks common source-writing commands" {
       is None,
     )
     let outside_python_c_source_write = "python3 -c 'open(\"/tmp/probe.mbt\", \"w\").write(\"x\")' *.txt"
-    assert_true(
-      dyn_tree_target(outside_python_c_source_write, real_root, Some(real_root))
-      is None,
-    )
+    assert_true(dyn_allows(outside_python_c_source_write))
     let cd_outside_glob_sed = "cd /tmp && sed -i '' 's/42/43/' *.mbt"
-    assert_true(
-      dyn_tree_target(cd_outside_glob_sed, real_root, Some(real_root)) is None,
-    )
+    assert_true(dyn_allows(cd_outside_glob_sed))
     let cd_workspace_glob_sed = "cd \{real_root} && sed -i '' 's/42/43/' *.mbt"
     assert_true(
       is_some_path(
@@ -1001,190 +589,62 @@ async test "sandbox preblocks common source-writing commands" {
       ),
     )
     let versioned_python_source_write = "python3.12 -c 'open(\"main.mbt\", \"w\").write(\"pub fn answer() -> Int { 43 }\\\\n\")'"
-    assert_true(
-      is_some_path(
-        tree_target(versioned_python_source_write, real_root, Some(real_root)),
-        main_path,
-      ),
-    )
+    assert_true(blocks(versioned_python_source_write, main_path))
     let python_exe_source_write = "Python.EXE -c 'open(\"main.mbt\", \"w+\").close()' 2>/dev/null || true"
-    assert_true(
-      is_some_path(
-        tree_target(python_exe_source_write, real_root, Some(real_root)),
-        main_path,
-      ),
-    )
+    assert_true(blocks(python_exe_source_write, main_path))
     let python_create_mode_source_write = "python -c 'open(\"main.mbt\", \"x\").close()' 2>/dev/null || true"
-    assert_true(
-      is_some_path(
-        tree_target(python_create_mode_source_write, real_root, Some(real_root)),
-        main_path,
-      ),
-    )
+    assert_true(blocks(python_create_mode_source_write, main_path))
     let masked_versioned_python_source_write = "python3.12 -c 'open(\"main.mbt\", \"w\").write(\"pub fn answer() -> Int { 43 }\\\\n\")' 2>/dev/null || true"
-    assert_true(
-      is_some_path(
-        tree_target(
-          masked_versioned_python_source_write,
-          real_root,
-          Some(real_root),
-        ),
-        main_path,
-      ),
-    )
+    assert_true(blocks(masked_versioned_python_source_write, main_path))
     let find_sed_branch = "find \{real_root} -name '*.txt' -o -exec sed -i '' 's/42/43/' {} +"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(find_sed_branch, real_root, Some(real_root)),
-        real_root,
-      ),
-    )
+    assert_true(dyn_blocks(find_sed_branch, real_root))
     let find_sed_branch_quoted = "find \{real_root} -name '*.txt' -o -exec sed -i '' 's/42/43/' '{}' +"
-    assert_true(
-      is_some_path(
-        tree_target(find_sed_branch_quoted, real_root, Some(real_root)),
-        real_root,
-      ),
-    )
+    assert_true(blocks(find_sed_branch_quoted, real_root))
     let find_sed_comma = "find \{real_root} -name '*.txt' -exec sed -i '' 's/42/43/' {} + , -exec sed -i '' 's/42/43/' {} +"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(find_sed_comma, real_root, Some(real_root)),
-        real_root,
-      ),
-    )
+    assert_true(dyn_blocks(find_sed_comma, real_root))
     let grouped_sed = "{ sed -i '' 's/42/43/' *.mbt; }"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(grouped_sed, real_root, Some(real_root)),
-        real_root,
-      ),
-    )
+    assert_true(dyn_blocks(grouped_sed, real_root))
     let until_sed = "until sed -i '' 's/42/43/' *.mbt; do true; done"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(until_sed, real_root, Some(real_root)),
-        real_root,
-      ),
-    )
+    assert_true(dyn_blocks(until_sed, real_root))
     let elif_sed = "if false; then true; elif sed -i '' 's/42/43/' *.mbt; then true; fi"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(elif_sed, real_root, Some(real_root)),
-        real_root,
-      ),
-    )
+    assert_true(dyn_blocks(elif_sed, real_root))
     let if_env_sed = "if env FOO=bar sed -i '' 's/42/43/' *.mbt; then true; fi"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(if_env_sed, real_root, Some(real_root)),
-        real_root,
-      ),
-    )
+    assert_true(dyn_blocks(if_env_sed, real_root))
     let if_command_sed = "if command sed -i '' 's/42/43/' *.mbt; then true; fi"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(if_command_sed, real_root, Some(real_root)),
-        real_root,
-      ),
-    )
+    assert_true(dyn_blocks(if_command_sed, real_root))
     let loop_sed = "while IFS= read -r f; do sed -i '' 's/42/43/' \"$f\"; done < /tmp/files.txt"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(loop_sed, real_root, Some(real_root)),
-        real_root,
-      ),
-    )
+    assert_true(dyn_blocks(loop_sed, real_root))
     let cd_glob_sed = "cd pkg && sed -i '' 's/42/43/' *.mbt"
-    assert_true(
-      is_some_path(
-        dyn_tree_target(cd_glob_sed, real_root, Some(real_root)),
-        "\{real_root}/pkg",
-      ),
-    )
+    assert_true(dyn_blocks(cd_glob_sed, "\{real_root}/pkg"))
     let mkdir_or_cp_source = "mkdir gen || true; cp /tmp/generated.mbt gen 2>/dev/null || true"
+    assert_true(blocks(mkdir_or_cp_source, "\{real_root}/gen"))
     assert_true(
-      is_some_path(
-        tree_target(mkdir_or_cp_source, real_root, Some(real_root)),
-        "\{real_root}/gen",
-      ),
+      blocks("cd src && mv pkg pkg.bak 2>/dev/null || true", src_pkg_path),
+    )
+    assert_true(dyn_allows("cp main.mbt backup.txt"))
+    assert_true(allows("cp main.mbt backup.txt"))
+    assert_true(blocks("cp main.mbt backup.mbt", backup_path))
+    assert_true(blocks("mv --force pkg pkg.bak", "\{real_root}/pkg"))
+    assert_true(blocks("mv -b main.mbt backup 2>/dev/null || true", main_path))
+    assert_true(
+      blocks("mv --no-target-directory _build/gen pkg", "\{real_root}/pkg"),
     )
     assert_true(
-      is_some_path(
-        tree_target(
-          "cd src && mv pkg pkg.bak 2>/dev/null || true",
-          real_root,
-          Some(real_root),
-        ),
-        src_pkg_path,
-      ),
-    )
-    assert_true(
-      dyn_tree_target("cp main.mbt backup.txt", real_root, Some(real_root))
-      is None,
-    )
-    assert_true(
-      tree_target("cp main.mbt backup.txt", real_root, Some(real_root)) is None,
-    )
-    assert_true(
-      is_some_path(
-        tree_target("cp main.mbt backup.mbt", real_root, Some(real_root)),
-        backup_path,
-      ),
-    )
-    assert_true(
-      is_some_path(
-        tree_target("mv --force pkg pkg.bak", real_root, Some(real_root)),
-        "\{real_root}/pkg",
-      ),
-    )
-    assert_true(
-      is_some_path(
-        tree_target(
-          "mv -b main.mbt backup 2>/dev/null || true",
-          real_root,
-          Some(real_root),
-        ),
-        main_path,
-      ),
-    )
-    assert_true(
-      is_some_path(
-        tree_target(
-          "mv --no-target-directory _build/gen pkg",
-          real_root,
-          Some(real_root),
-        ),
-        "\{real_root}/pkg",
-      ),
-    )
-    assert_true(
-      is_some_path(
-        tree_target(
-          "mkdir -p _build/gen.v1 && printf source > _build/gen.v1/main.mbt && mv _build/gen.v1 pkg.v1",
-          real_root,
-          Some(real_root),
-        ),
+      blocks(
+        "mkdir -p _build/gen.v1 && printf source > _build/gen.v1/main.mbt && mv _build/gen.v1 pkg.v1",
         "\{real_root}/pkg.v1",
       ),
     )
     assert_true(
-      is_some_path(
-        tree_target(
-          "mkdir -p assets _build/gen.tmp && printf source > _build/gen.tmp/main.mbt && mv _build/gen.tmp assets/pkg.tmp",
-          real_root,
-          Some(real_root),
-        ),
+      blocks(
+        "mkdir -p assets _build/gen.tmp && printf source > _build/gen.tmp/main.mbt && mv _build/gen.tmp assets/pkg.tmp",
         "\{real_root}/assets/pkg.tmp",
       ),
     )
     assert_true(
-      tree_target(
+      allows(
         "mkdir -p assets _build && printf data > _build/logo.txt && mv _build/logo.txt assets/logo.txt",
-        real_root,
-        Some(real_root),
-      )
-      is None,
+      ),
     )
   })
 }

--- a/agent_tool/shell/shell.mbt
+++ b/agent_tool/shell/shell.mbt
@@ -772,13 +772,7 @@ async fn read_output_prefix(
   let byte_budget = max_output_chars * 4 + 4
   for ;; {
     let remaining_budget = byte_budget - buffer.length()
-    let chunk_limit = if remaining_budget <= 0 {
-      1
-    } else if remaining_budget < 1024 {
-      remaining_budget
-    } else {
-      1024
-    }
+    let chunk_limit = remaining_budget.clamp(min=1, max=1024)
     match reader.read_some(max_len=chunk_limit) {
       None =>
         return {

--- a/agent_tool/shell/shell_test.mbt
+++ b/agent_tool/shell/shell_test.mbt
@@ -2181,6 +2181,22 @@ async test "run_in_background without timeout_ms is unaffected by defaults" {
 }
 
 ///|
+/// The worker-mode shell tool for a fixture tree: `<root>/w` is the worker tree
+/// and `<root>/admin` its private git admin dir, with `<root>` itself denied.
+fn worker_run(root : String) -> (async (Json) -> @agent_tool.ToolAction) raise {
+  let scope : @shell.WorkerSandbox = {
+    deny_roots: [root],
+    worker_root: "\{root}/w",
+    worker_admin_dir: "\{root}/admin",
+  }
+  match
+    @shell.definition(workspace_root="\{root}/w", worker_sandbox=scope).execute {
+    Async(execute) => execute
+    Sync(_) => fail("shell tool should be async")
+  }
+}
+
+///|
 /// The worker-mode static floor: obvious escapes are refused before launch
 /// with a readable explanation, independent of kernel availability; in-tree
 /// commands run normally.
@@ -2189,16 +2205,7 @@ async test "worker mode statically blocks obvious escapes" {
     let root = @fs.realpath(dir)
     @fs.mkdir("\{root}/w")
     @fs.mkdir("\{root}/admin")
-    let scope : @shell.WorkerSandbox = {
-      deny_roots: [root],
-      worker_root: "\{root}/w",
-      worker_admin_dir: "\{root}/admin",
-    }
-    let run = match
-      @shell.definition(workspace_root="\{root}/w", worker_sandbox=scope).execute {
-      Async(execute) => execute
-      Sync(_) => fail("shell tool should be async")
-    }
+    let run = worker_run(root)
     // A cwd outside the worker tree is refused up front.
     guard run({ "cmd": "pwd", "cwd": "/tmp" }) is Respond(cwd_escape) else {
       fail("expected Respond")
@@ -2235,16 +2242,7 @@ async test "worker mode tracks cd forms, pipelines, and symlinked cwds" {
     @fs.mkdir("\{root}/w")
     @fs.mkdir("\{root}/w/sub")
     @fs.mkdir("\{root}/admin")
-    let scope : @shell.WorkerSandbox = {
-      deny_roots: [root],
-      worker_root: "\{root}/w",
-      worker_admin_dir: "\{root}/admin",
-    }
-    let run = match
-      @shell.definition(workspace_root="\{root}/w", worker_sandbox=scope).execute {
-      Async(execute) => execute
-      Sync(_) => fail("shell tool should be async")
-    }
+    let run = worker_run(root)
     async fn blocked(cmd : Json) -> Unit {
       guard run(cmd) is Respond(output) else { fail("expected Respond") }
       assert_true(output.is_error)
@@ -2290,16 +2288,7 @@ async test "worker mode blocks the failed-cd-into-file escape chain" {
     @fs.mkdir("\{root}/w/sub")
     @fs.write_file("\{root}/w/file", "not a directory", create_mode=CreateNew)
     @fs.mkdir("\{root}/admin")
-    let scope : @shell.WorkerSandbox = {
-      deny_roots: [root],
-      worker_root: "\{root}/w",
-      worker_admin_dir: "\{root}/admin",
-    }
-    let run = match
-      @shell.definition(workspace_root="\{root}/w", worker_sandbox=scope).execute {
-      Async(execute) => execute
-      Sync(_) => fail("shell tool should be async")
-    }
+    let run = worker_run(root)
     guard run({
         "cmd": "cd file; cd sub && cd .. && cd .. && touch escaped.txt",
       })
@@ -2325,16 +2314,7 @@ async test "worker mode survives logical-cd and failure-rejoin chains" {
     @fs.mkdir("\{root}/w/sub")
     @fs.mkdir("\{root}/w/sub/deep")
     @fs.mkdir("\{root}/admin")
-    let scope : @shell.WorkerSandbox = {
-      deny_roots: [root],
-      worker_root: "\{root}/w",
-      worker_admin_dir: "\{root}/admin",
-    }
-    let run = match
-      @shell.definition(workspace_root="\{root}/w", worker_sandbox=scope).execute {
-      Async(execute) => execute
-      Sync(_) => fail("shell tool should be async")
-    }
+    let run = worker_run(root)
     async fn blocked(cmd : Json) -> Unit {
       guard run(cmd) is Respond(output) else { fail("expected Respond") }
       assert_true(output.is_error)

--- a/agent_tool/shell_exec/sink.mbt
+++ b/agent_tool/shell_exec/sink.mbt
@@ -70,16 +70,8 @@ fn ShellOutputSink::ShellOutputSink(
     file: None,
     file_bytes: 0,
     spill_path,
-    inline_cap: if inline_cap > 0 {
-      inline_cap
-    } else {
-      1
-    },
-    hard_cap: if hard_cap > 0 {
-      hard_cap
-    } else {
-      1
-    },
+    inline_cap: inline_cap.max(1),
+    hard_cap: hard_cap.max(1),
   }
 }
 
@@ -293,11 +285,7 @@ async fn ShellOutputSink::read_tail(self : ShellOutputSink, n : Int) -> String {
       // becomes a replacement char, dropped when we keep the last `n`), then keep
       // the last `n` characters.
       let want = n.to_int64() * 4 + 4
-      let start = if self.file_bytes > want {
-        self.file_bytes - want
-      } else {
-        0
-      }
+      let start = (self.file_bytes - want).max(0)
       let len = (self.file_bytes - start).to_int()
       let bytes = file.read_exactly_at(len, position=start) catch {
         _ => return self.head.to_string()
@@ -352,7 +340,7 @@ fn split_valid_utf8(bytes : Bytes) -> (String, Bytes, Bool) {
 ///|
 fn incomplete_suffix_len(bytes : Bytes) -> Int {
   let len = bytes.length()
-  let lookback = if len < 3 { len } else { 3 }
+  let lookback = len.min(3)
   for i in 0..<lookback {
     let pos = len - 1 - i
     let b = bytes[pos].to_int()


### PR DESCRIPTION
A pure **simplification** pass: no feature, no fix, no behaviour change. Part of a project-wide sweep; each PR is one package family so it can be reviewed on its own.

Candidates came from a read-only survey of the whole repository. The author was told to drop any that would not compile or would change behaviour, so this branch carries fewer than were proposed: **9 applied, 1 dropped, net -781 lines.**

## Applied

- **agent_tool/shell/sandbox_wbtest.mbt** — 105 repeated tree_target/dyn_tree_target assertions in "sandbox preblocks common source-writing commands"
  Applied, but NOT as proposed. The surveyor described one uniform shape; there are actually four (tree_target/dyn_tree_target x blocked/allowed), plus 4 assertions fitting none of them. I added four local `async fn` helpers that return Bool rather than the proposed `-> Unit` helpers that swallow the assert, so every case keeps its own assert_true line and a failure still names one command (brief's diagnosability rule). Done mechanically by script, then machine-verified: each of the 105 assertions was reduced to a canonical (detector, cmd, root, cwd, expected) tuple before and after, and the ordered lists are identical. 101 rewritten; 4 left spelled out (2 use cwd Some("/tmp") or Some("{real_root}-external"), 2 use the `is Some(_)` shape). All 70 let bindings identical, all 26 original comments preserved. Test body 877 -> 308 lines.
- **agent_tool/shell/moon_auto_check.mbt** — "detect moon command check cwd from -C option" repeats moon_auto_check_start_cwd(cmd, Some(base))
  33 assertions before, 33 one-line rows after (the finding said 30). Local `fn cwd_for(cmd, base)`. Kept `base` an explicit positional argument rather than defaulting it, so the one row using base="/repo/pkg" ("moon -C ../other info") stays visible instead of becoming a hidden exception. Order and inputs unchanged.
- **agent_tool/shell/review_guard.mbt** — "read-only guard blocks mutating moon anywhere" repeats the 6-line review_read_only_blocks call
  15 assertions before, 15 rows after (the finding said 17). Uses the identical `fn blocks(cmd : String) -> Bool` helper the very next test in the same file already defines. All four inline prose comments kept in position.
- **agent_tool/shell/internal/git_policy/git_policy.mbt** — `parse` re-implements `text_subcommand_index`, whose comment says "Mirrors `parse`"
  Applied. Verified the two textual differences are behaviour-identical rather than taking the surveyor's word: (a) parse's explicit `--` arm — in the scanner `--` is not matched by attached_cwd_option/attached_work_tree_option/global_no_arg_option/global_option_with_attached_value, so it reaches `has_prefix("-") && arg != "-"` and returns None; (b) parse's `index + 1 >= len -> None` — the scanner's `index += 2` steps past `end` and the while-guard returns None. Rewrote the helper's doc comment to record both facts instead of deleting it.
- **agent_tool/shell/shell_test.mbt** — Four worker-mode tests repeat the same 9-line WorkerSandbox + run construction
  Applied. The proposed signature did not compile twice: `async fn` tripped deny-warn unused_async [0067] (the function is not itself async), then the bare return type failed with [4122] because `fail` raises. Final form is `fn worker_run(root : String) -> (async (Json) -> @agent_tool.ToolAction) raise` — the parens are required so `raise` attaches to worker_run, not to the returned closure. All four blocks were byte-identical; replaced in place so side-effect order is untouched.
- **agent_tool/shell_exec/sink.mbt** — Hand-written cap clamping in the sink constructor is Int::max
  Applied at all three sites the finding's evidence names, not just the constructor: inline_cap/hard_cap -> .max(1), read_tail's start offset -> (self.file_bytes - want).max(0) (Int64::max), and incomplete_suffix_len's lookback -> len.min(3). The constructor's doc comment ("Non-positive caps are clamped to 1") still describes the code exactly, so it stands unchanged.
- **agent_tool/shell/shell.mbt** — Three-branch chunk-limit chain is exactly Int::clamp(min=1, max=1024)
  Applied verbatim as proposed.
- **agent_tool/shell/moon_auto_check.mbt** — moon_check_output_budget is remaining.clamp(min=0, max=MaxOutputChars)
  Applied verbatim as proposed. The three existing assertions in "bound follow-up check output by remaining shell output budget" still pass.
- **agent_tool/shell/internal/shell_parse/parser.mbt** — render_source builds parts with three push-loops that are two maps and a spread
  Applied. Kept the loop variable names (assignment, redirect) as the lambda parameters rather than the proposed one-letter a/r, so the interpolations read the same as before. Group order preserved.

## Dropped, and why

- **"submodule verbs" test is a strict subset of the submodule rows in the preceding preblock test (agent_tool/shell/internal/git_policy/git_policy_test.mbt:227)**
  Trips two of the brief's explicit drop criteria. (1) It deletes an explanatory comment: the test carries a four-line doc comment recording WHY verb-level submodule classification is exercised through the public preblock surface ("the sandbox layer keeps its own private mirror") — that rationale exists nowhere else and dies with the test. (2) It is not actually a strict subset. I checked all 16 rows against the earlier test: the 9 not-preblocked rows are verbatim duplicates, but only 5 of the 7 preblocked rows are; ["git","submodule","foreach","echo","hi"] and ["git","submodule","--quiet","foreach","echo","hi"] appear upstream only with the payload word "hello". The finding argues the payload is never inspected — true of today's submodule_verb_is_unsafe/submodule_foreach_is_help_request, but that is a claim about the implementation, not an equivalence a reviewer can see, and the brief forbids tidying a case away. Net saving was 34 lines; not worth either cost.

## Verification

Scope: the four packages touched — agent_tool/shell, agent_tool/shell/internal/git_policy, agent_tool/shell/internal/shell_parse, agent_tool/shell_exec. All are +wasm+native (shell_parse declares no supported_targets, so it builds on all); none is a desktop/frontend js package, so no --target js run was needed.

BASELINE (clean tree, before any edit): `moon test agent_tool/shell agent_tool/shell/internal/git_policy agent_tool/shell/internal/shell_parse agent_tool/shell_exec` -> "Total tests: 200, passed: 200, failed: 0." One benign libtool warning about an empty archive TOC in moonbitlang/async/types — present before and after, unrelated.

AFTER all edits:
- `moon fmt` then `moon fmt --check` -> "Finished. moon: ran 1740 tasks, now up to date", no diff produced. moon fmt reflowed my git_policy guard onto one line and re-added a trailing comma in the Invocation literal; I kept its output.
- `moon check <4 pkgs> --deny-warn` (native) -> "Finished. moon: no work to do" (clean).
- `moon check <4 pkgs> --target wasm --deny-warn` -> "Finished. moon: ran 48 tasks, now up to date" (clean).
- `moon test <4 pkgs>` -> "Total tests: 200, passed: 200, failed: 0." Same 200 before and after, as expected: the dedupes collapse assertions inside existing tests, they do not add or remove tests.
- `moon info <4 pkgs>` (SCOPED, never bare) -> "Finished. moon: ran 46 tasks, now up to date". `git status --short` afterwards listed only my 8 source files and ZERO .mbti files, confirming no public interface moved (agent_tool/shell/pkg.generated.mbti in particular is untouched).

ASSERTION COUNTS for the three test dedupes (assertions before -> rows after):
- sandbox_wbtest.mbt: 105 -> 105 (101 collapsed to helper calls, 4 left in long form). Verified by script, not by eye: I extracted a canonical (detector, cmd, root, cwd, expected) tuple for every assertion from the original file and from the rewritten file (expanding the four helpers back to their bodies) and compared the ordered lists — "SEMANTICALLY IDENTICAL", 105 vs 105, zero mismatches. Separately verified 70/70 let bindings identical and 26/26 comments preserved, 0 missing.
- moon_auto_check.mbt: 33 -> 33.
- review_guard.mbt: 15 -> 15.

THINGS THAT FAILED AND HOW I WORKED AROUND THEM:
1. `worker_run` did not compile as the finding proposed. First attempt `async fn worker_run(...) -> async (Json) -> ToolAction` failed deny-warn with unused_async [0067] (the function is not itself async). Dropping `async` then failed with [4122] "Function with error can only be used inside a function with error types in its signature" because `fail` raises. Fixed by parenthesizing the returned function type and annotating the outer fn: `fn worker_run(root : String) -> (async (Json) -> @agent_tool.ToolAction) raise`. Two attempts, within budget, so kept rather than dropped.
2. `git push -u origin simplify/shell` was REJECTED as non-fast-forward: a stale remote branch of the same name already existed, last touched 2026-07-02 by the same user, 1 commit ahead / 1367 behind my base. I did not force blindly. I checked it with `gh pr list --head simplify/shell --state all`: its PR is #298, state MERGED (squash-merged, which is why its SHA is not an ancestor of main). No open PR references the branch. I then pushed with `git push -u --force-with-lease=simplify/shell:bca4c650d origin simplify/shell`, pinning the lease to the exact stale SHA so a concurrent update would have aborted it. Result: "+ bca4c650d...f17a909f3 simplify/shell -> simplify/shell (forced update)". `git ls-remote origin simplify/shell` confirms the tip is f17a909f3. A reviewer should be aware a merged leftover ref was overwritten.

Final `git status --short`: clean. Staged by 8 explicit paths, never `git add -A`; no build artifacts or .mbti files entered the commit. No PR opened, nothing merged, no other branch touched.

## Worth a second look

Three things worth a second look.

1. The force-push. `simplify/shell` already existed on origin as a leftover from PR #298 (MERGED, 2026-07-02). I overwrote it with --force-with-lease after confirming the PR was merged and no open PR pointed at it. If that branch was being kept deliberately, the old tip was bca4c650d and it is recoverable from the reflog / PR #298.

2. git_policy `parse` now delegates to `text_subcommand_index`. This is the only change with real behavioural surface — it is a public function on the security-policy path, and the equivalence rests on two non-obvious arguments rather than on identical text: an explicit `--` reaching the scanner's trailing `has_prefix("-") && arg != "-"` arm, and a dangling value option stepping `index` past `end`. I traced all five option predicates (global_option_consumes_next, global_option_with_attached_value, global_no_arg_option, attached_cwd_option, attached_work_tree_option) against the input "--" to confirm none of them swallow it first. Worth re-deriving. Coverage: "parse fails closed" (git_policy_test.mbt:10-16, exercising --bogus, --help, --, -c, bare git) and "parse finds the subcommand past global options". Note `parse` also feeds `should_preblock`, so a regression here would silently un-block git forms.

3. sandbox_wbtest.mbt is a 794-line diff and cannot be reviewed line-by-line by hand. It was produced by script and verified by tuple comparison rather than by reading — the verification is the thing to check, not the diff. To re-run it independently: for each assertion, reduce it to (detector, cmd, root, cwd, expected) and confirm the before/after lists match in order. The four helpers deliberately return Bool instead of asserting internally so a failing case still reports its own line; that differs from the in-repo `async fn blocked(...) -> Unit` idiom at shell_test.mbt:2247, which the brief's diagnosability rule argues against.

Also note I applied the sink.mbt finding at three sites, not just the one in its `current` snippet — the other two were named in that finding's own evidence. And I deliberately did not shorten render_source's lambda parameters to one letter, so the interpolated strings read identically to the loop bodies they replaced.

Reviewed by OpenSeek's own review subagent (DeepSeek Flash); its verdict is posted as a comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXBYcYo74F1DGSPZsYYAdc