### PR TITLE
refactor(cmd/openseek): clean up subrun envelope parsing

### DIFF
--- a/cmd/openseek/subrun.mbt
+++ b/cmd/openseek/subrun.mbt
@@ -51,7 +51,9 @@ fn subrun_args(
 /// `pattern-repair` reads one JSON object from stdin:
 /// `{ "pattern": "...", "instruction": "..." }`.
 async fn run_subrun_command(matches : @argparse.Matches) -> Unit {
-  let report : Ref[Json?] = { val: None, }
+  // Written by the task-group body inside `with_jsonl_stdout` below, read
+  // after its teardown flushed the events; a captured `mut` replaces a Ref.
+  let mut report : Json? = None
   with_jsonl_stdout(() => {
     let workspace_root = prepare_workspace_root(matches, log_created=false)
     let (model, thinking, api_url) = agent_settings(matches)
@@ -64,36 +66,36 @@ async fn run_subrun_command(matches : @argparse.Matches) -> Unit {
       // EOF before input: the parent gave up before we started.
       return
     }
-    guard (Some(@json.parse(line.trim(chars="\r\n").to_owned())) catch {
-        _ => None
-      })
-      is Some(parsed) else {
-      @emit.emit(CommandError(error="subrun input is not JSON"))
-      return
+    let parsed = @json.parse(line.trim(chars="\r\n")) catch {
+      _ => {
+        @emit.emit(CommandError(error="subrun input is not JSON"))
+        return
+      }
     }
-    // The workflow contract's v1 request envelope carries the input
-    // under `input`; a bare input line (the engine's own older callers,
-    // hand-driven children) still works. Unknown future majors fail
-    // loudly rather than half-parse.
-    let input = match parsed {
-      { "workflow_contract": Number(1, ..), "input": inner, .. } => inner
+    // The workflow contract's v1 request envelope is
+    // `{ "workflow_contract": 1, "input": ..., "max_steps"?: ... }`:
+    // `input` is what the kind runs on, and the envelope's step ceiling —
+    // where a hosted snippet's `wf.agent(max_steps=N)` arrives, not on argv,
+    // because the library's argv is a template that cannot express an
+    // optional flag — rides along. A bare input line (the engine's own older
+    // callers, hand-driven children) still works, and unknown future majors
+    // fail loudly rather than half-parse. The explicit `--max-steps` flag
+    // still wins when both are present: it is the operator's word.
+    let (input, ceiling) : (Json, Int?) = match parsed {
+      {
+        "workflow_contract": 1,
+        "input": inner,
+        "max_steps": Number(steps, ..),
+        ..
+      } => (inner, Some(steps.to_int()))
+      { "workflow_contract": 1, "input": inner, .. } => (inner, None)
       { "workflow_contract": Number(version, ..), .. } => {
         @emit.emit(
           CommandError(error="unsupported workflow_contract version \{version}"),
         )
         return
       }
-      other => other
-    }
-    // The envelope also carries the caller's step ceiling. That is where the
-    // workflow contract puts it — a hosted snippet's `wf.agent(max_steps=N)`
-    // arrives HERE, not on argv, because the library's argv is a template
-    // that cannot express an optional flag. The explicit `--max-steps` flag
-    // still wins when both are present: it is the operator's word.
-    let ceiling : Int? = match parsed {
-      { "workflow_contract": Number(1, ..), "max_steps": Number(steps, ..), .. } =>
-        Some(steps.to_int())
-      _ => None
+      other => (other, None)
     }
     @async.with_task_group() <| group => {
       // Failures are caught INSIDE the task: a spawned task's failure
@@ -123,7 +125,7 @@ async fn run_subrun_command(matches : @argparse.Matches) -> Unit {
         }
         work.cancel()
       }
-      report.val = work.wait() catch {
+      report = work.wait() catch {
         // Parent-initiated cancel (stdin EOF): exit without a report; the
         // parent is already classifying the run from what it observed.
         error if @async.is_being_cancelled() ||
@@ -136,7 +138,7 @@ async fn run_subrun_command(matches : @argparse.Matches) -> Unit {
   // report through the SAME channel (@stdio.stdout, like the review CLI)
   // keeps one tracked writer on fd 1 — mixing println's C-stdio offset in
   // corrupts output when stdout is a regular file (review finding).
-  if report.val is Some(value) {
+  if report is Some(value) {
     @stdio.stdout.write(@agent_subrun.report_line(value) + "\n")
   }
 }


### PR DESCRIPTION
Addresses review feedback on `cmd/openseek/subrun.mbt` (the `openseek subrun`
child-mode input handling). Behavior is unchanged — the `echo`/unknown-kind/worker
cram cases still pass.

- `let mut report : Json? = None` replaces the `Ref[Json?] = { val: None, }` cell; the
  value is written inside the task-group body and read after `with_jsonl_stdout`'s
  teardown flushed the events.
- The stdin line is parsed with a plain `@json.parse(...) catch { _ => emit; return }`
  instead of the `guard (Some(parse) catch { _ => None }) is Some(parsed)` dance.
- The two separate `match parsed` dispatches (input, then step ceiling) collapse into
  one destructure of the v1 envelope into an `(input, ceiling)` pair, keeping the
  unsupported-version error and bare-input fallback identical.
- Json object patterns match the v1 literal directly (`"workflow_contract": 1`) instead
  of wrapping it in `Number(1, ..)`; `Number` remains only where a value is bound
  (`max_steps`, the unsupported-version report).

Verified: module-wide `moon check` clean; `moon fmt --check cmd/openseek` clean;
`moon cram test tests/cram/subrun.md` 3/3 pass.

Generated with SeekMoon