### PR TITLE
perf(editor): batch doc-comment zone measurement and color the viewport on open

### DIFF
--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -1172,6 +1172,7 @@ fn show_file_in_viewer(
       let current_view_state = viewer.save_view_state()
       viewer.set_value(content)
       viewer.restore_view_state(current_view_state)
+      viewer.handle_initialized()
     } else if !same_document {
       // Park the outgoing document's view state for its tab's return.
       if viewer_state.relative is Some(prev) {
@@ -1241,6 +1242,13 @@ fn show_file_in_viewer(
         if !restored_code_view_state && should_auto_fold_top_level(text_model) {
           viewer.fold_top_level()
         }
+        // Matches TextFileEditor.setInput and the reference workbench: model,
+        // restored state, and initial fold policy first, then the separate
+        // `handleInitialized` boundary. It publishes the stable visible range,
+        // so the viewport's syntax tokens are computed before the first paint;
+        // without it the document first paints as plain text and only colors
+        // once the background tokenizer's idle callback reaches the viewport.
+        viewer.handle_initialized()
       }
     } else if show_markdown {
       viewer.set_model(None)

--- a/editor/internal/viewer/code_editor_widget/markdown_comments_contribution.mbt
+++ b/editor/internal/viewer/code_editor_widget/markdown_comments_contribution.mbt
@@ -17,10 +17,18 @@ priv struct MarkdownCommentContributionState {
   listeners : Array[@base_common.Disposable]
   mut viewport_observer : @markdown_comments_browser.MarkdownCommentViewportObserver?
   mut geometry_lease : @base_common.Disposable?
+  /// One measurement pass per animation frame for every comment zone of this
+  /// kernel; its completion publishes `pending_layouts` in one transaction.
+  measure_batch : @markdown_comments_browser.MarkdownCommentMeasureBatch
+  /// Zone ids whose measured height changed during the current pass, in
+  /// report order.
+  pending_layouts : Map[String, Unit]
 }
 
 ///|
-fn MarkdownCommentContributionState::MarkdownCommentContributionState() -> MarkdownCommentContributionState {
+fn MarkdownCommentContributionState::MarkdownCommentContributionState(
+  viewer : CodeEditorWidget,
+) -> MarkdownCommentContributionState {
   {
     presentation_enabled: true,
     generation: 0,
@@ -28,6 +36,10 @@ fn MarkdownCommentContributionState::MarkdownCommentContributionState() -> Markd
     listeners: [],
     viewport_observer: None,
     geometry_lease: None,
+    measure_batch: MarkdownCommentMeasureBatch(on_pass_complete=() => {
+      viewer.flush_markdown_comment_layouts()
+    }),
+    pending_layouts: Map([]),
   }
 }
 
@@ -151,7 +163,7 @@ fn register_markdown_comment_contribution(
     markdown_comment_contribution_id,
     MarkdownComments,
     AfterFirstRender,
-    _viewer => MarkdownComments(MarkdownCommentContributionState()),
+    viewer => MarkdownComments(MarkdownCommentContributionState(viewer)),
     viewer => {
       guard viewer.markdown_comment_contribution() is Some(state) else {
         abort("Markdown-comment contribution variant mismatch")
@@ -627,7 +639,7 @@ fn CodeEditorWidget::refresh_markdown_comments(
           // Replace it before any observer or renderer can measure the node.
           dom.pin_to_content_viewport()
           let entry_generation = Ref(generation)
-          let size_observer = dom.observe_size(height => {
+          let size_observer = dom.observe_size(state.measure_batch, height => {
             self.apply_markdown_comment_height(
               state, key, zone_id, entry_generation, height,
             )
@@ -782,7 +794,37 @@ fn CodeEditorWidget::apply_markdown_comment_height(
   }
   entry.measured_height = measured
   entry.zone.height_in_px = Some(measured)
-  self.change_view_zones(accessor => accessor.layout_zone(expected_zone_id))
+  if state.measure_batch.in_pass() {
+    // The batch reports every zone of this frame back to back; one relayout
+    // transaction at pass completion replaces a per-zone whitespace change,
+    // ViewZones event, and full zone re-render.
+    state.pending_layouts.set(expected_zone_id, ())
+  } else {
+    self.change_view_zones(accessor => accessor.layout_zone(expected_zone_id))
+  }
+}
+
+///|
+/// Publishes every height reported by the measurement pass that just
+/// completed in one ViewZone transaction.
+fn CodeEditorWidget::flush_markdown_comment_layouts(
+  self : CodeEditorWidget,
+) -> Unit {
+  guard !self.disposed else { return }
+  guard self.markdown_comment_contribution() is Some(state) else { return }
+  if state.pending_layouts.is_empty() {
+    return
+  }
+  let zone_ids : Array[String] = []
+  for zone_id, _ in state.pending_layouts {
+    zone_ids.push(zone_id)
+  }
+  state.pending_layouts.clear()
+  self.change_view_zones(accessor => {
+    for zone_id in zone_ids {
+      accessor.layout_zone(zone_id)
+    }
+  })
 }
 
 ///|
@@ -813,6 +855,7 @@ fn CodeEditorWidget::clear_markdown_comment_model_state(
     None => ()
   }
   state.rendered.clear()
+  state.pending_layouts.clear()
   state.dispose_geometry_lease()
   self.set_hidden_areas([], source=markdown_comment_hidden_source)
 }
@@ -823,6 +866,7 @@ fn MarkdownCommentContributionState::dispose(
   viewer : CodeEditorWidget,
 ) -> Unit {
   viewer.clear_markdown_comment_model_state()
+  self.measure_batch.dispose()
   for listener in self.listeners {
     listener.dispose()
   }

--- a/editor/internal/viewer/contrib/markdown_comments/browser/README.mbt.md
+++ b/editor/internal/viewer/contrib/markdown_comments/browser/README.mbt.md
@@ -70,16 +70,24 @@ the caller's original `aria-hidden` state.
 contribution owns one model-scoped viewport-width observer and invalidates all
 live comment size observers when that width changes. Resize notifications and
 explicit viewport/renderer/image invalidations are coalesced through the
-realm-global `base/browser` animation-frame coordinator. A connected offscreen
-ViewZone is temporarily laid out invisibly using its already pinned
-viewport-safe width and horizontal offset; measurement never replaces
-`width` or `left`, and every touched inline style and priority is restored
-before its integer height is reported. The returned
-`MarkdownCommentSizeObserver` exposes `request_measure` and idempotent
-`dispose`; zero-size restore notifications cannot create a feedback loop.
-Disposal disconnects observation, cancels queued frame work, and makes late
-notifications inert. The root contribution remains responsible for the shared
-viewport observer, geometry lease, generation, and zone-id freshness.
+caller-owned `MarkdownCommentMeasureBatch`, which runs one measurement pass
+per animation frame for every zone of its owner (scheduled through the
+realm-global `base/browser` animation-frame coordinator). A pass reads every
+directly measurable height first, then shows every still-hidden connected
+ViewZone invisibly at once, reads all of their heights, restores their styles,
+and only then reports the changed integer heights before calling
+`on_pass_complete` once. Separating the writes from the reads keeps a document
+with thousands of doc comments at a constant number of forced layouts per
+pass instead of one per zone. Hidden measurement uses the zone's already
+pinned viewport-safe width and horizontal offset; it never replaces `width`
+or `left`, and every touched inline style and priority is restored before
+any height is reported. The returned `MarkdownCommentSizeObserver` exposes
+`request_measure` and idempotent `dispose`; zero-size restore notifications
+cannot create a feedback loop. Disposal disconnects observation and makes late
+notifications inert; disposing the batch cancels its queued frame work. The
+root contribution remains responsible for the shared viewport observer,
+geometry lease, generation, zone-id freshness, and for publishing the
+reported heights in one ViewZone transaction at pass completion.
 
 The shared `DiagramViewports` lifetime owns every successfully
 rendered direct Diago, UML, or Mermaid SVG viewport inside one Markdown-comment

--- a/editor/internal/viewer/contrib/markdown_comments/browser/markdown_comment_dom.mbt
+++ b/editor/internal/viewer/contrib/markdown_comments/browser/markdown_comment_dom.mbt
@@ -314,74 +314,211 @@ pub fn MarkdownCommentDom::expose_accessible_content(
 }
 
 ///|
+/// One zone's coalesced measurement request inside a
+/// `MarkdownCommentMeasureBatch`.
+priv struct MarkdownCommentMeasureEntry {
+  dom : MarkdownCommentDom
+  on_height_changed : (Int) -> Unit
+  mut last_height : Int
+  mut force_hidden : Bool
+  mut queued : Bool
+  mut disposed : Bool
+}
+
+///|
+/// Coalesces every comment zone's size measurement of one owner into a
+/// single animation-frame pass. A pass first reads every directly measurable
+/// content height, then lays out all still-hidden zones invisibly at once,
+/// reads their heights, restores their styles, and only then reports the
+/// changed heights. Grouping the DOM writes ahead of the reads keeps the
+/// browser at a constant number of forced layouts per pass instead of one
+/// per zone; measuring each zone on its own is what made opening a large
+/// MoonBit file stall for seconds. `on_pass_complete` runs once after a
+/// pass's height callbacks so the owner can publish every changed zone in one
+/// ViewZone transaction.
+struct MarkdownCommentMeasureBatch {
+  mut pending : Array[MarkdownCommentMeasureEntry]
+  mut frame : @base_common.Disposable?
+  mut frame_scheduled : Bool
+  mut in_pass : Bool
+  mut disposed : Bool
+  on_pass_complete : () -> Unit
+}
+
+///|
+/// Creates an empty batch owned by one root contribution.
+pub fn MarkdownCommentMeasureBatch::MarkdownCommentMeasureBatch(
+  on_pass_complete~ : () -> Unit,
+) -> MarkdownCommentMeasureBatch {
+  {
+    pending: [],
+    frame: None,
+    frame_scheduled: false,
+    in_pass: false,
+    disposed: false,
+    on_pass_complete,
+  }
+}
+
+///|
+/// Whether a measurement pass is reporting heights right now. Height callbacks
+/// use it to defer their ViewZone relayout to `on_pass_complete`.
+pub fn MarkdownCommentMeasureBatch::in_pass(
+  self : MarkdownCommentMeasureBatch,
+) -> Bool {
+  self.in_pass
+}
+
+///|
+/// Cancels queued frame work and makes every later request inert. The
+/// per-zone observer lifetimes remain caller-owned.
+pub fn MarkdownCommentMeasureBatch::dispose(
+  self : MarkdownCommentMeasureBatch,
+) -> Unit {
+  if self.disposed {
+    return
+  }
+  self.disposed = true
+  match self.frame {
+    Some(registration) => registration.dispose()
+    None => ()
+  }
+  self.frame = None
+  self.frame_scheduled = false
+  for entry in self.pending {
+    entry.queued = false
+  }
+  self.pending = []
+}
+
+///|
+fn MarkdownCommentMeasureBatch::enqueue(
+  self : MarkdownCommentMeasureBatch,
+  entry : MarkdownCommentMeasureEntry,
+  force_hidden : Bool,
+) -> Unit {
+  if self.disposed || entry.disposed {
+    return
+  }
+  entry.force_hidden = entry.force_hidden || force_hidden
+  if entry.queued {
+    return
+  }
+  entry.queued = true
+  self.pending.push(entry)
+  if self.frame_scheduled {
+    return
+  }
+  self.frame_scheduled = true
+  let registration = @base_browser.schedule_at_next_animation_frame(() => {
+    self.run_pass()
+  })
+  // Native requestAnimationFrame is asynchronous, but retaining this branch
+  // makes the owner correct under a synchronous test/browser shim too.
+  if self.frame_scheduled {
+    self.frame = Some(registration)
+  } else {
+    registration.dispose()
+  }
+}
+
+///|
+/// One frame's measurement pass: direct reads, then one invisible layout of
+/// every hidden zone, then the reports.
+fn MarkdownCommentMeasureBatch::run_pass(
+  self : MarkdownCommentMeasureBatch,
+) -> Unit {
+  self.frame_scheduled = false
+  self.frame = None
+  if self.disposed {
+    return
+  }
+  let entries = self.pending
+  self.pending = []
+  // Phase 1: direct reads. Visible content reports immediately; the first
+  // read may force one layout, later reads reuse it.
+  let hidden : Array[MarkdownCommentMeasureEntry] = []
+  let measured : Array[(MarkdownCommentMeasureEntry, Int)] = []
+  for entry in entries {
+    entry.queued = false
+    if entry.disposed || !@base_browser.element_is_connected(entry.dom.content) {
+      continue
+    }
+    let allow_hidden = entry.force_hidden || entry.last_height == 0
+    entry.force_hidden = false
+    let direct = @base_browser.element_offset_height(entry.dom.content).to_int()
+    if direct > 0 || !allow_hidden {
+      measured.push((entry, direct))
+    } else {
+      hidden.push(entry)
+    }
+  }
+  // Phase 2: writes. Every hidden zone is laid out invisibly at once.
+  let saved = hidden.map(entry => {
+    begin_hidden_markdown_comment_measure(entry.dom.outer)
+  })
+  // Phase 3: reads, all sharing the one layout the first read forces.
+  for entry in hidden {
+    measured.push(
+      (
+        entry,
+        read_hidden_markdown_comment_height(entry.dom.outer, entry.dom.content),
+      ),
+    )
+  }
+  // Phase 4: restore every touched inline style and priority.
+  for index, entry in hidden {
+    end_hidden_markdown_comment_measure(entry.dom.outer, saved[index])
+  }
+  // Phase 5: report. A callback may dispose a later entry, so re-check each.
+  self.in_pass = true
+  defer {
+    self.in_pass = false
+  }
+  for pair in measured {
+    let (entry, height) = pair
+    if entry.disposed || height <= 0 || height == entry.last_height {
+      continue
+    }
+    entry.last_height = height
+    (entry.on_height_changed)(height)
+  }
+  (self.on_pass_complete)()
+}
+
+///|
 /// Observes the inner Markdown content and reports its first/changed positive
-/// integer height after one shared animation-frame boundary. Explicit requests
-/// cover renderer replacement, image load, and model-scoped viewport-width
-/// changes while a zone is offscreen. The root callback owns generation and
-/// zone-id stale checks before relayout.
+/// integer height through `batch`, after one shared animation-frame boundary.
+/// Explicit requests cover renderer replacement, image load, and model-scoped
+/// viewport-width changes while a zone is offscreen. The root callback owns
+/// generation and zone-id stale checks before relayout.
 pub fn MarkdownCommentDom::observe_size(
   self : MarkdownCommentDom,
+  batch : MarkdownCommentMeasureBatch,
   on_height_changed : (Int) -> Unit,
 ) -> MarkdownCommentSizeObserver {
-  let disposed = Ref(false)
-  let frame_scheduled = Ref(false)
-  let force_hidden_measure = Ref(false)
-  let pending_frame : Ref[@base_common.Disposable?] = Ref(None)
-  let last_height = Ref(0)
-  let measure = () => {
-    frame_scheduled.val = false
-    pending_frame.val = None
-    if disposed.val || !@base_browser.element_is_connected(self.content) {
-      return
-    }
-    let allow_hidden = force_hidden_measure.val || last_height.val == 0
-    force_hidden_measure.val = false
-    let height = markdown_comment_measured_height(
-      self.outer,
-      self.content,
-      allow_hidden,
-    )
-    if height <= 0 || height == last_height.val {
-      return
-    }
-    last_height.val = height
-    on_height_changed(height)
-  }
-  let schedule_measure = (force_hidden : Bool) => {
-    if disposed.val {
-      return
-    }
-    force_hidden_measure.val = force_hidden_measure.val || force_hidden
-    if frame_scheduled.val {
-      return
-    }
-    frame_scheduled.val = true
-    let registration = @base_browser.schedule_at_next_animation_frame(measure)
-    // Native requestAnimationFrame is asynchronous, but retaining this branch
-    // makes the owner correct under a synchronous test/browser shim too.
-    if frame_scheduled.val {
-      pending_frame.val = Some(registration)
-    } else {
-      registration.dispose()
-    }
+  let entry : MarkdownCommentMeasureEntry = {
+    dom: self,
+    on_height_changed,
+    last_height: 0,
+    force_hidden: false,
+    queued: false,
+    disposed: false,
   }
   let observer = @base_browser.observe_element_resize(self.content, () => {
-    schedule_measure(false)
+    batch.enqueue(entry, false)
   })
   let lifetime = @base_common.Disposable::from(() => {
-    disposed.val = true
+    if entry.disposed {
+      return
+    }
+    entry.disposed = true
     match observer {
       Some(observer) => observer.dispose()
       None => ()
     }
-    match pending_frame.val {
-      Some(registration) => registration.dispose()
-      None => ()
-    }
-    pending_frame.val = None
-    frame_scheduled.val = false
   })
-  { request_measure_: () => schedule_measure(true), lifetime, }
+  { request_measure_: () => batch.enqueue(entry, true), lifetime, }
 }
 
 ///|
@@ -523,26 +660,17 @@ fn restore_markdown_comment_style(
 }
 
 ///|
-/// Reads visible content directly. For a connected `display:none` ViewZone,
-/// temporarily lays out the caller-owned outer node invisibly without replacing
-/// its viewport-pinned `left` or `width`, then restores every touched inline
-/// declaration and priority before returning. A later zero-size ResizeObserver
-/// notification is not allowed to repeat this hidden path unless the shared
-/// viewport observer or renderer explicitly invalidated it.
-fn markdown_comment_measured_height(
+/// Prepares a connected `display:none` ViewZone for an invisible layout: the
+/// caller-owned outer node is shown hidden at `top: 0` without replacing its
+/// viewport-pinned `left` or `width`. Returns every touched inline declaration
+/// and priority for `end_hidden_markdown_comment_measure`. A later zero-size
+/// ResizeObserver notification is not allowed to repeat this hidden path unless
+/// the shared viewport observer or renderer explicitly invalidated it.
+fn begin_hidden_markdown_comment_measure(
   outer : @rdom.Element,
-  content : @rdom.Element,
-  allow_hidden : Bool,
-) -> Int {
-  let direct = @base_browser.element_offset_height(content).to_int()
-  if direct > 0 || !allow_hidden || !@base_browser.element_is_connected(content) {
-    return direct
-  }
+) -> Array[MarkdownCommentSavedStyle] {
   let saved = ["display", "visibility", "pointer-events", "height", "top"].map(name => {
     save_markdown_comment_style(outer, name)
-  })
-  defer (for declaration in saved {
-    restore_markdown_comment_style(outer, declaration)
   })
   @base_browser.set_style_property_with_priority(
     outer, "display", "block", "important",
@@ -559,6 +687,16 @@ fn markdown_comment_measured_height(
   @base_browser.set_style_property_with_priority(
     outer, "top", "0px", "important",
   )
+  saved
+}
+
+///|
+/// Reads the invisibly laid out content height, or zero while the zone has no
+/// usable width yet.
+fn read_hidden_markdown_comment_height(
+  outer : @rdom.Element,
+  content : @rdom.Element,
+) -> Int {
   let rect_width = outer.get_bounding_client_rect().get_width()
   let width = if rect_width > 0.0 {
     rect_width
@@ -569,4 +707,15 @@ fn markdown_comment_measured_height(
     return 0
   }
   @base_browser.element_offset_height(content).to_int()
+}
+
+///|
+/// Restores the declarations captured by `begin_hidden_markdown_comment_measure`.
+fn end_hidden_markdown_comment_measure(
+  outer : @rdom.Element,
+  saved : Array[MarkdownCommentSavedStyle],
+) -> Unit {
+  for declaration in saved {
+    restore_markdown_comment_style(outer, declaration)
+  }
 }

--- a/editor/internal/viewer/contrib/markdown_comments/browser/markdown_comment_dom_wbtest.mbt
+++ b/editor/internal/viewer/contrib/markdown_comments/browser/markdown_comment_dom_wbtest.mbt
@@ -17,6 +17,8 @@ extern "js" fn install_markdown_comment_browser_test_dom() -> MarkdownCommentBro
   #|     frames: [],
   #|     observers: [],
   #|     hiddenMeasureCount: 0,
+  #|     // 'w' per inline style write, 'r' per hidden height read, in order.
+  #|     events: [],
   #|   };
   #|
   #|   class TestStyle {
@@ -29,12 +31,14 @@ extern "js" fn install_markdown_comment_browser_test_dom() -> MarkdownCommentBro
   #|     getPropertyPriority(name) { return this.priorities.get(name) ?? ""; }
   #|     setProperty(name, value, priority = "") {
   #|       this.writes.push({ operation: 'set', name: String(name) });
+  #|       harness.events.push('w');
   #|       this.values.set(name, String(value));
   #|       if (priority) this.priorities.set(name, String(priority));
   #|       else this.priorities.delete(name);
   #|     }
   #|     removeProperty(name) {
   #|       this.writes.push({ operation: 'remove', name: String(name) });
+  #|       harness.events.push('w');
   #|       const previous = this.getPropertyValue(name);
   #|       this.values.delete(name);
   #|       this.priorities.delete(name);
@@ -67,6 +71,7 @@ extern "js" fn install_markdown_comment_browser_test_dom() -> MarkdownCommentBro
   #|       const outer = this.parentNode;
   #|       if (!this.__hiddenHeights || outer?.style.getPropertyValue('display') !== 'block') return 0;
   #|       harness.hiddenMeasureCount += 1;
+  #|       harness.events.push('r');
   #|       const width = Math.trunc(outer.getBoundingClientRect().width);
   #|       return this.__hiddenHeights.get(width) ?? 0;
   #|     }
@@ -338,6 +343,16 @@ extern "js" fn markdown_comment_test_outer_style(
 extern "js" fn markdown_comment_test_hidden_measure_count(
   harness : MarkdownCommentBrowserTestHarness,
 ) -> Int = "harness => harness.hiddenMeasureCount"
+
+///|
+extern "js" fn markdown_comment_test_events(
+  harness : MarkdownCommentBrowserTestHarness,
+) -> String = "harness => harness.events.join('')"
+
+///|
+extern "js" fn markdown_comment_test_clear_events(
+  harness : MarkdownCommentBrowserTestHarness,
+) -> Unit = "harness => { harness.events.length = 0; }"
 
 ///|
 extern "js" fn markdown_comment_test_disconnect_count(
@@ -624,7 +639,8 @@ test "size observation coalesces and reports positive changed integer heights" {
   defer harness.dispose()
   let dom = MarkdownCommentDom(1, 2)
   let observed : Array[Int] = []
-  let lifetime = dom.observe_size(height => observed.push(height))
+  let batch = MarkdownCommentMeasureBatch(on_pass_complete=() => ())
+  let lifetime = dom.observe_size(batch, height => observed.push(height))
   assert_true(markdown_comment_test_observes(harness, dom.content))
   assert_eq(markdown_comment_test_observer_count(harness), 1)
   assert_eq(markdown_comment_test_observer_target_count(harness, 0), 1)
@@ -659,7 +675,8 @@ test "disconnected zero queued and late observer callbacks are inert" {
   defer harness.dispose()
   let dom = MarkdownCommentDom(5, 6)
   let observed : Array[Int] = []
-  let lifetime = dom.observe_size(height => observed.push(height))
+  let batch = MarkdownCommentMeasureBatch(on_pass_complete=() => ())
+  let lifetime = dom.observe_size(batch, height => observed.push(height))
 
   markdown_comment_test_set_measurement(dom.content, false, 20.0)
   markdown_comment_test_trigger_resize(harness)
@@ -713,7 +730,8 @@ test "offscreen measurement retains pinned width and offset and avoids zero feed
   assert_eq(markdown_comment_test_offset_width(dom.outer), 306)
   let original_style = markdown_comment_test_outer_style(dom.outer)
   let observed : Array[Int] = []
-  let observer = dom.observe_size(height => observed.push(height))
+  let batch = MarkdownCommentMeasureBatch(on_pass_complete=() => ())
+  let observer = dom.observe_size(batch, height => observed.push(height))
   let viewport_observer = dom.observe_viewport_width(() => {
     observer.request_measure()
   })
@@ -783,4 +801,83 @@ test "offscreen measurement retains pinned width and offset and avoids zero feed
   markdown_comment_test_set_viewport_width(viewport, 240)
   markdown_comment_test_trigger_resize_for(harness, viewport)
   assert_eq(markdown_comment_test_pending_frame_count(harness), 0)
+}
+
+///|
+test "a batch lays out every offscreen zone in one frame and completes once" {
+  let harness = install_markdown_comment_browser_test_dom()
+  defer harness.dispose()
+  let first = MarkdownCommentDom(1, 3)
+  let second = MarkdownCommentDom(10, 12)
+  first.pin_to_content_viewport()
+  second.pin_to_content_viewport()
+  markdown_comment_test_mount_offscreen(
+    first.outer,
+    first.content,
+    320,
+    40,
+    180,
+    60,
+  )
+  |> ignore
+  markdown_comment_test_mount_offscreen(
+    second.outer,
+    second.content,
+    320,
+    70,
+    180,
+    90,
+  )
+  |> ignore
+  let first_style = markdown_comment_test_outer_style(first.outer)
+  let second_style = markdown_comment_test_outer_style(second.outer)
+  let completed = Ref(0)
+  let observed : Array[(Int, Int)] = []
+  let batch = MarkdownCommentMeasureBatch(on_pass_complete=() => {
+    completed.val += 1
+  })
+  let first_observer = first.observe_size(batch, height => {
+    // Reports run after every zone's styles are restored, inside the pass.
+    assert_true(batch.in_pass()) catch {
+      _ => abort("report outside the measurement pass")
+    }
+    if markdown_comment_test_style(second.outer, "display") != "none" {
+      abort("report before every zone's styles were restored")
+    }
+    observed.push((1, height))
+  })
+  let second_observer = second.observe_size(batch, height => {
+    observed.push((2, height))
+  })
+  markdown_comment_test_clear_events(harness)
+  first_observer.request_measure()
+  second_observer.request_measure()
+  second_observer.request_measure()
+  // Both zones share one animation frame.
+  assert_eq(markdown_comment_test_pending_frame_count(harness), 1)
+  assert_false(batch.in_pass())
+  markdown_comment_test_flush_frame(harness)
+  assert_eq(observed, [(1, 40), (2, 70)])
+  assert_eq(completed.val, 1)
+  assert_false(batch.in_pass())
+  assert_eq(markdown_comment_test_hidden_measure_count(harness), 2)
+  // Every hidden zone is shown before any height is read, and every style is
+  // restored afterwards: five writes per zone, then one read per zone, then
+  // five restores per zone.
+  assert_eq(
+    markdown_comment_test_events(harness),
+    "wwwwwwwwww" + "rr" + "wwwwwwwwww",
+  )
+  assert_eq(markdown_comment_test_outer_style(first.outer), first_style)
+  assert_eq(markdown_comment_test_outer_style(second.outer), second_style)
+
+  // A disposed batch ignores later requests without scheduling frames.
+  batch.dispose()
+  batch.dispose()
+  first_observer.request_measure()
+  assert_eq(markdown_comment_test_pending_frame_count(harness), 0)
+  first_observer.dispose()
+  second_observer.dispose()
+  assert_eq(markdown_comment_test_disconnect_count(harness), 2)
+  assert_eq(completed.val, 1)
 }

--- a/editor/internal/viewer/contrib/markdown_comments/browser/pkg.generated.mbti
+++ b/editor/internal/viewer/contrib/markdown_comments/browser/pkg.generated.mbti
@@ -25,10 +25,15 @@ pub fn MarkdownCommentDom::disable_folding(Self) -> Unit
 pub fn MarkdownCommentDom::enable_folding(Self, @ref.Ref[Bool], () -> Unit) -> @common.Disposable
 pub fn MarkdownCommentDom::enable_source_toggle(Self, @ref.Ref[Bool], () -> Unit) -> @common.Disposable
 pub fn MarkdownCommentDom::expose_accessible_content(Self) -> Unit
-pub fn MarkdownCommentDom::observe_size(Self, (Int) -> Unit) -> MarkdownCommentSizeObserver
+pub fn MarkdownCommentDom::observe_size(Self, MarkdownCommentMeasureBatch, (Int) -> Unit) -> MarkdownCommentSizeObserver
 pub fn MarkdownCommentDom::observe_viewport_width(Self, () -> Unit) -> MarkdownCommentViewportObserver
 pub fn MarkdownCommentDom::pin_to_content_viewport(Self) -> Unit
 pub fn MarkdownCommentDom::set_margin_fold_lane_width(Self, Int) -> Unit
+
+type MarkdownCommentMeasureBatch
+pub fn MarkdownCommentMeasureBatch::MarkdownCommentMeasureBatch(on_pass_complete~ : () -> Unit) -> Self
+pub fn MarkdownCommentMeasureBatch::dispose(Self) -> Unit
+pub fn MarkdownCommentMeasureBatch::in_pass(Self) -> Bool
 
 type MarkdownCommentSizeObserver
 pub fn MarkdownCommentSizeObserver::dispose(Self) -> Unit

--- a/editor/viewer/common/model/text_model_tokens.mbt
+++ b/editor/viewer/common/model/text_model_tokens.mbt
@@ -420,7 +420,13 @@ fn TokenizerWithStateStoreAndTextModel::tokenize_heuristically(
   end_line_number : Int,
 ) -> HeuristicTokenizationResult {
   let first_invalid = self.base.store.get_first_invalid_end_state_line_number_or_max()
-  if end_line_number <= first_invalid {
+  // Deviation from the source's `endLineNumber <= firstInvalid` no-op: that
+  // form leaves a requested range whose last line is exactly the frontier
+  // untokenized, which shows as a plain first line whenever the first visible
+  // model range is a single line (a lone header comment followed by a hidden
+  // doc-comment block) and the background worker's idle turn is far away.
+  // Only ranges that end strictly before the frontier are already accurate.
+  if end_line_number < first_invalid {
     return { heuristic_tokens: false, }
   }
   if start_line_number <= first_invalid {

--- a/editor/viewer/common/model/tokenizer_syntax_token_backend_wbtest.mbt
+++ b/editor/viewer/common/model/tokenizer_syntax_token_backend_wbtest.mbt
@@ -92,6 +92,34 @@ test "passive reads never invoke support; stable attached ranges store exact ran
 }
 
 ///|
+/// A visible model range can be a single line ending exactly at the
+/// tokenization frontier (the first line of a file whose second line is hidden
+/// by a rich replacement). It must be tokenized by the stable refresh instead
+/// of waiting for the background worker's idle turn.
+test "stable single-line range at the frontier is tokenized synchronously" {
+  let harness = backend_harness(["one", "two"])
+  let attached_views = AttachedViews()
+  let calls : Array[String] = []
+  let backend = TokenizerSyntaxTokenBackend::new_with_support_resolver(
+    harness.model_state,
+    attached_views,
+    _ => Some(logging_support(calls, Ref(0))),
+  )
+  let events : Array[ModelTokensChangedEvent] = []
+  backend.on_did_change_tokens(event => events.push(event)) |> ignore
+  let view = attached_views.attach_view()
+  view.set_visible_lines([{ start_line_number: 1, end_line_number: 1, }], true)
+  assert_eq(calls.length(), 1)
+  assert_eq(events.length(), 1)
+  assert_eq(events[0].ranges[0].from_line_number, 1)
+  assert_eq(events[0].ranges[0].to_line_number, 1)
+  // The same stable range is now accurate and refreshes nothing.
+  view.set_visible_lines([{ start_line_number: 1, end_line_number: 1, }], true)
+  assert_eq(calls.length(), 1)
+  assert_eq(events.length(), 1)
+}
+
+///|
 test "too-large and missing support stay passive defaults and schedule nothing" {
   let harness = backend_harness(["one"], too_large=true)
   let resolves = Ref(0)


### PR DESCRIPTION
## Problem

Opening a large `.mbt` file in the desktop stalled for seconds before the first paint, and the visible lines were colored only after a later idle callback.

## Root cause

The MoonBit lexer and the Monaco-style background tokenizer are not the cost: 20k lines tokenize end to end in about 17 ms headless. A Chromium CPU profile of the desktop browser bundle attributed the stall to the rich `///` doc-comment feature. Every doc-comment block becomes a ViewZone, and each zone's height was measured on its own (`display:block`, `getBoundingClientRect`, `offsetHeight`, restore), so a 20k-line file forced about 1500 synchronous layouts inside one animation frame, then applied each height in its own ViewZone transaction that re-rendered all zones. The viewport's coloring waited on `requestIdleCallback`, which could not fire until that task ended.

Two smaller issues compounded it:

- The desktop never called `Viewer::handle_initialized` after `set_model`, unlike the reference workbench, so the viewport's tokens were never requested synchronously and even small files painted plain first.
- The viewport-priority pass kept the ported `end <= first_invalid` early return, which skips a range ending exactly at the tokenization frontier. A one-line first visible range (a header comment followed by a hidden doc comment) stayed plain until the idle pass.

## Changes

- `editor/internal/viewer/contrib/markdown_comments/browser`: new `MarkdownCommentMeasureBatch`. One measurement pass per animation frame: direct reads first, then all style writes for hidden zones, then all reads, then restores, then the height callbacks and a single `on_pass_complete`. `observe_size` now takes the batch. A test asserts the write, read, restore order across zones, the single frame, the single completion, and disposal.
- `editor/internal/viewer/code_editor_widget/markdown_comments_contribution.mbt`: the contribution owns one batch per editor and publishes the heights reported by a pass in one `change_view_zones` transaction.
- `desktop/frontend/fileeditor/editor_panel.mbt`: call `handle_initialized` after the model, restored view state, and initial fold policy are in place, matching `TextFileEditor.setInput` and the reference shell.
- `editor/viewer/common/model/text_model_tokens.mbt`: the early return is now `end < first_invalid`, documented as a deviation, with a backend regression test.

Geometry is unchanged by the batching: the same heights are measured in the same frame; only the number of forced layouts drops from one per zone to a constant per pass.

## Measurements

Chromium, desktop browser bundle via the e2e harness, time from click to a fully colored viewport:

| lines | before | after |
|---|---|---|
| 1k | 148 ms | 95 ms |
| 10k | 538 ms | 209 ms |
| 20k | 1204 ms | 370 ms |
| 40k | 3577 ms | 567 ms |

Before, the first paint itself was blocked until the measurement task finished (967 ms at 20k lines); after, every visible line is colored at the first paint.

## Verification

- `moon check --target js --deny-warn` and `--target native --deny-warn` in `editor/` and at the root
- `moon test --target js` in `editor/` (3186 tests), `moon test --target native viewer/common/model`
- `moon test --target js desktop/frontend/fileeditor` (147 tests)
- `moon fmt --check` in both workspaces; `moon info` for the two changed packages

## Follow-ups (not in this PR)

Every doc comment is still rendered to DOM and laid out once on open, so the remaining cost is linear in doc-comment content (about 0.3 s at 20k lines). Rendering and measuring only viewport zones would remove that, but it changes the geometry contract that reveal and review navigation rely on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGkUVgkpJqT3TQTu2hN5YW
