### PR TITLE
refactor: agent subagent packages: fold duplicated helpers and reuse stdlib

### DIFF
--- a/agent_explore/tool.mbt
+++ b/agent_explore/tool.mbt
@@ -182,16 +182,9 @@ async fn execute(
 /// the line is same-binary JSON, but the parent still refuses an oversized
 /// or malformed report rather than rendering it.
 fn parse_child_report(json : Json) -> Result[ExploreReport, String] {
-  match ExploreReport::parse(json) {
-    Err(msg) => Err(msg)
-    Ok(report) => {
-      let problems = report.validate()
-      if problems.length() > 0 {
-        Err(problems.join("; "))
-      } else {
-        Ok(report)
-      }
-    }
+  match parse_submission(json) {
+    Err(problems) => Err(problems.join("; "))
+    Ok(report) => Ok(report)
   }
 }
 

--- a/agent_explore/types.mbt
+++ b/agent_explore/types.mbt
@@ -133,13 +133,8 @@ test "validate accepts a good report" {
 test "validate rejects empties and oversizes" {
   assert_true({ ..sample_report(), answer: "  ", }.validate().length() > 0)
   assert_true({ ..sample_report(), schema_version: 2, }.validate().length() > 0)
-  let long = StringBuilder()
-  for _ in 0..<(max_answer_chars + 1) {
-    long.write_char('a')
-  }
-  assert_true(
-    { ..sample_report(), answer: long.to_string(), }.validate().length() > 0,
-  )
+  let long = "a".repeat(max_answer_chars + 1)
+  assert_true({ ..sample_report(), answer: long, }.validate().length() > 0)
   let many : Array[Citation] = []
   for i in 0..<=max_citations {
     many.push({ file: "f\{i}.mbt", line: None, note: None, })

--- a/agent_pattern_repair/types.mbt
+++ b/agent_pattern_repair/types.mbt
@@ -36,16 +36,14 @@ fn PatternRepairReport::validate(self : PatternRepairReport) -> Array[String] {
 }
 
 ///|
+/// Decode only. The contract check is `validate`, applied by the one caller
+/// through `@agent_subrun.validated`, exactly as the sibling report packages
+/// do it.
 fn PatternRepairReport::parse(
   json : Json,
 ) -> Result[PatternRepairReport, String] {
   let report : PatternRepairReport = @json.from_json(json) catch {
     error => return Err("invalid pattern repair report: \{error}")
   }
-  let problems = report.validate()
-  if problems.is_empty() {
-    Ok(report)
-  } else {
-    Err(problems.join("; "))
-  }
+  Ok(report)
 }

--- a/agent_review/audit.mbt
+++ b/agent_review/audit.mbt
@@ -120,8 +120,8 @@ let digest_max_chars : Int = 4_000
 /// summary, and up to `digest_max_findings` one-line findings with an
 /// explicit omission count — never more than `digest_max_chars` total.
 pub fn ReviewReport::digest(self : ReviewReport) -> String {
-  let blockers = self.findings.filter(f => f.severity == "blocker").length()
-  let highs = self.findings.filter(f => f.severity == "high").length()
+  let blockers = self.findings.count_if(f => f.severity == "blocker")
+  let highs = self.findings.count_if(f => f.severity == "high")
   let out = StringBuilder()
   out <+ "[review] worktree audit: \{self.findings.length()} finding(s)"
   if blockers > 0 || highs > 0 {

--- a/agent_subtask/capture.mbt
+++ b/agent_subtask/capture.mbt
@@ -88,12 +88,7 @@ pub async fn capture(
   if changes.is_empty() {
     // Terminal means undiscoverable by lifecycle actions, so the worktree
     // and branch must go NOW or they leak (and block reusing the name).
-    @fs.rmdir(entry.worker_root, recursive=true) catch {
-      error if @async.is_being_cancelled() => raise error
-      _ => ()
-    }
-    let _ = git_run(["worktree", "prune"], cwd=geometry.origin_root)
-    let _ = git_run(["branch", "-D", entry.branch], cwd=geometry.origin_root)
+    remove_worktree_and_branch(geometry.origin_root, entry, force=true)
     let entry = { ..entry, state: NoChanges, }
     let _ = save_entry(geometry.common_git_dir, entry)
     evidence.push("no changes in the worker tree; worktree and branch removed")

--- a/agent_subtask/integrate.mbt
+++ b/agent_subtask/integrate.mbt
@@ -200,14 +200,7 @@ async fn integrate_locked(
     let _ = save_entry(geometry.common_git_dir, entry)
     // The branch's content now lives in origin history: the worktree and
     // branch are provably redundant — the one auto-clean that is safe.
-    // (`git worktree remove` refuses ANY worktree in repos with tracked
-    // submodules, so removal is rm + prune by design.)
-    @fs.rmdir(entry.worker_root, recursive=true) catch {
-      error if @async.is_being_cancelled() => raise error
-      _ => ()
-    }
-    let _ = git_run(["worktree", "prune"], cwd=origin)
-    let _ = git_run(["branch", "-d", entry.branch], cwd=origin)
+    remove_worktree_and_branch(origin, entry, force=false)
     return {
       entry,
       result: "integrated",
@@ -337,12 +330,7 @@ async fn integrate_continue_locked(
   }
   let entry = { ..entry, state: Integrated, }
   let _ = save_entry(geometry.common_git_dir, entry)
-  @fs.rmdir(entry.worker_root, recursive=true) catch {
-    error if @async.is_being_cancelled() => raise error
-    _ => ()
-  }
-  let _ = git_run(["worktree", "prune"], cwd=origin)
-  let _ = git_run(["branch", "-d", entry.branch], cwd=origin)
+  remove_worktree_and_branch(origin, entry, force=false)
   { entry, result: "integrated", detail: ["conflict resolution committed"], }
 }
 
@@ -430,12 +418,7 @@ pub async fn discard(
       return Err("a merge of this subtask is in progress; abort it first")
     }
   }
-  @fs.rmdir(entry.worker_root, recursive=true) catch {
-    error if @async.is_being_cancelled() => raise error
-    _ => ()
-  }
-  let _ = git_run(["worktree", "prune"], cwd=origin)
-  let _ = git_run(["branch", "-D", entry.branch], cwd=origin)
+  remove_worktree_and_branch(origin, entry, force=true)
   let entry = { ..entry, state: Discarded, }
   let _ = save_entry(geometry.common_git_dir, entry)
   Ok(())

--- a/agent_subtask/provision.mbt
+++ b/agent_subtask/provision.mbt
@@ -8,14 +8,7 @@ let repo_mutexes : Map[String, @async.Mutex] = Map([])
 
 ///|
 fn repo_mutex(common_git_dir : String) -> @async.Mutex {
-  match repo_mutexes.get(common_git_dir) {
-    Some(mutex) => mutex
-    None => {
-      let mutex = @async.Mutex()
-      repo_mutexes[common_git_dir] = mutex
-      mutex
-    }
-  }
+  repo_mutexes.get_or_init(common_git_dir, () => Mutex())
 }
 
 ///|
@@ -190,15 +183,33 @@ async fn provision_locked(
 }
 
 ///|
-/// Undo a partial provision: worktree directory, bookkeeping, branch, and
-/// registry entry, in that order, each best-effort.
-async fn rollback_provision(geometry : Geometry, entry : SubtaskEntry) -> Unit {
+/// Tear down a slice's worktree: remove the directory, prune git's now-stale
+/// worktree bookkeeping, then drop the branch — in that order, each
+/// best-effort, because a teardown that stops at the first failure leaks the
+/// rest. (`git worktree remove` refuses ANY worktree in a repo with tracked
+/// submodules, so removal is rm + prune by design.) `force` picks `branch -D`
+/// for a branch being abandoned over `-d` for one a merge proved redundant.
+async fn remove_worktree_and_branch(
+  origin : String,
+  entry : SubtaskEntry,
+  force~ : Bool,
+) -> Unit {
   @fs.rmdir(entry.worker_root, recursive=true) catch {
     error if @async.is_being_cancelled() => raise error
     _ => ()
   }
-  let _ = git_run(["worktree", "prune"], cwd=geometry.origin_root)
-  let _ = git_run(["branch", "-D", entry.branch], cwd=geometry.origin_root)
+  let _ = git_run(["worktree", "prune"], cwd=origin)
+  let _ = git_run(
+    ["branch", if force { "-D" } else { "-d" }, entry.branch],
+    cwd=origin,
+  )
+}
+
+///|
+/// Undo a partial provision: worktree directory, bookkeeping, branch, and
+/// registry entry, in that order, each best-effort.
+async fn rollback_provision(geometry : Geometry, entry : SubtaskEntry) -> Unit {
+  remove_worktree_and_branch(geometry.origin_root, entry, force=true)
   let dir = registry_dir(geometry.common_git_dir)
   @fs.remove("\{dir}/\{entry.name}--\{entry.nonce}.json") catch {
     error if @async.is_being_cancelled() => raise error
@@ -296,11 +307,7 @@ test "subtask names are strict slugs" {
   assert_false(is_valid_name("Upper"))
   assert_false(is_valid_name("has space"))
   assert_false(is_valid_name(""))
-  let long = StringBuilder()
-  for _ in 0..<41 {
-    long.write_char('a')
-  }
-  assert_false(is_valid_name(long.to_string()))
+  assert_false(is_valid_name("a".repeat(41)))
 }
 
 ///|
@@ -313,10 +320,7 @@ fn normalize_allowed_paths(
 ) -> Result[Array[String], String] {
   let normalized : Array[String] = []
   for prefix in allowed_paths {
-    let mut cleaned = prefix.trim().to_owned()
-    while cleaned.has_suffix("/") {
-      cleaned = cleaned.view(end_offset=cleaned.length() - 1).to_owned()
-    }
+    let cleaned = prefix.trim().trim_end(chars="/").to_owned()
     guard cleaned != "" && !cleaned.has_prefix("/") else {
       return Err(
         "allowed_paths entries must be non-empty relative prefixes: \{prefix}",

--- a/agent_subtask/registry.mbt
+++ b/agent_subtask/registry.mbt
@@ -137,23 +137,29 @@ pub async fn load_entries(
 }
 
 ///|
+/// A path split into its slash-separated components. Path containment here
+/// is always component-wise, never textual: `src` must not cover `src2`.
+fn components(prefix : String) -> Array[String] {
+  prefix.split("/").map(part => part.to_owned()).collect()
+}
+
+///|
+/// Whether `shorter` is a component-wise prefix of `longer` (equal counts as
+/// covered).
+fn one_covers(shorter : Array[String], longer : Array[String]) -> Bool {
+  guard shorter.length() <= longer.length() else { return false }
+  for index in 0..<shorter.length() {
+    if shorter[index] != longer[index] {
+      return false
+    }
+  }
+  true
+}
+
+///|
 /// Component-wise prefix overlap between two allowed-path sets: `src`
 /// overlaps `src/lexer` and `src`, never `src2`.
 fn paths_overlap(a : Array[String], b : Array[String]) -> Bool {
-  fn components(prefix : String) -> Array[String] {
-    prefix.split("/").map(part => part.to_owned()).collect()
-  }
-
-  fn one_covers(shorter : Array[String], longer : Array[String]) -> Bool {
-    guard shorter.length() <= longer.length() else { return false }
-    for index in 0..<shorter.length() {
-      if shorter[index] != longer[index] {
-        return false
-      }
-    }
-    true
-  }
-
   a.any(left => {
     b.any(right => {
       let l = components(left)

--- a/agent_subtask/scope.mbt
+++ b/agent_subtask/scope.mbt
@@ -75,21 +75,11 @@ fn scope_violations(
   changes : Array[Change],
   allowed_paths : Array[String],
 ) -> Array[String] {
-  let allowed = allowed_paths.map(prefix => {
-    prefix.split("/").map(part => part.to_owned()).collect()
-  })
+  let allowed = allowed_paths.map(components)
   let violations : Array[String] = []
   for change in changes {
-    let parts = change.path.split("/").map(part => part.to_owned()).collect()
-    let admitted = allowed.any(prefix => {
-      guard parts.length() >= prefix.length() else { return false }
-      for index in 0..<prefix.length() {
-        if parts[index] != prefix[index] {
-          return false
-        }
-      }
-      true
-    })
+    let parts = components(change.path)
+    let admitted = allowed.any(prefix => one_covers(prefix, parts))
     if !admitted && !violations.contains(change.path) {
       violations.push(change.path)
     }

--- a/agent_worker/types.mbt
+++ b/agent_worker/types.mbt
@@ -109,13 +109,9 @@ test "validate accepts a good report and rejects contract violations" {
   assert_true(
     { ..sample_worker_report(), verification: "", }.validate().length() > 0,
   )
-  let long = StringBuilder()
-  for _ in 0..<(max_summary_chars + 1) {
-    long.write_char('a')
-  }
+  let long = "a".repeat(max_summary_chars + 1)
   assert_true(
-    { ..sample_worker_report(), summary: long.to_string(), }.validate().length() >
-    0,
+    { ..sample_worker_report(), summary: long, }.validate().length() > 0,
   )
 }
 


### PR DESCRIPTION
A pure **simplification** pass: no feature, no fix, no behaviour change. Part of a project-wide sweep; each PR is one package family so it can be reviewed on its own.

Candidates came from a read-only survey of the whole repository. The author was told to drop any that would not compile or would change behaviour, so this branch carries fewer than were proposed: **8 applied, 0 dropped, net -40 lines.**

## Applied

- **agent_subtask/provision.mbt, agent_subtask/integrate.mbt, agent_subtask/capture.mbt** — Worktree+prune+branch teardown is written out five times in agent_subtask
  Added `async fn remove_worktree_and_branch(origin, entry, force~)` in provision.mbt (next to rollback_provision, the natural sibling) and collapsed all five verbatim sites: integrate.mbt:205/340/433 and capture.mbt:91 and provision.mbt:196. Confirmed `let origin = geometry.origin_root` at integrate.mbt:61/233/357/410, so the cwd argument really is the same value at all five. Order of side effects (rmdir -> worktree prune -> branch -d/-D) and the cancellation re-raise are byte-identical. Comments preserved, not deleted: the site-specific `The branch's content now lives in origin history...` stays at integrate.mbt; the mechanism note `git worktree remove refuses ANY worktree in repos with tracked submodules, so removal is rm + prune by design` moved onto the helper's doc comment, where it now covers all five callers.
- **agent_subtask/registry.mbt, agent_subtask/scope.mbt** — scope_violations inlines the component-prefix test that registry.mbt already has as one_covers
  Hoisted `components` and `one_covers` out of `paths_overlap` to package level (in registry.mbt, in place, to keep the diff a de-indent) and gave each a doc comment. `paths_overlap`'s body is unchanged. `scope_violations` now reads `allowed_paths.map(components)` / `one_covers(prefix, parts)`. Verified no package-level name collision for either identifier in agent_subtask. Note the argument order flip is intentional and equivalent: the inlined closure guarded `parts.length() >= prefix.length()`, i.e. prefix is the shorter, which is exactly `one_covers(shorter=prefix, longer=parts)`.
- **agent_subtask/provision.mbt** — repo_mutex hand-rolls Map::get_or_init
  Now `repo_mutexes.get_or_init(common_git_dir, () => Mutex())`. Adjusted from the proposal: `() => @async.Mutex()` tripped `unnecessary_annotation`, which agent_subtask enables and CI runs as deny-warn, so the package qualifier is dropped and the type comes from `repo_mutexes : Map[String, @async.Mutex]`.
- **agent_subtask/provision.mbt** — normalize_allowed_paths hand-rolls trailing-slash stripping instead of trim_end(chars="/")
  `prefix.trim().trim_end(chars="/").to_owned()`, and `cleaned` loses its `mut`. Equivalent on the edge cases that matter: a bare "/" or "///" still reduces to "" and is still rejected by the `cleaned != ""` guard below, and whitespace is still trimmed before slashes so "lib /" still normalizes to "lib " (and is then rejected downstream) exactly as before.
- **agent_explore/tool.mbt** — parse_child_report re-implements the package's own parse_submission / @agent_subrun.validated
  Now `match parse_submission(json) { Err(problems) => Err(problems.join("; ")) ... }`. @agent_subrun.validated turns a decode Err(message) into Err([message]), so a decode failure still yields the same single-string error, and an invalid report still yields the same "; "-joined problem list. Identical in shape to the existing WorkerReport::parse_validated. The doc comment above it ("the same contract submit_answer enforced in the child") is now literally true and was left as-is.
- **agent_pattern_repair/types.mbt** — PatternRepairReport::parse validates a second time; its one caller already wraps it in validated()
  `parse` decodes only. Verified by grep across the repo (excluding _build/target) that `PatternRepairReport::parse` has exactly one caller, agent_pattern_repair/submit.mbt:18, and that it is private and absent from agent_pattern_repair/pkg.generated.mbti. That caller is `@agent_subrun.validated(PatternRepairReport::parse(args), PatternRepairReport::validate)`, and @agent_subrun.capture_tool renders the rejection as `"<name> rejected: {problems.join(\"; \")}"` -- the same string the in-parse join produced. Added a short doc comment saying parse decodes and validate is applied by the caller, so the removed check is not silently unexplained.
- **agent_review/audit.mbt** — filter(...).length() for a severity tally is Array::count_if
  Two lines, `count_if` instead of `filter(..).length()`; the intermediate arrays were discarded immediately. The digest snapshot test asserting "25 finding(s) (2 blocker, 0 high)" still passes.
- **agent_worker/types.mbt, agent_explore/types.mbt, agent_subtask/provision.mbt** — StringBuilder char loops that build a padding string are String::repeat
  All three sites from the finding's evidence: agent_worker/types.mbt (`"a".repeat(max_summary_chars + 1)`), agent_explore/types.mbt (`"a".repeat(max_answer_chars + 1)`), agent_subtask/provision.mbt (`is_valid_name("a".repeat(41))`). These are inside test bodies but this is NOT a test dedupe -- no case was merged, added, removed, or reordered, only the construction of one padding string changed. Assertion counts per test are unchanged (agent_worker 5 assert_true, agent_explore 5 assert_true in that test, agent_subtask 6 asserts in "subtask names are strict slugs"), and the suite total stayed at 52.

## Verification

All commands run in the worktree /private/tmp/.../scratchpad/wt/subagents on branch simplify/subagents (confirmed by `git branch --show-current`; `git status --short` was empty at start).

BASELINE (before any edit):
- `moon test agent_subtask agent_worker agent_explore agent_pattern_repair agent_review` -> "Total tests: 52, passed: 52, failed: 0."
- same with `--target wasm` -> "Total tests: 52, passed: 52, failed: 0."
(All five packages declare supported_targets = "+wasm+native"; none is a js/desktop package, so no --target js run applies. agent_subtask and agent_worker additionally set warnings = "+unnecessary_annotation".)

AFTER:
- `moon fmt` -> exit 0, "ran 1740 tasks". `moon fmt --check` afterwards -> exit 0, clean. moon fmt reformatted nothing outside my ten files (git status stayed at exactly those ten).
- `moon check agent_subtask agent_worker agent_explore agent_pattern_repair agent_review --deny-warn` -> FAILED on the first attempt: "Error [0073] ... provision.mbt:11:50 Error Warning (unnecessary_annotation): This `@async.` annotation is unnecessary. Failed with 0 warnings, 1 errors." That was the finding's own proposed `() => @async.Mutex()`. Fixed by writing `() => Mutex()` (type still pinned by `repo_mutexes : Map[String, @async.Mutex]`); re-run -> "Finished ... now up to date", exit 0. This is the one place I deviated from a `proposed` snippet.
- `moon check agent_subtask agent_worker agent_explore agent_pattern_repair agent_review --target wasm --deny-warn` -> "Finished. moon: ran 97 tasks", exit 0.
- `moon check --deny-warn` (whole repo, native) -> "Finished. moon: ran 810 tasks", exit 0. Run as extra insurance that no dependent package broke; not required by the scoped gate.
- `moon test agent_subtask agent_worker agent_explore agent_pattern_repair agent_review` -> "Total tests: 52, passed: 52, failed: 0." (52 before, 52 after)
- same with `--target wasm` -> "Total tests: 52, passed: 52, failed: 0." (52 before, 52 after)
- `moon info agent_subtask agent_worker agent_explore agent_pattern_repair agent_review` -> exit 0. NOTE: `moon info --package X --package Y` is rejected ("the argument '--package <PACKAGE>' cannot be used multiple times"), so packages were passed as positional paths, which scopes it the same way. NO .mbti changed: `git status --short` after moon info listed exactly the ten .mbt files and nothing else, so no public interface moved and nothing had to be reverted on that account.
- `git status --short` before staging: exactly the ten intended .mbt files, no build artifacts, no .mbti. Staged by explicit path (no `git add -A`).
- `git commit` -> c117c7adc, "10 files changed, 66 insertions(+), 106 deletions(-)".
- `git push -u origin simplify/subagents` -> "* [new branch] simplify/subagents -> simplify/subagents", tracking set. No PR opened, no merge, no other branch touched.

Nothing else failed and nothing else needed a workaround.

## Worth a second look

Three things are worth a second look.

1. agent_pattern_repair/types.mbt is the only change that removes a check rather than relocating one. `PatternRepairReport::parse` no longer calls `validate`. The argument that this is invisible rests on three facts a reviewer should re-confirm: (a) `parse` is private and does not appear in agent_pattern_repair/pkg.generated.mbti; (b) it has exactly one caller repo-wide, agent_pattern_repair/submit.mbt:18; (c) that caller is `@agent_subrun.validated(parse(args), validate)`, and @agent_subrun.capture_tool formats the rejection as `"<name> rejected: {problems.join("; ")}"`, byte-identical to the string the deleted in-parse `problems.join("; ")` produced. If anyone ever adds a second caller of `parse`, they now inherit an unvalidated report -- the new doc comment says so, but it is a real change in what the function guarantees.

2. `remove_worktree_and_branch` is defined in agent_subtask/provision.mbt but called from integrate.mbt and capture.mbt. Fine in MoonBit (one package), but if you would rather it lived in gitrun.mbt or its own file, say so; it is a pure move. Also check I picked `force` correctly per site: force=false (`branch -d`) at the two Integrated sites in integrate.mbt, force=true (`branch -D`) at discard, at capture's NoChanges path, and at rollback_provision -- that matches the original `-d`/`-D` one for one.

3. `one_covers(prefix, parts)` in scope.mbt reverses the argument order relative to the inlined closure it replaces. The closure guarded `parts.length() >= prefix.length()`; `one_covers(shorter, longer)` guards `shorter.length() <= longer.length()`. Same predicate, but it is the kind of thing worth reading twice, and there is no direct unit test on `scope_violations` -- its coverage is indirect.

Minor: `() => Mutex()` in provision.mbt reads a little bare (no `@async.` qualifier). That spelling is forced by `warnings = "+unnecessary_annotation"` in agent_subtask/moon.pkg, which CI runs as deny-warn.

Reviewed by OpenSeek's own review subagent (DeepSeek Flash); its verdict is posted as a comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXBYcYo74F1DGSPZsYYAdc