### PR TITLE
refactor: agent_tool file/misc tools: reuse stdlib, drop re-implemented helpers, dedupe tests

### DIFF
--- a/agent_tool/agent_tool.mbt
+++ b/agent_tool/agent_tool.mbt
@@ -194,16 +194,8 @@ pub fn brief_line(text : String, limit? : Int = 72) -> String {
   if one.length() <= limit {
     "\{one}"
   } else {
-    let kept = StringBuilder()
-    for ch in one; count = 0 {
-      if count >= limit {
-        break
-      }
-      kept.write_char(ch)
-      continue count + 1
-    }
-    kept.write_char('…')
-    kept.to_string()
+    // `iter()` yields characters, so `take` cuts on a character boundary.
+    "\{String::from_iter(one.iter().take(limit))}…"
   }
 }
 
@@ -362,34 +354,21 @@ test "ToolAction helpers build structured actions" {
 }
 
 ///|
-test "Tools::function_tools converts the registry to deepseek tool definitions" {
-  let tools = Tools([
-    {
-      name: "echo",
-      description: "Echo the input.",
-      schema: JsonSchema({ "type": "object" }),
-      execute: Sync(_args => respond("ok")),
-      control: false,
-      concurrent_safe: false,
-    },
-  ])
-  let function_tools = tools.function_tools()
-  assert_eq(function_tools.length(), 1)
-  assert_eq(function_tools[0].name, "echo")
+/// One minimal registry entry for the dispatch tests. The privileges
+/// (`control`, `concurrent_safe`) are the constructor's own defaults, so no
+/// test below has to restate them just to build an ordinary tool.
+fn test_tool(
+  name? : String = "echo",
+  description? : String = "Echo.",
+  schema? : Json = { "type": "object" },
+  execute? : ToolExecutor = Sync(_args => respond("ok")),
+) -> AgentToolDefinition {
+  AgentToolDefinition(name~, description~, schema=JsonSchema(schema), execute~)
 }
 
 ///|
 test "Tools::find returns the registered definition by name" {
-  let tools = Tools([
-    {
-      name: "echo",
-      description: "Echo.",
-      schema: JsonSchema({ "type": "object" }),
-      execute: Sync(_args => respond("ok")),
-      control: false,
-      concurrent_safe: false,
-    },
-  ])
+  let tools = Tools([test_tool()])
   guard tools.find("echo") is Some(definition) else { fail("missing echo") }
   assert_eq(definition.name, "echo")
   assert_true(tools.find("ghost") is None)
@@ -398,22 +377,8 @@ test "Tools::find returns the registered definition by name" {
 ///|
 test "Tools::Tools raises on duplicate tool names" {
   let _ = Tools([
-    {
-      name: "echo",
-      description: "First.",
-      schema: JsonSchema({ "type": "object" }),
-      execute: Sync(_args => respond("first")),
-      control: false,
-      concurrent_safe: false,
-    },
-    {
-      name: "echo",
-      description: "Second.",
-      schema: JsonSchema({ "type": "object" }),
-      execute: Sync(_args => respond("second")),
-      control: false,
-      concurrent_safe: false,
-    },
+    test_tool(description="First.", execute=Sync(_args => respond("first"))),
+    test_tool(description="Second.", execute=Sync(_args => respond("second"))),
   ]) catch {
     error => {
       assert_true("\{error}".contains("duplicate tool name: echo"))
@@ -437,19 +402,14 @@ async test "execute_tool_call reports unknown tool" {
 ///|
 async test "execute_tool_call dispatches to registered executor" {
   let tools = Tools([
-    {
-      name: "echo",
-      description: "Echo.",
-      schema: JsonSchema({ "type": "object" }),
-      execute: Sync(args => {
+    test_tool(
+      execute=Sync(args => {
         match args {
           { "value": String(v), .. } => respond(v)
           _ => respond("no value", is_error=true)
         }
       }),
-      control: false,
-      concurrent_safe: false,
-    },
+    ),
   ])
   let call = AgentToolCall(
     ToolCall(id="call_1", name="echo", arguments="{\"value\":\"hi\"}"),
@@ -472,14 +432,7 @@ async fn async_echo(args : Json) -> ToolAction {
 ///|
 async test "execute_tool_call dispatches to async executor" {
   let tools = Tools([
-    {
-      name: "echo",
-      description: "Async echo.",
-      schema: JsonSchema({ "type": "object" }),
-      execute: Async(async_echo),
-      control: false,
-      concurrent_safe: false,
-    },
+    test_tool(description="Async echo.", execute=Async(async_echo)),
   ])
   let call = AgentToolCall(
     ToolCall(id="call_1", name="echo", arguments="{\"value\":\"async-hi\"}"),
@@ -500,14 +453,11 @@ async test "execute_tool_call turns a tool failure into a recoverable error resu
   }
 
   let tools = Tools([
-    {
-      name: "boom",
-      description: "Always fails.",
-      schema: JsonSchema({ "type": "object" }),
-      execute: Async(async_boom),
-      control: false,
-      concurrent_safe: false,
-    },
+    test_tool(
+      name="boom",
+      description="Always fails.",
+      execute=Async(async_boom),
+    ),
   ])
   let call = AgentToolCall(ToolCall(id="call_1", name="boom", arguments="{}"))
   // The tool's failure is caught at the dispatch boundary and returned as an
@@ -521,19 +471,13 @@ async test "execute_tool_call turns a tool failure into a recoverable error resu
 ///|
 test "Tools::function_tools preserves description and schema" {
   let tools = Tools([
-    {
-      name: "echo",
-      description: "Echo what comes in.",
-      schema: JsonSchema({
-        "type": "object",
-        "properties": Json::empty_object(),
-      }),
-      execute: Sync(_args => respond("ok")),
-      control: false,
-      concurrent_safe: false,
-    },
+    test_tool(description="Echo what comes in.", schema={
+      "type": "object",
+      "properties": Json::empty_object(),
+    }),
   ])
   let function_tools = tools.function_tools()
+  assert_eq(function_tools.length(), 1)
   assert_eq(function_tools[0].name, "echo")
   assert_eq(function_tools[0].description, "Echo what comes in.")
   let text = function_tools[0].parameters.stringify()
@@ -551,30 +495,21 @@ test "Tools::Tools accepts an empty registry" {
 ///|
 test "Tools::function_tools yields one entry per definition" {
   let tools = Tools([
-    {
-      name: "first",
-      description: "First.",
-      schema: JsonSchema({ "type": "object" }),
-      execute: Sync(_args => respond("1")),
-      control: false,
-      concurrent_safe: false,
-    },
-    {
-      name: "second",
-      description: "Second.",
-      schema: JsonSchema({ "type": "object" }),
-      execute: Sync(_args => respond("2")),
-      control: false,
-      concurrent_safe: false,
-    },
-    {
-      name: "third",
-      description: "Third.",
-      schema: JsonSchema({ "type": "object" }),
-      execute: Sync(_args => respond("3")),
-      control: false,
-      concurrent_safe: false,
-    },
+    test_tool(
+      name="first",
+      description="First.",
+      execute=Sync(_args => respond("1")),
+    ),
+    test_tool(
+      name="second",
+      description="Second.",
+      execute=Sync(_args => respond("2")),
+    ),
+    test_tool(
+      name="third",
+      description="Third.",
+      execute=Sync(_args => respond("3")),
+    ),
   ])
   let function_tools = tools.function_tools()
   assert_eq(function_tools.length(), 3)

--- a/agent_tool/edit/edit.mbt
+++ b/agent_tool/edit/edit.mbt
@@ -851,19 +851,12 @@ fn select_edit_region(
 ///|
 /// How many lines `new_string` occupies once inserted: one per newline, plus
 /// one for a trailing fragment that does not end in a newline (that fragment
-/// shares its line with whatever follows the insertion point). `new_string`
-/// is non-empty on the insertion path — both-empty edits are rejected first.
+/// shares its line with whatever follows the insertion point). That is exactly
+/// `total_line_count`, whose only extra rule — empty content spans 0 lines —
+/// cannot apply here: `new_string` is non-empty on the insertion path, because
+/// both-empty edits are rejected first.
 fn inserted_line_span(new_string : String) -> Int {
-  let newlines = for ch in new_string; newlines = 0 {
-    continue if ch == '\n' { newlines + 1 } else { newlines }
-  } nobreak {
-    newlines
-  }
-  if new_string.has_suffix("\n") {
-    newlines
-  } else {
-    newlines + 1
-  }
+  total_line_count(new_string)
 }
 
 ///|
@@ -1005,7 +998,7 @@ fn normalize_whitespace(s : String) -> String {
   let result = StringBuilder()
   let mut in_ws = false
   for ch in s {
-    if ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r' {
+    if ch is (' ' | '\t' | '\n' | '\r') {
       if !in_ws {
         result.write_char(' ')
         in_ws = true
@@ -1046,20 +1039,14 @@ fn find_whitespace_normalized_candidates(
         // whitespace character in body (otherwise "a b" would match "ab").
         ni += 1
         let mut consumed_ws = false
-        while bi < body.length() &&
-              (
-                body[bi] == ' ' ||
-                body[bi] == '\t' ||
-                body[bi] == '\n' ||
-                body[bi] == '\r'
-              ) {
+        while bi < body.length() && body[bi] is (' ' | '\t' | '\n' | '\r') {
           bi += 1
           consumed_ws = true
         }
         if !consumed_ws {
           break
         }
-      } else if bc == ' ' || bc == '\t' || bc == '\n' || bc == '\r' {
+      } else if bc is (' ' | '\t' | '\n' | '\r') {
         // body has whitespace where norm_needle has non-space → mismatch
         break
       } else if nc != bc {

--- a/agent_tool/edit/edit_test.mbt
+++ b/agent_tool/edit/edit_test.mbt
@@ -734,25 +734,41 @@ async test "edit gates .mbt results through moonc before writing" {
 }
 
 ///|
-async test "edit gates a breaking edit made through a non-mbt symlink" {
-  @vfs.with_tmpdir(prefix="openseek-edit-gate-link-", dir => {
-    let src = "\{dir}/lib.mbt"
+/// Writes a valid `target` in a fresh tmpdir, points `link` at it, then edits
+/// THROUGH the link in a way that breaks the MoonBit source. Asserts the parse
+/// gate rejects it and the target is left byte-identical. The three symlink
+/// cases below differ only in how the two names are spelled.
+async fn assert_link_edit_gated(
+  prefix~ : String,
+  target~ : String,
+  link~ : String,
+) -> Unit {
+  @vfs.with_tmpdir(prefix~, dir => {
+    let target_path = "\{dir}/\{target}"
     let original = "///|\npub fn f() -> Int {\n  42\n}\n"
-    @fs.write_file(src, original, create_mode=CreateOrTruncate)
-    // alias.txt -> lib.mbt: the .txt spelling must not slip a broken result
-    // past the parse gate — the write lands in the .mbt target.
-    let link = "\{dir}/alias.txt"
-    @fs.symlink(target="lib.mbt", link)
+    @fs.write_file(target_path, original, create_mode=CreateOrTruncate)
+    @fs.symlink(target~, "\{dir}/\{link}")
     let out = run_edit({
-      "path": link,
+      "path": "\{dir}/\{link}",
       "old_string": "  42",
       "new_string": "  match 42 {",
       "start_line": 3,
     })
     assert_true(out.is_error)
     assert_true(out.content.contains("rejected: the edit would introduce"))
-    assert_eq(@fs.read_file(src).text(), original)
+    assert_eq(@fs.read_file(target_path).text(), original)
   })
+}
+
+///|
+/// alias.txt -> lib.mbt: the .txt spelling must not slip a broken result past
+/// the parse gate — the write lands in the .mbt target.
+async test "edit gates a breaking edit made through a non-mbt symlink" {
+  assert_link_edit_gated(
+    prefix="openseek-edit-gate-link-",
+    target="lib.mbt",
+    link="alias.txt",
+  )
 }
 
 ///|
@@ -761,22 +777,11 @@ async test "edit gates a breaking edit made through a non-mbt symlink" {
 /// not markdown. Parsing it as `.mbt.md` would ignore everything outside checked
 /// fences and let a broken edit to the real `.mbt` file slip through.
 async test "edit gates by the target kind through a .mbt.md-named symlink" {
-  @vfs.with_tmpdir(prefix="openseek-edit-gate-mdlink-", dir => {
-    let src = "\{dir}/lib.mbt"
-    let original = "///|\npub fn f() -> Int {\n  42\n}\n"
-    @fs.write_file(src, original, create_mode=CreateOrTruncate)
-    let link = "\{dir}/doc.mbt.md"
-    @fs.symlink(target="lib.mbt", link)
-    let out = run_edit({
-      "path": link,
-      "old_string": "  42",
-      "new_string": "  match 42 {",
-      "start_line": 3,
-    })
-    assert_true(out.is_error)
-    assert_true(out.content.contains("rejected: the edit would introduce"))
-    assert_eq(@fs.read_file(src).text(), original)
-  })
+  assert_link_edit_gated(
+    prefix="openseek-edit-gate-mdlink-",
+    target="lib.mbt",
+    link="doc.mbt.md",
+  )
 }
 
 ///|
@@ -787,22 +792,11 @@ async test "edit gates by the target kind through a .mbt.md-named symlink" {
 /// miss it — the gate must cover BOTH kinds. The target body is valid MoonBit
 /// source, so it parses clean under both kinds until the edit breaks it.
 async test "edit gates by the link kind through a .mbt-named symlink" {
-  @vfs.with_tmpdir(prefix="openseek-edit-gate-mbtlink-", dir => {
-    let target = "\{dir}/notes.mbt.md"
-    let original = "///|\npub fn f() -> Int {\n  42\n}\n"
-    @fs.write_file(target, original, create_mode=CreateOrTruncate)
-    let link = "\{dir}/link.mbt"
-    @fs.symlink(target="notes.mbt.md", link)
-    let out = run_edit({
-      "path": link,
-      "old_string": "  42",
-      "new_string": "  match 42 {",
-      "start_line": 3,
-    })
-    assert_true(out.is_error)
-    assert_true(out.content.contains("rejected: the edit would introduce"))
-    assert_eq(@fs.read_file(target).text(), original)
-  })
+  assert_link_edit_gated(
+    prefix="openseek-edit-gate-mbtlink-",
+    target="notes.mbt.md",
+    link="link.mbt",
+  )
 }
 
 ///|

--- a/agent_tool/job_output/job_output.mbt
+++ b/agent_tool/job_output/job_output.mbt
@@ -248,16 +248,6 @@ fn window_offset(arguments : Json) -> Result[Int?, String] {
 /// and `shown_chars` use, so the offsets a reader computes from them land
 /// where it expects.
 fn page_of(text : String, offset~ : Int, window~ : Int) -> String {
-  let out = StringBuilder()
-  let mut index = 0
-  for ch in text {
-    if index >= offset + window {
-      break
-    }
-    if index >= offset {
-      out.write_char(ch)
-    }
-    index += 1
-  }
-  out.to_string()
+  // `iter()` yields characters, so drop/take count characters, not code units.
+  String::from_iter(text.iter().drop(offset).take(window))
 }

--- a/agent_tool/multi_edit/multi_edit.mbt
+++ b/agent_tool/multi_edit/multi_edit.mbt
@@ -747,7 +747,7 @@ fn error_count_label(after : @auto_check.CheckErrors) -> String {
 fn check_contiguity(edits : Array[ResolvedEdit]) -> String? {
   // Set of paths whose contiguous block has already ended, so the membership
   // test stays O(1) even for a large batch touching many files.
-  let ended : Map[String, Unit] = Map([])
+  let ended : Set[String] = Set([])
   let mut current : String? = None
   for edit in edits {
     let same = current is Some(path) && path == edit.path
@@ -758,7 +758,7 @@ fn check_contiguity(edits : Array[ResolvedEdit]) -> String? {
         )
       }
       if current is Some(path) {
-        ended[path] = ()
+        ended.add(path)
       }
       current = Some(edit.path)
     }
@@ -792,9 +792,8 @@ priv struct FileGroup {
 fn group_contiguous(edits : Array[ResolvedEdit]) -> Array[FileGroup] {
   let groups : Array[FileGroup] = []
   for edit in edits {
-    let count = groups.length()
-    if count > 0 && groups[count - 1].path == edit.path {
-      groups[count - 1].items.push(edit)
+    if groups is [.., last] && last.path == edit.path {
+      last.items.push(edit)
     } else {
       groups.push({ file: edit.file, path: edit.path, items: [edit], })
     }

--- a/agent_tool/plan/steps/decode.mbt
+++ b/agent_tool/plan/steps/decode.mbt
@@ -92,17 +92,15 @@ pub fn decode(arguments : Json) -> PlanInput raise {
     )
   }
   let steps : Array[PlanStep] = []
-  for index, item in items; in_progress_count = 0 {
+  for index, item in items {
     let step = decode_step(index, item)
-    steps.push(step)
-    if step.status is InProgress {
-      if in_progress_count > 0 {
-        fail("arguments.steps to contain at most one in_progress step")
-      }
-      continue in_progress_count + 1
-    } else {
-      continue in_progress_count
+    // Checked before the push, so `steps` still holds only the earlier steps:
+    // the SECOND in_progress step is the one that fails, and no later item is
+    // decoded — same rejection point as a running counter.
+    if step.status is InProgress && steps.any(s => s.status is InProgress) {
+      fail("arguments.steps to contain at most one in_progress step")
     }
+    steps.push(step)
   }
   { steps, }
 }

--- a/agent_tool/plan/steps/decode_test.mbt
+++ b/agent_tool/plan/steps/decode_test.mbt
@@ -66,17 +66,50 @@ fn assert_decode_error(arguments : Json, expected : String) -> Unit raise {
       return
     }
   }
-  fail("expected decode error")
+  fail("expected decode error naming \{expected}")
 }
 
 ///|
-test "decode rejects missing steps" {
+/// One test for every malformed shape whose body was a single
+/// `assert_decode_error`: they differ only in the arguments and the rule the
+/// message must name. Cases needing computed input (the step and title caps)
+/// or their own scenario note stay in their own tests below.
+test "decode rejects malformed plans and names the broken rule" {
   assert_decode_error(Json::empty_object(), "arguments.steps to be an array")
-}
-
-///|
-test "decode rejects non-object arguments" {
   assert_decode_error(Json::null(), "arguments to be an object")
+  assert_decode_error(
+    { "steps": [], "note": "extra" },
+    "arguments to have only the steps field",
+  )
+  assert_decode_error(
+    { "steps": [{ "title": "one", "status": "pending", "id": 1 }] },
+    "arguments.steps[0] to have only title and status fields",
+  )
+  assert_decode_error(
+    { "steps": ["just a string"] },
+    "arguments.steps[0] to be an object",
+  )
+  assert_decode_error(
+    { "steps": [{ "status": "pending" }] },
+    "arguments.steps[0].title to be present",
+  )
+  assert_decode_error(
+    { "steps": [{ "title": "step" }] },
+    "arguments.steps[0].status to be present",
+  )
+  assert_decode_error(
+    { "steps": [{ "title": "step", "status": "active" }] },
+    "arguments.steps[0].status to be one of pending|in_progress|completed",
+  )
+  assert_decode_error(
+    {
+      "steps": [
+        { "title": "one", "status": "in_progress" },
+        { "title": "two", "status": "in_progress" },
+      ],
+    },
+    "at most one in_progress step",
+  )
 }
 
 ///|
@@ -90,22 +123,6 @@ test "decode accepts an empty plan as a clear" {
 }
 
 ///|
-test "decode rejects unknown argument fields" {
-  assert_decode_error(
-    { "steps": [], "note": "extra" },
-    "arguments to have only the steps field",
-  )
-}
-
-///|
-test "decode rejects unknown step fields" {
-  assert_decode_error(
-    { "steps": [{ "title": "one", "status": "pending", "id": 1 }] },
-    "arguments.steps[0] to have only title and status fields",
-  )
-}
-
-///|
 test "decode rejects more than MAX_STEPS steps" {
   let steps : Array[Json] = [
     for i in 0..<(@steps.MAX_STEPS + 1) => {
@@ -113,22 +130,6 @@ test "decode rejects more than MAX_STEPS steps" {
     }
   ]
   assert_decode_error({ "steps": steps.to_json() }, "at most 20 steps, got 21")
-}
-
-///|
-test "decode rejects a non-object step" {
-  assert_decode_error(
-    { "steps": ["just a string"] },
-    "arguments.steps[0] to be an object",
-  )
-}
-
-///|
-test "decode rejects a missing title" {
-  assert_decode_error(
-    { "steps": [{ "status": "pending" }] },
-    "arguments.steps[0].title to be present",
-  )
 }
 
 ///|
@@ -182,33 +183,4 @@ test "decode counts title length in code points, matching the schema" {
     "steps": [{ "title": title, "status": "pending" }],
   })
   assert_eq(input.steps[0].title.char_length(), 61)
-}
-
-///|
-test "decode rejects a missing status" {
-  assert_decode_error(
-    { "steps": [{ "title": "step" }] },
-    "arguments.steps[0].status to be present",
-  )
-}
-
-///|
-test "decode rejects an unknown status" {
-  assert_decode_error(
-    { "steps": [{ "title": "step", "status": "active" }] },
-    "arguments.steps[0].status to be one of pending|in_progress|completed",
-  )
-}
-
-///|
-test "decode rejects two in_progress steps and names the rule" {
-  assert_decode_error(
-    {
-      "steps": [
-        { "title": "one", "status": "in_progress" },
-        { "title": "two", "status": "in_progress" },
-      ],
-    },
-    "at most one in_progress step",
-  )
 }

--- a/agent_tool/read/internal/decode/decode.mbt
+++ b/agent_tool/read/internal/decode/decode.mbt
@@ -101,11 +101,7 @@ fn optional_positive_int_option(
 
 ///|
 fn cap_max_output_chars(value : Int) -> Int {
-  if value > hard_max_output_chars {
-    hard_max_output_chars
-  } else {
-    value
-  }
+  value.min(hard_max_output_chars)
 }
 
 ///|

--- a/agent_tool/read/internal/decode/decode_test.mbt
+++ b/agent_tool/read/internal/decode/decode_test.mbt
@@ -34,41 +34,32 @@ test "decode defaults optional limits" {
 }
 
 ///|
-test "decode rejects missing path" {
-  try @decode.decode(Json::empty_object()) catch {
-    error => assert_true("\{error}".contains("arguments.path"))
-  } noraise {
-    _ => fail("missing path decoded")
-  }
-}
-
-///|
-test "decode rejects paths array" {
-  try @decode.decode({ "paths": ["a.mbt", "b.mbt"] }) catch {
-    error =>
-      assert_true("\{error}".contains("arguments.paths is not supported"))
-  } noraise {
-    _ => fail("paths decoded")
-  }
-}
-
-///|
-test "decode rejects invalid limits" {
-  try @decode.decode({ "path": "file.mbt", "max_lines": 0 }) catch {
-    error =>
+/// Asserts that decoding `arguments` fails and the error message names the
+/// offending field.
+fn assert_decode_error(arguments : Json, expected : String) -> Unit raise {
+  let _ = @decode.decode(arguments) catch {
+    error => {
+      let message = "\{error}"
       assert_true(
-        "\{error}".contains("arguments.max_lines to be a positive number"),
+        message.contains(expected),
+        msg="\{message} should contain \{expected}",
       )
-  } noraise {
-    _ => fail("invalid max_lines decoded")
+      return
+    }
   }
+  fail("expected decode error naming \{expected}")
 }
 
 ///|
-test "decode rejects non-object arguments" {
-  try @decode.decode(Json::null()) catch {
-    error => assert_true("\{error}".contains("object arguments"))
-  } noraise {
-    _ => fail("non-object decoded")
-  }
+test "decode rejects malformed arguments and names the offending field" {
+  assert_decode_error(Json::empty_object(), "arguments.path")
+  assert_decode_error(
+    { "paths": ["a.mbt", "b.mbt"] },
+    "arguments.paths is not supported",
+  )
+  assert_decode_error(
+    { "path": "file.mbt", "max_lines": 0 },
+    "arguments.max_lines to be a positive number",
+  )
+  assert_decode_error(Json::null(), "object arguments")
 }

--- a/agent_tool/read/read.mbt
+++ b/agent_tool/read/read.mbt
@@ -452,21 +452,6 @@ test "read description encourages batched reads and directory inspection" {
 }
 
 ///|
-test "read parses and caps optional limits" {
-  let input = @decode.decode({
-    "path": "file.mbt",
-    "start_line": 3,
-    "max_lines": 4,
-    "max_output_chars": 999999,
-  })
-  assert_eq(input.path, "file.mbt")
-  assert_eq(input.start_line, 3)
-  guard input.max_lines is Some(max_lines) else { fail("missing max_lines") }
-  assert_eq(max_lines, 4)
-  assert_eq(input.max_output_chars, @decode.hard_max_output_chars)
-}
-
-///|
 async test "read rejects paths array and explains batching" {
   let result = execute({ "paths": ["a.mbt", "b.mbt"] })
   guard result is Respond(output) else { fail("expected Respond") }

--- a/agent_tool/write/internal/decode/decode_test.mbt
+++ b/agent_tool/write/internal/decode/decode_test.mbt
@@ -52,46 +52,29 @@ test "decode reads revert_on_parse_errors" {
 }
 
 ///|
-test "decode rejects non-boolean revert_on_parse_errors" {
-  try
-    @decode.decode({
-      "path": "/tmp/a.mbt",
-      "content": "x",
-      "revert_on_parse_errors": 1,
-    })
-  catch {
-    error =>
+/// Asserts that decoding `arguments` fails and the error message names the
+/// offending field.
+fn assert_decode_error(arguments : Json, expected : String) -> Unit raise {
+  let _ = @decode.decode(arguments) catch {
+    error => {
+      let message = "\{error}"
       assert_true(
-        "\{error}".contains("arguments.revert_on_parse_errors to be a boolean"),
+        message.contains(expected),
+        msg="\{message} should contain \{expected}",
       )
-  } noraise {
-    _ => fail("non-boolean flag decoded")
+      return
+    }
   }
+  fail("expected decode error naming \{expected}")
 }
 
 ///|
-test "decode rejects missing content" {
-  try @decode.decode({ "path": "/tmp/file.txt" }) catch {
-    error => assert_true("\{error}".contains("arguments.content"))
-  } noraise {
-    _ => fail("missing content decoded")
-  }
-}
-
-///|
-test "decode rejects missing path" {
-  try @decode.decode({ "content": "hello" }) catch {
-    error => assert_true("\{error}".contains("arguments.path"))
-  } noraise {
-    _ => fail("missing path decoded")
-  }
-}
-
-///|
-test "decode rejects non-object arguments" {
-  try @decode.decode(Json::null()) catch {
-    error => assert_true("\{error}".contains("object arguments"))
-  } noraise {
-    _ => fail("non-object decoded")
-  }
+test "decode rejects malformed arguments and names the offending field" {
+  assert_decode_error(
+    { "path": "/tmp/a.mbt", "content": "x", "revert_on_parse_errors": 1 },
+    "arguments.revert_on_parse_errors to be a boolean",
+  )
+  assert_decode_error({ "path": "/tmp/file.txt" }, "arguments.content")
+  assert_decode_error({ "content": "hello" }, "arguments.path")
+  assert_decode_error(Json::null(), "object arguments")
 }

--- a/agent_tool/write_scope/write_scope.mbt
+++ b/agent_tool/write_scope/write_scope.mbt
@@ -161,17 +161,7 @@ fn WriteScope::prefix_admits(self : WriteScope, path : String) -> Bool {
     path.view(start_offset=root.length() + 1).to_owned()
   }
   let parts = relative.split("/").map(p => p.to_owned()).collect()
-  self.allowed.any(prefix => {
-    if parts.length() < prefix.length() {
-      return false
-    }
-    for index in 0..<prefix.length() {
-      if parts[index] != prefix[index] {
-        return false
-      }
-    }
-    true
-  })
+  self.allowed.any(prefix => parts.starts_with(prefix))
 }
 
 ///|


### PR DESCRIPTION
A pure **simplification** pass: no feature, no fix, no behaviour change. Part of a project-wide sweep; each PR is one package family so it can be reviewed on its own.

Candidates came from a read-only survey of the whole repository. The author was told to drop any that would not compile or would change behaviour, so this branch carries fewer than were proposed: **16 applied, 2 dropped, net -180 lines.**

## Applied

- **agent_tool/agent_tool.mbt** — 11 test tool literals restate the AgentToolDefinition constructor's defaults; one helper replaces them
  Applied as proposed. Added a private `test_tool(name?, description?, schema?, execute?)` helper that calls the real constructor, so `control: false, concurrent_safe: false` is no longer restated 11 times. Every non-default value in each original literal (names, descriptions, executors, the two-key schema) is passed through unchanged, so the test data is identical.
- **agent_tool/agent_tool.mbt** — function_tools "converts the registry" test is a strict subset of "preserves description and schema"
  Applied. Deleted the block; its one unique assertion `assert_eq(function_tools.length(), 1)` now sits in "preserves description and schema", which already builds the same single-"echo" registry and asserts the name.
- **agent_tool/agent_tool.mbt** — brief_line's char-capped truncation loop is String::from_iter(one.iter().take(limit))
  Applied. `one` is a StringView; `.iter()` is Iter[Char], so the cap still counts and cuts on characters exactly as the loop did. Trimmed the proposed two-line comment to one line because the function's own doc comment already states the surrogate-pair rationale.
- **agent_tool/plan/steps/decode_test.mbt** — 11 decode-rejection tests differ only in arguments/expected; collapse to one table
  Applied with two adjustments. (a) Used the repo's own shape - successive `assert_decode_error(...)` calls inside one test, as at agent_tool/plan/plan.mbt:299 - rather than the proposed `for` over an Array[(Json, String)]. (b) Folded only the NINE tests whose body was a single call with no prose comment. Left separate: "rejects a blank title" (NBSP/ideographic-space scenario note), "rejects a multi-line title" (forged-row note), and the two computed-input cap tests. 9 assert_decode_error calls before, 9 after; package 28 -> 20 test blocks.
- **agent_tool/plan/steps/decode.mbt** — in_progress_count accumulator in decode is Array::any over the steps built so far
  Applied. The check moved before the push so `steps` holds only earlier steps; the second in_progress step still raises, with the same message, and no later item is decoded. O(n^2) in principle, but n <= MAX_STEPS = 20.
- **agent_tool/edit/edit_test.mbt** — Three symlink parse-gate tests have identical bodies; only target/link names differ
  Applied. Extracted `async fn assert_link_edit_gated(prefix~, target~, link~)`. The three tests stay separate and each keeps its own doc comment (the first test's inline comment was promoted to a `///` doc comment above it, not deleted). Test count unchanged at 66.
- **agent_tool/edit/edit.mbt** — inserted_line_span re-implements total_line_count verbatim (same file)
  Applied. Body is now `total_line_count(new_string)`. Kept and extended the doc comment so it names total_line_count and records why the one differing rule (empty content spans 0 lines) cannot fire on the insertion path.
- **agent_tool/edit/edit.mbt** — Whitespace membership written as 4-way `==` disjunctions instead of an alternation pattern
  Applied to all THREE sites, one more than the proposal spelled out: the two in find_whitespace_normalized_candidates and the third in normalize_whitespace that the finding's evidence named. Deliberately not Char::is_ascii_whitespace, which would also match \u{0B}/\u{0C}.
- **agent_tool/write/internal/decode/decode_test.mbt** — Four try/catch/noraise reject tests; the sibling decode packages already have the helper
  Applied. Declared the same `assert_decode_error` helper the edit/multi_edit decode packages carry (these are separate internal packages, so it must be local) and folded the four tests into one. 4 rejection cases before, 4 after; package 11 -> 8 test blocks. All four asserted substrings preserved verbatim.
- **agent_tool/read/internal/decode/decode_test.mbt** — Four try/catch/noraise reject tests collapse into one table-driven test
  Applied, same shape as the write sibling. 4 cases before, 4 after; package 12 -> 9 test blocks. Asserted substrings unchanged.
- **agent_tool/read/internal/decode/decode.mbt** — cap_max_output_chars hand-rolls Int::min
  Applied verbatim: `value.min(hard_max_output_chars)`.
- **agent_tool/read/read.mbt** — "read parses and caps optional limits" is a strict subset of the decode package's own test
  Applied: block deleted. Verified read/internal/decode/decode_test.mbt:2-19 decodes the byte-identical arguments and debug_inspects all four fields, with max_output_chars pinned at 50000 == @decode.hard_max_output_chars. The deleted test never called execute. Package 23 -> 22 test blocks.
- **agent_tool/job_output/job_output.mbt** — page_of hand-rolls Iter drop/take over chars; String::from_iter does it in one line
  Applied. Confirmed the offset can never be negative (window_offset at job_output.mbt:229 rejects `offset < 0`), which is the only input where drop/take would diverge from the index loop.
- **agent_tool/write_scope/write_scope.mbt** — prefix_admits hand-rolls Array::starts_with (length guard + index loop)
  Applied, with one correction: the proposed `parts.starts_with(prefix[:])` fails --deny-warn with `unnecessary_view_op` (the parameter is already a view, so MoonBit inserts the conversion). Final form is `self.allowed.any(prefix => parts.starts_with(prefix))`.
- **agent_tool/multi_edit/multi_edit.mbt** — group_contiguous indexes groups[count - 1] where an array pattern reads directly
  Applied. `groups is [.., last]` subsumes the `count > 0` guard (an empty array does not match), and `last.items` is the same Array object the index form mutated.
- **agent_tool/multi_edit/multi_edit.mbt** — check_contiguity uses Map[String, Unit] as a set; core's Set is in the prelude
  Applied even though it saves no lines: it makes the existing "Set of paths whose contiguous block has already ended" comment literally true. Set needed no moon.pkg import, as the finding predicted.

## Dropped, and why

- **Sandbox-denial classification is written twice (job_output running path and bgjobs terminal path)**
  Would add a NEW PUBLIC function `classify_denial` to agent_tool/bgjobs. job_output is a different package, so the shared helper cannot be private - it must be `pub`, which expands bgjobs's visible API and would rewrite agent_tool/bgjobs/pkg.generated.mbti. The brief forbids changing a public signature and treats a .mbti change as the signal to revert. Six lines saved is not worth permanently widening a package's public surface, especially since the two call sites read the rule off different types (BgJobSnapshot fields vs. the internal BgJob).
- **desktop/main.mbt: `match Option { Some(x) => x; None => default }` is `unwrap_or`**
  The only finding in the list tagged group "de-services" (every other one is "tool-files" or "tool-misc"), and the only one outside agent_tool. It is out of scope for this branch's stated subject (agent_tool file/misc tools) and, if the de-services branch carries the same finding, applying it here would duplicate the change and conflict on merge. The change itself looks correct and safe - it should land on the branch that owns desktop/.

## Verification

All commands run in the worktree /private/tmp/claude-501/-Users-hongbozhang-git-openseek/ee773eb3-cd66-4ac0-a331-789265556fad/scratchpad/wt/tools on branch simplify/tools (clean at start, base a227f6aae).

BASELINE (`moon test <pkg>` on the untouched tree; agent_tool.mbt was git-stashed to measure its own baseline, then popped): agent_tool 23; agent_tool/plan/steps 28; agent_tool/edit 66; agent_tool/write/internal/decode 11; agent_tool/read 23; agent_tool/read/internal/decode 12; agent_tool/job_output 14; agent_tool/write_scope 6; agent_tool/multi_edit 31. Aggregate over those plus agent_tool/bgjobs: "Total tests: 229, passed: 229, failed: 0".

AFTER: agent_tool 22; agent_tool/plan/steps 20; agent_tool/plan 12 (dependent, unchanged); agent_tool/edit 66; agent_tool/write 28 (dependent, unchanged); agent_tool/write/internal/decode 8; agent_tool/read 22; agent_tool/read/internal/decode 9; agent_tool/job_output 14; agent_tool/write_scope 6; agent_tool/multi_edit 31. Same aggregate command: "Total tests: 213, passed: 213, failed: 0". Zero failures throughout; no test ever failed during this task.

The 229 -> 213 delta is exactly the 16 test BLOCKS removed by the five dedupes, with no case lost: agent_tool -1 (subset block deleted, its unique length==1 assertion moved), plan/steps -8 (9 single-call rejection tests -> 1 test holding all 9 calls), write/internal/decode -3 (4 -> 1, 4 cases), read -1 (subset block deleted), read/internal/decode -3 (4 -> 1, 4 cases). Assertion/row counts for the collapses: plan/steps 9 assert_decode_error calls before, 9 rows after; write/internal/decode 4 before, 4 after; read/internal/decode 4 before, 4 after. agent_tool/edit stayed at 66 - that finding extracted a helper and kept all three tests.

GATE:
- `moon fmt` -> clean; reformatted nothing outside my edits (ran twice; `git status --short` listed only the 12 intended files both times).
- `moon check <11 touched+dependent pkgs> --deny-warn` (native) -> Finished, 0 warnings 0 errors.
- `moon check <same> --target wasm --deny-warn` -> Finished, 0 warnings 0 errors.
- `moon check --deny-warn` workspace-wide (native, 821 tasks) -> Finished, no warnings/errors. Run because brief_line, write_scope and agent_tool.mbt have many downstream consumers.
- `moon info agent_tool agent_tool/plan/steps agent_tool/plan agent_tool/edit agent_tool/write agent_tool/write/internal/decode agent_tool/read agent_tool/read/internal/decode agent_tool/job_output agent_tool/write_scope agent_tool/multi_edit` (SCOPED, never bare) -> Finished; `git status --short` afterwards showed the same 12 files and NO .mbti. Public interfaces unchanged, as required.

ONE FAILURE, CORRECTED RATHER THAN WORKED AROUND: the proposed `parts.starts_with(prefix[:])` in write_scope.mbt failed `moon check --deny-warn` with error 0075 `unnecessary_view_op: [:] is unnecessary here`. Dropped the explicit `[:]`; re-checked clean.

GIT: staged the 12 files by explicit path (no `git add -A`); committed as 06728a239 (12 files changed, 183 insertions, 363 deletions); `git push -u origin simplify/tools` created the branch on origin. Working tree clean afterwards. No PR opened, no merge, no other branch touched.

## Worth a second look

Four things are worth a second look.

1. agent_tool/plan/steps/decode.mbt - the one non-test change with an ordering subtlety. The in_progress check moved BEFORE `steps.push(step)`, so on the offending step `steps` holds only the earlier ones. Same rejection point (the second in_progress step), same message, and the raise discards `steps` either way. Complexity goes from O(n) to O(n^2), bounded by MAX_STEPS = 20.

2. agent_tool/edit/edit.mbt inserted_line_span now delegates to total_line_count. The bodies were identical except total_line_count's `if content == "" { return 0 }` guard, so the two differ ONLY on empty input, where inserted_line_span used to return 1. The claim that the insertion path never passes "" rests on edit.mbt:182-184 rejecting both-empty edits before line 212, which is the sole call site. If that rejection ever moves, this delegation changes behaviour - the doc comment now records the dependency.

3. agent_tool/write_scope/write_scope.mbt prefix_admits - `Array::starts_with` is `len >= prefix.len && elementwise Eq`, matching the loop including the short-parts early false. Worth confirming an empty prefix is impossible (validate_prefix at write_scope.mbt:266-275 never yields one); if one existed, both old and new forms return true, so it is a no-op either way.

4. The three test collapses fold N named tests into one. Diagnosability is preserved through the existing `msg="{message} should contain {expected}"` on assert_true, and I also changed each helper's unasserted no-raise `fail("expected decode error")` to `fail("expected decode error naming {expected}")` so a row that unexpectedly DECODES is identifiable too. Nothing asserts those strings. In plan/steps I deliberately did not fold the blank-title and multi-line-title tests: their bodies carry prose explaining a distinct scenario (Unicode-only whitespace; newline-forged plan rows), and that comment is the point of the separate test.

Reviewed by OpenSeek's own review subagent (DeepSeek Flash); its verdict is posted as a comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXBYcYo74F1DGSPZsYYAdc