### PR TITLE
refactor: share repeated helpers in the root module

### DIFF
--- a/agent/tool_definition.mbt
+++ b/agent/tool_definition.mbt
@@ -5,14 +5,11 @@ fn background_notice_text(snapshot : @bgjobs.BgJobSnapshot) -> String {
   let status = match snapshot.status {
     Exited(0) => "exit=0"
     Exited(code) => "exit=\{code}"
-    Stopped =>
-      if snapshot.killed_by_output_limit {
-        "killed: flooded past the output cap"
-      } else if snapshot.killed_by_time_limit {
-        "killed: outlived the wall-clock cap"
-      } else {
-        "stopped"
-      }
+    Stopped if snapshot.killed_by_output_limit =>
+      "killed: flooded past the output cap"
+    Stopped if snapshot.killed_by_time_limit =>
+      "killed: outlived the wall-clock cap"
+    Stopped => "stopped"
     Running => "running"
   }
   "background job \{snapshot.id} finished (\{status}): `\{snapshot.command}` — read its output with job_output (job_id=\"\{snapshot.id}\")."
@@ -155,6 +152,19 @@ async fn[X] mbtx_fixture(
 }
 
 ///|
+/// Poll `condition` every 25ms for up to `attempts` rounds, reporting whether
+/// it ever held. The first probe happens before the first sleep.
+async fn wait_until(attempts~ : Int, condition : async () -> Bool) -> Bool {
+  for _ in 0..<attempts {
+    if condition() {
+      return true
+    }
+    @async.sleep(25)
+  }
+  false
+}
+
+///|
 /// Run a tool definition's async executor, failing the test when the tool was
 /// registered with a synchronous one.
 async fn run_async_tool(
@@ -174,20 +184,16 @@ async test "agent registers the expected tool names" {
     let function_tools = tools.function_tools()
     assert_eq(function_tools.length(), 11)
     let names = [ for t in function_tools => t.name ]
-    assert_true(names.contains("job_output"))
-    assert_true(names.contains("job_stop"))
-    assert_true(names.contains("read"))
-    assert_true(names.contains("edit"))
-    assert_true(names.contains("multi_edit"))
-    assert_true(names.contains("write"))
-    assert_true(names.contains("remove"))
-    assert_true(names.contains("plan"))
-    assert_true(names.contains("goal"))
-    assert_true(names.contains("mbtx"))
-    assert_true(names.contains("finish"))
-    assert_false(names.contains("moon_check"))
-    assert_false(names.contains("moon_cmd"))
-    assert_false(names.contains("moon_ide"))
+    for
+      name in [
+        "job_output", "job_stop", "read", "edit", "multi_edit", "write", "remove",
+        "plan", "goal", "mbtx", "finish",
+      ] {
+      assert_true(names.contains(name), msg=name)
+    }
+    for name in ["moon_check", "moon_cmd", "moon_ide"] {
+      assert_false(names.contains(name), msg=name)
+    }
   }
 }
 
@@ -341,17 +347,9 @@ async test "a handed-off job cleans builds but keeps result files until teardown
     assert_false(result.is_error)
     assert_eq(@fs.read_file(result_path).text(), "kept")
     let build_dir = "\{spill_dir}/snippet-0/build"
-    let mut build_reclaimed = !@fs.exists(build_dir)
     // job_output may observe the terminal state just before its cleanup callback
     // finishes, so wait for that callback rather than racing it.
-    for _ in 0..<400 {
-      if !@fs.exists(build_dir) {
-        build_reclaimed = true
-        break
-      }
-      @async.sleep(25)
-    }
-    assert_true(build_reclaimed)
+    assert_true(wait_until(attempts=400, () => !@fs.exists(build_dir)))
     assert_true(@fs.exists("\{spill_dir}/snippet-0/tmp"))
     @fs.rmdir(spill_dir, recursive=true) catch {
       _ => ()
@@ -481,18 +479,16 @@ async test "an automatically handed-off snippet reads EOF on stdin" {
     assert_true(output.content.contains("moved to the background"))
     // The job read EOF rather than blocking on (or stealing from) fd 0.
     guard bg_runtime.list() is [job, ..] else { fail("no job registered") }
-    let mut saw_eof = false
     // Handoff can happen while a cold dependency build is still running. Wait
     // for the first program output instead of racing the compiler.
-    for _ in 0..<2400 {
-      let recent = bg_runtime.read_output_tail(job.id, 12000).unwrap_or("")
-      if recent.contains("got=false") {
-        saw_eof = true
-        break
-      }
-      @async.sleep(25)
-    }
-    assert_true(saw_eof)
+    assert_true(
+      wait_until(attempts=2400, () => {
+        bg_runtime
+        .read_output_tail(job.id, 12000)
+        .unwrap_or("")
+        .contains("got=false")
+      }),
+    )
     let read = run_async_tool(@job_output.definition(bg_runtime), {
       "job_id": job.id,
     })
@@ -664,12 +660,7 @@ async test "a finished background job queues a notice and wakes the controller" 
     // completion notice. The budget is generous because the job compiles the
     // snippet before running it, on a machine that may be running the rest of
     // the suite in parallel; the loop leaves as soon as the wake lands.
-    for _ in 0..<2400 {
-      if woke {
-        break
-      }
-      @async.sleep(25)
-    }
+    let _ = wait_until(attempts=2400, () => woke)
     assert_true(woke)
     let steers = runtime.drain_steers()
     assert_true(steers.any(s => s is Notice(_)))

--- a/agent_tool/shell/internal/git_policy/git_policy.mbt
+++ b/agent_tool/shell/internal/git_policy/git_policy.mbt
@@ -307,6 +307,27 @@ fn short_cluster_has(arg : String, flag : String) -> Bool {
 }
 
 ///|
+/// True when some argument in `words[start..end)` before a `--` terminator
+/// satisfies `matches`. Every option scan here stops at `--`: past it every
+/// word is an operand, and an operand cannot be an option.
+fn any_arg_before_ddash(
+  words : Array[String],
+  start : Int,
+  end : Int,
+  matches : (String) -> Bool,
+) -> Bool {
+  for arg in words[start:end] {
+    if arg == "--" {
+      return false
+    }
+    if matches(arg) {
+      return true
+    }
+  }
+  false
+}
+
+///|
 /// Whether a `git rebase` invocation's arguments (in `words[start..end)`)
 /// request running external commands: `-i`/`--interactive` (sequence-editor
 /// driven, `exec` todo lines), `--edit-todo` (opens the todo in an editor),
@@ -325,16 +346,7 @@ fn rebase_args_run_external_commands(
   start : Int,
   end : Int,
 ) -> Bool {
-  for index in start..<end {
-    let arg = words[index]
-    if arg == "--" {
-      return false
-    }
-    if rebase_arg_runs_external_commands(arg) {
-      return true
-    }
-  }
-  false
+  any_arg_before_ddash(words, start, end, rebase_arg_runs_external_commands)
 }
 
 ///|
@@ -363,24 +375,17 @@ fn merge_strategy_args_run_external_command(
   end : Int,
   short_s_is_strategy : Bool,
 ) -> Bool {
-  for index in start..<end {
-    let arg = words[index]
-    if arg == "--" {
-      return false
-    }
-    if (
-        arg.has_prefix("--") &&
-        (
-          long_option_selects(arg, "--strategy") ||
-          long_option_selects(arg, "--strategy-option")
-        )
-      ) ||
-      short_cluster_has(arg, "X") ||
-      (short_s_is_strategy && short_cluster_has(arg, "s")) {
-      return true
-    }
-  }
-  false
+  any_arg_before_ddash(words, start, end, arg => {
+    (
+      arg.has_prefix("--") &&
+      (
+        long_option_selects(arg, "--strategy") ||
+        long_option_selects(arg, "--strategy-option")
+      )
+    ) ||
+    short_cluster_has(arg, "X") ||
+    (short_s_is_strategy && short_cluster_has(arg, "s"))
+  })
 }
 
 ///|
@@ -392,16 +397,7 @@ fn pull_args_request_interactive_rebase(
   start : Int,
   end : Int,
 ) -> Bool {
-  for index in start..<end {
-    let arg = words[index]
-    if arg == "--" {
-      return false
-    }
-    if arg.has_prefix("--rebase=i") {
-      return true
-    }
-  }
-  false
+  any_arg_before_ddash(words, start, end, arg => arg.has_prefix("--rebase=i"))
 }
 
 ///|
@@ -430,16 +426,9 @@ fn worktree_verb_is_unsafe(
   if words[start] != "remove" {
     return false
   }
-  for index in (start + 1)..<end {
-    let arg = words[index]
-    if arg == "--" {
-      return false
-    }
-    if long_option_selects(arg, "--force") || short_cluster_has(arg, "f") {
-      return true
-    }
-  }
-  false
+  any_arg_before_ddash(words, start + 1, end, arg => {
+    long_option_selects(arg, "--force") || short_cluster_has(arg, "f")
+  })
 }
 
 ///|
@@ -552,11 +541,7 @@ fn text_subcommand_index(words : Array[String], start : Int, end : Int) -> Int? 
 
 ///|
 fn global_option_consumes_next(arg : String) -> Bool {
-  arg == "-c" ||
-  arg == "--config-env" ||
-  arg == "--exec-path" ||
-  arg == "--git-dir" ||
-  arg == "--namespace"
+  arg is ("-c" | "--config-env" | "--exec-path" | "--git-dir" | "--namespace")
 }
 
 ///|
@@ -640,16 +625,9 @@ fn submodule_verb_index(words : Array[String], start : Int, end : Int) -> Int? {
 /// permanently lose data that has no object-store copy. The scan stops at `--`,
 /// past which every word is a path.
 fn submodule_forced(words : Array[String], start : Int, end : Int) -> Bool {
-  for index in start..<end {
-    let arg = words[index]
-    if arg == "--" {
-      break
-    }
-    if arg == "--force" || short_cluster_has(arg, "f") {
-      return true
-    }
-  }
-  false
+  any_arg_before_ddash(words, start, end, arg => {
+    arg == "--force" || short_cluster_has(arg, "f")
+  })
 }
 
 ///|

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -92,16 +92,10 @@ async fn agent_shell_launch(
     }
   }
   let real_workspace_root = @fs.realpath(workspace_root)
-  let real_cwd = match cwd {
-    Some(cwd) => Some(@fs.realpath(cwd) catch { _ => cwd })
-    None => None
-  }
+  let real_cwd = realpath_or_same(cwd)
   // The lab is realpath'd for the static-policy checks below; the sandbox
   // capability resolves it again on its own before emitting any rule.
-  let scratch_dir = match scratch_dir {
-    Some(lab) => Some(@fs.realpath(lab) catch { _ => lab })
-    None => None
-  }
+  let scratch_dir = realpath_or_same(scratch_dir)
   let mode = source_write_mode_for_parse(parsed, real_workspace_root, real_cwd)
   // `moon new` is trusted to scaffold, but only into a genuinely new or empty
   // target. A scaffold that would land in an existing non-empty directory is
@@ -549,10 +543,7 @@ async fn direct_source_write_redirect_target(
   cwd : String?,
 ) -> String? {
   let real_workspace_root = @fs.realpath(workspace_root)
-  let real_cwd = match cwd {
-    Some(cwd) => Some(@fs.realpath(cwd) catch { _ => cwd })
-    None => None
-  }
+  let real_cwd = realpath_or_same(cwd)
   direct_source_write_redirect_target_for_root_following_existing_links(
     parsed, real_workspace_root, real_cwd,
   )
@@ -818,16 +809,38 @@ async fn existing_path_resolves_to_protected_workspace_source(
 }
 
 ///|
+/// The first path in `targets` that is protected workspace source — directly,
+/// or (when `follow_symlinks`) after resolving an existing symlink.
+async fn first_protected_workspace_source(
+  real_workspace_root : String,
+  targets : Array[String],
+  follow_symlinks? : Bool = true,
+) -> String? {
+  for target in targets {
+    if @source_write_policy.is_protected_workspace_source_path(
+        real_workspace_root, target,
+      ) {
+      return Some(target)
+    }
+    if follow_symlinks &&
+      existing_path_resolves_to_protected_workspace_source(
+        real_workspace_root, target,
+      )
+      is Some(resolved) {
+      return Some(resolved)
+    }
+  }
+  None
+}
+
+///|
 async fn direct_source_tree_operation_target(
   parsed : @shell_parse.ParseResult,
   workspace_root : String,
   cwd : String?,
 ) -> String? {
   let real_workspace_root = @fs.realpath(workspace_root)
-  let real_cwd = match cwd {
-    Some(cwd) => Some(@fs.realpath(cwd) catch { _ => cwd })
-    None => None
-  }
+  let real_cwd = realpath_or_same(cwd)
   direct_source_tree_operation_target_for_root(
     parsed, real_workspace_root, real_cwd,
   )
@@ -862,10 +875,7 @@ async fn dynamic_source_tree_operation_target(
     return None
   }
   let real_workspace_root = @fs.realpath(workspace_root)
-  let real_cwd = match cwd {
-    Some(cwd) => Some(@fs.realpath(cwd) catch { _ => cwd })
-    None => None
-  }
+  let real_cwd = realpath_or_same(cwd)
   dynamic_source_tree_operation_target_for_text(
     cmd,
     real_workspace_root,
@@ -1589,19 +1599,8 @@ fn heredoc_output_targets_in_line(line : String) -> Array[String] {
             (chars[index] == '>' || chars[index] == '|' || chars[index] == '&') {
             index += 1
           }
-          while index < chars.length() && command_text_line_space(chars[index]) {
-            index += 1
-          }
-          match read_command_word(chars, index) {
-            Some(result) => {
-              if !command_redirect_target_is_fd(result.word) {
-                targets.push(result.word)
-              }
-              index = result.next
-              continue
-            }
-            None => ()
-          }
+          index = scan_redirect_target(chars, index, targets)
+          continue
         } else if ch == '&' &&
           index + 1 < chars.length() &&
           chars[index + 1] == '>' {
@@ -1609,19 +1608,8 @@ fn heredoc_output_targets_in_line(line : String) -> Array[String] {
           if index < chars.length() && chars[index] == '>' {
             index += 1
           }
-          while index < chars.length() && command_text_line_space(chars[index]) {
-            index += 1
-          }
-          match read_command_word(chars, index) {
-            Some(result) => {
-              if !command_redirect_target_is_fd(result.word) {
-                targets.push(result.word)
-              }
-              index = result.next
-              continue
-            }
-            None => ()
-          }
+          index = scan_redirect_target(chars, index, targets)
+          continue
         }
     }
     index += 1
@@ -1749,21 +1737,12 @@ fn command_line_after_first_post_heredoc_pipe(line : String) -> String? {
           ch == '|' &&
           !(index > 0 && chars[index - 1] == '|') &&
           !(index + 1 < chars.length() && chars[index + 1] == '|') {
-          return Some(chars_to_string(chars, index + 1))
+          return Some(String::from_array(chars[index + 1:]))
         }
     }
     index += 1
   }
   None
-}
-
-///|
-fn chars_to_string(chars : Array[Char], start : Int) -> String {
-  let output = StringBuilder()
-  for index in start..<chars.length() {
-    output.write_char(chars[index])
-  }
-  output.to_string()
 }
 
 ///|
@@ -1789,6 +1768,30 @@ fn command_text_tee_targets(
     targets.push(arg)
   }
   targets
+}
+
+///|
+/// Read the word after a redirection operator at `index` (skipping blanks),
+/// push it as an output target unless it names a file descriptor, and return
+/// the scan index to continue from.
+fn scan_redirect_target(
+  chars : Array[Char],
+  index : Int,
+  targets : Array[String],
+) -> Int {
+  let mut index = index
+  while index < chars.length() && command_text_line_space(chars[index]) {
+    index += 1
+  }
+  match read_command_word(chars, index) {
+    Some(result) => {
+      if !command_redirect_target_is_fd(result.word) {
+        targets.push(result.word)
+      }
+      result.next
+    }
+    None => index + 1
+  }
 }
 
 ///|
@@ -1843,26 +1846,12 @@ fn read_command_word(
 
 ///|
 fn command_word_stop_char(ch : Char) -> Bool {
-  ch == ';' ||
-  ch == '&' ||
-  ch == '|' ||
-  ch == '<' ||
-  ch == '>' ||
-  ch == '(' ||
-  ch == ')'
+  ch is (';' | '&' | '|' | '<' | '>' | '(' | ')')
 }
 
 ///|
 fn command_redirect_target_is_fd(target : String) -> Bool {
-  if target == "-" || target == "" {
-    return true
-  }
-  for ch in target {
-    if !(ch is ('0'..='9')) {
-      return false
-    }
-  }
-  true
+  target == "-" || target.all(ch => ch is ('0'..='9'))
 }
 
 ///|
@@ -2167,14 +2156,7 @@ fn read_quoted_heredoc_marker(
 ///|
 fn heredoc_delimiter_char(ch : Char) -> Bool {
   !command_text_line_space(ch) &&
-  ch != '\r' &&
-  ch != ';' &&
-  ch != '&' &&
-  ch != '|' &&
-  ch != '<' &&
-  ch != '>' &&
-  ch != '(' &&
-  ch != ')'
+  !(ch is ('\r' | ';' | '&' | '|' | '<' | '>' | '(' | ')'))
 }
 
 ///|
@@ -2320,25 +2302,8 @@ fn push_command_text_word(
 
 ///|
 fn shell_token_char(ch : Char) -> Bool {
-  ch is ('a'..='z') ||
-  ch is ('A'..='Z') ||
-  ch is ('0'..='9') ||
-  ch == '_' ||
-  ch == '-' ||
-  ch == '.' ||
-  ch == '/' ||
-  ch == '=' ||
-  ch == '*' ||
-  ch == '?' ||
-  ch == '[' ||
-  ch == ']' ||
-  ch == '!' ||
-  ch == '^' ||
-  ch == ':' ||
-  ch == ',' ||
-  ch == '{' ||
-  ch == '}' ||
-  ch == '+'
+  ch is ('a'..='z' | 'A'..='Z' | '0'..='9') ||
+  "_-./=*?[]!^:,{}+".contains_char(ch)
 }
 
 ///|
@@ -2541,21 +2506,10 @@ async fn powershell_write_target(
   guard parse_powershell_path_operands(argv, arg_start) is Some(operands) else {
     return git_workspace_scope_target(real_workspace_root, cwd)
   }
-  for target in powershell_new_item_targets(operands, cwd) {
-    if @source_write_policy.is_protected_workspace_source_path(
-        real_workspace_root, target,
-      ) {
-      return Some(target)
-    }
-    match
-      existing_path_resolves_to_protected_workspace_source(
-        real_workspace_root, target,
-      ) {
-      Some(resolved) => return Some(resolved)
-      None => ()
-    }
-  }
-  None
+  first_protected_workspace_source(
+    real_workspace_root,
+    powershell_new_item_targets(operands, cwd),
+  )
 }
 
 ///|
@@ -2843,11 +2797,7 @@ fn record_created_dirs_for_command(
 ///|
 fn source_writing_shell_runtime(name : String) -> Bool {
   let name = source_writing_runtime_name(name)
-  name == "sh" ||
-  name == "bash" ||
-  name == "zsh" ||
-  name == "dash" ||
-  name == "ksh"
+  name is ("sh" | "bash" | "zsh" | "dash" | "ksh")
 }
 
 ///|
@@ -2950,13 +2900,7 @@ fn shell_c_command_text(argv : Array[String], arg_start : Int) -> String? {
 
 ///|
 fn shell_option_consumes_next(arg : String) -> Bool {
-  arg == "-o" ||
-  arg == "+o" ||
-  arg == "-O" ||
-  arg == "+O" ||
-  arg == "--init-file" ||
-  arg == "--rcfile" ||
-  arg == "--emulate"
+  arg is ("-o" | "+o" | "-O" | "+O" | "--init-file" | "--rcfile" | "--emulate")
 }
 
 ///|
@@ -3431,12 +3375,8 @@ fn find_source_filter_before(
 
 ///|
 fn find_filter_option_takes_pattern(arg : String) -> Bool {
-  arg == "-name" ||
-  arg == "-iname" ||
-  arg == "-path" ||
-  arg == "-ipath" ||
-  arg == "-wholename" ||
-  arg == "-iwholename"
+  arg
+  is ("-name" | "-iname" | "-path" | "-ipath" | "-wholename" | "-iwholename")
 }
 
 ///|
@@ -3571,12 +3511,6 @@ fn sed_targets_only_find_results(
     }
     if arg == "{}" {
       placeholder_seen = true
-    } else if find_pattern_mentions_protected_source(
-        arg,
-        case_insensitive=false,
-      ) ||
-      @source_write_policy.is_protected_source_path(arg) {
-      return false
     } else {
       return false
     }
@@ -4074,14 +4008,7 @@ fn script_quoted_literals(text : String) -> Array[String] {
 
 ///|
 fn command_tail_text(argv : Array[String], start : Int) -> String {
-  let text = StringBuilder()
-  for index in start..<argv.length() {
-    if index > start {
-      text.write_char(' ')
-    }
-    text.write_string(argv[index])
-  }
-  text.to_string()
+  argv[start:].join(" ")
 }
 
 ///|
@@ -4420,12 +4347,7 @@ fn looks_like_non_source_file_path(path : String) -> Bool {
 
 ///|
 fn looks_like_file_extension(ext : String) -> Bool {
-  for ch in ext {
-    if !(ch is ('a'..='z') || ch is ('A'..='Z')) {
-      return false
-    }
-  }
-  ext.length() > 0
+  ext != "" && ext.all(ch => ch is ('a'..='z' | 'A'..='Z'))
 }
 
 ///|
@@ -4963,12 +4885,7 @@ fn install_short_option_cluster_has(arg : String, needle : Char) -> Bool {
   guard arg.strip_prefix("-") is Some(options) && !options.has_prefix("-") else {
     return false
   }
-  for ch in options {
-    if ch == needle {
-      return true
-    }
-  }
-  false
+  options.contains_char(needle)
 }
 
 ///|
@@ -5010,24 +4927,14 @@ async fn source_tree_touch_target(
     is Some((operands, follow_symlinks)) else {
     return None
   }
-  for operand in operands {
-    let target = resolve_source_write_redirect_target(cwd, operand)
-    if @source_write_policy.is_protected_workspace_source_path(
-        real_workspace_root, target,
-      ) {
-      return Some(target)
-    }
-    if follow_symlinks {
-      match
-        existing_path_resolves_to_protected_workspace_source(
-          real_workspace_root, target,
-        ) {
-        Some(resolved) => return Some(resolved)
-        None => ()
-      }
-    }
-  }
-  None
+  let targets = [
+    for path in operands => resolve_source_write_redirect_target(cwd, path)
+  ]
+  first_protected_workspace_source(
+    real_workspace_root,
+    targets,
+    follow_symlinks~,
+  )
 }
 
 ///|
@@ -5076,11 +4983,7 @@ fn parse_touch_operands(
 
 ///|
 fn touch_option_consumes_next(arg : String) -> Bool {
-  arg == "-d" ||
-  arg == "--date" ||
-  arg == "-r" ||
-  arg == "--reference" ||
-  arg == "-t"
+  arg is ("-d" | "--date" | "-r" | "--reference" | "-t")
 }
 
 ///|
@@ -5126,22 +5029,10 @@ async fn source_tree_tee_target(
   guard parse_tee_operands(argv, arg_start) is Some(operands) else {
     return None
   }
-  for operand in operands {
-    let target = resolve_source_write_redirect_target(cwd, operand)
-    if @source_write_policy.is_protected_workspace_source_path(
-        real_workspace_root, target,
-      ) {
-      return Some(target)
-    }
-    match
-      existing_path_resolves_to_protected_workspace_source(
-        real_workspace_root, target,
-      ) {
-      Some(resolved) => return Some(resolved)
-      None => ()
-    }
-  }
-  None
+  let targets = [
+    for path in operands => resolve_source_write_redirect_target(cwd, path)
+  ]
+  first_protected_workspace_source(real_workspace_root, targets)
 }
 
 ///|
@@ -5350,6 +5241,16 @@ fn known_absolute_cd_target(target : String) -> CwdCommandEffect {
     UnknownCwd
   } else {
     KnownCwd(target_path.normalize().to_string())
+  }
+}
+
+///|
+/// `path` with existing symlinks resolved, keeping the given spelling when it
+/// cannot be resolved (a nonexistent path, or a realpath failure).
+async fn realpath_or_same(path : String?) -> String? {
+  match path {
+    Some(path) => Some(@fs.realpath(path) catch { _ => path })
+    None => None
   }
 }
 

--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -339,10 +339,7 @@ fn update(emit : @cmd.Emit[Msg], msg : Msg, model : Model) -> (@cmd.Cmd, Model) 
           Ok(text) =>
             match parse_load(text) {
               Loaded(parsed, system_prompt, _header_present, _bytes) => {
-                let children : Map[String, @agent_session.Session] = Map([])
-                for id, child in model.subrun_children {
-                  children.set(id, child)
-                }
+                let children = model.subrun_children.copy()
                 children.set(
                   child_id,
                   @viz.session_from_parse(parsed, id=child_id, system_prompt~),
@@ -469,81 +466,36 @@ fn update(emit : @cmd.Emit[Msg], msg : Msg, model : Model) -> (@cmd.Cmd, Model) 
     }
     SetArgsView(show_original) =>
       (@cmd.none, { ..model, show_original_args: show_original, })
-    ToggleErrorsOnly =>
-      (
-        @cmd.none,
-        {
-          ..model,
-          errors_only: !model.errors_only,
-          escalated_only: false,
-          build_errors_only: false,
-        },
-      )
+    ToggleErrorsOnly => only_filter(model, errors=!model.errors_only)
     // Scroll to the next/previous failed-tool card, cycling. The count is
     // recomputed for the active view, while the browser chooses the target
     // relative to the current viewport so manual scrolling is respected.
-    JumpToError(direction) => {
-      let count = current_error_count(model)
-      if count <= 0 {
-        (@cmd.none, model)
-      } else {
-        (
-          @cmd.effect(() => {
-            scroll_to_card_from_viewport(".card.tool.error", direction)
-          }),
-          model,
-        )
-      }
-    }
-    ToggleEscalatedOnly =>
-      (
-        @cmd.none,
-        {
-          ..model,
-          escalated_only: !model.escalated_only,
-          errors_only: false,
-          build_errors_only: false,
-        },
+    JumpToError(direction) =>
+      jump_to_card(
+        model,
+        current_count(model, @viz.rendered_error_count),
+        ".card.tool.error",
+        direction,
       )
-    JumpToEscalated(direction) => {
-      let count = current_escalated_count(model)
-      if count <= 0 {
-        (@cmd.none, model)
-      } else {
-        (
-          @cmd.effect(() => {
-            scroll_to_card_from_viewport(".tool-call-escalated", direction)
-          }),
-          model,
-        )
-      }
-    }
+    ToggleEscalatedOnly => only_filter(model, escalated=!model.escalated_only)
+    JumpToEscalated(direction) =>
+      jump_to_card(
+        model,
+        current_count(model, @viz.rendered_escalated_count),
+        ".tool-call-escalated",
+        direction,
+      )
     ToggleBuildErrorsOnly =>
-      (
-        @cmd.none,
-        {
-          ..model,
-          build_errors_only: !model.build_errors_only,
-          errors_only: false,
-          escalated_only: false,
-        },
+      only_filter(model, build_errors=!model.build_errors_only)
+    // Result cards, not call rows: every build failure has exactly one tagged
+    // result card — orphans included — so the jump set matches the count.
+    JumpToBuildError(direction) =>
+      jump_to_card(
+        model,
+        current_count(model, @viz.rendered_build_error_count),
+        ".card.build-failed",
+        direction,
       )
-    JumpToBuildError(direction) => {
-      let count = current_build_error_count(model)
-      if count <= 0 {
-        (@cmd.none, model)
-      } else {
-        (
-          @cmd.effect(() => {
-            // Result cards, not call rows: every build failure has exactly
-            // one tagged result card — orphans included — so the jump set
-            // matches the count.
-            scroll_to_card_from_viewport(".card.build-failed", direction)
-          }),
-          model,
-        )
-      }
-    }
     UnfoldCurrent => (@cmd.effect(() => unfold_nearest_details()), model)
     SetTheme(theme) =>
       // Apply the theme as a side effect (set `data-theme` on <html>) so the CSS
@@ -559,6 +511,46 @@ fn update(emit : @cmd.Emit[Msg], msg : Msg, model : Model) -> (@cmd.Cmd, Model) 
           collapsed_roots: toggle_collapsed_root(model.collapsed_roots, root),
         },
       )
+  }
+}
+
+///|
+/// Turn one card filter on or off, clearing the other two: the three filters
+/// are mutually exclusive, so switching any of them on retires the others.
+fn only_filter(
+  model : Model,
+  errors? : Bool = false,
+  escalated? : Bool = false,
+  build_errors? : Bool = false,
+) -> (@cmd.Cmd, Model) {
+  (
+    @cmd.none,
+    {
+      ..model,
+      errors_only: errors,
+      escalated_only: escalated,
+      build_errors_only: build_errors,
+    },
+  )
+}
+
+///|
+/// Scroll to the next/previous card matching `selector`, or do nothing when the
+/// active view draws none. The model never changes: the jump is a pure viewport
+/// effect.
+fn jump_to_card(
+  model : Model,
+  count : Int,
+  selector : String,
+  direction : Int,
+) -> (@cmd.Cmd, Model) {
+  if count <= 0 {
+    (@cmd.none, model)
+  } else {
+    (
+      @cmd.effect(() => scroll_to_card_from_viewport(selector, direction)),
+      model,
+    )
   }
 }
 
@@ -1664,21 +1656,13 @@ fn running_ms(parsed : @session_log.ParsedLog) -> Int64? {
 /// The first and last positive wall-clock stamps in the log (unix ms), in file
 /// order, or `None` when no event carries one.
 fn stamp_range(parsed : @session_log.ParsedLog) -> (Int64, Int64)? {
-  let mut first = 0L
-  let mut last = 0L
-  for event in parsed.events {
-    let stamp = event.unix_ms()
-    if stamp > 0 {
-      if first == 0L {
-        first = stamp
-      }
-      last = stamp
-    }
-  }
-  if first > 0L {
-    Some((first, last))
-  } else {
-    None
+  let stamps = [
+    for event in parsed.events if event.unix_ms() > 0 => event.unix_ms()
+  ]
+  match stamps {
+    [first, .., last] => Some((first, last))
+    [only] => Some((only, only))
+    [] => None
   }
 }
 
@@ -1914,40 +1898,22 @@ fn session_log_view(
 }
 
 ///|
-/// Number of failures the active view will draw, recomputed from the loaded
-/// log — served or dropped; the session id plays no part in the count.
-/// Returns 0 when nothing is loaded.
-fn current_error_count(model : Model) -> Int {
+/// What `counter` reports for the loaded log under the active view mode —
+/// failures the view will draw, explicitly escalated calls the projection will
+/// render, or mbtx build errors. Recomputed from the loaded log, served or
+/// dropped; the session id plays no part in the count. Returns 0 when nothing
+/// is loaded.
+fn current_count(
+  model : Model,
+  counter : (@agent_session.Session, @viz.ViewMode) -> Int,
+) -> Int {
   guard model.parsed is Some(parsed) else { return 0 }
   let session = @viz.session_from_parse(
     parsed,
     id="",
     system_prompt=model.system_prompt,
   )
-  @viz.rendered_error_count(session, model.view_mode)
-}
-
-///|
-/// Number of explicitly escalated calls the active projection will render.
-fn current_escalated_count(model : Model) -> Int {
-  guard model.parsed is Some(parsed) else { return 0 }
-  let session = @viz.session_from_parse(
-    parsed,
-    id="",
-    system_prompt=model.system_prompt,
-  )
-  @viz.rendered_escalated_count(session, model.view_mode)
-}
-
-///|
-fn current_build_error_count(model : Model) -> Int {
-  guard model.parsed is Some(parsed) else { return 0 }
-  let session = @viz.session_from_parse(
-    parsed,
-    id="",
-    system_prompt=model.system_prompt,
-  )
-  @viz.rendered_build_error_count(session, model.view_mode)
+  counter(session, model.view_mode)
 }
 
 ///|

--- a/eval/bgjobs_capability/main.mbt
+++ b/eval/bgjobs_capability/main.mbt
@@ -51,10 +51,7 @@ async fn scenario_overlap(engine : Engine) -> Unit {
     event is { "event": String("agent_finished"), .. }
   })
   let wall_s = (@env.now().reinterpret_as_int64() - started_ms) / 1000
-  let backgrounded = seen.search_by(event => {
-    event is { "event": String("tool_result"), "content": String(content), .. } &&
-    content.contains("moved to the background")
-  })
+  let backgrounded = seen.search_by(moved_to_background)
   // The marker inside a plain `mbtx` result means the slow program ran
   // (and blocked) in the foreground.
   let blocked_foreground = seen
@@ -131,13 +128,7 @@ async fn scenario_fire_and_forget(engine : Engine) -> Unit {
     event is { "event": String("agent_finished"), .. }
   })
   let wall_s = (@env.now().reinterpret_as_int64() - started_ms) / 1000
-  let backgrounded = seen
-    .iter()
-    .any(event => {
-      event
-      is { "event": String("tool_result"), "content": String(content), .. } &&
-      content.contains("moved to the background")
-    })
+  let backgrounded = seen.any(moved_to_background)
   report("S2 automatically handed off the slow run", backgrounded)
   report(
     "S2 finished well before the 45s job (did not block)",
@@ -153,6 +144,14 @@ async fn scenario_fire_and_forget(engine : Engine) -> Unit {
     "S2 completion later surfaced as an idle notice",
     idle_notice is Some(_),
   )
+}
+
+///|
+/// A tool result whose text says the engine moved the command to the
+/// background — the automatic-handoff marker both scenarios look for.
+fn moved_to_background(event : Json) -> Bool {
+  event is { "event": String("tool_result"), "content": String(content), .. } &&
+  content.contains("moved to the background")
 }
 
 ///|

--- a/eval/prompt_task/harness/manifest.mbt
+++ b/eval/prompt_task/harness/manifest.mbt
@@ -193,23 +193,18 @@ fn TrialArtifact::to_json(self : TrialArtifact) -> Json {
 ///|
 fn RunManifest::from_json(json : Json) -> RunManifest raise {
   let fields = object_fields(json, "manifest")
-  let validation_probes : Array[ValidationProbeSpec] = match
-    fields.get("validation_probes") {
-    Some(Array(items)) =>
-      [
-        for item in items => ValidationProbeSpec::from_json(item)
-      ]
-    Some(_) => fail("manifest.validation_probes must be an array")
-    None => fail("manifest.validation_probes is missing")
-  }
-  let trials : Array[TrialArtifact] = match fields.get("trials") {
-    Some(Array(items)) =>
-      [
-        for item in items => TrialArtifact::from_json(item)
-      ]
-    Some(_) => fail("manifest.trials must be an array")
-    None => fail("manifest.trials is missing")
-  }
+  let validation_probes = array_field(
+    fields,
+    "validation_probes",
+    "manifest.validation_probes",
+    ValidationProbeSpec::from_json,
+  )
+  let trials = array_field(
+    fields,
+    "trials",
+    "manifest.trials",
+    TrialArtifact::from_json,
+  )
   {
     model: string_field(fields, "model"),
     problem_id: string_field(fields, "problem_id"),
@@ -228,19 +223,12 @@ fn RunManifest::from_json(json : Json) -> RunManifest raise {
 ///|
 fn ValidationProbeSpec::from_json(json : Json) -> ValidationProbeSpec raise {
   let fields = object_fields(json, "validation probe")
-  let command : Array[String] = match fields.get("command") {
-    Some(Array(items)) =>
-      [
-        for item in items => {
-          match item {
-            String(value) => value
-            _ => fail("validation probe command entries must be strings")
-          }
-        }
-      ]
-    Some(_) => fail("validation probe command must be an array")
-    None => fail("validation probe command is missing")
-  }
+  let command = array_field(fields, "command", "validation probe command", item => {
+    match item {
+      String(value) => value
+      _ => fail("validation probe command entries must be strings")
+    }
+  })
   guard command.length() > 0 else {
     fail("validation probe command must not be empty")
   }
@@ -276,6 +264,22 @@ fn object_fields(json : Json, label : String) -> Map[String, Json] raise {
   match json {
     Object(fields) => fields
     _ => fail("\{label} must be a JSON object")
+  }
+}
+
+///|
+/// Decode the JSON array at `key`, mapping every element through `parse`.
+/// `label` names the field in the two shape errors an array field reports.
+fn[T] array_field(
+  fields : Map[String, Json],
+  key : String,
+  label : String,
+  parse : (Json) -> T raise,
+) -> Array[T] raise {
+  match fields.get(key) {
+    Some(Array(items)) => [ for item in items => parse(item) ]
+    Some(_) => fail("\{label} must be an array")
+    None => fail("\{label} is missing")
   }
 }
 

--- a/eval/prompt_task/harness/suite.mbt
+++ b/eval/prompt_task/harness/suite.mbt
@@ -268,19 +268,12 @@ fn suite_config_from_json(
 
 ///|
 fn parse_models(fields : Map[String, Json]) -> Array[@deepseek.Model] raise {
-  match fields.get("models") {
-    Some(Array(items)) =>
-      [
-        for item in items => {
-          match item {
-            String(value) => @deepseek.Model::parse(value)
-            _ => fail("suite model entries must be strings")
-          }
-        }
-      ]
-    Some(_) => fail("suite models must be an array")
-    None => fail("suite models is missing")
-  }
+  array_field(fields, "models", "suite models", item => {
+    match item {
+      String(value) => @deepseek.Model::parse(value)
+      _ => fail("suite model entries must be strings")
+    }
+  })
 }
 
 ///|
@@ -288,29 +281,21 @@ fn parse_problems(
   fields : Map[String, Json],
   base_dir : String,
 ) -> Array[ProblemSpec] raise {
-  match fields.get("problems") {
-    Some(Array(items)) =>
-      [
-        for item in items => ProblemSpec::from_json(item, base_dir)
-      ]
-    Some(_) => fail("suite problems must be an array")
-    None => fail("suite problems is missing")
-  }
+  array_field(fields, "problems", "suite problems", item => {
+    ProblemSpec::from_json(item, base_dir)
+  })
 }
 
 ///|
 fn ProblemSpec::from_json(json : Json, base_dir : String) -> ProblemSpec raise {
   let fields = object_fields(json, "suite problem")
   let id = string_field(fields, "id")
-  let probes : Array[ValidationProbeSpec] = match
-    fields.get("validation_probes") {
-    Some(Array(items)) =>
-      [
-        for item in items => ValidationProbeSpec::from_json(item)
-      ]
-    Some(_) => fail("suite problem validation_probes must be an array")
-    None => fail("suite problem validation_probes is missing")
-  }
+  let probes = array_field(
+    fields,
+    "validation_probes",
+    "suite problem validation_probes",
+    ValidationProbeSpec::from_json,
+  )
   guard probes.length() > 0 else {
     fail("suite problem validation_probes must not be empty")
   }
@@ -570,23 +555,17 @@ fn SuiteManifest::from_json(json : Json) -> SuiteManifest raise {
 fn suite_manifest_problems(
   fields : Map[String, Json],
 ) -> Array[ProblemSpec] raise {
-  match fields.get("problems") {
-    Some(Array(items)) =>
-      [
-        for item in items => ProblemSpec::from_manifest_json(item)
-      ]
-    Some(_) => fail("suite manifest problems must be an array")
-    None => fail("suite manifest problems is missing")
-  }
+  array_field(
+    fields,
+    "problems",
+    "suite manifest problems",
+    ProblemSpec::from_manifest_json,
+  )
 }
 
 ///|
 fn suite_manifest_combos(fields : Map[String, Json]) -> Array[ComboRun] raise {
-  match fields.get("combos") {
-    Some(Array(items)) => [ for item in items => ComboRun::from_json(item) ]
-    Some(_) => fail("suite manifest combos must be an array")
-    None => fail("suite manifest combos is missing")
-  }
+  array_field(fields, "combos", "suite manifest combos", ComboRun::from_json)
 }
 
 ///|
@@ -605,15 +584,12 @@ fn ProblemSpec::to_json(self : ProblemSpec) -> Json {
 ///|
 fn ProblemSpec::from_manifest_json(json : Json) -> ProblemSpec raise {
   let fields = object_fields(json, "suite manifest problem")
-  let probes : Array[ValidationProbeSpec] = match
-    fields.get("validation_probes") {
-    Some(Array(items)) =>
-      [
-        for item in items => ValidationProbeSpec::from_json(item)
-      ]
-    Some(_) => fail("suite manifest problem validation_probes must be an array")
-    None => fail("suite manifest problem validation_probes is missing")
-  }
+  let probes = array_field(
+    fields,
+    "validation_probes",
+    "suite manifest problem validation_probes",
+    ValidationProbeSpec::from_json,
+  )
   ProblemSpec(
     id=string_field(fields, "id"),
     prompt_label=string_field(fields, "prompt_label"),
@@ -652,19 +628,12 @@ fn string_array_field(
   fields : Map[String, Json],
   key : String,
 ) -> Array[String] raise {
-  match fields.get(key) {
-    Some(Array(items)) =>
-      [
-        for item in items => {
-          match item {
-            String(value) => value
-            _ => fail("\{key} entries must be strings")
-          }
-        }
-      ]
-    Some(_) => fail("\{key} must be an array")
-    None => fail("\{key} is missing")
-  }
+  array_field(fields, key, key, item => {
+    match item {
+      String(value) => value
+      _ => fail("\{key} entries must be strings")
+    }
+  })
 }
 
 ///|


### PR DESCRIPTION
**This half needs a careful read.** Every hunk here adds or removes something
SHARED, so correctness depends on code outside the hunk you are looking at. The
purely in-function rewrites this was mixed with have moved to a separate pull
request, so what is left is all shared-surface change.

What to check, hardest first:

1. **An extracted helper must be equivalent at every call site it replaced.**
   The trap is a call site that passed a different argument, or read state at a
   different moment, than its neighbours.
2. **A merged or-pattern arm must have had identical bodies.** Where the arms
   differed and the difference moved inside the arm, the fold buys less than it
   appears to.
3. **A reshaped loop must keep its iteration order and its early exits.**

Scope: the root module. The shared pieces are `any_arg_before_ddash` for the git-policy option scans, `realpath_or_same` and `first_protected_workspace_source` in the shell sandbox, the viz app's filter and card helpers, and `array_field` across the eval harness.

### Review comments addressed

- **"why such change in a refactoring?"** on `mbtx_fixture` — reverted. The
  fixture no longer registers a group defer for the spill directory, and all
  twelve tests reclaim it at the end of their own body as before. That hunk
  moved cleanup from end-of-test to end-of-group, which runs it later and also
  on assertion-failure paths where the old tail was never reached. It may be an
  improvement, but it is a behaviour change and does not belong in a refactor.
  `wait_until` and the table-driven registry test, which change nothing
  observable, stay.
- **`for arg in words[start:end]`?** — applied. `any_arg_before_ddash` iterates
  the slice directly instead of indexing.

### Verified on this branch alone

`moon fmt --check`, `moon check --target native --deny-warn`, `moon check
--target js --deny-warn`, and both full test suites, with no other part of the
refactor applied. No `.mbti` changed.

---

The refactor is split so each pull request asks one kind of question. Every file
appears in exactly one of them, each was verified on its own branch with no
other part applied, so they merge in any order.

| | easy to review | needs a careful read |
| --- | --- | --- |
| root | #1330 | this one (#1325) |
| `desktop/` | #1331 | #1326 |
| `editor/` | #1332 | #1327 |
| tests | #1333 | #1328 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JiBNGzCsZpN6e5Y4p9pXdn
