### PR TITLE
refactor(desktop): local stdlib and pattern rewrites

### DIFF
--- a/desktop/frontend/action_menu/action_menu.mbt
+++ b/desktop/frontend/action_menu/action_menu.mbt
@@ -647,31 +647,19 @@ fn focus_subscription(
             previous = next
             return
           }
-          let mut old_index : Int? = None
-          for index in previous {
-            if focused == item_id(target, index) {
-              old_index = Some(index)
-            }
-          }
+          let old_index = previous
+            .iter()
+            .find_first(index => focused == item_id(target, index))
           if old_index is Some(old_index) &&
             enabled_position(next, old_index) is None {
-            let mut replacement : Int? = None
-            for index in next {
-              if replacement is None && index > old_index {
-                replacement = Some(index)
-              }
-            }
-            if replacement is None {
-              replacement = Some(next[next.length() - 1])
-            }
-            if replacement is Some(index) {
-              let _ = @dom.window().set_timeout(
-                () => {
-                  scheduler.add(focus_element(item_id(target, index), false))
-                },
-                0,
-              )
-            }
+            let index = next
+              .iter()
+              .find_first(index => index > old_index)
+              .unwrap_or(next[next.length() - 1])
+            let _ = @dom.window().set_timeout(
+              () => scheduler.add(focus_element(item_id(target, index), false)),
+              0,
+            )
           }
           previous = next
         },

--- a/desktop/frontend/action_menu/context_menu.mbt
+++ b/desktop/frontend/action_menu/context_menu.mbt
@@ -354,24 +354,17 @@ fn context_definition(
             (actions.open_link)(url),
           ),
         )
-      } else if input.open_web_links_in_app {
-        navigation.push(
-          context_item(
-            "Open",
-            "Open",
-            @icons.icon_link_external(),
-            (actions.open_link)(url),
-          ),
-        )
-        navigation.push(
-          context_item(
-            "Open in Default Browser",
-            "Open in the system default browser",
-            @icons.icon_link_external(),
-            (actions.open_external_link)(url),
-          ),
-        )
       } else {
+        if input.open_web_links_in_app {
+          navigation.push(
+            context_item(
+              "Open",
+              "Open",
+              @icons.icon_link_external(),
+              (actions.open_link)(url),
+            ),
+          )
+        }
         navigation.push(
           context_item(
             "Open in Default Browser",

--- a/desktop/frontend/agent_model.mbt
+++ b/desktop/frontend/agent_model.mbt
@@ -68,12 +68,11 @@ fn ModelChoice::parse(value : String) -> ModelChoice? {
   if value == CodexUnavailableChoiceWire {
     return Some(CodexUnavailablePick)
   }
-  if value.has_prefix(OpenSeekChoicePrefix) {
-    let rest = value.view(start_offset=OpenSeekChoicePrefix.length()).to_owned()
-    return EngineModel::parse(rest).map(model => OpenSeekModel(model))
+  if value.strip_prefix(OpenSeekChoicePrefix) is Some(rest) {
+    return EngineModel::parse(rest.to_owned()).map(model => OpenSeekModel(model))
   }
-  if value.has_prefix(CodexChoicePrefix) {
-    let id = value.view(start_offset=CodexChoicePrefix.length()).to_owned()
+  if value.strip_prefix(CodexChoicePrefix) is Some(rest) {
+    let id = rest.to_owned()
     if !id.trim().is_empty() {
       return Some(CodexModel(id))
     }

--- a/desktop/frontend/browser_ops.mbt
+++ b/desktop/frontend/browser_ops.mbt
@@ -91,13 +91,13 @@ fn browser_set_theme_for_pages(
   model : Model,
   dark : Bool,
 ) -> @cmd.Cmd {
-  let commands : Array[@cmd.Cmd] = []
-  for id, page in model.preview.pages {
-    if page.url is Some(_) {
-      commands.push(browser_set_theme(dispatch, id, dark))
-    }
-  }
-  @cmd.batch(commands)
+  @cmd.batch(
+    [
+      for id, page in model.preview.pages if page.url is Some(_) => {
+        browser_set_theme(dispatch, id, dark)
+      }
+    ],
+  )
 }
 
 ///|

--- a/desktop/frontend/codex/completion.mbt
+++ b/desktop/frontend/codex/completion.mbt
@@ -53,31 +53,18 @@ priv struct CodexContext {
 
 ///|
 fn State::active_context(self : State) -> CodexContext? {
-  match self.selection {
-    CodexDraftTask(draft) =>
-      match draft.project_root {
-        Some(project_root) => {
-          let cwd = project_root.trim().to_owned()
-          if cwd.is_empty() {
-            None
-          } else {
-            Some({ thread_id: draft.id, cwd, })
-          }
-        }
-        None => None
-      }
-    CodexStoredTask(thread) => {
-      guard !self.has_missing_worktree() && thread.cwd is Some(raw_cwd) else {
-        return None
-      }
-      let cwd = raw_cwd.trim().to_owned()
-      if cwd.is_empty() {
-        None
-      } else {
-        Some({ thread_id: thread.id, cwd, })
-      }
-    }
-    CodexNoTask => None
+  let (thread_id, raw_cwd) = match self.selection {
+    CodexDraftTask(draft) if draft.project_root is Some(project_root) =>
+      (draft.id, project_root)
+    CodexStoredTask(thread) if !self.has_missing_worktree() &&
+      thread.cwd is Some(raw_cwd) => (thread.id, raw_cwd)
+    _ => return None
+  }
+  let cwd = raw_cwd.trim().to_owned()
+  if cwd.is_empty() {
+    None
+  } else {
+    Some({ thread_id, cwd, })
   }
 }
 

--- a/desktop/frontend/codex/model.mbt
+++ b/desktop/frontend/codex/model.mbt
@@ -734,16 +734,14 @@ fn State::with_selected_model(self : State, id : String) -> State {
     // Startup restores preferences before model/list settles.
     return { ..self, selected_model: id, }
   }
-  for model in self.models {
-    if model.id == id {
-      return {
-        ..self,
-        selected_model: id,
-        selected_effort: model.reasoning_effort(self.selected_effort),
-      }
-    }
+  guard self.models.iter().find_first(model => model.id == id) is Some(model) else {
+    return self
   }
-  self
+  {
+    ..self,
+    selected_model: id,
+    selected_effort: model.reasoning_effort(self.selected_effort),
+  }
 }
 
 ///|
@@ -763,12 +761,7 @@ fn State::with_selected_effort(self : State, effort : String) -> State {
 
 ///|
 fn State::selected_model_option(self : State) -> CodexModelOption? {
-  for model in self.models {
-    if model.id == self.selected_model {
-      return Some(model)
-    }
-  }
-  None
+  self.models.iter().find_first(model => model.id == self.selected_model)
 }
 
 ///|
@@ -802,10 +795,10 @@ pub enum CodexModelListing {
 ///|
 pub fn State::model_listing(self : State) -> CodexModelListing {
   if !self.models.is_empty() {
-    let options : Array[@composer.ModelOption] = []
-    for model in self.models {
-      options.push({ value: model.id, label: model.label, })
-    }
+    let options = self.models.map(model => @composer.ModelOption::{
+      value: model.id,
+      label: model.label,
+    })
     // `with_models` never leaves an empty selection beside a non-empty
     // catalog, so this selected id names a real option.
     return CodexModels(options, selected=self.selected_model)
@@ -931,25 +924,14 @@ fn State::accepts_reply(self : State, kind : CodexReplyKind) -> Bool {
     CodexThreadReply(thread_id, frontier) =>
       frontier.connection_epoch == self.activity.connection_epoch &&
       self.accepts_thread_reply(thread_id)
-    CodexResumeReply(thread_id) =>
-      self
-      .active_thread()
-      .map(thread => thread.id == thread_id)
-      .unwrap_or(false)
-    CodexDraftThreadReply(draft_id) =>
-      self.active_draft().map(draft => draft.id == draft_id).unwrap_or(false)
-    CodexTurnStartReply(thread_id)
+    CodexResumeReply(thread_id)
+    | CodexTurnStartReply(thread_id)
     | CodexTurnSteerReply(thread_id)
-    | CodexWorktreeTurnReply(thread_id, _) =>
-      self
-      .active_thread()
-      .map(thread => thread.id == thread_id)
-      .unwrap_or(false)
-    CodexWorktreeRepairReply(thread_id, _) =>
-      self
-      .active_thread()
-      .map(thread => thread.id == thread_id)
-      .unwrap_or(false)
+    | CodexWorktreeTurnReply(thread_id, _)
+    | CodexWorktreeRepairReply(thread_id, _) =>
+      self.active_thread() is Some(thread) && thread.id == thread_id
+    CodexDraftThreadReply(draft_id) =>
+      self.active_draft() is Some(draft) && draft.id == draft_id
     _ => true
   }
 }
@@ -1261,13 +1243,9 @@ fn CodexTurn::decode(value : Json) -> CodexTurn? {
   guard value is Object(fields) && @jsonx.json_text(fields, "id") is Some(id) else {
     return None
   }
-  let items : Array[CodexItem] = []
-  if fields.get("items") is Some(Array(values)) {
-    for value in values {
-      if CodexItem::decode(value) is Some(item) {
-        items.push(item)
-      }
-    }
+  let items = match fields.get("items") {
+    Some(Array(values)) => values.filter_map(CodexItem::decode)
+    _ => []
   }
   let error = match fields.get("error") {
     Some(Object(error)) => @jsonx.json_text(error, "message")
@@ -1331,13 +1309,9 @@ fn CodexThread::decode(value : Json) -> CodexThread? {
   guard value is Object(fields) && @jsonx.json_text(fields, "id") is Some(id) else {
     return None
   }
-  let turns : Array[CodexTurn] = []
-  if fields.get("turns") is Some(Array(values)) {
-    for value in values {
-      if CodexTurn::decode(value) is Some(turn) {
-        turns.push(turn)
-      }
-    }
+  let turns = match fields.get("turns") {
+    Some(Array(values)) => values.filter_map(CodexTurn::decode)
+    _ => []
   }
   let runtime = match CodexThreadRuntime::decode(fields.get("status")) {
     Some(runtime) => Some(runtime)
@@ -1418,18 +1392,10 @@ fn CodexThreadRow::title(fields : Map[String, Json]) -> String {
 /// final answer. The host's later `git.pull_request` request re-reads HEAD and
 /// replaces this label if the checkout moved since the thread was created.
 fn CodexThreadRow::branch(fields : Map[String, Json]) -> String? {
-  match fields.get("gitInfo") {
-    Some(Object(git)) =>
-      @jsonx.json_text(git, "branch").bind(branch => {
-        let branch = branch.trim().to_owned()
-        if branch.is_empty() {
-          None
-        } else {
-          Some(branch)
-        }
-      })
-    _ => None
-  }
+  guard fields.get("gitInfo") is Some(Object(git)) else { return None }
+  @jsonx.json_text(git, "branch")
+  .map(branch => branch.trim().to_owned())
+  .filter(branch => !branch.is_empty())
 }
 
 ///|
@@ -1557,12 +1523,7 @@ fn State::with_threads(
   guard value is Object(fields) && fields.get("data") is Some(Array(values)) else {
     return { ..self, notice: "Malformed Codex thread list", }
   }
-  let threads : Array[CodexThreadRow] = []
-  for value in values {
-    if CodexThreadRow::decode(value) is Some(thread) {
-      threads.push(thread)
-    }
-  }
+  let threads = values.filter_map(CodexThreadRow::decode)
   if archived {
     // The archived catalog is authoritative even when its notification was
     // missed while disconnected. Remove matching live rows in either reply
@@ -1597,13 +1558,10 @@ fn State::with_threads(
     // The list snapshot has no stamp for this thread; carry the one its
     // previous row held (the `thread/start` reply's), so the fresh thread
     // does not sink below stamped history until the next refresh.
-    let mut carried_ms : Double? = None
-    for existing in self.threads {
-      if existing.id == active.id {
-        carried_ms = existing.updated_at_ms
-        break
-      }
-    }
+    let carried_ms = self.threads
+      .iter()
+      .find_first(existing => existing.id == active.id)
+      .bind(existing => existing.updated_at_ms)
     let visible : Array[CodexThreadRow] = [
       {
         id: active.id,
@@ -1676,13 +1634,11 @@ fn State::with_requests(self : State, value : Json) -> State {
     // Preserve edits for a request already shown while replacing the list
     // with the actor's exact live ownership snapshot.
     let key = request_id.stringify()
-    let mut answers : Map[String, String] = Map([])
-    for existing in self.pending_requests {
-      if existing.request_id.stringify() == key {
-        answers = existing.answers
-        break
-      }
-    }
+    let answers = self.pending_requests
+      .iter()
+      .find_first(existing => existing.request_id.stringify() == key)
+      .map(existing => existing.answers)
+      .unwrap_or(Map([]))
     pending_requests.push({ ..decoded, answers, })
   }
   { ..self, pending_requests, request_generation: generation, }
@@ -1729,33 +1685,21 @@ fn State::with_thread_reply(
     runtime: active.runtime,
     updated_at_ms: reply_stamp_ms,
   }
-  let threads : Array[CodexThreadRow] = []
-  let mut replaced = false
-  for existing in self.threads {
+  let replaced = self.threads.iter().any(existing => existing.id == active.id)
+  let threads = self.threads.map(existing => {
     if existing.id == active.id {
       // A reply without a stamp must not erase the catalog's; keep the row
       // where the list already had it.
-      threads.push(
-        if reply_stamp_ms is Some(_) {
-          row
-        } else {
-          { ..row, updated_at_ms: existing.updated_at_ms, }
-        },
-      )
-      replaced = true
+      if reply_stamp_ms is Some(_) {
+        row
+      } else {
+        { ..row, updated_at_ms: existing.updated_at_ms, }
+      }
     } else {
-      threads.push(existing)
+      existing
     }
-  }
-  let visible = if replaced {
-    threads
-  } else {
-    let visible : Array[CodexThreadRow] = [row]
-    for thread in threads {
-      visible.push(thread)
-    }
-    visible
-  }
+  })
+  let visible = if replaced { threads } else { [row, ..threads] }
   let next = {
     ..self,
     threads: visible,
@@ -2014,12 +1958,10 @@ fn CodexTurn::is_running(self : CodexTurn) -> Bool {
 ///|
 fn State::active_turn_id(self : State) -> String? {
   guard self.active_thread() is Some(active) else { return None }
-  for index = active.turns.length() - 1; index >= 0; index = index - 1 {
-    if active.turns[index].status == "inProgress" {
-      return Some(active.turns[index].id)
-    }
-  }
-  None
+  active.turns
+  .rev_iter()
+  .find_first(turn => turn.is_running())
+  .map(turn => turn.id)
 }
 
 ///|
@@ -2091,12 +2033,9 @@ fn CodexThread::with_turn(self : CodexThread, turn : CodexTurn) -> CodexThread {
 /// the first submitted input. Item ids stay app-server-owned; the local
 /// preview needs only this semantic boundary and never tries to match text.
 fn CodexThread::has_user_item(self : CodexThread) -> Bool {
-  for turn in self.turns {
-    if turn.items.iter().any(item => item.kind == "userMessage") {
-      return true
-    }
-  }
-  false
+  self.turns
+  .iter()
+  .any(turn => turn.items.iter().any(item => item.kind == "userMessage"))
 }
 
 ///|
@@ -2131,17 +2070,12 @@ fn State::waiting_for_first_user_item(self : State) -> Bool {
 /// view holding only the agent message — replacing wholesale erased the
 /// user's own bubble from the transcript.
 fn CodexTurn::merged_onto(self : CodexTurn, existing : CodexTurn) -> CodexTurn {
-  let items : Array[CodexItem] = []
-  for item in existing.items {
-    let mut merged = item
-    for incoming in self.items {
-      if incoming.id == item.id {
-        merged = incoming
-        break
-      }
-    }
-    items.push(merged)
-  }
+  let items = existing.items.map(item => {
+    self.items
+    .iter()
+    .find_first(incoming => incoming.id == item.id)
+    .unwrap_or(item)
+  })
   for incoming in self.items {
     if !existing.items.iter().any(item => item.id == incoming.id) {
       items.push(incoming)
@@ -2510,20 +2444,16 @@ fn CodexItem::text(self : CodexItem) -> String {
       } else {
         match fields.get("summary") {
           Some(String(text)) => text
-          Some(Array(parts)) => {
-            let text : Array[String] = []
-            for part in parts {
+          Some(Array(parts)) =>
+            parts
+            .filter_map(part => {
               match part {
-                String(value) => text.push(value)
-                Object(fields) =>
-                  if @jsonx.json_text(fields, "text") is Some(value) {
-                    text.push(value)
-                  }
-                _ => ()
+                String(value) => Some(value)
+                Object(fields) => @jsonx.json_text(fields, "text")
+                _ => None
               }
-            }
-            text.join("\n")
-          }
+            })
+            .join("\n")
           _ => ""
         }
       }
@@ -2634,35 +2564,21 @@ fn CodexItem::tool_arguments(self : CodexItem) -> String? {
   guard self.value is Object(fields) else {
     return Some(self.value.stringify())
   }
-  match self.kind {
-    "commandExecution" => {
-      let arguments : Json = {
-        "command": @jsonx.json_text(fields, "command").unwrap_or(""),
-      }
-      Some(arguments.stringify())
-    }
+  let arguments : Json? = match self.kind {
+    "commandExecution" =>
+      Some({ "command": @jsonx.json_text(fields, "command").unwrap_or("") })
     "fileChange" =>
       match fields.get("changes") {
-        Some(changes) => {
-          let arguments : Json = { "changes": changes }
-          Some(arguments.stringify())
-        }
+        Some(changes) => Some({ "changes": changes })
         None => None
       }
-    "webSearch" => {
-      let arguments : Json = {
-        "query": @jsonx.json_text(fields, "query").unwrap_or(""),
-      }
-      Some(arguments.stringify())
-    }
-    "imageView" => {
-      let arguments : Json = {
-        "path": @jsonx.json_text(fields, "path").unwrap_or(""),
-      }
-      Some(arguments.stringify())
-    }
-    _ => Some(self.value.stringify())
+    "webSearch" =>
+      Some({ "query": @jsonx.json_text(fields, "query").unwrap_or("") })
+    "imageView" =>
+      Some({ "path": @jsonx.json_text(fields, "path").unwrap_or("") })
+    _ => Some(self.value)
   }
+  arguments.map(value => value.stringify())
 }
 
 ///|

--- a/desktop/frontend/codex/view.mbt
+++ b/desktop/frontend/codex/view.mbt
@@ -45,10 +45,10 @@ pub fn State::reasoning_effort_chip(
   }
   let selected = model.reasoning_effort(self.selected_effort)
   guard !selected.is_empty() else { return None }
-  let options : Array[@composer.ModelOption] = []
-  for option in model.reasoning_efforts {
-    options.push({ value: option.value, label: option.value, })
-  }
+  let options = model.reasoning_efforts.map(option => @composer.ModelOption::{
+    value: option.value,
+    label: option.value,
+  })
   let description = model.reasoning_efforts
     .iter()
     .find_first(option => option.value == selected)
@@ -174,16 +174,14 @@ pub fn State::project_conversations(
   // them even if a caller passes one.
   guard context.project_registered(root) else { return [] }
   let project = CodexProject(root)
-  let conversations : Array[CodexProjectRow] = []
-  for thread in self.threads {
-    if thread.project_key() == Some(project) {
-      conversations.push({
+  [
+    for thread in self.threads if thread.project_key() == Some(project) => {
+      CodexProjectRow::{
         input: thread.sidebar_input(self, context, true),
         updated_at_ms: thread.updated_at_ms,
-      })
+      }
     }
-  }
-  conversations
+  ]
 }
 
 ///|
@@ -295,17 +293,10 @@ fn CodexThreadRow::archived_sidebar_input(
 /// worktree could no longer be resolved. Keep those records together instead
 /// of promoting an opaque worktree directory into a project row.
 fn CodexThreadRow::project_key(self : CodexThreadRow) -> CodexProject? {
-  match self.project_root {
-    Some(root) => {
-      let project = root.trim().to_owned()
-      if project.is_empty() {
-        None
-      } else {
-        Some(CodexProject(project))
-      }
-    }
-    None => None
-  }
+  self.project_root
+  .map(root => root.trim().to_owned())
+  .filter(project => !project.is_empty())
+  .map(project => CodexProject(project))
 }
 
 ///|

--- a/desktop/frontend/component_transcript.mbt
+++ b/desktop/frontend/component_transcript.mbt
@@ -8,13 +8,10 @@
 fn Model::transcript_projects(
   self : Model,
 ) -> Array[@transcript_component.ProjectChoice] {
-  let choices : Array[@transcript_component.ProjectChoice] = []
-  if self.focused_device() is Some(dev) {
-    for root in dev.projects {
-      choices.push({ root, label: @resource.label(root), })
-    }
-  }
-  choices
+  guard self.focused_device() is Some(dev) else { return [] }
+  [
+    for root in dev.projects => { root, label: @resource.label(root), }
+  ]
 }
 
 ///|

--- a/desktop/frontend/composer/state.mbt
+++ b/desktop/frontend/composer/state.mbt
@@ -218,42 +218,28 @@ fn Input::completion(
     return None
   }
   match kind {
-    SlashCommands => {
-      let items = CompletionItem::slash_commands(self.slash_commands).filter(item => {
-        trigger.matches([item.label])
-      })
-      if items.is_empty() {
-        None
+    SlashCommands | SkillMentions => {
+      let items = if kind is SlashCommands {
+        CompletionItem::slash_commands(self.slash_commands).filter(item => {
+          trigger.matches([item.label])
+        })
       } else {
-        Some({
-          kind: SlashCommands,
-          menu: Menu(
-            items,
-            loading=false,
-            draft_without_token=trigger.draft_without_token(),
-          ),
+        self.installed_skills
+        .filter(skill => trigger.matches([skill.name, skill.description]))
+        .map(skill => CompletionItem::{
+          label: "$\{skill.name}",
+          detail: skill.description,
+          command: "",
+          insert: "\{skill.name} ",
+          path: None,
+          range: None,
         })
       }
-    }
-    SkillMentions => {
-      let items : Array[CompletionItem] = []
-      for skill in self.installed_skills {
-        if trigger.matches([skill.name, skill.description]) {
-          items.push({
-            label: "$\{skill.name}",
-            detail: skill.description,
-            command: "",
-            insert: "\{skill.name} ",
-            path: None,
-            range: None,
-          })
-        }
-      }
       if items.is_empty() {
         None
       } else {
         Some({
-          kind: SkillMentions,
+          kind,
           menu: Menu(
             items,
             loading=false,

--- a/desktop/frontend/console.mbt
+++ b/desktop/frontend/console.mbt
@@ -235,16 +235,12 @@ fn apply_roster(
   // Connect only the query-selected target when the roster reports it online.
   // A held target keeps its reconnect loop when the advisory `online` flag
   // drops; a page first opened while it is offline waits for a later refresh.
-  if console.page_device is Some(id) {
-    for meta in metas {
-      if meta.id == id && meta.online {
-        let channel : @interop.ChannelId = Remote(id)
-        if !devices.iter().any(dev => dev.channel == channel) {
-          websocket_epoch += 1
-          devices.push({ ..empty_device_state(channel), websocket_epoch, })
-        }
-        break
-      }
+  if console.page_device is Some(id) &&
+    metas.iter().any(meta => meta.id == id && meta.online) {
+    let channel : @interop.ChannelId = Remote(id)
+    if !devices.iter().any(dev => dev.channel == channel) {
+      websocket_epoch += 1
+      devices.push({ ..empty_device_state(channel), websocket_epoch, })
     }
   }
   // The browser's inert Local default is restored whenever its pinned target
@@ -274,14 +270,9 @@ fn apply_roster(
   }
   // The deferred boot half runs once the pinned device can take focus; if it
   // disappears and later returns, refocusing re-rotates onto that same device.
-  let mut booted = console.booted
-  if focus_held {
-    if !booted {
-      booted = true
-      commands.push(rotate_session(dispatch, focused))
-    } else if refocused {
-      commands.push(rotate_session(dispatch, focused))
-    }
+  let booted = console.booted || focus_held
+  if focus_held && (!console.booted || refocused) {
+    commands.push(rotate_session(dispatch, focused))
   }
   let reconciled = {
     ..model,

--- a/desktop/frontend/dock/state.mbt
+++ b/desktop/frontend/dock/state.mbt
@@ -74,13 +74,9 @@ pub fn State::empty() -> State {
 /// The strip's file paths, in strip order — the projection the root update
 /// hands to fileeditor's `Ctx` for its stat/watch/reload sweeps.
 pub fn file_paths(state : State) -> Array[@pathx.Relative] {
-  state.tabs.filter_map(tab => {
-    if tab is File(path~) {
-      Some(path)
-    } else {
-      None
-    }
-  })
+  [
+    for tab in state.tabs if tab is File(path~) => path
+  ]
 }
 
 ///|
@@ -94,13 +90,9 @@ pub fn active_file(state : State) -> @pathx.Relative? {
 
 ///|
 pub fn history_diffs(state : State) -> Array[GitHistoryDiff] {
-  state.tabs.filter_map(tab => {
-    if tab is GitDiff(diff~) {
-      Some(diff)
-    } else {
-      None
-    }
-  })
+  [
+    for tab in state.tabs if tab is GitDiff(diff~) => diff
+  ]
 }
 
 ///|

--- a/desktop/frontend/grep_search/view.mbt
+++ b/desktop/frontend/grep_search/view.mbt
@@ -222,51 +222,34 @@ fn mode_options(page : Page, emit : @cmd.Emit[Msg]) -> @html.Html {
 ///|
 fn pattern_repair_control(page : Page, emit : @cmd.Emit[Msg]) -> @html.Html {
   let requested = page.pattern_repair_phase is PatternRepairRequested
-  let completed = page.pattern_repair_phase is PatternRepairPreview
-  let failed = page.pattern_repair_phase is PatternRepairFailed
+  let settled = page.pattern_repair_phase
+    is (PatternRepairPreview | PatternRepairFailed)
+  let composing = page.pattern_repair_phase is PatternRepairComposer
+  let label = if requested {
+    "Pattern Repair in progress"
+  } else {
+    "Fix Pattern"
+  }
   @html.button(
-    class=if requested {
-      "search-option pressed pattern-repair-button"
-    } else if completed {
-      "search-option pressed pattern-repair-button"
-    } else if failed {
+    class=if requested || settled {
       "search-option pressed pattern-repair-button"
     } else {
       "search-option pattern-repair-button"
     },
-    title=if requested { "Pattern Repair in progress" } else { "Fix Pattern" },
+    title=label,
     attrs=@html.Attrs::build()
-      .aria_label(
-        if requested {
-          "Pattern Repair in progress"
-        } else {
-          "Fix Pattern"
-        },
-      )
-      .aria_pressed(
-        (requested ||
-        completed ||
-        failed ||
-        page.pattern_repair_phase is PatternRepairComposer).to_string(),
-      )
+      .aria_label(label)
+      .aria_pressed((requested || settled || composing).to_string())
       .on_click(_ => {
         if requested {
           @cmd.none
-        } else if page.pattern_repair_phase is PatternRepairComposer ||
-          completed ||
-          failed {
+        } else if composing || settled {
           emit(RejectPatternRepair)
         } else {
           emit(FixPattern)
         }
       }),
-    @icons.icon(
-      if requested {
-        @icons.icon_sparkle
-      } else {
-        @icons.icon_sparkle
-      },
-    ),
+    @icons.icon(@icons.icon_sparkle),
   )
 }
 

--- a/desktop/frontend/host_settings.mbt
+++ b/desktop/frontend/host_settings.mbt
@@ -166,33 +166,22 @@ fn legacy_settings_patch(
   // The host persists a one-shot fence with the first settings write.
   // Retrying this import after a lost reply therefore acknowledges and
   // clears localStorage without overwriting a newer host configuration.
-  let provider = provider.trim().to_owned()
-  let custom_url = custom_url.trim().to_owned()
-  let api_key = api_key.trim().to_owned()
-  let custom_api_key = custom_api_key.trim().to_owned()
+  fn carried(value : String) -> String? {
+    let value = value.trim().to_owned()
+    if value.is_empty() {
+      None
+    } else {
+      Some(value)
+    }
+  }
+
   {
-    provider: if provider.is_empty() {
-      None
-    } else {
-      Some(provider)
-    },
-    custom_api_url: if custom_url.is_empty() {
-      None
-    } else {
-      Some(custom_url)
-    },
-    deepseek_api_key: if api_key.is_empty() {
-      None
-    } else {
-      Some(api_key)
-    },
+    provider: carried(provider),
+    custom_api_url: carried(custom_url),
+    deepseek_api_key: carried(api_key),
     // No legacy page ever stored a GLM key; the import has nothing to carry.
     glm_api_key: None,
-    custom_api_key: if custom_api_key.is_empty() {
-      None
-    } else {
-      Some(custom_api_key)
-    },
+    custom_api_key: carried(custom_api_key),
     legacy_migration: Some(true),
     followup_behavior: None,
   }

--- a/desktop/frontend/interop/bridge_core.mbt
+++ b/desktop/frontend/interop/bridge_core.mbt
@@ -117,14 +117,7 @@ let ordered_request_lanes : Map[String, Lane] = Map([])
 
 ///|
 fn ordered_request_lane(lane : String) -> Lane {
-  match ordered_request_lanes.get(lane) {
-    Some(found) => found
-    None => {
-      let created = Lane::Lane()
-      ordered_request_lanes[lane] = created
-      created
-    }
-  }
+  ordered_request_lanes.get_or_init(lane, () => Lane::Lane())
 }
 
 ///|

--- a/desktop/frontend/preview/url.mbt
+++ b/desktop/frontend/preview/url.mbt
@@ -68,14 +68,10 @@ pub fn is_web_url(url : String) -> Bool {
 /// sharing a document differ only in the anchor a same-document jump
 /// scrolls to, which never reloads the page.
 fn document_of(url : String) -> String {
-  let buf = StringBuilder()
-  for ch in url {
-    if ch == '#' {
-      break
-    }
-    buf.write_char(ch)
+  match url.before("#") {
+    Some(document) => document.to_owned()
+    None => url
   }
-  buf.to_string()
 }
 
 ///|
@@ -154,10 +150,8 @@ pub fn normalize_url(input : String) -> String? {
   if trimmed.is_empty() {
     return None
   }
-  for ch in trimmed {
-    if ch == ' ' || ch == '\t' {
-      return None
-    }
+  if trimmed.contains_any(chars=" \t") {
+    return None
   }
   let lower = ascii_lower(trimmed)
   let candidate = if lower.has_prefix("http://") || lower.has_prefix("https://") {

--- a/desktop/frontend/project_picker/view.mbt
+++ b/desktop/frontend/project_picker/view.mbt
@@ -417,12 +417,9 @@ fn picker_breadcrumbs(emit : @cmd.Emit[Msg], picker : State) -> @html.Html {
     )
     return @html.div(class="picker-crumbs", crumbs)
   }
-  let segments : Array[String] = []
-  for part in path.split("/") {
-    if !part.is_empty() {
-      segments.push("\{part}")
-    }
-  }
+  let segments : Array[String] = [
+    for part in path.split("/") if !part.is_empty() => part.to_owned()
+  ]
   crumbs.push(
     @html.button(
       class=if segments.is_empty() {

--- a/desktop/frontend/quick_open/requests.mbt
+++ b/desktop/frontend/quick_open/requests.mbt
@@ -64,13 +64,9 @@ fn file_request(
         PopulateCache =>
           scheduler.add(emit(FileCacheLoaded(owner~, cache_key~, generation~)))
         QueryCache => {
-          let files = reply.files.filter_map(path => {
-            if path.is_empty() {
-              None
-            } else {
-              Some(@pathx.Relative(path))
-            }
-          })
+          let files = [
+            for path in reply.files if !path.is_empty() => @pathx.Relative(path)
+          ]
           scheduler.add(
             emit(
               FilesLoaded(

--- a/desktop/frontend/quick_open/state.mbt
+++ b/desktop/frontend/quick_open/state.mbt
@@ -532,12 +532,9 @@ fn with_file_candidates(
 /// provisional candidates after the query changes; the debounced Host request
 /// restores global top-K correctness.
 fn Open::result_files(self : Open) -> Array[@pathx.Relative] {
-  self.items.filter_map(item => {
-    match item {
-      FileRow(file) => Some(file.path)
-      SymbolRow(_) => None
-    }
-  })
+  [
+    for item in self.items if item is FileRow(file) => file.path
+  ]
 }
 
 ///|

--- a/desktop/frontend/quick_open/view.mbt
+++ b/desktop/frontend/quick_open/view.mbt
@@ -116,35 +116,14 @@ fn key_attrs(emit : @cmd.Emit[Msg], selected : Int?) -> @html.Attrs {
 
 ///|
 fn empty_view(open : Open) -> @html.Html {
-  let provider = open.provider()
-  let (class, message) = match open.phase {
-    Debouncing | Loading =>
-      (
-        "quick-open-empty",
-        if provider is Files {
-          "Indexing files…"
-        } else {
-          "Searching symbols…"
-        },
-      )
-    Failed =>
-      (
-        "quick-open-empty error",
-        if provider is Files {
-          "File search failed"
-        } else {
-          "Symbol search failed"
-        },
-      )
-    Ready =>
-      (
-        "quick-open-empty",
-        if provider is Files {
-          "No files found"
-        } else {
-          "No symbols found"
-        },
-      )
+  let (class, message) = match (open.phase, open.provider()) {
+    (Debouncing | Loading, Files) => ("quick-open-empty", "Indexing files…")
+    (Debouncing | Loading, Symbols) =>
+      ("quick-open-empty", "Searching symbols…")
+    (Failed, Files) => ("quick-open-empty error", "File search failed")
+    (Failed, Symbols) => ("quick-open-empty error", "Symbol search failed")
+    (Ready, Files) => ("quick-open-empty", "No files found")
+    (Ready, Symbols) => ("quick-open-empty", "No symbols found")
   }
   @html.div(
     class~,
@@ -164,27 +143,16 @@ fn State::view(self : State, emit : @cmd.Emit[Msg]) -> @html.Html {
 
 ///|
 fn dialog_view(emit : @cmd.Emit[Msg], open : Open) -> @html.Html {
-  let provider = open.provider()
-  let active_id = if open.current() is Some(_) {
-    row_id(open.selected)
-  } else {
-    ""
-  }
-  let dialog_label = if provider is Files {
-    "Search workspace files"
-  } else {
-    "Search workspace symbols"
-  }
-  let placeholder = if provider is Files {
-    "Search files"
-  } else {
-    "Search symbols"
-  }
-  let group_label = if provider is Files { "Files" } else { "Symbols" }
   let selected = if open.current() is Some(_) {
     Some(open.selected)
   } else {
     None
+  }
+  let active_id = selected.map(index => row_id(index)).unwrap_or("")
+  let (dialog_label, placeholder, group_label) = if open.provider() is Files {
+    ("Search workspace files", "Search files", "Files")
+  } else {
+    ("Search workspace symbols", "Search symbols", "Symbols")
   }
   let base_input_attrs = key_attrs(emit, selected)
     .id(InputId)
@@ -200,10 +168,9 @@ fn dialog_view(emit : @cmd.Emit[Msg], open : Open) -> @html.Html {
   } else {
     base_input_attrs.aria_activedescendant(active_id)
   }
-  let rows : Array[@html.Html] = []
-  for index, item in open.items {
-    let selected = index == open.selected
-    rows.push(
+  let rows : Array[@html.Html] = [
+    for index, item in open.items => {
+      let selected = index == open.selected
       @html.div(
         class=if selected {
           "quick-open-row selected"
@@ -230,9 +197,9 @@ fn dialog_view(emit : @cmd.Emit[Msg], open : Open) -> @html.Html {
             @html.div(class="quick-open-detail", item.detail()),
           ]),
         ],
-      ),
-    )
-  }
+      )
+    }
+  ]
   let list_children = if rows.is_empty() { [empty_view(open)] } else { rows }
   let list_busy = match open.phase {
     Debouncing | Loading => "true"

--- a/desktop/frontend/right_panel/view.mbt
+++ b/desktop/frontend/right_panel/view.mbt
@@ -46,30 +46,15 @@ fn panel_view(
           title: "Subagents this conversation delegated to",
           missing: false,
         }
-      FilePicker =>
-        match input.file_panel.explorer_mode {
+      FilePicker => {
+        let (label, title) = match input.file_panel.explorer_mode {
           ExplorerChanges =>
-            {
-              tab,
-              label: "Review Changes",
-              title: "Review changed files and diffs",
-              missing: false,
-            }
-          ExplorerSearch =>
-            {
-              tab,
-              label: "Search",
-              title: "Search across files",
-              missing: false,
-            }
-          ExplorerFiles =>
-            {
-              tab,
-              label: "Open File",
-              title: "Open a workspace file",
-              missing: false,
-            }
+            ("Review Changes", "Review changed files and diffs")
+          ExplorerSearch => ("Search", "Search across files")
+          ExplorerFiles => ("Open File", "Open a workspace file")
         }
+        { tab, label, title, missing: false, }
+      }
     }
   })
   let launcher : @dock.LauncherActions = {

--- a/desktop/frontend/session.mbt
+++ b/desktop/frontend/session.mbt
@@ -90,9 +90,5 @@ fn random_salt() -> String {
 
 ///|
 fn pad(value : Int, width : Int) -> String {
-  let mut text = value.to_string()
-  while text.length() < width {
-    text = "0\{text}"
-  }
-  text
+  value.to_string().pad_start(width, '0')
 }

--- a/desktop/frontend/sidebar/conversation/conversation.mbt
+++ b/desktop/frontend/sidebar/conversation/conversation.mbt
@@ -188,16 +188,11 @@ fn Input::menu_kind(self : Input) -> MenuKind? {
 
 ///|
 fn Input::menu_enabled(self : Input) -> (Bool, Bool) {
-  let mut archive = false
-  let mut delete = false
-  for action in self.trailing {
-    match action {
-      Archive(..) => archive = !(self.run_mark is RunningMark)
-      Delete(..) => delete = true
-      Restore(..) => ()
-    }
-  }
-  (archive, delete)
+  (
+    self.trailing.any(action => action is Archive(..)) &&
+    !(self.run_mark is RunningMark),
+    self.trailing.any(action => action is Delete(..)),
+  )
 }
 
 ///|

--- a/desktop/frontend/sidebar_resize.mbt
+++ b/desktop/frontend/sidebar_resize.mbt
@@ -107,24 +107,11 @@ fn on_sidebar_resize_move(event : @dom.Event) -> Unit {
 ///|
 /// Clamp the dragged width into the sidebar's allowed range.
 fn drag_width(raw : Double, ceiling~ : Double) -> Int {
-  let ceiling = if ceiling > MaxSidebarWidth.to_double() {
-    MaxSidebarWidth.to_double()
-  } else {
-    ceiling
-  }
-  let ceiling = if ceiling < MinSidebarWidth.to_double() {
-    MinSidebarWidth.to_double()
-  } else {
-    ceiling
-  }
-  let width = if raw < MinSidebarWidth.to_double() {
-    MinSidebarWidth.to_double()
-  } else if raw > ceiling {
-    ceiling
-  } else {
-    raw
-  }
-  width.to_int()
+  let ceiling = ceiling.clamp(
+    min=MinSidebarWidth.to_double(),
+    max=MaxSidebarWidth.to_double(),
+  )
+  raw.clamp(min=MinSidebarWidth.to_double(), max=ceiling).to_int()
 }
 
 ///|

--- a/desktop/frontend/skills/contract.mbt
+++ b/desktop/frontend/skills/contract.mbt
@@ -19,12 +19,7 @@ pub(all) struct Input {
 /// the local library — at that exact version; an older install keeps the
 /// Install button alive as the upgrade path.
 fn Input::has_installed(self : Input, source : String) -> Bool {
-  for skill in self.installed {
-    if skill.source == source {
-      return true
-    }
-  }
-  false
+  self.installed.any(skill => skill.source == source)
 }
 
 ///|

--- a/desktop/frontend/skills/document.mbt
+++ b/desktop/frontend/skills/document.mbt
@@ -39,13 +39,10 @@ fn parse_skill_document(source : String) -> SkillDocument {
 
 ///|
 fn find_frontmatter_close(lines : Array[String]) -> Int? {
-  for index, line in lines {
+  lines.search_by(line => {
     let marker = line.trim()
-    if marker == "---" || marker == "..." {
-      return Some(index)
-    }
-  }
-  None
+    marker == "---" || marker == "..."
+  })
 }
 
 ///|

--- a/desktop/frontend/skills/view.mbt
+++ b/desktop/frontend/skills/view.mbt
@@ -147,11 +147,10 @@ fn skill_document_view(source : String) -> @html.Html {
   let document = parse_skill_document(source)
   let nodes : Array[@html.Html] = []
   if !document.metadata.is_empty() {
-    let rows : Array[@html.Html] = []
-    for entry in document.metadata {
+    let rows = document.metadata.map(entry => {
       let (key, value) = entry
-      rows.push(@html.tr([@html.th(key), @html.td(value)]))
-    }
+      @html.tr([@html.th(key), @html.td(value)])
+    })
     nodes.push(
       @html.div(class="skill-metadata", [
         @html.div(class="skill-metadata-title", "Metadata"),
@@ -288,15 +287,7 @@ fn detail_action(
 /// (case-insensitive).
 fn matches(query : String, fields : Array[String]) -> Bool {
   let query = query.trim().to_owned().to_lower()
-  if query.is_empty() {
-    return true
-  }
-  for field in fields {
-    if field.to_lower().contains(query) {
-      return true
-    }
-  }
-  false
+  query.is_empty() || fields.any(field => field.to_lower().contains(query))
 }
 
 ///|

--- a/desktop/frontend/system_notification.mbt
+++ b/desktop/frontend/system_notification.mbt
@@ -101,17 +101,13 @@ fn show_system_notification(
 /// not opened. It is derived from replicated conversation state rather than
 /// incremented by events, so replay and reconnect converge to one value.
 fn Model::notification_badge_count(self : Model) -> Int {
-  let mut count = 0
-  for conv in self.conversations {
-    if conv.device is Local &&
-      (
-        conv.pending_approval is Some({ answered: false, .. }) ||
-        conv.unseen_finish
-      ) {
-      count += 1
-    }
-  }
-  count
+  self.conversations.count_if(conv => {
+    conv.device is Local &&
+    (
+      conv.pending_approval is Some({ answered: false, .. }) ||
+      conv.unseen_finish
+    )
+  })
 }
 
 ///|

--- a/desktop/frontend/terminal/host.mbt
+++ b/desktop/frontend/terminal/host.mbt
@@ -473,13 +473,7 @@ fn TermHost::clear_pending(
   channel : @interop.ChannelId,
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(_ => {
-    let retained : Map[String, (@interop.ChannelId, String)] = Map([])
-    for id, owner in term_host.owners {
-      if owner.0 != channel {
-        retained[id] = owner
-      }
-    }
-    term_host.owners = retained
+    term_host.owners.retain((_, owner) => owner.0 != channel)
     term_host.opening_channels = term_host.opening_channels.filter(existing => {
       existing != channel
     })
@@ -491,13 +485,7 @@ fn TermHost::clear_pending(
 /// Dispose a closed tab's emulator and remove its element.
 fn dispose_tab(key : String) -> @cmd.Cmd {
   @cmd.custom_cmd(_ => {
-    let retained : Map[String, (@interop.ChannelId, String)] = Map([])
-    for id, owner in term_host.owners {
-      if owner.1 != key {
-        retained[id] = owner
-      }
-    }
-    term_host.owners = retained
+    term_host.owners.retain((_, owner) => owner.1 != key)
     guard term_host.entries.get(key) is Some(entry) else { return }
     term_host.entries.remove(key)
     let _ : @js.Value = entry.term.apply_with_string("dispose", no_args())

--- a/desktop/frontend/terminal/state.mbt
+++ b/desktop/frontend/terminal/state.mbt
@@ -162,35 +162,22 @@ fn State::active_tab(self : State, ctx : Ctx) -> Tab? {
   guard !visible.is_empty() else { return None }
   guard workspace_key(ctx) is Some(group) else { return None }
   for entry in self.active {
-    if entry.0 == group {
-      for tab in visible {
-        if tab.key == entry.1 {
-          return Some(tab)
-        }
-      }
+    guard entry.0 == group else { continue }
+    if visible.iter().find_first(tab => tab.key == entry.1) is Some(tab) {
+      return Some(tab)
     }
   }
-  visible.get(visible.length() - 1)
+  visible.last()
 }
 
 ///|
 fn State::tab_by_key(self : State, key : String) -> Tab? {
-  for tab in self.tabs {
-    if tab.key == key {
-      return Some(tab)
-    }
-  }
-  None
+  self.tabs.iter().find_first(tab => tab.key == key)
 }
 
 ///|
 fn State::tab_by_id(self : State, id : String) -> Tab? {
-  for tab in self.tabs {
-    if tab.id is Some(tab_id) && tab_id == id {
-      return Some(tab)
-    }
-  }
-  None
+  self.tabs.iter().find_first(tab => tab.id is Some(tab_id) && tab_id == id)
 }
 
 ///|

--- a/desktop/frontend/terminal/view.mbt
+++ b/desktop/frontend/terminal/view.mbt
@@ -5,22 +5,17 @@
 
 ///|
 fn tab_view(dispatch : @cmd.Emit[Msg], tab : Tab, active : Bool) -> @html.Html {
-  let classes = StringBuilder()
-  classes.write_string("terminal-tab")
-  if active {
-    classes.write_string(" active")
-  }
   let title = match tab.status {
     TabOpening => "starting…"
     TabRunning => tab.workspace_label
     TabFailed(message~) => message
   }
-  let status : Array[@html.Html] = []
-  match tab.status {
-    TabFailed(..) => status.push(@html.span(class="terminal-tab-failed", "!"))
-    TabOpening | TabRunning => ()
+  let status : Array[@html.Html] = if tab.status is TabFailed(..) {
+    [@html.span(class="terminal-tab-failed", "!")]
+  } else {
+    []
   }
-  @html.div(class=classes.to_string(), [
+  @html.div(class=if active { "terminal-tab active" } else { "terminal-tab" }, [
     @html.button(
       class="terminal-tab-select",
       title~,

--- a/desktop/frontend/transcript/goal.mbt
+++ b/desktop/frontend/transcript/goal.mbt
@@ -50,18 +50,8 @@ pub fn apply_goal_marker(
   match marker {
     GoalSet(text) => Some({ text, blocked: None, })
     GoalCleared => None
-    GoalBlocked(reason) =>
-      if goal is Some(goal) {
-        Some({ ..goal, blocked: Some(reason), })
-      } else {
-        None
-      }
-    GoalUnblocked =>
-      if goal is Some(goal) {
-        Some({ ..goal, blocked: None, })
-      } else {
-        None
-      }
+    GoalBlocked(reason) => goal.map(goal => { ..goal, blocked: Some(reason), })
+    GoalUnblocked => goal.map(goal => { ..goal, blocked: None, })
   }
 }
 

--- a/desktop/frontend/transcript_overview/view.mbt
+++ b/desktop/frontend/transcript_overview/view.mbt
@@ -57,15 +57,9 @@ pub fn rail(
   // The hover's enter-time anchor replaces the tick position it can no
   // longer inherit.
   let children : Array[@html.Html] = [@html.div(class="overview-rail", ticks)]
-  if state.hover is Some(hover) {
-    for entry in entries {
-      if entry.key == hover.key {
-        children.push(
-          preview(entry, clock, flip=hover.flip, anchor=hover.anchor),
-        )
-        break
-      }
-    }
+  if state.hover is Some(hover) &&
+    entries.iter().find_first(entry => entry.key == hover.key) is Some(entry) {
+    children.push(preview(entry, clock, flip=hover.flip, anchor=hover.anchor))
   }
   @html.nav(
     class="transcript-overview",

--- a/desktop/frontend/transcript_rendering.mbt
+++ b/desktop/frontend/transcript_rendering.mbt
@@ -63,11 +63,9 @@ fn Conversation::reasoning_for_render(self : Conversation) -> (String?, Bool) {
   }
   let candidate = live.content.trim()
   if live.complete && !candidate.is_empty() {
-    let mut index = self.messages.length()
-    while index > 0 {
-      index -= 1
-      if self.messages[index].kind is Assistant(reasoning=Some(thought), ..) {
-        if self.messages[index].sequence is Some(sequence) &&
+    for message in self.messages.rev_iter() {
+      if message.kind is Assistant(reasoning=Some(thought), ..) {
+        if message.sequence is Some(sequence) &&
           sequence > self.turn.reasoning_frontier &&
           thought.trim() == candidate {
           return (None, live.complete)

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -1050,18 +1050,14 @@ fn api_settings_rows(
   // The key lives on the host and is never echoed back — the page only
   // knows one is saved; saving a new one overwrites it.
   {
-    let key_saved = match model.api_provider {
-      Deepseek => model.deepseek_key_saved
-      Glm => model.glm_key_saved
-      Custom => model.custom_key_saved
+    let (key_label, key_saved) = match model.api_provider {
+      Deepseek => ("DeepSeek API key", model.deepseek_key_saved)
+      Glm => ("GLM API key", model.glm_key_saved)
+      Custom => ("Custom API key", model.custom_key_saved)
     }
     rows.push(
       @settings.row(
-        match model.api_provider {
-          Deepseek => "DeepSeek API key"
-          Glm => "GLM API key"
-          Custom => "Custom API key"
-        },
+        key_label,
         [
           @html.input(
             input_type=@html.InputType::Password,
@@ -1528,13 +1524,9 @@ fn console_gate_view(
             )
           }
           RosterReady => {
-            let mut selected : DeviceMeta? = None
-            for meta in console.roster {
-              if meta.id == id {
-                selected = Some(meta)
-                break
-              }
-            }
+            let selected = console.roster
+              .iter()
+              .find_first(meta => meta.id == id)
             if selected is Some(meta) {
               if meta.online {
                 card.push(@html.h2("Connecting to \{meta.name}…"))

--- a/desktop/frontend/workflow/state.mbt
+++ b/desktop/frontend/workflow/state.mbt
@@ -347,13 +347,12 @@ pub fn Run::tokens(self : Run) -> Int {
 ///|
 /// Total cost across children that reported one; `None` when none did.
 pub fn Run::cost_usd(self : Run) -> Double? {
-  let mut total : Double? = None
-  for row in self.rows {
-    if row.cost_usd is Some(cost) {
-      total = Some(total.unwrap_or(0.0) + cost)
+  self.rows.fold(init=None, (total : Double?, row) => {
+    match row.cost_usd {
+      Some(cost) => Some(total.unwrap_or(0.0) + cost)
+      None => total
     }
-  }
-  total
+  })
 }
 
 ///|

--- a/desktop/frontend/workspace_settings.mbt
+++ b/desktop/frontend/workspace_settings.mbt
@@ -178,12 +178,7 @@ fn DeviceState::workspace_settings_row(
   self : DeviceState,
   project : @common.Uri,
 ) -> ProjectSettings? {
-  for row in self.workspace_settings {
-    if row.project == project {
-      return Some(row)
-    }
-  }
-  None
+  self.workspace_settings.iter().find_first(row => row.project == project)
 }
 
 ///|

--- a/desktop/frontend/worktrees.mbt
+++ b/desktop/frontend/worktrees.mbt
@@ -398,17 +398,9 @@ fn worktree_rows(
     guard !info.name.is_empty() else { continue }
     rows.push({
       name: info.name,
-      session: if info.session is Some(id) && !id.is_empty() {
-        Some(id)
-      } else {
-        None
-      },
+      session: info.session.filter(id => !id.is_empty()),
       path: @resource.of_path(channel, info.path),
-      codex_thread: if info.codex_thread is Some(id) && !id.is_empty() {
-        Some(id)
-      } else {
-        None
-      },
+      codex_thread: info.codex_thread.filter(id => !id.is_empty()),
       present: info.present,
     })
   }
@@ -549,12 +541,11 @@ fn DeviceState::worktree_generation(
   self : DeviceState,
   project : @common.Uri,
 ) -> Int {
-  for group in self.worktrees {
-    if group.project == project {
-      return group.generation
-    }
-  }
-  -1
+  self.worktrees
+  .iter()
+  .find_first(group => group.project == project)
+  .map(group => group.generation)
+  .unwrap_or(-1)
 }
 
 ///|

--- a/desktop/internal/api/api.mbt
+++ b/desktop/internal/api/api.mbt
@@ -1096,17 +1096,12 @@ async fn ApiState::codex_request(
     "codex.thread.start"
     | "codex.thread.resume"
     | "codex.thread.read"
-    | "codex.thread.list" => self.codex_projects.annotate(reply)
-    _ => reply
-  }
-  let reply = match desktop_method {
-    "codex.thread.start"
-    | "codex.thread.resume"
-    | "codex.thread.read"
-    | "codex.thread.list" =>
+    | "codex.thread.list" => {
+      let annotated = self.codex_projects.annotate(reply)
       CodexWorktreeCatalog(@worktree.list_codex_worktree_bindings()).annotate(
-        reply,
+        annotated,
       )
+    }
     _ => reply
   }
   // App-server is the Codex task's writer and therefore archives first. Only

--- a/desktop/internal/api/hub.mbt
+++ b/desktop/internal/api/hub.mbt
@@ -81,13 +81,9 @@ fn Hub::record_finished(
   self : Hub,
   payload : @protocol.FinishedPayload,
 ) -> Unit {
-  let mut session = ""
-  let mut submission_id : String? = None
-  if self.active_starts.get(payload.run_id) is Some(started) {
-    session = started.session
-    if started.submission_id is Some(value) {
-      submission_id = Some(value)
-    }
+  let (session, submission_id) = match self.active_starts.get(payload.run_id) {
+    Some(started) => (started.session, started.submission_id)
+    None => ("", None)
   }
   if self.settlements.get(payload.run_id) is Some(existing) {
     if existing.session.is_empty() && !session.is_empty() {

--- a/desktop/internal/codex/project_catalog.mbt
+++ b/desktop/internal/codex/project_catalog.mbt
@@ -63,11 +63,9 @@ async fn ProjectCatalog::resolve(
   ) catch {
     error if @async.is_being_cancelled() => raise error
     _ => {
-      let root = if @fs.exists(cwd) { Some(cwd) } else { None }
-      if root is Some(root) {
-        self.roots[cwd] = root
-      }
-      return root
+      guard @fs.exists(cwd) else { return None }
+      self.roots[cwd] = cwd
+      return Some(cwd)
     }
   }
   if code == 0 {
@@ -76,11 +74,9 @@ async fn ProjectCatalog::resolve(
       return Some(project)
     }
   }
-  let root = if @fs.exists(cwd) { Some(cwd) } else { None }
-  if root is Some(root) {
-    self.roots[cwd] = root
-  }
-  root
+  guard @fs.exists(cwd) else { return None }
+  self.roots[cwd] = cwd
+  Some(cwd)
 }
 
 ///|

--- a/desktop/internal/entropy/entropy.mbt
+++ b/desktop/internal/entropy/entropy.mbt
@@ -17,11 +17,7 @@ pub fn random_hex(byte_count : Int) -> String? {
   guard random_bytes(byte_count) is Some(bytes) else { return None }
   let builder = StringBuilder()
   for byte in bytes {
-    let value = byte.to_int()
-    if value < 16 {
-      builder <+ "0"
-    }
-    builder <+ "\{value.to_string(radix=16)}"
+    builder <+ "\{byte.to_int().to_string(radix=16).pad_start(2, '0')}"
   }
   Some(builder.to_string())
 }

--- a/desktop/internal/env/path.mbt
+++ b/desktop/internal/env/path.mbt
@@ -50,23 +50,16 @@ pub fn prepend_path_entry(
   env : Map[String, String],
   bin_dir : String,
 ) -> String {
-  let mut key = "PATH"
-  let mut current : String? = None
-  let duplicates : Array[String] = []
-  for name, value in env {
-    if name.to_upper() == "PATH" {
-      if current is None {
-        key = name
-        current = Some(value)
-      } else {
-        duplicates.push(name)
-      }
+  let spellings = [
+    for name in env.keys() if name.to_upper() == "PATH" => name
+  ]
+  for index, name in spellings {
+    if index > 0 {
+      env.remove(name)
     }
   }
-  for name in duplicates {
-    env.remove(name)
-  }
-  let joined = prepend_to_path_env(bin_dir, current)
+  let key = spellings.get(0).unwrap_or("PATH")
+  let joined = prepend_to_path_env(bin_dir, env.get(key))
   env[key] = joined
   joined
 }

--- a/desktop/internal/extension/browser_views.mbt
+++ b/desktop/internal/extension/browser_views.mbt
@@ -118,11 +118,7 @@ impl Show for BrowserViewError with fn output(self, logger) {
 /// app's own scheme. Schemes are case-insensitive (RFC 3986), and the
 /// frontend passes URLs as typed, so the check lowercases before matching.
 fn allowed_page_url(url : String) -> Bool {
-  let buf = StringBuilder()
-  for ch in url {
-    buf.write_char(ch.to_ascii_lowercase())
-  }
-  let lower = buf.to_string()
+  let lower = url.to_lower()
   if lower.strip_prefix("https://") is Some(rest) {
     !rest.is_empty()
   } else if lower.strip_prefix("http://") is Some(rest) {

--- a/desktop/internal/file_search_score/score.mbt
+++ b/desktop/internal/file_search_score/score.mbt
@@ -66,8 +66,7 @@ pub fn PathQuery::key(self : PathQuery) -> String {
 
 ///|
 fn path_label(path : String) -> String {
-  let segments : Array[StringView] = path.split("/").collect()
-  segments.last().map_or(path, label => label.to_owned())
+  path.rev_after("/").map_or(path, label => label.to_owned())
 }
 
 ///|
@@ -162,7 +161,7 @@ pub fn PathQuery::rank_paths(
     }
   }
   let ranked = best.to_array()
-  ranked.sort_by((left, right) => Compare::compare(left, right))
+  ranked.sort()
   ranked.map(entry => entry.path)
 }
 

--- a/desktop/internal/host/github_ops.mbt
+++ b/desktop/internal/host/github_ops.mbt
@@ -384,10 +384,7 @@ fn encode_url_path(path : String) -> String {
 ///|
 /// RFC 3986's unreserved set, plus the separator a branch path uses.
 fn is_url_path_plain(char : Char) -> Bool {
-  (char >= 'a' && char <= 'z') ||
-  (char >= 'A' && char <= 'Z') ||
-  (char >= '0' && char <= '9') ||
-  ['-', '.', '_', '~', '/'].contains(char)
+  char is ('a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '.' | '_' | '~' | '/')
 }
 
 ///|

--- a/desktop/internal/host/moon_cli_ops.mbt
+++ b/desktop/internal/host/moon_cli_ops.mbt
@@ -304,11 +304,7 @@ async fn lsp_open_op(
   for push in diagnostics_pushes(request_root.absolute, previous, current) {
     ignore(state.diagnostics.try_put(push) catch { _ => false })
   }
-  let paths : Array[@pathx.Absolute] = []
-  for path, _ in current {
-    paths.push(path)
-  }
-  state.published.set(root, paths)
+  state.published.set(root, current.keys().to_array())
   { diagnostics: Some(current.get(file).unwrap_or([])), }
 }
 
@@ -460,27 +456,17 @@ fn parse_ide_hover(output : String) -> LspHoverReply {
   } else {
     None
   }
-  match range {
-    Some((start_line, start_character, end_line, end_character)) =>
-      {
-        value,
-        markdown: true,
-        has_range: true,
-        start_line,
-        start_character,
-        end_line,
-        end_character,
-      }
-    None =>
-      {
-        value,
-        markdown: true,
-        has_range: false,
-        start_line: 0,
-        start_character: 0,
-        end_line: 0,
-        end_character: 0,
-      }
+  let (start_line, start_character, end_line, end_character) = range.unwrap_or(
+    (0, 0, 0, 0),
+  )
+  {
+    value,
+    markdown: true,
+    has_range: range is Some(_),
+    start_line,
+    start_character,
+    end_line,
+    end_character,
   }
 }
 

--- a/desktop/internal/remote/serve.mbt
+++ b/desktop/internal/remote/serve.mbt
@@ -399,14 +399,8 @@ async fn run_request(
   method_ : String,
   params : Json,
 ) -> Json {
-  let mut selected_endpoint = None
-  for endpoint in endpoints {
-    if endpoint.name() == method_ {
-      selected_endpoint = Some(endpoint)
-      break
-    }
-  }
-  guard selected_endpoint is Some(endpoint) else {
+  guard endpoints.iter().find_first(endpoint => endpoint.name() == method_)
+    is Some(endpoint) else {
     return error_envelope(id, CodeMethodNotFound, "unknown method '\{method_}'")
   }
   let result = endpoint.invoke_remote(params) catch {

--- a/desktop/internal/shellenv/shellenv.mbt
+++ b/desktop/internal/shellenv/shellenv.mbt
@@ -141,19 +141,19 @@ pub fn path_prepend_command(
     return None
   }
   if shell_name == "fish" {
-    let quoted_dirs : Array[String] = []
-    for bin_dir in bin_dirs {
-      let quoted = bin_dir
-        .replace_all(old="\\", new="\\\\")
-        .replace_all(old="'", new="\\'")
-      quoted_dirs.push("'\{quoted}'")
-    }
+    let quoted_dirs = [
+      for bin_dir in bin_dirs => {
+        let quoted = bin_dir
+          .replace_all(old="\\", new="\\\\")
+          .replace_all(old="'", new="\\'")
+        "'\{quoted}'"
+      }
+    ]
     return Some("set -gx PATH \{quoted_dirs.join(" ")} $PATH\r")
   }
-  let quoted_dirs : Array[String] = []
-  for bin_dir in bin_dirs {
-    quoted_dirs.push("'\{bin_dir.replace_all(old="'", new="'\\''")}'")
-  }
+  let quoted_dirs = [
+    for bin_dir in bin_dirs => "'\{bin_dir.replace_all(old="'", new="'\\''")}'"
+  ]
   if shell_name is ("csh" | "tcsh") {
     return Some("setenv PATH \{quoted_dirs.join(":")}:\"$PATH\"\r")
   }

--- a/desktop/internal/skillmarket/archive.mbt
+++ b/desktop/internal/skillmarket/archive.mbt
@@ -86,10 +86,8 @@ fn safe_archive_path(path : String) -> Bool {
     if segment.is_empty() || segment == "." || segment == ".." {
       return false
     }
-    for ch in segment {
-      if ch is ('\\' | ':' | '\u{0}') {
-        return false
-      }
+    if segment.iter().any(ch => ch is ('\\' | ':' | '\u{0}')) {
+      return false
     }
   }
   true

--- a/desktop/internal/skillmarket/library.mbt
+++ b/desktop/internal/skillmarket/library.mbt
@@ -52,12 +52,7 @@ fn valid_slug(name : String) -> Bool {
   if name.is_empty() || name.length() > 64 {
     return false
   }
-  for ch in name {
-    if !(ch is ('a'..='z' | '0'..='9' | '-')) {
-      return false
-    }
-  }
-  true
+  name.iter().all(ch => ch is ('a'..='z' | '0'..='9' | '-'))
 }
 
 ///|

--- a/desktop/internal/workflow/tail.mbt
+++ b/desktop/internal/workflow/tail.mbt
@@ -205,11 +205,7 @@ fn parse_journal(
   guard entry.get("outcome") is Some(Array([String(tag), Object(body)])) else {
     return None
   }
-  let attempt = match body.get("attempt") {
-    Some(Object(attempt)) => Some(attempt)
-    _ => None
-  }
-  guard attempt is Some(attempt) &&
+  guard body.get("attempt") is Some(Object(attempt)) &&
     attempt.get("attempt_id") is Some(String(child)) else {
     // A call that never launched (a refused or skipped one) has no child and
     // nothing for a per-subagent view to point at; the sidecar did not report


### PR DESCRIPTION
**This one is meant to be readable at a glance.** Every hunk is a LOCAL
rewrite: the replacement sits exactly where the old code sat. No helper is
added or removed, no code moves between functions, no signature changes, and
no test changes. If a hunk reads correctly on its own, it is correct.

The complete list of shapes used:

| before | after |
| --- | --- |
| `x == "a" \|\| x == "b"` | `x is ("a" \| "b")` |
| `match o { Some(v) => Some(f(v)); None => None }` | `o.map(f)` |
| `match o { Some(v) => v; None => d }` | `o.unwrap_or(d)` |
| `match r { Ok(v) => Ok(v); Err(e) => Err(g(e)) }` | `r.map_err(g)` |
| a push loop | `[for x in xs if p(x) => f(x)]` |
| a break-on-match scan | `find_first` / `any` / `all` / `contains` |
| a manual accumulator | `fold` / `count_if` |
| a get-then-insert | `Map::get_or_init` |
| a hand-rolled char loop | `to_lower` / `pad_start` / `replace_all` / `repeat` |
| a nested `if`/`match` ladder | one `match`, or `guard ... is Some(..)` |

Scope: `desktop/` — the frontend components and the internal host, engine and protocol packages.

### Verified on this branch alone

`moon fmt --check`, `moon check --target native --deny-warn`, `moon check
--target js --deny-warn`, and the full native and JS test suites — with no
other part of the sweep applied. No `.mbti` changed, so no package interface
moves.

---

Part of a project-wide simplification sweep, split into seven independent pull
requests. Every file appears in exactly one of them, so they can be reviewed and
merged in any order, and each was verified on its own branch with no other part
of the sweep applied.

| | PR | what it is |
| --- | --- | --- |
| 1 | `simplify/mechanical-root` | local rewrites, root module |
| 2 | `simplify/mechanical-desktop` | local rewrites, `desktop/` |
| 3 | `simplify/mechanical-editor` | local rewrites, `editor/` |
| 4 | `simplify/structural-root` | shared helpers, root module |
| 5 | `simplify/structural-desktop` | shared helpers, `desktop/` |
| 6 | `simplify/structural-editor` | shared helpers, `editor/` |
| 7 | `simplify/tests` | test fixtures and folds |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JiBNGzCsZpN6e5Y4p9pXdn
