### PR TITLE
refactor(cli): let argparse read argv itself; keep only the env hand-off

### DIFF
--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -23,11 +23,12 @@ async fn main {
 ///|
 /// Parse the whole `openseek` command tree and dispatch on the chosen subcommand.
 /// The command tree requires a subcommand, so the parser rejects a bare
-/// `openseek` (headless automation has no default action).
+/// `openseek` (headless automation has no default action). argparse reads the
+/// process arguments itself (dropping the program name); only the environment
+/// has to be handed over, because `parse` defaults it to an empty map and the
+/// `[env: OPENSEEK_*]` fallbacks would otherwise silently never fire.
 async fn dispatch() -> Unit {
-  let argv = @env.args()[1:]
-  let env = @env.get_env_vars()
-  let matches = root_command().parse(argv~, env~)
+  let matches = @argparse.parse(root_command(), env=@env.get_env_vars())
   match matches.subcommand {
     Some(("run", m)) => run_task_command(m)
     Some(("serve", m)) => run_serve_command(m)

--- a/tests/cram/cli.md
+++ b/tests/cram/cli.md
@@ -162,6 +162,18 @@ error: --approval ask needs a controller to ask: this command reads no commands,
 [1]
 ```
 
+The `[env: OPENSEEK_APPROVAL]` fallback is the same option arriving through the
+process environment instead of argv, so it is refused the same way. This is the
+one piece of `main` that argparse cannot pick up on its own: `parse` reads the
+process arguments itself but defaults the environment to empty, so the binary
+must hand it `@env.get_env_vars()` — and this case fails if it ever stops.
+
+```mooncram
+$ env DEEPSEEK=test-key OPENSEEK_APPROVAL=ask openseek.exe run "probe" 2>&1
+error: --approval ask needs a controller to ask: this command reads no commands, so use never (refuse escalation) or always (grant it unasked)
+[1]
+```
+
 ## API Key Is Required For Agent Runs
 
 With no `--api-key` flag and no `DEEPSEEK` in the environment, a run reports the


### PR DESCRIPTION
## Why

`@argparse.parse` already defaults `argv` to the process arguments minus the program name (`default_argv()` in core, which also guards the empty-args case the hand-written `@env.args()[1:]` slice did not). `dispatch` in `cmd/openseek/main.mbt` was re-deriving that before calling `parse`, a leftover from the hand-rolled dispatcher replaced in #4af3a9ee0.

## What

- `dispatch` now calls `@argparse.parse(root_command(), env=@env.get_env_vars())` and nothing else. The doc comment says why `env` is the one thing that still has to be passed: `parse` defaults it to an empty map, so dropping it would silently disable every `[env: OPENSEEK_*]` fallback.
- New cram case in `tests/cram/cli.md`: `OPENSEEK_APPROVAL=ask openseek.exe run "probe"` is refused with the same error as `--approval ask`. This is the regression guard for the env hand-off on the real binary; the existing cram cases (top-level help, bare `openseek`, misspelled subcommand, `--`, `run --help`) already cover the argv side.

## Verification

- `moon check --target native cmd/openseek`: clean
- `moon test --target native cmd/openseek`: 82 passed, 0 failed
- `moon cram test tests/cram`: 24 succeeded, 0 failed (23 before this PR)
- `moon info` for `cmd/openseek`: no `.mbti` change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQGgqqN4dPTdUYW4J6UVBw
