### PR TITLE
perf(cli): make failure_message return a StringView

### DIFF
--- a/cli/cli.mbt
+++ b/cli/cli.mbt
@@ -87,14 +87,17 @@ test "terminal_safe_line collapses whitespace, drops controls, elides at limit" 
 /// a `FAILED: ` marker, so strip those to avoid `error: error: …`. This is the
 /// single sanitizer both command mains (`cmd/openseek` here and the
 /// `openseek_tui` binary in `moonbitlang/openseek_tui`) run untrusted failure
-/// text through.
-pub fn failure_message(error_text : String) -> String {
+/// text through. The result is a `StringView` that borrows `error_text` — the
+/// matched arms strip prefixes without copying; callers that need owned text
+/// (or pass a temporary whose lifetime ends before the view is used) call
+/// `.to_owned()`.
+pub fn failure_message(error_text : StringView) -> StringView {
   lexmatch error_text {
-    (re"^error: ", after=message) => message.to_owned()
+    (re"^error: ", after=message) => message
     // `(.|\n)*` is greedy across lines, so the remainder follows the LAST
     // marker occurrence — the same piece the split-and-take-last form chose.
     (re"^(.|\n)* FAILED: ", after=last) =>
-      last.strip_suffix(")").unwrap_or(last).to_owned()
+      last.strip_suffix(")").unwrap_or(last)
     _ => error_text
   }
 }

--- a/cli/pkg.generated.mbti
+++ b/cli/pkg.generated.mbti
@@ -8,7 +8,7 @@ import {
 // Values
 pub fn agent_shared_options(global? : Bool) -> Array[@argparse.OptionArg]
 
-pub fn failure_message(String) -> String
+pub fn failure_message(StringView) -> StringView
 
 pub fn parse_positive_int(String, String) -> Int raise
 

--- a/cmd/openseek/concurrent.mbt
+++ b/cmd/openseek/concurrent.mbt
@@ -218,7 +218,9 @@ async fn run_one_attempt(
         dir: run_dir,
         session: id.value(),
         status: "error",
-        detail: @cli.failure_message("\{error}"),
+        // `failure_message` returns a view; `detail` is an owned String that
+        // outlives the temporary `"\{error}"` it borrows, so own it here.
+        detail: @cli.failure_message("\{error}").to_owned(),
         ok: false,
       }
   }


### PR DESCRIPTION
`failure_message` stripped argparse's `error: ` / Moon's `FAILED: ` prefixes by calling
`.to_owned()` on the `lexmatch` `after=` captures — allocating a fresh String
on every error-report path even though the captures are already `StringView`s.

The function now returns a `StringView` that borrows its input, so the matched
arms hand back the captured view directly and no copy is made:

- `cli/cli.mbt`: `pub fn failure_message(error_text : StringView) -> StringView`; both matched arms
  return the view captures as-is, the catch-all returns the (widened) parameter unchanged.
- `cmd/openseek/main.mbt`: unchanged — it interpolates the view into the stderr line within the
  same statement, dropping one allocation on that path.
- `cmd/openseek/concurrent.mbt`: keeps `.to_owned()` at the call site, because `detail` is an owned
  `String` field that outlives the temporary `"\{error}"` the view would borrow.

Interface regenerated (`moon info` → `pkg.generated.mbti`).

Verified: module-wide `moon check` clean; `moon test cli` 3/3 pass; `moon fmt --check` clean.

Note: the out-of-tree `openseek_tui` binary (`moonbitlang/openseek_tui`) imports `@cli` and may call
`failure_message`; it isn't visible to this repo's `moon check` and will need the signature update on
its side when it syncs.

Generated with SeekMoon