### PR TITLE
refactor: bare Json literals in object patterns for fixed values

### DIFF
--- a/agent/auto_compact_test.mbt
+++ b/agent/auto_compact_test.mbt
@@ -135,7 +135,7 @@ fn message_content(message : Json) -> String raise {
 /// checkpoint prompt in the last message pins the classification.
 fn is_checkpoint_request(request : Json) -> Bool raise {
   let messages = request_messages(request)
-  !(request is { "stream": True, .. }) &&
+  !(request is { "stream": true, .. }) &&
   message_content(messages[messages.length() - 1]).contains(
     "CONTEXT CHECKPOINT COMPACTION",
   )

--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -1996,7 +1996,7 @@ fn session_row_of(json : Json) -> SessionRow? {
     { "last_active": Number(value, ..), .. } => Some(value.to_int64())
     _ => None
   }
-  let is_marker = json is { "is_marker": True, .. }
+  let is_marker = json is { "is_marker": true, .. }
   Some({ key, id, root_label, last_active, is_marker, first_prompt, })
 }
 
@@ -2008,8 +2008,8 @@ fn session_row_of(json : Json) -> SessionRow? {
 fn parse_load(text : String) -> LoadOutcome {
   let json = @json.parse(text) catch { _ => return Malformed }
   match json {
-    { "found": False, .. } => NotFound
-    { "found": True, "events": String(events_text), .. } => {
+    { "found": false, .. } => NotFound
+    { "found": true, "events": String(events_text), .. } => {
       let parsed = @viz.parse_events(events_text)
       let (system_prompt, header_present) = header_info(parsed)
       let log_bytes = match json {

--- a/mcp/stdio/stdio_wbtest.mbt
+++ b/mcp/stdio/stdio_wbtest.mbt
@@ -111,9 +111,7 @@ async test "recv reads a JSON-RPC line from a real subprocess" {
     guard transport.recv() is Some(json) else {
       fail("expected a JSON-RPC line from the subprocess")
     }
-    assert_true(
-      json is { "id": Number(7, ..), "result": { "ok": True, .. }, .. },
-    )
+    assert_true(json is { "id": 7, "result": { "ok": true, .. }, .. })
     transport.close()
   })
 }

--- a/mcp/types.mbt
+++ b/mcp/types.mbt
@@ -134,7 +134,7 @@ fn decode_call_result(result : Json) -> CallToolResult raise {
     _ => None
   }
   let is_error = match result {
-    { "isError": True, .. } => true
+    { "isError": true, .. } => true
     _ => false
   }
   { content, structured_content, is_error, }

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -2180,7 +2180,7 @@ fn raw_failed_call_ids(session : @agent_session.Session) -> Map[String, Unit] {
 /// the runtime for escalation.
 fn tool_call_is_escalated(call : @deepseek.ToolCall) -> Bool {
   let json = @json.parse(call.arguments) catch { _ => return false }
-  json is { "escalated": True, .. }
+  json is { "escalated": true, .. }
 }
 
 ///|


### PR DESCRIPTION
Json object patterns accept literal patterns directly, so fixed-value checks need
no constructor wrapper. This generalizes the rule applied to `cmd/openseek/subrun.mbt`
(`"workflow_contract": 1` instead of `Number(1, ..)`): use a bare literal when matching a
fixed constant, keep `Number(value, ..)` only where the value is bound and used.

Sites changed (all verified Json-typed):

- `mcp/stdio/stdio_wbtest.mbt` — initialize handshake: `"id": Number(7, ..)` → `"id": 7`,
  `"ok": True` → `"ok": true`
- `viz/view.mbt` — `tool_call_is_escalated`: `"escalated": True` → `"escalated": true`
- `agent/auto_compact_test.mbt` — checkpoint request check: `"stream": True` → `"stream": true`
- `cmd/viz_app/app.mbt` — session header/load decoding: `"is_marker": True` → `true`,
  `"found": False/True` → `false`/`true`
- `mcp/types.mbt` — content decode: `"isError": True` → `true`

`Number(value, ..)` bindings (`last_active`, `events_bytes`, `max_steps`, versions, …) are
unchanged; editor JS-extern `Number(...)` strings are not Json patterns.

Verified: probes confirm int/negative/bool literals compile and match parsed JSON;
root-module `moon check` clean; `cmd/viz_app` module check clean; `moon fmt` clean;
mcp/stdio 4/4 tests, viz_app `parse_load` (js) 3/3, agent checkpoint-path test 1/1.

Generated with SeekMoon