### PR TITLE
refactor: local stdlib and pattern rewrites in the root module

### DIFF
--- a/agent_session/store/store.mbt
+++ b/agent_session/store/store.mbt
@@ -75,20 +75,16 @@ pub fn SessionStore::SessionStore(root : String) -> SessionStore {
 
 ///|
 fn validate_session_id(id : @agent_session.SessionId) -> Unit raise {
-  let value = id.value()
-  if value == "" {
-    fail("session id must not be empty")
-  }
-  if value.contains("/") || value.contains("\\") {
-    fail("session id must not contain path separators: \{value}")
-  }
-  if value.contains("\u{0}") {
+  match id.value() {
+    "" => fail("session id must not be empty")
+    value if value.contains("/") || value.contains("\\") =>
+      fail("session id must not contain path separators: \{value}")
     // A NUL truncates the path at the C boundary, silently mapping distinct
     // ids onto one directory.
-    fail("session id must not contain a NUL character")
-  }
-  if value == "." || value == ".." {
-    fail("session id must not be `.` or `..`")
+    value if value.contains("\u{0}") =>
+      fail("session id must not contain a NUL character")
+    "." | ".." => fail("session id must not be `.` or `..`")
+    _ => ()
   }
 }
 
@@ -645,11 +641,7 @@ async fn first_prompt_in_log(path : String) -> String {
 fn[T] stamped_newest_first(a : (T, Int64, Int), b : (T, Int64, Int)) -> Int {
   let (_, a_seconds, a_nanoseconds) = a
   let (_, b_seconds, b_nanoseconds) = b
-  if b_seconds != a_seconds {
-    b_seconds.compare(a_seconds)
-  } else {
-    b_nanoseconds.compare(a_nanoseconds)
-  }
+  (b_seconds, b_nanoseconds).compare((a_seconds, a_nanoseconds))
 }
 
 ///|

--- a/agent_session/store/store.mbt
+++ b/agent_session/store/store.mbt
@@ -641,7 +641,14 @@ async fn first_prompt_in_log(path : String) -> String {
 fn[T] stamped_newest_first(a : (T, Int64, Int), b : (T, Int64, Int)) -> Int {
   let (_, a_seconds, a_nanoseconds) = a
   let (_, b_seconds, b_nanoseconds) = b
-  (b_seconds, b_nanoseconds).compare((a_seconds, a_nanoseconds))
+  // Compared field by field rather than as a tuple: this is a `sort_by`
+  // comparator, so it runs O(n log n) times per listing and must not build a
+  // pair on every call.
+  if b_seconds != a_seconds {
+    b_seconds.compare(a_seconds)
+  } else {
+    b_nanoseconds.compare(a_nanoseconds)
+  }
 }
 
 ///|

--- a/agent_skill/skill.mbt
+++ b/agent_skill/skill.mbt
@@ -135,30 +135,24 @@ pub fn merge_skills(
 /// use a skill: read the listed file first, then follow it.
 pub fn skills_prompt_section(skills : Array[Skill]) -> String? {
   guard skills.length() > 0 else { return None }
-  // Stream the listing into the multiline block's writer: the `$|` separator
-  // supplies the newline before the first entry, so each entry only needs a
-  // leading newline once another already precedes it.
-  fn list(out : StringBuilder) {
-    for index, skill in skills {
+  // Entries are joined with newlines; the `$|` block below supplies the one
+  // before the first entry.
+  let listing = [
+    for skill in skills => {
       let description = if skill.description() == "" {
         "(no description)"
       } else {
         skill.description()
       }
-      if index > 0 {
-        out <+ "\n"
-      }
-      out <+ "- \{skill.name()} — \{description} (file: \{skill.path()})"
+      "- \{skill.name()} — \{description} (file: \{skill.path()})"
     }
-  }
-
-  let sb = StringBuilder()
-  sb <+
+  ].join("\n")
+  let section =
     $|## Skills
     $|
     $|Reusable skills are available. When a task matches one, read its file with the read tool BEFORE doing the work, then follow it. Listed skill files are pre-approved reads even when they sit outside the working directory.
-    $|\{out => list(out)}
-  Some(sb.to_string())
+    $|\{listing}
+  Some(section)
 }
 
 ///|

--- a/agent_subtask/geometry.mbt
+++ b/agent_subtask/geometry.mbt
@@ -50,11 +50,8 @@ pub async fn resolve_geometry(
   }
   let worktree_roots : Array[String] = []
   for record in listing.output.split("\u{0}") {
-    let record = record.to_owned()
-    if record.has_prefix("worktree ") {
-      worktree_roots.push(
-        canonical(record.view(start_offset="worktree ".length()).to_owned()),
-      )
+    if record.strip_prefix("worktree ") is Some(root) {
+      worktree_roots.push(canonical(root.to_owned()))
     }
   }
   guard !worktree_roots.is_empty() else {
@@ -68,11 +65,7 @@ pub async fn resolve_geometry(
 /// directory is listed explicitly because it is not necessarily nested under
 /// a worktree root (for example, repositories using `--separate-git-dir`).
 pub fn Geometry::worker_deny_roots(self : Geometry) -> Array[String] {
-  let roots = Set([self.common_git_dir])
-  for root in self.worktree_roots {
-    roots.add(root)
-  }
-  roots.to_array()
+  Set([self.common_git_dir, ..self.worktree_roots]).to_array()
 }
 
 ///|

--- a/agent_subtask/provision.mbt
+++ b/agent_subtask/provision.mbt
@@ -219,14 +219,9 @@ async fn rollback_provision(geometry : Geometry, entry : SubtaskEntry) -> Unit {
 
 ///|
 fn is_valid_name(name : String) -> Bool {
-  guard name.length() >= 1 && name.length() <= 40 else { return false }
-  for index, ch in name {
-    let ok = ch is ('a'..='z' | '0'..='9') || (ch == '-' && index > 0)
-    if !ok {
-      return false
-    }
-  }
-  true
+  name.length() <= 40 &&
+  name is ['a'..='z' | '0'..='9', .. rest] &&
+  rest.iter().all(ch => ch is ('a'..='z' | '0'..='9' | '-'))
 }
 
 ///|

--- a/agent_subtask/registry.mbt
+++ b/agent_subtask/registry.mbt
@@ -147,13 +147,7 @@ fn components(prefix : String) -> Array[String] {
 /// Whether `shorter` is a component-wise prefix of `longer` (equal counts as
 /// covered).
 fn one_covers(shorter : Array[String], longer : Array[String]) -> Bool {
-  guard shorter.length() <= longer.length() else { return false }
-  for index in 0..<shorter.length() {
-    if shorter[index] != longer[index] {
-      return false
-    }
-  }
-  true
+  longer.starts_with(shorter)
 }
 
 ///|

--- a/agent_tool/edit/edit.mbt
+++ b/agent_tool/edit/edit.mbt
@@ -624,11 +624,7 @@ fn total_line_count(content : String) -> Int {
   if content == "" {
     return 0
   }
-  let count = for ch in content; count = 0 {
-    continue if ch == '\n' { count + 1 } else { count }
-  } nobreak {
-    count
-  }
+  let count = content.iter().count_if(ch => ch == '\n')
   if content.has_suffix("\n") {
     count
   } else {
@@ -952,31 +948,23 @@ fn first_diff_info(
   expected : String,
   actual : String,
 ) -> (Int, String, String)? {
+  // The code unit at `pos`, or `∅` when `s` has already ended there.
+  fn unit_at(s : String, pos : Int) -> String {
+    if pos < s.length() {
+      s.unsafe_substring(start=pos, end=pos + 1)
+    } else {
+      "∅"
+    }
+  }
+
   let len = expected.length().min(actual.length())
   for i in 0..<len {
     if expected[i] != actual[i] {
-      return Some(
-        (
-          i,
-          expected.unsafe_substring(start=i, end=i + 1),
-          actual.unsafe_substring(start=i, end=i + 1),
-        ),
-      )
+      return Some((i, unit_at(expected, i), unit_at(actual, i)))
     }
   }
   if expected.length() != actual.length() {
-    let pos = len
-    let expected_str = if pos < expected.length() {
-      expected.unsafe_substring(start=pos, end=pos + 1)
-    } else {
-      "∅"
-    }
-    let actual_str = if pos < actual.length() {
-      actual.unsafe_substring(start=pos, end=pos + 1)
-    } else {
-      "∅"
-    }
-    return Some((pos, expected_str, actual_str))
+    return Some((len, unit_at(expected, len), unit_at(actual, len)))
   }
   None
 }

--- a/agent_tool/internal/source_write_policy/source_write_policy.mbt
+++ b/agent_tool/internal/source_write_policy/source_write_policy.mbt
@@ -53,13 +53,9 @@ pub fn is_moon_managed_workspace_path(root : String, path : String) -> Bool {
     return false
   }
   let relative_start = if root == "/" { 1 } else { root.length() + 1 }
-  let relative = path[relative_start:].to_owned()
-  for part in relative.split("/") {
-    if part == "_build" || part == ".mooncakes" {
-      return true
-    }
-  }
-  false
+  path[relative_start:]
+  .split("/")
+  .any(part => part is ("_build" | ".mooncakes"))
 }
 
 ///|

--- a/agent_tool/job_output/job_output.mbt
+++ b/agent_tool/job_output/job_output.mbt
@@ -186,12 +186,10 @@ fn apply_output_rewrites(
   text : String,
   rewrites : Array[(String, String)],
 ) -> String {
-  let mut output = text
-  for rewrite in rewrites {
+  rewrites.fold(init=text, (output, rewrite) => {
     let (old, replacement) = rewrite
-    output = output.replace_all(old~, new=replacement)
-  }
-  output
+    output.replace_all(old~, new=replacement)
+  })
 }
 
 ///|

--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -1170,12 +1170,10 @@ fn temp_path_rewrites(bases : Array[String]) -> Array[(String, String)] {
 
 ///|
 fn rewrite_temp_paths(text : String, bases : Array[String]) -> String {
-  let mut out = text
-  for rewrite in temp_path_rewrites(bases) {
+  temp_path_rewrites(bases).fold(init=text, (out, rewrite) => {
     let (old, replacement) = rewrite
-    out = out.replace_all(old~, new=replacement)
-  }
-  out
+    out.replace_all(old~, new=replacement)
+  })
 }
 
 ///|

--- a/agent_tool/multi_edit/multi_edit.mbt
+++ b/agent_tool/multi_edit/multi_edit.mbt
@@ -951,11 +951,9 @@ fn compare_plan_descending(a : PlannedEdit, b : PlannedEdit) -> Int {
 fn apply_plans(content : String, plans : Array[PlannedEdit]) -> String {
   let ordered = plans.copy()
   ordered.sort_by(compare_plan_descending)
-  let mut output = content
-  for plan in ordered {
-    output = "\{output.unsafe_substring(start=0, end=plan.start)}\{plan.new_string}\{output.unsafe_substring(start=plan.end, end=output.length())}"
-  }
-  output
+  ordered.fold(init=content, (output, plan) => {
+    "\{output.unsafe_substring(start=0, end=plan.start)}\{plan.new_string}\{output.unsafe_substring(start=plan.end, end=output.length())}"
+  })
 }
 
 ///|

--- a/agent_tool/plan/steps/decode.mbt
+++ b/agent_tool/plan/steps/decode.mbt
@@ -78,10 +78,8 @@ pub fn decode(arguments : Json) -> PlanInput raise {
   guard arguments is Object(fields) else {
     fail("arguments to be an object with a steps array")
   }
-  for key, _ in fields {
-    if key != "steps" {
-      fail("arguments to have only the steps field")
-    }
+  if fields.keys().any(key => key != "steps") {
+    fail("arguments to have only the steps field")
   }
   guard fields is { "steps": Array(items), .. } else {
     fail("arguments.steps to be an array of steps")
@@ -110,10 +108,8 @@ fn decode_step(index : Int, item : Json) -> PlanStep raise {
   guard item is Object(fields) else {
     fail("arguments.steps[\{index}] to be an object")
   }
-  for key, _ in fields {
-    if key != "title" && key != "status" {
-      fail("arguments.steps[\{index}] to have only title and status fields")
-    }
+  if fields.keys().any(key => !(key is ("title" | "status"))) {
+    fail("arguments.steps[\{index}] to have only title and status fields")
   }
   let raw_title = match fields {
     { "title": String(value), .. } => value

--- a/agent_tool/read/html/read_output.mbt
+++ b/agent_tool/read/html/read_output.mbt
@@ -55,17 +55,16 @@ fn moonbit_output_for_path(path : String, content : String) -> @rhtml.Html? {
   }
   let highlighted = @syntax_html.moonbit_source_lines(source_lines.join("\n"))
   guard highlighted.length() == source_lines.length() else { return None }
-  let children : Array[@rhtml.Html] = []
-  for index, gutter in gutters {
-    children.push(
+  let children = [
+    for index, gutter in gutters => {
       @rhtml.span(class="read-moonbit-line", [
         @rhtml.span(class="read-moonbit-gutter", gutter),
         @rhtml.code(class="language-moonbit read-moonbit-code", [
           highlighted[index],
         ]),
-      ]),
-    )
-  }
+      ])
+    }
+  ]
   children.push(@rhtml.span(class="read-moonbit-status", status))
   Some(@rhtml.span(class="read-moonbit-output moonbit-source", children))
 }
@@ -78,11 +77,8 @@ pub fn moonbit_output_for_brief(
   content : String,
 ) -> @rhtml.Html? {
   guard brief.strip_prefix("read ") is Some(path_view) else { return None }
-  let path = match path_view.strip_suffix(" (truncated)") {
-    Some(path) => path.to_owned()
-    None => path_view.to_owned()
-  }
-  moonbit_output_for_path(path, content)
+  let path = path_view.strip_suffix(" (truncated)").unwrap_or(path_view)
+  moonbit_output_for_path(path.to_owned(), content)
 }
 
 ///|

--- a/agent_tool/shell/internal/decode/decode.mbt
+++ b/agent_tool/shell/internal/decode/decode.mbt
@@ -95,11 +95,7 @@ fn optional_positive_int(
 
 ///|
 fn cap_max_output_chars(value : Int) -> Int {
-  if value > hard_max_output_chars {
-    hard_max_output_chars
-  } else {
-    value
-  }
+  value.min(hard_max_output_chars)
 }
 
 ///|

--- a/agent_tool/shell/internal/shell_parse/parser.mbt
+++ b/agent_tool/shell/internal/shell_parse/parser.mbt
@@ -166,26 +166,12 @@ fn is_separator(op : String) -> Bool {
 
 ///|
 fn is_redirect_op(op : String) -> Bool {
-  op == ">" ||
-  op == ">|" ||
-  op == ">>" ||
-  op == "<>" ||
-  op == "<" ||
-  op == "&>" ||
-  op == "&>>" ||
-  op == ">&" ||
-  op == "<&"
+  op is (">" | ">|" | ">>" | "<>" | "<" | "&>" | "&>>" | ">&" | "<&")
 }
 
 ///|
 fn is_fd_redirect_op(op : String) -> Bool {
-  op == ">" ||
-  op == ">|" ||
-  op == ">>" ||
-  op == ">&" ||
-  op == "<>" ||
-  op == "<" ||
-  op == "<&"
+  op is (">" | ">|" | ">>" | ">&" | "<>" | "<" | "<&")
 }
 
 ///|

--- a/agent_tool/shell/moon_auto_check.mbt
+++ b/agent_tool/shell/moon_auto_check.mbt
@@ -231,23 +231,13 @@ fn cd_command_effect(
   arg_start : Int,
   base_cwd : String,
 ) -> CwdCommandEffect {
-  let remaining = argv.length() - arg_start
-  if remaining == 1 {
-    let target = argv[arg_start]
-    if target == "--" || target.has_prefix("-") {
-      UnknownCwd
-    } else if cd_target_resolves_from_base(target) {
-      KnownCwd(resolve_command_cwd(base_cwd, target))
-    } else {
-      UnknownCwd
-    }
-  } else if remaining == 2 && argv[arg_start] == "--" {
-    let target = argv[arg_start + 1]
-    if cd_target_resolves_from_base(target) {
-      KnownCwd(resolve_command_cwd(base_cwd, target))
-    } else {
-      UnknownCwd
-    }
+  let target = match argv.length() - arg_start {
+    1 if !argv[arg_start].has_prefix("-") => argv[arg_start]
+    2 if argv[arg_start] == "--" => argv[arg_start + 1]
+    _ => return UnknownCwd
+  }
+  if cd_target_resolves_from_base(target) {
+    KnownCwd(resolve_command_cwd(base_cwd, target))
   } else {
     UnknownCwd
   }

--- a/agent_tool/shell/worker_sandbox.mbt
+++ b/agent_tool/shell/worker_sandbox.mbt
@@ -168,32 +168,26 @@ async fn worker_cd_escapes(
       _ => ()
     }
     for index, arg in argv {
-      let operand = if arg == "-C" || arg == "--work-tree" {
-        if index + 1 < argv.length() {
-          Some(argv[index + 1])
-        } else {
-          None
-        }
-      } else if arg.has_prefix("--work-tree=") {
-        arg.view(start_offset="--work-tree=".length()).to_owned() |> Some
-      } else {
-        None
-      }
-      match operand {
-        Some(op) =>
-          for cwd in candidates {
-            match resolve_worker_operand(cwd, op) {
-              Some(resolved) =>
-                if !@workspace_path.is_under_workspace_root(
-                    worker_root,
-                    canonicalize_existing(resolved),
-                  ) {
-                  return Some("`\{arg} \{op}` points outside your worker tree")
-                }
-              None => ()
-            }
+      let operand = match arg {
+        "-C" | "--work-tree" =>
+          if index + 1 < argv.length() {
+            Some(argv[index + 1])
+          } else {
+            None
           }
-        None => ()
+        _ => arg.strip_prefix("--work-tree=").map(value => value.to_owned())
+      }
+      guard operand is Some(op) else { continue }
+      for cwd in candidates {
+        guard resolve_worker_operand(cwd, op) is Some(resolved) else {
+          continue
+        }
+        if !@workspace_path.is_under_workspace_root(
+            worker_root,
+            canonicalize_existing(resolved),
+          ) {
+          return Some("`\{arg} \{op}` points outside your worker tree")
+        }
       }
     }
   }

--- a/agent_tool/write_scope/write_scope.mbt
+++ b/agent_tool/write_scope/write_scope.mbt
@@ -253,15 +253,11 @@ fn validate_prefix(prefix : String) -> Result[Array[String], String] {
   guard !@path.Path(normalized).is_absolute() && !normalized.has_prefix("/") else {
     return Err("allowed_paths entries must be relative, got: \{prefix}")
   }
-  let parts : Array[String] = []
-  for part in normalized.split("/") {
-    let part = part.to_owned()
-    guard part != "" && part != "." && part != ".." else {
-      return Err(
-        "allowed_paths entries must not contain empty, `.`, or `..` components: \{prefix}",
-      )
-    }
-    parts.push(part)
+  let parts = [ for part in normalized.split("/") => part.to_owned() ]
+  guard !parts.any(part => part is ("" | "." | "..")) else {
+    return Err(
+      "allowed_paths entries must not contain empty, `.`, or `..` components: \{prefix}",
+    )
   }
   guard parts[0] != ".git" && parts[0] != ".worktrees" else {
     return Err(

--- a/agent_worker/types.mbt
+++ b/agent_worker/types.mbt
@@ -122,10 +122,7 @@ test "validate accepts a good report and rejects contract violations" {
 pub fn WorkerReport::parse_validated(
   json : Json,
 ) -> Result[WorkerReport, String] {
-  match parse_submission(json) {
-    Err(problems) => Err(problems.join("; "))
-    Ok(report) => Ok(report)
-  }
+  parse_submission(json).map_err(problems => problems.join("; "))
 }
 
 ///|

--- a/agent_workflow/fixit/main.mbt
+++ b/agent_workflow/fixit/main.mbt
@@ -77,14 +77,5 @@ async fn main {
 
 ///|
 fn clip(text : String, limit : Int) -> String {
-  let out = StringBuilder()
-  let mut count = 0
-  for ch in text {
-    if count >= limit {
-      break
-    }
-    out.write_char(ch)
-    count += 1
-  }
-  out.to_string()
+  String::from_iter(text.iter().take(limit))
 }

--- a/agent_workflow/worker_runner.mbt
+++ b/agent_workflow/worker_runner.mbt
@@ -413,13 +413,9 @@ pub async fn discard_slice(
   workspace_root~ : String,
   name~ : String,
 ) -> Result[Unit, String] {
-  match
-    with_slice(workspace_root, name, (geometry, entry) => {
-      @agent_subtask.discard(geometry, entry)
-    }) {
-    Ok(result) => result
-    Err(reason) => Err(reason)
-  }
+  with_slice(workspace_root, name, (geometry, entry) => {
+    @agent_subtask.discard(geometry, entry)
+  }).flatten()
 }
 
 ///|
@@ -459,13 +455,9 @@ async fn worker_nonce() -> String {
     _ => ()
   }
   guard dir.rev_split_once(prefix) is Some((_, suffix)) else { return "n0" }
-  let salt = StringBuilder()
-  for ch in suffix {
-    if ch is ('0'..='9' | 'a'..='z' | 'A'..='Z') {
-      salt.write_char(ch)
-    }
-  }
-  let salt = salt.to_string()
+  let salt = String::from_iter(
+    suffix.iter().filter(ch => ch is ('0'..='9' | 'a'..='z' | 'A'..='Z')),
+  )
   if salt.is_empty() {
     "n0"
   } else {

--- a/cmd/openseek/concurrent.mbt
+++ b/cmd/openseek/concurrent.mbt
@@ -230,18 +230,17 @@ async fn run_one_attempt(
 /// The terminal status and message of a finished run, read from its last
 /// `Terminal` event. `("(no terminal)", "")` when the run recorded none.
 fn terminal_summary(session : @agent_session.Session) -> (String, String) {
-  let mut out = ("(no terminal)", "")
-  for event in session.events() {
-    if event.item() is Terminal(terminal) {
-      out = match terminal {
-        Finished(answer) => ("finished", answer)
-        Aborted(reason) => ("aborted", reason)
-        Interrupted(reason) => ("interrupted", reason)
-        Failed(message) => ("failed", message)
-      }
+  session
+  .events()
+  .fold(init=("(no terminal)", ""), (out, event) => {
+    match event.item() {
+      Terminal(Finished(answer)) => ("finished", answer)
+      Terminal(Aborted(reason)) => ("aborted", reason)
+      Terminal(Interrupted(reason)) => ("interrupted", reason)
+      Terminal(Failed(message)) => ("failed", message)
+      _ => out
     }
-  }
-  out
+  })
 }
 
 ///|
@@ -416,12 +415,7 @@ fn one_line_brief(text : String, max : Int) -> String {
   if one.length() <= max {
     "\{one}"
   } else {
-    let kept = StringBuilder()
-    for ch in one.iter().take(max) {
-      kept.write_char(ch)
-    }
-    kept.write_char('…')
-    kept.to_string()
+    "\{String::from_iter(one.iter().take(max))}…"
   }
 }
 

--- a/cmd/openseek/subrun.mbt
+++ b/cmd/openseek/subrun.mbt
@@ -151,13 +151,12 @@ async fn first_free_child_ordinal(
   store : @store.SessionStore,
   parent : String,
 ) -> Int {
-  let mut highest = 0
-  for id in store.list() {
-    if child_session_ordinal(id.value(), parent) is Some(ordinal) &&
-      ordinal > highest {
-      highest = ordinal
-    }
-  }
+  let highest = store
+    .list()
+    .iter()
+    .filter_map(id => child_session_ordinal(id.value(), parent))
+    .maximum()
+    .unwrap_or(0)
   highest + 1
 }
 

--- a/deepseek/client/stream.mbt
+++ b/deepseek/client/stream.mbt
@@ -140,16 +140,11 @@ async fn apply_stream_json(
   on_content_delta~ : async (String) -> Unit,
   on_reasoning_delta~ : async (String) -> Unit,
 ) -> Unit {
-  match json {
-    { "usage": Null, .. } => ()
-    { "usage": usage_json, .. } => acc.usage = Some(usage_json)
-    _ => ()
+  if json is { "usage": usage_json, .. } && !(usage_json is Null) {
+    acc.usage = Some(usage_json)
   }
-  match json {
-    { "choices": [{ "delta": Object(delta), .. }, ..], .. } =>
-      apply_stream_delta(acc, delta, on_content_delta~, on_reasoning_delta~)
-    { "choices": [], .. } => ()
-    _ => ()
+  if json is { "choices": [{ "delta": Object(delta), .. }, ..], .. } {
+    apply_stream_delta(acc, delta, on_content_delta~, on_reasoning_delta~)
   }
 }
 

--- a/deepseek/json_decode.mbt
+++ b/deepseek/json_decode.mbt
@@ -140,11 +140,6 @@ pub impl FromJson for ChatResponse with fn from_json(
     { "content"? : Some(String(content)) | (Some(Null) with content = ""), .. } =>
       content
     { "content"? : None, .. } if tool_calls.length() > 0 => ""
-    { "content"? : None, .. } =>
-      json_decode_error(
-        message_path.add_key("content"),
-        "ChatResponse::from_json: expected message content",
-      )
     _ =>
       json_decode_error(
         message_path.add_key("content"),

--- a/inspect/main.mbt
+++ b/inspect/main.mbt
@@ -896,17 +896,10 @@ async fn SessionCatalog::lookup(
   key : String,
 ) -> SessionListRow? {
   let rows = self.rows()
-  for row in rows {
-    if row.key == key {
-      return Some(row)
-    }
+  match rows.iter().find_first(row => row.key == key) {
+    Some(row) => Some(row)
+    None => rows.iter().find_first(row => row.id == key)
   }
-  for row in rows {
-    if row.id == key {
-      return Some(row)
-    }
-  }
-  None
 }
 
 ///|

--- a/mcp/config/config.mbt
+++ b/mcp/config/config.mbt
@@ -47,11 +47,9 @@ pub fn decode(json : Json) -> Array[McpServer] raise {
   guard json is { "mcpServers": Object(servers), .. } else {
     raise Invalid("configuration is missing an `mcpServers` object")
   }
-  let out = []
-  for name, entry in servers {
-    out.push(decode_server(name, entry))
-  }
-  out
+  [
+    for name, entry in servers => decode_server(name, entry)
+  ]
 }
 
 ///|

--- a/mcp/streamhttp/transport.mbt
+++ b/mcp/streamhttp/transport.mbt
@@ -493,7 +493,13 @@ fn SseLineReader::SseLineReader(client : @http.Client) -> SseLineReader {
 async fn SseLineReader::next_line(self : SseLineReader) -> String? {
   // Drop consumed bytes so memory tracks the current line, not the stream.
   if self.start >= SseCompactAt {
-    self.buf.drain(0, self.start) |> ignore
+    // Shifted in place rather than with `drain`: `drain` allocates a fresh
+    // array for the >= 4 KB it removes and then throws it away.
+    let remaining = self.buf.length() - self.start
+    for j in 0..<remaining {
+      self.buf[j] = self.buf[self.start + j]
+    }
+    self.buf.truncate(remaining)
     self.scan -= self.start
     self.start = 0
   }

--- a/mcp/streamhttp/transport.mbt
+++ b/mcp/streamhttp/transport.mbt
@@ -493,11 +493,7 @@ fn SseLineReader::SseLineReader(client : @http.Client) -> SseLineReader {
 async fn SseLineReader::next_line(self : SseLineReader) -> String? {
   // Drop consumed bytes so memory tracks the current line, not the stream.
   if self.start >= SseCompactAt {
-    let remaining = self.buf.length() - self.start
-    for j in 0..<remaining {
-      self.buf[j] = self.buf[self.start + j]
-    }
-    self.buf.truncate(remaining)
+    self.buf.drain(0, self.start) |> ignore
     self.scan -= self.start
     self.start = 0
   }
@@ -532,10 +528,7 @@ async fn SseLineReader::next_line(self : SseLineReader) -> String? {
     }
     match self.client.read_some() {
       None => self.eof = true
-      Some(chunk) =>
-        for byte in chunk {
-          self.buf.push(byte)
-        }
+      Some(chunk) => self.buf.push_iter(chunk.iter())
     }
   }
 }

--- a/mcp/types.mbt
+++ b/mcp/types.mbt
@@ -133,10 +133,7 @@ fn decode_call_result(result : Json) -> CallToolResult raise {
     { "structuredContent": value, .. } => Some(value)
     _ => None
   }
-  let is_error = match result {
-    { "isError": true, .. } => true
-    _ => false
-  }
+  let is_error = result is { "isError": true, .. }
   { content, structured_content, is_error, }
 }
 

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -1783,12 +1783,10 @@ fn model_event_covered_by_later_summary(
   event : @agent_session.SessionEvent,
   events : @vector.Vector[@agent_session.SessionEvent],
 ) -> Bool {
-  for candidate in events {
-    if model_summary_covers_event(candidate, event.sequence()) {
-      return true
-    }
-  }
-  false
+  let sequence = event.sequence()
+  events
+  .iter()
+  .any(candidate => model_summary_covers_event(candidate, sequence))
 }
 
 ///|
@@ -1796,13 +1794,9 @@ fn remove_pending_tool_id(
   pending : Array[String],
   tool_call_id : String,
 ) -> Bool {
-  for index, id in pending {
-    if id == tool_call_id {
-      ignore(pending.remove(index))
-      return true
-    }
-  }
-  false
+  guard pending.search(tool_call_id) is Some(index) else { return false }
+  ignore(pending.remove(index))
+  true
 }
 
 ///|
@@ -2964,13 +2958,7 @@ fn encode_hash_component(value : String) -> String {
 
   for c in value {
     let code = c.to_int()
-    if (code >= 0x61 && code <= 0x7A) ||
-      (code >= 0x41 && code <= 0x5A) ||
-      (code >= 0x30 && code <= 0x39) ||
-      code == 0x2D ||
-      code == 0x5F ||
-      code == 0x2E ||
-      code == 0x7E {
+    if c is ('a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' | '.' | '~') {
       out <+ "\{c}"
     } else if code < 0x80 {
       put_byte(code)


### PR DESCRIPTION
**This one is meant to be readable at a glance.** Every hunk is a LOCAL
rewrite: the replacement sits exactly where the old code sat. No helper is
added or removed, no code moves between functions, no signature changes, and
no test changes. If a hunk reads correctly on its own, it is correct.

The complete list of shapes used:

| before | after |
| --- | --- |
| `x == "a" \|\| x == "b"` | `x is ("a" \| "b")` |
| `match o { Some(v) => Some(f(v)); None => None }` | `o.map(f)` |
| `match o { Some(v) => v; None => d }` | `o.unwrap_or(d)` |
| `match r { Ok(v) => Ok(v); Err(e) => Err(g(e)) }` | `r.map_err(g)` |
| a push loop | `[for x in xs if p(x) => f(x)]` |
| a break-on-match scan | `find_first` / `any` / `all` / `contains` |
| a manual accumulator | `fold` / `count_if` |
| a get-then-insert | `Map::get_or_init` |
| a hand-rolled char loop | `to_lower` / `pad_start` / `replace_all` / `repeat` |
| a nested `if`/`match` ladder | one `match`, or `guard ... is Some(..)` |

Scope: the root module — `agent*`, `cmd/`, `mcp/`, `eval/`, `viz*`, `deepseek/`, `inspect/`.

### Verified on this branch alone

`moon fmt --check`, `moon check --target native --deny-warn`, `moon check
--target js --deny-warn`, and the full native and JS test suites — with no
other part of the sweep applied. No `.mbti` changed, so no package interface
moves.

---

Part of a project-wide simplification sweep, split into seven independent pull
requests. Every file appears in exactly one of them, so they can be reviewed and
merged in any order, and each was verified on its own branch with no other part
of the sweep applied.

| | PR | what it is |
| --- | --- | --- |
| 1 | `simplify/mechanical-root` | local rewrites, root module |
| 2 | `simplify/mechanical-desktop` | local rewrites, `desktop/` |
| 3 | `simplify/mechanical-editor` | local rewrites, `editor/` |
| 4 | `simplify/structural-root` | shared helpers, root module |
| 5 | `simplify/structural-desktop` | shared helpers, `desktop/` |
| 6 | `simplify/structural-editor` | shared helpers, `editor/` |
| 7 | `simplify/tests` | test fixtures and folds |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JiBNGzCsZpN6e5Y4p9pXdn
