### PR TITLE
refactor(editor): local stdlib and pattern rewrites

### DIFF
--- a/editor/base/common/lifecycle.mbt
+++ b/editor/base/common/lifecycle.mbt
@@ -62,9 +62,7 @@ pub fn[T] Emitter::event(
   self.listeners.push({ id, listener, active, })
   Disposable::from(() => {
     active.val = false
-    let retained = self.listeners.filter(cell => cell.id != id)
-    self.listeners.clear()
-    self.listeners.append(retained)
+    self.listeners.retain(cell => cell.id != id)
   })
 }
 
@@ -72,12 +70,7 @@ pub fn[T] Emitter::event(
 /// Whether any active listener is registered, `Emitter.hasListeners`
 /// (`event.ts`).
 pub fn[T] Emitter::has_listeners(self : Emitter[T]) -> Bool {
-  for cell in self.listeners {
-    if cell.active.val {
-      return true
-    }
-  }
-  false
+  self.listeners.any(cell => cell.active.val)
 }
 
 ///|

--- a/editor/base/common/uri.mbt
+++ b/editor/base/common/uri.mbt
@@ -707,16 +707,7 @@ fn uri_to_fs_path_impl(uri : Uri, keep_drive_letter_casing : Bool) -> String {
     // unc path: file://shares/c$/far/boo
     value = "//\{uri.authority}\{uri.path}"
   } else if char_code_at(uri.path, 0) == char_forward_slash &&
-    (
-      (
-        char_code_at(uri.path, 1) >= 'A'.to_int() &&
-        char_code_at(uri.path, 1) <= 'Z'.to_int()
-      ) ||
-      (
-        char_code_at(uri.path, 1) >= 'a'.to_int() &&
-        char_code_at(uri.path, 1) <= 'z'.to_int()
-      )
-    ) &&
+    is_windows_device_root(char_code_at(uri.path, 1)) &&
     char_code_at(uri.path, 2) == char_colon {
     if !keep_drive_letter_casing {
       // windows drive letter: file:///c:/far/boo

--- a/editor/internal/shell/widgets/file_tree/file_tree.mbt
+++ b/editor/internal/shell/widgets/file_tree/file_tree.mbt
@@ -78,20 +78,15 @@ fn FileTreeModel::update(
     DirectoryResolved(uri, result) =>
       self.with_directory_resolved(provider, emit, uri, result)
     ToggleDirectory(uri) =>
-      match self.root {
-        Some(root) =>
-          match root.toggle(uri) {
-            Some((root, effect)) => {
-              let model = { ..self, root: Some(root), }
-              match effect {
-                ToggleResolve(uri) =>
-                  (FileTree::resolve_directory(provider, emit, uri), model)
-                ToggleNone => (@rabbita.none, model)
-              }
-            }
-            None => (@rabbita.none, self)
-          }
-        None => (@rabbita.none, self)
+      if self.root is Some(root) && root.toggle(uri) is Some((toggled, effect)) {
+        let model = { ..self, root: Some(toggled), }
+        match effect {
+          ToggleResolve(uri) =>
+            (FileTree::resolve_directory(provider, emit, uri), model)
+          ToggleNone => (@rabbita.none, model)
+        }
+      } else {
+        (@rabbita.none, self)
       }
     OpenFile(uri) =>
       (@cmd.custom_cmd(_ => on_open(uri)), { ..self, selected: Some(uri), })
@@ -122,28 +117,22 @@ fn FileTreeModel::with_directory_resolved(
             self.selected
           },
         }
+      } else if self.root is Some(root) &&
+        root.with_resolved(uri, stat) is Some(resolved) {
+        { ..self, root: Some(resolved), }
       } else {
-        match self.root {
-          Some(root) =>
-            match root.with_resolved(uri, stat) {
-              Some(root) => { ..self, root: Some(root), }
-              None => self
-            }
-          None => self
-        }
+        self
       }
       model.continue_reveal(provider, emit)
     }
     WorkspaceResolveError(_) => {
       // The folder keeps rendering as an empty-with-error level; children
       // stay unresolved so the next expand retries the resolve.
-      let model = match self.root {
-        Some(root) =>
-          match root.with_resolve_failed(uri) {
-            Some(root) => { ..self, root: Some(root), pending_reveal: None, }
-            None => { ..self, pending_reveal: None, }
-          }
-        None => { ..self, pending_reveal: None, }
+      let model = if self.root is Some(root) &&
+        root.with_resolve_failed(uri) is Some(failed) {
+        { ..self, root: Some(failed), pending_reveal: None, }
+      } else {
+        { ..self, pending_reveal: None, }
       }
       (@rabbita.none, model)
     }
@@ -197,16 +186,14 @@ fn FileTreeModel::view(
   emit : @rabbita.Emit[FileTreeMsg],
 ) -> @html.Html {
   let children : Array[@html.Html] = []
-  match self.root {
-    Some(root) =>
-      for row in root.visible_rows() {
-        if row.node.kind == Directory {
-          children.push(row.folder_view(emit))
-        } else {
-          children.push(row.file_view(emit, self))
-        }
+  if self.root is Some(root) {
+    for row in root.visible_rows() {
+      if row.node.kind == Directory {
+        children.push(row.folder_view(emit))
+      } else {
+        children.push(row.file_view(emit, self))
       }
-    None => ()
+    }
   }
   @html.div(class="file-tree", children)
 }
@@ -273,9 +260,8 @@ fn TreeRow::file_view(
 
 ///|
 fn FileTree::indent_guides(depth : Int) -> @html.Html {
-  let guides : Array[@html.Html] = []
-  for _ in 0..<depth {
-    guides.push(@html.span(class="indent-guide", ""))
-  }
+  let guides : Array[@html.Html] = [
+    for _ in 0..<depth => @html.span(class="indent-guide", "")
+  ]
   @html.span(class="workspace-guides", guides)
 }

--- a/editor/internal/shell/workbench/app.mbt
+++ b/editor/internal/shell/workbench/app.mbt
@@ -867,27 +867,15 @@ fn active_document_error_update(
     workbench_services().remote_language.invalidate()
     clear_workbench_model()
   })
-  if error.code == FileNotFound {
-    (
-      @rabbita.batch([clear, dom_mounted_status_cmd("missing")]),
-      {
-        ..model,
-        status: "missing",
-        status_message: "Source file is missing.",
-        viewer_has_frame: false,
-      },
-    )
+  let (status, status_message) = if error.code == FileNotFound {
+    ("missing", "Source file is missing.")
   } else {
-    (
-      @rabbita.batch([clear, dom_mounted_status_cmd("error")]),
-      {
-        ..model,
-        status: "error",
-        status_message: error.message,
-        viewer_has_frame: false,
-      },
-    )
+    ("error", error.message)
   }
+  (
+    @rabbita.batch([clear, dom_mounted_status_cmd(status)]),
+    { ..model, status, status_message, viewer_has_frame: false, },
+  )
 }
 
 ///|

--- a/editor/internal/shell/workbench/language_client.mbt
+++ b/editor/internal/shell/workbench/language_client.mbt
@@ -67,19 +67,16 @@ fn RemoteLanguageFreshness::is_current(
   self : RemoteLanguageFreshness,
   stamp : RemoteDocumentStamp,
 ) -> Bool {
-  match self.current {
-    Some(registration) =>
-      registration.stamp.generation == stamp.generation &&
-      registration.stamp.model.same(stamp.model) &&
-      registration.stamp.model_identity == stamp.model_identity &&
-      registration.stamp.model_version == stamp.model_version &&
-      registration.stamp.content_version == stamp.content_version &&
-      registration.stamp.uri == stamp.uri &&
-      registration.stamp.revision == stamp.revision &&
-      stamp.generation == self.generation &&
-      stamp.matches_model(registration.stamp.model)
-    None => false
-  }
+  self.current is Some(registration) &&
+  registration.stamp.generation == stamp.generation &&
+  registration.stamp.model.same(stamp.model) &&
+  registration.stamp.model_identity == stamp.model_identity &&
+  registration.stamp.model_version == stamp.model_version &&
+  registration.stamp.content_version == stamp.content_version &&
+  registration.stamp.uri == stamp.uri &&
+  registration.stamp.revision == stamp.revision &&
+  stamp.generation == self.generation &&
+  stamp.matches_model(registration.stamp.model)
 }
 
 ///|
@@ -87,15 +84,9 @@ fn RemoteLanguageFreshness::capture_model(
   self : RemoteLanguageFreshness,
   model : @model.TextModel,
 ) -> RemoteDocumentStamp? {
-  match self.current {
-    Some(registration) =>
-      if registration.stamp.matches_model(model) {
-        Some(registration.stamp)
-      } else {
-        None
-      }
-    None => None
-  }
+  guard self.current is Some(registration) else { return None }
+  guard registration.stamp.matches_model(model) else { return None }
+  Some(registration.stamp)
 }
 
 ///|
@@ -103,12 +94,9 @@ fn RemoteLanguageFreshness::invalidate_generation(
   self : RemoteLanguageFreshness,
   generation : Int,
 ) -> Unit {
-  match self.current {
-    Some(registration) =>
-      if registration.stamp.generation == generation {
-        self.invalidate()
-      }
-    None => ()
+  if self.current is Some(registration) &&
+    registration.stamp.generation == generation {
+    self.invalidate()
   }
 }
 
@@ -117,13 +105,11 @@ fn RemoteLanguageFreshness::invalidate(self : RemoteLanguageFreshness) -> Unit {
   self.generation += 1
   guard self.current is Some(registration) else { return }
   self.current = None
-  match registration.content_subscription {
-    Some(subscription) => subscription.dispose()
-    None => ()
+  if registration.content_subscription is Some(subscription) {
+    subscription.dispose()
   }
-  match registration.dispose_subscription {
-    Some(subscription) => subscription.dispose()
-    None => ()
+  if registration.dispose_subscription is Some(subscription) {
+    subscription.dispose()
   }
   self.markers.remove_owner_resource("moon", registration.stamp.model.uri)
 }
@@ -169,19 +155,14 @@ fn RemoteLanguageFreshness::prepare_diagnostics(
   self : RemoteLanguageFreshness,
   payload : @remote_protocol.DiagnosticsPayload,
 ) -> RemoteDocumentStamp? {
-  match self.current {
-    Some(registration) => {
-      let stamp = registration.stamp
-      if stamp.uri == payload.uri.to_string() &&
-        stamp.revision == payload.revision &&
-        self.is_current(stamp) {
-        Some(stamp)
-      } else {
-        None
-      }
-    }
-    None => None
+  guard self.current is Some(registration) else { return None }
+  let stamp = registration.stamp
+  guard stamp.uri == payload.uri.to_string() &&
+    stamp.revision == payload.revision &&
+    self.is_current(stamp) else {
+    return None
   }
+  Some(stamp)
 }
 
 ///|

--- a/editor/internal/shell/workbench/tree_provider.mbt
+++ b/editor/internal/shell/workbench/tree_provider.mbt
@@ -106,33 +106,26 @@ async fn first_moonbit_file(
     return None
   }
   budget.val -= 1
-  match workspace_tree_provider.resolve(uri) {
-    WorkspaceResolved(stat) =>
-      match stat.children {
-        Some(children) => {
-          for child in children {
-            if child.kind == File {
-              if child.name.has_suffix(".mbt") {
-                return Some(child.uri)
-              }
-              if first_file.val is None {
-                first_file.val = Some(child.uri)
-              }
-            }
-          }
-          for child in children {
-            if child.kind == Directory {
-              match
-                first_moonbit_file(child.uri, budget, depth + 1, first_file) {
-                Some(found) => return Some(found)
-                None => ()
-              }
-            }
-          }
-          None
-        }
-        None => None
-      }
-    WorkspaceResolveError(_) => None
+  guard workspace_tree_provider.resolve(uri)
+    is WorkspaceResolved({ children: Some(children), .. }) else {
+    return None
   }
+  for child in children {
+    if child.kind == File {
+      if child.name.has_suffix(".mbt") {
+        return Some(child.uri)
+      }
+      if first_file.val is None {
+        first_file.val = Some(child.uri)
+      }
+    }
+  }
+  for child in children {
+    if child.kind == Directory &&
+      first_moonbit_file(child.uri, budget, depth + 1, first_file)
+      is Some(found) {
+      return Some(found)
+    }
+  }
+  None
 }

--- a/editor/internal/viewer/browser/config/char_width_reader.mbt
+++ b/editor/internal/viewer/browser/config/char_width_reader.mbt
@@ -68,11 +68,7 @@ fn read_char_widths(
     // Repeat the character 256 (2^8) times; a space measures as NBSP so
     // the test span doesn't collapse.
     let chr = if request.chr == " " { "\u{a0}" } else { request.chr }
-    let test_string = for _ in 0..<8; test_string = chr {
-      continue test_string + test_string
-    } nobreak {
-      test_string
-    }
+    let test_string = chr.repeat(256)
     test_element.append_child(document.create_text_node(test_string).as_node())
     parent.append_child(test_element.as_node())
     test_elements.push(test_element)

--- a/editor/internal/viewer/browser/config/font_measurements.mbt
+++ b/editor/internal/viewer/browser/config/font_measurements.mbt
@@ -89,28 +89,14 @@ fn FontMeasurementsImpl::remove_from_cache(
   id : String,
 ) -> Unit {
   self.cache.remove(id)
-  let retained : Array[String] = []
-  for key in self.cache_keys {
-    if key != id {
-      retained.push(key)
-    }
-  }
-  self.cache_keys.clear()
-  self.cache_keys.append(retained)
+  self.cache_keys.retain(key => key != id)
 }
 
 ///|
 fn FontMeasurementsImpl::cached_values(
   self : FontMeasurementsImpl,
 ) -> Array[@common_config.FontInfo] {
-  let result : Array[@common_config.FontInfo] = []
-  for id in self.cache_keys {
-    match self.cache.get(id) {
-      Some(value) => result.push(value)
-      None => ()
-    }
-  }
-  result
+  self.cache_keys.filter_map(id => self.cache.get(id))
 }
 
 ///|
@@ -217,16 +203,9 @@ fn FontMeasurementsImpl::actual_read_font_info(
   )
   let space = create_request(" ", Regular, all, Some(monospace))
   let digits = [
-    create_request("0", Regular, all, Some(monospace)),
-    create_request("1", Regular, all, Some(monospace)),
-    create_request("2", Regular, all, Some(monospace)),
-    create_request("3", Regular, all, Some(monospace)),
-    create_request("4", Regular, all, Some(monospace)),
-    create_request("5", Regular, all, Some(monospace)),
-    create_request("6", Regular, all, Some(monospace)),
-    create_request("7", Regular, all, Some(monospace)),
-    create_request("8", Regular, all, Some(monospace)),
-    create_request("9", Regular, all, Some(monospace)),
+    for digit in 0..<10 => {
+      create_request(digit.to_string(), Regular, all, Some(monospace))
+    }
   ]
   // monospace test: used for whitespace rendering.
   let rightwards_arrow = create_request("→", Regular, all, Some(monospace))

--- a/editor/internal/viewer/browser/controller/drag_scrolling.mbt
+++ b/editor/internal/viewer/browser/controller/drag_scrolling.mbt
@@ -108,12 +108,9 @@ fn DragScrolling::start(
 
 ///|
 fn DragScrolling::stop(self : DragScrolling) -> Unit {
-  match self.operation {
-    Some(operation) => {
-      operation.dispose()
-      self.operation = None
-    }
-    None => ()
+  if self.operation is Some(operation) {
+    operation.dispose()
+    self.operation = None
   }
 }
 
@@ -178,9 +175,8 @@ fn DragScrollingOperation::schedule(self : DragScrollingOperation) -> Unit {
 ///|
 fn DragScrollingOperation::dispose(self : DragScrollingOperation) -> Unit {
   self.disposed = true
-  match self.animation_frame_id {
-    Some(id) => @rdom.window().cancel_animation_frame(id)
-    None => ()
+  if self.animation_frame_id is Some(id) {
+    @rdom.window().cancel_animation_frame(id)
   }
   self.animation_frame_id = None
 }
@@ -325,21 +321,16 @@ fn DragScrollingOperation::execute(self : DragScrollingOperation) -> Unit {
       // First, try to find a position that matches the horizontal position
       // of the mouse
       let probed = self.probe_mouse_target(layout_info)
-      let mouse_target = if outside_position is Left {
-        @editor_browser.MouseTarget::create_outside_editor(
-          probed.mouse_column(),
-          Position(edge_line_number, probed.mouse_column()),
-          Left,
-          outside_distance,
-        )
-      } else {
-        @editor_browser.MouseTarget::create_outside_editor(
-          probed.mouse_column(),
-          Position(edge_line_number, probed.mouse_column()),
-          Right,
-          outside_distance,
-        )
-      }
+      let mouse_target = @editor_browser.MouseTarget::create_outside_editor(
+        probed.mouse_column(),
+        Position(edge_line_number, probed.mouse_column()),
+        if outside_position is Left {
+          Left
+        } else {
+          Right
+        },
+        outside_distance,
+      )
       (self.dispatch_mouse)(mouse_target, true, None)
       self.schedule()
     }

--- a/editor/internal/viewer/browser/controller/mouse_handler.mbt
+++ b/editor/internal/viewer/browser/controller/mouse_handler.mbt
@@ -193,22 +193,16 @@ pub fn MouseHandler::MouseHandler(
       // editor, we remove this listener
       if handler.mouse_leave_monitor is None {
         let recover = (event : @rdom.Event) => {
-          match event.to_mouse_event() {
-            Some(mouse) =>
-              if !mouse_event_target_within(
-                  mouse,
-                  handler.view_helper.view_dom_node,
-                ) {
-                // went outside the editor!
-                handler.on_mouse_leave(
-                  EditorDomMouseEvent(
-                    mouse,
-                    false,
-                    handler.view_helper.view_dom_node,
-                  ),
-                )
-              }
-            None => ()
+          if event.to_mouse_event() is Some(mouse) &&
+            !mouse_event_target_within(mouse, handler.view_helper.view_dom_node) {
+            // went outside the editor!
+            handler.on_mouse_leave(
+              EditorDomMouseEvent(
+                mouse,
+                false,
+                handler.view_helper.view_dom_node,
+              ),
+            )
           }
         }
         @rdom.document().add_event_listener("mousemove", recover)
@@ -273,18 +267,16 @@ pub fn MouseHandler::dispose(self : MouseHandler) -> Unit {
   self.disposed = true
   self.end_scrollable_drag()
   self.scrollbar_drag_monitor.dispose()
-  match self.touch_scroll_gesture {
-    Some(gesture) => gesture.dispose()
-    None => ()
+  if self.touch_scroll_gesture is Some(gesture) {
+    gesture.dispose()
   }
   self.touch_scroll_gesture = None
   for listener in self.listeners {
     listener.dispose()
   }
   self.listeners.clear()
-  match self.mouse_leave_monitor {
-    Some(monitor) => monitor.dispose()
-    None => ()
+  if self.mouse_leave_monitor is Some(monitor) {
+    monitor.dispose()
   }
   self.mouse_leave_monitor = None
   self.mouse_down_operation.dispose()
@@ -347,9 +339,8 @@ fn MouseHandler::on_mouse_leave(
   self : MouseHandler,
   e : @editor_browser.EditorDomMouseEvent,
 ) -> Unit {
-  match self.mouse_leave_monitor {
-    Some(monitor) => monitor.dispose()
-    None => ()
+  if self.mouse_leave_monitor is Some(monitor) {
+    monitor.dispose()
   }
   self.mouse_leave_monitor = None
   self.last_mouse_leave_time = @base_browser.wall_clock_now_ms()
@@ -621,21 +612,18 @@ fn MouseDownOperation::get_position_outside_editor(
     let outside_distance = editor_content.y - e.posy
     let scrolled_above = view_layout.get_current_scroll_top() - outside_distance
     let vertical_offset = scrolled_above.max(0.0)
-    match hit_test_get_zone_at_coord(view_model, vertical_offset) {
-      Some(view_zone_data) =>
-        match self.help_position_jump_over_view_zone(view_zone_data) {
-          Some(new_position) =>
-            return Some(
-              @editor_browser.MouseTarget::create_outside_editor(
-                mouse_column,
-                new_position,
-                Above,
-                outside_distance,
-              ),
-            )
-          None => ()
-        }
-      None => ()
+    if hit_test_get_zone_at_coord(view_model, vertical_offset)
+      is Some(view_zone_data) &&
+      self.help_position_jump_over_view_zone(view_zone_data)
+      is Some(new_position) {
+      return Some(
+        @editor_browser.MouseTarget::create_outside_editor(
+          mouse_column,
+          new_position,
+          Above,
+          outside_distance,
+        ),
+      )
     }
     let above_line_number = view_layout.line_at_vertical_offset(vertical_offset)
     return Some(
@@ -651,21 +639,18 @@ fn MouseDownOperation::get_position_outside_editor(
     let outside_distance = e.posy - editor_content.y - editor_content.height
     let vertical_offset = view_layout.get_current_scroll_top() +
       e.relative_pos().y
-    match hit_test_get_zone_at_coord(view_model, vertical_offset) {
-      Some(view_zone_data) =>
-        match self.help_position_jump_over_view_zone(view_zone_data) {
-          Some(new_position) =>
-            return Some(
-              @editor_browser.MouseTarget::create_outside_editor(
-                mouse_column,
-                new_position,
-                Below,
-                outside_distance,
-              ),
-            )
-          None => ()
-        }
-      None => ()
+    if hit_test_get_zone_at_coord(view_model, vertical_offset)
+      is Some(view_zone_data) &&
+      self.help_position_jump_over_view_zone(view_zone_data)
+      is Some(new_position) {
+      return Some(
+        @editor_browser.MouseTarget::create_outside_editor(
+          mouse_column,
+          new_position,
+          Below,
+          outside_distance,
+        ),
+      )
     }
     let below_line_number = view_layout.line_at_vertical_offset(vertical_offset)
     return Some(
@@ -722,9 +707,8 @@ fn MouseDownOperation::find_mouse_position(
   e : @editor_browser.EditorDomMouseEvent,
   test_event_target : Bool,
 ) -> @editor_browser.MouseTarget? {
-  match self.get_position_outside_editor(e) {
-    Some(position_outside_editor) => return Some(position_outside_editor)
-    None => ()
+  if self.get_position_outside_editor(e) is Some(position_outside_editor) {
+    return Some(position_outside_editor)
   }
   let t = self.mouse_target_factory.create_mouse_target(
     (self.view_helper.get_last_render_data)(),
@@ -738,18 +722,13 @@ fn MouseDownOperation::find_mouse_position(
     },
   )
   guard t.position() is Some(_) else { return None }
-  match t {
-    MouseTargetViewZone(type_~, element~, mouse_column~, detail~, ..) =>
-      match self.help_position_jump_over_view_zone(detail) {
-        Some(new_position) =>
-          return Some(
-            @editor_browser.MouseTarget::create_view_zone(
-              type_, element, mouse_column, new_position, detail,
-            ),
-          )
-        None => ()
-      }
-    _ => ()
+  if t is MouseTargetViewZone(type_~, element~, mouse_column~, detail~, ..) &&
+    self.help_position_jump_over_view_zone(detail) is Some(new_position) {
+    return Some(
+      @editor_browser.MouseTarget::create_view_zone(
+        type_, element, mouse_column, new_position, detail,
+      ),
+    )
   }
   Some(t)
 }

--- a/editor/internal/viewer/browser/controller/touch_scroll_gesture.mbt
+++ b/editor/internal/viewer/browser/controller/touch_scroll_gesture.mbt
@@ -68,12 +68,9 @@ fn TouchScrollGesture::TouchScrollGesture(
 
 ///|
 fn TouchScrollGesture::cancel_inertia(self : TouchScrollGesture) -> Unit {
-  match self.inertia_frame {
-    Some(frame) => {
-      self.inertia_frame = None
-      frame.dispose()
-    }
-    None => ()
+  if self.inertia_frame is Some(frame) {
+    self.inertia_frame = None
+    frame.dispose()
   }
 }
 
@@ -144,11 +141,8 @@ fn TouchScrollGesture::end_touch(
     return false
   }
   guard self.active_touches.get(identifier) is Some(data) else { return false }
-  guard data.rolling_page_x.last() is Some(final_x) else {
-    self.active_touches.remove(identifier)
-    return true
-  }
-  guard data.rolling_page_y.last() is Some(final_y) else {
+  guard (data.rolling_page_x.last(), data.rolling_page_y.last())
+    is (Some(final_x), Some(final_y)) else {
     self.active_touches.remove(identifier)
     return true
   }

--- a/editor/internal/viewer/browser/markdown/markdown_dom.mbt
+++ b/editor/internal/viewer/browser/markdown/markdown_dom.mbt
@@ -114,14 +114,8 @@ fn MarkdownDomLifetime::postprocess_images(
       continue
     }
     image.set_attribute("src", resolved)
-    match self.on_size_changed {
-      Some(on_size_changed) =>
-        self.listen(image, "load", _event => {
-          if self.active {
-            on_size_changed()
-          }
-        })
-      None => ()
+    if self.on_size_changed is Some(on_size_changed) {
+      self.listen(image, "load", _event => if self.active { on_size_changed() })
     }
   }
 }
@@ -269,14 +263,8 @@ fn MarkdownDomLifetime::dispose(self : MarkdownDomLifetime) -> Unit {
     let listener = self.listeners.remove(self.listeners.length() - 1)
     listener.dispose()
   }
-  match self.target_token {
-    Some(token) =>
-      clear_markdown_target_lifetime(
-        markdown_target_registry,
-        self.target,
-        token,
-      )
-    None => ()
+  if self.target_token is Some(token) {
+    clear_markdown_target_lifetime(markdown_target_registry, self.target, token)
   }
   self.target_token = None
 }
@@ -384,12 +372,7 @@ fn markdown_element_has_class(
     .replace_all(old="\n", new=" ")
     .replace_all(old="\r", new=" ")
     .replace_all(old="\f", new=" ")
-  for token in normalized.split(" ") {
-    if token == class_name {
-      return true
-    }
-  }
-  false
+  normalized.split(" ").any(token => token == class_name)
 }
 
 ///|

--- a/editor/internal/viewer/browser/markdown_document/markdown_document.mbt
+++ b/editor/internal/viewer/browser/markdown_document/markdown_document.mbt
@@ -167,45 +167,23 @@ pub fn MarkdownDocumentView::MarkdownDocumentView(
     if target.closest(".moonbit-viewer-markdown-toc-toggle") is Some(_) {
       let expanded = view.toc_nav.get_attribute("data-toc-expanded") ==
         Some("true")
-      view.toc_nav.set_attribute(
-        "data-toc-expanded",
-        if expanded {
-          "false"
-        } else {
-          "true"
-        },
-      )
-      view.toc_toggle.set_attribute(
-        "aria-expanded",
-        if expanded {
-          "false"
-        } else {
-          "true"
-        },
-      )
+      let next = if expanded { "false" } else { "true" }
+      view.toc_nav.set_attribute("data-toc-expanded", next)
+      view.toc_toggle.set_attribute("aria-expanded", next)
       return
     }
-    match target.closest("[data-toc-offset]") {
-      Some(row) =>
-        match row.get_attribute("data-toc-offset") {
-          Some(raw) =>
-            match markdown_parse_section_index(raw) {
-              Some(offset) => {
-                // Row activation is a completed navigation, so return the
-                // TOC to its compact state before reveal math runs. Otherwise
-                // the expanded overlay can cover the heading aligned to the
-                // viewport start edge.
-                @base_browser.focus_prevent_scroll(view.toc_toggle)
-                view.toc_nav.set_attribute("data-toc-expanded", "false")
-                view.toc_toggle.set_attribute("aria-expanded", "false")
-                (view.on_toc_navigate)(offset)
-                view.scroll_toc_entry_into_view(offset)
-              }
-              None => ()
-            }
-          None => ()
-        }
-      None => ()
+    if target.closest("[data-toc-offset]") is Some(row) &&
+      row.get_attribute("data-toc-offset") is Some(raw) &&
+      markdown_parse_section_index(raw) is Some(offset) {
+      // Row activation is a completed navigation, so return the
+      // TOC to its compact state before reveal math runs. Otherwise
+      // the expanded overlay can cover the heading aligned to the
+      // viewport start edge.
+      @base_browser.focus_prevent_scroll(view.toc_toggle)
+      view.toc_nav.set_attribute("data-toc-expanded", "false")
+      view.toc_toggle.set_attribute("aria-expanded", "false")
+      (view.on_toc_navigate)(offset)
+      view.scroll_toc_entry_into_view(offset)
     }
   })
   view.listen(viewport, "scroll", _event => if !view.disposed { on_scroll() })
@@ -772,39 +750,22 @@ pub fn MarkdownDocumentView::install_section_fold_controls(
             button
           }
         }
+        let (collapsed, expanded, label) = if control.collapsed {
+          ("true", "false", "Expand section")
+        } else {
+          ("false", "true", "Collapse section")
+        }
         button.set_attribute(
           "data-markdown-fold-section",
           control.section_index.to_string(),
         )
-        button.set_attribute(
-          "data-collapsed",
-          if control.collapsed {
-            "true"
-          } else {
-            "false"
-          },
-        )
-        button.set_attribute(
-          "aria-expanded",
-          if control.collapsed {
-            "false"
-          } else {
-            "true"
-          },
-        )
-        button.set_attribute(
-          "aria-label",
-          if control.collapsed {
-            "Expand section"
-          } else {
-            "Collapse section"
-          },
-        )
+        button.set_attribute("data-collapsed", collapsed)
+        button.set_attribute("aria-expanded", expanded)
+        button.set_attribute("aria-label", label)
       }
       None =>
-        match existing {
-          Some(button) => child.as_node().remove_child(button.as_node())
-          None => ()
+        if existing is Some(button) {
+          child.as_node().remove_child(button.as_node())
         }
     }
   }
@@ -969,12 +930,11 @@ fn MarkdownDocumentView::element_for_source_offset(
   for block in self.rendered.projection.code_blocks {
     if block.block_source_range.contains(source_offset) ||
       source_offset == block.block_source_range.end_exclusive {
-      match
-        self.article.query_selector(
+      if self.article.query_selector(
           "[data-markdown-code-block=\"\{block.block_index}\"]",
-        ) {
-        Some(element) => return Some(element)
-        None => ()
+        )
+        is Some(element) {
+        return Some(element)
       }
     }
   }

--- a/editor/internal/viewer/browser/view/content_widgets.mbt
+++ b/editor/internal/viewer/browser/view/content_widgets.mbt
@@ -70,10 +70,9 @@ pub fn ContentWidgetHandle::ContentWidgetHandle(
   allow_editor_overflow? : Bool = false,
   after_render? : (ContentWidgetPositionPreference?) -> Unit raise,
 ) -> ContentWidgetHandle {
-  let after_render_with_coordinate = match after_render {
-    Some(callback) => Some((position, _coordinate) => callback(position))
-    None => None
-  }
+  let after_render_with_coordinate = after_render.map(callback => {
+    (position, _coordinate) => callback(position)
+  })
   ContentWidgetHandle::with_render_callbacks(
     get_id,
     get_dom_node,
@@ -324,26 +323,14 @@ pub fn ContentWidgets::set_widget_position(
   actual : ContentWidgetHandle,
 ) -> Unit {
   let widget = self.widgets[(actual.get_id)()]
-  match (actual.get_position)() {
-    Some(position) => {
-      widget.affinity = position.position_affinity
-      widget.set_anchor_positions(
-        position.position,
-        position.secondary_position,
-        self.model_position_to_valid_view_position,
-      )
-      widget.preference = position.preference
-    }
-    None => {
-      widget.affinity = None
-      widget.set_anchor_positions(
-        None,
-        None,
-        self.model_position_to_valid_view_position,
-      )
-      widget.preference = None
-    }
-  }
+  let placement = (actual.get_position)()
+  widget.affinity = placement.bind(position => position.position_affinity)
+  widget.set_anchor_positions(
+    placement.bind(position => position.position),
+    placement.bind(position => position.secondary_position),
+    self.model_position_to_valid_view_position,
+  )
+  widget.preference = placement.bind(position => position.preference)
   let display = match widget.preference {
     Some(preferences) =>
       if !widget.use_display_none &&
@@ -399,11 +386,9 @@ fn ContentWidgets::update_anchors_view_positions(self : ContentWidgets) -> Unit 
 /// moment that id is visited. A reentrant callback can mutate the live map but
 /// cannot change the phase's key traversal.
 fn ContentWidgets::widget_ids_snapshot(self : ContentWidgets) -> Array[String] {
-  let widget_ids : Array[String] = []
-  for widget_id, _ in self.widgets {
-    widget_ids.push(widget_id)
-  }
-  widget_ids
+  [
+    for widget_id, _ in self.widgets => widget_id
+  ]
 }
 
 ///|
@@ -633,10 +618,9 @@ fn Widget::prepare_render_widget(
   }
   if self.cached_dom_node_offset_width == -1.0 ||
     self.cached_dom_node_offset_height == -1.0 {
-    let preferred_dimensions = match self.actual.before_render {
-      Some(before_render) => safe_invoke_before_render(before_render)
-      None => None
-    }
+    let preferred_dimensions = self.actual.before_render.bind(
+      safe_invoke_before_render,
+    )
     match preferred_dimensions {
       Some(dimensions) => {
         self.cached_dom_node_offset_width = dimensions.width
@@ -747,24 +731,14 @@ fn Widget::anchors_coordinates(
       height: (ctx.line_height_for_line)(position.line_number),
     })
   }
-  let primary = match primary_view {
-    Some(position) => coordinate(position)
-    None => None
-  }
+  let primary = primary_view.bind(coordinate)
   let secondary_view = match
     (self.secondary_anchor.view_position, primary_view) {
-    (Some(secondary), Some(primary)) =>
-      if secondary.line_number == primary.line_number {
-        Some(secondary)
-      } else {
-        None
-      }
+    (Some(secondary), Some(primary)) if secondary.line_number ==
+      primary.line_number => Some(secondary)
     _ => None
   }
-  let secondary = match secondary_view {
-    Some(position) => coordinate(position)
-    None => None
-  }
+  let secondary = secondary_view.bind(coordinate)
   (primary, secondary)
 }
 

--- a/editor/internal/viewer/browser/view/current_line_highlight.mbt
+++ b/editor/internal/viewer/browser/view/current_line_highlight.mbt
@@ -185,10 +185,7 @@ fn prepare_current_line_render(
   render_line_highlight_only_when_focus : Bool,
   width : Double,
 ) -> Array[String] {
-  let render_data : Array[String] = []
-  for _ in 0..<viewport.lines.length() {
-    render_data.push("")
-  }
+  let render_data = Array::make(viewport.lines.length(), "")
   // `_shouldRenderThis` (`:213-215`) → `_shouldRenderInContent` (`:191-197`).
   if !@view_layout.should_render_line_highlight_in_content(
       render_line_highlight, render_line_highlight_only_when_focus, editor_has_focus,

--- a/editor/internal/viewer/browser/view/current_line_margin_highlight.mbt
+++ b/editor/internal/viewer/browser/view/current_line_margin_highlight.mbt
@@ -38,10 +38,7 @@ fn prepare_current_line_margin_render(
   render_line_highlight_only_when_focus : Bool,
   width : Double,
 ) -> Array[String] {
-  let render_data : Array[String] = []
-  for _ in 0..<viewport.lines.length() {
-    render_data.push("")
-  }
+  let render_data = Array::make(viewport.lines.length(), "")
   guard cursor_view_line is Some(cursor_line) else { return render_data }
   let in_margin = @view_layout.should_render_line_highlight_in_margin(
     render_line_highlight, render_line_highlight_only_when_focus, editor_has_focus,

--- a/editor/internal/viewer/browser/view/rendering_context.mbt
+++ b/editor/internal/viewer/browser/view/rendering_context.mbt
@@ -172,14 +172,9 @@ fn RenderingContext::visible_range_for_position(
   self : RenderingContext,
   position : @base_common.Position,
 ) -> HorizontalPosition? {
-  match
-    self.view_lines.raw_visible_range_for_position(
-      position.line_number,
-      position.column,
-    ) {
-    Some(left) => Some(HorizontalPosition(left))
-    None => None
-  }
+  self.view_lines
+  .raw_visible_range_for_position(position.line_number, position.column)
+  .map(left => HorizontalPosition(left))
 }
 
 ///|
@@ -192,11 +187,9 @@ fn RenderingContext::lines_visible_ranges_for_range(
   range : @base_common.Range,
   include_new_lines : Bool,
 ) -> Array[LineVisibleRanges]? {
-  match
-    self.view_lines.raw_lines_visible_ranges_for_range(range, include_new_lines) {
-    Some(raw_lines) => Some(line_visible_ranges_from_raw(raw_lines))
-    None => None
-  }
+  self.view_lines
+  .raw_lines_visible_ranges_for_range(range, include_new_lines)
+  .map(line_visible_ranges_from_raw)
 }
 
 ///|
@@ -205,15 +198,16 @@ fn RenderingContext::lines_visible_ranges_for_range(
 fn line_visible_ranges_from_raw(
   raw_lines : Array[(Int, Array[(Int, Int)])],
 ) -> Array[LineVisibleRanges] {
-  let result : Array[LineVisibleRanges] = []
-  for raw in raw_lines {
-    let horizontal_ranges : Array[HorizontalRange] = []
-    for range in raw.1 {
-      horizontal_ranges.push({ left: range.0, width: range.1, })
+  [
+    for raw in raw_lines => {
+      LineVisibleRanges(
+        raw.0,
+        [
+          for range in raw.1 => { left: range.0, width: range.1, }
+        ],
+      )
     }
-    result.push(LineVisibleRanges(raw.0, horizontal_ranges))
-  }
-  result
+  ]
 }
 
 ///|
@@ -227,10 +221,9 @@ fn RenderingContext::content_widgets_render_context(
     vertical_offset_for_line: line => self.vertical_offset_for_line(line),
     line_height_for_line: line => self.line_height_for_line(line),
     visible_range_for_position: position => {
-      match self.visible_range_for_position(position) {
-        Some(horizontal) => Some(horizontal.left.to_double())
-        None => None
-      }
+      self
+      .visible_range_for_position(position)
+      .map(horizontal => horizontal.left.to_double())
     },
     typical_fullwidth_character_width: self.input.typical_fullwidth_character_width,
     scroll_top: self.position.scroll_top,

--- a/editor/internal/viewer/browser/view/selection_measure.mbt
+++ b/editor/internal/viewer/browser/view/selection_measure.mbt
@@ -17,13 +17,9 @@ pub fn View::offset_for_column(
   view_line_number : Int,
   view_column : Int,
 ) -> Double {
-  match
-    self.view_lines.raw_visible_range_for_position(
-      view_line_number, view_column,
-    ) {
-    Some(left) => left
-    None => -1.0
-  }
+  self.view_lines
+  .raw_visible_range_for_position(view_line_number, view_column)
+  .unwrap_or(-1.0)
 }
 
 ///|
@@ -76,11 +72,7 @@ pub fn View::visible_range_for_position(
   view_line_number : Int,
   view_column : Int,
 ) -> HorizontalPosition? {
-  match
-    self.view_lines.raw_visible_range_for_position(
-      view_line_number, view_column,
-    ) {
-    Some(left) => Some(HorizontalPosition(left))
-    None => None
-  }
+  self.view_lines
+  .raw_visible_range_for_position(view_line_number, view_column)
+  .map(left => HorizontalPosition(left))
 }

--- a/editor/internal/viewer/browser/view/selections.mbt
+++ b/editor/internal/viewer/browser/view/selections.mbt
@@ -71,10 +71,7 @@ fn prepare_selections_render_from_visible_ranges(
 ) -> Array[String] {
   let lines : Array[LineSelectionRanges] = []
   for visible_line in visible_ranges {
-    let ranges : Array[StyledRange] = []
-    for range in visible_line.1 {
-      ranges.push(new_styled_range(range.0, range.1))
-    }
+    let ranges = visible_line.1.map(range => new_styled_range(range.0, range.1))
     if !ranges.is_empty() {
       lines.push({ line_number: visible_line.0, ranges, })
     }
@@ -105,23 +102,14 @@ fn render_selection_lines(
     rest_of_selection[line_index] += selection_html
   }
   // `output.map(([innerCorners, rest]) => innerCorners + rest)`.
-  let result : Array[String] = []
-  for index in 0..<rest_of_selection.length() {
-    result.push(inner_corners[index] + rest_of_selection[index])
-  }
-  result
+  rest_of_selection.mapi((index, rest) => inner_corners[index] + rest)
 }
 
 ///|
 /// Whether any line carries more than one range, in which case Monaco skips
 /// corner enrichment (the staircase math assumes one range per line).
 fn visible_ranges_have_gaps(lines : Array[LineSelectionRanges]) -> Bool {
-  for line in lines {
-    if line.ranges.length() > 1 {
-      return true
-    }
-  }
-  false
+  lines.any(line => line.ranges.length() > 1)
 }
 
 ///|

--- a/editor/internal/viewer/browser/view/view.mbt
+++ b/editor/internal/viewer/browser/view/view.mbt
@@ -392,11 +392,5 @@ pub fn View::render(
 
 ///|
 fn View::get_view_parts_to_render(self : View) -> Array[ViewPartHandle] {
-  let parts : Array[ViewPartHandle] = []
-  for part in self.view_parts {
-    if part.should_render() {
-      parts.push(part)
-    }
-  }
-  parts
+  self.view_parts.filter(part => part.should_render())
 }

--- a/editor/internal/viewer/browser/view/view_line.mbt
+++ b/editor/internal/viewer/browser/view/view_line.mbt
@@ -131,10 +131,9 @@ fn ViewLine::on_selection_changed(self : ViewLine) -> Bool {
 
 ///|
 fn ViewLine::get_dom_node(self : ViewLine) -> @rdom.Element? {
-  match self.rendered_view_line {
-    Some(rendered) => rendered.dom_node.map(node => node.element())
-    None => None
-  }
+  self.rendered_view_line.bind(rendered => {
+    rendered.dom_node.map(node => node.element())
+  })
 }
 
 ///|
@@ -158,17 +157,10 @@ fn ViewLine::layout_line(
   delta_top : Double,
   line_height : Int,
 ) -> Unit {
-  match self.rendered_view_line {
-    Some(rendered) =>
-      match rendered.dom_node {
-        Some(node) => {
-          node.set_top(Pixels(delta_top))
-          node.set_height(Pixels(line_height.to_double()))
-          node.set_line_height(Pixels(line_height.to_double()))
-        }
-        None => ()
-      }
-    None => ()
+  if self.rendered_view_line is Some({ dom_node: Some(node), .. }) {
+    node.set_top(Pixels(delta_top))
+    node.set_height(Pixels(line_height.to_double()))
+    node.set_line_height(Pixels(line_height.to_double()))
   }
 }
 
@@ -205,10 +197,9 @@ fn ViewLine::render_line(
   }
   builder <+
     $|px;" class="\{@viewer_common.render_line_class()}" data-line="\{line_number}">\{output.html}</div>
-  let prior_dom_node = match self.rendered_view_line {
-    Some(rendered) => rendered.dom_node
-    None => None
-  }
+  let prior_dom_node = self.rendered_view_line.bind(rendered => {
+    rendered.dom_node
+  })
   self.rendered_view_line = Some(
     create_rendered_line(
       prior_dom_node,

--- a/editor/internal/viewer/browser/view/view_overlays.mbt
+++ b/editor/internal/viewer/browser/view/view_overlays.mbt
@@ -54,22 +54,16 @@ fn DynamicViewOverlayHandle::render(
   start_line_number : Int,
   line_number : Int,
 ) -> String {
-  match self {
-    CurrentLine(overlay) =>
-      render_result_slice(overlay.render_result, start_line_number, line_number)
-    Selections(overlay) =>
-      render_result_slice(overlay.render_result, start_line_number, line_number)
-    Decorations(overlay) =>
-      render_result_slice(overlay.render_result, start_line_number, line_number)
-    CurrentLineMargin(overlay) =>
-      render_result_slice(overlay.render_result, start_line_number, line_number)
-    MarginDecorations(overlay) =>
-      render_result_slice(overlay.render_result, start_line_number, line_number)
-    LinesDecorations(overlay) =>
-      render_result_slice(overlay.render_result, start_line_number, line_number)
-    LineNumbers(overlay) =>
-      render_result_slice(overlay.render_result, start_line_number, line_number)
+  let render_result = match self {
+    CurrentLine(overlay) => overlay.render_result
+    Selections(overlay) => overlay.render_result
+    Decorations(overlay) => overlay.render_result
+    CurrentLineMargin(overlay) => overlay.render_result
+    MarginDecorations(overlay) => overlay.render_result
+    LinesDecorations(overlay) => overlay.render_result
+    LineNumbers(overlay) => overlay.render_result
   }
+  render_result_slice(render_result, start_line_number, line_number)
 }
 
 ///|

--- a/editor/internal/viewer/browser/view/view_overlays_lifecycle.mbt
+++ b/editor/internal/viewer/browser/view/view_overlays_lifecycle.mbt
@@ -167,15 +167,11 @@ fn prepare_line_numbers_overlay(
   // line-decorations lane.
   let line_numbers_width = context.gutter_width -
     context.input.line_decorations_width
-  let active_model_line_number = match context.input.view_selection {
-    Some(selection) =>
-      Some(
-        context.input.view_model
-        .coordinates_converter()
-        .view_position_to_model_position(selection.get_position()).line_number,
-      )
-    None => None
-  }
+  let active_model_line_number = context.input.view_selection.map(selection => {
+    context.input.view_model
+    .coordinates_converter()
+    .view_position_to_model_position(selection.get_position()).line_number
+  })
   self.render_result = prepare_line_numbers_render(
     context.viewport,
     Some(context.input.view_model),
@@ -361,20 +357,14 @@ fn prepare_selections_overlay(
 ) -> Unit {
   let self = part
   let visible_ranges : Array[(Int, Array[(Double, Double)])] = []
-  match context.input.selection_view_range {
-    Some(selection) =>
-      match context.lines_visible_ranges_for_range(selection, true) {
-        Some(lines) =>
-          for line in lines {
-            let ranges : Array[(Double, Double)] = []
-            for range in line.ranges {
-              ranges.push((range.left.to_double(), range.width.to_double()))
-            }
-            visible_ranges.push((line.line_number, ranges))
-          }
-        None => ()
-      }
-    None => ()
+  if context.input.selection_view_range is Some(selection) &&
+    context.lines_visible_ranges_for_range(selection, true) is Some(lines) {
+    for line in lines {
+      let ranges = line.ranges.map(range => {
+        (range.left.to_double(), range.width.to_double())
+      })
+      visible_ranges.push((line.line_number, ranges))
+    }
   }
   self.render_result = prepare_selections_render_from_visible_ranges(
     context.viewport,

--- a/editor/internal/viewer/browser/view/view_widgets_cursors_lifecycle.mbt
+++ b/editor/internal/viewer/browser/view/view_widgets_cursors_lifecycle.mbt
@@ -97,18 +97,11 @@ fn view_cursors_on_view_event(part : ViewCursors, event : ViewEvent) -> Bool {
     ViewDecorationsChanged => true
     ViewConfigurationChanged(_) => true
     ViewTokensChanged(e) =>
-      match self.last_position {
-        None => false
-        Some(position) => {
-          for range in e.ranges {
-            if position.line_number >= range.from_line_number &&
-              position.line_number <= range.to_line_number {
-              return true
-            }
-          }
-          false
-        }
-      }
+      self.last_position is Some(position) &&
+      e.ranges.any(range => {
+        position.line_number >= range.from_line_number &&
+        position.line_number <= range.to_line_number
+      })
     ViewZonesChanged => true
     ViewFocusChanged(e) => {
       // Source `onFocusChanged`: update cursor visibility immediately, but do

--- a/editor/internal/viewer/code_editor_widget/agent_feedback_host.mbt
+++ b/editor/internal/viewer/code_editor_widget/agent_feedback_host.mbt
@@ -117,10 +117,8 @@ fn CodeEditorWidget::is_current_resource(
   self : CodeEditorWidget,
   resource : @base_common.Uri,
 ) -> Bool {
-  match self.get_model() {
-    Some(model) => model.uri.to_string() == resource.to_string()
-    None => false
-  }
+  self.get_model() is Some(model) &&
+  model.uri.to_string() == resource.to_string()
 }
 
 ///|
@@ -146,10 +144,7 @@ fn CodeEditorWidget::agent_feedback_input_contribution(
 fn CodeEditorWidget::agent_feedback_input_visible(
   self : CodeEditorWidget,
 ) -> Bool {
-  match self.agent_feedback_input_contribution() {
-    Some(ic) => ic.visible
-    None => false
-  }
+  self.agent_feedback_input_contribution() is Some(ic) && ic.visible
 }
 
 ///|
@@ -157,10 +152,8 @@ fn CodeEditorWidget::agent_feedback_input_visible(
 /// the `_getSessionForFile` stand-in.
 fn CodeEditorWidget::agent_feedback_enabled(self : CodeEditorWidget) -> Bool {
   guard self.is_code_presentation() else { return false }
-  match self.get_model() {
-    Some(model) => self.services.agent_feedback.is_feedback_enabled(model.uri)
-    None => false
-  }
+  self.get_model() is Some(model) &&
+  self.services.agent_feedback.is_feedback_enabled(model.uri)
 }
 
 ///|
@@ -522,10 +515,7 @@ fn CodeEditorWidget::ensure_agent_feedback_input(
   self : CodeEditorWidget,
 ) -> @agent_feedback_browser.AgentFeedbackInputWidget {
   let ic = self.agent_feedback_input_contribution()
-  let existing = match ic {
-    Some(ic) => ic.widget
-    None => None
-  }
+  let existing = ic.bind(contribution => contribution.widget)
   match existing {
     Some(widget) => widget
     None => {

--- a/editor/internal/viewer/code_editor_widget/content_hover_widget_host.mbt
+++ b/editor/internal/viewer/code_editor_widget/content_hover_widget_host.mbt
@@ -15,10 +15,9 @@ fn CodeEditorWidget::sync_content_hover_widget(self : CodeEditorWidget) -> Unit 
   guard self.content_hover_contribution() is Some(state) else { return }
   let hc = state.controller
   let loading_message = if hc.hover.operation.shows_loading_message() {
-    match hc.hover.anchor {
-      Some(anchor) => self.make_hover_computer().create_loading_message(anchor)
-      None => None
-    }
+    hc.hover.anchor.bind(anchor => {
+      self.make_hover_computer().create_loading_message(anchor)
+    })
   } else {
     None
   }
@@ -86,13 +85,10 @@ fn CodeEditorWidget::rendered_content_hover(
   self : CodeEditorWidget,
   view : @hover.HoverWidgetView,
 ) -> @hover_browser.RenderedContentHover {
-  let placement_parts : Array[@hover.HoverPositionPart] = []
-  for part in view.parts {
-    placement_parts.push({
-      range: @hover.hover_part_range(part),
-      force_show_at_range: false,
-    })
-  }
+  let placement_parts : Array[@hover.HoverPositionPart] = view.parts.map(part => {
+    range: @hover.hover_part_range(part),
+    force_show_at_range: false,
+  })
   // `startColumnBoundary` (`contentHoverRendered.ts:127-133`): the anchor view
   // line's minimum column, converted back to model space — under wrapping this
   // is the wrapped row's first model column.

--- a/editor/internal/viewer/code_editor_widget/context_menu_contribution.mbt
+++ b/editor/internal/viewer/code_editor_widget/context_menu_contribution.mbt
@@ -145,31 +145,24 @@ fn CodeEditorWidget::on_editor_context_menu(
   event.event.prevent_default()
   event.event.stop_propagation()
   self.focus()
-  match event.target.position() {
-    Some(position) => {
-      let mut inside_selection = false
-      match self.get_selections() {
-        Some(selections) =>
-          for selection in selections {
-            let start = selection.start()
-            let end = selection.end()
-            if @base_common.Range(
-                start.line_number,
-                start.column,
-                end.line_number,
-                end.column,
-              ).contains_position(position) {
-              inside_selection = true
-              break
-            }
-          }
-        None => ()
-      }
-      if !inside_selection {
-        self.set_position(position, source="contextmenu")
-      }
+  if event.target.position() is Some(position) {
+    let inside_selection = match self.get_selections() {
+      Some(selections) =>
+        selections.any(selection => {
+          let start = selection.start()
+          let end = selection.end()
+          @base_common.Range(
+            start.line_number,
+            start.column,
+            end.line_number,
+            end.column,
+          ).contains_position(position)
+        })
+      None => false
     }
-    None => ()
+    if !inside_selection {
+      self.set_position(position, source="contextmenu")
+    }
   }
   let client = event.event.pos.to_client_coordinates()
   self.show_context_menu_at(client.client_x, client.client_y) |> ignore

--- a/editor/internal/viewer/code_editor_widget/controller_host.mbt
+++ b/editor/internal/viewer/code_editor_widget/controller_host.mbt
@@ -59,20 +59,13 @@ fn CodeEditorWidget::pointer_handler_helper(
     overflow_guard: view.overflow_guard,
     editor_scrollable: view.editor_scrollbar.scrollable(),
     hover_scrollable: () => {
-      match self.content_hover_contribution() {
-        Some(state) =>
-          match state.widget {
-            Some(widget) => Some(widget.scrollable)
-            None => None
-          }
-        None => None
-      }
+      self
+      .content_hover_contribution()
+      .bind(state => state.widget)
+      .map(widget => widget.scrollable)
     },
     view_layout: () => {
-      match self.get_view_model() {
-        Some(view_model) => Some(view_model.view_layout)
-        None => None
-      }
+      self.get_view_model().map(view_model => view_model.view_layout)
     },
     schedule_render: () => self.schedule_render(),
   }

--- a/editor/internal/viewer/code_editor_widget/cursor_event_delivery.mbt
+++ b/editor/internal/viewer/code_editor_widget/cursor_event_delivery.mbt
@@ -88,10 +88,7 @@ fn CursorEventDelivery::take_next_ready(
   }
   let event = self.queue.remove(0)
   if is_model_flush_cursor_event(event) {
-    match
-      self.completed_content_versions.search_by(version => {
-        version == event.model_version_id
-      }) {
+    match self.completed_content_versions.search(event.model_version_id) {
       Some(index) => self.completed_content_versions.remove(index) |> ignore
       None => ()
     }

--- a/editor/internal/viewer/code_editor_widget/editor_events.mbt
+++ b/editor/internal/viewer/code_editor_widget/editor_events.mbt
@@ -15,18 +15,11 @@ fn CodeEditorWidget::editor_context(
     typical_halfwidth_character_width: self.configuration.snapshot().font_info.typical_halfwidth_character_width,
     mouse_posx,
     mouse_posy,
-    show_at_position: match self.content_hover_contribution() {
-      Some(state) =>
-        match state.widget {
-          Some(widget) =>
-            match widget.rendered_hover {
-              Some(rendered) => Some(rendered.show_at_position)
-              None => None
-            }
-          None => None
-        }
-      None => None
-    },
+    show_at_position: self
+    .content_hover_contribution()
+    .bind(state => state.widget)
+    .bind(widget => widget.rendered_hover)
+    .map(rendered => rendered.show_at_position),
     content_hover_visible: self.content_hover_visible(),
   }
 }
@@ -55,10 +48,7 @@ fn CodeEditorWidget::content_hover_contribution(
 fn CodeEditorWidget::content_hover_controller(
   self : CodeEditorWidget,
 ) -> @hover_browser.ContentHoverController? {
-  match self.content_hover_contribution() {
-    Some(state) => Some(state.controller)
-    None => None
-  }
+  self.content_hover_contribution().map(state => state.controller)
 }
 
 ///|

--- a/editor/internal/viewer/code_editor_widget/folding_contribution.mbt
+++ b/editor/internal/viewer/code_editor_widget/folding_contribution.mbt
@@ -15,35 +15,26 @@ fn register_folding_contribution(registry : EditorContributionRegistry) -> Unit 
     Eager,
     _viewer => Folding(FoldingController()),
     viewer => {
-      let listeners : Array[@base_common.Disposable] = []
-      // `this.editor.onDidChangeModel(() => this.onModelChanged())`
-      listeners.push(
+      let listeners : Array[@base_common.Disposable] = [
+        // `this.editor.onDidChangeModel(() => this.onModelChanged())`
         viewer.on_did_change_model(_ => viewer.folding_on_model_changed()),
-      )
-      // `this.editor.onDidChangeModelContent(e => this.onDidChangeModelContent(e))`
-      // (`folding.ts`, the localToDispose set): recompute the regions against
-      // the new content; `FoldingModel.update`'s region matching preserves
-      // collapse state where ranges still match, and its decoration delta
-      // tolerates the ids the flush destroyed.
-      listeners.push(
+        // `this.editor.onDidChangeModelContent(e => this.onDidChangeModelContent(e))`
+        // (`folding.ts`, the localToDispose set): recompute the regions against
+        // the new content; `FoldingModel.update`'s region matching preserves
+        // collapse state where ranges still match, and its decoration delta
+        // tolerates the ids the flush destroyed.
         viewer.on_did_change_model_content(_ => {
           viewer.trigger_folding_model_changed()
         }),
-      )
-      // `this.editor.onDidChangeCursorPosition(...)` (model-scoped in the
-      // source; the viewer's cursor events already gate on a model)
-      listeners.push(
+        // `this.editor.onDidChangeCursorPosition(...)` (model-scoped in the
+        // source; the viewer's cursor events already gate on a model)
         viewer.on_did_change_cursor_position(_ => {
           viewer.folding_on_cursor_position_changed()
         }),
-      )
-      // `this.editor.onMouseDown/Up(...)`
-      listeners.push(
+        // `this.editor.onMouseDown/Up(...)`
         viewer.on_mouse_down(e => viewer.folding_on_editor_mouse_down(e)),
-      )
-      listeners.push(
         viewer.on_mouse_up(e => viewer.folding_on_editor_mouse_up(e)),
-      )
+      ]
       // the constructor's trailing `this.onModelChanged()`
       viewer.folding_on_model_changed()
       listeners

--- a/editor/internal/viewer/code_editor_widget/hover_contribution.mbt
+++ b/editor/internal/viewer/code_editor_widget/hover_contribution.mbt
@@ -86,27 +86,20 @@ fn CodeEditorWidget::with_hover_widget(
   self : CodeEditorWidget,
   f : (@hover_browser.ContentHoverWidget) -> Unit,
 ) -> Unit {
-  match self.content_hover_contribution() {
-    Some(state) =>
-      match state.widget {
-        Some(widget) => f(widget)
-        None => ()
-      }
-    None => ()
+  guard self.content_hover_contribution() is Some(state) &&
+    state.widget is Some(widget) else {
+    return
   }
+  f(widget)
 }
 
 ///|
 /// The `EditorContextKeys.hoverFocused` context key as a live predicate:
 /// whether the document's active element sits inside the hover widget.
 fn CodeEditorWidget::is_hover_focused(self : CodeEditorWidget) -> Bool {
-  match self.content_hover_contribution() {
-    Some(state) =>
-      match state.widget {
-        Some(widget) =>
-          @base_browser.element_contains_active_element(widget.wrapper)
-        None => false
-      }
-    None => false
+  guard self.content_hover_contribution() is Some(state) &&
+    state.widget is Some(widget) else {
+    return false
   }
+  @base_browser.element_contains_active_element(widget.wrapper)
 }

--- a/editor/internal/viewer/code_editor_widget/markdown_comments_contribution.mbt
+++ b/editor/internal/viewer/code_editor_widget/markdown_comments_contribution.mbt
@@ -545,10 +545,7 @@ fn CodeEditorWidget::refresh_markdown_comments(
   for block in blocks {
     next.set(markdown_comment_key(block), block)
   }
-  let old_keys : Array[String] = []
-  for key, _ in state.rendered {
-    old_keys.push(key)
-  }
+  let old_keys : Array[String] = [ for key, _entry in state.rendered => key ]
   self.change_view_zones(accessor => {
     // Renderer and observer lifetimes end before their caller-owned zone DOM
     // leaves the retained ViewZones registry.
@@ -794,10 +791,9 @@ fn CodeEditorWidget::clear_markdown_comment_model_state(
   // Stop model-wide invalidation first. Per-comment content/renderer
   // lifetimes follow, then structural zones, and finally ViewLines geometry.
   state.dispose_viewport_observer()
-  let entries : Array[RenderedMarkdownComment] = []
-  for _, entry in state.rendered {
-    entries.push(entry)
-  }
+  let entries : Array[RenderedMarkdownComment] = [
+    for _key, entry in state.rendered => entry
+  ]
   // Dispose before structural removal so late image/ResizeObserver callbacks
   // cannot reach a zone while the outgoing View is being torn down.
   for entry in entries {

--- a/editor/internal/viewer/code_editor_widget/moonbit_outline_folding.mbt
+++ b/editor/internal/viewer/code_editor_widget/moonbit_outline_folding.mbt
@@ -55,21 +55,24 @@ fn is_moonbit_outline_identifier_continue(code : Int) -> Bool {
 /// `is_moonbit_leading_continuation_line` catches those when a run is
 /// flushed.
 fn is_moonbit_expression_continuation_code(code : Int) -> Bool {
-  code == '=' ||
-  code == '+' ||
-  code == '-' ||
-  code == '*' ||
-  code == '/' ||
-  code == '%' ||
-  code == '<' ||
-  code == '>' ||
-  code == '&' ||
-  code == '|' ||
-  code == '^' ||
-  code == ':' ||
-  code == ',' ||
-  code == '.' ||
-  code == '!'
+  match code {
+    '='
+    | '+'
+    | '-'
+    | '*'
+    | '/'
+    | '%'
+    | '<'
+    | '>'
+    | '&'
+    | '|'
+    | '^'
+    | ':'
+    | ','
+    | '.'
+    | '!' => true
+    _ => false
+  }
 }
 
 ///|

--- a/editor/internal/viewer/code_editor_widget/overview_ruler.mbt
+++ b/editor/internal/viewer/code_editor_widget/overview_ruler.mbt
@@ -149,23 +149,15 @@ fn merge_code_editor_overview_ruler_bands(
   bands.sort_by(compare_code_editor_overview_ruler_bands)
   let merged : Array[CodeEditorOverviewRulerBand] = []
   for band in bands {
-    if merged.is_empty() {
-      merged.push(band)
-      continue
-    }
-    let previous = merged[merged.length() - 1]
-    if previous.lane == band.lane &&
-      previous.color == band.color &&
-      previous.to >= band.from {
-      merged[merged.length() - 1] = {
-        id: previous.id,
-        from: previous.from,
-        to: previous.to.max(band.to),
-        color: previous.color,
-        lane: previous.lane,
-      }
-    } else {
-      merged.push(band)
+    match merged.last() {
+      Some(previous) if previous.lane == band.lane &&
+        previous.color == band.color &&
+        previous.to >= band.from =>
+        merged[merged.length() - 1] = {
+          ..previous,
+          to: previous.to.max(band.to),
+        }
+      _ => merged.push(band)
     }
   }
   merged
@@ -331,17 +323,9 @@ fn CodeEditorOverviewRuler::render(self : CodeEditorOverviewRuler) -> Unit {
   let render_bands = merge_code_editor_overview_ruler_bands(self.bands)
   let resolved_colors : Map[String, String] = Map([])
   for band in render_bands {
-    let color = match resolved_colors.get(band.color) {
-      Some(color) => color
-      None => {
-        let color = resolve_code_editor_overview_ruler_color(
-          self.root,
-          band.color,
-        )
-        resolved_colors[band.color] = color
-        color
-      }
-    }
+    let color = resolved_colors.get_or_init(band.color, () => {
+      resolve_code_editor_overview_ruler_color(self.root, band.color)
+    })
     let (left, width) = code_editor_overview_ruler_lane_geometry(
       band.lane,
       code_editor_overview_ruler_canvas_width(self.root),

--- a/editor/internal/viewer/code_editor_widget/quick_diff_contribution.mbt
+++ b/editor/internal/viewer/code_editor_widget/quick_diff_contribution.mbt
@@ -47,12 +47,9 @@ fn register_quick_diff_contribution(
       // scoped to this editor's resource.
       state.listeners.push(
         viewer.services.quick_diff.on_did_change_original(resource => {
-          match viewer.get_model() {
-            Some(model) =>
-              if model.uri.to_string() == resource.to_string() {
-                viewer.quick_diff_update(state.collection)
-              }
-            None => ()
+          if viewer.get_model() is Some(model) &&
+            model.uri.to_string() == resource.to_string() {
+            viewer.quick_diff_update(state.collection)
           }
         }),
       )

--- a/editor/internal/viewer/code_editor_widget/quick_diff_host.mbt
+++ b/editor/internal/viewer/code_editor_widget/quick_diff_host.mbt
@@ -18,23 +18,15 @@ fn CodeEditorWidget::quick_diff_update(
   self : CodeEditorWidget,
   collection : EditorDecorationsCollection,
 ) -> Unit {
-  if !self.is_code_presentation() {
+  guard self.is_code_presentation() &&
+    self.get_model() is Some(model) &&
+    self.services.quick_diff.get_original_content(model.uri) is Some(original) else {
     collection.set([]) |> ignore
     return
   }
-  match self.get_model() {
-    Some(model) =>
-      match self.services.quick_diff.get_original_content(model.uri) {
-        Some(original) => {
-          let changes = @quick_diff_browser.compute_changes(
-            @base_common.split_lines(original),
-            model.get_lines_content(),
-          )
-          collection.set(@quick_diff_browser.changes_to_decorations(changes))
-          |> ignore
-        }
-        None => collection.set([]) |> ignore
-      }
-    None => collection.set([]) |> ignore
-  }
+  let changes = @quick_diff_browser.compute_changes(
+    @base_common.split_lines(original),
+    model.get_lines_content(),
+  )
+  collection.set(@quick_diff_browser.changes_to_decorations(changes)) |> ignore
 }

--- a/editor/internal/viewer/code_editor_widget/viewer.mbt
+++ b/editor/internal/viewer/code_editor_widget/viewer.mbt
@@ -613,14 +613,10 @@ pub fn CodeEditorWidget::set_model(
       }
     _ => ()
   }
-  let old_model_url = match self.model_slot.current {
-    Some(model_data) => Some(model_data.model.uri)
-    None => None
-  }
-  let new_model_url = match model {
-    Some(model) => Some(model.uri)
-    None => None
-  }
+  let old_model_url = self.model_slot.current.map(model_data => {
+    model_data.model.uri
+  })
+  let new_model_url = model.map(model => model.uri)
   let had_text_focus = self.has_text_focus()
   let had_definition_peek_focus = self.definition_peek_contains_focus()
   let previous_layout_identity = self.configuration.event_snapshot().layout
@@ -740,10 +736,7 @@ fn CodeEditorWidget::detach_model(self : CodeEditorWidget) -> @model.TextModel? 
 pub fn CodeEditorWidget::get_model(
   self : CodeEditorWidget,
 ) -> @model.TextModel? {
-  match self.model_slot.current {
-    Some(model_data) => Some(model_data.model)
-    None => None
-  }
+  self.model_slot.current.map(model_data => model_data.model)
 }
 
 ///|
@@ -758,20 +751,14 @@ fn CodeEditorWidget::has_model(self : CodeEditorWidget) -> Bool {
 fn CodeEditorWidget::get_view_model(
   self : CodeEditorWidget,
 ) -> @view_model.ViewModel? {
-  match self.model_slot.current {
-    Some(model_data) => Some(model_data.view_model)
-    None => None
-  }
+  self.model_slot.current.map(model_data => model_data.view_model)
 }
 
 ///|
 /// The attached bundle's view — `None` with no model, and `None` headless
 /// (the `hasRealView = false` analog).
 fn CodeEditorWidget::current_code_view(self : CodeEditorWidget) -> @view.View? {
-  match self.current_code_browser_data() {
-    Some(browser) => Some(browser.view)
-    None => None
-  }
+  self.current_code_browser_data().map(browser => browser.view)
 }
 
 ///|
@@ -839,10 +826,9 @@ pub fn CodeEditorWidget::save_view_state(
   self : CodeEditorWidget,
 ) -> CodeEditorViewState? {
   guard self.active_scroll_position() is Some(position) else { return None }
-  let folding_state = match self.folding_controller() {
-    Some(controller) => controller.save_view_state()
-    None => None
-  }
+  let folding_state = self
+    .folding_controller()
+    .bind(controller => controller.save_view_state())
   Some({
     scroll_top: position.scroll_top,
     scroll_left: position.scroll_left,

--- a/editor/internal/viewer/contrib/agent_feedback/agent_feedback_service.mbt
+++ b/editor/internal/viewer/contrib/agent_feedback/agent_feedback_service.mbt
@@ -139,15 +139,7 @@ fn AgentFeedbackService::items_for(
   self : AgentFeedbackService,
   resource : @base_common.Uri,
 ) -> Array[@agent_feedback_api.AgentFeedback] {
-  let key = resource.to_string()
-  match self.items_by_resource.get(key) {
-    Some(items) => items
-    None => {
-      let created : Array[@agent_feedback_api.AgentFeedback] = []
-      self.items_by_resource.set(key, created)
-      created
-    }
-  }
+  self.items_by_resource.get_or_init(resource.to_string(), () => [])
 }
 
 ///|
@@ -158,12 +150,9 @@ fn AgentFeedbackService::replace_item(
   updated : @agent_feedback_api.AgentFeedback,
 ) -> Unit {
   let items = self.items_for(resource)
-  match items.search_by(item => item.id == updated.id) {
-    Some(index) => {
-      items[index] = updated
-      self.handle_items_changed(resource)
-    }
-    None => ()
+  if items.search_by(item => item.id == updated.id) is Some(index) {
+    items[index] = updated
+    self.handle_items_changed(resource)
   }
 }
 
@@ -288,24 +277,20 @@ fn AgentFeedbackService::remove_feedback(
   feedback_id : String,
 ) -> Unit {
   let key = resource.to_string()
-  match self.navigation_anchor_by_resource.get(key) {
-    Some(anchor) =>
-      if anchor == feedback_id ||
-        anchor == to_session_editor_comment_id(feedback_id) {
-        self.navigation_anchor_by_resource.remove(key)
-      }
-    None => ()
+  if self.navigation_anchor_by_resource.get(key) is Some(anchor) &&
+    (
+      anchor == feedback_id ||
+      anchor == to_session_editor_comment_id(feedback_id)
+    ) {
+    self.navigation_anchor_by_resource.remove(key)
   }
   let items = self.items_for(resource)
-  match items.search_by(item => item.id == feedback_id) {
-    Some(index) => {
-      items.remove(index) |> ignore
-      if items.is_empty() {
-        self.items_by_resource.remove(key)
-      }
-      self.handle_items_changed(resource)
+  if items.search_by(item => item.id == feedback_id) is Some(index) {
+    items.remove(index) |> ignore
+    if items.is_empty() {
+      self.items_by_resource.remove(key)
     }
-    None => ()
+    self.handle_items_changed(resource)
   }
 }
 

--- a/editor/internal/viewer/contrib/folding/browser/folding.mbt
+++ b/editor/internal/viewer/contrib/folding/browser/folding.mbt
@@ -53,13 +53,10 @@ pub fn to_selected_lines(selections : Array[@core.Selection]) -> SelectedLines {
   }
   {
     starts_inside: (start_line, end_line) => {
-      for s in selections {
+      selections.any(s => {
         let line = s.start().line_number
-        if line >= start_line && line <= end_line {
-          return true
-        }
-      }
-      false
+        line >= start_line && line <= end_line
+      })
     },
   }
 }

--- a/editor/internal/viewer/contrib/folding/browser/folding_ranges.mbt
+++ b/editor/internal/viewer/contrib/folding/browser/folding_ranges.mbt
@@ -256,20 +256,8 @@ fn FoldingRegions::set_source(
   index : Int,
   source : FoldSource,
 ) -> Unit {
-  match source {
-    UserDefined => {
-      self.user_defined_states.set(index, true)
-      self.recovered_states.set(index, false)
-    }
-    Recovered => {
-      self.user_defined_states.set(index, false)
-      self.recovered_states.set(index, true)
-    }
-    Provider => {
-      self.user_defined_states.set(index, false)
-      self.recovered_states.set(index, false)
-    }
-  }
+  self.user_defined_states.set(index, source is UserDefined)
+  self.recovered_states.set(index, source is Recovered)
 }
 
 ///|
@@ -371,27 +359,21 @@ pub fn FoldingRegions::from_fold_ranges(
   let ranges_length = ranges.length()
   let start_indexes = FixedArray::make(ranges_length, 0U)
   let end_indexes = FixedArray::make(ranges_length, 0U)
-  let types : Array[String?] = []
-  let mut got_types = false
-  for i in 0..<ranges_length {
-    let range = ranges[i]
+  let types : Array[String?] = [ for range in ranges => range.type_ ]
+  for i, range in ranges {
     start_indexes[i] = range.start_line_number.reinterpret_as_uint()
     end_indexes[i] = range.end_line_number.reinterpret_as_uint()
-    types.push(range.type_)
-    if range.type_ is Some(_) {
-      got_types = true
-    }
   }
   let regions = FoldingRegions(
     start_indexes,
     end_indexes,
-    types?=if got_types { Some(types) } else { None },
+    types?=if types.any(t => t is Some(_)) { Some(types) } else { None },
   )
-  for i in 0..<ranges_length {
-    if ranges[i].is_collapsed {
+  for i, range in ranges {
+    if range.is_collapsed {
       regions.set_collapsed(i, true)
     }
-    regions.set_source(i, ranges[i].source)
+    regions.set_source(i, range.source)
   }
   regions
 }

--- a/editor/internal/viewer/contrib/hover/browser/markdown_document_hover.mbt
+++ b/editor/internal/viewer/contrib/hover/browser/markdown_document_hover.mbt
@@ -568,16 +568,11 @@ fn markdown_sorted_hover_parts(
   sync_parts : Array[@hover.HoverPart],
   async_parts : Array[@hover.HoverPart],
 ) -> Array[@hover.HoverPart] {
-  let indexed : Array[(Int, @hover.HoverPart)] = []
-  let mut arrival = 0
-  for part in sync_parts {
-    indexed.push((arrival, part))
-    arrival += 1
-  }
-  for part in async_parts {
-    indexed.push((arrival, part))
-    arrival += 1
-  }
+  let merged = sync_parts.copy()
+  merged.append(async_parts)
+  let indexed : Array[(Int, @hover.HoverPart)] = [
+    for index, part in merged => (index, part)
+  ]
   indexed.sort_by((left, right) => {
     let order = @hover.compare_hover_parts(left.1, right.1)
     if order != 0 {
@@ -663,14 +658,12 @@ fn MarkdownDocumentHoverBridge::start_pointer_request(
         guard self.request_pending && self.stamp_is_current(stamp) else {
           return
         }
-        match self.computer.create_loading_message(anchor) {
-          Some(loading) =>
-            self.accept_parts(
-              stamp,
-              hit,
-              markdown_sorted_hover_parts(sync_parts, [loading]),
-            )
-          None => ()
+        if self.computer.create_loading_message(anchor) is Some(loading) {
+          self.accept_parts(
+            stamp,
+            hit,
+            markdown_sorted_hover_parts(sync_parts, [loading]),
+          )
         }
       },
       loading_delay_ms,
@@ -1150,10 +1143,7 @@ fn MarkdownDocumentHoverBridge::refresh_diagnostics(
             line.line_index == item.line_index else {
             continue
           }
-          let mut class_name = "moonbit-viewer-markdown-diagnostic"
-          if resolved.options.class_name != "" {
-            class_name = "\{class_name} \{resolved.options.class_name}"
-          }
+          let class_name = "moonbit-viewer-markdown-diagnostic \{resolved.options.class_name}"
           self.append_projected_span(
             line,
             item.displayed_range,

--- a/editor/internal/viewer/contrib/hover/hover_controller.mbt
+++ b/editor/internal/viewer/contrib/hover/hover_controller.mbt
@@ -24,13 +24,7 @@ fn filter_hover_parts(
   parts : Array[HoverPart],
   anchor : HoverAnchor,
 ) -> Array[HoverPart] {
-  let kept : Array[HoverPart] = []
-  for part in parts {
-    if hover_part_valid_for_anchor(part, anchor) {
-      kept.push(part)
-    }
-  }
-  kept
+  parts.filter(part => hover_part_valid_for_anchor(part, anchor))
 }
 
 ///|
@@ -481,38 +475,26 @@ pub fn HoverController::start_showing_or_update_hover(
     )
   }
   // A hover is shown. The new anchor equals the shown one: keep it untouched.
-  let visible_result_anchor = match self.current_anchor {
-    Some(anchor) => Some(anchor)
-    None =>
-      if content_hover_is_visible {
-        match self.operation.options {
-          Some(options) => Some(options.anchor)
-          None => None
-        }
-      } else {
-        None
-      }
+  let visible_result_anchor = match
+    (self.current_anchor, self.operation.options) {
+    (Some(anchor), _) => Some(anchor)
+    (None, Some(options)) => Some(options.anchor)
+    (None, None) => None
   }
-  match visible_result_anchor {
-    Some(current) =>
-      if hover_anchor_equals(current, anchor) {
-        return (HoverNoEffect, self)
-      }
-    None => ()
+  if visible_result_anchor is Some(current) &&
+    hover_anchor_equals(current, anchor) {
+    return (HoverNoEffect, self)
   }
   let compatible = match visible_result_anchor {
     Some(current) => {
-      let shown_position = match show_at_position {
-        Some(position) => position
-        None =>
-          match self.view {
-            Some(view) => view.range.get_start_position()
-            None => current.range().get_start_position()
-          }
+      let shown_position = match (show_at_position, self.view) {
+        (Some(position), _) => position
+        (None, Some(view)) => view.range.get_start_position()
+        (None, None) => current.range().get_start_position()
       }
       hover_anchor_can_adopt_at(anchor, current, shown_position)
     }
-    _ => false
+    None => false
   }
   if !compatible {
     // Hide the incompatible hover, then start a fresh operation.

--- a/editor/internal/viewer/contrib/markdown_comments/browser/markdown_comment_dom.mbt
+++ b/editor/internal/viewer/contrib/markdown_comments/browser/markdown_comment_dom.mbt
@@ -122,30 +122,9 @@ pub fn MarkdownCommentDom::enable_source_toggle(
     } else {
       "Show original source"
     }
-    self.outer.set_attribute(
-      "data-source-visible",
-      if visible {
-        "true"
-      } else {
-        "false"
-      },
-    )
-    self.margin.set_attribute(
-      "data-source-visible",
-      if visible {
-        "true"
-      } else {
-        "false"
-      },
-    )
-    self.source_toggle.set_attribute(
-      "aria-pressed",
-      if visible {
-        "true"
-      } else {
-        "false"
-      },
-    )
+    self.outer.set_attribute("data-source-visible", visible.to_string())
+    self.margin.set_attribute("data-source-visible", visible.to_string())
+    self.source_toggle.set_attribute("aria-pressed", visible.to_string())
     self.source_toggle.set_attribute("title", label)
   }
   apply_state()
@@ -201,20 +180,9 @@ pub fn MarkdownCommentDom::enable_folding(
     }
     self.outer.set_attribute(
       "data-documentation-expanded",
-      if is_expanded {
-        "true"
-      } else {
-        "false"
-      },
+      is_expanded.to_string(),
     )
-    self.toggle.set_attribute(
-      "aria-expanded",
-      if is_expanded {
-        "true"
-      } else {
-        "false"
-      },
-    )
+    self.toggle.set_attribute("aria-expanded", is_expanded.to_string())
     self.toggle.set_attribute("aria-label", label)
     self.toggle.set_attribute("title", label)
     self.toggle_icon.set_attribute(
@@ -370,13 +338,11 @@ pub fn MarkdownCommentDom::observe_size(
   })
   let lifetime = @base_common.Disposable::from(() => {
     disposed.val = true
-    match observer {
-      Some(observer) => observer.dispose()
-      None => ()
+    if observer is Some(observer) {
+      observer.dispose()
     }
-    match pending_frame.val {
-      Some(registration) => registration.dispose()
-      None => ()
+    if pending_frame.val is Some(registration) {
+      registration.dispose()
     }
     pending_frame.val = None
     frame_scheduled.val = false
@@ -435,9 +401,8 @@ pub fn MarkdownCommentDom::observe_viewport_width(
       })
       @base_common.Disposable::from(() => {
         disposed.val = true
-        match observer {
-          Some(observer) => observer.dispose()
-          None => ()
+        if observer is Some(observer) {
+          observer.dispose()
         }
       })
     }
@@ -463,14 +428,11 @@ fn markdown_comment_content_viewport(element : @rdom.Element) -> @rdom.Element? 
   if markdown_comment_element_has_class(element, "editor-scrollable") {
     return Some(element)
   }
-  match element.get_parent_node().to_option() {
-    Some(parent) =>
-      match parent.to_element() {
-        Some(parent) => markdown_comment_content_viewport(parent)
-        None => None
-      }
-    None => None
+  guard element.get_parent_node().to_option() is Some(parent_node) &&
+    parent_node.to_element() is Some(parent_element) else {
+    return None
   }
+  markdown_comment_content_viewport(parent_element)
 }
 
 ///|

--- a/editor/internal/viewer/contrib/quick_diff/browser/quick_diff_decorator.mbt
+++ b/editor/internal/viewer/contrib/quick_diff/browser/quick_diff_decorator.mbt
@@ -78,20 +78,12 @@ let deleted_options : @model.ModelDecorationOptions = create_decoration(
 pub fn changes_to_decorations(
   changes : Array[@diff.DetailedLineRangeMapping],
 ) -> Array[@model.ModelDeltaDecoration] {
-  let decorations : Array[@model.ModelDeltaDecoration] = []
-  for change in changes {
-    match @quick_diff.get_change_type(change) {
-      Add => {
-        let start_line_number = change.modified.start_line_number
-        let end_line_number = change.modified.end_line_number_exclusive - 1
-        decorations.push({
-          range: Range(start_line_number, 1, end_line_number, 1),
-          options: added_options,
-        })
-      }
+  changes.map(change => {
+    let change_type = @quick_diff.get_change_type(change)
+    match change_type {
       Delete => {
         let anchor_line_number = change.modified.start_line_number - 1
-        decorations.push({
+        {
           range: Range(
             anchor_line_number,
             MAX_COLUMN,
@@ -99,17 +91,20 @@ pub fn changes_to_decorations(
             MAX_COLUMN,
           ),
           options: deleted_options,
-        })
+        }
       }
-      Modify => {
+      Add | Modify => {
         let start_line_number = change.modified.start_line_number
         let end_line_number = change.modified.end_line_number_exclusive - 1
-        decorations.push({
+        {
           range: Range(start_line_number, 1, end_line_number, 1),
-          options: modified_options,
-        })
+          options: if change_type is Add {
+            added_options
+          } else {
+            modified_options
+          },
+        }
       }
     }
-  }
-  decorations
+  })
 }

--- a/editor/internal/viewer/contrib/references/browser/reference_results_tree.mbt
+++ b/editor/internal/viewer/contrib/references/browser/reference_results_tree.mbt
@@ -93,24 +93,20 @@ fn ReferenceResultsTree::set_results(
     return
   }
   self.model = Some(model)
-  self.previews = []
-  self.expanded_groups = []
-  self.requested_groups = []
-  self.group_rows = []
-  self.group_children = []
-  self.reference_rows = []
-  for group in model.groups {
-    let group_previews : Array[@references.ReferenceRowPreview] = []
-    for reference in group.references {
-      group_previews.push(LocationFallback(reference.fallback_label()))
-      self.reference_rows.push(None)
+  self.previews = [
+    for group in model.groups => {
+      [
+        for reference in group.references => {
+          LocationFallback(reference.fallback_label())
+        }
+      ]
     }
-    self.previews.push(group_previews)
-    self.expanded_groups.push(false)
-    self.requested_groups.push(false)
-    self.group_rows.push(None)
-    self.group_children.push(None)
-  }
+  ]
+  self.expanded_groups = Array::make(model.groups.length(), false)
+  self.requested_groups = Array::make(model.groups.length(), false)
+  self.group_rows = Array::make(model.groups.length(), None)
+  self.group_children = Array::make(model.groups.length(), None)
+  self.reference_rows = Array::make(model.references.length(), None)
   let selected_item = match selected {
     Some(item) if self.contains_reference(item) => Some(item)
     _ => model.references.get(0)
@@ -163,22 +159,15 @@ fn ReferenceResultsTree::set_group_previews(
       _ => false
     })
   self.previews[group_index] = previews.copy()
-  match self.group_reference_container(group_index) {
-    Some(container) => {
-      self.render_group_references(group_index, container)
-      self.update_row_states()
-      if restore_row_focus {
-        match self.roving {
-          Some(row) =>
-            match self.row_node(row) {
-              Some(node) => @base_browser.focus_prevent_scroll(node)
-              None => ()
-            }
-          None => ()
-        }
-      }
-    }
-    None => ()
+  guard self.group_reference_container(group_index) is Some(container) else {
+    return
+  }
+  self.render_group_references(group_index, container)
+  self.update_row_states()
+  if restore_row_focus &&
+    self.roving is Some(row) &&
+    self.row_node(row) is Some(node) {
+    @base_browser.focus_prevent_scroll(node)
   }
 }
 
@@ -659,24 +648,17 @@ fn ReferenceResultsTree::focus_row(
   }
   self.roving = Some(row)
   self.update_row_states()
-  match self.row_node(row) {
-    Some(node) => {
-      if reveal {
-        self.reveal_row(node)
-      }
-      @base_browser.focus_prevent_scroll(node)
+  if self.row_node(row) is Some(node) {
+    if reveal {
+      self.reveal_row(node)
     }
-    None => ()
+    @base_browser.focus_prevent_scroll(node)
   }
-  if selection_changed && notify_selection {
-    match row {
-      ReferenceRow(flat_index) =>
-        match self.reference_at(flat_index) {
-          Some(reference) => (self.callbacks.on_select)(reference)
-          None => ()
-        }
-      GroupRow(_) => ()
-    }
+  if selection_changed &&
+    notify_selection &&
+    row is ReferenceRow(flat_index) &&
+    self.reference_at(flat_index) is Some(reference) {
+    (self.callbacks.on_select)(reference)
   }
 }
 
@@ -955,12 +937,7 @@ fn reference_results_row_index(
   rows : Array[ReferenceResultsTreeRow],
   target : ReferenceResultsTreeRow,
 ) -> Int {
-  for index, row in rows {
-    if row == target {
-      return index
-    }
-  }
-  -1
+  rows.search(target).unwrap_or(-1)
 }
 
 ///|

--- a/editor/internal/viewer/diff_editor/alignment_geometry.mbt
+++ b/editor/internal/viewer/diff_editor/alignment_geometry.mbt
@@ -458,34 +458,26 @@ fn compute_range_alignments(
       last_original_in_hunk = original_line_number_exclusive
       last_modified_in_hunk = modified_line_number_exclusive
     }
-    if inner_hunk_alignment {
-      match alignment.diff {
-        Some(change) =>
-          match change.inner_changes {
-            Some(inner_changes) =>
-              for inner in inner_changes {
-                if inner.original.start_column > 1 &&
-                  inner.modified.start_column > 1 {
-                  emit_alignment(
-                    inner.original.start_line_number,
-                    inner.modified.start_line_number,
-                    false,
-                  )
-                }
-                match
-                  original_geometry.max_column(inner.original.end_line_number) {
-                  Some(max_column) if inner.original.end_column < max_column =>
-                    emit_alignment(
-                      inner.original.end_line_number,
-                      inner.modified.end_line_number,
-                      false,
-                    )
-                  _ => ()
-                }
-              }
-            None => ()
-          }
-        None => ()
+    if inner_hunk_alignment &&
+      alignment.diff is Some(change) &&
+      change.inner_changes is Some(inner_changes) {
+      for inner in inner_changes {
+        if inner.original.start_column > 1 && inner.modified.start_column > 1 {
+          emit_alignment(
+            inner.original.start_line_number,
+            inner.modified.start_line_number,
+            false,
+          )
+        }
+        if original_geometry.max_column(inner.original.end_line_number)
+          is Some(max_column) &&
+          inner.original.end_column < max_column {
+          emit_alignment(
+            inner.original.end_line_number,
+            inner.modified.end_line_number,
+            false,
+          )
+        }
       }
     }
     emit_alignment(

--- a/editor/internal/viewer/diff_editor/widget.mbt
+++ b/editor/internal/viewer/diff_editor/widget.mbt
@@ -316,9 +316,8 @@ fn DiffEditorWidget::complete_layout_pane_render(
   // Every outer layout, including height-only resizes, gets exactly one
   // reconcile using geometry from the completed pane render(s).
   self.reconcile_view_model()
-  match self.pending_layout_modified_viewport {
-    Some(state) => self.restore_modified_viewport_and_sync_original(state)
-    None => ()
+  if self.pending_layout_modified_viewport is Some(state) {
+    self.restore_modified_viewport_and_sync_original(state)
   }
   self.refresh_overview_viewport()
 }
@@ -818,77 +817,65 @@ fn DiffEditorWidget::apply_diff_state_decorations(
     let change = mapping.line_range_mapping
     let original_range = changed_line_range(change.original, original_snapshot)
     let modified_range = changed_line_range(change.modified, modified_snapshot)
-    match original_range {
-      Some(range) =>
-        original_decorations.append(
-          diff_whole_line_decorations(
-            [range],
-            "diff-editor-line-delete",
-            "delete-sign codicon codicon-diff-remove",
-            "diff-editor-gutter-delete",
-            self.options.render_indicators,
-            "diff-editor-original-line",
-          ),
-        )
-      None => ()
+    if original_range is Some(range) {
+      original_decorations.append(
+        diff_whole_line_decorations(
+          [range],
+          "diff-editor-line-delete",
+          "delete-sign codicon codicon-diff-remove",
+          "diff-editor-gutter-delete",
+          self.options.render_indicators,
+          "diff-editor-original-line",
+        ),
+      )
     }
-    match modified_range {
-      Some(range) =>
-        modified_decorations.append(
-          diff_whole_line_decorations(
-            [range],
-            "diff-editor-line-insert",
-            "insert-sign codicon codicon-diff-insert",
-            "diff-editor-gutter-insert",
-            self.options.render_indicators,
-            "diff-editor-modified-line",
-          ),
-        )
-      None => ()
+    if modified_range is Some(range) {
+      modified_decorations.append(
+        diff_whole_line_decorations(
+          [range],
+          "diff-editor-line-insert",
+          "insert-sign codicon codicon-diff-insert",
+          "diff-editor-gutter-insert",
+          self.options.render_indicators,
+          "diff-editor-modified-line",
+        ),
+      )
     }
     if change.modified.is_empty() || change.original.is_empty() {
-      match original_range {
-        Some(range) =>
+      if original_range is Some(range) {
+        original_decorations.push(
+          whole_line_character_decoration(
+            range, "diff-editor-char-delete", "diff-editor-original-character",
+          ),
+        )
+      }
+      if modified_range is Some(range) {
+        modified_decorations.push(
+          whole_line_character_decoration(
+            range, "diff-editor-char-insert", "diff-editor-modified-character",
+          ),
+        )
+      }
+    } else if change.inner_changes is Some(inner_changes) {
+      for inner in inner_changes {
+        if change.original.contains(inner.original.start_line_number) {
           original_decorations.push(
-            whole_line_character_decoration(
-              range, "diff-editor-char-delete", "diff-editor-original-character",
+            inner_character_decoration(
+              inner.original,
+              "diff-editor-char-delete",
+              "diff-editor-original-character",
             ),
           )
-        None => ()
-      }
-      match modified_range {
-        Some(range) =>
+        }
+        if change.modified.contains(inner.modified.start_line_number) {
           modified_decorations.push(
-            whole_line_character_decoration(
-              range, "diff-editor-char-insert", "diff-editor-modified-character",
+            inner_character_decoration(
+              inner.modified,
+              "diff-editor-char-insert",
+              "diff-editor-modified-character",
             ),
           )
-        None => ()
-      }
-    } else {
-      match change.inner_changes {
-        Some(inner_changes) =>
-          for inner in inner_changes {
-            if change.original.contains(inner.original.start_line_number) {
-              original_decorations.push(
-                inner_character_decoration(
-                  inner.original,
-                  "diff-editor-char-delete",
-                  "diff-editor-original-character",
-                ),
-              )
-            }
-            if change.modified.contains(inner.modified.start_line_number) {
-              modified_decorations.push(
-                inner_character_decoration(
-                  inner.modified,
-                  "diff-editor-char-insert",
-                  "diff-editor-modified-character",
-                ),
-              )
-            }
-          }
-        None => ()
+        }
       }
     }
   }
@@ -972,13 +959,11 @@ fn DiffEditorWidget::clear_overview_ruler(
   self : DiffEditorWidget,
   generation : Int,
 ) -> Unit {
-  match self.original_overview_ruler {
-    Some(ruler) => ruler.clear(generation)
-    None => ()
+  if self.original_overview_ruler is Some(ruler) {
+    ruler.clear(generation)
   }
-  match self.modified_overview_ruler {
-    Some(ruler) => ruler.clear(generation)
-    None => ()
+  if self.modified_overview_ruler is Some(ruler) {
+    ruler.clear(generation)
   }
 }
 
@@ -988,21 +973,17 @@ fn DiffEditorWidget::apply_overview_diff_state(
   diff_state : DiffState,
   generation : Int,
 ) -> Unit {
-  match self.original_overview_ruler {
-    Some(ruler) =>
-      ruler.set_entries(
-        generation,
-        original_diff_overview_ruler_entries(diff_state),
-      )
-    None => ()
+  if self.original_overview_ruler is Some(ruler) {
+    ruler.set_entries(
+      generation,
+      original_diff_overview_ruler_entries(diff_state),
+    )
   }
-  match self.modified_overview_ruler {
-    Some(ruler) =>
-      ruler.set_entries(
-        generation,
-        modified_diff_overview_ruler_entries(diff_state),
-      )
-    None => ()
+  if self.modified_overview_ruler is Some(ruler) {
+    ruler.set_entries(
+      generation,
+      modified_diff_overview_ruler_entries(diff_state),
+    )
   }
 }
 
@@ -1049,13 +1030,11 @@ fn DiffEditorWidget::sync_overview_ruler_option(
   if !self.options.overview_ruler {
     self.root.remove_attribute("data-overview-ruler")
     self.overview_root.set_attribute("hidden", "")
-    match self.original_overview_ruler {
-      Some(ruler) => ruler.dispose()
-      None => ()
+    if self.original_overview_ruler is Some(ruler) {
+      ruler.dispose()
     }
-    match self.modified_overview_ruler {
-      Some(ruler) => ruler.dispose()
-      None => ()
+    if self.modified_overview_ruler is Some(ruler) {
+      ruler.dispose()
     }
     self.original_overview_ruler = None
     self.modified_overview_ruler = None
@@ -1138,9 +1117,8 @@ fn DiffEditorWidget::commit_empty_diff_features(
     [],
     generation,
   )
-  match modified_viewport {
-    Some(state) => self.restore_modified_viewport_and_sync_original(state)
-    None => ()
+  if modified_viewport is Some(state) {
+    self.restore_modified_viewport_and_sync_original(state)
   }
   self.clear_overview_ruler(generation)
   self.original_alignment_geometry = None
@@ -1211,9 +1189,8 @@ fn DiffEditorWidget::commit_diff_state(
     generation,
   )
   self.inline_deleted_zones = next_inline_deleted_zones
-  match modified_viewport {
-    Some(state) => self.restore_modified_viewport_and_sync_original(state)
-    None => ()
+  if modified_viewport is Some(state) {
+    self.restore_modified_viewport_and_sync_original(state)
   }
   self.apply_overview_diff_state(diff_state, generation)
   self.diff_state = Some(diff_state)
@@ -1944,9 +1921,8 @@ pub fn DiffEditorWidget::dispose(self : DiffEditorWidget) -> Unit {
   }
   self.clear_diff_features_for_transition()
   self.disposed = true
-  match self.resize_observer {
-    Some(observer) => observer.dispose()
-    None => ()
+  if self.resize_observer is Some(observer) {
+    observer.dispose()
   }
   self.resize_observer = None
   self.pointer_monitor.dispose()
@@ -1956,13 +1932,11 @@ pub fn DiffEditorWidget::dispose(self : DiffEditorWidget) -> Unit {
   }
   self.lifetime.clear()
   self.view_model.dispose()
-  match self.original_overview_ruler {
-    Some(ruler) => ruler.dispose()
-    None => ()
+  if self.original_overview_ruler is Some(ruler) {
+    ruler.dispose()
   }
-  match self.modified_overview_ruler {
-    Some(ruler) => ruler.dispose()
-    None => ()
+  if self.modified_overview_ruler is Some(ruler) {
+    ruler.dispose()
   }
   self.original_overview_ruler = None
   self.modified_overview_ruler = None

--- a/editor/internal/viewer/markdown/markdown.mbt
+++ b/editor/internal/viewer/markdown/markdown.mbt
@@ -74,19 +74,14 @@ pub fn render_markdown(
           is Some(code_block) else {
           return false
         }
-        match render_diagram_code_block(code_block) {
-          Some(html) => {
-            ctx.string(html)
-            true
-          }
-          None =>
-            match code_block_renderer {
-              Some(render) => {
-                ctx.string(render(code_block, language_id))
-                true
-              }
-              None => false
-            }
+        if render_diagram_code_block(code_block) is Some(html) {
+          ctx.string(html)
+          true
+        } else if code_block_renderer is Some(render) {
+          ctx.string(render(code_block, language_id))
+          true
+        } else {
+          false
         }
       }
       _ => false

--- a/editor/internal/viewer/markdown/source_projection.mbt
+++ b/editor/internal/viewer/markdown/source_projection.mbt
@@ -109,9 +109,8 @@ pub fn MarkdownCodeBlock::project_source_range(
 ) -> Array[MarkdownProjectedCodeRange] {
   let projected : Array[MarkdownProjectedCodeRange] = []
   for line_index, line in self.code_lines {
-    match line.project_source_range(source_range) {
-      Some(displayed_range) => projected.push({ line_index, displayed_range, })
-      None => ()
+    if line.project_source_range(source_range) is Some(displayed_range) {
+      projected.push({ line_index, displayed_range, })
     }
   }
   projected
@@ -140,34 +139,27 @@ fn markdown_document_projection(doc : @cmark.Doc) -> MarkdownDocumentProjection 
     builder : MarkdownProjectionBuilder,
     block,
   ) {
-    if markdown_block_has_anchor(block) {
-      match markdown_offset_range(block.meta().loc) {
-        Some(source_range) =>
-          builder.block_anchors.push({
-            index: builder.block_anchors.length(),
-            source_range,
-            rendered_element_index: markdown_take_rendered_element_index(
-              rendered_element_indices,
-              block.meta().id,
-            ),
-            heading_level: markdown_block_heading_level(block),
-            heading_text: markdown_block_heading_text(block),
-          })
-        None => ()
-      }
+    if markdown_block_has_anchor(block) &&
+      markdown_offset_range(block.meta().loc) is Some(source_range) {
+      builder.block_anchors.push({
+        index: builder.block_anchors.length(),
+        source_range,
+        rendered_element_index: markdown_take_rendered_element_index(
+          rendered_element_indices,
+          block.meta().id,
+        ),
+        heading_level: markdown_block_heading_level(block),
+        heading_text: markdown_block_heading_text(block),
+      })
     }
-    match block {
-      CodeBlock(node) =>
-        match
-          markdown_code_block_from_cmark(
-            node.v,
-            node.meta.loc,
-            builder.code_blocks.length(),
-          ) {
-          Some(code_block) => builder.code_blocks.push(code_block)
-          None => ()
-        }
-      _ => ()
+    if block is CodeBlock(node) &&
+      markdown_code_block_from_cmark(
+        node.v,
+        node.meta.loc,
+        builder.code_blocks.length(),
+      )
+      is Some(code_block) {
+      builder.code_blocks.push(code_block)
     }
     @cmark.Folder::none(folder, builder, block)
   })
@@ -308,9 +300,9 @@ fn markdown_code_block_from_cmark(
   )
   let code_lines : Array[MarkdownCodeLine] = []
   for line in block.code {
-    match markdown_code_line_from_cmark(line.v, line.meta.loc) {
-      Some(projected_line) => code_lines.push(projected_line)
-      None => ()
+    if markdown_code_line_from_cmark(line.v, line.meta.loc)
+      is Some(projected_line) {
+      code_lines.push(projected_line)
     }
   }
   Some({

--- a/editor/internal/viewer/markdown/tokenized_code_block.mbt
+++ b/editor/internal/viewer/markdown/tokenized_code_block.mbt
@@ -43,15 +43,10 @@ fn markdown_code_language(
   code_block : MarkdownCodeBlock,
   active_language_id : String?,
 ) -> String {
-  let language = match code_block.language_id {
-    Some(language) => language
-    None => active_language_id.unwrap_or("")
-  }
-  match language {
-    "mbt" => "moonbit"
-    "mbtx" => "moonbit"
+  match code_block.language_id.unwrap_or(active_language_id.unwrap_or("")) {
+    "mbt" | "mbtx" => "moonbit"
     "js" => "javascript"
     "ts" => "typescript"
-    _ => language
+    language => language
   }
 }

--- a/editor/internal/viewer/markdown_viewer/markdown_viewer_definition.mbt
+++ b/editor/internal/viewer/markdown_viewer/markdown_viewer_definition.mbt
@@ -55,21 +55,19 @@ fn MarkdownViewerWidgetDefinitionBridge::MarkdownViewerWidgetDefinitionBridge(
 ) -> MarkdownViewerWidgetDefinitionBridge {
   let bridge_slot : Ref[MarkdownViewerWidgetDefinitionBridge?] = Ref(None)
   let anchor_is_current = anchor => {
-    match bridge_slot.val {
-      Some(bridge) => bridge.anchor_is_current(anchor)
-      None => false
-    }
+    bridge_slot.val.map_or(false, bridge => bridge.anchor_is_current(anchor))
   }
   let navigation_action = @goto_symbol.SymbolNavigationAction(
     viewer.services.languages(),
     {
       prepare_navigation: () => {
-        match bridge_slot.val {
-          Some(bridge) => bridge.prepare_navigation()
-          None => ()
+        if bridge_slot.val is Some(bridge) {
+          bridge.prepare_navigation()
         }
       },
       is_anchor_current: anchor_is_current,
+      // `open_location` is async, so its body stays a match rather than moving
+      // into a non-async `map_or` closure.
       open_location: (_anchor, location, mode, _source) => {
         match bridge_slot.val {
           Some(bridge) => bridge.open_location(location, mode)
@@ -77,15 +75,13 @@ fn MarkdownViewerWidgetDefinitionBridge::MarkdownViewerWidgetDefinitionBridge(
         }
       },
       open_in_peek: (anchor, mode, locations) => {
-        match bridge_slot.val {
-          Some(bridge) => bridge.open_in_peek(anchor, mode, locations)
-          None => false
-        }
+        bridge_slot.val.map_or(false, bridge => {
+          bridge.open_in_peek(anchor, mode, locations)
+        })
       },
       show_message: (_anchor, message) => {
-        match bridge_slot.val {
-          Some(bridge) => bridge.show_message(message)
-          None => ()
+        if bridge_slot.val is Some(bridge) {
+          bridge.show_message(message)
         }
       },
     },
@@ -96,45 +92,40 @@ fn MarkdownViewerWidgetDefinitionBridge::MarkdownViewerWidgetDefinitionBridge(
     is_anchor_current=anchor_is_current,
     markdown_navigation_run_provider_tasks,
   )
-  let controller = match viewer.services.preview_factory() {
-    None => None
-    Some(preview_factory) =>
-      Some(
-        @references_browser.ReferencesController(
-          {
-            is_anchor_current: anchor_is_current,
-            mount: (root, anchor) => {
-              match bridge_slot.val {
-                Some(bridge) => bridge.mount_peek(root, anchor)
-                None => None
-              }
-            },
-            reveal_anchor: anchor => {
-              match bridge_slot.val {
-                Some(bridge) => bridge.reveal_anchor(anchor)
-                None => ()
-              }
-            },
-            restore_source_focus: () => viewer.focus(),
-            open_location: (location, mode, _source) => {
-              match bridge_slot.val {
-                Some(bridge) => bridge.open_location(location, mode)
-                None => false
-              }
-            },
-            show_message: (_anchor, message) => {
-              match bridge_slot.val {
-                Some(bridge) => bridge.show_message(message)
-                None => ()
-              }
-            },
+  let controller = viewer.services
+    .preview_factory()
+    .map(preview_factory => {
+      @references_browser.ReferencesController(
+        {
+          is_anchor_current: anchor_is_current,
+          mount: (root, anchor) => {
+            bridge_slot.val.bind(bridge => bridge.mount_peek(root, anchor))
           },
-          preview_factory,
-          resolver?=viewer.services.text_model_resolver(),
-          task => viewer.services.launch_async_task(task),
-        ),
+          reveal_anchor: anchor => {
+            if bridge_slot.val is Some(bridge) {
+              bridge.reveal_anchor(anchor)
+            }
+          },
+          restore_source_focus: () => viewer.focus(),
+          // `open_location` is async, so its body stays a match rather than
+          // moving into a non-async `map_or` closure.
+          open_location: (location, mode, _source) => {
+            match bridge_slot.val {
+              Some(bridge) => bridge.open_location(location, mode)
+              None => false
+            }
+          },
+          show_message: (_anchor, message) => {
+            if bridge_slot.val is Some(bridge) {
+              bridge.show_message(message)
+            }
+          },
+        },
+        preview_factory,
+        resolver?=viewer.services.text_model_resolver(),
+        task => viewer.services.launch_async_task(task),
       )
-  }
+    })
   let bridge : MarkdownViewerWidgetDefinitionBridge = {
     viewer,
     view,
@@ -438,9 +429,8 @@ fn MarkdownViewerWidgetDefinitionBridge::get_or_create_context_menu(
 fn MarkdownViewerWidgetDefinitionBridge::hide_context_menu(
   self : MarkdownViewerWidgetDefinitionBridge,
 ) -> Unit {
-  match self.context_menu {
-    Some(widget) => widget.hide(was_cancelled=true)
-    None => ()
+  if self.context_menu is Some(widget) {
+    widget.hide(was_cancelled=true)
   }
 }
 
@@ -748,9 +738,8 @@ fn MarkdownViewerWidgetDefinitionBridge::before_projection_replaced(
   self.surface_generation += 1
   self.navigation_action.cancel()
   self.link_resolver.cancel()
-  match self.controller {
-    Some(controller) => controller.close(restore_focus=false)
-    None => ()
+  if self.controller is Some(controller) {
+    controller.close(restore_focus=false)
   }
   self.reset_link()
   self.hide_context_menu()
@@ -784,14 +773,12 @@ fn MarkdownViewerWidgetDefinitionBridge::dispose(
   self.active = false
   self.navigation_action.dispose()
   self.link_resolver.dispose()
-  match self.controller {
-    Some(controller) => controller.dispose()
-    None => ()
+  if self.controller is Some(controller) {
+    controller.dispose()
   }
   self.reset_link()
-  match self.context_menu {
-    Some(widget) => widget.dispose()
-    None => ()
+  if self.context_menu is Some(widget) {
+    widget.dispose()
   }
   self.context_menu = None
   while self.listeners.length() > 0 {

--- a/editor/internal/viewer/ui/scrollbar/scrollable_element.mbt
+++ b/editor/internal/viewer/ui/scrollbar/scrollable_element.mbt
@@ -127,9 +127,8 @@ pub fn ScrollableElementDom::ScrollableElementDom(
 fn ScrollableElementDom::cancel_hide_timeout(
   self : ScrollableElementDom,
 ) -> Unit {
-  match self.hide_timeout {
-    Some(timeout) => timeout.dispose()
-    None => ()
+  if self.hide_timeout is Some(timeout) {
+    timeout.dispose()
   }
   self.hide_timeout = None
   self.hide_generation += 1
@@ -205,22 +204,18 @@ fn ScrollableElementDom::write_vertical_bar(
     "class",
     self.scrollbar_class(vertical=true, needed~),
   )
-  if self.vertical_state.is_needed() {
-    self.vertical_bar.set_attribute(
-      "style",
-      "width:\{self.vertical_size.to_string()}px;height:\{self.vertical_state.rectangle_large_size().to_string()}px;right:0px;top:0px",
-    )
-    self.vertical_slider.set_attribute(
-      "style",
-      "width:\{self.vertical_size.to_string()}px;height:\{self.vertical_state.slider_size().to_string()}px;transform:translateY(\{self.vertical_state.slider_position().to_string()}px)",
-    )
-  } else {
-    self.vertical_bar.set_attribute(
-      "style",
-      "width:\{self.vertical_size.to_string()}px;height:\{self.vertical_state.rectangle_large_size().to_string()}px;right:0px;top:0px",
-    )
-    self.vertical_slider.set_attribute("style", "")
-  }
+  self.vertical_bar.set_attribute(
+    "style",
+    "width:\{self.vertical_size.to_string()}px;height:\{self.vertical_state.rectangle_large_size().to_string()}px;right:0px;top:0px",
+  )
+  self.vertical_slider.set_attribute(
+    "style",
+    if needed {
+      "width:\{self.vertical_size.to_string()}px;height:\{self.vertical_state.slider_size().to_string()}px;transform:translateY(\{self.vertical_state.slider_position().to_string()}px)"
+    } else {
+      ""
+    },
+  )
 }
 
 ///|
@@ -236,26 +231,19 @@ fn ScrollableElementDom::write_horizontal_bar(
     "class",
     self.scrollbar_class(vertical=false, needed~),
   )
-  if self.horizontal_state.is_needed() {
-    let mut bar_style = "height:\{self.horizontal_size.to_string()}px;width:\{self.horizontal_state.rectangle_large_size().to_string()}px;bottom:0px"
-    match horizontal_left {
-      Some(left) => bar_style = "\{bar_style};left:\{left.to_string()}px"
-      None => ()
-    }
-    self.horizontal_bar.set_attribute("style", bar_style)
-    self.horizontal_slider.set_attribute(
-      "style",
-      "height:\{self.horizontal_size.to_string()}px;width:\{self.horizontal_state.slider_size().to_string()}px;transform:translateX(\{self.horizontal_state.slider_position().to_string()}px)",
-    )
-  } else {
-    let mut bar_style = "height:\{self.horizontal_size.to_string()}px;width:\{self.horizontal_state.rectangle_large_size().to_string()}px;bottom:0px"
-    match horizontal_left {
-      Some(left) => bar_style = "\{bar_style};left:\{left.to_string()}px"
-      None => ()
-    }
-    self.horizontal_bar.set_attribute("style", bar_style)
-    self.horizontal_slider.set_attribute("style", "")
+  let mut bar_style = "height:\{self.horizontal_size.to_string()}px;width:\{self.horizontal_state.rectangle_large_size().to_string()}px;bottom:0px"
+  if horizontal_left is Some(left) {
+    bar_style = "\{bar_style};left:\{left.to_string()}px"
   }
+  self.horizontal_bar.set_attribute("style", bar_style)
+  self.horizontal_slider.set_attribute(
+    "style",
+    if needed {
+      "height:\{self.horizontal_size.to_string()}px;width:\{self.horizontal_state.slider_size().to_string()}px;transform:translateX(\{self.horizontal_state.slider_position().to_string()}px)"
+    } else {
+      ""
+    },
+  )
 }
 
 ///|

--- a/editor/language/selectors.mbt
+++ b/editor/language/selectors.mbt
@@ -135,12 +135,8 @@ fn path_pattern_matches(pattern : String, path : String) -> Bool {
     return true
   }
   let path = if path.has_prefix("/") { path[1:].to_owned() } else { path }
-  match pattern.find("*") {
-    Some(index) => {
-      let prefix = pattern[0:index].to_owned()
-      let suffix = pattern[index + 1:].to_owned()
-      path.has_prefix(prefix) && path.has_suffix(suffix)
-    }
+  match pattern.split_once("*") {
+    Some((prefix, suffix)) => path.has_prefix(prefix) && path.has_suffix(suffix)
     None => path == pattern
   }
 }

--- a/editor/shell/workspace/exports.mbt
+++ b/editor/shell/workspace/exports.mbt
@@ -76,13 +76,8 @@ pub fn SourcePath::normalize_root_relative_path(
       segments.push(segment)
     }
   }
-  guard segments is [first, ..] else { return SourcePathError(InvalidPath) }
-  let normalized = for i in 1..<segments.length(); normalized = first {
-    continue "\{normalized}/\{segments[i]}"
-  } nobreak {
-    normalized
-  }
-  ParsedSourcePath({ value: normalized, })
+  guard segments is [_, ..] else { return SourcePathError(InvalidPath) }
+  ParsedSourcePath({ value: segments.join("/"), })
 }
 
 ///|

--- a/editor/viewer/browser/diagram_viewport/diagram_viewport.mbt
+++ b/editor/viewer/browser/diagram_viewport/diagram_viewport.mbt
@@ -245,10 +245,7 @@ fn MarkdownDiagramViewportLifetime::dispose(
     return
   }
   self.active = false
-  while self.controllers.length() > 0 {
-    let index = self.controllers.length() - 1
-    let controller = self.controllers[index]
-    self.controllers.pop() |> ignore
+  while self.controllers.pop() is Some(controller) {
     controller.dispose()
   }
 }
@@ -1165,23 +1162,18 @@ fn MarkdownDiagramViewport::dispose(self : MarkdownDiagramViewport) -> Unit {
     return
   }
   self.active = false
-  match self.pending_frame {
-    Some(cancel) => cancel()
-    None => ()
+  if self.pending_frame is Some(cancel) {
+    cancel()
   }
   self.pending_frame = None
-  match self.observer {
-    Some(observer) => observer.dispose()
-    None => ()
+  if self.observer is Some(observer) {
+    observer.dispose()
   }
   self.observer = None
   self.finish_resize()
   self.is_panning = false
   self.pan_pointer_id = None
-  while self.listeners.length() > 0 {
-    let index = self.listeners.length() - 1
-    let listener = self.listeners[index]
-    self.listeners.pop() |> ignore
+  while self.listeners.pop() is Some(listener) {
     listener.dispose()
   }
   @base_browser.remove_element(self.controls)
@@ -1227,12 +1219,10 @@ fn release_body_cursor_lease(lease : DiagramBodyCursorLease) -> Unit {
   lease.active = false
   restore_element_style(lease.body, "cursor", lease.saved_cursor)
   lease.coordinator.active = false
-  let retained = diagram_body_cursor_coordinators.filter(coordinator => {
+  diagram_body_cursor_coordinators.retain(coordinator => {
     coordinator.active ||
     !same_document(coordinator.document, lease.coordinator.document)
   })
-  diagram_body_cursor_coordinators.clear()
-  diagram_body_cursor_coordinators.append(retained)
 }
 
 ///|
@@ -1247,24 +1237,16 @@ fn is_positive_finite(value : Double) -> Bool {
 
 ///|
 fn element_class_tokens(element : @rdom.Element) -> Array[String] {
-  let tokens : Array[String] = []
-  for token in element_attribute_or_empty(element, "class").split(" ") {
-    let value = token.to_owned()
-    if value != "" {
-      tokens.push(value)
+  [
+    for token in element_attribute_or_empty(element, "class").split(" ") if !token.is_empty() => {
+      token.to_owned()
     }
-  }
-  tokens
+  ]
 }
 
 ///|
 fn element_has_class(element : @rdom.Element, class_name : String) -> Bool {
-  for token in element_class_tokens(element) {
-    if token == class_name {
-      return true
-    }
-  }
-  false
+  element_class_tokens(element).contains(class_name)
 }
 
 ///|

--- a/editor/viewer/common/core/cursor_columns.mbt
+++ b/editor/viewer/common/core/cursor_columns.mbt
@@ -80,11 +80,7 @@ pub fn visible_column_from_column(
   column : Int,
   tab_size : Int,
 ) -> Int {
-  let text_len = if column - 1 < line_content.length() {
-    column - 1
-  } else {
-    line_content.length()
-  }
+  let text_len = (column - 1).min(line_content.length())
   for offset = 0, result = 0; offset < text_len; {
     let code_point = get_next_code_point(line_content, text_len, offset)
     continue offset + code_point_utf16_length(code_point),
@@ -102,11 +98,7 @@ pub fn to_statusbar_column(
   column : Int,
   tab_size : Int,
 ) -> Int {
-  let text_len = if column - 1 < line_content.length() {
-    column - 1
-  } else {
-    line_content.length()
-  }
+  let text_len = (column - 1).min(line_content.length())
   let result = for offset = 0, result = 0; offset < text_len; {
     let code_point = get_next_code_point(line_content, text_len, offset)
     let result = if code_point == 9 {

--- a/editor/viewer/common/cursor/cursor_event_state.mbt
+++ b/editor/viewer/common/cursor/cursor_event_state.mbt
@@ -84,11 +84,9 @@ pub fn CursorState::from_model_selection(
 pub fn CursorState::from_model_selections(
   selections : Array[@core.Selection],
 ) -> Array[PartialCursorState] {
-  let result : Array[PartialCursorState] = []
-  for selection in selections {
-    result.push(CursorState::from_model_selection(selection))
-  }
-  result
+  [
+    for selection in selections => CursorState::from_model_selection(selection)
+  ]
 }
 
 ///|

--- a/editor/viewer/common/diff/inner_changes.mbt
+++ b/editor/viewer/common/diff/inner_changes.mbt
@@ -115,16 +115,15 @@ fn flatten_inner_diff_sequence(
     let anchor = empty_line_range_anchor(lines, range.start_line_number)
     return { values: [], start_boundaries: [anchor], end_boundaries: [anchor], }
   }
-  let line_sequences : Array[InnerDiffLine] = []
-  for line_number in range.start_line_number..<range.end_line_number_exclusive {
-    line_sequences.push(
+  let line_sequences : Array[InnerDiffLine] = [
+    for line_number in range.start_line_number..<range.end_line_number_exclusive => {
       flatten_inner_diff_line(
         lines[line_number - 1],
         line_number,
         ignore_trim_whitespace,
-      ),
-    )
-  }
+      )
+    }
+  ]
   let values : Array[Int] = []
   let start_boundaries : Array[@base_common.Position] = []
   let end_boundaries : Array[@base_common.Position] = []
@@ -138,12 +137,9 @@ fn flatten_inner_diff_sequence(
     start_boundaries.push(previous_end)
     end_boundaries.push(previous_end)
     values.push('\n'.to_int())
-    start_boundaries.push(first.start_right)
-    end_boundaries.push(first.start_left)
-  } else {
-    start_boundaries.push(first.start_right)
-    end_boundaries.push(first.start_left)
   }
+  start_boundaries.push(first.start_right)
+  end_boundaries.push(first.start_left)
   for line_index in 0..<line_sequences.length() {
     let line = line_sequences[line_index]
     for value_index in 0..<line.values.length() {
@@ -248,14 +244,12 @@ fn compute_inner_changes(
     modified_trailing_newline,
   )
   let diffs = compute_advanced_scalar_diffs(original.values, modified.values)
-  let changes : Array[RangeMapping] = []
-  for diff in diffs {
-    changes.push(
+  Some(
+    diffs.map(diff => {
       RangeMapping(
         original.range(diff.original.start, diff.original.end_exclusive),
         modified.range(diff.modified.start, diff.modified.end_exclusive),
-      ),
-    )
-  }
-  Some(changes)
+      )
+    }),
+  )
 }

--- a/editor/viewer/common/languages/language_configuration.mbt
+++ b/editor/viewer/common/languages/language_configuration.mbt
@@ -73,28 +73,18 @@ fn Languages::set_language_configuration_impl(
   language_id : String,
   configuration : LanguageConfiguration,
 ) -> Unit {
-  match configuration.comments {
-    Some(comments) => {
-      match comments.line_comment {
-        Some(rule) =>
-          if rule.comment == "" {
-            abort("line comment delimiter must not be empty")
-          }
-        None => ()
+  if configuration.comments is Some(comments) {
+    if comments.line_comment is Some(rule) && rule.comment == "" {
+      abort("line comment delimiter must not be empty")
+    }
+    if comments.block_comment is Some(pair) {
+      if pair.open == "" {
+        abort("block comment opening delimiter must not be empty")
       }
-      match comments.block_comment {
-        Some(pair) => {
-          if pair.open == "" {
-            abort("block comment opening delimiter must not be empty")
-          }
-          if pair.close == "" {
-            abort("block comment closing delimiter must not be empty")
-          }
-        }
-        None => ()
+      if pair.close == "" {
+        abort("block comment closing delimiter must not be empty")
       }
     }
-    None => ()
   }
   self.language_configurations[language_id] = configuration
 }

--- a/editor/viewer/common/markers/marker_decorations.mbt
+++ b/editor/viewer/common/markers/marker_decorations.mbt
@@ -93,15 +93,10 @@ fn MarkerDecorations::update(
       added.push(marker)
     }
   }
-  let retained : Array[(Marker, String)] = []
-  let old_ids : Array[String] = []
-  for index in 0..<self.entries.length() {
-    if matched_entries[index] {
-      retained.push(self.entries[index])
-    } else {
-      old_ids.push(self.entries[index].1)
-    }
-  }
+  let retained = [ for i, entry in self.entries if matched_entries[i] => entry ]
+  let old_ids = [
+    for i, entry in self.entries if !matched_entries[i] => entry.1
+  ]
   if added.length() == 0 && old_ids.length() == 0 {
     return false
   }
@@ -135,9 +130,8 @@ fn MarkerDecorations::get_markers(
   let res : Array[(@base_common.Range, Marker)] = []
   for entry in self.entries {
     let (marker, id) = entry
-    match self.model.get_decoration_range(id) {
-      Some(range) => res.push((range, marker))
-      None => ()
+    if self.model.get_decoration_range(id) is Some(range) {
+      res.push((range, marker))
     }
   }
   res

--- a/editor/viewer/common/markers/marker_service.mbt
+++ b/editor/viewer/common/markers/marker_service.mbt
@@ -24,24 +24,8 @@ fn DoubleResourceMap::set(
   value : Array[Marker],
 ) -> Unit {
   let key = resource.to_string()
-  let owner_map = match self.by_resource.get(key) {
-    Some(m) => m
-    None => {
-      let m : Map[String, Array[Marker]] = Map([])
-      self.by_resource.set(key, m)
-      m
-    }
-  }
-  owner_map.set(owner, value)
-  let resource_map = match self.by_owner.get(owner) {
-    Some(m) => m
-    None => {
-      let m : Map[String, Array[Marker]] = Map([])
-      self.by_owner.set(owner, m)
-      m
-    }
-  }
-  resource_map.set(key, value)
+  self.by_resource.get_or_init(key, () => Map([])).set(owner, value)
+  self.by_owner.get_or_init(owner, () => Map([])).set(key, value)
 }
 
 ///|
@@ -93,13 +77,7 @@ fn DoubleResourceMap::delete(
 fn DoubleResourceMap::values_all(
   self : DoubleResourceMap,
 ) -> Array[Array[Marker]] {
-  let out : Array[Array[Marker]] = []
-  for owner_map in self.by_owner.values() {
-    for v in owner_map.values() {
-      out.push(v)
-    }
-  }
-  out
+  self.by_owner.values().flat_map(m => m.values()).to_array()
 }
 
 ///|
@@ -109,13 +87,7 @@ fn DoubleResourceMap::values_by_resource(
   resource : @base_common.Uri,
 ) -> Array[Array[Marker]] {
   match self.by_resource.get(resource.to_string()) {
-    Some(owner_map) => {
-      let out : Array[Array[Marker]] = []
-      for v in owner_map.values() {
-        out.push(v)
-      }
-      out
-    }
+    Some(owner_map) => owner_map.values().to_array()
     None => []
   }
 }
@@ -127,13 +99,7 @@ fn DoubleResourceMap::values_by_owner(
   owner : String,
 ) -> Array[Array[Marker]] {
   match self.by_owner.get(owner) {
-    Some(resource_map) => {
-      let out : Array[Array[Marker]] = []
-      for v in resource_map.values() {
-        out.push(v)
-      }
-      out
-    }
+    Some(resource_map) => resource_map.values().to_array()
     None => []
   }
 }
@@ -231,9 +197,8 @@ fn MarkerService::change_one_impl(
     // insert marker for this (owner,resource)-tuple
     let markers : Array[Marker] = []
     for data in marker_data {
-      match data.to_marker(owner, resource) {
-        Some(marker) => markers.push(marker)
-        None => ()
+      if data.to_marker(owner, resource) is Some(marker) {
+        markers.push(marker)
       }
     }
     self.data.set(resource, owner, markers)

--- a/editor/viewer/common/model/decorations.mbt
+++ b/editor/viewer/common/model/decorations.mbt
@@ -61,11 +61,7 @@ pub(all) struct ModelDecorationMinimapOptions {
 fn clean_class_name(class_name : String) -> String {
   let sb = StringBuilder()
   for unit in class_name.code_units() {
-    if (unit >= 'a' && unit <= 'z') ||
-      (unit >= 'A' && unit <= 'Z') ||
-      (unit >= '0' && unit <= '9') ||
-      unit == '-' ||
-      unit == '_' {
+    if unit is ('a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_') {
       sb.write_char(unit.to_int().unsafe_to_char())
     } else {
       sb.write_char(' ')

--- a/editor/viewer/common/model/interval_tree.mbt
+++ b/editor/viewer/common/model/interval_tree.mbt
@@ -1119,16 +1119,10 @@ fn right_rotate(t : IntervalTree, y : IntervalNode) -> Unit {
 fn compute_max_end(node : IntervalNode) -> Int {
   let mut max_end = node.end
   if !same_interval_node(node.left(), sentinel) {
-    let left_max_end = node.left().max_end
-    if left_max_end > max_end {
-      max_end = left_max_end
-    }
+    max_end = max_end.max(node.left().max_end)
   }
   if !same_interval_node(node.right(), sentinel) {
-    let right_max_end = node.right().max_end + node.delta
-    if right_max_end > max_end {
-      max_end = right_max_end
-    }
+    max_end = max_end.max(node.right().max_end + node.delta)
   }
   max_end
 }

--- a/editor/viewer/common/model/text_model.mbt
+++ b/editor/viewer/common/model/text_model.mbt
@@ -254,15 +254,10 @@ pub fn TextModel::on_before_attached(
   scheduler? : TokenizationScheduler,
 ) -> AttachedViewImpl {
   let mut installed_late_scheduler = false
-  if self.tokenization_state.scheduler.val is None {
-    match scheduler {
-      Some(scheduler) => {
-        self.tokenization_state.scheduler.val = Some(scheduler)
-        installed_late_scheduler = self.tokenization_state.attached_count.val >
-          0
-      }
-      None => ()
-    }
+  if self.tokenization_state.scheduler.val is None &&
+    scheduler is Some(scheduler) {
+    self.tokenization_state.scheduler.val = Some(scheduler)
+    installed_late_scheduler = self.tokenization_state.attached_count.val > 0
   }
   if installed_late_scheduler {
     self.tokenization.handle_did_change_attached()
@@ -429,11 +424,9 @@ pub fn TextModel::get_line_content(
 /// Every line's content, EOLs excluded. Mirrors `getLinesContent`
 /// (`textModel.ts:869`).
 pub fn TextModel::get_lines_content(self : TextModel) -> Array[String] {
-  let lines : Array[String] = []
-  for line in 0..<self.snapshot.line_count() {
-    lines.push(self.snapshot.line_text(line))
-  }
-  lines
+  [
+    for line in 0..<self.snapshot.line_count() => self.snapshot.line_text(line)
+  ]
 }
 
 ///|

--- a/editor/viewer/common/model/text_model_events.mbt
+++ b/editor/viewer/common/model/text_model_events.mbt
@@ -98,12 +98,7 @@ pub fn ModelRawContentChangedEvent::contains_event(
   self : ModelRawContentChangedEvent,
   change_type : RawContentChangedType,
 ) -> Bool {
-  for change in self.changes {
-    if change.change_type() == change_type {
-      return true
-    }
-  }
-  false
+  self.changes.any(change => change.change_type() == change_type)
 }
 
 ///|
@@ -280,9 +275,7 @@ pub fn TextModel::register_view_model(
   })
   @base_common.Disposable::from(() => {
     active.val = false
-    let retained = self.view_models.filter(callbacks => callbacks.active.val)
-    self.view_models.clear()
-    self.view_models.append(retained)
+    self.view_models.retain(callbacks => callbacks.active.val)
   })
 }
 

--- a/editor/viewer/common/model/text_model_tokens.mbt
+++ b/editor/viewer/common/model/text_model_tokens.mbt
@@ -148,14 +148,7 @@ fn RangePriorityQueueImpl::delete(
   self : RangePriorityQueueImpl,
   value : Int,
 ) -> Unit {
-  let index = for i, range in self.ranges {
-    if range.contains(value) {
-      break i
-    }
-  } nobreak {
-    -1
-  }
-  if index == -1 {
+  guard self.ranges.search_by(range => range.contains(value)) is Some(index) else {
     return
   }
   let range = self.ranges[index]

--- a/editor/viewer/common/model/token_theme.mbt
+++ b/editor/viewer/common/model/token_theme.mbt
@@ -56,24 +56,17 @@ const COLOR_ID_INVALID : Int = 13
 /// colors under different class names.
 fn tag_foreground_color_id(tag : @syntax.HighlightTag) -> Int {
   match tag {
-    Keyword => COLOR_ID_KEYWORD
-    Identifier => COLOR_ID_VARIABLE
+    Keyword | Constant | Tag => COLOR_ID_KEYWORD
+    Identifier | Variable | Attribute => COLOR_ID_VARIABLE
     String => COLOR_ID_STRING
     Number => COLOR_ID_NUMBER
-    Comment => COLOR_ID_COMMENT
-    Punctuation => COLOR_ID_PUNCTUATION
+    Comment | CommentDoc => COLOR_ID_COMMENT
+    Punctuation | Operator | Delimiter => COLOR_ID_PUNCTUATION
     Plain => @common_tokens.COLOR_ID_DEFAULT_FOREGROUND
-    Operator => COLOR_ID_PUNCTUATION
-    Delimiter => COLOR_ID_PUNCTUATION
     Type => COLOR_ID_TYPE
     Function => COLOR_ID_FUNCTION
-    Variable => COLOR_ID_VARIABLE
-    Constant => COLOR_ID_KEYWORD
     StringEscape => COLOR_ID_STRING_ESCAPE
-    CommentDoc => COLOR_ID_COMMENT
     Regexp => COLOR_ID_REGEXP
-    Tag => COLOR_ID_KEYWORD
-    Attribute => COLOR_ID_VARIABLE
     Invalid => COLOR_ID_INVALID
   }
 }

--- a/editor/viewer/common/model/tokenization_text_model_part.mbt
+++ b/editor/viewer/common/model/tokenization_text_model_part.mbt
@@ -42,15 +42,13 @@ fn TokenizationTextModelPart::TokenizationTextModelPart(
     model_state,
     attached_views,
     language_id => {
-      match @syntax.tokenization_registry.get(language_id) {
-        Some(tokenizer) =>
-          Some(
-            public_tokenizer_adapter(
-              tokenizer, @services.language_id_codec, language_id,
-            ),
-          )
-        None => None
-      }
+      @syntax.tokenization_registry
+      .get(language_id)
+      .map(tokenizer => {
+        public_tokenizer_adapter(
+          tokenizer, @services.language_id_codec, language_id,
+        )
+      })
     },
     subscribe_registry=true,
   )

--- a/editor/viewer/common/model/word_helper.mbt
+++ b/editor/viewer/common/model/word_helper.mbt
@@ -20,16 +20,13 @@ pub struct WordAtPosition {
 
 ///|
 fn is_ascii_digit(code : UInt16) -> Bool {
-  code >= '0' && code <= '9'
+  code is ('0'..='9')
 }
 
 ///|
 /// `\w` = `[A-Za-z0-9_]` (ASCII, no `u` flag).
 fn is_regex_word_char(code : UInt16) -> Bool {
-  (code >= 'A' && code <= 'Z') ||
-  (code >= 'a' && code <= 'z') ||
-  is_ascii_digit(code) ||
-  code == '_'
+  code is ('A'..='Z' | 'a'..='z' | '0'..='9' | '_')
 }
 
 ///|
@@ -37,15 +34,7 @@ fn is_regex_word_char(code : UInt16) -> Bool {
 /// the `[^...\s]+` character class (`wordHelper.ts:39`). Whitespace follows the
 /// repo convention (space/tab), the only whitespace present in line content.
 fn is_word_break(code : UInt16) -> Bool {
-  if code is (' ' | '\t') {
-    return true
-  }
-  for unit in usual_word_separators.code_units() {
-    if unit == code {
-      return true
-    }
-  }
-  false
+  code is (' ' | '\t') || usual_word_separators.code_units().contains(code)
 }
 
 ///|

--- a/editor/viewer/common/tokens/contiguous_tokens_store.mbt
+++ b/editor/viewer/common/tokens/contiguous_tokens_store.mbt
@@ -128,22 +128,14 @@ fn ContiguousTokensStore::massage_tokens(
     top_level_language_id,
   )
   if line_text_length == 0 {
-    let has_different_language_id = match tokens {
-      Some(words) if words.length() > 1 =>
-        TokenMetadata(words[1]).get_language_id() != encoded_language_id
-      _ => false
-    }
+    let has_different_language_id = tokens is Some([_, second, ..]) &&
+      TokenMetadata(second).get_language_id() != encoded_language_id
     if !has_different_language_id {
       return Empty
     }
   }
   match tokens {
-    None =>
-      Words([
-        line_text_length.reinterpret_as_uint(),
-        self.default_metadata(top_level_language_id),
-      ])
-    Some(words) if words.length() == 0 =>
+    None | Some([]) =>
       Words([
         line_text_length.reinterpret_as_uint(),
         self.default_metadata(top_level_language_id),
@@ -204,17 +196,7 @@ fn syntactic_line_tokens_equal(
 ) -> Bool {
   match (left, right) {
     (Missing, Missing) | (Empty, Empty) => true
-    (Words(left_words), Words(right_words)) => {
-      if left_words.length() != right_words.length() {
-        return false
-      }
-      for index in 0..<left_words.length() {
-        if left_words[index] != right_words[index] {
-          return false
-        }
-      }
-      true
-    }
+    (Words(left_words), Words(right_words)) => left_words == right_words
     _ => false
   }
 }

--- a/editor/viewer/common/view_layout/line_decorations.mbt
+++ b/editor/viewer/common/view_layout/line_decorations.mbt
@@ -94,15 +94,10 @@ pub fn LineDecorationsNormalizer::normalize(
       end_column -= 1
     }
     let start_offset = (start_column - 1).clamp(min=0, max=line_length)
-    let max_end_offset = if line_length == 0 {
+    let end_offset_high = if line_length == 0 {
       start_offset - 1
     } else {
-      line_length - 1
-    }
-    let end_offset_high = if max_end_offset < start_offset - 1 {
-      start_offset - 1
-    } else {
-      max_end_offset
+      (line_length - 1).max(start_offset - 1)
     }
     let end_offset = (end_column - 2).clamp(
       min=start_offset - 1,
@@ -206,11 +201,7 @@ fn DecorationSegmentStack::insert(
 
 ///|
 fn decoration_stack_metadata(metadata : Array[Int]) -> Int {
-  let mut result = 0
-  for item in metadata {
-    result = result | item
-  }
-  result
+  metadata.fold(init=0, (bits, item) => bits | item)
 }
 
 ///|

--- a/editor/viewer/common/view_layout/lines_layout.mbt
+++ b/editor/viewer/common/view_layout/lines_layout.mbt
@@ -386,16 +386,12 @@ fn LinesLayout::commit_pending_changes(
       if to_remove.contains(whitespace.id) {
         continue
       }
-      match to_change.get(whitespace.id) {
-        Some(change) => {
-          whitespace.after_line_number = change.new_after_line_number
-          whitespace.height = change.new_height
-          match change.new_min_width {
-            Some(min_width) => whitespace.min_width = min_width
-            None => ()
-          }
+      if to_change.get(whitespace.id) is Some(change) {
+        whitespace.after_line_number = change.new_after_line_number
+        whitespace.height = change.new_height
+        if change.new_min_width is Some(min_width) {
+          whitespace.min_width = min_width
         }
-        None => ()
       }
       result.push(whitespace)
     }
@@ -412,25 +408,14 @@ fn LinesLayout::commit_pending_changes(
   for index, whitespace in result {
     original_sequence[whitespace.id] = index
   }
-  result.sort_by(fn(a, b) {
-    if a.after_line_number < b.after_line_number {
-      -1
-    } else if a.after_line_number > b.after_line_number {
-      1
-    } else if a.ordinal < b.ordinal {
-      -1
-    } else if a.ordinal > b.ordinal {
-      1
-    } else {
-      let a_sequence = original_sequence[a.id]
-      let b_sequence = original_sequence[b.id]
-      if a_sequence < b_sequence {
-        -1
-      } else if a_sequence > b_sequence {
-        1
-      } else {
-        0
-      }
+  result.sort_by((a, b) => {
+    match a.after_line_number.compare(b.after_line_number) {
+      0 =>
+        match a.ordinal.compare(b.ordinal) {
+          0 => original_sequence[a.id].compare(original_sequence[b.id])
+          ordinal_order => ordinal_order
+        }
+      line_order => line_order
     }
   })
   self.arr = result
@@ -455,13 +440,7 @@ fn LinesLayout::insert_whitespace(
 
 ///|
 fn LinesLayout::find_whitespace_index(self : LinesLayout, id : String) -> Int {
-  let arr = self.arr
-  for i in 0..<arr.length() {
-    if arr[i].id == id {
-      return i
-    }
-  }
-  -1
+  self.arr.search_by(whitespace => whitespace.id == id).unwrap_or(-1)
 }
 
 ///|
@@ -480,13 +459,9 @@ fn LinesLayout::change_one_whitespace(
     self.arr[index].height = new_height
     self.prefix_sum_valid_index = self.prefix_sum_valid_index.min(index - 1)
   }
-  match new_min_width {
-    Some(min_width) =>
-      if self.arr[index].min_width != min_width {
-        self.arr[index].min_width = min_width
-        self.min_width = -1
-      }
-    None => ()
+  if new_min_width is Some(min_width) && self.arr[index].min_width != min_width {
+    self.arr[index].min_width = min_width
+    self.min_width = -1
   }
   if self.arr[index].after_line_number != new_after_line_number {
     // `afterLineNumber` changed: removing then re-inserting may reorder it.
@@ -710,12 +685,9 @@ pub fn LinesLayout::has_whitespace(self : LinesLayout) -> Bool {
 /// The maximum min width over all whitespaces.
 pub fn LinesLayout::get_whitespace_min_width(self : LinesLayout) -> Int {
   if self.min_width == -1 {
-    let min_width = for whitespace in self.arr; min_width = 0 {
-      continue min_width.max(whitespace.min_width)
-    } nobreak {
-      min_width
-    }
-    self.min_width = min_width
+    self.min_width = self.arr.fold(init=0, (widest, whitespace) => {
+      widest.max(whitespace.min_width)
+    })
   }
   self.min_width
 }

--- a/editor/viewer/common/view_layout/prefix_sum_computer.mbt
+++ b/editor/viewer/common/view_layout/prefix_sum_computer.mbt
@@ -245,11 +245,7 @@ pub fn ConstantTimePrefixSumComputer::get_index_of(
   // A faithful re-build always fills [0, totalSum), so an out-of-range sum is
   // the "undefined entry" case in the upstream sparse array.
   if sum < 0 || sum >= self.index_by_sum.length() {
-    let last_idx = if self.values.length() - 1 > 0 {
-      self.values.length() - 1
-    } else {
-      0
-    }
+    let last_idx = (self.values.length() - 1).max(0)
     let last_prefix_sum = if last_idx > 0 {
       self.prefix_sum[last_idx - 1]
     } else {
@@ -268,13 +264,8 @@ pub fn ConstantTimePrefixSumComputer::remove_values(
   start : Int,
   delete_count : Int,
 ) -> Unit {
-  let next : Array[Int] = []
-  for i in 0..<self.values.length() {
-    if i < start || i >= start + delete_count {
-      next.push(self.values[i])
-    }
-  }
-  self.values = next
+  let delete_end = start + delete_count
+  self.values = [ for i, v in self.values if i < start || i >= delete_end => v ]
   self.invalidate(start)
 }
 
@@ -284,17 +275,11 @@ pub fn ConstantTimePrefixSumComputer::insert_values(
   insert_index : Int,
   insert_arr : Array[Int],
 ) -> Unit {
-  let next : Array[Int] = []
-  for i in 0..<insert_index {
-    next.push(self.values[i])
-  }
-  for v in insert_arr {
-    next.push(v)
-  }
-  for i in insert_index..<self.values.length() {
-    next.push(self.values[i])
-  }
-  self.values = next
+  self.values = [
+    ..self.values[:insert_index],
+    ..insert_arr,
+    ..self.values[insert_index:],
+  ]
   self.invalidate(insert_index)
 }
 
@@ -326,11 +311,7 @@ fn ConstantTimePrefixSumComputer::ensure_valid(self : Self) -> Unit {
   }
   let len = self.values.length()
   let prefix_sum = Array::make(len, 0)
-  let total = for value in self.values; total = 0 {
-    continue total + value
-  } nobreak {
-    total
-  }
+  let total = self.values.fold(init=0, (sum, value) => sum + value)
   let index_by_sum = Array::make(total, 0)
   for i in 0..<len {
     let value = self.values[i]

--- a/editor/viewer/common/view_layout/view_lines_viewport_data.mbt
+++ b/editor/viewer/common/view_layout/view_lines_viewport_data.mbt
@@ -28,7 +28,12 @@ pub fn ViewportData::decorations_for_line(
   self : ViewportData,
   line_number : Int,
 ) -> Array[LineDecoration] {
-  self.line_decorations.get(line_number - self.start_line_number).unwrap_or([])
+  // Matched rather than `unwrap_or([])`: this runs once per rendered line, and
+  // `unwrap_or` builds the empty fallback array on the hit path too.
+  match self.line_decorations.get(line_number - self.start_line_number) {
+    Some(decorations) => decorations
+    None => []
+  }
 }
 
 ///|

--- a/editor/viewer/common/view_layout/view_lines_viewport_data.mbt
+++ b/editor/viewer/common/view_layout/view_lines_viewport_data.mbt
@@ -19,12 +19,7 @@ pub fn ViewportData::line_data(
   self : ViewportData,
   line_number : Int,
 ) -> ViewLineRenderingData? {
-  let index = line_number - self.start_line_number
-  if index >= 0 && index < self.lines.length() {
-    Some(self.lines[index])
-  } else {
-    None
-  }
+  self.lines.get(line_number - self.start_line_number)
 }
 
 ///|
@@ -33,11 +28,7 @@ pub fn ViewportData::decorations_for_line(
   self : ViewportData,
   line_number : Int,
 ) -> Array[LineDecoration] {
-  let index = line_number - self.start_line_number
-  match self.line_decorations.get(index) {
-    Some(decorations) => decorations
-    None => []
-  }
+  self.line_decorations.get(line_number - self.start_line_number).unwrap_or([])
 }
 
 ///|
@@ -45,13 +36,7 @@ pub fn ViewportData::decorations_for_line(
 pub fn ViewportData::decorations_in_viewport(
   self : ViewportData,
 ) -> Array[LineDecoration] {
-  let out : Array[LineDecoration] = []
-  for line in self.line_decorations {
-    for decoration in line {
-      out.push(decoration)
-    }
-  }
-  out
+  self.line_decorations.flatten()
 }
 
 ///|

--- a/editor/viewer/common/view_model/cursor_event_dispatcher.mbt
+++ b/editor/viewer/common/view_model/cursor_event_dispatcher.mbt
@@ -47,21 +47,7 @@ fn selections_are_equal(
   a : Array[@core.Selection]?,
   b : Array[@core.Selection]?,
 ) -> Bool {
-  match (a, b) {
-    (None, None) => true
-    (None, Some(_)) | (Some(_), None) => false
-    (Some(a), Some(b)) => {
-      if a.length() != b.length() {
-        return false
-      }
-      for index in 0..<a.length() {
-        if a[index] != b[index] {
-          return false
-        }
-      }
-      true
-    }
-  }
+  a == b
 }
 
 ///|
@@ -339,11 +325,8 @@ fn CursorEventDispatcher::on_event(
   listener : (CursorStateChangedEvent) -> Unit,
 ) -> @base_common.Disposable {
   self.on_outgoing_event(event => {
-    match event {
-      CursorEvent(event) => listener(event)
-      ViewZonesEvent(_) => ()
-      HiddenAreasEvent(_) => ()
-      ModelTokensEvent(_) => ()
+    if event is CursorEvent(event) {
+      listener(event)
     }
   })
 }
@@ -355,11 +338,8 @@ fn CursorEventDispatcher::on_view_zones_changed(
   listener : (ViewZonesChangedEvent) -> Unit,
 ) -> @base_common.Disposable {
   self.on_outgoing_event(event => {
-    match event {
-      CursorEvent(_) => ()
-      ViewZonesEvent(event) => listener(event)
-      HiddenAreasEvent(_) => ()
-      ModelTokensEvent(_) => ()
+    if event is ViewZonesEvent(event) {
+      listener(event)
     }
   })
 }
@@ -371,9 +351,8 @@ fn CursorEventDispatcher::on_hidden_areas_changed(
   listener : (HiddenAreasChangedOutgoingEvent) -> Unit,
 ) -> @base_common.Disposable {
   self.on_outgoing_event(event => {
-    match event {
-      HiddenAreasEvent(event) => listener(event)
-      CursorEvent(_) | ViewZonesEvent(_) | ModelTokensEvent(_) => ()
+    if event is HiddenAreasEvent(event) {
+      listener(event)
     }
   })
 }
@@ -385,9 +364,8 @@ fn CursorEventDispatcher::on_model_tokens_changed(
   listener : (ModelTokensChangedOutgoingEvent) -> Unit,
 ) -> @base_common.Disposable {
   self.on_outgoing_event(event => {
-    match event {
-      CursorEvent(_) | ViewZonesEvent(_) | HiddenAreasEvent(_) => ()
-      ModelTokensEvent(event) => listener(event)
+    if event is ModelTokensEvent(event) {
+      listener(event)
     }
   })
 }
@@ -455,12 +433,9 @@ fn CursorEventDispatcher::add_outgoing_event(
     return
   }
   for index, pending in self.outgoing_events {
-    match pending.attempt_to_merge(event) {
-      Some(merged) => {
-        self.outgoing_events[index] = merged
-        return
-      }
-      None => ()
+    if pending.attempt_to_merge(event) is Some(merged) {
+      self.outgoing_events[index] = merged
+      return
     }
   }
   self.outgoing_events.push(event)

--- a/editor/viewer/common/view_model/cursor_move_operations.mbt
+++ b/editor/viewer/common/view_model/cursor_move_operations.mbt
@@ -407,17 +407,14 @@ fn cursor_vertical(
       tab_size,
     )
   }
-  match normalization_affinity {
-    Some(affinity) => {
-      let new_position = model.normalize_position(
-        Position(line_number, column),
-        affinity,
-      )
-      leftover_visible_columns += column - new_position.column
-      line_number = new_position.line_number
-      column = new_position.column
-    }
-    None => ()
+  if normalization_affinity is Some(affinity) {
+    let new_position = model.normalize_position(
+      Position(line_number, column),
+      affinity,
+    )
+    leftover_visible_columns += column - new_position.column
+    line_number = new_position.line_number
+    column = new_position.column
   }
   { line_number, column, leftover_visible_columns, }
 }

--- a/editor/viewer/common/view_model/injected_text.mbt
+++ b/editor/viewer/common/view_model/injected_text.mbt
@@ -262,27 +262,21 @@ pub fn ProjectedTextLine::injected_text_index_at_projected_column(
 
 ///|
 fn identity_projected_text_line(line_text : String) -> ProjectedTextLine {
-  let model_columns : Array[Int] = []
-  let injected_text_indices : Array[Int] = []
-  let model_to_projected_columns : Array[Int] = []
-  for column in 0..<=line_text.length() {
-    model_columns.push(column)
-    model_to_projected_columns.push(column)
-    if column < line_text.length() {
-      injected_text_indices.push(-1)
-    }
-  }
+  let length = line_text.length()
+  let model_columns = Array::makei(length + 1, column => column)
+  let injected_text_indices = Array::make(length, -1)
+  let model_to_projected_columns = Array::makei(length + 1, column => column)
   let parts : Array[ProjectedLinePart] = []
-  if line_text.length() > 0 {
+  if length > 0 {
     parts.push({
       start: 0,
-      end: line_text.length(),
-      kind: SourceSegment(model_start=0, model_end=line_text.length()),
+      end: length,
+      kind: SourceSegment(model_start=0, model_end=length),
     })
   }
   {
     text: line_text,
-    model_line_length: line_text.length(),
+    model_line_length: length,
     model_columns,
     injected_text_indices,
     model_to_projected_columns,
@@ -314,10 +308,7 @@ fn normalize_injected_text(
 
 ///|
 fn initial_model_to_projected_columns(line_length : Int) -> Array[Int] {
-  let columns : Array[Int] = []
-  for _ in 0..<=line_length {
-    columns.push(-1)
-  }
+  let columns = Array::make(line_length + 1, -1)
   columns[0] = 0
   columns
 }

--- a/editor/viewer/common/view_model/inline_decorations.mbt
+++ b/editor/viewer/common/view_model/inline_decorations.mbt
@@ -295,39 +295,44 @@ fn InlineModelDecorationsComputer::get_or_create_view_model_decoration(
   decoration_options : ResolvedInlineDecorationOptions,
 ) -> ViewModelDecoration {
   let id = model_decoration.id
-  self.decorations_cache.get_or_init(id, () => {
-    let model_range = model_decoration.range
-    let options = model_decoration.options
-    let view_range = if decoration_options.is_whole_line {
-      // For backwards compatibility, whole-line decorations span min..max
-      // col, kept outside injected text (inlineDecorations.ts:171-172).
-      // DEFERRED: the source belowHiddenRanges switch is absent; hidden-line
-      // handling remains in the projection.
-      let start = self.coordinates_converter.model_position_to_view_position(
-        Position(model_range.start_line_number, 1),
-        affinity=Left,
-      )
-      let end = self.coordinates_converter.model_position_to_view_position(
-        Position(
-          model_range.end_line_number,
-          self.model.snapshot.get_line_max_column(model_range.end_line_number),
-        ),
-        affinity=Right,
-      )
-      @base_common.Range(
-        start.line_number,
-        start.column,
-        end.line_number,
-        end.column,
-      )
-    } else {
-      // inlineDecorations.ts:177: Right keeps an empty decoration right of
-      // injected text at its position.
-      self.coordinates_converter.model_range_to_view_range(
-        model_range,
-        affinity=Right,
-      )
+  match self.decorations_cache.get(id) {
+    Some(r) => r
+    None => {
+      let model_range = model_decoration.range
+      let options = model_decoration.options
+      let view_range = if decoration_options.is_whole_line {
+        // For backwards compatibility, whole-line decorations span min..max
+        // col, kept outside injected text (inlineDecorations.ts:171-172).
+        // DEFERRED: the source belowHiddenRanges switch is absent; hidden-line
+        // handling remains in the projection.
+        let start = self.coordinates_converter.model_position_to_view_position(
+          Position(model_range.start_line_number, 1),
+          affinity=Left,
+        )
+        let end = self.coordinates_converter.model_position_to_view_position(
+          Position(
+            model_range.end_line_number,
+            self.model.snapshot.get_line_max_column(model_range.end_line_number),
+          ),
+          affinity=Right,
+        )
+        @base_common.Range(
+          start.line_number,
+          start.column,
+          end.line_number,
+          end.column,
+        )
+      } else {
+        // inlineDecorations.ts:177: Right keeps an empty decoration right of
+        // injected text at its position.
+        self.coordinates_converter.model_range_to_view_range(
+          model_range,
+          affinity=Right,
+        )
+      }
+      let r = ViewModelDecoration::ViewModelDecoration(view_range, options)
+      self.decorations_cache[id] = r
+      r
     }
-    ViewModelDecoration(view_range, options)
-  })
+  }
 }

--- a/editor/viewer/common/view_model/inline_decorations.mbt
+++ b/editor/viewer/common/view_model/inline_decorations.mbt
@@ -191,76 +191,69 @@ fn InlineModelDecorationsComputer::compute_decorations(
     )
     let view_range = view_model_decoration.range
     decorations_in_viewport.push(view_model_decoration)
-    match decoration_options.inline_class_name {
-      Some(inline_class_name) => {
-        let type_ = if decoration_options.inline_class_name_affects_letter_spacing {
-          RegularAffectingLetterSpacing
-        } else {
-          Regular
-        }
-        let inline_decoration = InlineDecoration::InlineDecoration(
-          view_range, inline_class_name, type_,
-        )
-        let intersected_start_line_number = start_line_number.max(
-          view_range.start_line_number,
-        )
-        let intersected_end_line_number = end_line_number.min(
-          view_range.end_line_number,
-        )
-        for j in intersected_start_line_number..<=intersected_end_line_number {
-          inline_decorations[j - start_line_number].push(inline_decoration)
-          if decoration_options.affects_font {
-            has_variable_fonts[j - start_line_number] = true
-          }
+    if decoration_options.inline_class_name is Some(inline_class_name) {
+      let type_ = if decoration_options.inline_class_name_affects_letter_spacing {
+        RegularAffectingLetterSpacing
+      } else {
+        Regular
+      }
+      let inline_decoration = InlineDecoration::InlineDecoration(
+        view_range, inline_class_name, type_,
+      )
+      let intersected_start_line_number = start_line_number.max(
+        view_range.start_line_number,
+      )
+      let intersected_end_line_number = end_line_number.min(
+        view_range.end_line_number,
+      )
+      for j in intersected_start_line_number..<=intersected_end_line_number {
+        inline_decorations[j - start_line_number].push(inline_decoration)
+        if decoration_options.affects_font {
+          has_variable_fonts[j - start_line_number] = true
         }
       }
-      None => ()
     }
-    match decoration_options.before_content_class_name {
-      Some(before_content_class_name) =>
-        if start_line_number <= view_range.start_line_number &&
-          view_range.start_line_number <= end_line_number {
-          let inline_decoration = InlineDecoration::InlineDecoration(
-            Range(
-              view_range.start_line_number,
-              view_range.start_column,
-              view_range.start_line_number,
-              view_range.start_column,
-            ),
-            before_content_class_name,
-            Before,
-          )
-          inline_decorations[view_range.start_line_number - start_line_number].push(
-            inline_decoration,
-          )
-          if decoration_options.affects_font {
-            has_variable_fonts[view_range.start_line_number - start_line_number] = true
-          }
-        }
-      None => ()
+    if decoration_options.before_content_class_name
+      is Some(before_content_class_name) &&
+      start_line_number <= view_range.start_line_number &&
+      view_range.start_line_number <= end_line_number {
+      let inline_decoration = InlineDecoration::InlineDecoration(
+        Range(
+          view_range.start_line_number,
+          view_range.start_column,
+          view_range.start_line_number,
+          view_range.start_column,
+        ),
+        before_content_class_name,
+        Before,
+      )
+      inline_decorations[view_range.start_line_number - start_line_number].push(
+        inline_decoration,
+      )
+      if decoration_options.affects_font {
+        has_variable_fonts[view_range.start_line_number - start_line_number] = true
+      }
     }
-    match decoration_options.after_content_class_name {
-      Some(after_content_class_name) =>
-        if start_line_number <= view_range.end_line_number &&
-          view_range.end_line_number <= end_line_number {
-          let inline_decoration = InlineDecoration::InlineDecoration(
-            Range(
-              view_range.end_line_number,
-              view_range.end_column,
-              view_range.end_line_number,
-              view_range.end_column,
-            ),
-            after_content_class_name,
-            After,
-          )
-          inline_decorations[view_range.end_line_number - start_line_number].push(
-            inline_decoration,
-          )
-          if decoration_options.affects_font {
-            has_variable_fonts[view_range.end_line_number - start_line_number] = true
-          }
-        }
-      None => ()
+    if decoration_options.after_content_class_name
+      is Some(after_content_class_name) &&
+      start_line_number <= view_range.end_line_number &&
+      view_range.end_line_number <= end_line_number {
+      let inline_decoration = InlineDecoration::InlineDecoration(
+        Range(
+          view_range.end_line_number,
+          view_range.end_column,
+          view_range.end_line_number,
+          view_range.end_column,
+        ),
+        after_content_class_name,
+        After,
+      )
+      inline_decorations[view_range.end_line_number - start_line_number].push(
+        inline_decoration,
+      )
+      if decoration_options.affects_font {
+        has_variable_fonts[view_range.end_line_number - start_line_number] = true
+      }
     }
   }
   {
@@ -302,44 +295,39 @@ fn InlineModelDecorationsComputer::get_or_create_view_model_decoration(
   decoration_options : ResolvedInlineDecorationOptions,
 ) -> ViewModelDecoration {
   let id = model_decoration.id
-  match self.decorations_cache.get(id) {
-    Some(r) => r
-    None => {
-      let model_range = model_decoration.range
-      let options = model_decoration.options
-      let view_range = if decoration_options.is_whole_line {
-        // For backwards compatibility, whole-line decorations span min..max
-        // col, kept outside injected text (inlineDecorations.ts:171-172).
-        // DEFERRED: the source belowHiddenRanges switch is absent; hidden-line
-        // handling remains in the projection.
-        let start = self.coordinates_converter.model_position_to_view_position(
-          Position(model_range.start_line_number, 1),
-          affinity=Left,
-        )
-        let end = self.coordinates_converter.model_position_to_view_position(
-          Position(
-            model_range.end_line_number,
-            self.model.snapshot.get_line_max_column(model_range.end_line_number),
-          ),
-          affinity=Right,
-        )
-        @base_common.Range(
-          start.line_number,
-          start.column,
-          end.line_number,
-          end.column,
-        )
-      } else {
-        // inlineDecorations.ts:177: Right keeps an empty decoration right of
-        // injected text at its position.
-        self.coordinates_converter.model_range_to_view_range(
-          model_range,
-          affinity=Right,
-        )
-      }
-      let r = ViewModelDecoration::ViewModelDecoration(view_range, options)
-      self.decorations_cache[id] = r
-      r
+  self.decorations_cache.get_or_init(id, () => {
+    let model_range = model_decoration.range
+    let options = model_decoration.options
+    let view_range = if decoration_options.is_whole_line {
+      // For backwards compatibility, whole-line decorations span min..max
+      // col, kept outside injected text (inlineDecorations.ts:171-172).
+      // DEFERRED: the source belowHiddenRanges switch is absent; hidden-line
+      // handling remains in the projection.
+      let start = self.coordinates_converter.model_position_to_view_position(
+        Position(model_range.start_line_number, 1),
+        affinity=Left,
+      )
+      let end = self.coordinates_converter.model_position_to_view_position(
+        Position(
+          model_range.end_line_number,
+          self.model.snapshot.get_line_max_column(model_range.end_line_number),
+        ),
+        affinity=Right,
+      )
+      @base_common.Range(
+        start.line_number,
+        start.column,
+        end.line_number,
+        end.column,
+      )
+    } else {
+      // inlineDecorations.ts:177: Right keeps an empty decoration right of
+      // injected text at its position.
+      self.coordinates_converter.model_range_to_view_range(
+        model_range,
+        affinity=Right,
+      )
     }
-  }
+    ViewModelDecoration(view_range, options)
+  })
 }

--- a/editor/viewer/common/view_model/margin_decorations.mbt
+++ b/editor/viewer/common/view_model/margin_decorations.mbt
@@ -30,25 +30,21 @@ pub fn lines_decorations_to_render(
 ) -> Array[DecorationToRender] {
   let result : Array[DecorationToRender] = []
   for decoration in decorations {
-    match decoration.options.lines_decorations_class_name {
-      Some(class_name) =>
-        result.push({
-          start_line_number: decoration.range.start_line_number,
-          end_line_number: decoration.range.end_line_number,
-          class_name,
-          z_index: decoration.options.z_index,
-        })
-      None => ()
+    if decoration.options.lines_decorations_class_name is Some(class_name) {
+      result.push({
+        start_line_number: decoration.range.start_line_number,
+        end_line_number: decoration.range.end_line_number,
+        class_name,
+        z_index: decoration.options.z_index,
+      })
     }
-    match decoration.options.first_line_decoration_class_name {
-      Some(class_name) =>
-        result.push({
-          start_line_number: decoration.range.start_line_number,
-          end_line_number: decoration.range.start_line_number,
-          class_name,
-          z_index: decoration.options.z_index,
-        })
-      None => ()
+    if decoration.options.first_line_decoration_class_name is Some(class_name) {
+      result.push({
+        start_line_number: decoration.range.start_line_number,
+        end_line_number: decoration.range.start_line_number,
+        class_name,
+        z_index: decoration.options.z_index,
+      })
     }
   }
   result
@@ -89,28 +85,16 @@ pub fn dedup_margin_decorations(
   let mut prev_end_line_index = 0
   for decoration in decorations {
     let class_name = decoration.class_name
-    let mut start_line_index = if decoration.start_line_number >
-      visible_start_line_number {
-      decoration.start_line_number - visible_start_line_number
-    } else {
-      0
-    }
-    let end_line_index = if decoration.end_line_number < visible_end_line_number {
-      decoration.end_line_number - visible_start_line_number
-    } else {
-      visible_end_line_number - visible_start_line_number
-    }
+    let mut start_line_index = (decoration.start_line_number -
+    visible_start_line_number).max(0)
+    let end_line_index = (decoration.end_line_number - visible_start_line_number).min(
+      visible_end_line_number - visible_start_line_number,
+    )
     if prev_class_name == Some(class_name) {
       // Here we avoid rendering the same className multiple times on the
       // same line.
-      start_line_index = if prev_end_line_index + 1 > start_line_index {
-        prev_end_line_index + 1
-      } else {
-        start_line_index
-      }
-      if end_line_index > prev_end_line_index {
-        prev_end_line_index = end_line_index
-      }
+      start_line_index = start_line_index.max(prev_end_line_index + 1)
+      prev_end_line_index = prev_end_line_index.max(end_line_index)
     } else {
       prev_class_name = Some(class_name)
       prev_end_line_index = end_line_index

--- a/editor/viewer/common/view_model/model_line_projection.mbt
+++ b/editor/viewer/common/view_model/model_line_projection.mbt
@@ -521,11 +521,7 @@ fn view_line_data_for_segment_with_injections(
 /// A run of `n` spaces — the leading indent prepended to a wrapped continuation
 /// line. Monaco's `spaces(count)`.
 fn spaces(n : Int) -> String {
-  let sb = StringBuilder()
-  for _ in 0..<n {
-    sb.write_char(' ')
-  }
-  sb.to_string()
+  " ".repeat(n.max(0))
 }
 
 ///|
@@ -533,11 +529,10 @@ fn spaces(n : Int) -> String {
 fn injection_options_for_projected_line(
   projected_line : ProjectedTextLine,
 ) -> Array[@model.InjectedTextOptions] {
-  let options : Array[@model.InjectedTextOptions] = []
-  for part in projected_line.parts {
+  projected_line.parts.filter_map(part => {
     match part.kind {
       InjectedSegment(class_name~, ..) =>
-        options.push(
+        Some(
           InjectedTextOptions(
             projected_line.text[part.start:part.end].to_owned(),
             inline_class_name?=if class_name == "" {
@@ -547,10 +542,9 @@ fn injection_options_for_projected_line(
             },
           ),
         )
-      SourceSegment(_) => ()
+      SourceSegment(_) => None
     }
-  }
-  options
+  })
 }
 
 ///|
@@ -575,14 +569,12 @@ fn resolve_injection_options(
 fn injection_offsets_for_projected_line(
   projected_line : ProjectedTextLine,
 ) -> Array[Int] {
-  let offsets : Array[Int] = []
-  for part in projected_line.parts {
+  projected_line.parts.filter_map(part => {
     match part.kind {
-      InjectedSegment(model_column~, ..) => offsets.push(model_column)
-      SourceSegment(_) => ()
+      InjectedSegment(model_column~, ..) => Some(model_column)
+      SourceSegment(_) => None
     }
-  }
-  offsets
+  })
 }
 
 ///|
@@ -668,44 +660,41 @@ fn InjectedTextInlineDecorationsComputer::get_inline_decorations(
       }
       if line_start_offset_in_input_with_injections <
         injected_text_end_offset_in_input_with_injections {
-        match options.inline_class_name {
-          Some(inline_class_name) => {
-            let wrapped_text_indent_length = (self.context.get_wrapped_text_indent_length)(
-              model_line_number,
-            )
-            let offset = if output_line_index > 0 {
-              wrapped_text_indent_length
-            } else {
-              0
-            }
-            let start = offset +
-              (injected_text_start_offset_in_input_with_injections -
-              line_start_offset_in_input_with_injections).max(0)
-            let end = offset +
-              (injected_text_end_offset_in_input_with_injections -
-              line_start_offset_in_input_with_injections).min(
-                line_end_offset_in_input_with_injections -
-                line_start_offset_in_input_with_injections,
-              )
-            if start != end {
-              let view_line_number = (self.context.get_base_view_line_number)(
-                  model_line_number,
-                ) +
-                output_line_index
-              inline_decorations.push(
-                InlineDecoration(
-                  Range(view_line_number, start + 1, view_line_number, end + 1),
-                  inline_class_name,
-                  if options.inline_class_name_affects_letter_spacing {
-                    RegularAffectingLetterSpacing
-                  } else {
-                    Regular
-                  },
-                ),
-              )
-            }
+        if options.inline_class_name is Some(inline_class_name) {
+          let wrapped_text_indent_length = (self.context.get_wrapped_text_indent_length)(
+            model_line_number,
+          )
+          let offset = if output_line_index > 0 {
+            wrapped_text_indent_length
+          } else {
+            0
           }
-          None => ()
+          let start = offset +
+            (injected_text_start_offset_in_input_with_injections -
+            line_start_offset_in_input_with_injections).max(0)
+          let end = offset +
+            (injected_text_end_offset_in_input_with_injections -
+            line_start_offset_in_input_with_injections).min(
+              line_end_offset_in_input_with_injections -
+              line_start_offset_in_input_with_injections,
+            )
+          if start != end {
+            let view_line_number = (self.context.get_base_view_line_number)(
+                model_line_number,
+              ) +
+              output_line_index
+            inline_decorations.push(
+              InlineDecoration(
+                Range(view_line_number, start + 1, view_line_number, end + 1),
+                inline_class_name,
+                if options.inline_class_name_affects_letter_spacing {
+                  RegularAffectingLetterSpacing
+                } else {
+                  Regular
+                },
+              ),
+            )
+          }
         }
       }
       if injected_text_end_offset_in_input_with_injections <=

--- a/editor/viewer/common/view_model/view_line_data.mbt
+++ b/editor/viewer/common/view_model/view_line_data.mbt
@@ -222,10 +222,5 @@ fn line_decorations_for_line(
 
 ///|
 fn is_basic_ascii(text : String) -> Bool {
-  for unit in text.code_units() {
-    if unit > 127 {
-      return false
-    }
-  }
-  true
+  text.code_units().all(unit => unit <= 127)
 }

--- a/editor/viewer/common/view_model/view_model.mbt
+++ b/editor/viewer/common/view_model/view_model.mbt
@@ -165,22 +165,19 @@ pub fn ViewModel::with_options(
 /// registered cursor listeners and is retired here before layout teardown.
 /// Called from the Viewer's `ModelData::dispose`.
 pub fn ViewModel::dispose(self : ViewModel) -> Unit {
-  match self.visible_lines_subscription {
-    Some(subscription) => subscription.dispose()
-    None => ()
+  if self.visible_lines_subscription is Some(subscription) {
+    subscription.dispose()
   }
   self.visible_lines_subscription = None
-  match self.model_tokens_subscription {
-    Some(subscription) => subscription.dispose()
-    None => ()
+  if self.model_tokens_subscription is Some(subscription) {
+    subscription.dispose()
   }
   self.model_tokens_subscription = None
   self.cursor_event_dispatcher.dispose()
   self.lines.dispose()
   self.view_layout.dispose()
-  match self.model_registration {
-    Some(registration) => registration.dispose()
-    None => ()
+  if self.model_registration is Some(registration) {
+    registration.dispose()
   }
   self.model_registration = None
 }

--- a/editor/viewer/common/view_model/view_model_lines_projected.mbt
+++ b/editor/viewer/common/view_model/view_model_lines_projected.mbt
@@ -214,14 +214,9 @@ fn ViewModelLinesFromProjectedModel::rebuild_prefix_sums(
 pub fn ViewModelLinesFromProjectedModel::get_hidden_areas(
   self : ViewModelLinesFromProjectedModel,
 ) -> Array[@base_common.Range] {
-  let ranges : Array[@base_common.Range] = []
-  for decoration_id in self.hidden_areas_decoration_ids {
-    match self.model.get_decoration_range(decoration_id) {
-      Some(range) => ranges.push(range)
-      None => ()
-    }
-  }
-  ranges
+  self.hidden_areas_decoration_ids.filter_map(decoration_id => {
+    self.model.get_decoration_range(decoration_id)
+  })
 }
 
 ///|
@@ -241,17 +236,8 @@ pub fn ViewModelLinesFromProjectedModel::set_hidden_areas(
   old_ranges.sort_by((a, b) => {
     @base_common.Range::compare_ranges_using_starts(a, b)
   })
-  if new_ranges.length() == old_ranges.length() {
-    let mut has_difference = false
-    for i in 0..<new_ranges.length() {
-      if new_ranges[i] != old_ranges[i] {
-        has_difference = true
-        break
-      }
-    }
-    if !has_difference {
-      return false
-    }
+  if new_ranges == old_ranges {
+    return false
   }
   let new_decorations : Array[@model.ModelDeltaDecoration] = new_ranges.map(r => {
     range: r,
@@ -805,33 +791,26 @@ fn line_injected_text_from_decorations(
   }
   let entries : Array[(Int, Int, Int, @model.InjectedTextOptions)] = []
   for decoration in model.get_injected_text_decorations() {
-    match decoration.options.before {
-      Some(before) =>
-        if before.content().length() > 0 {
-          entries.push(
-            (
-              decoration.range.start_line_number,
-              decoration.range.start_column,
-              0,
-              before,
-            ),
-          )
-        }
-      None => ()
+    if decoration.options.before is Some(before) &&
+      before.content().length() > 0 {
+      entries.push(
+        (
+          decoration.range.start_line_number,
+          decoration.range.start_column,
+          0,
+          before,
+        ),
+      )
     }
-    match decoration.options.after {
-      Some(after) =>
-        if after.content().length() > 0 {
-          entries.push(
-            (
-              decoration.range.end_line_number,
-              decoration.range.end_column,
-              1,
-              after,
-            ),
-          )
-        }
-      None => ()
+    if decoration.options.after is Some(after) && after.content().length() > 0 {
+      entries.push(
+        (
+          decoration.range.end_line_number,
+          decoration.range.end_column,
+          1,
+          after,
+        ),
+      )
     }
   }
   entries.sort_by((left, right) => {
@@ -880,29 +859,23 @@ fn injected_text_for_model_line(
   )
   let entries : Array[(Int, Int, @model.InjectedTextOptions)] = []
   for decoration in model.get_injected_text_decorations() {
-    match decoration.options.before {
-      Some(before) =>
-        if before.content().length() > 0 &&
-          (decoration.range.start_line_number - 1).clamp(
-            min=0,
-            max=snapshot.line_count() - 1,
-          ) ==
-          target_line0 {
-          entries.push((decoration.range.start_column, 0, before))
-        }
-      None => ()
+    if decoration.options.before is Some(before) &&
+      before.content().length() > 0 &&
+      (decoration.range.start_line_number - 1).clamp(
+        min=0,
+        max=snapshot.line_count() - 1,
+      ) ==
+      target_line0 {
+      entries.push((decoration.range.start_column, 0, before))
     }
-    match decoration.options.after {
-      Some(after) =>
-        if after.content().length() > 0 &&
-          (decoration.range.end_line_number - 1).clamp(
-            min=0,
-            max=snapshot.line_count() - 1,
-          ) ==
-          target_line0 {
-          entries.push((decoration.range.end_column, 1, after))
-        }
-      None => ()
+    if decoration.options.after is Some(after) &&
+      after.content().length() > 0 &&
+      (decoration.range.end_line_number - 1).clamp(
+        min=0,
+        max=snapshot.line_count() - 1,
+      ) ==
+      target_line0 {
+      entries.push((decoration.range.end_column, 1, after))
     }
   }
   entries.sort_by((left, right) => {

--- a/editor/viewer/common/view_model/visible_token_ranges.mbt
+++ b/editor/viewer/common/view_model/visible_token_ranges.mbt
@@ -12,14 +12,11 @@ fn ViewModel::model_visible_ranges_for_tokenization(
     viewport.end_line_number,
     self.get_line_max_column(viewport.end_line_number),
   )
-  let ranges : Array[@model.VisibleLineRange] = []
-  for model_range in self.to_model_visible_ranges(visible_view_range) {
-    ranges.push({
-      start_line_number: model_range.start_line_number,
-      end_line_number: model_range.end_line_number,
-    })
-  }
-  ranges
+  let model_ranges = self.to_model_visible_ranges(visible_view_range)
+  model_ranges.map(model_range => {
+    start_line_number: model_range.start_line_number,
+    end_line_number: model_range.end_line_number,
+  })
 }
 
 ///|
@@ -28,13 +25,11 @@ fn ViewModel::model_visible_ranges_for_tokenization(
 /// this source method (`viewModelImpl.ts:234-237`). Model attach itself
 /// deliberately does not own the initialization publication.
 pub fn ViewModel::visible_lines_stabilized(self : ViewModel) -> Unit {
-  match self.attached_view {
-    Some(attached_view) =>
-      attached_view.set_visible_lines(
-        self.model_visible_ranges_for_tokenization(),
-        true,
-      )
-    None => ()
+  if self.attached_view is Some(attached_view) {
+    attached_view.set_visible_lines(
+      self.model_visible_ranges_for_tokenization(),
+      true,
+    )
   }
 }
 
@@ -43,12 +38,10 @@ pub fn ViewModel::visible_lines_stabilized(self : ViewModel) -> Unit {
 /// (`viewModelImpl.ts:239-242`). Horizontal-only scroll is filtered by the
 /// constructor listener before this method is called.
 fn ViewModel::handle_visible_lines_changed(self : ViewModel) -> Unit {
-  match self.attached_view {
-    Some(attached_view) =>
-      attached_view.set_visible_lines(
-        self.model_visible_ranges_for_tokenization(),
-        false,
-      )
-    None => ()
+  if self.attached_view is Some(attached_view) {
+    attached_view.set_visible_lines(
+      self.model_visible_ranges_for_tokenization(),
+      false,
+    )
   }
 }

--- a/editor/viewer/diff_editor_facade.mbt
+++ b/editor/viewer/diff_editor_facade.mbt
@@ -180,23 +180,13 @@ pub fn DiffEditor::create(
       (provider, Some(line))
     }
   }
-  let widget = match services {
-    Some(services) =>
-      @diff_editor.DiffEditorWidget::create(
-        host,
-        provider,
-        services=services.code_services(),
-        editor_options=options.editor_options.code_options(),
-        options=options.internal(),
-      )
-    None =>
-      @diff_editor.DiffEditorWidget::create(
-        host,
-        provider,
-        editor_options=options.editor_options.code_options(),
-        options=options.internal(),
-      )
-  }
+  let widget = @diff_editor.DiffEditorWidget::create(
+    host,
+    provider,
+    services?=services.map(services => services.code_services()),
+    editor_options=options.editor_options.code_options(),
+    options=options.internal(),
+  )
   { widget, owned_line_provider, }
 }
 

--- a/editor/viewer/diff_provider/moondiff/provider.mbt
+++ b/editor/viewer/diff_provider/moondiff/provider.mbt
@@ -118,27 +118,19 @@ fn paired_inner_changes(
   if original_ranges.is_empty() && modified_ranges.is_empty() {
     return Some([])
   }
-  let mappings : Array[@diff.RangeMapping] = []
   let count = original_ranges.length().max(modified_ranges.length())
   let original_anchor = line_end_anchor(original)
   let modified_anchor = line_end_anchor(modified)
-  for index in 0..<count {
-    mappings.push(
-      RangeMapping(
-        if index < original_ranges.length() {
-          original_ranges[index]
-        } else {
-          original_anchor
-        },
-        if index < modified_ranges.length() {
-          modified_ranges[index]
-        } else {
-          modified_anchor
-        },
-      ),
-    )
-  }
-  Some(mappings)
+  Some(
+    [
+      for index in 0..<count => {
+        RangeMapping(
+          original_ranges.get(index).unwrap_or(original_anchor),
+          modified_ranges.get(index).unwrap_or(modified_anchor),
+        )
+      }
+    ],
+  )
 }
 
 ///|

--- a/editor/viewer/markdown_viewer_facade.mbt
+++ b/editor/viewer/markdown_viewer_facade.mbt
@@ -119,26 +119,16 @@ pub fn MarkdownViewer::create(
   services? : ViewerServices,
   options? : MarkdownViewerOptions = MarkdownViewerOptions::default(),
 ) -> MarkdownViewer {
-  match services {
-    Some(services) => {
-      let markdown_services = services.markdown_services(options)
-      {
-        widget: @markdown_viewer.MarkdownViewerWidget::create(
-          host,
-          services=markdown_services,
-          options=options.internal(),
-        ),
-        borrowed_services: Some(markdown_services),
-      }
-    }
-    None =>
-      {
-        widget: @markdown_viewer.MarkdownViewerWidget::create(
-          host,
-          options=options.internal(),
-        ),
-        borrowed_services: None,
-      }
+  let markdown_services = services.map(services => {
+    services.markdown_services(options)
+  })
+  {
+    widget: @markdown_viewer.MarkdownViewerWidget::create(
+      host,
+      services?=markdown_services,
+      options=options.internal(),
+    ),
+    borrowed_services: markdown_services,
   }
 }
 
@@ -320,9 +310,8 @@ pub fn MarkdownViewer::has_text_focus(self : MarkdownViewer) -> Bool {
 ///|
 pub fn MarkdownViewer::dispose(self : MarkdownViewer) -> Unit {
   self.widget.dispose()
-  match self.borrowed_services {
-    Some(services) => services.dispose()
-    None => ()
+  if self.borrowed_services is Some(services) {
+    services.dispose()
   }
 }
 

--- a/editor/viewer/viewer_facade_forwarding.mbt
+++ b/editor/viewer/viewer_facade_forwarding.mbt
@@ -185,10 +185,7 @@ pub fn Viewer::on_mouse_leave(
 
 ///|
 pub fn Viewer::save_view_state(self : Viewer) -> ViewerViewState? {
-  match self.widget.save_view_state() {
-    Some(inner) => Some({ inner, })
-    None => None
-  }
+  self.widget.save_view_state().map(inner => { inner, })
 }
 
 ///|
@@ -196,10 +193,7 @@ pub fn Viewer::restore_view_state(
   self : Viewer,
   state : ViewerViewState?,
 ) -> Unit {
-  match state {
-    Some(state) => self.widget.restore_view_state(Some(state.inner))
-    None => self.widget.restore_view_state(None)
-  }
+  self.widget.restore_view_state(state.map(state => state.inner))
 }
 
 ///|


### PR DESCRIPTION
**This one is meant to be readable at a glance.** Every hunk is a LOCAL
rewrite: the replacement sits exactly where the old code sat. No helper is
added or removed, no code moves between functions, no signature changes, and
no test changes. If a hunk reads correctly on its own, it is correct.

The complete list of shapes used:

| before | after |
| --- | --- |
| `x == "a" \|\| x == "b"` | `x is ("a" \| "b")` |
| `match o { Some(v) => Some(f(v)); None => None }` | `o.map(f)` |
| `match o { Some(v) => v; None => d }` | `o.unwrap_or(d)` |
| `match r { Ok(v) => Ok(v); Err(e) => Err(g(e)) }` | `r.map_err(g)` |
| a push loop | `[for x in xs if p(x) => f(x)]` |
| a break-on-match scan | `find_first` / `any` / `all` / `contains` |
| a manual accumulator | `fold` / `count_if` |
| a get-then-insert | `Map::get_or_init` |
| a hand-rolled char loop | `to_lower` / `pad_start` / `replace_all` / `repeat` |
| a nested `if`/`match` ladder | one `match`, or `guard ... is Some(..)` |

Scope: `editor/` — the viewer, its contributions, the common model and view layers, and the shell.

### Verified on this branch alone

`moon fmt --check`, the native and JS workspace checks with `--deny-warn`, the
full native and JS test suites, and from `editor/` both `moon check --target
all --warn-list +73 --deny-warn` and `moon test --target all` — with no other
part of the sweep applied. No `.mbti` changed, so no package interface moves.

---

Part of a project-wide simplification sweep, split into seven independent pull
requests. Every file appears in exactly one of them, so they can be reviewed and
merged in any order, and each was verified on its own branch with no other part
of the sweep applied.

| | PR | what it is |
| --- | --- | --- |
| 1 | `simplify/mechanical-root` | local rewrites, root module |
| 2 | `simplify/mechanical-desktop` | local rewrites, `desktop/` |
| 3 | `simplify/mechanical-editor` | local rewrites, `editor/` |
| 4 | `simplify/structural-root` | shared helpers, root module |
| 5 | `simplify/structural-desktop` | shared helpers, `desktop/` |
| 6 | `simplify/structural-editor` | shared helpers, `editor/` |
| 7 | `simplify/tests` | test fixtures and folds |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JiBNGzCsZpN6e5Y4p9pXdn
