### PR TITLE
feat(editor/syntax): classify defer and errdefer as MoonBit keywords

### DIFF
--- a/editor/syntax/lang_moonbit/lexer.mbt
+++ b/editor/syntax/lang_moonbit/lexer.mbt
@@ -52,6 +52,8 @@ fn classify_word(word : StringView) -> @syntax.HighlightTag {
     | "try"
     | "catch"
     | "noraise"
+    | "defer"
+    | "errdefer"
     | "async"
     | "test"
     | "if"

--- a/editor/syntax/lang_moonbit/lexer_test.mbt
+++ b/editor/syntax/lang_moonbit/lexer_test.mbt
@@ -236,6 +236,25 @@ test "word classification distinguishes keywords from identifiers" {
 }
 
 ///|
+test "defer and errdefer classify as keywords" {
+  inspect(
+    render_tokens("defer close(); errdefer rollback(); let deferred = 1"),
+    content=(
+      #|0-5 Keyword defer
+      #|6-11 Identifier close
+      #|11-14 Delimiter ();
+      #|15-23 Keyword errdefer
+      #|24-32 Identifier rollback
+      #|32-35 Delimiter ();
+      #|36-39 Keyword let
+      #|40-48 Identifier deferred
+      #|49-50 Operator =
+      #|51-52 Number 1
+    ),
+  )
+}
+
+///|
 test "fallback punctuation preserves UTF-16 offsets" {
   inspect(
     render_tokens("🌟"),


### PR DESCRIPTION
## Change

The MoonBit lexer behind syntax coloring (`editor/syntax/lang_moonbit/lexer.mbt`) did not know `defer` and `errdefer`, so both rendered as ordinary identifiers. This adds them to the keyword list.

`classify_word` matches whole lexemes, so keyword-prefixed identifiers such as `deferred` keep classifying as identifiers; the new token-stream snapshot covers both keywords and that case.

## Verification

- `moon test syntax/lang_moonbit` on native and `--target js` in `editor/` (17 tests)
- `moon fmt`, `moon check --target js --deny-warn` in `editor/`
- No public interface change.

Independent of #1314.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGkUVgkpJqT3TQTu2hN5YW
