### PR TITLE
refactor(desktop): share the repeated codec, engine and frontend helpers

### DIFF
--- a/desktop/frontend/bridge.mbt
+++ b/desktop/frontend/bridge.mbt
@@ -668,30 +668,17 @@ fn started_msg(
   // malformed and dropped. The durable `session_root` is genuinely optional,
   // and the host resolved it itself, so this is the decode boundary where its
   // absolute provenance is collapsed into the type.
-  let session = payload.session
-  guard !session.is_empty() &&
-    payload.model is Some(model) &&
-    EngineModel::parse(model) is Some(model) &&
-    payload.max_steps is Some(max_steps) else {
+  guard RecoveredRun::from_started(channel, payload) is Some(run) else {
     return None
-  }
-  let session_root = match payload.session_root {
-    Some(path) => {
-      guard @resource.of_path(channel, path) is Some(absolute) else {
-        return None
-      }
-      Some(absolute)
-    }
-    None => None
   }
   Some(
     Started(
-      run_id=payload.run_id,
-      session~,
-      model~,
-      max_steps~,
-      session_root~,
-      submission_id=payload.submission_id,
+      run_id=run.run_id,
+      session=run.session,
+      model=run.model,
+      max_steps=run.max_steps,
+      session_root=run.session_root,
+      submission_id=run.submission_id,
     ),
   )
 }
@@ -1249,6 +1236,20 @@ fn queue_openseek(
 ) -> @cmd.Cmd {
   let root_dispatch = dispatch
   let dispatch = dispatch.map((msg : DeviceMsg) => FromDevice(channel, msg))
+  // Both endings refuse the same way — the host rejected the call, or it
+  // answered that the queued message is gone. Only the wording differs.
+  let refuse : (String) -> @cmd.Cmd = message => {
+    match action {
+      QueueAdd(id~, ..) =>
+        dispatch(QueueAddRejected(session~, submission_id=id, run_id~))
+      QueueSteer(id~) =>
+        dispatch(
+          QueueSteerRejected(session~, submission_id=id, run_id~, message~),
+        )
+      QueueEdit(..) | QueueWithdraw(..) =>
+        root_dispatch(HostActionFailed(message))
+    }
+  }
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
       let accepted = try {
@@ -1260,49 +1261,13 @@ fn queue_openseek(
       } catch {
         error => {
           scheduler.add(
-            match action {
-              QueueAdd(id~, ..) =>
-                dispatch(QueueAddRejected(session~, submission_id=id, run_id~))
-              QueueSteer(id~) =>
-                dispatch(
-                  QueueSteerRejected(
-                    session~,
-                    submission_id=id,
-                    run_id~,
-                    message="Queue action failed: \{@interop.bridge_error_text(error)}",
-                  ),
-                )
-              QueueEdit(..) | QueueWithdraw(..) =>
-                root_dispatch(
-                  HostActionFailed(
-                    "Queue action failed: \{@interop.bridge_error_text(error)}",
-                  ),
-                )
-            },
+            refuse("Queue action failed: \{@interop.bridge_error_text(error)}"),
           )
           return
         }
       }
       if !accepted {
-        scheduler.add(
-          match action {
-            QueueAdd(id~, ..) =>
-              dispatch(QueueAddRejected(session~, submission_id=id, run_id~))
-            QueueSteer(id~) =>
-              dispatch(
-                QueueSteerRejected(
-                  session~,
-                  submission_id=id,
-                  run_id~,
-                  message="The queued message is no longer available.",
-                ),
-              )
-            QueueEdit(..) | QueueWithdraw(..) =>
-              root_dispatch(
-                HostActionFailed("The queued message is no longer available."),
-              )
-          },
-        )
+        scheduler.add(refuse("The queued message is no longer available."))
       } else {
         scheduler.add(dispatch(QueueAccepted(session~, action~, run_id~)))
       }
@@ -1537,6 +1502,12 @@ fn approve_openseek(
   allow~ : Bool,
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
+    // Both endings put the card back and say why: nothing else will, since a
+    // settlement only follows a decision that actually arrived.
+    let restore = (message : String) => {
+      scheduler.add(dispatch(ApprovalAnswerFailed(channel~, session~, id~)))
+      scheduler.add(dispatch(HostActionFailed(message)))
+    }
     @js.async_run(() => {
       let reply : @protocol.ApprovalReply = @interop.bridge_request(
         channel,
@@ -1544,14 +1515,9 @@ fn approve_openseek(
         { id, allow, run_id, },
       ) catch {
         error => {
-          scheduler.add(dispatch(ApprovalAnswerFailed(channel~, session~, id~)))
-          scheduler.add(
-            dispatch(
-              HostActionFailed(
-                "Failed to answer the approval request: " +
-                @interop.bridge_error_text(error),
-              ),
-            ),
+          restore(
+            "Failed to answer the approval request: " +
+            @interop.bridge_error_text(error),
           )
           return
         }
@@ -1560,13 +1526,8 @@ fn approve_openseek(
         // The host had no live engine to hand it to. Restore it anyway: being
         // refused a second time is a better end than a card that cannot be
         // pressed at all.
-        scheduler.add(dispatch(ApprovalAnswerFailed(channel~, session~, id~)))
-        scheduler.add(
-          dispatch(
-            HostActionFailed(
-              "That approval request is no longer waiting — the turn it belonged to has ended.",
-            ),
-          ),
+        restore(
+          "That approval request is no longer waiting — the turn it belonged to has ended.",
         )
       }
     })

--- a/desktop/frontend/codex/bridge.mbt
+++ b/desktop/frontend/codex/bridge.mbt
@@ -637,6 +637,13 @@ fn State::prompt_text(self : State) -> String {
 }
 
 ///|
+/// Every mention Codex cannot express natively degrades to the shared textual
+/// envelope form.
+fn mention_text_input(mention : @composer.Mention) -> Json {
+  { "type": "text", "text": @mention_context.encode([mention.ref_], "") }
+}
+
+///|
 fn State::mention_input(self : State, mention : @composer.Mention) -> Json? {
   match mention.ref_ {
     @mention_context.File(path~) => {
@@ -649,27 +656,14 @@ fn State::mention_input(self : State, mention : @composer.Mention) -> Json? {
     @mention_context.Skill(name~) => {
       guard self.active_context() is Some(context) &&
         self.skills is CodexSkillsReady(cwd, skills) &&
-        cwd == context.cwd else {
-        return Some({
-          "type": "text",
-          "text": @mention_context.encode([mention.ref_], ""),
-        })
+        cwd == context.cwd &&
+        skills.iter().find_first(skill => skill.name == name) is Some(skill) else {
+        return Some(mention_text_input(mention))
       }
-      for skill in skills {
-        if skill.name == name {
-          return Some({ "type": "skill", "name": name, "path": skill.path })
-        }
-      }
-      Some({
-        "type": "text",
-        "text": @mention_context.encode([mention.ref_], ""),
-      })
+      Some({ "type": "skill", "name": name, "path": skill.path })
     }
     @mention_context.Symbol(..) | @mention_context.Annotation(..) =>
-      Some({
-        "type": "text",
-        "text": @mention_context.encode([mention.ref_], ""),
-      })
+      Some(mention_text_input(mention))
   }
 }
 
@@ -915,16 +909,15 @@ fn State::respond(
   request_key : String,
   decision : Json,
 ) -> @cmd.Cmd {
-  let mut selected : CodexPendingRequest? = None
-  for request in self.pending_requests {
-    if request.request_id.stringify() == request_key &&
-      self.active_thread() is Some(active) &&
-      request.thread_id == active.id {
-      selected = Some(request)
-      break
-    }
-  }
-  guard selected is Some(request) && request.response(decision) is Some(result) else {
+  guard self.active_thread() is Some(active) &&
+    self.pending_requests
+    .iter()
+    .find_first(request => {
+      request.request_id.stringify() == request_key &&
+      request.thread_id == active.id
+    })
+    is Some(request) &&
+    request.response(decision) is Some(result) else {
     return @cmd.none
   }
   CodexApprovalReply.request(

--- a/desktop/frontend/composer/codex_request.mbt
+++ b/desktop/frontend/composer/codex_request.mbt
@@ -28,23 +28,16 @@ fn CodexRequestInput::approval_details(
     fields.get("networkApprovalContext") is Some(Object(network)) &&
     @jsonx.json_text(network, "host") is Some(host) {
     let protocol = @jsonx.json_text(network, "protocol")
-    let port = network
-      .get("port")
-      .bind(value => {
-        match value {
-          String(port) => Some(port)
-          Number(_) => Some(value.stringify())
-          _ => None
-        }
-      })
-    let destination = if protocol is Some(protocol) && port is Some(port) {
-      "\{protocol}://\{host}:\{port}"
-    } else if protocol is Some(protocol) {
-      "\{protocol}://\{host}"
-    } else if port is Some(port) {
-      "\{host}:\{port}"
-    } else {
-      host
+    let port = match network.get("port") {
+      Some(String(port)) => Some(port)
+      Some(value) if value is Number(_) => Some(value.stringify())
+      _ => None
+    }
+    let destination = match (protocol, port) {
+      (Some(protocol), Some(port)) => "\{protocol}://\{host}:\{port}"
+      (Some(protocol), None) => "\{protocol}://\{host}"
+      (None, Some(port)) => "\{host}:\{port}"
+      (None, None) => host
     }
     details.push(
       @html.div(class="codex-request-detail", [
@@ -163,87 +156,57 @@ fn CodexRequestInput::execpolicy_label(
 }
 
 ///|
+/// Every reverse-request control is the same button: one class, one label, and
+/// the identity-scoped decision it sends back.
+fn CodexRequestInput::decision_button(
+  self : CodexRequestInput,
+  identity : Identity,
+  action_emit : @cmd.Emit[Action],
+  class_name~ : String,
+  decision~ : Json,
+  label~ : String,
+) -> @html.Html {
+  @html.button(
+    class=class_name,
+    on_click=action_emit(
+      CodexRequestResponded(identity~, request_key=self.request_key, decision~),
+    ),
+    label,
+  )
+}
+
+///|
 fn CodexRequestInput::approval_actions(
   self : CodexRequestInput,
   identity : Identity,
   action_emit : @cmd.Emit[Action],
 ) -> @html.Html {
-  let controls : Array[@html.Html] = []
-  for decision in self.approval_decisions() {
-    match decision {
-      String("accept") =>
-        controls.push(
-          @html.button(
-            class="codex-request-action codex-request-action-primary",
-            on_click=action_emit(
-              CodexRequestResponded(
-                identity~,
-                request_key=self.request_key,
-                decision~,
-              ),
-            ),
-            "Approve once",
-          ),
-        )
-      String("acceptForSession") =>
-        controls.push(
-          @html.button(
-            class="codex-request-action",
-            on_click=action_emit(
-              CodexRequestResponded(
-                identity~,
-                request_key=self.request_key,
-                decision~,
-              ),
-            ),
-            "Approve for session",
-          ),
-        )
-      String("decline") =>
-        controls.push(
-          @html.button(
-            class="codex-request-action codex-request-action-danger",
-            on_click=action_emit(
-              CodexRequestResponded(
-                identity~,
-                request_key=self.request_key,
-                decision~,
-              ),
-            ),
-            "Decline",
-          ),
-        )
-      String("cancel") =>
-        controls.push(
-          @html.button(
-            class="codex-request-action codex-request-action-danger",
-            on_click=action_emit(
-              CodexRequestResponded(
-                identity~,
-                request_key=self.request_key,
-                decision~,
-              ),
-            ),
-            "Cancel",
-          ),
-        )
-      Object(fields) if fields.get("acceptWithExecpolicyAmendment") is Some(_) =>
-        controls.push(
-          @html.button(
-            class="codex-request-action",
-            on_click=action_emit(
-              CodexRequestResponded(
-                identity~,
-                request_key=self.request_key,
-                decision~,
-              ),
-            ),
-            self.execpolicy_label(decision),
-          ),
-        )
-      _ => ()
-    }
-  }
+  let controls = self
+    .approval_decisions()
+    .filter_map(decision => {
+      let (class_name, label) = match decision {
+        String("accept") =>
+          ("codex-request-action codex-request-action-primary", "Approve once")
+        String("acceptForSession") =>
+          ("codex-request-action", "Approve for session")
+        String("decline") =>
+          ("codex-request-action codex-request-action-danger", "Decline")
+        String("cancel") =>
+          ("codex-request-action codex-request-action-danger", "Cancel")
+        Object(fields) if fields.get("acceptWithExecpolicyAmendment") is Some(_) =>
+          ("codex-request-action", self.execpolicy_label(decision))
+        _ => return None
+      }
+      Some(
+        self.decision_button(
+          identity,
+          action_emit,
+          class_name~,
+          decision~,
+          label~,
+        ),
+      )
+    })
   if controls.is_empty() {
     controls.push(
       @html.span(
@@ -345,38 +308,26 @@ fn CodexRequestInput::render(
       body.push(@html.pre(class="codex-raw", self.params.stringify(indent=2)))
       body.push(
         @html.div(class="codex-request-actions", [
-          @html.button(
-            class="codex-request-action codex-request-action-primary",
-            on_click=action_emit(
-              CodexRequestResponded(
-                identity~,
-                request_key=self.request_key,
-                decision=Json("accept"),
-              ),
-            ),
-            "Grant for turn",
+          self.decision_button(
+            identity,
+            action_emit,
+            class_name="codex-request-action codex-request-action-primary",
+            decision=Json("accept"),
+            label="Grant for turn",
           ),
-          @html.button(
-            class="codex-request-action",
-            on_click=action_emit(
-              CodexRequestResponded(
-                identity~,
-                request_key=self.request_key,
-                decision=Json("acceptForSession"),
-              ),
-            ),
-            "Grant for session",
+          self.decision_button(
+            identity,
+            action_emit,
+            class_name="codex-request-action",
+            decision=Json("acceptForSession"),
+            label="Grant for session",
           ),
-          @html.button(
-            class="codex-request-action codex-request-action-danger",
-            on_click=action_emit(
-              CodexRequestResponded(
-                identity~,
-                request_key=self.request_key,
-                decision=Json("decline"),
-              ),
-            ),
-            "Deny",
+          self.decision_button(
+            identity,
+            action_emit,
+            class_name="codex-request-action codex-request-action-danger",
+            decision=Json("decline"),
+            label="Deny",
           ),
         ]),
       )
@@ -389,30 +340,27 @@ fn CodexRequestInput::render(
           @html.div(class="codex-question-text", question.question),
         ]
         if !question.options.is_empty() {
-          let options : Array[@html.Html] = []
-          for option in question.options {
-            options.push(
-              @html.button(
-                class=if answer == option.0 {
-                  "codex-option selected"
-                } else {
-                  "codex-option"
-                },
-                on_click=action_emit(
-                  CodexRequestAnswerChanged(
-                    identity~,
-                    request_key=self.request_key,
-                    question_id=question.id,
-                    answer=option.0,
-                  ),
+          let options = question.options.map(option => {
+            @html.button(
+              class=if answer == option.0 {
+                "codex-option selected"
+              } else {
+                "codex-option"
+              },
+              on_click=action_emit(
+                CodexRequestAnswerChanged(
+                  identity~,
+                  request_key=self.request_key,
+                  question_id=question.id,
+                  answer=option.0,
                 ),
-                [
-                  @html.span(class="codex-option-label", option.0),
-                  @html.span(class="codex-option-desc", option.1),
-                ],
               ),
+              [
+                @html.span(class="codex-option-label", option.0),
+                @html.span(class="codex-option-desc", option.1),
+              ],
             )
-          }
+          })
           controls.push(@html.div(class="codex-options", options))
         }
         controls.push(
@@ -434,16 +382,12 @@ fn CodexRequestInput::render(
       }
       body.push(
         @html.div(class="codex-request-actions", [
-          @html.button(
-            class="codex-request-action codex-request-action-primary",
-            on_click=action_emit(
-              CodexRequestResponded(
-                identity~,
-                request_key=self.request_key,
-                decision=Json("accept"),
-              ),
-            ),
-            "Submit answers",
+          self.decision_button(
+            identity,
+            action_emit,
+            class_name="codex-request-action codex-request-action-primary",
+            decision=Json("accept"),
+            label="Submit answers",
           ),
         ]),
       )
@@ -468,27 +412,19 @@ fn CodexRequestInput::render(
       )
       body.push(
         @html.div(class="codex-request-actions", [
-          @html.button(
-            class="codex-request-action codex-request-action-primary",
-            on_click=action_emit(
-              CodexRequestResponded(
-                identity~,
-                request_key=self.request_key,
-                decision=Json("accept"),
-              ),
-            ),
-            "Submit JSON",
+          self.decision_button(
+            identity,
+            action_emit,
+            class_name="codex-request-action codex-request-action-primary",
+            decision=Json("accept"),
+            label="Submit JSON",
           ),
-          @html.button(
-            class="codex-request-action codex-request-action-danger",
-            on_click=action_emit(
-              CodexRequestResponded(
-                identity~,
-                request_key=self.request_key,
-                decision=Json("decline"),
-              ),
-            ),
-            "Decline",
+          self.decision_button(
+            identity,
+            action_emit,
+            class_name="codex-request-action codex-request-action-danger",
+            decision=Json("decline"),
+            label="Decline",
           ),
         ]),
       )

--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -1005,8 +1005,11 @@ fn show_transient_navigation_target_highlight(
 }
 
 ///|
-fn dispose_markdown_model(model : @viewer.MarkdownViewerModel) -> Unit {
-  model.model.dispose()
+fn dispose_markdown_model(model : @viewer.MarkdownViewerModel?) -> Unit {
+  match model {
+    Some(model) => model.model.dispose()
+    None => ()
+  }
 }
 
 ///|
@@ -1206,10 +1209,7 @@ fn show_file_in_viewer(
             ),
           ),
         )
-        match previous {
-          Some(previous) => dispose_markdown_model(previous)
-          None => ()
-        }
+        dispose_markdown_model(previous)
         if restore_view_state &&
           relative is Some(rel) &&
           viewer_state.markdown_view_states.get(rel.0) is Some(saved) {
@@ -1219,10 +1219,7 @@ fn show_file_in_viewer(
         // `MarkdownViewer::set_model` returns only after its attachment and
         // bridges are detached, so the caller-owned TextModel can be retired
         // immediately before Code takes over.
-        match markdown_viewer.set_model(None) {
-          Some(previous) => dispose_markdown_model(previous)
-          None => ()
-        }
+        dispose_markdown_model(markdown_viewer.set_model(None))
         viewer.set_model(Some(text_model))
         dispose_source_model(code_model)
         let restored_code_view_state = if restore_view_state &&
@@ -1246,10 +1243,7 @@ fn show_file_in_viewer(
       viewer.set_model(None)
       dispose_source_model(code_model)
     } else {
-      match markdown_viewer.set_model(None) {
-        Some(previous) => dispose_markdown_model(previous)
-        None => ()
-      }
+      dispose_markdown_model(markdown_viewer.set_model(None))
     }
     // Gate incoming diagnostics to the file now on screen (a notice document,
     // with no absolute path, takes no diagnostics). The relative name rides
@@ -1397,6 +1391,34 @@ fn should_auto_fold_top_level(text_model : @model.TextModel) -> Bool {
 }
 
 ///|
+/// Retire the source and Markdown documents on screen, the file identity they
+/// were shown under, and the MBTI diagram.
+fn clear_source_presentation() -> Unit {
+  if viewer_state.viewer is Some(viewer) {
+    if viewer_state.point_range_highlight is Some(highlight) {
+      highlight.clear()
+    }
+    if viewer_state.search_match_highlights is Some(highlights) {
+      highlights.clear()
+    }
+    if viewer_state.services is Some(services) &&
+      viewer.get_model() is Some(model) {
+      services.quick_diff.set_original_content(model.uri, None)
+    }
+    let previous = viewer.get_model()
+    viewer.set_model(None)
+    dispose_source_model(previous)
+  }
+  if viewer_state.markdown_viewer is Some(markdown_viewer) {
+    dispose_markdown_model(markdown_viewer.set_model(None))
+  }
+  viewer_state.absolute = None
+  viewer_state.relative = None
+  viewer_state.navigation = None
+  clear_mbti_diagram()
+}
+
+///|
 /// Drop the viewer's current document so it falls back to the placeholder.
 /// Used when the active conversation changes (which also invalidates every
 /// parked scroll position — they belong to the previous workspace's tabs)
@@ -1407,31 +1429,7 @@ fn clear_viewer() -> @cmd.Cmd {
   @cmd.custom_cmd(_scheduler => {
     viewer_state.view_states.clear()
     viewer_state.markdown_view_states.clear()
-    if viewer_state.viewer is Some(viewer) {
-      if viewer_state.point_range_highlight is Some(highlight) {
-        highlight.clear()
-      }
-      if viewer_state.search_match_highlights is Some(highlights) {
-        highlights.clear()
-      }
-      if viewer_state.services is Some(services) &&
-        viewer.get_model() is Some(model) {
-        services.quick_diff.set_original_content(model.uri, None)
-      }
-      let previous = viewer.get_model()
-      viewer.set_model(None)
-      dispose_source_model(previous)
-    }
-    if viewer_state.markdown_viewer is Some(markdown_viewer) {
-      match markdown_viewer.set_model(None) {
-        Some(previous) => dispose_markdown_model(previous)
-        None => ()
-      }
-    }
-    viewer_state.absolute = None
-    viewer_state.relative = None
-    viewer_state.navigation = None
-    clear_mbti_diagram()
+    clear_source_presentation()
     clear_diff_comparison()
     clear_semantic_review_editors()
   })
@@ -1444,33 +1442,7 @@ fn clear_viewer() -> @cmd.Cmd {
 /// CSS, while the next complete comparison replaces it atomically. Its memory
 /// stays bounded to one pair and `clear_viewer` retires it at an owner boundary.
 fn clear_document() -> @cmd.Cmd {
-  @cmd.custom_cmd(_scheduler => {
-    if viewer_state.viewer is Some(viewer) {
-      if viewer_state.point_range_highlight is Some(highlight) {
-        highlight.clear()
-      }
-      if viewer_state.search_match_highlights is Some(highlights) {
-        highlights.clear()
-      }
-      if viewer_state.services is Some(services) &&
-        viewer.get_model() is Some(model) {
-        services.quick_diff.set_original_content(model.uri, None)
-      }
-      let previous = viewer.get_model()
-      viewer.set_model(None)
-      dispose_source_model(previous)
-    }
-    if viewer_state.markdown_viewer is Some(markdown_viewer) {
-      match markdown_viewer.set_model(None) {
-        Some(previous) => dispose_markdown_model(previous)
-        None => ()
-      }
-    }
-    viewer_state.absolute = None
-    viewer_state.relative = None
-    viewer_state.navigation = None
-    clear_mbti_diagram()
-  })
+  @cmd.custom_cmd(_scheduler => clear_source_presentation())
 }
 
 ///|

--- a/desktop/frontend/fileeditor/semantic_review_view.mbt
+++ b/desktop/frontend/fileeditor/semantic_review_view.mbt
@@ -1376,14 +1376,20 @@ fn refresh_semantic_review_editor_options() -> Unit {
 }
 
 ///|
+/// Retire one mounted section widget and drop its map entry.
+fn remove_semantic_review_editor(key : String) -> Unit {
+  if semantic_review_editors.get(key) is Some(entry) {
+    dispose_semantic_review_editor(entry)
+    semantic_review_editors.remove(key)
+  }
+}
+
+///|
 fn clear_semantic_review_editors() -> Unit {
   semantic_review_navigation_generation.val += 1
-  let keys = semantic_review_editors.to_array().map(pair => pair.0)
+  let keys = [ for key, _ in semantic_review_editors => key ]
   for key in keys {
-    if semantic_review_editors.get(key) is Some(entry) {
-      dispose_semantic_review_editor(entry)
-      semantic_review_editors.remove(key)
-    }
+    remove_semantic_review_editor(key)
   }
   semantic_review_order.clear()
   semantic_review_active_key.val = None
@@ -1499,15 +1505,12 @@ fn sync_semantic_review_editors(state : State) -> @cmd.Cmd {
         !desired_keys.contains(key) {
         semantic_review_active_key.val = None
       }
-      let stale = semantic_review_editors
-        .to_array()
-        .map(pair => pair.0)
-        .filter(key => !desired_keys.contains(key))
+      let is_stale = key => !desired_keys.contains(key)
+      let stale = [
+        for key, _ in semantic_review_editors if is_stale(key) => key
+      ]
       for key in stale {
-        if semantic_review_editors.get(key) is Some(entry) {
-          dispose_semantic_review_editor(entry)
-          semantic_review_editors.remove(key)
-        }
+        remove_semantic_review_editor(key)
       }
       for section in desired {
         let key = section.key
@@ -1515,35 +1518,23 @@ fn sync_semantic_review_editors(state : State) -> @cmd.Cmd {
           .get_element_by_id(semantic_editor_host_id(key))
           .to_option()
           is Some(host) else {
-          if semantic_review_editors.get(key) is Some(previous) {
-            dispose_semantic_review_editor(previous)
-            semantic_review_editors.remove(key)
-          }
+          remove_semantic_review_editor(key)
           continue
         }
-        let reusable = semantic_review_editors
-          .get(key)
-          .map(previous => {
-            previous.section == section &&
-            previous.old_name == input.old_name &&
-            previous.new_name == input.new_name &&
-            previous.feedback_file == input.feedback_file &&
-            previous.live_modified == input.live_modified &&
-            previous.host.is_same_node(host.as_node())
-          })
-          .unwrap_or(false)
-        if reusable {
-          let entry = semantic_review_editors[key]
-          entry.editor.update_options(
+        if semantic_review_editors.get(key) is Some(previous) &&
+          previous.section == section &&
+          previous.old_name == input.old_name &&
+          previous.new_name == input.new_name &&
+          previous.feedback_file == input.feedback_file &&
+          previous.live_modified == input.live_modified &&
+          previous.host.is_same_node(host.as_node()) {
+          previous.editor.update_options(
             semantic_diff_options(state.review_diff_layout),
           )
-          entry.editor.layout()
+          previous.editor.layout()
           continue
         }
-        if semantic_review_editors.get(key) is Some(previous) {
-          dispose_semantic_review_editor(previous)
-          semantic_review_editors.remove(key)
-        }
+        remove_semantic_review_editor(key)
         if create_semantic_review_editor(
             input,
             section,

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -625,36 +625,22 @@ pub fn open_changed_document(
     )
   }
   if change.has_working_tree_file() {
-    if doc_state is TabLoaded(..) {
-      // Clear a previous review baseline immediately while keeping the cached
-      // working document and view state; the new HEAD side fills in later.
-      // The tagged read below is the sole refresh owner, so this command only
-      // displays the cached document instead of scheduling a duplicate reload.
-      cmds.push(
-        show_pending_review(
-          dispatch,
-          ctx,
-          state.editor_search_highlights(path),
-          path,
-          review_doc,
-        ),
-      )
-    } else {
-      // The Viewer can still contain the previously active reviewed document.
-      // The dock has already switched to this uncached path, so clear the
-      // outgoing document while its tagged working-tree read is pending. Use
-      // the same review-loading presentation path as later activations so the
-      // old source, navigation context, and gutter all disappear together.
-      cmds.push(
-        show_pending_review(
-          dispatch,
-          ctx,
-          state.editor_search_highlights(path),
-          path,
-          review_doc,
-        ),
-      )
-    }
+    // Show the review-loading presentation for this path whether or not a
+    // working document is already cached. Either way the previous review
+    // baseline clears at once and the new HEAD side fills in later, and the
+    // Viewer stops showing the outgoing document while its tagged working-tree
+    // read is pending, so the old source, navigation context and gutter
+    // disappear together. The tagged read below is the sole refresh owner, so
+    // this command only presents; it never schedules a duplicate reload.
+    cmds.push(
+      show_pending_review(
+        dispatch,
+        ctx,
+        state.editor_search_highlights(path),
+        path,
+        review_doc,
+      ),
+    )
     cmds.push(
       read_file(
         dispatch,
@@ -689,6 +675,17 @@ pub fn open_changed_document(
 }
 
 ///|
+/// The Git object a changed row compares against: a rename/copy keeps its
+/// original path, every other kind compares the row's own path.
+fn ChangedFile::compared_source(self : ChangedFile) -> @pathx.Relative? {
+  if self.kind is (ChangeRenamed | ChangeCopied) {
+    self.original_path
+  } else {
+    Some(self.path)
+  }
+}
+
+///|
 /// Find the refreshed form of the exact Changes row that opened a review.
 /// Git may emit multiple rows with the same destination path, so prefer the
 /// original porcelain identity, then progressively weaker *unique* matches.
@@ -699,56 +696,41 @@ fn selected_review_change(
   selected : ChangedFile,
 ) -> ChangedFile? {
   let candidates = files.filter(change => change.path == selected.path)
+  // A predicate several rows satisfy is ambiguous, not a match.
+  fn unique(matches : (ChangedFile) -> Bool) -> ChangedFile? {
+    let found = candidates.filter(matches)
+    if found.length() == 1 {
+      Some(found[0])
+    } else {
+      None
+    }
+  }
+
   for change in candidates {
     if change == selected {
       return Some(change)
     }
   }
-  let mut status_match : ChangedFile? = None
-  let mut status_matches = 0
-  for change in candidates {
-    if change.original_path == selected.original_path &&
-      change.index_status == selected.index_status &&
-      change.worktree_status == selected.worktree_status {
-      status_match = Some(change)
-      status_matches += 1
-    }
+  let by_status = unique(change => {
+    change.original_path == selected.original_path &&
+    change.index_status == selected.index_status &&
+    change.worktree_status == selected.worktree_status
+  })
+  if by_status is Some(_) {
+    return by_status
   }
-  if status_matches == 1 {
-    return status_match
+  let by_input = unique(change => {
+    change.compared_source() == selected.compared_source() &&
+    change.has_working_tree_file() == selected.has_working_tree_file()
+  })
+  if by_input is Some(_) {
+    return by_input
   }
-  let selected_source = if selected.kind is (ChangeRenamed | ChangeCopied) {
-    selected.original_path
-  } else {
-    Some(selected.path)
-  }
-  let mut input_match : ChangedFile? = None
-  let mut input_matches = 0
-  for change in candidates {
-    let source = if change.kind is (ChangeRenamed | ChangeCopied) {
-      change.original_path
-    } else {
-      Some(change.path)
-    }
-    if source == selected_source &&
-      change.has_working_tree_file() == selected.has_working_tree_file() {
-      input_match = Some(change)
-      input_matches += 1
-    }
-  }
-  if input_matches == 1 {
-    return input_match
-  }
-  let mut availability_match : ChangedFile? = None
-  let mut availability_matches = 0
-  for change in candidates {
-    if change.has_working_tree_file() == selected.has_working_tree_file() {
-      availability_match = Some(change)
-      availability_matches += 1
-    }
-  }
-  if availability_matches == 1 {
-    return availability_match
+  let by_availability = unique(change => {
+    change.has_working_tree_file() == selected.has_working_tree_file()
+  })
+  if by_availability is Some(_) {
+    return by_availability
   }
   if candidates.length() == 1 &&
     previous_files.filter(change => change.path == selected.path).length() <= 1 {
@@ -874,22 +856,9 @@ fn reconcile_reviews_after_changes(
           )
         let review_inputs_changed = review_incomplete ||
           head_changed ||
-          ({
-            let previous_source = if review.selected.kind
-              is (ChangeRenamed | ChangeCopied) {
-              review.selected.original_path
-            } else {
-              Some(review.selected.path)
-            }
-            let source = if change.kind is (ChangeRenamed | ChangeCopied) {
-              change.original_path
-            } else {
-              Some(change.path)
-            }
-            previous_source != source ||
-            review.selected.has_working_tree_file() !=
-            change.has_working_tree_file()
-          })
+          review.selected.compared_source() != change.compared_source() ||
+          review.selected.has_working_tree_file() !=
+          change.has_working_tree_file()
         if !review_inputs_changed {
           if review.selected != change {
             docs[path] = {
@@ -1263,20 +1232,12 @@ fn active_moonbit_diagnostics(
 ///|
 fn moonbit_check_input(path : @pathx.Relative) -> Bool {
   let text = path.0
-  if text.has_suffix(".mbt") ||
-    text.has_suffix(".mbti") ||
-    text.has_suffix(".mbt.md") {
-    return true
-  }
-  for
-    name in [
-      "moon.pkg", "moon.mod", "moon.work", "moon.pkg.json", "moon.mod.json",
-    ] {
-    if text == name || text.has_suffix("/" + name) {
-      return true
-    }
-  }
-  false
+  text.has_suffix(".mbt") ||
+  text.has_suffix(".mbti") ||
+  text.has_suffix(".mbt.md") ||
+  ["moon.pkg", "moon.mod", "moon.work", "moon.pkg.json", "moon.mod.json"].any(name => {
+    text == name || text.has_suffix("/" + name)
+  })
 }
 
 ///|
@@ -1510,15 +1471,8 @@ fn changes_visible(state : State, ctx : Ctx) -> Bool {
 /// low-rate refresh alive until every reviewed document is closed or ordinarily
 /// reopened.
 fn changes_live(state : State, ctx : Ctx) -> Bool {
-  if changes_visible(state, ctx) {
-    return true
-  }
-  for _, doc in state.docs {
-    if doc.review is Some(_) {
-      return true
-    }
-  }
-  false
+  changes_visible(state, ctx) ||
+  state.docs.values().any(doc => doc.review is Some(_))
 }
 
 ///|
@@ -1583,15 +1537,10 @@ fn ChangedFile::touched_by(
   self : ChangedFile,
   changes : Array[FileChange],
 ) -> Bool {
-  for change in changes {
-    if change.touches(self.path) {
-      return true
-    }
-    if self.original_path is Some(original) && change.touches(original) {
-      return true
-    }
-  }
-  false
+  changes.any(change => {
+    change.touches(self.path) ||
+    (self.original_path is Some(original) && change.touches(original))
+  })
 }
 
 ///|
@@ -1611,19 +1560,15 @@ fn review_needs_unknown_head_refresh(
     // A genuinely unborn repository gives additions/untracked rows an
     // empty baseline. Old hosts can give the same row real HEAD content,
     // which must be refreshed after a commit removes that baseline.
-    ReviewMissing if review.selected.kind is (ChangeAdded | ChangeUntracked) => {
+    ReviewMissing if review.selected.kind is (ChangeAdded | ChangeUntracked) =>
       // A genuinely unborn repository can only expose added/untracked rows.
       // On a legacy host, a transition can retain the exact untracked row
       // while a same-path tracked/deleted row proves that HEAD now owns a
       // baseline. Refresh that case without polling unborn files forever.
-      for change in files {
-        if change.path == review.selected.path &&
-          !(change.kind is (ChangeAdded | ChangeUntracked)) {
-          return true
-        }
-      }
-      false
-    }
+      files.any(change => {
+        change.path == review.selected.path &&
+        !(change.kind is (ChangeAdded | ChangeUntracked))
+      })
     _ => true
   }
 }
@@ -2847,9 +2792,7 @@ pub fn update(
         } else {
           ([], docs, review_generation, state.background_review_requests)
         }
-        for cmd in legacy_cmds {
-          review_cmds.push(cmd)
-        }
+        review_cmds.append(legacy_cmds)
         let settle = if follow_up {
           list_changes(
             dispatch,
@@ -3470,6 +3413,42 @@ pub fn update(
         // Whether the loop below already reloads the active tab — that path
         // re-requests diagnostics on its own.
         let mut active_reloading = false
+        // Replace a document the host can no longer vouch for, and return the
+        // review generation the caller must carry forward.
+        fn settle_unreadable(
+          doc : Doc,
+          path : @pathx.Relative,
+          next_state : TabState,
+          generation : Int,
+        ) -> Int {
+          let (review, next_generation) = match doc.review {
+            Some(review) if review.selected.has_working_tree_file() =>
+              // A missing or unreadable stat is newer than any tagged
+              // read still in flight. Advance its token so an older
+              // successful read cannot resurrect working text the host
+              // can no longer vouch for.
+              (
+                Some({ ..review, working_generation: generation + 1, }),
+                generation + 1,
+              )
+            _ => (doc.review, generation)
+          }
+          let settled = { ..doc, state: next_state, review, stale: false, }
+          docs[path] = settled
+          if ctx.active_file == Some(path) {
+            cmds.push(
+              show_tab(
+                dispatch,
+                ctx,
+                state.editor_search_highlights(path),
+                path,
+                settled,
+              ),
+            )
+          }
+          next_generation
+        }
+
         for stat in stats {
           guard docs.get(stat.path) is Some(doc) else { continue }
           let current_sig = match stat.signature {
@@ -3479,35 +3458,12 @@ pub fn update(
               // tab already reviewing a textual HEAD side instead switches
               // to that deleted-file preview.
               if !(doc.state is (TabDeleted | TabUnavailable(_))) {
-                let review = match doc.review {
-                  Some(review) if review.selected.has_working_tree_file() => {
-                    // The missing signature is newer than any tagged read
-                    // that was already in flight. Advance its token so an
-                    // older successful read cannot resurrect deleted working
-                    // text.
-                    review_generation += 1
-                    Some({ ..review, working_generation: review_generation, })
-                  }
-                  _ => doc.review
-                }
-                let deleted = {
-                  ..doc,
-                  state: TabDeleted,
-                  review,
-                  stale: false,
-                }
-                docs[stat.path] = deleted
-                if ctx.active_file == Some(stat.path) {
-                  cmds.push(
-                    show_tab(
-                      dispatch,
-                      ctx,
-                      state.editor_search_highlights(stat.path),
-                      stat.path,
-                      deleted,
-                    ),
-                  )
-                }
+                review_generation = settle_unreadable(
+                  doc,
+                  stat.path,
+                  TabDeleted,
+                  review_generation,
+                )
               }
               continue
             }
@@ -3532,34 +3488,12 @@ pub fn update(
                   false
               }
               if affected {
-                let review = match doc.review {
-                  Some(review) if review.selected.has_working_tree_file() => {
-                    // Like a deletion, the failure is newer than any tagged
-                    // read still in flight: an older success must not settle
-                    // text the host can no longer vouch for.
-                    review_generation += 1
-                    Some({ ..review, working_generation: review_generation, })
-                  }
-                  _ => doc.review
-                }
-                let failed = {
-                  ..doc,
-                  state: TabReadFailed(message),
-                  review,
-                  stale: false,
-                }
-                docs[stat.path] = failed
-                if ctx.active_file == Some(stat.path) {
-                  cmds.push(
-                    show_tab(
-                      dispatch,
-                      ctx,
-                      state.editor_search_highlights(stat.path),
-                      stat.path,
-                      failed,
-                    ),
-                  )
-                }
+                review_generation = settle_unreadable(
+                  doc,
+                  stat.path,
+                  TabReadFailed(message),
+                  review_generation,
+                )
               }
               continue
             }
@@ -3680,6 +3614,26 @@ pub fn update(
         Some(generation) => state.file_link_generation != generation
         None => false
       }
+      // A read failure replaces the tab's snapshot with a retryable notice,
+      // redrawing it only when the failure is current and the tab is on screen.
+      fn settle_failed(doc : Doc, show : Bool) -> (@cmd.Cmd, State) {
+        let docs = state.docs.copy()
+        let failed = { ..doc, state: TabReadFailed(message), stale: false, }
+        docs[path] = failed
+        let cmd = if show && ctx.active_file == Some(path) {
+          show_tab(
+            dispatch,
+            ctx,
+            state.editor_search_highlights(path),
+            path,
+            failed,
+          )
+        } else {
+          @cmd.none
+        }
+        (cmd, { ..state, docs, error: None, })
+      }
+
       if state.owner != Some(owner) || state.request_epoch != epoch {
         (@cmd.none, state)
       } else if file_link_generation is Some(_) {
@@ -3693,21 +3647,7 @@ pub fn update(
             if stale_file_link && !(doc.state is TabLoading) {
               return (@cmd.none, state)
             }
-            let docs = state.docs.copy()
-            let failed = { ..doc, state: TabReadFailed(message), stale: false, }
-            docs[path] = failed
-            let cmd = if !stale_file_link && ctx.active_file == Some(path) {
-              show_tab(
-                dispatch,
-                ctx,
-                state.editor_search_highlights(path),
-                path,
-                failed,
-              )
-            } else {
-              @cmd.none
-            }
-            (cmd, { ..state, docs, error: None, })
+            settle_failed(doc, !stale_file_link)
           }
           Some({ review: Some(_), .. }) | None if stale_file_link =>
             (@cmd.none, state)
@@ -3722,21 +3662,7 @@ pub fn update(
           current == generation else {
           return (@cmd.none, state)
         }
-        let docs = state.docs.copy()
-        let failed = { ..doc, state: TabReadFailed(message), stale: false, }
-        docs[path] = failed
-        let cmd = if ctx.active_file == Some(path) {
-          show_tab(
-            dispatch,
-            ctx,
-            state.editor_search_highlights(path),
-            path,
-            failed,
-          )
-        } else {
-          @cmd.none
-        }
-        (cmd, { ..state, docs, error: None, })
+        settle_failed(doc, true)
       } else if state.docs.get(path) is Some({ review: Some(_), .. }) {
         // Like an untagged success, this failure belongs to an ordinary read
         // that predates the review click and is no longer user-visible.
@@ -3854,10 +3780,7 @@ fn owned_state_at(ctx : Ctx) -> State {
 
 ///|
 fn loaded_doc(path : String) -> Doc raise {
-  guard @resource.of_path(@interop.ChannelId::Local, "/work/" + path)
-    is Some(absolute) else {
-    fail("test document resource was not absolute")
-  }
+  let absolute = test_ctx().test_resource("/work/" + path)
   {
     name: basename(Relative(path)),
     state: TabLoaded(content="", absolute~, sig="1:0"),
@@ -3875,6 +3798,45 @@ fn test_modified_change(path : @pathx.Relative) -> ChangedFile {
     worktree_status: "M",
     kind: ChangeModified,
   }
+}
+
+///|
+/// A settled `git.changes` reply for the state-transition fixtures. Every
+/// test snapshot describes a repository, so only the owner, generation, HEAD
+/// identity, and rows vary.
+fn changes_loaded(
+  owner : @interop.ConversationKey,
+  generation~ : Int,
+  files~ : Array[ChangedFile],
+  repository? : Bool = true,
+  head? : String,
+) -> Msg {
+  ChangesLoaded(owner~, generation~, repository~, head~, files~)
+}
+
+///|
+/// A settled `fs.read_file` reply for the state-transition fixtures. No test
+/// reply carries a navigation token or a reveal position, so only the owner,
+/// epoch, path, name, payload, and review token vary.
+fn file_loaded(
+  owner : @interop.ConversationKey,
+  path~ : @pathx.Relative,
+  name~ : String,
+  file~ : FileContent,
+  epoch? : Int = 0,
+  review_generation? : Int,
+) -> Msg {
+  FileLoaded(
+    owner~,
+    epoch~,
+    path~,
+    name~,
+    file~,
+    file_link_generation=None,
+    review_generation~,
+    range=None,
+    annotation=None,
+  )
 }
 
 ///|
@@ -4180,13 +4142,7 @@ test "changed-file review fences paired replies and ordinary opens leave review"
   let emit = test_emit()
   let path = @pathx.Relative("a.mbt")
   let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path), }
-  let change : ChangedFile = {
-    path,
-    original_path: None,
-    index_status: " ",
-    worktree_status: "M",
-    kind: ChangeModified,
-  }
+  let change = test_modified_change(path)
   let (_, first) = open_changed_document(
     emit,
     owned_state(),
@@ -4227,24 +4183,16 @@ test "changed-file review fences paired replies and ordinary opens leave review"
     different_row,
     had_active=true,
   )
-  guard @resource.of_path(@interop.ChannelId::Local, "/work/a.mbt")
-    is Some(absolute) else {
-    fail("test file resource was not absolute")
-  }
+  let absolute = test_ctx().test_resource("/work/a.mbt")
   // An ordinary read that began before the first review click carries no
   // token. It must not inherit the newer baseline if it settles afterward.
   let (_, pre_review_working) = update(
     emit,
-    FileLoaded(
-      owner=ctx.owner,
-      epoch=0,
+    file_loaded(
+      ctx.owner,
       path~,
       name="a.mbt",
       file=Content(content="pre-review working", absolute~, sig="0:18"),
-      file_link_generation=None,
-      review_generation=None,
-      range=None,
-      annotation=None,
     ),
     second,
     ctx,
@@ -4261,16 +4209,12 @@ test "changed-file review fences paired replies and ordinary opens leave review"
   )
   let (_, old_working) = update(
     emit,
-    FileLoaded(
-      owner=ctx.owner,
-      epoch=0,
+    file_loaded(
+      ctx.owner,
       path~,
       name="a.mbt",
       file=Content(content="stale working", absolute~, sig="1:13"),
-      file_link_generation=None,
-      review_generation=Some(1),
-      range=None,
-      annotation=None,
+      review_generation=1,
     ),
     pre_review_working,
     ctx,
@@ -4363,16 +4307,12 @@ test "changed-file review fences paired replies and ordinary opens leave review"
   assert_true(ordinary.docs.get(path) is Some({ review: None, .. }))
   let (_, review_after_ordinary) = update(
     emit,
-    FileLoaded(
-      owner=ctx.owner,
-      epoch=0,
+    file_loaded(
+      ctx.owner,
       path~,
       name="a.mbt",
       file=Content(content="late review", absolute~, sig="3:11"),
-      file_link_generation=None,
-      review_generation=Some(2),
-      range=None,
-      annotation=None,
+      review_generation=2,
     ),
     ordinary,
     ctx,
@@ -4432,13 +4372,7 @@ test "changed-file review preserves a stale cached working document until reload
   let docs : Map[@pathx.Relative, Doc] = Map([])
   docs[path] = { ..loaded_doc("stale.mbt"), stale: true, }
   let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path), }
-  let change : ChangedFile = {
-    path,
-    original_path: None,
-    index_status: " ",
-    worktree_status: "M",
-    kind: ChangeModified,
-  }
+  let change = test_modified_change(path)
   let (_, reviewing) = open_changed_document(
     emit,
     { ..owned_state(), docs, },
@@ -4692,22 +4626,15 @@ test "deleted changes preview HEAD and working-file loads retain early baselines
     live_loading,
     live_ctx,
   )
-  guard @resource.of_path(@interop.ChannelId::Local, "/work/live.mbt")
-    is Some(absolute) else {
-    fail("test file resource was not absolute")
-  }
+  let absolute = test_ctx().test_resource("/work/live.mbt")
   let (_, loaded) = update(
     emit,
-    FileLoaded(
-      owner=live_ctx.owner,
-      epoch=0,
+    file_loaded(
+      live_ctx.owner,
       path=live_path,
       name="live.mbt",
       file=Content(content="new", absolute~, sig="2:3"),
-      file_link_generation=None,
-      review_generation=Some(1),
-      range=None,
-      annotation=None,
+      review_generation=1,
     ),
     baseline_first,
     live_ctx,
@@ -4827,10 +4754,7 @@ test "close_document drops the entry and forces the tree open on the last one" {
 ///|
 test "FileLoaded settles content into its document, active or not" {
   let emit = test_emit()
-  guard @resource.of_path(@interop.ChannelId::Local, "/work/a.mbt")
-    is Some(absolute) else {
-    fail("test file resource was not absolute")
-  }
+  let absolute = test_ctx().test_resource("/work/a.mbt")
   let docs : Map[@pathx.Relative, Doc] = Map([])
   docs[Relative("a.mbt")] = {
     name: "a.mbt",
@@ -4847,16 +4771,11 @@ test "FileLoaded settles content into its document, active or not" {
   }
   let (_, next) = update(
     emit,
-    FileLoaded(
-      owner=test_ctx().owner,
-      epoch=0,
+    file_loaded(
+      test_ctx().owner,
       path=Relative("a.mbt"),
       name="a.mbt",
       file=Content(content="fn main {}", absolute~, sig="2:0"),
-      file_link_generation=None,
-      review_generation=None,
-      range=None,
-      annotation=None,
     ),
     state,
     ctx,
@@ -4866,22 +4785,14 @@ test "FileLoaded settles content into its document, active or not" {
     is Some({ state: TabLoaded(content="fn main {}", ..), .. }),
   )
   // A reply for a closed document (or another conversation) is dropped.
-  guard @resource.of_path(@interop.ChannelId::Local, "/work/gone.mbt")
-    is Some(gone_absolute) else {
-    fail("test closed file resource was not absolute")
-  }
+  let gone_absolute = test_ctx().test_resource("/work/gone.mbt")
   let (_, stray) = update(
     emit,
-    FileLoaded(
-      owner=test_ctx().owner,
-      epoch=0,
+    file_loaded(
+      test_ctx().owner,
       path=Relative("gone.mbt"),
       name="gone.mbt",
       file=Content(content="", absolute=gone_absolute, sig="2:0"),
-      file_link_generation=None,
-      review_generation=None,
-      range=None,
-      annotation=None,
     ),
     next,
     ctx,
@@ -4889,19 +4800,11 @@ test "FileLoaded settles content into its document, active or not" {
   assert_true(stray.docs.length() == 2)
   let (_, other) = update(
     emit,
-    FileLoaded(
-      owner={
-        channel: @interop.ChannelId::Remote("other"),
-        session: "desktop-test",
-      },
-      epoch=0,
+    file_loaded(
+      { channel: @interop.ChannelId::Remote("other"), session: "desktop-test", },
       path=Relative("a.mbt"),
       name="a.mbt",
       file=Binary,
-      file_link_generation=None,
-      review_generation=None,
-      range=None,
-      annotation=None,
     ),
     stray,
     ctx,
@@ -4921,22 +4824,15 @@ test "FileLoaded settles content into its document, active or not" {
     ctx,
   )
   assert_true(old_epoch == epoch_state)
-  guard @resource.of_path(@interop.ChannelId::Local, "/work/a.mbt")
-    is Some(absolute) else {
-    fail("test file resource was not absolute")
-  }
+  let absolute = test_ctx().test_resource("/work/a.mbt")
   let (_, old_read) = update(
     emit,
-    FileLoaded(
-      owner=test_ctx().owner,
-      epoch=1,
+    file_loaded(
+      test_ctx().owner,
       path=Relative("a.mbt"),
       name="a.mbt",
       file=Content(content="stale", absolute~, sig="9:0"),
-      file_link_generation=None,
-      review_generation=None,
-      range=None,
-      annotation=None,
+      epoch=1,
     ),
     epoch_state,
     ctx,
@@ -5079,10 +4975,7 @@ test "a closed panel still re-roots when the conversation switches" {
 test "a resolved placement change reroots documents and fences old replies" {
   let emit = test_emit()
   let path = @pathx.Relative("reviewed.mbt")
-  guard @resource.of_path(@interop.ChannelId::Local, "/project-a")
-    is Some(old_workspace) else {
-    fail("test workspace resource was not absolute")
-  }
+  let old_workspace = test_ctx().test_resource("/project-a")
   let docs : Map[@pathx.Relative, Doc] = Map([])
   docs[path] = {
     ..loaded_doc("reviewed.mbt"),
@@ -5172,22 +5065,16 @@ test "a resolved placement change reroots documents and fences old replies" {
       }
     ),
   )
-  guard @resource.of_path(@interop.ChannelId::Local, "/project-a/reviewed.mbt")
-    is Some(old_absolute) else {
-    fail("test file resource was not absolute")
-  }
+  let old_absolute = test_ctx().test_resource("/project-a/reviewed.mbt")
   let (_, after_old_reply) = update(
     emit,
-    FileLoaded(
-      owner=worktree_ctx.owner,
-      epoch=state.request_epoch,
+    file_loaded(
+      worktree_ctx.owner,
       path~,
       name="reviewed.mbt",
       file=Content(content="old root reply", absolute=old_absolute, sig="1:1"),
-      file_link_generation=None,
-      review_generation=Some(4),
-      range=None,
-      annotation=None,
+      epoch=state.request_epoch,
+      review_generation=4,
     ),
     moved,
     { ..worktree_ctx, request_epoch: moved.request_epoch, },
@@ -5195,11 +5082,10 @@ test "a resolved placement change reroots documents and fences old replies" {
   assert_true(after_old_reply == moved)
   let (_, after_old_changes) = update(
     emit,
-    ChangesLoaded(
-      owner=worktree_ctx.owner,
+    changes_loaded(
+      worktree_ctx.owner,
       generation=state.changes_generation,
-      repository=true,
-      head=Some("root-head"),
+      head="root-head",
       files=[test_modified_change(path)],
     ),
     moved,
@@ -5209,10 +5095,7 @@ test "a resolved placement change reroots documents and fences old replies" {
 
   // A workspace reassignment for the same conversation is the same hard
   // boundary even when both sides resolve to the ordinary project root.
-  guard @resource.of_path(@interop.ChannelId::Local, "/project-b")
-    is Some(new_workspace) else {
-    fail("test workspace resource was not absolute")
-  }
+  let new_workspace = test_ctx().test_resource("/project-b")
   let (reassigned, _) = sync(emit, state, {
     ..worktree_ctx,
     placement: Some(@interop.WorkspaceRoot(root=new_workspace)),
@@ -5527,13 +5410,7 @@ test "a missing checkout settles an in-flight Changes request for retry" {
   // it. The sync above has already removed the liveness hazard.
   let (_, after_reply) = update(
     emit,
-    ChangesLoaded(
-      owner=present.owner,
-      generation=1,
-      repository=true,
-      head=None,
-      files=[],
-    ),
+    changes_loaded(present.owner, generation=1, files=[]),
     parked,
     missing,
   )
@@ -5548,13 +5425,7 @@ test "checkout recovery restarts a review whose paired replies were parked" {
   let emit = test_emit()
   let present = test_ctx().test_worktree("wt")
   let path = @pathx.Relative("reviewed.mbt")
-  let change : ChangedFile = {
-    path,
-    original_path: None,
-    index_status: " ",
-    worktree_status: "M",
-    kind: ChangeModified,
-  }
+  let change = test_modified_change(path)
   let docs : Map[@pathx.Relative, Doc] = Map([])
   docs[path] = {
     name: "reviewed.mbt",
@@ -5625,13 +5496,7 @@ test "checkout recovery restarts a review whose paired replies were parked" {
   assert_eq(parked_again.request_epoch, restored.request_epoch + 1)
   let (_, restarted) = update(
     emit,
-    ChangesLoaded(
-      owner=present.owner,
-      generation=3,
-      repository=true,
-      head=Some("same-head"),
-      files=[change],
-    ),
+    changes_loaded(present.owner, generation=3, head="same-head", files=[change]),
     restored,
     { ..present, open_files: [path], active_file: Some(path), },
   )
@@ -5654,13 +5519,7 @@ test "hidden checkout recovery retries failed Changes once before parking" {
   let emit = test_emit()
   let present = test_ctx().test_worktree("wt")
   let path = @pathx.Relative("reviewed.mbt")
-  let change : ChangedFile = {
-    path,
-    original_path: None,
-    index_status: " ",
-    worktree_status: "M",
-    kind: ChangeModified,
-  }
+  let change = test_modified_change(path)
   let docs : Map[@pathx.Relative, Doc] = Map([])
   docs[path] = {
     name: "reviewed.mbt",
@@ -5718,13 +5577,7 @@ test "hidden checkout recovery retries failed Changes once before parking" {
   assert_true(still_failed.changes_generation == 3)
   let (_, restarted) = update(
     emit,
-    ChangesLoaded(
-      owner=present.owner,
-      generation=3,
-      repository=true,
-      head=Some("same-head"),
-      files=[change],
-    ),
+    changes_loaded(present.owner, generation=3, head="same-head", files=[change]),
     restored,
     restored_ctx,
   )
@@ -5737,13 +5590,7 @@ test "ordinary Changes polls do not supersede healthy in-flight reviews" {
   let emit = test_emit()
   let present = test_ctx()
   let path = @pathx.Relative("slow.mbt")
-  let change : ChangedFile = {
-    path,
-    original_path: None,
-    index_status: " ",
-    worktree_status: "M",
-    kind: ChangeModified,
-  }
+  let change = test_modified_change(path)
   let docs : Map[@pathx.Relative, Doc] = Map([])
   docs[path] = {
     name: "slow.mbt",
@@ -5773,13 +5620,7 @@ test "ordinary Changes polls do not supersede healthy in-flight reviews" {
   }
   let (_, polled) = update(
     emit,
-    ChangesLoaded(
-      owner=present.owner,
-      generation=1,
-      repository=true,
-      head=Some("same-head"),
-      files=[change],
-    ),
+    changes_loaded(present.owner, generation=1, head="same-head", files=[change]),
     state,
     { ..present, open_files: [path], active_file: Some(path), },
   )
@@ -6089,13 +5930,7 @@ test "selecting Changes loads once and coalesces an in-flight refresh" {
   assert_true(latched.changes is ChangeListLoading(refresh_again=true))
   let (_, following_up) = update(
     emit,
-    ChangesLoaded(
-      owner=test_ctx().owner,
-      generation=1,
-      repository=true,
-      head=None,
-      files=[],
-    ),
+    changes_loaded(test_ctx().owner, generation=1, files=[]),
     latched,
     test_ctx(),
   )
@@ -6171,24 +6006,10 @@ test "changed-file replies are owner-and-generation-fenced" {
     changes: ChangeListLoading(refresh_again=false),
     changes_generation: 1,
   }
-  let files = [
-    {
-      path: Relative("src/main.mbt"),
-      original_path: None,
-      index_status: " ",
-      worktree_status: "M",
-      kind: ChangeModified,
-    },
-  ]
+  let files = [test_modified_change(Relative("src/main.mbt"))]
   let (_, ready) = update(
     emit,
-    ChangesLoaded(
-      owner=test_ctx().owner,
-      generation=1,
-      repository=true,
-      head=None,
-      files~,
-    ),
+    changes_loaded(test_ctx().owner, generation=1, files~),
     state,
     test_ctx(),
   )
@@ -6203,14 +6024,9 @@ test "changed-file replies are owner-and-generation-fenced" {
   )
   let (_, stale) = update(
     emit,
-    ChangesLoaded(
-      owner={
-        channel: @interop.ChannelId::Remote("other"),
-        session: "desktop-test",
-      },
+    changes_loaded(
+      { channel: @interop.ChannelId::Remote("other"), session: "desktop-test", },
       generation=1,
-      repository=true,
-      head=None,
       files=[],
     ),
     ready,
@@ -6233,13 +6049,7 @@ test "changed-file replies are owner-and-generation-fenced" {
   assert_true(stale_failure == ready)
   let (_, stale_generation) = update(
     emit,
-    ChangesLoaded(
-      owner=test_ctx().owner,
-      generation=0,
-      repository=true,
-      head=None,
-      files=[],
-    ),
+    changes_loaded(test_ctx().owner, generation=0, files=[]),
     ready,
     test_ctx(),
   )
@@ -6283,13 +6093,7 @@ test "a settled Changes snapshot re-stats loaded reviews whose rows disappeared"
   let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path), }
   let (_, settled) = update(
     test_emit(),
-    ChangesLoaded(
-      owner=test_ctx().owner,
-      generation=1,
-      repository=true,
-      head=None,
-      files=[],
-    ),
+    changes_loaded(test_ctx().owner, generation=1, files=[]),
     state,
     ctx,
   )
@@ -6330,9 +6134,7 @@ test "a review that becomes a symlink clears its cached regular-file source" {
   let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path), }
   let (_, unavailable) = update(
     test_emit(),
-    ChangesLoaded(owner=ctx.owner, generation=1, repository=true, head=None, files=[
-      symlink,
-    ]),
+    changes_loaded(ctx.owner, generation=1, files=[symlink]),
     {
       ..owned_state(),
       explorer_mode: ExplorerChanges,
@@ -6366,20 +6168,12 @@ test "a review that becomes a symlink clears its cached regular-file source" {
     ctx,
   )
   assert_true(still_unavailable == unavailable)
-  guard @resource.of_path(@interop.ChannelId::Local, "/work/src/replaced.mbt")
-    is Some(absolute) else {
-    fail("test file resource was not absolute")
-  }
-  let stale_reply = FileLoaded(
-    owner=ctx.owner,
-    epoch=0,
+  let absolute = test_ctx().test_resource("/work/src/replaced.mbt")
+  let stale_reply = file_loaded(
+    ctx.owner,
     path~,
     name="replaced.mbt",
     file=Content(content="stale regular source", absolute~, sig="4:0"),
-    file_link_generation=None,
-    review_generation=None,
-    range=None,
-    annotation=None,
   )
   let (_, fenced) = update(test_emit(), stale_reply, still_unavailable, ctx)
   assert_true(fenced == still_unavailable)
@@ -6459,7 +6253,7 @@ test "a disappearing review row hands an active reload to an ordinary read" {
   )
   let (_, settled) = update(
     test_emit(),
-    ChangesLoaded(owner=ctx.owner, generation=1, repository=true, head=None, files=[]),
+    changes_loaded(ctx.owner, generation=1, files=[]),
     {
       ..reloading,
       changes: ChangeListLoading(refresh_again=false),
@@ -6471,22 +6265,15 @@ test "a disappearing review row hands an active reload to an ordinary read" {
     settled.docs.get(path)
     is Some({ state: TabLoaded(..), review: None, stale: true, .. }),
   )
-  guard @resource.of_path(@interop.ChannelId::Local, "/work/src/committed.mbt")
-    is Some(absolute) else {
-    fail("test file resource was not absolute")
-  }
+  let absolute = test_ctx().test_resource("/work/src/committed.mbt")
   let (_, fenced) = update(
     test_emit(),
-    FileLoaded(
-      owner=ctx.owner,
-      epoch=0,
+    file_loaded(
+      ctx.owner,
       path~,
       name="committed.mbt",
       file=Content(content="stale review read", absolute~, sig="2:7"),
-      file_link_generation=None,
-      review_generation=Some(3),
-      range=None,
-      annotation=None,
+      review_generation=3,
     ),
     settled,
     ctx,
@@ -6494,16 +6281,11 @@ test "a disappearing review row hands an active reload to an ordinary read" {
   assert_true(fenced == settled)
   let (_, current) = update(
     test_emit(),
-    FileLoaded(
-      owner=ctx.owner,
-      epoch=0,
+    file_loaded(
+      ctx.owner,
       path~,
       name="committed.mbt",
       file=Content(content="current working", absolute~, sig="2:7"),
-      file_link_generation=None,
-      review_generation=None,
-      range=None,
-      annotation=None,
     ),
     fenced,
     ctx,
@@ -6558,22 +6340,15 @@ test "a newer review reload fences an older working-tree reply" {
       }
     ),
   )
-  guard @resource.of_path(@interop.ChannelId::Local, "/work/src/racing.mbt")
-    is Some(absolute) else {
-    fail("test file resource was not absolute")
-  }
+  let absolute = test_ctx().test_resource("/work/src/racing.mbt")
   let (_, newest) = update(
     test_emit(),
-    FileLoaded(
-      owner=ctx.owner,
-      epoch=0,
+    file_loaded(
+      ctx.owner,
       path~,
       name="racing.mbt",
       file=Content(content="newest working", absolute~, sig="2:0"),
-      file_link_generation=None,
-      review_generation=Some(4),
-      range=None,
-      annotation=None,
+      review_generation=4,
     ),
     reloading,
     ctx,
@@ -6591,16 +6366,12 @@ test "a newer review reload fences an older working-tree reply" {
   )
   let (_, stale) = update(
     test_emit(),
-    FileLoaded(
-      owner=ctx.owner,
-      epoch=0,
+    file_loaded(
+      ctx.owner,
       path~,
       name="racing.mbt",
       file=Content(content="older working", absolute~, sig="1:0"),
-      file_link_generation=None,
-      review_generation=Some(3),
-      range=None,
-      annotation=None,
+      review_generation=3,
     ),
     newest,
     ctx,
@@ -6627,16 +6398,12 @@ test "a newer review reload fences an older working-tree reply" {
   )
   let (_, resurrected) = update(
     test_emit(),
-    FileLoaded(
-      owner=ctx.owner,
-      epoch=0,
+    file_loaded(
+      ctx.owner,
       path~,
       name="racing.mbt",
       file=Content(content="pre-deletion working", absolute~, sig="2:0"),
-      file_link_generation=None,
-      review_generation=Some(4),
-      range=None,
-      annotation=None,
+      review_generation=4,
     ),
     deleted,
     ctx,
@@ -6673,13 +6440,7 @@ test "only a final Changes snapshot reconciles reviews and moved HEAD refreshes 
   // clear the review or consume the new HEAD identity before the follow-up.
   let (_, following_up) = update(
     test_emit(),
-    ChangesLoaded(
-      owner=test_ctx().owner,
-      generation=1,
-      repository=true,
-      head=Some("new-head"),
-      files=[],
-    ),
+    changes_loaded(test_ctx().owner, generation=1, head="new-head", files=[]),
     state,
     ctx,
   )
@@ -6694,24 +6455,10 @@ test "only a final Changes snapshot reconciles reviews and moved HEAD refreshes 
   )
   assert_true(following_up.changes_head == Some("old-head"))
   assert_true(following_up.changes_generation == 2)
-  let files = [
-    {
-      path,
-      original_path: None,
-      index_status: " ",
-      worktree_status: "M",
-      kind: ChangeModified,
-    },
-  ]
+  let files = [test_modified_change(path)]
   let (_, settled) = update(
     test_emit(),
-    ChangesLoaded(
-      owner=test_ctx().owner,
-      generation=2,
-      repository=true,
-      head=Some("new-head"),
-      files~,
-    ),
+    changes_loaded(test_ctx().owner, generation=2, head="new-head", files~),
     following_up,
     ctx,
   )
@@ -6783,13 +6530,7 @@ test "HEAD refresh restarts the generation-fenced working-tree read" {
   let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path), }
   let (_, refreshed) = update(
     test_emit(),
-    ChangesLoaded(
-      owner=ctx.owner,
-      generation=1,
-      repository=true,
-      head=Some("new-head"),
-      files=[change],
-    ),
+    changes_loaded(ctx.owner, generation=1, head="new-head", files=[change]),
     state,
     ctx,
   )
@@ -6803,22 +6544,15 @@ test "HEAD refresh restarts the generation-fenced working-tree read" {
       }
     ),
   )
-  guard @resource.of_path(@interop.ChannelId::Local, "/work/src/paired.mbt")
-    is Some(absolute) else {
-    fail("test file resource was not absolute")
-  }
+  let absolute = test_ctx().test_resource("/work/src/paired.mbt")
   let (_, ignored_old_working) = update(
     test_emit(),
-    FileLoaded(
-      owner=ctx.owner,
-      epoch=0,
+    file_loaded(
+      ctx.owner,
       path~,
       name="paired.mbt",
       file=Content(content="stale working", absolute~, sig="2:13"),
-      file_link_generation=None,
-      review_generation=Some(3),
-      range=None,
-      annotation=None,
+      review_generation=3,
     ),
     refreshed,
     ctx,
@@ -6848,16 +6582,12 @@ test "HEAD refresh restarts the generation-fenced working-tree read" {
   )
   let (_, paired) = update(
     test_emit(),
-    FileLoaded(
-      owner=ctx.owner,
-      epoch=0,
+    file_loaded(
+      ctx.owner,
       path~,
       name="paired.mbt",
       file=Content(content="current working", absolute~, sig="3:15"),
-      file_link_generation=None,
-      review_generation=Some(4),
-      range=None,
-      annotation=None,
+      review_generation=4,
     ),
     baseline_ready,
     ctx,
@@ -6901,13 +6631,7 @@ test "legacy Changes replies without HEAD refresh baseline-bearing reviews" {
   }
   let (_, settled) = update(
     test_emit(),
-    ChangesLoaded(
-      owner=test_ctx().owner,
-      generation=1,
-      repository=true,
-      head=None,
-      files=[change],
-    ),
+    changes_loaded(test_ctx().owner, generation=1, files=[change]),
     state,
     { ..test_ctx(), open_files: [path], active_file: Some(path), },
   )
@@ -6938,13 +6662,7 @@ test "legacy Changes replies without HEAD refresh baseline-bearing reviews" {
   assert_true(polling.changes_generation == 2)
   let (_, coalesced) = update(
     test_emit(),
-    ChangesLoaded(
-      owner=test_ctx().owner,
-      generation=2,
-      repository=true,
-      head=None,
-      files=[change],
-    ),
+    changes_loaded(test_ctx().owner, generation=2, files=[change]),
     polling,
     ctx,
   )
@@ -7013,13 +6731,7 @@ test "unborn repository polls do not churn untracked reviews" {
   }
   let (_, settled) = update(
     test_emit(),
-    ChangesLoaded(
-      owner=test_ctx().owner,
-      generation=1,
-      repository=true,
-      head=None,
-      files=[change],
-    ),
+    changes_loaded(test_ctx().owner, generation=1, files=[change]),
     state,
     { ..test_ctx(), open_files: [path], active_file: Some(path), },
   )
@@ -7071,13 +6783,7 @@ test "legacy HEAD omission refreshes a missing baseline once tracking is proven"
   }
   let (_, refreshed) = update(
     test_emit(),
-    ChangesLoaded(
-      owner=test_ctx().owner,
-      generation=1,
-      repository=true,
-      head=None,
-      files=[deleted, untracked],
-    ),
+    changes_loaded(test_ctx().owner, generation=1, files=[deleted, untracked]),
     state,
     { ..test_ctx(), open_files: [path], active_file: Some(path), },
   )
@@ -7131,13 +6837,9 @@ test "Changes reconciliation preserves the selected duplicate-path row" {
   // never silently turn the document into a deleted-file preview.
   let (_, settled) = update(
     test_emit(),
-    ChangesLoaded(
-      owner=ctx.owner,
-      generation=1,
-      repository=true,
-      head=Some("new-head"),
-      files=[deleted, untracked],
-    ),
+    changes_loaded(ctx.owner, generation=1, head="new-head", files=[
+      deleted, untracked,
+    ]),
     refreshing,
     ctx,
   )
@@ -7197,13 +6899,7 @@ test "moved HEAD normalizes reviewed tabs across the working-file boundary" {
   }
   let (_, became_deleted) = update(
     test_emit(),
-    ChangesLoaded(
-      owner=ctx.owner,
-      generation=1,
-      repository=true,
-      head=Some("new-head"),
-      files=[deleted],
-    ),
+    changes_loaded(ctx.owner, generation=1, head="new-head", files=[deleted]),
     loading,
     ctx,
   )
@@ -7236,13 +6932,7 @@ test "moved HEAD normalizes reviewed tabs across the working-file boundary" {
   let restored = { ..deleted, worktree_status: "M", kind: ChangeModified, }
   let (_, became_loading) = update(
     test_emit(),
-    ChangesLoaded(
-      owner=ctx.owner,
-      generation=1,
-      repository=true,
-      head=Some("new-head"),
-      files=[restored],
-    ),
+    changes_loaded(ctx.owner, generation=1, head="new-head", files=[restored]),
     deleted_state,
     ctx,
   )
@@ -7302,13 +6992,9 @@ test "a changed rename source refreshes its review without moving HEAD" {
   }
   let (_, settled) = update(
     test_emit(),
-    ChangesLoaded(
-      owner=test_ctx().owner,
-      generation=1,
-      repository=true,
-      head=Some("same-head"),
-      files=[current],
-    ),
+    changes_loaded(test_ctx().owner, generation=1, head="same-head", files=[
+      current,
+    ]),
     state,
     { ..test_ctx(), open_files: [path], active_file: Some(path), },
   )
@@ -7503,11 +7189,10 @@ test "a parked checkout stops the fallback poll until repair" {
   assert_true(restored.changes is ChangeListReady(refreshing=true, ..))
   let (_, settled) = update(
     emit,
-    ChangesLoaded(
-      owner=present.owner,
+    changes_loaded(
+      present.owner,
       generation=restored.changes_generation,
-      repository=true,
-      head=Some("same-head"),
+      head="same-head",
       files=[change],
     ),
     restored,
@@ -7532,13 +7217,7 @@ test "hidden explorer drops coalesced follow-ups when requests settle" {
   }
   let (_, loaded) = update(
     emit,
-    ChangesLoaded(
-      owner=test_ctx().owner,
-      generation=4,
-      repository=true,
-      head=None,
-      files=[],
-    ),
+    changes_loaded(test_ctx().owner, generation=4, files=[]),
     refreshing,
     hidden,
   )
@@ -7652,13 +7331,7 @@ test "watcher refresh keeps the ready change snapshot visible" {
   // second reply settles the snapshot.
   let (_, following_up) = update(
     emit,
-    ChangesLoaded(
-      owner=test_ctx().owner,
-      generation=1,
-      repository=true,
-      head=None,
-      files=[],
-    ),
+    changes_loaded(test_ctx().owner, generation=1, files=[]),
     latched,
     test_ctx(),
   )
@@ -7674,13 +7347,7 @@ test "watcher refresh keeps the ready change snapshot visible" {
   )
   let (_, settled) = update(
     emit,
-    ChangesLoaded(
-      owner=test_ctx().owner,
-      generation=2,
-      repository=true,
-      head=None,
-      files=[],
-    ),
+    changes_loaded(test_ctx().owner, generation=2, files=[]),
     following_up,
     test_ctx(),
   )
@@ -8255,13 +7922,7 @@ test "a selected deletion hands a clean restoration to an ordinary read" {
   // after the earlier, deliberately ignored review-side stat.
   let (_, ordinary) = update(
     emit,
-    ChangesLoaded(
-      owner=ctx.owner,
-      generation=1,
-      repository=true,
-      head=Some("same-head"),
-      files=[],
-    ),
+    changes_loaded(ctx.owner, generation=1, head="same-head", files=[]),
     {
       ..reviewed,
       changes: ChangeListLoading(refresh_again=false),
@@ -8283,22 +7944,14 @@ test "a selected deletion hands a clean restoration to an ordinary read" {
     ordinary,
     ctx,
   )
-  guard @resource.of_path(@interop.ChannelId::Local, "/work/recreated.mbt")
-    is Some(absolute) else {
-    fail("test file resource was not absolute")
-  }
+  let absolute = test_ctx().test_resource("/work/recreated.mbt")
   let (_, restored) = update(
     emit,
-    FileLoaded(
-      owner=ctx.owner,
-      epoch=0,
+    file_loaded(
+      ctx.owner,
       path~,
       name="recreated.mbt",
       file=Content(content="HEAD source", absolute~, sig="3:0"),
-      file_link_generation=None,
-      review_generation=None,
-      range=None,
-      annotation=None,
     ),
     reloading,
     ctx,
@@ -8339,13 +7992,7 @@ test "a vanished review retries a failed ordinary read" {
   // stranding the ordinary tab in the review read's transient failure.
   let (_, ordinary) = update(
     emit,
-    ChangesLoaded(
-      owner=ctx.owner,
-      generation=1,
-      repository=true,
-      head=Some("new-head"),
-      files=[],
-    ),
+    changes_loaded(ctx.owner, generation=1, head="new-head", files=[]),
     {
       ..owned_state(),
       docs,
@@ -8368,22 +8015,14 @@ test "a vanished review retries a failed ordinary read" {
     ordinary,
     ctx,
   )
-  guard @resource.of_path(@interop.ChannelId::Local, "/work/committed.mbt")
-    is Some(absolute) else {
-    fail("test file resource was not absolute")
-  }
+  let absolute = test_ctx().test_resource("/work/committed.mbt")
   let (_, restored) = update(
     emit,
-    FileLoaded(
-      owner=ctx.owner,
-      epoch=0,
+    file_loaded(
+      ctx.owner,
       path~,
       name="committed.mbt",
       file=Content(content="committed source", absolute~, sig="4:0"),
-      file_link_generation=None,
-      review_generation=None,
-      range=None,
-      annotation=None,
     ),
     reloading,
     ctx,

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -117,14 +117,13 @@ fn breadcrumb_entry_id(index : Int) -> String {
 }
 
 ///|
-fn focus_breadcrumb_entry_after_render(index : Int) -> @cmd.Cmd {
+/// Move DOM focus to the element with `id` after the next render. Every
+/// roving-tabindex list in the panel shares this one imperative effect.
+fn focus_element_after_render(id : String) -> @cmd.Cmd {
   @cmd.custom_cmd(
     _ => {
-      if @dom.document()
-        .get_element_by_id(breadcrumb_entry_id(index))
-        .to_option()
-        is Some(row) {
-        let _ : @js.Value = @js.Value::cast_from(row).apply_with_string(
+      if @dom.document().get_element_by_id(id).to_option() is Some(element) {
+        let _ : @js.Value = @js.Value::cast_from(element).apply_with_string(
           "focus",
           ([] : Array[@js.Value]),
         )
@@ -135,18 +134,8 @@ fn focus_breadcrumb_entry_after_render(index : Int) -> @cmd.Cmd {
 }
 
 ///|
-fn focus_explorer_tab_after_render(id : String) -> @cmd.Cmd {
-  @cmd.custom_cmd(
-    _ => {
-      if @dom.document().get_element_by_id(id).to_option() is Some(tab) {
-        let _ : @js.Value = @js.Value::cast_from(tab).apply_with_string(
-          "focus",
-          ([] : Array[@js.Value]),
-        )
-      }
-    },
-    kind=@cmd.after_render,
-  )
+fn focus_breadcrumb_entry_after_render(index : Int) -> @cmd.Cmd {
+  focus_element_after_render(breadcrumb_entry_id(index))
 }
 
 ///|
@@ -214,7 +203,7 @@ fn explorer_tab(
             event.prevent_default()
             @cmd.batch([
               dispatch(ExplorerModeSelected(target)),
-              focus_explorer_tab_after_render(explorer_tab_id(target)),
+              focus_element_after_render(explorer_tab_id(target)),
             ])
           }
           None => @cmd.none
@@ -231,20 +220,7 @@ fn changed_file_row_id(index : Int) -> String {
 
 ///|
 fn focus_changed_file_after_render(index : Int) -> @cmd.Cmd {
-  @cmd.custom_cmd(
-    _ => {
-      if @dom.document()
-        .get_element_by_id(changed_file_row_id(index))
-        .to_option()
-        is Some(row) {
-        let _ : @js.Value = @js.Value::cast_from(row).apply_with_string(
-          "focus",
-          ([] : Array[@js.Value]),
-        )
-      }
-    },
-    kind=@cmd.after_render,
-  )
+  focus_element_after_render(changed_file_row_id(index))
 }
 
 ///|
@@ -349,76 +325,63 @@ pub fn body_view(
       None =>
         ctx.active_file.map(path => supports_moon_diff(path.0)).unwrap_or(false)
     })
+  // Every surface host is the same never-re-keyed element: its id, the shared
+  // `viewer-host editor-shell` classes plus its own, and the app's theme.
+  fn surface_attrs(
+    id : String,
+    extra_class : String,
+    visible : Bool,
+  ) -> @html.Attrs {
+    @html.Attrs::build()
+    .id(id)
+    .class(
+      "viewer-host editor-shell" +
+      extra_class +
+      (if visible { "" } else { " moonbit-viewer-surface-hidden" }),
+    )
+    .data_set("theme", if ctx.dark_mode { "dark" } else { "light" })
+  }
+
   let viewer_host = @html.div(
-    attrs=@html.Attrs::build()
-      .id(ViewerHostId)
-      .class(
-        if use_diff_surface || use_markdown_surface || use_mbti_surface {
-          "viewer-host editor-shell moonbit-viewer-surface-hidden"
-        } else {
-          "viewer-host editor-shell"
-        },
-      )
-      .data_set("theme", if ctx.dark_mode { "dark" } else { "light" }),
+    attrs=surface_attrs(
+      ViewerHostId,
+      "",
+      !(use_diff_surface || use_markdown_surface || use_mbti_surface),
+    ),
     ([] : Array[@html.Html]),
   )
   let markdown_viewer_host = @html.div(
-    attrs=@html.Attrs::build()
-      .id(MarkdownViewerHostId)
-      .class(
-        if use_markdown_surface {
-          "viewer-host editor-shell"
-        } else {
-          "viewer-host editor-shell moonbit-viewer-surface-hidden"
-        },
-      )
-      .data_set("theme", if ctx.dark_mode { "dark" } else { "light" }),
+    attrs=surface_attrs(MarkdownViewerHostId, "", use_markdown_surface),
     ([] : Array[@html.Html]),
   )
   let mbti_diagram_host = @html.div(
-    attrs=@html.Attrs::build()
-      .id(MbtiDiagramHostId)
-      .class(
-        if use_mbti_surface {
-          "viewer-host editor-shell mbti-diagram-host"
-        } else {
-          "viewer-host editor-shell mbti-diagram-host moonbit-viewer-surface-hidden"
-        },
-      )
-      .data_set("theme", if ctx.dark_mode { "dark" } else { "light" }),
+    attrs=surface_attrs(
+      MbtiDiagramHostId,
+      " mbti-diagram-host",
+      use_mbti_surface,
+    ),
     ([] : Array[@html.Html]),
   )
   let diff_editor_host = @html.div(
-    attrs=@html.Attrs::build()
-      .id(DiffEditorHostId)
-      .class(
-        if use_diff_surface && !use_semantic_surface {
-          "viewer-host editor-shell"
-        } else {
-          "viewer-host editor-shell moonbit-viewer-surface-hidden"
-        },
-      )
-      .data_set("theme", if ctx.dark_mode { "dark" } else { "light" }),
+    attrs=surface_attrs(
+      DiffEditorHostId,
+      "",
+      use_diff_surface && !use_semantic_surface,
+    ),
     ([] : Array[@html.Html]),
   )
   let semantic_review_host = @html.div(
-    attrs=@html.Attrs::build()
-      .id(SemanticReviewHostId)
-      .class(
-        if use_semantic_surface {
-          "viewer-host editor-shell semantic-review-host"
-        } else {
-          "viewer-host editor-shell semantic-review-host moonbit-viewer-surface-hidden"
-        },
-      )
-      .data_set("theme", if ctx.dark_mode { "dark" } else { "light" })
-      .on_scroll(event => {
-        guard event.target().to_element() is Some(element) else {
-          return @cmd.none
-        }
-        sync_semantic_review_scroll_left(element.get_scroll_left())
-        @cmd.none
-      }),
+    attrs=surface_attrs(
+      SemanticReviewHostId,
+      " semantic-review-host",
+      use_semantic_surface,
+    ).on_scroll(event => {
+      guard event.target().to_element() is Some(element) else {
+        return @cmd.none
+      }
+      sync_semantic_review_scroll_left(element.get_scroll_left())
+      @cmd.none
+    }),
     semantic_review,
   )
   @html.div(class="editor-body", [
@@ -810,18 +773,7 @@ fn git_commit_row_id(index : Int) -> String {
 
 ///|
 fn focus_git_commit_after_render(index : Int) -> @cmd.Cmd {
-  @cmd.custom_cmd(
-    _ => {
-      if @dom.document().get_element_by_id(git_commit_row_id(index)).to_option()
-        is Some(row) {
-        let _ : @js.Value = @js.Value::cast_from(row).apply_with_string(
-          "focus",
-          ([] : Array[@js.Value]),
-        )
-      }
-    },
-    kind=@cmd.after_render,
-  )
+  focus_element_after_render(git_commit_row_id(index))
 }
 
 ///|
@@ -1009,6 +961,17 @@ fn git_graph_placeholder(
 }
 
 ///|
+/// One swimlane edge: every Git Graph edge is the same round-capped path in
+/// its lane color.
+fn graph_edge(color : Int, d : String) -> @svg.Svg {
+  @svg.path(
+    class="git-graph-edge " + graph_color_class(color),
+    d~,
+    attrs=@svg.Attrs::build().stroke_linecap("round"),
+  )
+}
+
+///|
 fn git_graph_cell(
   row : GraphRow,
   commit : @protocol.GitHistoryCommit,
@@ -1025,10 +988,9 @@ fn git_graph_cell(
     if node.id == commit.id {
       if index != circle_index {
         children.push(
-          @svg.path(
-            class="git-graph-edge " + graph_color_class(node.color),
-            d="M \{graph_lane_x(index)} 0 A 11 11 0 0 1 \{11 * index} 11 H \{circle_x}",
-            attrs=@svg.Attrs::build().stroke_linecap("round"),
+          graph_edge(
+            node.color,
+            "M \{graph_lane_x(index)} 0 A 11 11 0 0 1 \{11 * index} 11 H \{circle_x}",
           ),
         )
       } else {
@@ -1043,13 +1005,7 @@ fn git_graph_cell(
       } else {
         "M \{x} 0 V 6 A 5 5 0 0 1 \{x - 5} 11 H \{output_x + 5} A 5 5 0 0 0 \{output_x} 16 V 22"
       }
-      children.push(
-        @svg.path(
-          class="git-graph-edge " + graph_color_class(node.color),
-          d~,
-          attrs=@svg.Attrs::build().stroke_linecap("round"),
-        ),
-      )
+      children.push(graph_edge(node.color, d))
       output_swimlane_index += 1
     }
   }
@@ -1064,45 +1020,34 @@ fn git_graph_cell(
     }
     let start_x = 11 * parent_output_index
     children.push(
-      @svg.path(
-        class="git-graph-edge " +
-          graph_color_class(row.output_swimlanes[parent_output_index].color),
-        d="M \{start_x} 11 A 11 11 0 0 1 \{graph_lane_x(parent_output_index)} 22 M \{start_x} 11 H \{circle_x}",
-        attrs=@svg.Attrs::build().stroke_linecap("round"),
+      graph_edge(
+        row.output_swimlanes[parent_output_index].color,
+        "M \{start_x} 11 A 11 11 0 0 1 \{graph_lane_x(parent_output_index)} 22 M \{start_x} 11 H \{circle_x}",
       ),
     )
   }
 
   if input_index is Some(index) {
     children.push(
-      @svg.path(
-        class="git-graph-edge " +
-          graph_color_class(row.input_swimlanes[index].color),
-        d="M \{circle_x} 0 V 11",
-        attrs=@svg.Attrs::build().stroke_linecap("round"),
-      ),
+      graph_edge(row.input_swimlanes[index].color, "M \{circle_x} 0 V 11"),
     )
   }
   if !commit.parent_ids.is_empty() {
-    children.push(
-      @svg.path(
-        class="git-graph-edge " + graph_color_class(circle_color),
-        d="M \{circle_x} 11 V 22",
-        attrs=@svg.Attrs::build().stroke_linecap("round"),
-      ),
-    )
+    children.push(graph_edge(circle_color, "M \{circle_x} 11 V 22"))
   }
 
   let node_color = graph_color_class(circle_color)
-  if head {
-    children.push(
-      @svg.circle(
-        class="git-graph-node git-graph-node-head-outer " + node_color,
-        cx=circle_x,
-        cy=11,
-        r=7,
-      ),
+  fn node_circle(name : String, r : Int) -> @svg.Svg {
+    @svg.circle(
+      class="git-graph-node \{name} " + node_color,
+      cx=circle_x,
+      cy=11,
+      r~,
     )
+  }
+
+  if head {
+    children.push(node_circle("git-graph-node-head-outer", 7))
     children.push(
       @svg.circle(
         class="git-graph-node git-graph-node-head-inner " + node_color,
@@ -1113,31 +1058,10 @@ fn git_graph_cell(
       ),
     )
   } else if commit.parent_ids.length() > 1 {
-    children.push(
-      @svg.circle(
-        class="git-graph-node git-graph-node-merge-outer " + node_color,
-        cx=circle_x,
-        cy=11,
-        r=6,
-      ),
-    )
-    children.push(
-      @svg.circle(
-        class="git-graph-node git-graph-node-merge-inner " + node_color,
-        cx=circle_x,
-        cy=11,
-        r=3,
-      ),
-    )
+    children.push(node_circle("git-graph-node-merge-outer", 6))
+    children.push(node_circle("git-graph-node-merge-inner", 3))
   } else {
-    children.push(
-      @svg.circle(
-        class="git-graph-node git-graph-node-commit " + node_color,
-        cx=circle_x,
-        cy=11,
-        r=5,
-      ),
-    )
+    children.push(node_circle("git-graph-node-commit", 5))
   }
   @html.span(
     class="git-graph-cell",
@@ -2106,21 +2030,13 @@ fn review_diff_mode_toolbar(
       .role("toolbar")
       .aria_label("Comparison algorithm"),
     [
-      review_diff_mode_button(
-        ReviewDiffLine,
-        state.review_diff_mode == ReviewDiffLine,
-        dispatch(ReviewDiffModeSelected(ReviewDiffLine)),
-      ),
-      review_diff_mode_button(
-        ReviewDiffToken,
-        state.review_diff_mode == ReviewDiffToken,
-        dispatch(ReviewDiffModeSelected(ReviewDiffToken)),
-      ),
-      review_diff_mode_button(
-        ReviewDiffTree,
-        state.review_diff_mode == ReviewDiffTree,
-        dispatch(ReviewDiffModeSelected(ReviewDiffTree)),
-      ),
+      for mode in [ReviewDiffLine, ReviewDiffToken, ReviewDiffTree] => {
+        review_diff_mode_button(
+          mode,
+          state.review_diff_mode == mode,
+          dispatch(ReviewDiffModeSelected(mode)),
+        )
+      }
     ],
   )
 }

--- a/desktop/frontend/goal.mbt
+++ b/desktop/frontend/goal.mbt
@@ -7,6 +7,24 @@ fn test_goal_command(request : GoalRequest) -> GoalCommand {
 }
 
 ///|
+/// Test-only: commit one runtime notice into the fixture conversation's
+/// durable record and return the model it produced.
+fn commit_notice(model : Model, sequence : Int, content : String) -> Model {
+  let (_, next) = update_dev(
+    test_dispatch(),
+    SessionCommitted(
+      session="desktop-test",
+      sequence~,
+      ts=None,
+      item=@protocol.RuntimeNotice({ content, }),
+      session_root=@interop.ChannelId::Local.test_store_root(),
+    ),
+    model,
+  )
+  next
+}
+
+///|
 test "the goal slash command opens the editor prefilled from the mirror" {
   let dispatch = test_dispatch()
   let model = test_model().replace_conversation({
@@ -50,47 +68,31 @@ test "submit holds the text until its marker lands" {
 
 ///|
 test "only the matching set marker settles the pending text" {
-  let dispatch = test_dispatch()
   let model = test_model().replace_conversation({
     ..test_conversation(),
     goal_pending: Some(test_goal_command(Setting("ship the feature"))),
   })
-  fn commit(model, sequence, content) {
-    let (_, next) = update_dev(
-      dispatch,
-      SessionCommitted(
-        session="desktop-test",
-        sequence~,
-        ts=None,
-        item=@protocol.RuntimeNotice({ content, }),
-        session_root=@interop.ChannelId::Local.test_store_root(),
-      ),
-      model,
-    )
-    next
-  }
-
   // A marker proves the engine is committing, not that this command landed.
   // An earlier set from a second submit, and a block on the goal that still
   // stands, both leave the recovery copy alone — the append it belongs to
   // can still fail.
-  let other_set = commit(model, 1, "[goal]\nan earlier goal")
+  let other_set = commit_notice(model, 1, "[goal]\nan earlier goal")
   assert_true(
     other_set.active().goal_pending
     is Some({ request: Setting("ship the feature"), .. }),
   )
-  let blocked = commit(other_set, 2, "[goal blocked]\nneeds a decision")
+  let blocked = commit_notice(other_set, 2, "[goal blocked]\nneeds a decision")
   assert_true(
     blocked.active().goal_pending
     is Some({ request: Setting("ship the feature"), .. }),
   )
-  let cleared = commit(blocked, 3, "[goal cleared]")
+  let cleared = commit_notice(blocked, 3, "[goal cleared]")
   assert_true(
     cleared.active().goal_pending
     is Some({ request: Setting("ship the feature"), .. }),
   )
   // Its own set does settle it, and moves the mirror.
-  let settled = commit(cleared, 4, "[goal]\nship the feature")
+  let settled = commit_notice(cleared, 4, "[goal]\nship the feature")
   assert_true(settled.active().goal_pending is None)
   assert_true(
     settled.active().goal is Some({ text: "ship the feature", blocked: None, }),
@@ -139,35 +141,19 @@ test "clear sends from goal mode and from the standing row alike" {
 
 ///|
 test "a clear waits for its tombstone, not for any goal marker" {
-  let dispatch = test_dispatch()
   let model = test_model().replace_conversation({
     ..test_conversation(),
     goal: Some({ text: "ship the feature", blocked: None, }),
     goal_pending: Some(test_goal_command(Clearing)),
   })
-  fn commit(model, sequence, content) {
-    let (_, next) = update_dev(
-      dispatch,
-      SessionCommitted(
-        session="desktop-test",
-        sequence~,
-        ts=None,
-        item=@protocol.RuntimeNotice({ content, }),
-        session_root=@interop.ChannelId::Local.test_store_root(),
-      ),
-      model,
-    )
-    next
-  }
-
   // Someone else's set, and a block on the goal this clear is removing,
   // both leave it in flight: neither is the tombstone it asked for.
-  let other = commit(model, 1, "[goal]\nsomething else")
+  let other = commit_notice(model, 1, "[goal]\nsomething else")
   assert_true(other.active().goal_pending is Some({ request: Clearing, .. }))
-  let blocked = commit(other, 2, "[goal blocked]\nneeds a decision")
+  let blocked = commit_notice(other, 2, "[goal blocked]\nneeds a decision")
   assert_true(blocked.active().goal_pending is Some({ request: Clearing, .. }))
   // The tombstone settles it, and the mirror empties with it.
-  let settled = commit(blocked, 3, "[goal cleared]")
+  let settled = commit_notice(blocked, 3, "[goal cleared]")
   assert_true(settled.active().goal_pending is None)
   assert_true(settled.active().goal is None)
 }
@@ -213,52 +199,19 @@ test "each conversation owns its own goal edit" {
 
 ///|
 test "goal marker commits write the mirror and render cards" {
-  let dispatch = test_dispatch()
-  let (_, set) = update_dev(
-    dispatch,
-    SessionCommitted(
-      session="desktop-test",
-      sequence=1,
-      ts=None,
-      item=@protocol.RuntimeNotice({ content: "[goal]\nship the feature", }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
-    ),
-    test_model(),
-  )
+  let set = commit_notice(test_model(), 1, "[goal]\nship the feature")
   guard set.active().goal is Some(goal) else {
     fail("the set marker should write the mirror")
   }
   inspect(goal.text, content="ship the feature")
   assert_true(goal.blocked is None)
   inspect(set.active().messages.length(), content="1")
-  let (_, blocked) = update_dev(
-    dispatch,
-    SessionCommitted(
-      session="desktop-test",
-      sequence=2,
-      ts=None,
-      item=@protocol.RuntimeNotice({
-        content: "[goal blocked]\nneeds a decision",
-      }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
-    ),
-    set,
-  )
+  let blocked = commit_notice(set, 2, "[goal blocked]\nneeds a decision")
   guard blocked.active().goal is Some(goal) else {
     fail("a blocked goal keeps standing")
   }
   assert_true(goal.blocked is Some("needs a decision"))
-  let (_, cleared) = update_dev(
-    dispatch,
-    SessionCommitted(
-      session="desktop-test",
-      sequence=3,
-      ts=None,
-      item=@protocol.RuntimeNotice({ content: "[goal cleared]", }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
-    ),
-    blocked,
-  )
+  let cleared = commit_notice(blocked, 3, "[goal cleared]")
   assert_true(cleared.active().goal is None)
   inspect(cleared.active().messages.length(), content="3")
 }
@@ -356,7 +309,6 @@ test "the editor opens on the newest text, not on the retired one" {
 
 ///|
 test "a clear over an unconfirmed set waits for a goal to actually go away" {
-  let dispatch = test_dispatch()
   // The row keeps its ✕ while a set is out, so this is reachable: the set has
   // no marker yet, and the mirror is still empty. Goallessness is also what a
   // record carries before anything is set, so reading it as the clear's own
@@ -367,38 +319,22 @@ test "a clear over an unconfirmed set waits for a goal to actually go away" {
     ..test_conversation(),
     goal_pending: Some(test_goal_command(Clearing)),
   })
-  fn commit(model, sequence, content) {
-    let (_, next) = update_dev(
-      dispatch,
-      SessionCommitted(
-        session="desktop-test",
-        sequence~,
-        ts=None,
-        item=@protocol.RuntimeNotice({ content, }),
-        session_root=@interop.ChannelId::Local.test_store_root(),
-      ),
-      model,
-    )
-    next
-  }
-
-  let unrelated = commit(model, 1, "just some runtime notice")
+  let unrelated = commit_notice(model, 1, "just some runtime notice")
   assert_true(
     unrelated.active().goal_pending is Some({ request: Clearing, .. }),
   )
   // The set it was sent over lands first; the clear is still outstanding.
-  let landed = commit(unrelated, 2, "[goal]\nthe goal being removed")
+  let landed = commit_notice(unrelated, 2, "[goal]\nthe goal being removed")
   assert_true(landed.active().goal_pending is Some({ request: Clearing, .. }))
   assert_true(landed.active().goal is Some(_))
   // Only a goal actually going away is this clear's result.
-  let settled = commit(landed, 3, "[goal cleared]")
+  let settled = commit_notice(landed, 3, "[goal cleared]")
   assert_true(settled.active().goal_pending is None)
   assert_true(settled.active().goal is None)
 }
 
 ///|
 test "a tombstone over an empty mirror still ends the clear" {
-  let dispatch = test_dispatch()
   // The other side of that coin: the set never appended, the user hit ✕ to
   // escape, and the engine records the clear as the no-op it is. Nothing
   // stands before this commit and nothing stands after, so the transition
@@ -408,17 +344,7 @@ test "a tombstone over an empty mirror still ends the clear" {
     ..test_conversation(),
     goal_pending: Some(test_goal_command(Clearing)),
   })
-  let (_, settled) = update_dev(
-    dispatch,
-    SessionCommitted(
-      session="desktop-test",
-      sequence=1,
-      ts=None,
-      item=@protocol.RuntimeNotice({ content: "[goal cleared]", }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
-    ),
-    model,
-  )
+  let settled = commit_notice(model, 1, "[goal cleared]")
   assert_true(settled.active().goal is None)
   assert_true(settled.active().goal_pending is None)
 }
@@ -436,22 +362,7 @@ test "re-asserting an unchanged goal waits for its own marker too" {
     goal: Some({ text: "ship the feature", blocked: None, }),
     goal_pending: Some(test_goal_command(Setting("ship the feature"))),
   })
-  fn commit(model, sequence, content) {
-    let (_, next) = update_dev(
-      dispatch,
-      SessionCommitted(
-        session="desktop-test",
-        sequence~,
-        ts=None,
-        item=@protocol.RuntimeNotice({ content, }),
-        session_root=@interop.ChannelId::Local.test_store_root(),
-      ),
-      model,
-    )
-    next
-  }
-
-  let unrelated = commit(model, 1, "just some runtime notice")
+  let unrelated = commit_notice(model, 1, "just some runtime notice")
   assert_true(
     unrelated.active().goal_pending
     is Some({ request: Setting("ship the feature"), .. }),
@@ -493,7 +404,7 @@ test "re-asserting an unchanged goal waits for its own marker too" {
     is None,
   )
   // Its own marker arriving live says so outright too.
-  let settled = commit(unrelated, 2, "[goal]\nship the feature")
+  let settled = commit_notice(unrelated, 2, "[goal]\nship the feature")
   assert_true(settled.active().goal_pending is None)
 }
 
@@ -537,7 +448,6 @@ test "a set is recorded even when the record has moved on since" {
 
 ///|
 test "re-asserting a blocked goal waits for its own marker" {
-  let dispatch = test_dispatch()
   // Edit on a blocked goal seeds from the mirror, so resubmitting unchanged
   // is the ordinary way to re-assert one. The record already spells that
   // text, and a set clears the block — so matching on text alone would let
@@ -548,29 +458,14 @@ test "re-asserting a blocked goal waits for its own marker" {
     goal: Some({ text: "ship the feature", blocked: Some("needs a decision"), }),
     goal_pending: Some(test_goal_command(Setting("ship the feature"))),
   })
-  fn commit(model, sequence, content) {
-    let (_, next) = update_dev(
-      dispatch,
-      SessionCommitted(
-        session="desktop-test",
-        sequence~,
-        ts=None,
-        item=@protocol.RuntimeNotice({ content, }),
-        session_root=@interop.ChannelId::Local.test_store_root(),
-      ),
-      model,
-    )
-    next
-  }
-
-  let unrelated = commit(model, 1, "just some runtime notice")
+  let unrelated = commit_notice(model, 1, "just some runtime notice")
   assert_true(
     unrelated.active().goal_pending
     is Some({ request: Setting("ship the feature"), .. }),
   )
   // Its own marker is what unblocks it, and that is the state it was waiting
   // for.
-  let settled = commit(unrelated, 2, "[goal]\nship the feature")
+  let settled = commit_notice(unrelated, 2, "[goal]\nship the feature")
   assert_true(settled.active().goal_pending is None)
   assert_true(
     settled.active().goal is Some({ text: "ship the feature", blocked: None, }),
@@ -915,17 +810,7 @@ test "an undelivered reply goes quiet once its send has been settled" {
       since: 0,
     }),
   })
-  let (_, settled) = update_dev(
-    dispatch,
-    SessionCommitted(
-      session="desktop-test",
-      sequence=1,
-      ts=None,
-      item=@protocol.RuntimeNotice({ content: "[goal]\nship the feature", }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
-    ),
-    model,
-  )
+  let settled = commit_notice(model, 1, "[goal]\nship the feature")
   assert_true(settled.active().goal_pending is None)
   fn undelivered(model, command) {
     let (_, next) = update_dev(
@@ -972,17 +857,7 @@ test "a rejection that arrives after the record has spoken only reports" {
       since: 0,
     }),
   })
-  let (_, settled) = update_dev(
-    dispatch,
-    SessionCommitted(
-      session="desktop-test",
-      sequence=1,
-      ts=None,
-      item=@protocol.RuntimeNotice({ content: "[goal]\nthe goal that won", }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
-    ),
-    model,
-  )
+  let settled = commit_notice(model, 1, "[goal]\nthe goal that won")
   assert_true(settled.active().goal_pending is None)
   let (_, late) = update_dev(
     dispatch,

--- a/desktop/frontend/project_picker/requests.mbt
+++ b/desktop/frontend/project_picker/requests.mbt
@@ -27,15 +27,7 @@ fn browse(
         },
       }) catch {
         error => {
-          scheduler.add(
-            emit(
-              Failed(
-                channel~,
-                message=@interop.bridge_error_text(error),
-                generation~,
-              ),
-            ),
-          )
+          scheduler.add(emit(browse_failure(channel, error, generation~)))
           return
         }
       }
@@ -79,15 +71,7 @@ fn create_folder(
           }
         }
         error => {
-          scheduler.add(
-            emit(
-              Failed(
-                channel~,
-                message=@interop.bridge_error_text(error),
-                generation~,
-              ),
-            ),
-          )
+          scheduler.add(emit(browse_failure(channel, error, generation~)))
           return
         }
       }
@@ -96,6 +80,17 @@ fn create_folder(
       )
     })
   })
+}
+
+///|
+/// The state machine's failure result for one host error, carrying the
+/// channel and generation the request was fenced with.
+fn browse_failure(
+  channel : @interop.ChannelId,
+  error : Error,
+  generation~ : Int,
+) -> Msg {
+  Failed(channel~, message=@interop.bridge_error_text(error), generation~)
 }
 
 ///|

--- a/desktop/frontend/skills/state.mbt
+++ b/desktop/frontend/skills/state.mbt
@@ -124,42 +124,14 @@ pub fn State::handle(
     QueryChanged(value) => (@cmd.none, { ..self, query: value, }, None)
     PreviewMarket(item) => {
       let target = preview_target_for_market(input.installed, item)
-      match self.preview_cache.get(preview_cache_key(target)) {
-        Some(content) =>
-          (
-            @cmd.none,
-            { ..self, preview: Ready(target~, request=0, content~), },
-            None,
-          )
-        None => {
-          let request = preview_request_id(self.preview) + 1
-          (
-            fetch_content(emit, input.channel, request, target),
-            { ..self, preview: Loading(target~, request~), },
-            None,
-          )
-        }
-      }
+      self.open_preview(target, request => {
+        fetch_content(emit, input.channel, request, target)
+      })
     }
-    PreviewInstalled(item) => {
-      let target = Installed(item)
-      match self.preview_cache.get(preview_cache_key(target)) {
-        Some(content) =>
-          (
-            @cmd.none,
-            { ..self, preview: Ready(target~, request=0, content~), },
-            None,
-          )
-        None => {
-          let request = preview_request_id(self.preview) + 1
-          (
-            fetch_installed_content(emit, input.channel, request, item),
-            { ..self, preview: Loading(target~, request~), },
-            None,
-          )
-        }
-      }
-    }
+    PreviewInstalled(item) =>
+      self.open_preview(Installed(item), request => {
+        fetch_installed_content(emit, input.channel, request, item)
+      })
     PreviewLoaded(request~, target~, content~) => {
       guard self.preview is Loading(request=current, target=current_target) &&
         current == request &&
@@ -264,6 +236,29 @@ pub fn State::handle(
       } else {
         (@cmd.none, { ..self, busy, notice: error, }, None)
       }
+    }
+  }
+}
+
+///|
+/// Show one skill's SKILL.md: straight from the page's own cache when it
+/// already holds the document, and otherwise by asking the host for it under
+/// a fresh request id.
+fn State::open_preview(
+  self : State,
+  target : PreviewTarget,
+  fetch : (Int) -> @cmd.Cmd,
+) -> (@cmd.Cmd, State, Outcome?) {
+  match self.preview_cache.get(preview_cache_key(target)) {
+    Some(content) =>
+      (
+        @cmd.none,
+        { ..self, preview: Ready(target~, request=0, content~), },
+        None,
+      )
+    None => {
+      let request = preview_request_id(self.preview) + 1
+      (fetch(request), { ..self, preview: Loading(target~, request~), }, None)
     }
   }
 }

--- a/desktop/frontend/storage.mbt
+++ b/desktop/frontend/storage.mbt
@@ -217,16 +217,16 @@ fn load_setting(storage_key : String) -> String {
 }
 
 ///|
-fn save_setting(storage_key : String, value : String) -> Unit {
+/// One guarded `localStorage` mutation. A profile that denies storage, and a
+/// call that throws, are both silently no-ops — the defaults come back on the
+/// next launch.
+fn storage_write(call : String, args : Array[@js.Value]) -> Unit {
   @js.Error_::wrap(
     fn() {
       guard @interop.js_prop(@js.globalThis, "localStorage") is Some(storage) else {
         return @js.Value::cast_from(())
       }
-      storage.apply_with_string("setItem", [
-        @js.Value::cast_from(storage_key),
-        @js.Value::cast_from(value),
-      ])
+      storage.apply_with_string(call, args)
     },
     map_ok=_ => (),
   ) catch {
@@ -235,18 +235,14 @@ fn save_setting(storage_key : String, value : String) -> Unit {
 }
 
 ///|
+fn save_setting(storage_key : String, value : String) -> Unit {
+  storage_write("setItem", [
+    @js.Value::cast_from(storage_key),
+    @js.Value::cast_from(value),
+  ])
+}
+
+///|
 fn remove_setting(storage_key : String) -> Unit {
-  @js.Error_::wrap(
-    fn() {
-      guard @interop.js_prop(@js.globalThis, "localStorage") is Some(storage) else {
-        return @js.Value::cast_from(())
-      }
-      storage.apply_with_string("removeItem", [
-        @js.Value::cast_from(storage_key),
-      ])
-    },
-    map_ok=_ => (),
-  ) catch {
-    _ => ()
-  }
+  storage_write("removeItem", [@js.Value::cast_from(storage_key)])
 }

--- a/desktop/frontend/transcript/component/view_tests.mbt
+++ b/desktop/frontend/transcript/component/view_tests.mbt
@@ -28,27 +28,19 @@ test "transcript stream children use stable typed keys in display order" {
     ts: None,
     sequence: Some(42),
   }
-  let input = Input(
-    source=OpenSeek,
-    focused=@interop.ChannelId::Local,
-    active_session="desktop-test",
-    current_project=None,
-    projects=[],
-    can_choose_project=false,
-    project_menu_open=false,
-    project_query="",
-    root=None,
-    submission_generation=1,
-    items=[
+  let input = {
+    ..base_input(),
+    submission_generation: 1,
+    items: [
       {
         item: { kind: User("question"), ts: None, sequence: Some(41), },
         identity: "s41",
       },
       { item: response, identity: "s42", },
     ],
-    streaming_response=Some("partial answer"),
-    streaming_identity="r7",
-  )
+    streaming_response: Some("partial answer"),
+    streaming_identity: "r7",
+  }
   let keys = stream_keys(input)
   assert_eq(keys, ["row\u{0}s41", "rule\u{0}s41", "row\u{0}s42", "live\u{0}r7"])
   // The result filling the call, and the durable reasoning the same event
@@ -87,22 +79,13 @@ test "the live response is one node, replaced by the durable one" {
     item: { kind: User("question"), ts: None, sequence: Some(1), },
     identity: "s1",
   }
-  let live_input = Input(
-    source=OpenSeek,
-    focused=@interop.ChannelId::Local,
-    active_session="desktop-test",
-    current_project=None,
-    projects=[],
-    can_choose_project=false,
-    project_menu_open=false,
-    project_query="",
-    root=None,
-    submission_generation=1,
-    items=[user],
-    streaming_response=None,
-    streaming_reasoning="next thought",
-    streaming_identity="r7",
-  )
+  let live_input = {
+    ..base_input(),
+    submission_generation: 1,
+    items: [user],
+    streaming_reasoning: Some("next thought"),
+    streaming_identity: "r7",
+  }
   let live_keys = stream_keys(live_input)
   assert_eq(live_keys, ["row\u{0}s1", "rule\u{0}s1", "live\u{0}r7"])
   // The answer streaming after the thought joins the same node.
@@ -135,18 +118,10 @@ test "the live response is one node, replaced by the durable one" {
 
 ///|
 test "a streaming delta changes only the live block" {
-  let input = Input(
-    source=OpenSeek,
-    focused=@interop.ChannelId::Local,
-    active_session="desktop-test",
-    current_project=None,
-    projects=[],
-    can_choose_project=false,
-    project_menu_open=false,
-    project_query="",
-    root=None,
-    submission_generation=1,
-    items=[
+  let input = {
+    ..base_input(),
+    submission_generation: 1,
+    items: [
       {
         item: { kind: User("question"), ts: Some(1.0e12), sequence: Some(1), },
         identity: "s1",
@@ -166,9 +141,9 @@ test "a streaming delta changes only the live block" {
         identity: "s2",
       },
     ],
-    streaming_response=Some("partial"),
-    streaming_identity="r7",
-  )
+    streaming_response: Some("partial"),
+    streaming_identity: "r7",
+  }
   let before = stream_blocks(input).to_array()
   let after = stream_blocks({
     ..input,
@@ -186,21 +161,7 @@ test "a streaming delta changes only the live block" {
 
 ///|
 test "transcript stream section key scopes equal session ids by channel" {
-  let local_input = Input(
-    source=OpenSeek,
-    focused=@interop.ChannelId::Local,
-    active_session="desktop-test",
-    current_project=None,
-    projects=[],
-    can_choose_project=false,
-    project_menu_open=false,
-    project_query="",
-    root=None,
-    submission_generation=0,
-    items=[],
-    streaming_response=None,
-    streaming_identity="idle",
-  )
+  let local_input = base_input()
   let remote = {
     ..local_input,
     focused: @interop.ChannelId::Remote("device-a"),

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1893,6 +1893,49 @@ fn close_all_tabs(
 }
 
 ///|
+/// One Codex transition for the focused device: every call site maps the
+/// emitter the same way, hands the same channel to the package, and opens
+/// external links through the same command.
+fn codex_update(
+  dispatch : @cmd.Emit[Msg],
+  model : Model,
+  msg : @codex.Msg,
+) -> (@cmd.Cmd, Model) {
+  let channel = model.focused
+  let (cmd, codex) = @codex.update(
+    dispatch.map(next => Codex(channel~, next)),
+    msg,
+    model.codex,
+    channel,
+    url => open_external_link(dispatch, url),
+  )
+  (cmd, { ..model, codex, })
+}
+
+///|
+/// Run one root message against the conversation that owns a composer action,
+/// then restore the navigation the action itself did not change.
+fn composer_owner_msg(
+  dispatch : @cmd.Emit[Msg],
+  model : Model,
+  identity : ComposerActionIdentity,
+  inner : Msg,
+) -> (@cmd.Cmd, Model) {
+  guard model.conversation_for_composer_action(identity) is Some(conv) else {
+    return (@cmd.none, model)
+  }
+  let (command, changed) = update_msg(dispatch, inner, {
+    ..model,
+    focused: conv.device,
+    active_session: conv.session_id,
+  })
+  (
+    command,
+    { ..changed, focused: model.focused, active_session: model.active_session, },
+  )
+}
+
+///|
 fn update_msg(
   dispatch : @cmd.Emit[Msg],
   msg : Msg,
@@ -2069,80 +2112,58 @@ fn update_msg(
       }
     CodexComposerAction(action) =>
       match action {
-        @composer.ModelMenuToggled(identity~) => {
+        @composer.ModelMenuToggled(..)
+        | @composer.ReasoningMenuToggled(..)
+        | @composer.SelectMenuDismissed(..)
+        | @composer.ModelSelected(..)
+        | @composer.ReasoningSelected(..)
+        | @composer.MentionOpened(..)
+        | @composer.FileIndexEnsured(..) => {
           guard model.screen is Codex &&
-            model.codex.accepts_composer_identity(identity, model.focused) else {
+            model.codex.accepts_composer_identity(
+              action.identity(),
+              model.focused,
+            ) else {
             return (@cmd.none, model)
           }
-          update_msg(dispatch, ToggleSelectMenu(CodexModelMenu), model)
-        }
-        @composer.ReasoningMenuToggled(identity~) => {
-          guard model.screen is Codex &&
-            model.codex.accepts_composer_identity(identity, model.focused) else {
-            return (@cmd.none, model)
+          match action {
+            @composer.ModelMenuToggled(..) =>
+              update_msg(dispatch, ToggleSelectMenu(CodexModelMenu), model)
+            @composer.ReasoningMenuToggled(..) =>
+              update_msg(dispatch, ToggleSelectMenu(CodexReasoningMenu), model)
+            @composer.SelectMenuDismissed(..) =>
+              update_msg(dispatch, CloseSelectMenu, model)
+            @composer.ModelSelected(value~, ..) =>
+              update_msg(dispatch, ModelPicked(value), model)
+            @composer.ReasoningSelected(value~, ..) =>
+              update_msg(dispatch, CodexEffortPicked(value), model)
+            @composer.MentionOpened(mention~, ..) => {
+              guard @mention_context.target(mention.ref_) is Some(target) else {
+                return (@cmd.none, model)
+              }
+              let range = if mention.range is Some(_) {
+                mention.range
+              } else {
+                target.range
+              }
+              open_editor_at(
+                dispatch,
+                model,
+                target.file,
+                range,
+                annotation?=target.annotation,
+              )
+            }
+            @composer.FileIndexEnsured(..) =>
+              update_msg(
+                dispatch,
+                FileEditor(@fileeditor.EnsureFileIndex),
+                model,
+              )
+            _ => (@cmd.none, model)
           }
-          update_msg(dispatch, ToggleSelectMenu(CodexReasoningMenu), model)
         }
-        @composer.SelectMenuDismissed(identity~) => {
-          guard model.screen is Codex &&
-            model.codex.accepts_composer_identity(identity, model.focused) else {
-            return (@cmd.none, model)
-          }
-          update_msg(dispatch, CloseSelectMenu, model)
-        }
-        @composer.ModelSelected(identity~, value~) => {
-          guard model.screen is Codex &&
-            model.codex.accepts_composer_identity(identity, model.focused) else {
-            return (@cmd.none, model)
-          }
-          update_msg(dispatch, ModelPicked(value), model)
-        }
-        @composer.ReasoningSelected(identity~, value~) => {
-          guard model.screen is Codex &&
-            model.codex.accepts_composer_identity(identity, model.focused) else {
-            return (@cmd.none, model)
-          }
-          update_msg(dispatch, CodexEffortPicked(value), model)
-        }
-        @composer.MentionOpened(identity~, mention~) => {
-          guard model.screen is Codex &&
-            model.codex.accepts_composer_identity(identity, model.focused) else {
-            return (@cmd.none, model)
-          }
-          guard @mention_context.target(mention.ref_) is Some(target) else {
-            return (@cmd.none, model)
-          }
-          let range = if mention.range is Some(_) {
-            mention.range
-          } else {
-            target.range
-          }
-          open_editor_at(
-            dispatch,
-            model,
-            target.file,
-            range,
-            annotation?=target.annotation,
-          )
-        }
-        @composer.FileIndexEnsured(identity~) => {
-          guard model.screen is Codex &&
-            model.codex.accepts_composer_identity(identity, model.focused) else {
-            return (@cmd.none, model)
-          }
-          update_msg(dispatch, FileEditor(@fileeditor.EnsureFileIndex), model)
-        }
-        _ => {
-          let channel = model.focused
-          let (command, codex) = @codex.update(
-            dispatch.map(next => Codex(channel~, next)),
-            @codex.Msg::composer_action(action),
-            model.codex,
-            channel,
-            url => open_external_link(dispatch, url),
-          )
-          (command, { ..model, codex, })
-        }
+        _ => codex_update(dispatch, model, @codex.Msg::composer_action(action))
       }
     ComposerAction(action) =>
       match action {
@@ -2413,42 +2434,10 @@ fn update_msg(
           }
           (@cmd.none, model.replace_conversation({ ..conv, goal_edit: None, }))
         }
-        @composer.GoalEditStarted(identity~) => {
-          guard model.conversation_for_composer_action(identity) is Some(conv) else {
-            return (@cmd.none, model)
-          }
-          let (command, changed) = update_msg(dispatch, OpenGoalEditor, {
-            ..model,
-            focused: conv.device,
-            active_session: conv.session_id,
-          })
-          (
-            command,
-            {
-              ..changed,
-              focused: model.focused,
-              active_session: model.active_session,
-            },
-          )
-        }
-        @composer.GoalCleared(identity~) => {
-          guard model.conversation_for_composer_action(identity) is Some(conv) else {
-            return (@cmd.none, model)
-          }
-          let (command, changed) = update_msg(dispatch, ClearGoal, {
-            ..model,
-            focused: conv.device,
-            active_session: conv.session_id,
-          })
-          (
-            command,
-            {
-              ..changed,
-              focused: model.focused,
-              active_session: model.active_session,
-            },
-          )
-        }
+        @composer.GoalEditStarted(identity~) =>
+          composer_owner_msg(dispatch, model, identity, OpenGoalEditor)
+        @composer.GoalCleared(identity~) =>
+          composer_owner_msg(dispatch, model, identity, ClearGoal)
         @composer.GoalSubmitted(identity~, draft~, prompt_present~) => {
           guard model.conversation_for_composer_action(identity) is Some(conv) else {
             return (@cmd.none, model)
@@ -2473,42 +2462,15 @@ fn update_msg(
             },
           )
         }
-        @composer.FileIndexEnsured(identity~) => {
-          guard model.conversation_for_composer_action(identity) is Some(conv) else {
-            return (@cmd.none, model)
-          }
-          let (command, indexed) = update_msg(
+        @composer.FileIndexEnsured(identity~) =>
+          composer_owner_msg(
             dispatch,
+            model,
+            identity,
             FileEditor(@fileeditor.EnsureFileIndex),
-            { ..model, focused: conv.device, active_session: conv.session_id, },
           )
-          (
-            command,
-            {
-              ..indexed,
-              focused: model.focused,
-              active_session: model.active_session,
-            },
-          )
-        }
-        @composer.StopRequested(identity~) => {
-          guard model.conversation_for_composer_action(identity) is Some(conv) else {
-            return (@cmd.none, model)
-          }
-          let (command, stopped) = update_msg(dispatch, Stop, {
-            ..model,
-            focused: conv.device,
-            active_session: conv.session_id,
-          })
-          (
-            command,
-            {
-              ..stopped,
-              focused: model.focused,
-              active_session: model.active_session,
-            },
-          )
-        }
+        @composer.StopRequested(identity~) =>
+          composer_owner_msg(dispatch, model, identity, Stop)
       }
     JumpToMention(index) => {
       guard model.active_conversation() is Some(conv) else {
@@ -2907,16 +2869,13 @@ fn update_msg(
               return (@cmd.none, model)
             }
             let root = model.codex.new_thread_cwd()
-            let (abandon_cmd, codex) = @codex.update(
-              dispatch.map(msg => Codex(channel=model.focused, msg)),
+            let (abandon_cmd, model) = codex_update(
+              dispatch,
+              model,
               @codex.Msg::abandon_draft(),
-              model.codex,
-              model.focused,
-              url => open_external_link(dispatch, url),
             )
             let next = {
               ..model,
-              codex,
               default_model: engine_model,
               default_agent: OpenSeekAgent,
               loading_conversation: None,
@@ -3026,17 +2985,12 @@ fn update_msg(
     }
     CodexEffortPicked(value) => {
       let model = { ..model, select_menu: None, }
-      let (effort_cmd, codex) = @codex.update(
-        dispatch.map(msg => Codex(channel=model.focused, msg)),
+      let (effort_cmd, model) = codex_update(
+        dispatch,
+        model,
         @codex.Msg::effort_changed(value),
-        model.codex,
-        model.focused,
-        url => open_external_link(dispatch, url),
       )
-      (
-        @cmd.batch([effort_cmd, save_codex_reasoning_effort(value)]),
-        { ..model, codex, },
-      )
+      (@cmd.batch([effort_cmd, save_codex_reasoning_effort(value)]), model)
     }
     OpenSeekEffortPicked(value) => {
       guard OpenSeekReasoning::parse(value) is Some(reasoning) else {
@@ -3386,30 +3340,21 @@ fn update_msg(
     OpenCodexConfig => (open_codex_config(dispatch, model.focused), model)
     CodexConfigOpenFailed(message) => model.notify_error(dispatch, message)
     OpenCodex => {
-      let (cmd, codex) = @codex.update(
-        dispatch.map(msg => Codex(channel=model.focused, msg)),
-        @codex.Msg::refresh(),
-        model.codex,
-        model.focused,
-        url => open_external_link(dispatch, url),
-      )
+      let (cmd, model) = codex_update(dispatch, model, @codex.Msg::refresh())
       (
         cmd,
         {
           ..model,
           screen: Codex,
           sidebar_open: model.sidebar_open && !model.narrow,
-          codex,
         },
       )
     }
     CodexDraftRotated(cwd~, id~) => {
-      let (cmd, codex) = @codex.update(
-        dispatch.map(msg => Codex(channel=model.focused, msg)),
+      let (cmd, model) = codex_update(
+        dispatch,
+        model,
         @codex.Msg::start_draft(id, cwd),
-        model.codex,
-        model.focused,
-        url => open_external_link(dispatch, url),
       )
       (
         cmd,
@@ -3417,17 +3362,14 @@ fn update_msg(
           ..model,
           screen: Codex,
           sidebar_open: model.sidebar_open && !model.narrow,
-          codex,
         },
       )
     }
     CodexOpenThread(thread_id) => {
-      let (cmd, codex) = @codex.update(
-        dispatch.map(msg => Codex(channel=model.focused, msg)),
+      let (cmd, model) = codex_update(
+        dispatch,
+        model,
         @codex.Msg::open_thread(thread_id),
-        model.codex,
-        model.focused,
-        url => open_external_link(dispatch, url),
       )
       (
         cmd,
@@ -3435,44 +3377,20 @@ fn update_msg(
           ..model,
           screen: Codex,
           sidebar_open: model.sidebar_open && !model.narrow,
-          codex,
         },
       )
     }
-    CodexArchiveThread(thread_id) => {
-      let (cmd, codex) = @codex.update(
-        dispatch.map(msg => Codex(channel=model.focused, msg)),
-        @codex.Msg::archive_thread(thread_id),
-        model.codex,
-        model.focused,
-        url => open_external_link(dispatch, url),
-      )
-      (cmd, { ..model, codex, })
-    }
-    CodexUnarchiveThread(thread_id) => {
-      let (cmd, codex) = @codex.update(
-        dispatch.map(msg => Codex(channel=model.focused, msg)),
-        @codex.Msg::unarchive_thread(thread_id),
-        model.codex,
-        model.focused,
-        url => open_external_link(dispatch, url),
-      )
-      (cmd, { ..model, codex, })
-    }
+    CodexArchiveThread(thread_id) =>
+      codex_update(dispatch, model, @codex.Msg::archive_thread(thread_id))
+    CodexUnarchiveThread(thread_id) =>
+      codex_update(dispatch, model, @codex.Msg::unarchive_thread(thread_id))
     Codex(channel~, msg) => {
       // A reply, approval request, or status event belongs to the host that
       // produced it. Device focus is the root authority boundary.
       if channel != model.focused {
         return (@cmd.none, model)
       }
-      let (cmd, codex) = @codex.update(
-        dispatch.map(next => Codex(channel~, next)),
-        msg,
-        model.codex,
-        channel,
-        url => open_external_link(dispatch, url),
-      )
-      (cmd, { ..model, codex, })
+      codex_update(dispatch, model, msg)
     }
     ToggleSidebar =>
       (@cmd.none, { ..model, sidebar_open: !model.sidebar_open, })
@@ -4230,9 +4148,7 @@ fn update_msg(
       let sessions : Array[String] = [key.session]
       for row in @transcript.session_tree(dev.archived) {
         if key.matches(row.item) {
-          for child in row.children {
-            sessions.push(child.id)
-          }
+          sessions.push_iter(row.children.iter().map(child => child.id))
         }
       }
       (
@@ -5339,8 +5255,9 @@ fn Model::apply_codex_worktree_snapshot(
   }
   for row in rows {
     if row.codex_thread == Some(thread_id) && row.path is Some(path) {
-      let (command, codex) = @codex.update(
-        dispatch.map(msg => Codex(channel~, msg)),
+      return codex_update(
+        dispatch,
+        self,
         @codex.Msg::worktree_changed(
           thread_id,
           workspace.path,
@@ -5348,11 +5265,7 @@ fn Model::apply_codex_worktree_snapshot(
           path.path,
           row.present,
         ),
-        self.codex,
-        channel,
-        url => open_external_link(dispatch, url),
       )
-      return (command, { ..self, codex, })
     }
   }
   (@cmd.none, self)
@@ -5977,11 +5890,9 @@ fn update_device_msg(
       for fact in dev.archive_overrides {
         if fact.disposition is ArchiveLive &&
           !items.iter().any(item => fact.key.matches(item)) {
-          for current in dev.sessions {
-            if fact.key.matches(current) {
-              items.push(current)
-            }
-          }
+          items.push_iter(
+            dev.sessions.iter().filter(item => fact.key.matches(item)),
+          )
         }
       }
       // A commit or Started broadcast can materialize a conversation before
@@ -6433,11 +6344,9 @@ fn update_device_msg(
       for fact in dev.archive_overrides {
         if fact.disposition is ArchiveStored &&
           !items.iter().any(item => fact.key.matches(item)) {
-          for current in dev.archived {
-            if fact.key.matches(current) {
-              items.push(current)
-            }
-          }
+          items.push_iter(
+            dev.archived.iter().filter(item => fact.key.matches(item)),
+          )
         }
       }
       // An archive mutation response can beat its session.changed callback.
@@ -6634,12 +6543,9 @@ fn update_device_msg(
         )
       }
       if change == "unarchived" {
-        let mut restored : @transcript.SessionListItem? = None
-        for item in dev.archived {
-          if key.matches(item) {
-            restored = Some(item)
-          }
-        }
+        let restored = dev.archived
+          .rev_iter()
+          .find_first(item => key.matches(item))
         let archived = dev.archived.filter(item => !key.matches(item))
         let sessions = dev.sessions.copy()
         if restored is Some(item) &&
@@ -6896,13 +6802,9 @@ fn update_device_msg(
               // carried it. Re-broadcasts are safe by construction.
               (@cmd.none, model)
             } else if sequence == conv.watermark + 1 {
-              let (changed, next) = conv.apply_commit(sequence, item, ts?)
+              let (_, next) = conv.apply_commit(sequence, item, ts?)
               (
-                if changed {
-                  @cmd.none
-                } else {
-                  @cmd.none
-                },
+                @cmd.none,
                 model.replace_conversation({ ..next, watermark: sequence, }),
               )
             } else {
@@ -7553,9 +7455,8 @@ fn update_device_msg(
         // an even newer Started can already have replaced last_run_id. Prefer
         // the exact pending-steer match before the legacy run fallback.
         let exact = match event {
-          SteerApplied(submission_id=Some(submission_id), ..) =>
-            model.conversation_by_pending_steer(channel, submission_id, id)
-          SteerDropped(submission_id=Some(submission_id), ..) =>
+          SteerApplied(submission_id=Some(submission_id), ..)
+          | SteerDropped(submission_id=Some(submission_id), ..) =>
             model.conversation_by_pending_steer(channel, submission_id, id)
           _ => None
         }
@@ -7601,11 +7502,12 @@ fn update_device_msg(
         let (report_cmd, updated) = if report is Some(text) {
           updated.notify_error(dispatch, text)
         } else {
-          let command = match approval_notification {
-            Some(notification) => notification.command()
-            None => @cmd.none
-          }
-          (command, updated)
+          (
+            approval_notification.map_or(@cmd.none, notification => {
+              notification.command()
+            }),
+            updated,
+          )
         }
         (@cmd.batch([finished_cmd, report_cmd]), updated)
       } else {
@@ -7753,7 +7655,7 @@ fn update_device_msg(
         // ends and the reload below shows what the record actually holds.
         ignore(message)
         let owns_submission = conv.has_initial_submission(submission_id)
-        let (settled, changed) = conv.settle_pending_prompt(submission_id)
+        let (settled, _) = conv.settle_pending_prompt(submission_id)
         if !owns_submission {
           (@cmd.none, model)
         } else {
@@ -7778,9 +7680,6 @@ fn update_device_msg(
               dev.connection_generation,
             ),
           ]
-          if changed {
-            commands.push(@cmd.none)
-          }
           (@cmd.batch(commands), updated)
         }
       } else {
@@ -8123,12 +8022,33 @@ fn @interop.ChannelId::test_worktrees(
 }
 
 ///|
-fn test_conversation() -> Conversation {
+/// Test-only: a conversation on the page's one channel, in the fixture
+/// project — the shape every conversation fixture in this file builds.
+fn local_conversation(session : String) -> Conversation {
   empty_conversation(
     @interop.ChannelId::Local,
-    "desktop-test",
+    session,
     @interop.ChannelId::Local.test_project(),
   )
+}
+
+///|
+fn test_conversation() -> Conversation {
+  local_conversation("desktop-test")
+}
+
+///|
+/// Test-only: one durable assistant answer, in the shape a snapshot carries.
+fn assistant_item(
+  prose? : String,
+  reasoning? : String,
+  sequence? : Int,
+) -> @transcript.TranscriptItem {
+  {
+    kind: Assistant(reasoning~, prose~, calls=[], replay=false, finished=false),
+    ts: None,
+    sequence,
+  }
 }
 
 ///|
@@ -8222,6 +8142,17 @@ fn Model::with_listed(self : Model, ids : Array[String]) -> Model raise {
         } : @transcript.SessionListItem)
     }),
   })
+}
+
+///|
+/// Test-only: activate `session` on the page's one channel, in the fixture
+/// project — the placement every activation in these tests uses.
+fn Model::activate_local(self : Model, session : String) -> Model {
+  self.activate(
+    @interop.ChannelId::Local,
+    session,
+    @interop.ChannelId::Local.test_project(),
+  )
 }
 
 ///|
@@ -8379,34 +8310,18 @@ fn encoded_start_workspace(conv : Conversation) -> String? {
 ///|
 test "runs resync names exact Starting Open and Idle owners" {
   let starting = {
-    ..empty_conversation(
-      @interop.ChannelId::Local,
-      "starting-session",
-      @interop.ChannelId::Local.test_project(),
-    ),
+    ..local_conversation("starting-session"),
     run: Starting(submission_id="submission-starting"),
   }
   let open = {
-    ..empty_conversation(
-      @interop.ChannelId::Local,
-      "open-session",
-      @interop.ChannelId::Local.test_project(),
-    ),
+    ..local_conversation("open-session"),
     run: Open(run_id="run-open", stage=Opened),
   }
   let idle = {
-    ..empty_conversation(
-      @interop.ChannelId::Local,
-      "idle-session",
-      @interop.ChannelId::Local.test_project(),
-    ),
+    ..local_conversation("idle-session"),
     last_run_id: Some("run-idle"),
   }
-  let empty = empty_conversation(
-    @interop.ChannelId::Local,
-    "never-started",
-    @interop.ChannelId::Local.test_project(),
-  )
+  let empty = local_conversation("never-started")
   let model = test_model()
     .replace_conversation(starting)
     .replace_conversation(open)
@@ -8832,17 +8747,11 @@ test "a later run does not confuse identical historical reasoning for its commit
   let historical = {
     ..running_conversation(),
     messages: [
-      {
-        kind: Assistant(
-          reasoning=Some("shared opening"),
-          prose=Some("older answer"),
-          calls=[],
-          replay=false,
-          finished=false,
-        ),
-        ts: None,
-        sequence: Some(2),
-      },
+      assistant_item(
+        prose="older answer",
+        reasoning="shared opening",
+        sequence=2,
+      ),
     ],
     watermark: 3,
     turn: RunState::for_run(3),
@@ -8872,19 +8781,7 @@ test "a later run does not confuse identical historical reasoning for its commit
 test "a new model step advances past identical reasoning from the prior step" {
   let previous_step = {
     ..running_conversation(),
-    messages: [
-      {
-        kind: Assistant(
-          reasoning=Some("shared opening"),
-          prose=None,
-          calls=[],
-          replay=false,
-          finished=false,
-        ),
-        ts: None,
-        sequence: Some(2),
-      },
-    ],
+    messages: [assistant_item(reasoning="shared opening", sequence=2)],
     watermark: 2,
     turn: {
       ..RunState::for_run(0),
@@ -9113,17 +9010,7 @@ test "finished run reloads the named durable session for an old host" {
       session="desktop-test",
       items=[
         { kind: User("question"), ts: None, sequence: None, },
-        {
-          kind: Assistant(
-            reasoning=None,
-            prose=Some("done"),
-            calls=[],
-            replay=false,
-            finished=false,
-          ),
-          ts: None,
-          sequence: None,
-        },
+        assistant_item(prose="done"),
       ],
       watermark=3,
       generation=1,
@@ -9241,11 +9128,7 @@ test "a background finish marks its conversation until it is opened" {
     fail("conversation missing")
   }
   inspect(conv.unseen_finish, content="true")
-  let opened = next.activate(
-    @interop.ChannelId::Local,
-    "desktop-test",
-    @interop.ChannelId::Local.test_project(),
-  )
+  let opened = next.activate_local("desktop-test")
   guard opened.find_conversation(@interop.ChannelId::Local, "desktop-test")
     is Some(seen) else {
     fail("conversation missing after activate")
@@ -9439,11 +9322,7 @@ test "session list assigns a commit-first conversation to its durable workspace"
       ],
       request_generation=committed.dev().sessions_request_generation,
     ),
-    committed.activate(
-      @interop.ChannelId::Local,
-      "desktop-foreign",
-      @interop.ChannelId::Local.test_project(),
-    ),
+    committed.activate_local("desktop-foreign"),
   )
   guard listed.find_conversation(@interop.ChannelId::Local, "desktop-foreign")
     is Some(reconciled) else {
@@ -9651,11 +9530,7 @@ test "a background session list updates only its channel's same-id workspace" {
   let dispatch = test_dispatch()
   let remote : @interop.ChannelId = Remote("d-remote")
   let local_conv = {
-    ..empty_conversation(
-      @interop.ChannelId::Local,
-      "shared",
-      @interop.ChannelId::Local.test_project(),
-    ),
+    ..local_conversation("shared"),
     workspace: Project(root=@interop.ChannelId::Local.test_resource("/local")),
   }
   let remote_conv = {
@@ -9861,19 +9736,11 @@ test "a sub-run child opens through its parent before the store lists it" {
 test "open session keeps live state on screen while re-reading the store" {
   let dispatch = test_dispatch()
   let background = {
-    ..empty_conversation(
-      @interop.ChannelId::Local,
-      "desktop-bg",
-      @interop.ChannelId::Local.test_project(),
-    ),
+    ..local_conversation("desktop-bg"),
     run: Open(run_id="r9", stage=Opened),
     messages: [{ kind: User("background task"), ts: None, sequence: None, }],
     turn: {
-      ..empty_conversation(
-        @interop.ChannelId::Local,
-        "desktop-bg",
-        @interop.ChannelId::Local.test_project(),
-      ).turn,
+      ..local_conversation("desktop-bg").turn,
       streaming_response: Some("mid-stream"),
     },
   }
@@ -9950,18 +9817,10 @@ test "BridgeReady clears every non-replayable stream and compaction phase" {
     },
   }
   let background = {
-    ..empty_conversation(
-      @interop.ChannelId::Local,
-      "desktop-bg",
-      @interop.ChannelId::Local.test_project(),
-    ),
+    ..local_conversation("desktop-bg"),
     compaction: Compacting,
     turn: {
-      ..empty_conversation(
-        @interop.ChannelId::Local,
-        "desktop-bg",
-        @interop.ChannelId::Local.test_project(),
-      ).turn,
+      ..local_conversation("desktop-bg").turn,
       streaming_response: Some("background answer"),
     },
   }
@@ -10116,18 +9975,10 @@ test "BridgeReady resets only conversations owned by its channel" {
   let dispatch = test_dispatch()
   let background : @interop.ChannelId = Remote("d-bg")
   let local_conv = {
-    ..empty_conversation(
-      @interop.ChannelId::Local,
-      "shared",
-      @interop.ChannelId::Local.test_project(),
-    ),
+    ..local_conversation("shared"),
     compaction: Queued,
     turn: {
-      ..empty_conversation(
-        @interop.ChannelId::Local,
-        "shared",
-        @interop.ChannelId::Local.test_project(),
-      ).turn,
+      ..local_conversation("shared").turn,
       streaming_response: Some("local answer"),
     },
   }
@@ -10424,11 +10275,7 @@ test "same-id session loads are fenced by channel owner" {
   let dispatch = test_dispatch()
   let remote : @interop.ChannelId = Remote("d-remote")
   let local_conv = {
-    ..empty_conversation(
-      @interop.ChannelId::Local,
-      "shared",
-      @interop.ChannelId::Local.test_project(),
-    ),
+    ..local_conversation("shared"),
     messages: [{ kind: User("local"), ts: None, sequence: None, }],
   }
   let remote_conv = {
@@ -10466,19 +10313,7 @@ test "same-id session loads are fenced by channel owner" {
         goal=None,
         goal_markers=[],
         session="shared",
-        items=[
-          {
-            kind: Assistant(
-              reasoning=None,
-              prose=Some("remote loaded"),
-              calls=[],
-              replay=false,
-              finished=false,
-            ),
-            ts: None,
-            sequence: None,
-          },
-        ],
+        items=[assistant_item(prose="remote loaded")],
         watermark=1,
         generation=1,
       ),
@@ -10540,19 +10375,7 @@ test "reselecting a synced active session reloads idle external writes" {
       goal=None,
       goal_markers=[],
       session="desktop-test",
-      items=[
-        {
-          kind: Assistant(
-            reasoning=None,
-            prose=Some("written elsewhere"),
-            calls=[],
-            replay=false,
-            finished=false,
-          ),
-          ts: None,
-          sequence: None,
-        },
-      ],
+      items=[assistant_item(prose="written elsewhere")],
       watermark=1,
       generation=1,
     ),
@@ -10599,11 +10422,7 @@ test "pruning and reopening cannot reuse a transcript request token" {
     first.sync is Reloading(generation=1, ..) else {
     fail("expected the original request")
   }
-  let pruned = opening.activate(
-    @interop.ChannelId::Local,
-    "desktop-other",
-    @interop.ChannelId::Local.test_project(),
-  )
+  let pruned = opening.activate_local("desktop-other")
   assert_true(
     pruned.find_conversation(@interop.ChannelId::Local, "desktop-pruned")
     is None,
@@ -11008,17 +10827,7 @@ test "session loaded swaps the active conversation onto the stored session" {
   )
   let items : Array[@transcript.TranscriptItem] = [
     { kind: User("stored question"), ts: None, sequence: None, },
-    {
-      kind: Assistant(
-        reasoning=None,
-        prose=Some("stored answer"),
-        calls=[],
-        replay=false,
-        finished=false,
-      ),
-      ts: None,
-      sequence: None,
-    },
+    assistant_item(prose="stored answer"),
   ]
   let (_, once) = update_dev(
     dispatch,
@@ -11601,17 +11410,7 @@ test "an accepted start response opens the run without Started" {
       session="desktop-test",
       items=[
         { kind: User("external prompt"), ts: None, sequence: None, },
-        {
-          kind: Assistant(
-            reasoning=None,
-            prose=Some("external answer"),
-            calls=[],
-            replay=false,
-            finished=false,
-          ),
-          ts: None,
-          sequence: None,
-        },
+        assistant_item(prose="external answer"),
         { kind: User("prompt"), ts: None, sequence: None, },
       ],
       watermark=4,
@@ -11719,29 +11518,17 @@ test "runs settled closes runs the host no longer has, sparing live and starting
   // A run that ended while this client was away: its terminal event is
   // gone for good, so only the `agent.runs` reply can close it.
   let stale = {
-    ..empty_conversation(
-      @interop.ChannelId::Local,
-      "desktop-stale",
-      @interop.ChannelId::Local.test_project(),
-    ),
+    ..local_conversation("desktop-stale"),
     run: Open(run_id="r9", stage=AtStep(Some(4))),
     turn: {
-      ..empty_conversation(
-        @interop.ChannelId::Local,
-        "desktop-stale",
-        @interop.ChannelId::Local.test_project(),
-      ).turn,
+      ..local_conversation("desktop-stale").turn,
       streaming_response: Some("mid-step"),
     },
   }
   // A send still in flight has no run id yet; its own `started` (or
   // failure) is coming and must be the one to settle it.
   let starting = {
-    ..empty_conversation(
-      @interop.ChannelId::Local,
-      "desktop-starting",
-      @interop.ChannelId::Local.test_project(),
-    ),
+    ..local_conversation("desktop-starting"),
     run: Starting(submission_id="pending-start"),
   }
   let model = running_model()
@@ -11849,10 +11636,7 @@ test "an old empty runs snapshot cannot close a start sent after reconnect" {
   // restores the saved key (the BYOK fixture is a ready app).
   let (_, ready) = update_dev(
     dispatch,
-    HostSettingsLoaded(
-      host_settings(provider="deepseek", has_deepseek_key=true),
-      connection_generation=None,
-    ),
+    settings_snapshot(host_settings(provider="deepseek", has_deepseek_key=true)),
     bridged,
   )
   // A reconnect drops the worktree mirror and re-requests it; path-based work
@@ -12217,11 +12001,7 @@ test "an accepted response consumes a fast-finished prompt without reopening" {
 test "concurrent conversations keep their streams apart" {
   let dispatch = test_dispatch()
   let second = {
-    ..empty_conversation(
-      @interop.ChannelId::Local,
-      "desktop-second",
-      @interop.ChannelId::Local.test_project(),
-    ),
+    ..local_conversation("desktop-second"),
     run: Open(run_id="r8", stage=Opened),
   }
   let model = running_model().replace_conversation(second)
@@ -12243,11 +12023,7 @@ test "concurrent conversations keep their streams apart" {
 test "a background run finishes without disturbing the conversation on screen" {
   let dispatch = test_dispatch()
   let second = {
-    ..empty_conversation(
-      @interop.ChannelId::Local,
-      "desktop-second",
-      @interop.ChannelId::Local.test_project(),
-    ),
+    ..local_conversation("desktop-second"),
     run: Open(run_id="r8", stage=Opened),
     messages: [{ kind: User("background ask"), ts: None, sequence: None, }],
   }
@@ -12589,11 +12365,7 @@ test "a foreign background run schedules one causal read after Started" {
   let dispatch = test_dispatch()
   let session = "desktop-background"
   let conv = {
-    ..empty_conversation(
-      @interop.ChannelId::Local,
-      session,
-      @interop.ChannelId::Local.test_project(),
-    ),
+    ..local_conversation(session),
     watermark: 1,
     sync: test_reloading([]),
   }
@@ -12684,17 +12456,7 @@ test "a foreign background run schedules one causal read after Started" {
     SessionRefreshed(
       session~,
       items=[
-        {
-          kind: Assistant(
-            reasoning=None,
-            prose=Some("previous answer"),
-            calls=[],
-            replay=false,
-            finished=false,
-          ),
-          ts: None,
-          sequence: None,
-        },
+        assistant_item(prose="previous answer"),
         { kind: User("current question"), ts: None, sequence: None, },
       ],
       watermark=4,
@@ -12947,11 +12709,7 @@ test "loaded UI preferences parse their wire names" {
 test "the model selector switches one conversation, not the app" {
   let dispatch = test_dispatch()
   let model = test_model().replace_conversation(
-    empty_conversation(
-      @interop.ChannelId::Local,
-      "other-chat",
-      @interop.ChannelId::Local.test_project(),
-    ),
+    local_conversation("other-chat"),
   )
   let (_, flash) = update(
     dispatch,
@@ -12981,14 +12739,7 @@ test "the model selector switches one conversation, not the app" {
   // The tier just picked is what conversations opened afterwards start from.
   assert_true(flash.default_model is DsFlash)
   assert_true(
-    flash
-    .activate(
-      @interop.ChannelId::Local,
-      "fresh-chat",
-      @interop.ChannelId::Local.test_project(),
-    )
-    .active().engine_model
-    is DsFlash,
+    flash.activate_local("fresh-chat").active().engine_model is DsFlash,
   )
   let (_, pro) = update(
     dispatch,
@@ -13037,11 +12788,7 @@ test "reopening a conversation recovers its own tier, not the last pick" {
     ModelPicked("openseek:deepseek-v4-flash"),
     test_model(),
   )
-  let other = flash.activate(
-    @interop.ChannelId::Local,
-    "other-chat",
-    @interop.ChannelId::Local.test_project(),
-  )
+  let other = flash.activate_local("other-chat")
   assert_true(other.active().engine_model is DsFlash)
   let (_, pro) = update(
     dispatch,
@@ -13052,11 +12799,7 @@ test "reopening a conversation recovers its own tier, not the last pick" {
   // Reopening drops the conversation and mints it again (nothing was sent,
   // so `activate` does not retain it) — exactly the path that used to hand
   // back the unrelated default.
-  let reopened = pro.activate(
-    @interop.ChannelId::Local,
-    "desktop-test",
-    @interop.ChannelId::Local.test_project(),
-  )
+  let reopened = pro.activate_local("desktop-test")
   assert_true(reopened.active().engine_model is DsFlash)
 }
 
@@ -13082,11 +12825,7 @@ test "a run pins an inherited tier the user never clicked for" {
     is Some(DsPro),
   )
   // Another chat moves the page default to DsFlash...
-  let elsewhere = ran.activate(
-    @interop.ChannelId::Local,
-    "other-chat",
-    @interop.ChannelId::Local.test_project(),
-  )
+  let elsewhere = ran.activate_local("other-chat")
   let (_, moved) = update(
     dispatch,
     ModelPicked("openseek:deepseek-v4-flash"),
@@ -13094,11 +12833,7 @@ test "a run pins an inherited tier the user never clicked for" {
   )
   assert_true(moved.default_model is DsFlash)
   // ...and the first one still comes back on the tier it ran with.
-  let reopened = moved.activate(
-    @interop.ChannelId::Local,
-    "desktop-test",
-    @interop.ChannelId::Local.test_project(),
-  )
+  let reopened = moved.activate_local("desktop-test")
   assert_true(reopened.active().engine_model is DsPro)
 }
 
@@ -13376,6 +13111,13 @@ fn host_settings(
 }
 
 ///|
+/// A `settings.get` reply carrying `settings` from the focused host, as every
+/// settings test here sends it: unfenced by a connection generation.
+fn settings_snapshot(settings : HostSettings) -> DeviceMsg {
+  HostSettingsLoaded(settings, connection_generation=None)
+}
+
+///|
 test "host settings edits wait for the focused host snapshot" {
   let dispatch = test_dispatch()
   // Model a queued DOM message from the old Settings page after focus already
@@ -13416,10 +13158,7 @@ test "an unusable first settings snapshot opens the setup modal" {
   // default: keyless DeepSeek, which needs setup.
   let (_, zero_config) = update_dev(
     dispatch,
-    HostSettingsLoaded(
-      host_settings(provider="openseek"),
-      connection_generation=None,
-    ),
+    settings_snapshot(host_settings(provider="openseek")),
     test_model(),
   )
   assert_true(zero_config.screen is Chat)
@@ -13428,10 +13167,7 @@ test "an unusable first settings snapshot opens the setup modal" {
   assert_true(zero_config.display_status() is ApiKeyRequired)
   let (_, keyless) = update_dev(
     dispatch,
-    HostSettingsLoaded(
-      host_settings(provider="deepseek"),
-      connection_generation=None,
-    ),
+    settings_snapshot(host_settings(provider="deepseek")),
     test_model(),
   )
   assert_true(keyless.screen is Chat)
@@ -13439,10 +13175,7 @@ test "an unusable first settings snapshot opens the setup modal" {
   assert_true(keyless.display_status() is ApiKeyRequired)
   let (_, restored) = update_dev(
     dispatch,
-    HostSettingsLoaded(
-      host_settings(provider="deepseek", has_deepseek_key=true),
-      connection_generation=None,
-    ),
+    settings_snapshot(host_settings(provider="deepseek", has_deepseek_key=true)),
     test_model(),
   )
   assert_true(restored.screen is Chat)
@@ -13455,10 +13188,7 @@ test "the setup modal tracks endpoint usability without toasts" {
   let dispatch = test_dispatch()
   let (_, keyless) = update_dev(
     dispatch,
-    HostSettingsLoaded(
-      host_settings(provider="deepseek"),
-      connection_generation=None,
-    ),
+    settings_snapshot(host_settings(provider="deepseek")),
     test_model(),
   )
   assert_true(keyless.api_setup_open)
@@ -13467,10 +13197,7 @@ test "the setup modal tracks endpoint usability without toasts" {
   // A snapshot that is usable closes the modal.
   let (_, ready) = update_dev(
     dispatch,
-    HostSettingsLoaded(
-      host_settings(provider="deepseek", has_deepseek_key=true),
-      connection_generation=None,
-    ),
+    settings_snapshot(host_settings(provider="deepseek", has_deepseek_key=true)),
     { ..test_model(), api_setup_open: true, },
   )
   assert_true(!ready.api_setup_open)
@@ -13478,10 +13205,7 @@ test "the setup modal tracks endpoint usability without toasts" {
   // A later change that breaks a usable endpoint reopens the modal.
   let (_, broken) = update_dev(
     dispatch,
-    HostSettingsLoaded(
-      host_settings(provider="custom", custom_api_url=""),
-      connection_generation=None,
-    ),
+    settings_snapshot(host_settings(provider="custom", custom_api_url="")),
     {
       ..test_model(),
       host_settings_revision: 0,
@@ -13499,10 +13223,7 @@ test "the setup modal tracks endpoint usability without toasts" {
   assert_true(!dismissed.api_setup_open)
   let (_, still) = update_dev(
     dispatch,
-    HostSettingsLoaded(
-      host_settings(provider="deepseek"),
-      connection_generation=None,
-    ),
+    settings_snapshot(host_settings(provider="deepseek")),
     dismissed,
   )
   assert_true(!still.api_setup_open)
@@ -13517,10 +13238,7 @@ test "the setup modal tracks endpoint usability without toasts" {
   // the form; the guide there already explains it.
   let (_, mid_edit) = update_dev(
     dispatch,
-    HostSettingsLoaded(
-      host_settings(provider="custom", custom_api_url=""),
-      connection_generation=None,
-    ),
+    settings_snapshot(host_settings(provider="custom", custom_api_url="")),
     {
       ..test_model(),
       screen: Settings,
@@ -13574,10 +13292,7 @@ test "the GLM provider aligns only a fresh chat to its model family" {
   // though the page-local model preference loads before host settings do.
   let (_, restored) = update_dev(
     dispatch,
-    HostSettingsLoaded(
-      host_settings(provider="glm", has_glm_key=true),
-      connection_generation=None,
-    ),
+    settings_snapshot(host_settings(provider="glm", has_glm_key=true)),
     test_model(),
   )
   assert_true(restored.default_model is Glm53)
@@ -13620,10 +13335,7 @@ test "a dismissal survives the mirror reset a reconnect performs" {
   let dispatch = test_dispatch()
   let (_, keyless) = update_dev(
     dispatch,
-    HostSettingsLoaded(
-      host_settings(provider="deepseek"),
-      connection_generation=None,
-    ),
+    settings_snapshot(host_settings(provider="deepseek")),
     test_model(),
   )
   let (_, dismissed) = update(dispatch, DismissApiSetup, keyless)
@@ -13634,10 +13346,7 @@ test "a dismissal survives the mirror reset a reconnect performs" {
   assert_true(!cleared.api_setup_open)
   let (_, reconnected) = update_dev(
     dispatch,
-    HostSettingsLoaded(
-      host_settings(provider="deepseek"),
-      connection_generation=None,
-    ),
+    settings_snapshot(host_settings(provider="deepseek")),
     cleared,
   )
   assert_true(!reconnected.api_setup_open)
@@ -13645,19 +13354,13 @@ test "a dismissal survives the mirror reset a reconnect performs" {
   // again even after an earlier "Not now".
   let (_, ready) = update_dev(
     dispatch,
-    HostSettingsLoaded(
-      host_settings(provider="deepseek", has_deepseek_key=true),
-      connection_generation=None,
-    ),
+    settings_snapshot(host_settings(provider="deepseek", has_deepseek_key=true)),
     reconnected,
   )
   assert_true(!ready.api_setup_open)
   let (_, broken) = update_dev(
     dispatch,
-    HostSettingsLoaded(
-      host_settings(provider="deepseek"),
-      connection_generation=None,
-    ),
+    settings_snapshot(host_settings(provider="deepseek")),
     ready,
   )
   assert_true(broken.api_setup_open)
@@ -13668,10 +13371,7 @@ test "the composer's BYOK notice outlives a dismissal and reopens the modal" {
   let dispatch = test_dispatch()
   let (_, keyless) = update_dev(
     dispatch,
-    HostSettingsLoaded(
-      host_settings(provider="deepseek"),
-      connection_generation=None,
-    ),
+    settings_snapshot(host_settings(provider="deepseek")),
     test_model(),
   )
   let (_, dismissed) = update(dispatch, DismissApiSetup, keyless)
@@ -13688,10 +13388,7 @@ test "the composer's BYOK notice outlives a dismissal and reopens the modal" {
   assert_true(reopened.api_setup_open)
   let (_, still_open) = update_dev(
     dispatch,
-    HostSettingsLoaded(
-      host_settings(provider="deepseek"),
-      connection_generation=None,
-    ),
+    settings_snapshot(host_settings(provider="deepseek")),
     reopened,
   )
   assert_true(still_open.api_setup_open)
@@ -13832,10 +13529,7 @@ test "a background device's pushes leave the focused mirrors alone" {
     dispatch,
     FromDevice(
       background,
-      HostSettingsLoaded(
-        host_settings(provider="deepseek"),
-        connection_generation=None,
-      ),
+      settings_snapshot(host_settings(provider="deepseek")),
     ),
     model,
   )
@@ -13851,10 +13545,7 @@ test "host settings are deferred while this client's writes are in flight" {
   // the optimistic mirror.
   let (_, ignored) = update_dev(
     dispatch,
-    HostSettingsLoaded(
-      host_settings(provider="deepseek", revision=1),
-      connection_generation=None,
-    ),
+    settings_snapshot(host_settings(provider="deepseek", revision=1)),
     model,
   )
   assert_true(ignored.api_provider is Deepseek)
@@ -13899,10 +13590,7 @@ test "a newer peer broadcast beats a delayed local settings reply" {
   }
   let (_, broadcast) = update_dev(
     dispatch,
-    HostSettingsLoaded(
-      host_settings(provider="deepseek", revision=7),
-      connection_generation=None,
-    ),
+    settings_snapshot(host_settings(provider="deepseek", revision=7)),
     model,
   )
   // Preserve the optimistic form until the local RPC settles.
@@ -14888,19 +14576,7 @@ test "switching same-id archived stores fences the first transcript load" {
     dispatch,
     SessionLoaded(
       session=first_item.id,
-      items=[
-        {
-          kind: Assistant(
-            reasoning=None,
-            prose=Some("first store answer"),
-            calls=[],
-            replay=false,
-            finished=false,
-          ),
-          ts: None,
-          sequence: Some(1),
-        },
-      ],
+      items=[assistant_item(prose="first store answer", sequence=1)],
       watermark=1,
       goal=None,
       goal_markers=[],
@@ -14914,19 +14590,7 @@ test "switching same-id archived stores fences the first transcript load" {
     dispatch,
     SessionLoaded(
       session=second_item.id,
-      items=[
-        {
-          kind: Assistant(
-            reasoning=None,
-            prose=Some("second store answer"),
-            calls=[],
-            replay=false,
-            finished=false,
-          ),
-          ts: None,
-          sequence: Some(1),
-        },
-      ],
+      items=[assistant_item(prose="second store answer", sequence=1)],
       watermark=1,
       goal=None,
       goal_markers=[],
@@ -14982,19 +14646,7 @@ test "an archived snapshot stays open across archived-list reconciliation" {
       goal=None,
       goal_markers=[],
       session=item.id,
-      items=[
-        {
-          kind: Assistant(
-            reasoning=None,
-            prose=Some("archived answer"),
-            calls=[],
-            replay=false,
-            finished=false,
-          ),
-          ts: None,
-          sequence: Some(1),
-        },
-      ],
+      items=[assistant_item(prose="archived answer", sequence=1)],
       watermark=1,
       generation=1,
     ),
@@ -15013,25 +14665,9 @@ test "unarchiving an open transcript fences its archived snapshot" {
   let dispatch = test_dispatch()
   let item = archived_item("desktop-archived")
   let archived = {
-    ..empty_conversation(
-      @interop.ChannelId::Local,
-      item.id,
-      @interop.ChannelId::Local.test_project(),
-    ),
+    ..local_conversation(item.id),
     record: ArchivedRecord,
-    messages: [
-      {
-        kind: Assistant(
-          reasoning=None,
-          prose=Some("visible archived answer"),
-          calls=[],
-          replay=false,
-          finished=false,
-        ),
-        ts: None,
-        sequence: Some(1),
-      },
-    ],
+    messages: [assistant_item(prose="visible archived answer", sequence=1)],
     watermark: 1,
   }
   let model = {
@@ -15060,19 +14696,7 @@ test "unarchiving an open transcript fences its archived snapshot" {
       goal=None,
       goal_markers=[],
       session=item.id,
-      items=[
-        {
-          kind: Assistant(
-            reasoning=None,
-            prose=Some("late archived answer"),
-            calls=[],
-            replay=false,
-            finished=false,
-          ),
-          ts: None,
-          sequence: Some(1),
-        },
-      ],
+      items=[assistant_item(prose="late archived answer", sequence=1)],
       watermark=1,
       generation=1,
     ),
@@ -15190,11 +14814,7 @@ test "archived deletion keeps same-id rows in other stores" {
   let model = {
     ..test_model()
     .replace_conversation({
-      ..empty_conversation(
-        @interop.ChannelId::Local,
-        "shared",
-        @interop.ChannelId::Local.test_project(),
-      ),
+      ..local_conversation("shared"),
       workspace: Project(root=project),
       record: ArchivedRecord,
       task: "project draft",
@@ -15253,19 +14873,11 @@ test "delete response tombstones a family before stale list replies" {
     }),
     conversations: [
       {
-        ..empty_conversation(
-          @interop.ChannelId::Local,
-          "desktop-parent",
-          @interop.ChannelId::Local.test_project(),
-        ),
+        ..local_conversation("desktop-parent"),
         record: ArchivedRecord,
         task: "keep local draft",
       },
-      empty_conversation(
-        @interop.ChannelId::Local,
-        "desktop-parent-sr-1",
-        @interop.ChannelId::Local.test_project(),
-      ),
+      local_conversation("desktop-parent-sr-1"),
     ],
     active_session: "desktop-parent",
   }
@@ -15449,11 +15061,7 @@ test "deleted broadcast is immediate and idempotent" {
   let model = {
     ..test_model()
     .replace_conversation({
-      ..empty_conversation(
-        @interop.ChannelId::Local,
-        "desktop-gone",
-        @interop.ChannelId::Local.test_project(),
-      ),
+      ..local_conversation("desktop-gone"),
       record: ArchivedRecord,
       task: "carry this draft",
     })
@@ -15504,11 +15112,7 @@ test "deleted broadcast rotates the active conversation's exact store" {
   let model = {
     ..test_model()
     .replace_conversation({
-      ..empty_conversation(
-        @interop.ChannelId::Local,
-        "shared",
-        @interop.ChannelId::Local.test_project(),
-      ),
+      ..local_conversation("shared"),
       workspace: Project(root=project),
       record: ArchivedRecord,
       task: "project draft",
@@ -15548,11 +15152,7 @@ test "archive facts rotate the open conversation's exact store" {
   let model = {
     ..test_model()
     .replace_conversation({
-      ..empty_conversation(
-        @interop.ChannelId::Local,
-        "shared",
-        @interop.ChannelId::Local.test_project(),
-      ),
+      ..local_conversation("shared"),
       workspace: Project(root=project),
       task: "project draft",
     })
@@ -15764,11 +15364,7 @@ test "a background archive removes only its channel's same-id conversation" {
   let dispatch = test_dispatch()
   let remote : @interop.ChannelId = Remote("d-remote")
   let local_conv = {
-    ..empty_conversation(
-      @interop.ChannelId::Local,
-      "shared",
-      @interop.ChannelId::Local.test_project(),
-    ),
+    ..local_conversation("shared"),
     messages: [{ kind: User("local"), ts: None, sequence: None, }],
   }
   let remote_conv = {
@@ -15840,25 +15436,9 @@ test "BridgeReady replaces archive overrides with fresh-list truth" {
   let dispatch = test_dispatch()
   let item = archived_item("desktop-old")
   let archived = {
-    ..empty_conversation(
-      @interop.ChannelId::Local,
-      item.id,
-      @interop.ChannelId::Local.test_project(),
-    ),
+    ..local_conversation(item.id),
     record: ArchivedRecord,
-    messages: [
-      {
-        kind: Assistant(
-          reasoning=None,
-          prose=Some("cached archived answer"),
-          calls=[],
-          replay=false,
-          finished=false,
-        ),
-        ts: None,
-        sequence: Some(1),
-      },
-    ],
+    messages: [assistant_item(prose="cached archived answer", sequence=1)],
     watermark: 1,
   }
   let model = {
@@ -15903,19 +15483,7 @@ test "BridgeReady replaces archive overrides with fresh-list truth" {
       goal=None,
       goal_markers=[],
       session=item.id,
-      items=[
-        {
-          kind: Assistant(
-            reasoning=None,
-            prose=Some("late archived answer"),
-            calls=[],
-            replay=false,
-            finished=false,
-          ),
-          ts: None,
-          sequence: Some(1),
-        },
-      ],
+      items=[assistant_item(prose="late archived answer", sequence=1)],
       watermark=1,
       generation=1,
     ),
@@ -16039,14 +15607,7 @@ test "an archived background session drops its live state, active stays" {
   let dispatch = test_dispatch()
   let model = {
     ..test_model(),
-    conversations: [
-      test_conversation(),
-      empty_conversation(
-        @interop.ChannelId::Local,
-        "desktop-old",
-        @interop.ChannelId::Local.test_project(),
-      ),
-    ],
+    conversations: [test_conversation(), local_conversation("desktop-old")],
   }
   let (_, next) = update(
     dispatch,
@@ -17744,7 +17305,6 @@ test "quiet startup outcomes leave no trace; explicit ones answer" {
     test_model(),
   )
   assert_true(
-    offline.update_ux is UpdateCheckFailed(..) &&
     offline.update_ux is UpdateCheckFailed(message~) &&
     message.contains("offline"),
   )
@@ -18044,17 +17604,7 @@ test "a snapshot drains buffered commits in sequence order" {
       session="desktop-test",
       items=[
         { kind: User("one"), ts: None, sequence: None, },
-        {
-          kind: Assistant(
-            reasoning=None,
-            prose=Some("two"),
-            calls=[],
-            replay=false,
-            finished=false,
-          ),
-          ts: None,
-          sequence: None,
-        },
+        assistant_item(prose="two"),
       ],
       watermark=2,
       generation=1,
@@ -18549,17 +18099,14 @@ test "commit-first assistant semantics do not append again" {
 ///|
 test "a sequence-one commit materializes an unknown hidden conversation" {
   let dispatch = test_dispatch()
-  let (_, next) = update_dev(
-    dispatch,
-    SessionCommitted(
-      session="desktop-elsewhere",
-      sequence=1,
-      ts=None,
-      item=@protocol.User({ content: "hi", submission_id: None, }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
-    ),
-    test_model(),
+  let commit = SessionCommitted(
+    session="desktop-elsewhere",
+    sequence=1,
+    ts=None,
+    item=@protocol.User({ content: "hi", submission_id: None, }),
+    session_root=@interop.ChannelId::Local.test_store_root(),
   )
+  let (_, next) = update_dev(dispatch, commit, test_model())
   inspect(next.conversations.length(), content="2")
   inspect(next.active().messages.length(), content="0")
   guard next.find_conversation(@interop.ChannelId::Local, "desktop-elsewhere")
@@ -18570,17 +18117,7 @@ test "a sequence-one commit materializes an unknown hidden conversation" {
   assert_eq(hidden.messages[0].text(), Some("hi"))
   inspect(hidden.watermark, content="1")
   inspect(next.dev().sessions_request_generation, content="1")
-  let (_, repeated) = update_dev(
-    dispatch,
-    SessionCommitted(
-      session="desktop-elsewhere",
-      sequence=1,
-      ts=None,
-      item=@protocol.User({ content: "hi", submission_id: None, }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
-    ),
-    next,
-  )
+  let (_, repeated) = update_dev(dispatch, commit, next)
   inspect(repeated.dev().sessions_request_generation, content="1")
 }
 
@@ -18758,6 +18295,21 @@ fn desktop_model() -> Model {
     model,
   )
   model
+}
+
+///|
+/// Test-only: a desktop page showing one Browser tab whose native view has
+/// been placed, with the pane rectangle it was measured at.
+fn placed_browser_page() -> (Model, @preview.Rect) {
+  let dispatch = test_dispatch()
+  let rect : @preview.Rect = { x: 480, y: 46, width: 640, height: 700, }
+  let (_, opened) = update(
+    dispatch,
+    ExternalLinkClicked("http://127.0.0.1:5173/"),
+    desktop_model(),
+  )
+  let (_, placed) = update(dispatch, BrowserPaneMeasured(rect~), opened)
+  (placed, rect)
 }
 
 ///|
@@ -19211,14 +18763,7 @@ test "re-clicking a chat link re-navigates the reused tab to the clicked URL" {
   // whatever the tab currently displays, and the stale pane placement must
   // not survive a possibly rebuilt view (#1021).
   let dispatch = test_dispatch()
-  let model = desktop_model()
-  let (_, model) = update(
-    dispatch,
-    ExternalLinkClicked("http://127.0.0.1:5173/"),
-    model,
-  )
-  let rect : @preview.Rect = { x: 480, y: 46, width: 640, height: 700, }
-  let (_, model) = update(dispatch, BrowserPaneMeasured(rect~), model)
+  let (model, rect) = placed_browser_page()
   assert_true(model.browser_pane.shown == Some(1))
   let (_, model) = update(
     dispatch,
@@ -19294,14 +18839,7 @@ test "submitting the address bar normalizes the draft and commits it" {
 ///|
 test "navigating an already-placed tab re-places its view" {
   let dispatch = test_dispatch()
-  let model = desktop_model()
-  let (_, model) = update(
-    dispatch,
-    ExternalLinkClicked("http://127.0.0.1:5173/"),
-    model,
-  )
-  let rect : @preview.Rect = { x: 480, y: 46, width: 640, height: 700, }
-  let (_, model) = update(dispatch, BrowserPaneMeasured(rect~), model)
+  let (model, rect) = placed_browser_page()
   assert_true(model.browser_pane.shown == Some(1))
   // The host may have rebuilt the view under `browser.navigate` (nothing
   // acknowledges the ops that placed the old one), and a rebuilt view is
@@ -19480,14 +19018,7 @@ test "Search requests survive hidden Explorer Browser and panel states" {
 ///|
 test "pane measurements place the active view and idempotently settle" {
   let dispatch = test_dispatch()
-  let model = desktop_model()
-  let (_, model) = update(
-    dispatch,
-    ExternalLinkClicked("http://127.0.0.1:5173/"),
-    model,
-  )
-  let rect : @preview.Rect = { x: 480, y: 46, width: 640, height: 700, }
-  let (_, model) = update(dispatch, BrowserPaneMeasured(rect~), model)
+  let (model, rect) = placed_browser_page()
   assert_true(model.browser_pane.shown == Some(1))
   assert_true(model.browser_pane.rect == Some(rect))
   let (_, again) = update(dispatch, BrowserPaneMeasured(rect~), model)
@@ -19502,14 +19033,7 @@ test "pane measurements place the active view and idempotently settle" {
 ///|
 test "the launcher popup and final tab close both retire the shown view" {
   let dispatch = test_dispatch()
-  let model = desktop_model()
-  let (_, model) = update(
-    dispatch,
-    ExternalLinkClicked("http://127.0.0.1:5173/"),
-    model,
-  )
-  let rect : @preview.Rect = { x: 480, y: 46, width: 640, height: 700, }
-  let (_, model) = update(dispatch, BrowserPaneMeasured(rect~), model)
+  let (model, _) = placed_browser_page()
   assert_true(model.browser_pane.shown == Some(1))
   // The popup overlaps the pane, so the native view must hide under it.
   let (_, covered) = update(dispatch, ToggleRightPanelMenu, model)
@@ -19566,14 +19090,7 @@ test "closing a background Browser tab keeps the shown view placement" {
 ///|
 test "full-screen modals hide the native view and closing restores it" {
   let dispatch = test_dispatch()
-  let model = desktop_model()
-  let (_, model) = update(
-    dispatch,
-    ExternalLinkClicked("http://127.0.0.1:5173/"),
-    model,
-  )
-  let rect : @preview.Rect = { x: 480, y: 46, width: 640, height: 700, }
-  let (_, model) = update(dispatch, BrowserPaneMeasured(rect~), model)
+  let (model, rect) = placed_browser_page()
   assert_true(model.browser_pane.shown == Some(1))
   // The workspace picker's modal covers the pane; native views z-order
   // above HTML, so the view must hide first.
@@ -19646,11 +19163,7 @@ fn subrun_page(active~ : String, child_sync? : TranscriptSync) -> Model {
   let base = running_conversation()
   let parent = { ..base, turn: { ..base.turn, subruns: [lane], }, }
   let child = {
-    ..empty_conversation(
-      @interop.ChannelId::Local,
-      "desktop-test-sr-1",
-      @interop.ChannelId::Local.test_project(),
-    )
+    ..local_conversation("desktop-test-sr-1")
     // A child already read once. The positive watermark is what proves a
     // durable record exists, which is `can_reload_transcript`'s gate.
     ,
@@ -19673,20 +19186,23 @@ fn subrun_child_of(model : Model) -> Conversation raise {
 }
 
 ///|
+/// Test-only: the probe push a sub-run's progress produces for the fixture
+/// child, three steps in.
+fn subrun_progress() -> DeviceMsg {
+  SubrunProgressed(
+    id="sr-1",
+    session="desktop-test-sr-1",
+    steps=3,
+    activity="shell",
+  )
+}
+
+///|
 test "a sub-run's progress refreshes the child transcript on screen" {
   // No follower broadcasts a child's commits, so this probe push is the only
   // thing that can move a transcript the reader opened mid-run.
   let page = subrun_page(active="desktop-test-sr-1")
-  let (_, next) = update_dev(
-    test_dispatch(),
-    SubrunProgressed(
-      id="sr-1",
-      session="desktop-test-sr-1",
-      steps=3,
-      activity="shell",
-    ),
-    page,
-  )
+  let (_, next) = update_dev(test_dispatch(), subrun_progress(), page)
   // A fresh generation was minted for the read. `Cmd` is opaque, so this is
   // what separates an issued load from a conversation parked in `Reloading`
   // with nothing on the way to settle it.
@@ -19703,19 +19219,7 @@ test "a sub-run's progress refreshes the child transcript on screen" {
     test_dispatch(),
     SessionRefreshed(
       session="desktop-test-sr-1",
-      items=[
-        {
-          kind: Assistant(
-            reasoning=Some("child thought"),
-            prose=None,
-            calls=[],
-            replay=false,
-            finished=false,
-          ),
-          ts: None,
-          sequence: Some(5),
-        },
-      ],
+      items=[assistant_item(reasoning="child thought", sequence=5)],
       watermark=5,
       goal=None,
       goal_markers=[],
@@ -19742,12 +19246,7 @@ test "a sub-run's progress leaves a child nobody is viewing alone" {
   // a record no one is looking at is work with no reader.
   let (_, next) = update_dev(
     test_dispatch(),
-    SubrunProgressed(
-      id="sr-1",
-      session="desktop-test-sr-1",
-      steps=3,
-      activity="shell",
-    ),
+    subrun_progress(),
     subrun_page(active="desktop-test"),
   )
   assert_true(subrun_child_of(next).sync is Synced)
@@ -19766,12 +19265,7 @@ test "progress during an in-flight read is coalesced, not dropped" {
   // step short with nothing left to correct it.
   let (_, next) = update_dev(
     test_dispatch(),
-    SubrunProgressed(
-      id="sr-1",
-      session="desktop-test-sr-1",
-      steps=3,
-      activity="shell",
-    ),
+    subrun_progress(),
     subrun_page(
       active="desktop-test-sr-1",
       child_sync=Reloading(
@@ -19799,16 +19293,7 @@ test "a lane whose parent is gone still refreshes the child on screen" {
       conv.session_id != "desktop-test"
     }),
   }
-  let (_, next) = update_dev(
-    test_dispatch(),
-    SubrunProgressed(
-      id="sr-1",
-      session="desktop-test-sr-1",
-      steps=3,
-      activity="shell",
-    ),
-    orphaned,
-  )
+  let (_, next) = update_dev(test_dispatch(), subrun_progress(), orphaned)
   guard subrun_child_of(next).sync is Reloading(..) else {
     fail("expected the viewed child to reload without its parent")
   }

--- a/desktop/internal/auth/pkce.mbt
+++ b/desktop/internal/auth/pkce.mbt
@@ -11,17 +11,7 @@
 fn pkce_challenge(verifier : String) -> String {
   let digest = Bytes::from_array(@crypto.sha256(@utf8.encode(verifier)))
   let standard = @base64.encode(digest, padding=false)
-  let builder = StringBuilder()
-  for c in standard {
-    builder.write_char(
-      match c {
-        '+' => '-'
-        '/' => '_'
-        c => c
-      },
-    )
-  }
-  builder.to_string()
+  standard.replace_all(old="+", new="-").replace_all(old="/", new="_")
 }
 
 ///|
@@ -35,10 +25,7 @@ fn start_url(
   port~ : Int,
   name~ : String,
 ) -> String {
-  let origin = match server_url.strip_suffix("/") {
-    Some(origin) => origin.to_owned()
-    None => server_url
-  }
+  let origin = without_suffix(server_url, "/")
   "\{origin}/v1/auth/desktop/start" +
   "?state=\{oauth_state}" +
   "&code_challenge=\{challenge}" +

--- a/desktop/internal/auth/signin.mbt
+++ b/desktop/internal/auth/signin.mbt
@@ -48,10 +48,7 @@ pub async fn AuthStore::sign_in(self : AuthStore, server_url~ : String) -> Unit 
   let port = server.addr.port()
 
   // Hand the browser the consent URL.
-  let name = match @platform.machine_hostname() {
-    Some(hostname) => hostname
-    None => "desktop"
-  }
+  let name = @platform.machine_hostname().unwrap_or("desktop")
   let url = start_url(server_url~, oauth_state~, challenge~, port~, name~)
   let code = @platform.open_url(url) catch {
     error if @async.is_being_cancelled() => raise error
@@ -340,10 +337,7 @@ async fn exchange_code(
   verifier~ : String,
   name~ : String,
 ) -> AuthSession {
-  let origin = match server_url.strip_suffix("/") {
-    Some(origin) => origin.to_owned()
-    None => server_url
-  }
+  let origin = without_suffix(server_url, "/")
   let body : Json = {
     "code": code.to_json(),
     "code_verifier": verifier.to_json(),

--- a/desktop/internal/auth/urls.mbt
+++ b/desktop/internal/auth/urls.mbt
@@ -4,13 +4,21 @@
 // only derives from it.
 
 ///|
+/// `text` without a trailing `suffix`, or `text` unchanged when it does not
+/// end with one. Callers strip either the optional trailing slash from a
+/// server origin, or the `/v1/tunnel` path from a relay URL.
+fn without_suffix(text : String, suffix : StringView) -> String {
+  match text.strip_suffix(suffix) {
+    Some(rest) => rest.to_owned()
+    None => text
+  }
+}
+
+///|
 /// The control-WebSocket URL a host dials to register with `server_url`'s
 /// relay: `https` becomes `wss` (`http` → `ws` for local development).
 pub fn tunnel_url(server_url : String) -> String {
-  let origin = match server_url.strip_suffix("/") {
-    Some(origin) => origin.to_owned()
-    None => server_url
-  }
+  let origin = without_suffix(server_url, "/")
   let ws_origin = if origin.strip_prefix("https://") is Some(rest) {
     "wss://\{rest}"
   } else if origin.strip_prefix("http://") is Some(rest) {
@@ -31,10 +39,7 @@ pub fn device_url(
   device : String,
   app_version~ : String,
 ) -> String {
-  let origin = match server_url.strip_suffix("/") {
-    Some(origin) => origin.to_owned()
-    None => server_url
-  }
+  let origin = without_suffix(server_url, "/")
   if app_version == "development" {
     "\{origin}/console/?device=\{device}"
   } else {
@@ -54,8 +59,5 @@ pub fn origin_from_relay_url(relay_url : String) -> String {
   } else {
     relay_url
   }
-  match origin.strip_suffix("/v1/tunnel") {
-    Some(base) => base.to_owned()
-    None => origin
-  }
+  without_suffix(origin, "/v1/tunnel")
 }

--- a/desktop/internal/codex/actor.mbt
+++ b/desktop/internal/codex/actor.mbt
@@ -252,6 +252,22 @@ pub fn Actor::status(self : Actor) -> Json {
 }
 
 ///|
+/// Queue one input on its own reply channel, wake the actor, and wait for the
+/// single settlement it sends back.
+async fn Actor::submit(
+  self : Actor,
+  input : (@async.Queue[Result[Json, CodexError]]) -> ActorInput,
+) -> Json {
+  let reply : @async.Queue[Result[Json, CodexError]] = Queue(kind=Blocking(1))
+  self.inputs.put(input(reply))
+  self.signal()
+  match reply.get() {
+    Ok(value) => value
+    Err(error) => raise error
+  }
+}
+
+///|
 /// Send one allowlisted app-server request through the actor. The API package,
 /// not this process owner, decides which method names are exposed to clients.
 pub async fn Actor::call(
@@ -259,13 +275,7 @@ pub async fn Actor::call(
   method_~ : String,
   params~ : Json,
 ) -> Json {
-  let reply : @async.Queue[Result[Json, CodexError]] = Queue(kind=Blocking(1))
-  self.inputs.put(Call(method_, params, reply))
-  self.signal()
-  match reply.get() {
-    Ok(value) => value
-    Err(error) => raise error
-  }
+  self.submit(reply => Call(method_, params, reply))
 }
 
 ///|
@@ -277,13 +287,7 @@ pub async fn Actor::respond(
   request_id~ : Json,
   result~ : Json,
 ) -> Json {
-  let reply : @async.Queue[Result[Json, CodexError]] = Queue(kind=Blocking(1))
-  self.inputs.put(Respond(request_id, result, reply))
-  self.signal()
-  match reply.get() {
-    Ok(value) => value
-    Err(error) => raise error
-  }
+  self.submit(reply => Respond(request_id, result, reply))
 }
 
 ///|
@@ -291,13 +295,7 @@ pub async fn Actor::respond(
 /// this after attaching or reloading so a missed approval event cannot leave a
 /// turn waiting forever with no visible prompt.
 pub async fn Actor::requests(self : Actor) -> Json {
-  let reply : @async.Queue[Result[Json, CodexError]] = Queue(kind=Blocking(1))
-  self.inputs.put(ListRequests(reply))
-  self.signal()
-  match reply.get() {
-    Ok(value) => value
-    Err(error) => raise error
-  }
+  self.submit(reply => ListRequests(reply))
 }
 
 ///|

--- a/desktop/internal/engine/archive.mbt
+++ b/desktop/internal/engine/archive.mbt
@@ -193,13 +193,9 @@ async fn EngineManager::claim_session_family_move(
   let (workspace, workspace_token) = if selected is Some(selected) {
     (Some(selected.workspace), selected.workspace_token)
   } else {
-    let mut workspace : @pathx.Absolute? = None
-    for project in @workspaces.registered() {
-      if @workspaces.store_root(project) == root {
-        workspace = Some(project)
-        break
-      }
-    }
+    let workspace = @workspaces.registered()
+      .iter()
+      .find_first(project => @workspaces.store_root(project) == root)
     let workspace_token = match workspace {
       Some(project) => project.resource_path()
       None => ""
@@ -331,25 +327,10 @@ async fn move_session_family(
         moved.push(session_id)
       }
     } catch {
-      error => {
-        let mut rollback_failed = false
-        for session_id in moved.rev_iter() {
-          move_session_record(destination.join(session_id), source, session_id) catch {
-            _ => rollback_failed = true
-          }
-        }
-        let detail = match error {
-          EngineError(detail) => detail
-          _ => "\{error}"
-        }
-        raise EngineError(
-          if rollback_failed {
-            "\{detail}; some session-family moves could not be rolled back"
-          } else {
-            detail
-          },
+      error =>
+        raise_after_rollback(
+          moved, destination, source, error, "some session-family moves could not be rolled back",
         )
-      }
     }
     for session_id in order {
       on_committed(session_id, family.workspace_token)
@@ -568,30 +549,46 @@ async fn SessionFamilyMove::delete_archived_records(
       }
       self.remove_worktree_placements(on_committed?=on_worktree_changed)
     } catch {
-      error => {
-        let mut rollback_failed = false
-        for session_id in moved.rev_iter() {
-          move_session_record(deleting.join(session_id), archived, session_id) catch {
-            _ => rollback_failed = true
-          }
-        }
-        let detail = match error {
-          EngineError(detail) => detail
-          _ => "\{error}"
-        }
-        raise EngineError(
-          if rollback_failed {
-            "\{detail}; some condemned conversation records could not be restored"
-          } else {
-            detail
-          },
+      error =>
+        raise_after_rollback(
+          moved, deleting, archived, error, "some condemned conversation records could not be restored",
         )
-      }
     }
     for session_id in order {
       on_committed(session_id, self.workspace_token)
     }
   })
+}
+
+///|
+/// Put the records already moved out of `from` back into `to`, newest move
+/// first, then refuse with the failure that stopped the family mid-move. When
+/// the undo itself fails the refusal also carries `rollback_detail`, so the
+/// caller learns the store was left in a mixed state rather than restored.
+async fn raise_after_rollback(
+  moved : Array[String],
+  from : @pathx.Absolute,
+  to : @pathx.Absolute,
+  error : Error,
+  rollback_detail : String,
+) -> Unit {
+  let mut rollback_failed = false
+  for session_id in moved.rev_iter() {
+    move_session_record(from.join(session_id), to, session_id) catch {
+      _ => rollback_failed = true
+    }
+  }
+  let detail = match error {
+    EngineError(detail) => detail
+    _ => "\{error}"
+  }
+  raise EngineError(
+    if rollback_failed {
+      "\{detail}; \{rollback_detail}"
+    } else {
+      detail
+    },
+  )
 }
 
 ///|
@@ -663,6 +660,22 @@ fn restore_home_env(previous : String?) -> Unit {
 }
 
 ///|
+/// The `EngineError` message `body` refuses with, or "no error" when it
+/// commits. Cancellation is never a refusal and stays observable, so a test
+/// torn down mid-operation still fails as cancelled instead of silently
+/// reading the cancellation as the refusal it was asserting on.
+async fn engine_refusal(body : async () -> Unit) -> String {
+  try {
+    body()
+    "no error"
+  } catch {
+    EngineError(detail) => detail
+    error if @async.is_being_cancelled() => raise error
+    error => "\{error}"
+  }
+}
+
+///|
 #cfg(not(platform="windows"))
 async test "archive refuses a durable record while the pump is stopped" {
   ambient_env_test_lock.acquire()
@@ -677,18 +690,13 @@ async test "archive refuses a durable record while the pump is stopped" {
   @fsx.ensure_dir(Path(store + "/sessions/s-stopped"))
   let manager = new_engine_manager("unused")
   let committed = Ref(false)
-  let detail = try {
+  let detail = engine_refusal(() => {
     ignore(
       archive_session_commit(manager, "s-stopped", (_, _) => {
         committed.val = true
       }),
     )
-    "no error"
-  } catch {
-    EngineError(detail) => detail
-    error if @async.is_being_cancelled() => raise error
-    error => "\{error}"
-  }
+  })
   assert_true(detail.contains("not connected"))
   assert_false(committed.val)
   assert_true(@fsx.is_dir(Path(store + "/sessions/s-stopped")))
@@ -913,19 +921,14 @@ async test "permanent deletion refuses a live twin in the selected store" {
   )
   let manager = new_engine_manager("unused")
   manager.pump = Serving(sessions=Map([]))
-  let detail = try {
+  let detail = engine_refusal(() => {
     delete_archived_session_commit(
       manager,
       "chat",
       @pathx.Path(workspace).resolve().resource_path(),
       (_, _) => (),
     )
-    "no error"
-  } catch {
-    EngineError(detail) => detail
-    error if @async.is_being_cancelled() => raise error
-    error => "\{error}"
-  }
+  })
   assert_true(detail.contains("live record"))
   assert_true(@fsx.is_dir(Path(workspace + "/.openseek/sessions/chat")))
   assert_true(
@@ -982,19 +985,14 @@ async test "selected archived store is revalidated after detachment" {
   let workspace_token = workspace.resource_path()
   let selected = @session_store.ArchivedStore::for_workspace(workspace_token)
   ignore(detach_workspace(manager, workspace_token, fn(_) { () }))
-  let detail = try {
+  let detail = engine_refusal(() => {
     let family = manager.claim_session_family_move(
       "chat",
       archived=true,
       selected~,
     )
     family.release()
-    "no error"
-  } catch {
-    EngineError(detail) => detail
-    error if @async.is_being_cancelled() => raise error
-    error => "\{error}"
-  }
+  })
   assert_true(detail.contains("not a registered workspace"))
   assert_true(
     @fsx.is_dir(workspace.join(".openseek/archived/sessions/chat").to_path()),
@@ -1024,14 +1022,9 @@ async test "a claimed child prevents a partial family archive" {
     StartPending,
   )
   defer child_claim.release(manager)
-  let detail = try {
+  let detail = engine_refusal(() => {
     ignore(archive_session_commit(manager, "chat", (_, _) => ()))
-    "no error"
-  } catch {
-    EngineError(detail) => detail
-    error if @async.is_being_cancelled() => raise error
-    error => "\{error}"
-  }
+  })
   assert_true(detail.contains("already starting"))
   assert_true(@fsx.is_dir(Path(store + "/sessions/chat")))
   assert_true(@fsx.is_dir(Path(store + "/sessions/chat-sr-1")))

--- a/desktop/internal/engine/archive_lookup_wbtest.mbt
+++ b/desktop/internal/engine/archive_lookup_wbtest.mbt
@@ -9,14 +9,7 @@
 /// Cancellation is never a refusal and stays observable.
 #cfg(not(platform="windows"))
 async fn archive_refusal(manager : EngineManager, session : String) -> String {
-  try {
-    ignore(archive_session(manager, session, (_, _) => ()))
-    "no error"
-  } catch {
-    EngineError(detail) => detail
-    error if @async.is_being_cancelled() => raise error
-    error => "\{error}"
-  }
+  engine_refusal(() => ignore(archive_session(manager, session, (_, _) => ())))
 }
 
 ///|
@@ -132,14 +125,9 @@ async test "loading a conversation from a detached workspace names that state" {
   // A stale client's transcript reload names the conversation without a
   // workspace hint; the reply must say the record is unreachable rather
   // than surface the engine's raw file error.
-  let detail = try {
+  let detail = engine_refusal(() => {
     ignore(load_session(manager, { session: "s-ws", workspace: None, }))
-    "no error"
-  } catch {
-    EngineError(detail) => detail
-    error if @async.is_being_cancelled() => raise error
-    error => "\{error}"
-  }
+  })
   debug_inspect(
     detail,
     content=(

--- a/desktop/internal/engine/config.mbt
+++ b/desktop/internal/engine/config.mbt
@@ -432,7 +432,7 @@ async test "run config ignores OPENSEEK_API_URL in favor of the settings" {
 async test "run config rejects a blank session" {
   let manager = new_engine_manager("openseek")
   for session in ["", "   "] {
-    let detail = try {
+    let detail = engine_refusal(() => {
       ignore(
         run_config(manager, {
           task: "hello",
@@ -444,12 +444,7 @@ async test "run config rejects a blank session" {
           workspace: None,
         }),
       )
-      "no error"
-    } catch {
-      EngineError(detail) => detail
-      error if @async.is_being_cancelled() => raise error
-      error => "\{error}"
-    }
+    })
     assert_true(detail.contains("session id must not be empty"))
   }
 }
@@ -508,7 +503,7 @@ async test "host chooses durable placement from workspace state" {
   // A hint-less session that no attached workspace claims has nowhere to run.
   // The host refuses instead of inventing a directory and a store for it,
   // which is what would fork one id into two histories.
-  let unclaimed = try {
+  let unclaimed = engine_refusal(() => {
     ignore(
       run_config(manager, {
         task: "fresh",
@@ -520,12 +515,7 @@ async test "host chooses durable placement from workspace state" {
         workspace: None,
       }),
     )
-    "no error"
-  } catch {
-    EngineError(detail) => detail
-    error if @async.is_being_cancelled() => raise error
-    error => "\{error}"
-  }
+  })
   assert_true(unclaimed.contains("has no workspace"))
   let attached = run_config(manager, {
     task: "attached",

--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -759,17 +759,9 @@ fn EngineManager::record_guard(
   self : EngineManager,
   session : String,
 ) -> SessionRecordGuard {
-  if self.record_guards.get(session) is Some(state) {
-    state
-  } else {
-    let state : SessionRecordGuard = {
-      readers: 0,
-      active_ops: 0,
-      moving: false,
-    }
-    self.record_guards[session] = state
-    state
-  }
+  self.record_guards.get_or_init(session, () => {
+    ({ readers: 0, active_ops: 0, moving: false, } : SessionRecordGuard)
+  })
 }
 
 ///|
@@ -908,13 +900,9 @@ pub fn EngineManager::worktree_host(
 ///|
 /// This conversation's slot, created empty on first touch.
 fn slot_for(sessions : Map[String, SessionSlot], key : String) -> SessionSlot {
-  if sessions.get(key) is Some(slot) {
-    slot
-  } else {
-    let slot : SessionSlot = { pending: None, engine: None, }
-    sessions.set(key, slot)
-    slot
-  }
+  sessions.get_or_init(key, () => {
+    ({ pending: None, engine: None, } : SessionSlot)
+  })
 }
 
 ///|
@@ -983,12 +971,10 @@ async fn EngineManager::close_engines_for_workspace(
   // exact follower still rooted in this workspace before the registry commit;
   // replacement/start cannot install another one while the lifecycle lock is
   // held, and identity checks make already-retired captures harmless.
-  let retained : Array[SessionFollower] = []
-  for _, follower in self.followers {
-    if follower.root.to_string() == root {
-      retained.push(follower)
-    }
-  }
+  let retained = self.followers
+    .values()
+    .filter(follower => follower.root.to_string() == root)
+    .to_array()
   for follower in retained {
     stop_follower_instance(self, follower, writer_exited=true)
   }
@@ -1271,10 +1257,7 @@ fn reset_engine_generation(
   // Actor defers normally retire themselves. Defensively retire any identity
   // still present so queued/in-flight load callers are answered and both
   // control queues close before a successor pump starts.
-  let followers : Array[SessionFollower] = []
-  for _, follower in manager.followers {
-    followers.push(follower)
-  }
+  let followers = manager.followers.values().to_array()
   for follower in followers {
     retire_follower_actor(manager, follower)
   }
@@ -2194,17 +2177,7 @@ fn emit_session_error(
   engine : ServeEngine,
   reason : String,
 ) -> Unit {
-  emit(
-    sink,
-    StreamEvent({
-      run_id: engine.phase.latest_run(),
-      session: engine.session_key,
-      event: {
-        event: (SessionError(error=reason) : @wire.Event),
-        submission_id: None,
-      },
-    }),
-  )
+  emit_engine_stream_event(sink, engine, SessionError(error=reason))
 }
 
 ///|
@@ -2213,15 +2186,24 @@ fn emit_compaction_failed(
   engine : ServeEngine,
   reason : String,
 ) -> Unit {
+  emit_engine_stream_event(sink, engine, CompactionFailed(error=reason))
+}
+
+///|
+/// Publish one host-made stream event on the engine's behalf: routed by its
+/// session, with the latest run id as the frontend's fallback, and carrying
+/// no submission id because nothing the client sent is being answered.
+fn emit_engine_stream_event(
+  sink : EventSink,
+  engine : ServeEngine,
+  event : @wire.Event,
+) -> Unit {
   emit(
     sink,
     StreamEvent({
       run_id: engine.phase.latest_run(),
       session: engine.session_key,
-      event: {
-        event: (CompactionFailed(error=reason) : @wire.Event),
-        submission_id: None,
-      },
+      event: { event, submission_id: None, },
     }),
   )
 }

--- a/desktop/internal/engine/follower.mbt
+++ b/desktop/internal/engine/follower.mbt
@@ -753,14 +753,9 @@ async test "an unreadable existing record refuses the spawn baseline" {
     // A record that exists and cannot be read refuses the spawn instead,
     // and leaves no follower installed.
     write_damaged_record(root, "s-baseline")
-    let detail = try {
+    let detail = engine_refusal(() => {
       install_test_follower(engine, "s-baseline", root, sink~, group~, manager~)
-      "no error"
-    } catch {
-      EngineError(detail) => detail
-      error if @async.is_being_cancelled() => raise error
-      error => "\{error}"
-    }
+    })
     assert_true(detail.contains("failed to baseline the session record"))
     assert_true(manager.followers.get("s-baseline") is None)
     group.return_immediately(())
@@ -786,14 +781,9 @@ async test "failed final scan keeps the follower active and propagates" {
       fail("expected follower")
     }
     write_damaged_record(root, "s-fail")
-    let detail = try {
+    let detail = engine_refusal(() => {
       stop_follower(manager, "s-fail", writer_exited=true)
-      "no error"
-    } catch {
-      EngineError(detail) => detail
-      error if @async.is_being_cancelled() => raise error
-      error => "\{error}"
-    }
+    })
     assert_true(detail.contains("session record"))
     assert_true(
       manager.followers.get("s-fail") is Some(current) &&
@@ -1118,14 +1108,9 @@ async test "workspace detach refuses an idle engine whose follower cannot drain"
     let slot = slot_for(sessions, session)
     slot.engine = Some(engine)
     manager.pump = Serving(sessions~)
-    let detail = try {
+    let detail = engine_refusal(() => {
       manager.close_engines_for_workspace(workspace)
-      "no error"
-    } catch {
-      EngineError(detail) => detail
-      error if @async.is_being_cancelled() => raise error
-      error => "\{error}"
-    }
+    })
     assert_true(detail.contains("session record"))
     assert_true(
       manager.followers.get(session) is Some(current) &&
@@ -1165,14 +1150,9 @@ async test "record stat failure is not mistaken for an empty final drain" {
       "file",
       create_mode=CreateOrTruncate,
     )
-    let detail = try {
+    let detail = engine_refusal(() => {
       stop_follower(manager, "s-stat", writer_exited=true)
-      "no error"
-    } catch {
-      EngineError(detail) => detail
-      error if @async.is_being_cancelled() => raise error
-      error => "\{error}"
-    }
+    })
     // The reader takes the record's lock first, so ENOTDIR surfaces there —
     // still the failure this test is about, and still not the ENOENT that
     // would prove no record was ever created.
@@ -1416,14 +1396,9 @@ async test "stop requires its generation proof when follower identity vanishes" 
   manager.followers["s-stop-proof"] = follower
   @async.with_task_group(group => {
     let caller = group.spawn(() => {
-      try {
+      engine_refusal(() => {
         stop_follower(manager, "s-stop-proof", writer_exited=false)
-        "no error"
-      } catch {
-        EngineError(detail) => detail
-        error if @async.is_being_cancelled() => raise error
-        error => "\{error}"
-      }
+      })
     })
     guard follower.inbox.get() is Stop(generation~, ..) else {
       fail("expected Stop")

--- a/desktop/internal/engine/ops.mbt
+++ b/desktop/internal/engine/ops.mbt
@@ -756,10 +756,9 @@ pub async fn load_archived_session(
     }
     Some(@session_store.archived_root(@workspaces.store_root(workspace)))
   } else {
-    match @session_store.archived_root_of(session) {
-      Some(root) => Some(@session_store.archived_root(root))
-      None => None
-    }
+    @session_store.archived_root_of(session).map(root => {
+      @session_store.archived_root(root)
+    })
   }
   guard root is Some(root) else {
     if @session_store.live_root_of(session) is Some(_) {
@@ -866,12 +865,7 @@ pub async fn detach_workspace(
 ///|
 #cfg(not(platform="windows"))
 fn has_finished_run(events : Array[EngineEvent], run_id : String) -> Bool {
-  for event in events {
-    if event is Finished(payload) && payload.run_id == run_id {
-      return true
-    }
-  }
-  false
+  events.any(event => event is Finished(payload) && payload.run_id == run_id)
 }
 
 ///|
@@ -947,6 +941,32 @@ async fn configure_custom_provider(manager : EngineManager) -> Unit {
 }
 
 ///|
+/// Stage the fixture every run test needs under `root`: the fake MoonBit seed
+/// beside a shell engine running `script`, the prepared runtime payload the
+/// spawn resolves its toolchain from, and an actor whose manager already has
+/// a stub custom endpoint. The layout (`bin/engine.sh`,
+/// `bin/toolchains/...`, `runtime/toolchains/...`) is the one every one of
+/// these tests already uses.
+#cfg(not(platform="windows"))
+async fn prepare_run_actor(root : @pathx.Path, script : String) -> EngineActor {
+  let engine = root.join("bin/engine.sh")
+  let runtime = root.join("runtime")
+  prepare_fake_moonbit_seed(
+    root.join("bin/toolchains/moonbit/macos-arm64"),
+    version="0.10.0-test",
+  )
+  prepare_fake_bundled_moonbit_home(
+    runtime.join("toolchains/moonbit/macos-arm64"),
+    version="0.10.0-test",
+  )
+  @fs.write_file(engine.to_string(), script, create_mode=CreateOrTruncate)
+  assert_eq(@process.run("chmod", ["+x", engine.to_string()]), 0)
+  let actor = new_engine_actor(engine.to_string(), runtime_dir=runtime)
+  configure_custom_provider(actor.manager())
+  actor
+}
+
+///|
 /// Serve `actor` in `group` and wait until its pump accepts commands: the
 /// first thing every run test does after building the manager.
 #cfg(not(platform="windows"))
@@ -1000,23 +1020,10 @@ async test "start echoes the client submission id in Started" {
   @sys.set_env_var("HOME", root.join("home").to_string())
   defer restore_home_env(previous_home)
   let workspace = attach_run_workspace(root)
-  let engine = root.join("bin/engine.sh")
-  let seed = root.join("bin/toolchains/moonbit/macos-arm64")
-  let runtime = root.join("runtime")
-  prepare_fake_moonbit_seed(seed, version="0.10.0-test")
-  prepare_fake_bundled_moonbit_home(
-    runtime.join("toolchains/moonbit/macos-arm64"),
-    version="0.10.0-test",
+  let actor = prepare_run_actor(
+    root, "#!/bin/sh\nif [ \"$1\" = \"sessions\" ]; then printf '%s' '{\"events\":[]}'; exit 0; fi\nwhile IFS= read -r line; do :; done\n",
   )
-  @fs.write_file(
-    engine.to_string(),
-    "#!/bin/sh\nif [ \"$1\" = \"sessions\" ]; then printf '%s' '{\"events\":[]}'; exit 0; fi\nwhile IFS= read -r line; do :; done\n",
-    create_mode=CreateOrTruncate,
-  )
-  assert_eq(@process.run("chmod", ["+x", engine.to_string()]), 0)
-  let actor = new_engine_actor(engine.to_string(), runtime_dir=runtime)
   let manager = actor.manager()
-  configure_custom_provider(manager)
   let emitted : Array[EngineEvent] = []
   // Starts are durable now, so each test owns a fresh conversation record
   // instead of sharing a fixed id across test processes.
@@ -1065,26 +1072,14 @@ async test "a goal is delivered only once its command is on the wire" {
   @sys.set_env_var("HOME", root.join("home").to_string())
   defer restore_home_env(previous_home)
   let workspace = attach_run_workspace(root)
-  let engine = root.join("bin/engine.sh")
-  let seed = root.join("bin/toolchains/moonbit/macos-arm64")
-  let runtime = root.join("runtime")
   let received = root.join("received")
-  prepare_fake_moonbit_seed(seed, version="0.10.0-test")
-  prepare_fake_bundled_moonbit_home(
-    runtime.join("toolchains/moonbit/macos-arm64"),
-    version="0.10.0-test",
-  )
   // Echoes every command it reads back into a file, so the test can check the
   // goal really left the host rather than only that the op returned.
-  @fs.write_file(
-    engine.to_string(),
+  let actor = prepare_run_actor(
+    root,
     "#!/bin/sh\nif [ \"$1\" = \"sessions\" ]; then printf '%s' '{\"events\":[]}'; exit 0; fi\nwhile IFS= read -r line; do printf '%s\\n' \"$line\" >> '\{received}'; done\n",
-    create_mode=CreateOrTruncate,
   )
-  assert_eq(@process.run("chmod", ["+x", engine.to_string()]), 0)
-  let actor = new_engine_actor(engine.to_string(), runtime_dir=runtime)
   let manager = actor.manager()
-  configure_custom_provider(manager)
   let session = "s-" + mint_run_id()
   let sink = EventSink(fn(_) { () })
   @async.with_task_group(group => {
@@ -1178,26 +1173,14 @@ async test "setup failure retires the writer before an immediate next start" {
   @sys.set_env_var("HOME", root.join("home").to_string())
   defer restore_home_env(previous_home)
   let workspace = attach_run_workspace(root)
-  let engine = root.join("bin/engine.sh")
-  let seed = root.join("bin/toolchains/moonbit/macos-arm64")
-  let runtime = root.join("runtime")
   let count = root.join("count")
   let old_done = root.join("old-done")
   let overlapped = root.join("overlapped")
-  prepare_fake_moonbit_seed(seed, version="0.10.0-test")
-  prepare_fake_bundled_moonbit_home(
-    runtime.join("toolchains/moonbit/macos-arm64"),
-    version="0.10.0-test",
-  )
-  @fs.write_file(
-    engine.to_string(),
+  let actor = prepare_run_actor(
+    root,
     "#!/bin/sh\nif [ \"$1\" = \"sessions\" ]; then printf '%s' '{\"events\":[]}'; exit 0; fi\nn=0\nif [ -f '\{count}' ]; then n=$(cat '\{count}'); fi\nn=$((n + 1))\nprintf '%s' \"$n\" > '\{count}'\nif [ \"$n\" -eq 1 ]; then\n  IFS= read -r line || exit 0\n  printf '%s\\n' '{\"event\":\"agent_setup_failed\",\"error\":\"boom\"}'\n  sleep 1\n  printf '%s\\n' '{\"event\":\"turn_failed\",\"error\":\"append failed\"}'\n  printf '' > '\{old_done}'\n  exit 0\nfi\nif [ ! -f '\{old_done}' ]; then printf '' > '\{overlapped}'; fi\nwhile IFS= read -r line; do\n\{commit_terminal_sh()}  printf '%s\\n' '{\"event\":\"agent_finished\",\"answer\":\"ok\"}'\ndone\n",
-    create_mode=CreateOrTruncate,
   )
-  assert_eq(@process.run("chmod", ["+x", engine.to_string()]), 0)
-  let actor = new_engine_actor(engine.to_string(), runtime_dir=runtime)
   let manager = actor.manager()
-  configure_custom_provider(manager)
   let emitted : Array[EngineEvent] = []
   let session = "s-" + mint_run_id()
   let sink = EventSink(fn(event) { emitted.push(event) })
@@ -1272,26 +1255,13 @@ async test "a prompt bigger than the pipe still settles exactly once" {
   @sys.set_env_var("HOME", root.join("home").to_string())
   defer restore_home_env(previous_home)
   let workspace = attach_run_workspace(root)
-  let engine = root.join("bin/engine.sh")
-  let seed = root.join("bin/toolchains/moonbit/macos-arm64")
-  let runtime = root.join("runtime")
-  prepare_fake_moonbit_seed(seed, version="0.10.0-test")
-  prepare_fake_bundled_moonbit_home(
-    runtime.join("toolchains/moonbit/macos-arm64"),
-    version="0.10.0-test",
-  )
   // Deliberately never read stdin, then die with the prompt still half
   // written: the JSONL frame on the wire is partial, so the handle must
   // become unusable and the run must be reported as failed.
-  @fs.write_file(
-    engine.to_string(),
-    "#!/bin/sh\nif [ \"$1\" = \"sessions\" ]; then printf '%s' '{\"events\":[]}'; exit 0; fi\nsleep 1\n",
-    create_mode=CreateOrTruncate,
+  let actor = prepare_run_actor(
+    root, "#!/bin/sh\nif [ \"$1\" = \"sessions\" ]; then printf '%s' '{\"events\":[]}'; exit 0; fi\nsleep 1\n",
   )
-  assert_eq(@process.run("chmod", ["+x", engine.to_string()]), 0)
-  let actor = new_engine_actor(engine.to_string(), runtime_dir=runtime)
   let manager = actor.manager()
-  configure_custom_provider(manager)
   let emitted : Array[EngineEvent] = []
   let session = "s-" + mint_run_id()
   let started : Ref[String?] = Ref(None)
@@ -1347,33 +1317,21 @@ async test "named session retries after its first prompt creates no record" {
   let previous_home = @sys.get_env_var("HOME")
   @sys.set_env_var("HOME", root.join("home").to_string())
   defer restore_home_env(previous_home)
-  let engine = root.join("bin/engine.sh")
-  let seed = root.join("bin/toolchains/moonbit/macos-arm64")
-  let runtime = root.join("runtime")
   let workspace = attach_run_workspace(root)
   // The conversation's record lives in its workspace's in-project store.
   let store = root.join("ws/.openseek")
   let count = root.join("serve-count")
   let first_ready = root.join("first-ready")
   let session = "s-" + mint_run_id()
-  prepare_fake_moonbit_seed(seed, version="0.10.0-test")
-  prepare_fake_bundled_moonbit_home(
-    runtime.join("toolchains/moonbit/macos-arm64"),
-    version="0.10.0-test",
-  )
   // No first-turn record exists to read. The first serve process creates only
   // the session directory, never reads stdin, and dies with the large prompt's
   // JSONL frame still partial. The successor accepts a normal prompt and
   // finishes it.
-  @fs.write_file(
-    engine.to_string(),
+  let actor = prepare_run_actor(
+    root,
     "#!/bin/sh\nif [ \"$1\" = \"sessions\" ]; then\n  printf '%s\\n' 'session record does not exist' >&2\n  exit 7\nfi\nn=0\nif [ -f '\{count}' ]; then n=$(cat '\{count}'); fi\nn=$((n + 1))\nprintf '%s' \"$n\" > '\{count}'\nif [ \"$n\" -eq 1 ]; then\n  mkdir -p '\{store}/sessions/\{session}'\n  printf '' > '\{first_ready}'\n  exec sleep 1\nfi\nwhile IFS= read -r line; do\n\{commit_terminal_sh()}  printf '%s\\n' '{\"event\":\"agent_finished\",\"answer\":\"ok\"}'\ndone\n",
-    create_mode=CreateOrTruncate,
   )
-  assert_eq(@process.run("chmod", ["+x", engine.to_string()]), 0)
-  let actor = new_engine_actor(engine.to_string(), runtime_dir=runtime)
   let manager = actor.manager()
-  configure_custom_provider(manager)
   let emitted : Array[EngineEvent] = []
   let started : Ref[String?] = Ref(None)
   let sink = EventSink(fn(event) {
@@ -1534,19 +1492,14 @@ async test "load rejects a detached workspace hint instead of probing global" {
   )
   assert_eq(@process.run("chmod", ["+x", engine]), 0)
   let manager = new_engine_manager(engine)
-  let detail = try {
+  let detail = engine_refusal(() => {
     ignore(
       load_session(manager, {
         session: "s-detached",
         workspace: Some(dir + "/detached-workspace"),
       }),
     )
-    "no error"
-  } catch {
-    EngineError(detail) => detail
-    error if @async.is_being_cancelled() => raise error
-    error => "\{error}"
-  }
+  })
   assert_true(detail.contains("not a registered workspace"))
   assert_false(@fsx.exists(Path(marker)))
 }
@@ -1565,28 +1518,13 @@ async test "workspace detach refuses a running conversation without hiding it" {
   defer @fs.rmdir(root.to_string(), recursive=true)
   let global_store = root.join("global")
   let workspace = root.join("workspace")
-  let engine = root.join("bin/engine.sh")
-  let runtime = root.join("runtime")
   @sys.set_env_var("HOME", global_store.to_string())
   defer restore_home_env(previous)
   @fsx.ensure_dir(workspace)
-  prepare_fake_moonbit_seed(
-    root.join("bin/toolchains/moonbit/macos-arm64"),
-    version="0.10.0-test",
+  let actor = prepare_run_actor(
+    root, "#!/bin/sh\nif [ \"$1\" = \"sessions\" ]; then printf '%s' '{\"events\":[]}' ; exit 0; fi\nwhile IFS= read -r line; do sleep 30; done\n",
   )
-  prepare_fake_bundled_moonbit_home(
-    runtime.join("toolchains/moonbit/macos-arm64"),
-    version="0.10.0-test",
-  )
-  @fs.write_file(
-    engine.to_string(),
-    "#!/bin/sh\nif [ \"$1\" = \"sessions\" ]; then printf '%s' '{\"events\":[]}' ; exit 0; fi\nwhile IFS= read -r line; do sleep 30; done\n",
-    create_mode=CreateOrTruncate,
-  )
-  assert_eq(@process.run("chmod", ["+x", engine.to_string()]), 0)
-  let actor = new_engine_actor(engine.to_string(), runtime_dir=runtime)
   let manager = actor.manager()
-  configure_custom_provider(manager)
   let sink = EventSink(fn(_) { () })
   @async.with_task_group(group => {
     serve_until_pumping(actor, manager, sink, group~)
@@ -1602,18 +1540,13 @@ async test "workspace detach refuses a running conversation without hiding it" {
     )
     assert_eq(reply.status, "accepted")
     let committed : Ref[Bool] = Ref(false)
-    let detail = try {
+    let detail = engine_refusal(() => {
       ignore(
         detach_workspace(manager, workspace.to_string(), fn(_) {
           committed.val = true
         }),
       )
-      "no error"
-    } catch {
-      EngineError(detail) => detail
-      error if @async.is_being_cancelled() => raise error
-      error => "\{error}"
-    }
+    })
     assert_true(detail.contains("still running"))
     assert_false(committed.val)
     guard workspace.to_absolute() is Some(workspace_path) else {
@@ -1638,29 +1571,15 @@ async test "workspace detach drains an idle writer and its follower first" {
   defer @fs.rmdir(root.to_string(), recursive=true)
   let global_store = root.join("global")
   let workspace = root.join("workspace")
-  let engine = root.join("bin/engine.sh")
-  let runtime = root.join("runtime")
   let exited = root.join("writer-exited")
   @sys.set_env_var("HOME", global_store.to_string())
   defer restore_home_env(previous)
   @fsx.ensure_dir(workspace)
-  prepare_fake_moonbit_seed(
-    root.join("bin/toolchains/moonbit/macos-arm64"),
-    version="0.10.0-test",
-  )
-  prepare_fake_bundled_moonbit_home(
-    runtime.join("toolchains/moonbit/macos-arm64"),
-    version="0.10.0-test",
-  )
-  @fs.write_file(
-    engine.to_string(),
+  let actor = prepare_run_actor(
+    root,
     "#!/bin/sh\nif [ \"$1\" = \"sessions\" ]; then printf '%s' '{\"events\":[]}' ; exit 0; fi\nwhile IFS= read -r line; do\n\{commit_terminal_sh()}  printf '%s\\n' '{\"event\":\"agent_finished\",\"answer\":\"ok\"}'\ndone\nprintf '' > '\{exited}'\n",
-    create_mode=CreateOrTruncate,
   )
-  assert_eq(@process.run("chmod", ["+x", engine.to_string()]), 0)
-  let actor = new_engine_actor(engine.to_string(), runtime_dir=runtime)
   let manager = actor.manager()
-  configure_custom_provider(manager)
   let events : Array[EngineEvent] = []
   let sink = EventSink(fn(event) { events.push(event) })
   @async.with_task_group(group => {
@@ -1706,14 +1625,7 @@ async test "workspace detach drains an idle writer and its follower first" {
 async test "a goal request is refused before it can reach the wrong engine" {
   let manager = new_engine_manager("/nonexistent/engine")
   async fn refusal(payload : @protocol.GoalPayload) -> String {
-    try {
-      ignore(goal_run(manager, payload))
-      "no error"
-    } catch {
-      EngineError(detail) => detail
-      error if @async.is_being_cancelled() => raise error
-      error => "\{error}"
-    }
+    engine_refusal(() => ignore(goal_run(manager, payload)))
   }
 
   // Arming is not wired end to end, and this endpoint serves the relay: a

--- a/desktop/internal/engine/worktree_seam_wbtest.mbt
+++ b/desktop/internal/engine/worktree_seam_wbtest.mbt
@@ -257,32 +257,15 @@ async test "worktree remove refuses a running conversation without unmapping it"
   let previous = @sys.get_env_var("HOME")
   let root = worktree_test_root("openseek-worktree-busy-")
   defer @fs.rmdir(root.to_string(), recursive=true)
-  let engine = root.join("bin/engine.sh")
-  let runtime = root.join("runtime")
   @sys.set_env_var("HOME", root.join("global").to_string())
   defer restore_home_env(previous)
   let ws = root.join("ws")
   @fsx.ensure_dir(ws.join(".worktrees/wt").to_path())
-  prepare_fake_moonbit_seed(
-    root.join("bin/toolchains/moonbit/macos-arm64").to_path(),
-    version="0.10.0-test",
-  )
-  prepare_fake_bundled_moonbit_home(
-    runtime.join("toolchains/moonbit/macos-arm64").to_path(),
-    version="0.10.0-test",
-  )
-  @fs.write_file(
-    engine.to_string(),
+  let actor = prepare_run_actor(
+    root.to_path(),
     "#!/bin/sh\nif [ \"$1\" = \"sessions\" ]; then printf '%s' '{\"events\":[]}' ; exit 0; fi\nwhile IFS= read -r line; do sleep 30; done\n",
-    create_mode=CreateOrTruncate,
-  )
-  assert_eq(@process.run("chmod", ["+x", engine.to_string()]), 0)
-  let actor = new_engine_actor(
-    engine.to_string(),
-    runtime_dir=runtime.to_path(),
   )
   let manager = actor.manager()
-  configure_custom_provider(manager)
   let sink = EventSink(fn(_) {  })
   @async.with_task_group(group => {
     serve_until_pumping(actor, manager, sink, group~)
@@ -301,7 +284,7 @@ async test "worktree remove refuses a running conversation without unmapping it"
     )
     assert_eq(reply.status, "accepted")
     let committed : Ref[Bool] = Ref(false)
-    let detail = try {
+    let detail = engine_refusal(() => {
       ignore(
         @worktree.remove(manager.worktree_host(), ws.to_string(), "wt", false, fn(
           _,
@@ -309,12 +292,7 @@ async test "worktree remove refuses a running conversation without unmapping it"
           committed.val = true
         }),
       )
-      "no error"
-    } catch {
-      EngineError(detail) => detail
-      error if @async.is_being_cancelled() => raise error
-      error => "\{error}"
-    }
+    })
     assert_true(detail.contains("still running"))
     assert_false(committed.val)
     assert_true(@fsx.is_dir(ws.join(".worktrees/wt").to_path()))
@@ -391,16 +369,9 @@ async test "a checkout deleted outside the app refuses runs and is repairable" {
     @work_dir.resolve_in_workspace("s-vanish", "", workspace=repo.to_string())
     is None,
   )
-  let refusal = try {
-    ignore(@worktree.run_dir(repo, "s-vanish"))
-    "no error"
-  } catch {
-    EngineError(detail) => detail
-    error if @async.is_being_cancelled() => raise error
-    error => "\{error}"
-  }
+  let refusal = engine_refusal(() => ignore(@worktree.run_dir(repo, "s-vanish")))
   assert_true(refusal.contains("wt") && refusal.contains("gone"))
-  let hinted_refusal = try {
+  let hinted_refusal = engine_refusal(() => {
     ignore(
       run_config(manager, {
         task: "continue",
@@ -412,14 +383,9 @@ async test "a checkout deleted outside the app refuses runs and is repairable" {
         workspace: Some(repo.to_string()),
       }),
     )
-    "no error"
-  } catch {
-    EngineError(detail) => detail
-    error if @async.is_being_cancelled() => raise error
-    error => "\{error}"
-  }
+  })
   assert_true(hinted_refusal.contains("wt") && hinted_refusal.contains("gone"))
-  let resumed_refusal = try {
+  let resumed_refusal = engine_refusal(() => {
     ignore(
       run_config(manager, {
         task: "resume",
@@ -431,12 +397,7 @@ async test "a checkout deleted outside the app refuses runs and is repairable" {
         workspace: None,
       }),
     )
-    "no error"
-  } catch {
-    EngineError(detail) => detail
-    error if @async.is_being_cancelled() => raise error
-    error => "\{error}"
-  }
+  })
   assert_true(
     resumed_refusal.contains("wt") && resumed_refusal.contains("gone"),
   )

--- a/desktop/internal/host/git_ops.mbt
+++ b/desktop/internal/host/git_ops.mbt
@@ -68,21 +68,21 @@ async fn git_branch(dir : String) -> String? {
 }
 
 ///|
+/// One line of Git output, with a command that failed and one that printed
+/// nothing both reading as None.
+async fn git_line_opt(dir : String, args : Array[String]) -> String? {
+  git_output_opt(dir, args)
+  .map(git_single_line)
+  .filter(line => !line.is_empty())
+}
+
+///|
 /// The branch `HEAD` points at, and nothing else. Unlike `git_branch` this
 /// does not stand in a short hash for a detached checkout: a hash is a fine
 /// thing to show a person and a nonsense thing to hand an API that filters by
 /// branch name.
 async fn git_symbolic_branch(dir : String) -> String? {
-  guard git_output_opt(dir, ["symbolic-ref", "--short", "--quiet", "HEAD"])
-    is Some(output) else {
-    return None
-  }
-  let name = git_single_line(output)
-  if name.is_empty() {
-    None
-  } else {
-    Some(name)
-  }
+  git_line_opt(dir, ["symbolic-ref", "--short", "--quiet", "HEAD"])
 }
 
 ///|
@@ -183,19 +183,10 @@ async fn git_base_ref(dir : String, hint? : String) -> String? {
       return Some(hinted)
     }
   }
-  guard git_output_opt(dir, [
-      "rev-parse", "--abbrev-ref", "--verify", "--quiet", "origin/HEAD",
-    ])
-    is Some(output) else {
-    return None
-  }
-  let name = git_single_line(output)
   // A dangling `origin/HEAD` abbreviates to itself and names no branch.
-  if name.is_empty() || name == "origin/HEAD" {
-    None
-  } else {
-    Some(name)
-  }
+  git_line_opt(dir, [
+    "rev-parse", "--abbrev-ref", "--verify", "--quiet", "origin/HEAD",
+  ]).filter(name => name != "origin/HEAD")
 }
 
 ///|
@@ -230,15 +221,10 @@ async fn git_branch_base(dir : String, hint? : String) -> (String, String?) {
   guard git_base_ref(dir, hint?) is Some(base_ref) else {
     return ("HEAD", None)
   }
-  guard git_output_opt(dir, ["merge-base", "HEAD", base_ref]) is Some(output) else {
+  guard git_line_opt(dir, ["merge-base", "HEAD", base_ref]) is Some(commit) else {
     return ("HEAD", None)
   }
-  let commit = git_single_line(output)
-  if commit.is_empty() {
-    ("HEAD", None)
-  } else {
-    (commit, Some(base_ref))
-  }
+  (commit, Some(base_ref))
 }
 
 ///|
@@ -255,15 +241,7 @@ async fn git_branch_base(dir : String, hint? : String) -> (String, String?) {
 async fn git_review_branch_base(dir : String, head : String?) -> String? {
   guard head is Some(head) else { return None }
   guard git_base_ref(dir) is Some(base_ref) else { return None }
-  guard git_output_opt(dir, ["merge-base", head, base_ref]) is Some(output) else {
-    return None
-  }
-  let base = git_single_line(output)
-  if base.is_empty() || base == head {
-    None
-  } else {
-    Some(base)
-  }
+  git_line_opt(dir, ["merge-base", head, base_ref]).filter(base => base != head)
 }
 
 ///|
@@ -502,27 +480,17 @@ async fn git_output(dir : String, args : Array[String]) -> String {
 ///|
 /// The presentation category for Git's two porcelain status columns.
 fn git_change_kind(index_status : String, worktree_status : String) -> String {
-  let pair = index_status + worktree_status
-  if ["DD", "AU", "UD", "UA", "DU", "AA", "UU"].contains(pair) {
-    "unmerged"
-  } else if index_status == "U" || worktree_status == "U" {
-    // `git diff --name-status` uses one column rather than porcelain's
-    // two-column conflict pairs.
-    "unmerged"
-  } else if pair == "??" {
-    "untracked"
-  } else if index_status == "R" || worktree_status == "R" {
-    "renamed"
-  } else if index_status == "C" || worktree_status == "C" {
-    "copied"
-  } else if index_status == "D" || worktree_status == "D" {
-    "deleted"
-  } else if index_status == "A" || worktree_status == "A" {
-    "added"
-  } else if index_status == "T" || worktree_status == "T" {
-    "type-changed"
-  } else {
-    "modified"
+  match (index_status, worktree_status) {
+    // A single `U` column covers `git diff --name-status`, which uses one
+    // column rather than porcelain's two-column conflict pairs.
+    ("D", "D") | ("A", "A") | ("U", _) | (_, "U") => "unmerged"
+    ("?", "?") => "untracked"
+    ("R", _) | (_, "R") => "renamed"
+    ("C", _) | (_, "C") => "copied"
+    ("D", _) | (_, "D") => "deleted"
+    ("A", _) | (_, "A") => "added"
+    ("T", _) | (_, "T") => "type-changed"
+    _ => "modified"
   }
 }
 
@@ -859,6 +827,18 @@ async fn git_collect(
 }
 
 ///|
+/// Git's own diagnostic for a failed command, or `fallback` when it printed
+/// none (stderr this host could not decode included).
+fn git_failure_detail(stderr : &@io.Data, fallback : String) -> String {
+  let detail = (stderr.text() catch { _ => "" }).trim().to_owned()
+  if detail.is_empty() {
+    fallback
+  } else {
+    detail
+  }
+}
+
+///|
 /// Capture the exact index entries used by one review snapshot. Task mode
 /// reads this again after its diff/untracked queries, so an index-only change
 /// retries just like a concurrent commit instead of publishing mixed rows.
@@ -867,14 +847,7 @@ async fn git_index_metadata(dir : String) -> String {
     "ls-files", "--full-name", "--stage", "-z", "--", ".",
   ])
   guard code == 0 else {
-    let detail = (stderr.text() catch { _ => "" }).trim().to_owned()
-    raise HostError(
-      if detail.is_empty() {
-        "failed to inspect Git index"
-      } else {
-        detail
-      },
-    )
+    raise HostError(git_failure_detail(stderr, "failed to inspect Git index"))
   }
   stdout.text() catch {
     _ => raise HostError("Git returned a non-UTF-8 index path")
@@ -911,16 +884,7 @@ fn valid_commit_identity(revision : String) -> Bool {
   if revision.length() != 40 && revision.length() != 64 {
     return false
   }
-  for character in revision {
-    let code = character.to_int()
-    let digit = code >= '0'.to_int() && code <= '9'.to_int()
-    let lower = code >= 'a'.to_int() && code <= 'f'.to_int()
-    let upper = code >= 'A'.to_int() && code <= 'F'.to_int()
-    if !(digit || lower || upper) {
-      return false
-    }
-  }
-  true
+  revision.iter().all(character => character.is_ascii_hexdigit())
 }
 
 ///|
@@ -978,13 +942,8 @@ async fn git_change_snapshot(
         ".",
       ])
       guard code == 0 else {
-        let detail = (stderr.text() catch { _ => "" }).trim().to_owned()
         raise HostError(
-          if detail.is_empty() {
-            "failed to read untracked Git paths"
-          } else {
-            detail
-          },
+          git_failure_detail(stderr, "failed to read untracked Git paths"),
         )
       }
       let raw = stdout.text() catch {
@@ -999,13 +958,8 @@ async fn git_change_snapshot(
         "status", "--porcelain=v1", "-z", "--untracked-files=all", "--", ".",
       ])
       guard code == 0 else {
-        let detail = (stderr.text() catch { _ => "" }).trim().to_owned()
         raise HostError(
-          if detail.is_empty() {
-            "failed to read Git changes"
-          } else {
-            detail
-          },
+          git_failure_detail(stderr, "failed to read Git changes"),
         )
       }
       let raw = stdout.text() catch {
@@ -1026,13 +980,8 @@ async fn git_change_snapshot(
         ".",
       ])
       guard diff_code == 0 else {
-        let detail = (diff_stderr.text() catch { _ => "" }).trim().to_owned()
         raise HostError(
-          if detail.is_empty() {
-            "failed to read Git task changes"
-          } else {
-            detail
-          },
+          git_failure_detail(diff_stderr, "failed to read Git task changes"),
         )
       }
       let diff_raw = diff_stdout.text() catch {
@@ -1073,13 +1022,8 @@ async fn git_change_snapshot(
       }
       let (tree_code, tree_stdout, tree_stderr) = git_collect(dir, tree_args)
       guard tree_code == 0 else {
-        let detail = (tree_stderr.text() catch { _ => "" }).trim().to_owned()
         raise HostError(
-          if detail.is_empty() {
-            "failed to inspect Git review tree"
-          } else {
-            detail
-          },
+          git_failure_detail(tree_stderr, "failed to inspect Git review tree"),
         )
       }
       let comparison_metadata = tree_stdout.text() catch {
@@ -1146,13 +1090,10 @@ async fn git_changes_op(payload : GitChangesPayload) -> GitChangesReply {
     "rev-parse", "--show-prefix",
   ])
   guard prefix_code == 0 else {
-    let detail = (prefix_stderr.text() catch { _ => "" }).trim().to_owned()
     raise HostError(
-      if detail.is_empty() {
-        "failed to resolve Git workspace prefix"
-      } else {
-        detail
-      },
+      git_failure_detail(
+        prefix_stderr, "failed to resolve Git workspace prefix",
+      ),
     )
   }
   let workspace_prefix = git_single_line(
@@ -1238,18 +1179,9 @@ fn push_history_ref(
 
 ///|
 async fn git_history_upstream(dir : String) -> String? {
-  guard git_output_opt(dir, [
-      "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}",
-    ])
-    is Some(output) else {
-    return None
-  }
-  let upstream = git_single_line(output)
-  if upstream.is_empty() || upstream == "@{upstream}" {
-    None
-  } else {
-    Some(upstream)
-  }
+  git_line_opt(dir, [
+    "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}",
+  ]).filter(upstream => upstream != "@{upstream}")
 }
 
 ///|
@@ -1258,12 +1190,10 @@ async fn git_history_upstream(dir : String) -> String? {
 async fn git_history_default_ref(dir : String, upstream : String?) -> String? {
   if upstream is Some(upstream) && upstream.split_once("/") is Some((remote, _)) {
     let symbolic = "refs/remotes/\{remote}/HEAD"
-    if git_output_opt(dir, ["symbolic-ref", "--quiet", "--short", symbolic])
-      is Some(output) {
-      let name = git_single_line(output)
-      if !name.is_empty() && name != symbolic {
-        return Some(name)
-      }
+    if git_line_opt(dir, ["symbolic-ref", "--quiet", "--short", symbolic])
+      is Some(name) &&
+      name != symbolic {
+      return Some(name)
     }
   }
   git_base_ref(dir)
@@ -1275,18 +1205,7 @@ async fn capture_git_history_snapshot(
   review_base : String?,
 ) -> GitHistorySnapshot {
   let head = git_revision_commit(dir, "HEAD")
-  let branch = match
-    git_output_opt(dir, ["symbolic-ref", "--quiet", "--short", "HEAD"]) {
-    Some(output) => {
-      let name = git_single_line(output)
-      if name.is_empty() {
-        None
-      } else {
-        Some(name)
-      }
-    }
-    None => None
-  }
+  let branch = git_line_opt(dir, ["symbolic-ref", "--quiet", "--short", "HEAD"])
   let refs : Array[GitHistoryRef] = []
   let tips : Array[String] = []
   if head is Some(head) {
@@ -1408,14 +1327,7 @@ async fn git_history_page(
   args.push("--")
   let (code, stdout, stderr) = git_collect(dir, args)
   guard code == 0 else {
-    let detail = (stderr.text() catch { _ => "" }).trim().to_owned()
-    raise HostError(
-      if detail.is_empty() {
-        "failed to read Git history"
-      } else {
-        detail
-      },
-    )
+    raise HostError(git_failure_detail(stderr, "failed to read Git history"))
   }
   let raw = stdout.text() catch {
     _ => raise HostError("Git returned non-UTF-8 history metadata")
@@ -1488,13 +1400,8 @@ async fn git_tree_object_modes(
     "ls-tree", "-r", "--full-name", "-z", revision, "--", ".",
   ])
   guard code == 0 else {
-    let detail = (stderr.text() catch { _ => "" }).trim().to_owned()
     raise HostError(
-      if detail.is_empty() {
-        "failed to inspect Git commit tree"
-      } else {
-        detail
-      },
+      git_failure_detail(stderr, "failed to inspect Git commit tree"),
     )
   }
   let output = stdout.text() catch {
@@ -1538,13 +1445,8 @@ async fn git_commit_changes_at(
     base, commit, "--", ".",
   ])
   guard code == 0 else {
-    let detail = (stderr.text() catch { _ => "" }).trim().to_owned()
     raise HostError(
-      if detail.is_empty() {
-        "failed to read Git commit changes"
-      } else {
-        detail
-      },
+      git_failure_detail(stderr, "failed to read Git commit changes"),
     )
   }
   let raw = stdout.text() catch {
@@ -1602,13 +1504,10 @@ async fn git_commit_changes_op(
     "rev-parse", "--show-prefix",
   ])
   guard prefix_code == 0 else {
-    let detail = (prefix_stderr.text() catch { _ => "" }).trim().to_owned()
     raise HostError(
-      if detail.is_empty() {
-        "failed to resolve Git workspace prefix"
-      } else {
-        detail
-      },
+      git_failure_detail(
+        prefix_stderr, "failed to resolve Git workspace prefix",
+      ),
     )
   }
   let workspace_prefix = git_single_line(
@@ -1649,13 +1548,8 @@ async fn git_original_file_at(
     "cat-file", "-t", oid,
   ])
   guard type_code == 0 else {
-    let detail = (type_stderr.text() catch { _ => "" }).trim().to_owned()
     raise HostError(
-      if detail.is_empty() {
-        "failed to inspect Git baseline"
-      } else {
-        detail
-      },
+      git_failure_detail(type_stderr, "failed to inspect Git baseline"),
     )
   }
   let object_type = git_single_line(type_stdout.text() catch { _ => "" })
@@ -1666,13 +1560,8 @@ async fn git_original_file_at(
     "cat-file", "-s", oid,
   ])
   guard size_code == 0 else {
-    let detail = (size_stderr.text() catch { _ => "" }).trim().to_owned()
     raise HostError(
-      if detail.is_empty() {
-        "failed to size Git baseline"
-      } else {
-        detail
-      },
+      git_failure_detail(size_stderr, "failed to size Git baseline"),
     )
   }
   let size_text = git_single_line(size_stdout.text() catch { _ => "" })
@@ -1684,14 +1573,7 @@ async fn git_original_file_at(
   }
   let (content_code, content, stderr) = git_collect(dir, ["cat-file", "-p", oid])
   guard content_code == 0 else {
-    let detail = (stderr.text() catch { _ => "" }).trim().to_owned()
-    raise HostError(
-      if detail.is_empty() {
-        "failed to read Git baseline"
-      } else {
-        detail
-      },
-    )
+    raise HostError(git_failure_detail(stderr, "failed to read Git baseline"))
   }
   // Use the same content policy as working-tree reads so a tab cannot treat
   // its current file and Git baseline as different kinds of content.
@@ -2109,10 +1991,7 @@ async test "Git recognizes only origin HEAD's branch as the default" {
   git_test_run(dir, ["init", "--quiet"])
   @fs.write_file("\{dir}/tracked.txt", "first\n", create_mode=CreateOrTruncate)
   git_test_run(dir, ["add", "tracked.txt"])
-  git_test_run(dir, [
-    "-c", "user.name=OpenSeek Test", "-c", "user.email=openseek@example.invalid",
-    "-c", "commit.gpgSign=false", "commit", "--quiet", "-m", "first",
-  ])
+  git_test_commit(dir, "first")
   // A branch spelling alone proves nothing until the remote declares its
   // default. Once it does, only that exact name is suppressed from PR lookup.
   assert_false(git_is_default_branch(dir, branch="main"))
@@ -2131,10 +2010,7 @@ async test "ordinary checkout reviews retain committed branch changes" {
   git_test_run(dir, ["init", "--quiet"])
   @fs.write_file("\{dir}/review.txt", "first\n", create_mode=CreateOrTruncate)
   git_test_run(dir, ["add", "review.txt"])
-  git_test_run(dir, [
-    "-c", "user.name=OpenSeek Test", "-c", "user.email=openseek@example.invalid",
-    "-c", "commit.gpgSign=false", "commit", "--quiet", "-m", "first",
-  ])
+  git_test_commit(dir, "first")
   let first = git_revision_commit(dir, "HEAD").unwrap()
   git_test_run(dir, ["update-ref", "refs/remotes/origin/main", first])
   git_test_run(dir, [
@@ -2155,10 +2031,7 @@ async test "ordinary checkout reviews retain committed branch changes" {
     is [{ path: "review.txt", index_status: " ", worktree_status: "M", .. }],
   )
   git_test_run(dir, ["add", "review.txt"])
-  git_test_run(dir, [
-    "-c", "user.name=OpenSeek Test", "-c", "user.email=openseek@example.invalid",
-    "-c", "commit.gpgSign=false", "commit", "--quiet", "-m", "second",
-  ])
+  git_test_commit(dir, "second")
   let second = git_revision_commit(dir, "HEAD").unwrap()
   let (after_head, after_base, _, _, _, _, after_changes) = git_change_snapshot(
     dir,

--- a/desktop/internal/host/host.mbt
+++ b/desktop/internal/host/host.mbt
@@ -132,24 +132,9 @@ pub async fn HostConnection::run(
     group.spawn_bg(allow_failure=true, () => {
       @terminal.run_terminal_pump(self.terminal, async fn(push) {
         match push {
-          Output(id~, sequence~, data~) => {
-            let payload : TerminalOutputPayload = {
-              id,
-              sequence,
-              data: @base64.encode(data),
-            }
-            emit(
-              TerminalOutput({
-                id: payload.id,
-                sequence: payload.sequence,
-                data: payload.data,
-              }),
-            )
-          }
-          Exited(id~, code~) => {
-            let payload : TerminalExitPayload = { id, code, }
-            emit(TerminalExit({ id: payload.id, code: payload.code, }))
-          }
+          Output(id~, sequence~, data~) =>
+            emit(TerminalOutput({ id, sequence, data: @base64.encode(data), }))
+          Exited(id~, code~) => emit(TerminalExit({ id, code, }))
         }
       })
     })

--- a/desktop/internal/host/terminal_ops.mbt
+++ b/desktop/internal/host/terminal_ops.mbt
@@ -36,19 +36,6 @@ type TerminalAckPayload = @protocol.TerminalAckPayload
 type TerminalClosePayload = @protocol.TerminalClosePayload
 
 ///|
-priv struct TerminalOutputPayload {
-  id : String
-  sequence : Int
-  data : String
-}
-
-///|
-priv struct TerminalExitPayload {
-  id : String
-  code : Int
-}
-
-///|
 async fn terminal_open_op(
   state : HostState,
   terminals : @terminal.TerminalState,

--- a/desktop/internal/host/text_search.mbt
+++ b/desktop/internal/host/text_search.mbt
@@ -793,12 +793,18 @@ fn utf16_offset_for_byte(line : String, byte_offset : Int) -> Int? {
 }
 
 ///|
+/// Whether `offset` falls between the two halves of one surrogate pair.
+fn splits_surrogate_pair(text : String, offset : Int) -> Bool {
+  offset > 0 &&
+  offset < text.length() &&
+  text[offset - 1].to_int().is_leading_surrogate() &&
+  text[offset].to_int().is_trailing_surrogate()
+}
+
+///|
 fn safe_utf16_start(text : String, offset : Int) -> Int {
   let offset = offset.max(0).min(text.length())
-  if offset > 0 &&
-    offset < text.length() &&
-    text[offset - 1].to_int().is_leading_surrogate() &&
-    text[offset].to_int().is_trailing_surrogate() {
+  if splits_surrogate_pair(text, offset) {
     offset - 1
   } else {
     offset
@@ -808,10 +814,7 @@ fn safe_utf16_start(text : String, offset : Int) -> Int {
 ///|
 fn safe_utf16_end(text : String, offset : Int) -> Int {
   let offset = offset.max(0).min(text.length())
-  if offset > 0 &&
-    offset < text.length() &&
-    text[offset - 1].to_int().is_leading_surrogate() &&
-    text[offset].to_int().is_trailing_surrogate() {
+  if splits_surrogate_pair(text, offset) {
     offset + 1
   } else {
     offset
@@ -874,24 +877,18 @@ fn project_text_match(
 
 ///|
 fn text_search_diagnostic_line(detail : String, needle : String) -> String? {
-  for raw_line in detail.split("\n") {
-    let line = raw_line.trim().to_owned()
-    if line.to_lower().contains(needle) {
-      return Some(line)
-    }
-  }
-  None
+  detail
+  .split("\n")
+  .map(raw_line => raw_line.trim().to_owned())
+  .find_first(line => line.to_lower().contains(needle))
 }
 
 ///|
 fn text_search_first_diagnostic_line(detail : String) -> String? {
-  for raw_line in detail.split("\n") {
-    let line = raw_line.trim().to_owned()
-    if !line.is_empty() {
-      return Some(line)
-    }
-  }
-  None
+  detail
+  .split("\n")
+  .map(raw_line => raw_line.trim().to_owned())
+  .find_first(line => !line.is_empty())
 }
 
 ///|

--- a/desktop/internal/protocol/agent_payload_codec.mbt
+++ b/desktop/internal/protocol/agent_payload_codec.mbt
@@ -4,24 +4,13 @@
 // at their exact path instead of silently changing the engine configuration.
 
 ///|
-fn JsonObject::optional_thinking(
-  self : JsonObject,
-  name : String,
-) -> OpenSeekThinking? raise @json.JsonDecodeError {
-  match self.fields.get(name) {
-    Some(Null) | None => None
-    Some(value) => Some(@json.from_json(value, path=self.path.add_key(name)))
-  }
-}
-
-///|
 pub impl FromJson for StartPayload with fn from_json(json, path) {
   let object = JsonObject::decode(json, path, "agent.start payload")
   {
     task: object.required_string("task"),
     submission_id: object.optional_string("submission_id"),
     model: object.optional_string("model"),
-    thinking: object.optional_thinking("thinking"),
+    thinking: object.optional_of("thinking"),
     max_steps: object.optional_int("max_steps"),
     session: object.required_string("session"),
     workspace: object.optional_string("workspace"),
@@ -34,21 +23,11 @@ pub impl ToJson for StartPayload with fn to_json(self) {
     "task": self.task.to_json(),
     "session": self.session.to_json(),
   }
-  if self.submission_id is Some(submission_id) {
-    fields["submission_id"] = submission_id.to_json()
-  }
-  if self.model is Some(model) {
-    fields["model"] = model.to_json()
-  }
-  if self.thinking is Some(thinking) {
-    fields["thinking"] = thinking.to_json()
-  }
-  if self.max_steps is Some(max_steps) {
-    fields["max_steps"] = max_steps.to_json()
-  }
-  if self.workspace is Some(workspace) {
-    fields["workspace"] = workspace.to_json()
-  }
+  set_optional(fields, "submission_id", self.submission_id)
+  set_optional(fields, "model", self.model)
+  set_optional(fields, "thinking", self.thinking)
+  set_optional(fields, "max_steps", self.max_steps)
+  set_optional(fields, "workspace", self.workspace)
   Json(fields)
 }
 
@@ -101,7 +80,7 @@ pub impl FromJson for CompactPayload with fn from_json(json, path) {
   {
     session: object.required_string("session"),
     model: object.optional_string("model"),
-    thinking: object.optional_thinking("thinking"),
+    thinking: object.optional_of("thinking"),
     max_steps: object.optional_int("max_steps"),
     workspace: object.optional_string("workspace"),
   }
@@ -110,18 +89,10 @@ pub impl FromJson for CompactPayload with fn from_json(json, path) {
 ///|
 pub impl ToJson for CompactPayload with fn to_json(self) {
   let fields : Map[String, Json] = { "session": self.session.to_json() }
-  if self.model is Some(model) {
-    fields["model"] = model.to_json()
-  }
-  if self.thinking is Some(thinking) {
-    fields["thinking"] = thinking.to_json()
-  }
-  if self.max_steps is Some(max_steps) {
-    fields["max_steps"] = max_steps.to_json()
-  }
-  if self.workspace is Some(workspace) {
-    fields["workspace"] = workspace.to_json()
-  }
+  set_optional(fields, "model", self.model)
+  set_optional(fields, "thinking", self.thinking)
+  set_optional(fields, "max_steps", self.max_steps)
+  set_optional(fields, "workspace", self.workspace)
   Json(fields)
 }
 
@@ -133,7 +104,7 @@ pub impl FromJson for GoalPayload with fn from_json(json, path) {
     text: object.optional_string("text"),
     auto: object.optional_bool("auto"),
     model: object.optional_string("model"),
-    thinking: object.optional_thinking("thinking"),
+    thinking: object.optional_of("thinking"),
     max_steps: object.optional_int("max_steps"),
     workspace: object.optional_string("workspace"),
   }
@@ -142,24 +113,12 @@ pub impl FromJson for GoalPayload with fn from_json(json, path) {
 ///|
 pub impl ToJson for GoalPayload with fn to_json(self) {
   let fields : Map[String, Json] = { "session": self.session.to_json() }
-  if self.text is Some(text) {
-    fields["text"] = text.to_json()
-  }
-  if self.auto is Some(auto) {
-    fields["auto"] = auto.to_json()
-  }
-  if self.model is Some(model) {
-    fields["model"] = model.to_json()
-  }
-  if self.thinking is Some(thinking) {
-    fields["thinking"] = thinking.to_json()
-  }
-  if self.max_steps is Some(max_steps) {
-    fields["max_steps"] = max_steps.to_json()
-  }
-  if self.workspace is Some(workspace) {
-    fields["workspace"] = workspace.to_json()
-  }
+  set_optional(fields, "text", self.text)
+  set_optional(fields, "auto", self.auto)
+  set_optional(fields, "model", self.model)
+  set_optional(fields, "thinking", self.thinking)
+  set_optional(fields, "max_steps", self.max_steps)
+  set_optional(fields, "workspace", self.workspace)
   Json(fields)
 }
 
@@ -204,9 +163,7 @@ pub impl ToJson for ApprovalPayload with fn to_json(self) {
     "id": self.id.to_json(),
     "allow": self.allow.to_json(),
   }
-  if self.run_id is Some(run_id) {
-    fields["run_id"] = run_id.to_json()
-  }
+  set_optional(fields, "run_id", self.run_id)
   Json(fields)
 }
 
@@ -237,31 +194,22 @@ pub impl ToJson for ApprovalReply with fn to_json(self) {
 /// with nothing in flight sends.
 pub impl FromJson for RunsReply with fn from_json(json, path) {
   let object = JsonObject::decode(json, path, "agent.runs reply")
-  let runs : Array[StartedPayload] = []
-  for index, raw in object.required_array("runs") {
-    runs.push(@json.from_json(raw, path=path.add_key("runs").add_index(index)))
-  }
-  let settled : Array[RunSettlementPayload] = []
-  for index, raw in object.required_array("settled") {
-    settled.push(
-      @json.from_json(raw, path=path.add_key("settled").add_index(index)),
-    )
-  }
-  let approvals : Array[PendingApprovalPayload] = []
-  for index, raw in object.required_array("approvals") {
-    approvals.push(
-      @json.from_json(raw, path=path.add_key("approvals").add_index(index)),
-    )
-  }
+  let runs : Array[StartedPayload] = object.required_array_of("runs")
+  let settled : Array[RunSettlementPayload] = object.required_array_of(
+    "settled",
+  )
+  let approvals : Array[PendingApprovalPayload] = object.required_array_of(
+    "approvals",
+  )
   { runs, settled, approvals, }
 }
 
 ///|
 pub impl ToJson for RunsReply with fn to_json(self) {
   {
-    "runs": Json(self.runs.map(run => run.to_json())),
-    "settled": Json(self.settled.map(entry => entry.to_json())),
-    "approvals": Json(self.approvals.map(approval => approval.to_json())),
+    "runs": self.runs.to_json(),
+    "settled": self.settled.to_json(),
+    "approvals": self.approvals.to_json(),
   }
 }
 
@@ -291,11 +239,7 @@ pub impl ToJson for PendingApprovalPayload with fn to_json(self) {
     "tool_name": self.tool_name.to_json(),
     "detail": self.detail.to_json(),
   }
-  if self.run_id is Some(run_id) {
-    fields["run_id"] = run_id.to_json()
-  }
-  if self.body is Some(body) {
-    fields["body"] = body.to_json()
-  }
+  set_optional(fields, "run_id", self.run_id)
+  set_optional(fields, "body", self.body)
   Json(fields)
 }

--- a/desktop/internal/protocol/codex_commands.mbt
+++ b/desktop/internal/protocol/codex_commands.mbt
@@ -386,25 +386,16 @@ pub impl FromJson for CodexThreadStartPayload with fn from_json(json, path) {
     cwd: object.optional_string("cwd"),
     model: object.optional_string("model"),
     draft_id: object.optional_string("openseekDraftId"),
-    permission_mode: @json.from_json(
-      object.required_json("permissionMode"),
-      path=path.add_key("permissionMode"),
-    ),
+    permission_mode: object.required_of("permissionMode"),
   }
 }
 
 ///|
 pub impl ToJson for CodexThreadStartPayload with fn to_json(self) {
   let fields : Map[String, Json] = Map([])
-  if self.cwd is Some(cwd) {
-    fields["cwd"] = Json(cwd)
-  }
-  if self.model is Some(model) {
-    fields["model"] = Json(model)
-  }
-  if self.draft_id is Some(draft_id) {
-    fields["openseekDraftId"] = Json(draft_id)
-  }
+  set_optional(fields, "cwd", self.cwd)
+  set_optional(fields, "model", self.model)
+  set_optional(fields, "openseekDraftId", self.draft_id)
   fields["permissionMode"] = ToJson::to_json(self.permission_mode)
   Json(fields)
 }
@@ -425,10 +416,7 @@ pub impl FromJson for CodexThreadResumePayload with fn from_json(json, path) {
   let object = JsonObject::decode(json, path, "Codex thread resume payload")
   {
     thread_id: object.required_string("threadId"),
-    permission_mode: @json.from_json(
-      object.required_json("permissionMode"),
-      path=path.add_key("permissionMode"),
-    ),
+    permission_mode: object.required_of("permissionMode"),
   }
 }
 
@@ -452,9 +440,7 @@ pub impl FromJson for CodexThreadReadPayload with fn from_json(json, path) {
 ///|
 pub impl ToJson for CodexThreadReadPayload with fn to_json(self) {
   let fields : Map[String, Json] = { "threadId": Json(self.thread_id) }
-  if self.include_turns is Some(include_turns) {
-    fields["includeTurns"] = Json(include_turns)
-  }
+  set_optional(fields, "includeTurns", self.include_turns)
   Json(fields)
 }
 
@@ -474,9 +460,7 @@ pub impl ToJson for CodexThreadListPayload with fn to_json(self) {
     "limit": Json(self.limit.to_double()),
     "archived": Json(self.archived),
   }
-  if self.cursor is Some(cursor) {
-    fields["cursor"] = Json(cursor)
-  }
+  set_optional(fields, "cursor", self.cursor)
   Json(fields)
 }
 
@@ -510,10 +494,7 @@ pub impl FromJson for CodexReviewStartPayload with fn from_json(json, path) {
   let object = JsonObject::decode(json, path, "Codex review start payload")
   {
     thread_id: object.required_string("threadId"),
-    target: @json.from_json(
-      object.required_json("target"),
-      path=path.add_key("target"),
-    ),
+    target: object.required_of("target"),
   }
 }
 
@@ -531,10 +512,7 @@ pub impl FromJson for CodexTurnStartPayload with fn from_json(json, path) {
     model: object.optional_string("model"),
     effort: object.optional_string("effort"),
     cwd: object.optional_string("cwd"),
-    permission_mode: @json.from_json(
-      object.required_json("permissionMode"),
-      path=path.add_key("permissionMode"),
-    ),
+    permission_mode: object.required_of("permissionMode"),
   }
 }
 
@@ -544,15 +522,9 @@ pub impl ToJson for CodexTurnStartPayload with fn to_json(self) {
     "threadId": Json(self.thread_id),
     "input": Json(self.input),
   }
-  if self.model is Some(model) {
-    fields["model"] = Json(model)
-  }
-  if self.effort is Some(effort) {
-    fields["effort"] = Json(effort)
-  }
-  if self.cwd is Some(cwd) {
-    fields["cwd"] = Json(cwd)
-  }
+  set_optional(fields, "model", self.model)
+  set_optional(fields, "effort", self.effort)
+  set_optional(fields, "cwd", self.cwd)
   fields["permissionMode"] = ToJson::to_json(self.permission_mode)
   Json(fields)
 }
@@ -602,9 +574,7 @@ pub impl FromJson for CodexStatusReply with fn from_json(json, path) {
 ///|
 pub impl ToJson for CodexStatusReply with fn to_json(self) {
   let fields : Map[String, Json] = { "status": Json(self.status) }
-  if self.message is Some(message) {
-    fields["message"] = Json(message)
-  }
+  set_optional(fields, "message", self.message)
   Json(fields)
 }
 
@@ -639,9 +609,7 @@ pub impl FromJson for CodexDataReply with fn from_json(json, path) {
 ///|
 pub impl ToJson for CodexDataReply with fn to_json(self) {
   let fields : Map[String, Json] = { "data": Json(self.data) }
-  if self.next_cursor is Some(next_cursor) {
-    fields["nextCursor"] = Json(next_cursor)
-  }
+  set_optional(fields, "nextCursor", self.next_cursor)
   Json(fields)
 }
 
@@ -673,9 +641,7 @@ pub impl ToJson for CodexAccountReply with fn to_json(self) {
   let fields : Map[String, Json] = {
     "requiresOpenaiAuth": Json(self.requires_openai_auth),
   }
-  if self.account is Some(account) {
-    fields["account"] = account
-  }
+  set_optional(fields, "account", self.account)
   Json(fields)
 }
 
@@ -740,12 +706,8 @@ pub impl FromJson for CodexTurnReply with fn from_json(json, path) {
 ///|
 pub impl ToJson for CodexTurnReply with fn to_json(self) {
   let fields : Map[String, Json] = Map([])
-  if self.turn is Some(turn) {
-    fields["turn"] = turn
-  }
-  if self.turn_id is Some(turn_id) {
-    fields["turnId"] = Json(turn_id)
-  }
+  set_optional(fields, "turn", self.turn)
+  set_optional(fields, "turnId", self.turn_id)
   Json(fields)
 }
 

--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -233,27 +233,13 @@ pub impl FromJson for SettingsSetPayload with fn from_json(json, path) {
 ///|
 pub impl ToJson for SettingsSetPayload with fn to_json(self) {
   let fields : Map[String, Json] = Map([])
-  if self.legacy_migration is Some(value) {
-    fields["legacy_migration"] = value.to_json()
-  }
-  if self.provider is Some(value) {
-    fields["provider"] = value.to_json()
-  }
-  if self.custom_api_url is Some(value) {
-    fields["custom_api_url"] = value.to_json()
-  }
-  if self.deepseek_api_key is Some(value) {
-    fields["deepseek_api_key"] = value.to_json()
-  }
-  if self.glm_api_key is Some(value) {
-    fields["glm_api_key"] = value.to_json()
-  }
-  if self.followup_behavior is Some(value) {
-    fields["followup_behavior"] = value.to_json()
-  }
-  if self.custom_api_key is Some(value) {
-    fields["custom_api_key"] = value.to_json()
-  }
+  set_optional(fields, "legacy_migration", self.legacy_migration)
+  set_optional(fields, "provider", self.provider)
+  set_optional(fields, "custom_api_url", self.custom_api_url)
+  set_optional(fields, "deepseek_api_key", self.deepseek_api_key)
+  set_optional(fields, "glm_api_key", self.glm_api_key)
+  set_optional(fields, "followup_behavior", self.followup_behavior)
+  set_optional(fields, "custom_api_key", self.custom_api_key)
   Json(fields)
 }
 
@@ -301,12 +287,8 @@ pub impl FromJson for WorktreeCreatePayload with fn from_json(json, path) {
 ///|
 pub impl ToJson for WorktreeCreatePayload with fn to_json(self) {
   let fields : Map[String, Json] = { "workspace": Json(self.workspace) }
-  if self.session is Some(session) {
-    fields["session"] = Json(session)
-  }
-  if self.codex_thread is Some(codex_thread) {
-    fields["codex_thread"] = Json(codex_thread)
-  }
+  set_optional(fields, "session", self.session)
+  set_optional(fields, "codex_thread", self.codex_thread)
   Json(fields)
 }
 
@@ -376,12 +358,8 @@ pub impl FromJson for GitPullRequestPayload with fn from_json(json, path) {
 ///|
 pub impl ToJson for GitPullRequestPayload with fn to_json(self) {
   let fields : Map[String, Json] = { "session": Json(self.session) }
-  if self.cwd is Some(cwd) {
-    fields["cwd"] = Json(cwd)
-  }
-  if self.branch_hint is Some(branch_hint) {
-    fields["branch_hint"] = Json(branch_hint)
-  }
+  set_optional(fields, "cwd", self.cwd)
+  set_optional(fields, "branch_hint", self.branch_hint)
   Json(fields)
 }
 
@@ -656,12 +634,8 @@ pub impl FromJson for TerminalInputPayload with fn from_json(json, path) {
 ///|
 pub impl ToJson for TerminalInputPayload with fn to_json(self) {
   let fields : Map[String, Json] = { "id": self.id.to_json() }
-  if self.data is Some(data) {
-    fields["data"] = data.to_json()
-  }
-  if self.data_base64 is Some(data_base64) {
-    fields["data_base64"] = data_base64.to_json()
-  }
+  set_optional(fields, "data", self.data)
+  set_optional(fields, "data_base64", self.data_base64)
   Json::object(fields)
 }
 
@@ -942,10 +916,7 @@ pub impl FromJson for ConnectedPayload with fn from_json(json, path) {
   guard json is Object(fields) else {
     raise JsonDecodeError((path, "expected connected payload"))
   }
-  guard fields.get("stage") is Some(stage) else {
-    raise JsonDecodeError((path.add_key("stage"), "missing required field"))
-  }
-  { stage: @json.from_json(stage, path=path.add_key("stage")), }
+  { stage: JsonObject::of(fields, path).required_of("stage"), }
 }
 
 ///|
@@ -1011,12 +982,8 @@ pub(all) struct FinishedPayload {
 ///|
 pub impl ToJson for FinishedPayload with fn to_json(self) {
   let fields = { "run_id": Json(self.run_id), "status": Json(self.status) }
-  if self.answer is Some(answer) {
-    fields["answer"] = Json(answer)
-  }
-  if self.exit_code is Some(exit_code) {
-    fields["exit_code"] = Json(exit_code.to_double())
-  }
+  set_optional(fields, "answer", self.answer)
+  set_optional(fields, "exit_code", self.exit_code)
   Json(fields)
 }
 
@@ -1186,9 +1153,7 @@ pub impl ToJson for SettingsStatusPayload with fn to_json(self) {
     "has_custom_key": self.has_custom_key.to_json(),
     "followup_behavior": self.followup_behavior.to_json(),
   }
-  if self.custom_api_url is Some(value) {
-    fields["custom_api_url"] = value.to_json()
-  }
+  set_optional(fields, "custom_api_url", self.custom_api_url)
   Json(fields)
 }
 

--- a/desktop/internal/protocol/desktop_replies.mbt
+++ b/desktop/internal/protocol/desktop_replies.mbt
@@ -75,9 +75,7 @@ pub(all) struct CancelReply {
 /// same thing as one that inspects its value.
 pub impl ToJson for CancelReply with fn to_json(self) {
   let fields : Map[String, Json] = Map([])
-  if self.run_id is Some(run_id) {
-    fields["run_id"] = Json(run_id)
-  }
+  set_optional(fields, "run_id", self.run_id)
   Json(fields)
 }
 
@@ -90,12 +88,7 @@ pub impl FromJson for CancelReply with fn from_json(json, path) {
   guard json is Object(fields) else {
     raise JsonDecodeError((path, "expected a cancel reply"))
   }
-  {
-    run_id: match fields.get("run_id") {
-      Some(String(run_id)) => Some(run_id)
-      _ => None
-    },
-  }
+  { run_id: lenient_string(fields, "run_id"), }
 }
 
 ///|
@@ -165,12 +158,8 @@ pub impl ToJson for RunSettlementPayload with fn to_json(self) {
     "session": Json(self.session),
     "status": Json(self.status),
   }
-  if self.submission_id is Some(submission_id) {
-    fields["submission_id"] = Json(submission_id)
-  }
-  if self.exit_code is Some(exit_code) {
-    fields["exit_code"] = Json(exit_code.to_double())
-  }
+  set_optional(fields, "submission_id", self.submission_id)
+  set_optional(fields, "exit_code", self.exit_code)
   Json(fields)
 }
 
@@ -244,10 +233,7 @@ pub impl FromJson for SessionListEntry with fn from_json(json, path) {
   guard json is Object(fields) else {
     raise JsonDecodeError((path, "session list entry must be an object"))
   }
-  let title = match fields.get("title") {
-    Some(String(title)) => Some(title)
-    _ => None
-  }
+  let title = lenient_string(fields, "title")
   let updated_at_ms = match fields.get("updated_at_ms") {
     Some(Number(value, ..)) => Some(value)
     _ => None
@@ -379,9 +365,7 @@ pub(all) struct SessionUserMessage {
 /// held before the field existed.
 pub impl ToJson for SessionUserMessage with fn to_json(self) {
   let fields = { "content": Json(self.content) }
-  if self.submission_id is Some(submission_id) {
-    fields["submission_id"] = Json(submission_id)
-  }
+  set_optional(fields, "submission_id", self.submission_id)
   Json(fields)
 }
 
@@ -403,11 +387,7 @@ pub impl FromJson for SessionUserMessage with fn from_json(json, path) {
   guard fields.get("content") is Some(String(content)) else {
     raise JsonDecodeError((path.add_key("content"), "expected message content"))
   }
-  let submission_id = if fields.get("submission_id") is Some(String(value)) {
-    Some(value)
-  } else {
-    None
-  }
+  let submission_id = lenient_string(fields, "submission_id")
   { content, submission_id, }
 }
 
@@ -424,15 +404,9 @@ pub(all) struct SessionAssistantMessage {
 /// rather than null, and replay provenance appears only on checkpoint copies.
 pub impl ToJson for SessionAssistantMessage with fn to_json(self) {
   let fields = { "content": Json(self.content) }
-  if self.tool_calls is Some(tool_calls) {
-    fields["tool_calls"] = ToJson::to_json(tool_calls)
-  }
-  if self.reasoning_content is Some(reasoning_content) {
-    fields["reasoning_content"] = Json(reasoning_content)
-  }
-  if self.is_replay is Some(is_replay) {
-    fields["is_replay"] = Json(is_replay)
-  }
+  set_optional(fields, "tool_calls", self.tool_calls)
+  set_optional(fields, "reasoning_content", self.reasoning_content)
+  set_optional(fields, "is_replay", self.is_replay)
   Json(fields)
 }
 
@@ -452,12 +426,7 @@ pub impl FromJson for SessionAssistantMessage with fn from_json(json, path) {
     None | Some(Null) => None
     Some(value) => Some(@json.from_json(value, path=path.add_key("tool_calls")))
   }
-  let reasoning_content = if fields.get("reasoning_content")
-    is Some(String(value)) {
-    Some(value)
-  } else {
-    None
-  }
+  let reasoning_content = lenient_string(fields, "reasoning_content")
   let is_replay = match fields.get("is_replay") {
     Some(True) => Some(true)
     Some(False) => Some(false)
@@ -486,9 +455,7 @@ pub impl ToJson for SessionToolResult with fn to_json(self) {
     "content": Json(self.content),
     "is_error": Json(self.is_error),
   }
-  if self.brief is Some(brief) {
-    fields["brief"] = Json(brief)
-  }
+  set_optional(fields, "brief", self.brief)
   Json(fields)
 }
 
@@ -526,11 +493,7 @@ pub impl FromJson for SessionToolResult with fn from_json(json, path) {
         (path.add_key("is_error"), "expected tool result error flag"),
       )
   }
-  let brief = if fields.get("brief") is Some(String(value)) {
-    Some(value)
-  } else {
-    None
-  }
+  let brief = lenient_string(fields, "brief")
   { tool_call_id, tool_name, content, is_error, brief, }
 }
 
@@ -712,9 +675,7 @@ pub impl FromJson for SessionExportReply with fn from_json(json, path) {
 /// optional Desktop reply fields.
 pub impl ToJson for SessionExportReply with fn to_json(self) {
   let fields : Map[String, Json] = { "opened": Json(self.opened) }
-  if self.path is Some(path) {
-    fields["path"] = Json(path)
-  }
+  set_optional(fields, "path", self.path)
   Json(fields)
 }
 
@@ -788,7 +749,6 @@ pub impl FromJson for WorktreeInfo with fn from_json(json, path) {
       (path, "worktree cannot belong to both session and codex_thread"),
     )
   }
-  let object = JsonObject::of(fields, path)
   let checkout_path = object.required_string("path")
   let present = object.required_bool("present")
   { name, branch, base, session, codex_thread, path: checkout_path, present, }
@@ -803,12 +763,8 @@ pub impl ToJson for WorktreeInfo with fn to_json(self) {
     "path": Json(self.path),
     "present": Json(self.present),
   }
-  if self.session is Some(session) {
-    fields["session"] = Json(session)
-  }
-  if self.codex_thread is Some(thread_id) {
-    fields["codex_thread"] = Json(thread_id)
-  }
+  set_optional(fields, "session", self.session)
+  set_optional(fields, "codex_thread", self.codex_thread)
   Json(fields)
 }
 
@@ -1487,10 +1443,7 @@ pub impl FromJson for FileStat with fn from_json(json, path) {
   let object = JsonObject::decode(json, path, "file stat")
   {
     path: object.required_string("path"),
-    signature: @json.from_json(
-      object.required_json("signature"),
-      path=path.add_key("signature"),
-    ),
+    signature: object.required_of("signature"),
   }
 }
 
@@ -1534,9 +1487,7 @@ pub impl ToJson for BrowseDirectoryReply with fn to_json(self) {
         "path": path.to_json(),
         "entries": entries.to_json(),
       }
-      if parent is Some(parent) {
-        fields["parent"] = parent.to_json()
-      }
+      set_optional(fields, "parent", parent)
       Json(fields)
     }
     Drives(entries~) => { "drives": entries.to_json() }
@@ -1742,10 +1693,7 @@ pub impl FromJson for CheckUpdateReply with fn from_json(json, path) {
         Some(False) => false
         _ => raise JsonDecodeError((path, "malformed available update"))
       }
-      let unavailable_reason = match fields.get("unavailable_reason") {
-        Some(String(reason)) => Some(reason)
-        _ => None
-      }
+      let unavailable_reason = lenient_string(fields, "unavailable_reason")
       Available(version~, installable~, unavailable_reason~)
     }
     "unreachable" => {

--- a/desktop/internal/protocol/git_protocol_codec.mbt
+++ b/desktop/internal/protocol/git_protocol_codec.mbt
@@ -5,10 +5,7 @@
 ///|
 pub impl FromJson for GitHistoryPayload with fn from_json(json, path) {
   let object = JsonObject::decode(json, path, "Git history payload")
-  let snapshot = match object.optional_json("snapshot") {
-    Some(raw) => Some(@json.from_json(raw, path=path.add_key("snapshot")))
-    None => None
-  }
+  let snapshot : GitHistorySnapshot? = object.optional_of("snapshot")
   {
     session: object.required_string("session"),
     workspace: object.optional_string("workspace"),
@@ -25,12 +22,8 @@ pub impl ToJson for GitHistoryPayload with fn to_json(self) {
     "skip": self.skip.to_json(),
     "limit": self.limit.to_json(),
   }
-  if self.workspace is Some(workspace) {
-    fields["workspace"] = workspace.to_json()
-  }
-  if self.snapshot is Some(snapshot) {
-    fields["snapshot"] = ToJson::to_json(snapshot)
-  }
+  set_optional(fields, "workspace", self.workspace)
+  set_optional(fields, "snapshot", self.snapshot)
   Json(fields)
 }
 
@@ -50,9 +43,7 @@ pub impl ToJson for GitCommitChangesPayload with fn to_json(self) {
     "session": self.session.to_json(),
     "commit": self.commit.to_json(),
   }
-  if self.workspace is Some(workspace) {
-    fields["workspace"] = workspace.to_json()
-  }
+  set_optional(fields, "workspace", self.workspace)
   Json(fields)
 }
 
@@ -89,12 +80,8 @@ pub impl ToJson for GitHistorySnapshot with fn to_json(self) {
     "refs": self.refs.to_json(),
     "tips": self.tips.to_json(),
   }
-  if self.head is Some(head) {
-    fields["head"] = head.to_json()
-  }
-  if self.branch is Some(branch) {
-    fields["branch"] = branch.to_json()
-  }
+  set_optional(fields, "head", self.head)
+  set_optional(fields, "branch", self.branch)
   Json(fields)
 }
 
@@ -124,10 +111,7 @@ pub impl ToJson for GitHistoryCommit with fn to_json(self) {
 ///|
 pub impl FromJson for GitHistoryReply with fn from_json(json, path) {
   let object = JsonObject::decode(json, path, "Git history reply")
-  let snapshot : GitHistorySnapshot = @json.from_json(
-    object.required_json("snapshot"),
-    path=path.add_key("snapshot"),
-  )
+  let snapshot : GitHistorySnapshot = object.required_of("snapshot")
   let commits : Array[GitHistoryCommit] = object.required_array_of("commits")
   {
     repository: object.required_bool("repository"),
@@ -165,9 +149,7 @@ pub impl ToJson for GitHistoricalChange with fn to_json(self) {
     "status": self.status.to_json(),
     "kind": self.kind.to_json(),
   }
-  if self.original_path is Some(original_path) {
-    fields["original_path"] = original_path.to_json()
-  }
+  set_optional(fields, "original_path", self.original_path)
   Json(fields)
 }
 
@@ -188,8 +170,6 @@ pub impl ToJson for GitCommitChangesReply with fn to_json(self) {
     "commit": self.commit.to_json(),
     "changes": self.changes.to_json(),
   }
-  if self.parent is Some(parent) {
-    fields["parent"] = parent.to_json()
-  }
+  set_optional(fields, "parent", self.parent)
   Json(fields)
 }

--- a/desktop/internal/protocol/json_object.mbt
+++ b/desktop/internal/protocol/json_object.mbt
@@ -42,6 +42,20 @@ fn JsonObject::of(
 }
 
 ///|
+/// Write `value` under `name` only when it is present. Every Desktop encoder
+/// omits an absent optional instead of writing `null`; each field used to
+/// spell that rule out in three lines of its own.
+fn[T : ToJson] set_optional(
+  fields : Map[String, Json],
+  name : String,
+  value : T?,
+) -> Unit {
+  if value is Some(value) {
+    fields[name] = Json(value)
+  }
+}
+
+///|
 /// A tolerant optional read: a wrong-typed value reads as absent instead of
 /// refusing the whole payload, which is what the lifecycle readers want — a
 /// report must not disappear because one display field is malformed. The
@@ -79,6 +93,26 @@ fn JsonObject::optional_json(self : JsonObject, name : String) -> Json? {
     Some(Null) | None => None
     Some(value) => Some(value)
   }
+}
+
+///|
+/// The value at `name`, decoded into `T` with the failing path naming the
+/// field — the scalar sibling of `required_array_of`.
+fn[T : @json.FromJson] JsonObject::required_of(
+  self : JsonObject,
+  name : String,
+) -> T raise @json.JsonDecodeError {
+  @json.from_json(self.required_json(name), path=self.path.add_key(name))
+}
+
+///|
+/// `required_of` for a field that may be absent or explicitly null.
+fn[T : @json.FromJson] JsonObject::optional_of(
+  self : JsonObject,
+  name : String,
+) -> T? raise @json.JsonDecodeError {
+  guard self.optional_json(name) is Some(value) else { return None }
+  Some(@json.from_json(value, path=self.path.add_key(name)))
 }
 
 ///|
@@ -137,7 +171,7 @@ fn JsonObject::required_int(
   self : JsonObject,
   name : String,
 ) -> Int raise @json.JsonDecodeError {
-  @json.from_json(self.required_json(name), path=self.path.add_key(name))
+  self.required_of(name)
 }
 
 ///|
@@ -145,8 +179,7 @@ fn JsonObject::optional_int(
   self : JsonObject,
   name : String,
 ) -> Int? raise @json.JsonDecodeError {
-  guard self.optional_json(name) is Some(value) else { return None }
-  Some(@json.from_json(value, path=self.path.add_key(name)))
+  self.optional_of(name)
 }
 
 ///|

--- a/desktop/internal/protocol/semantic_search_codec.mbt
+++ b/desktop/internal/protocol/semantic_search_codec.mbt
@@ -7,27 +7,19 @@
 //|
 
 ///|
-fn sem_one_based_line(
-  value : Int,
-  path : @json.JsonPath,
+/// A one-based coordinate, refused at the field's own path. `noun` names what
+/// the field is — "line" or "column" — which is all the two spellings of this
+/// check ever differed by.
+fn JsonObject::required_one_based(
+  self : JsonObject,
   name : String,
+  noun : String,
 ) -> Int raise @json.JsonDecodeError {
+  let value = self.required_int(name)
   if value < 1 {
-    raise JsonDecodeError((path.add_key(name), "expected one-based line"))
-  }
-  value
-}
-
-//|
-
-///|
-fn sem_one_based_column(
-  value : Int,
-  path : @json.JsonPath,
-  name : String,
-) -> Int raise @json.JsonDecodeError {
-  if value < 1 {
-    raise JsonDecodeError((path.add_key(name), "expected one-based column"))
+    raise JsonDecodeError(
+      (self.path.add_key(name), "expected one-based " + noun),
+    )
   }
   value
 }
@@ -43,14 +35,8 @@ pub impl FromJson for SearchSemanticPayload with fn from_json(json, path) {
     include_glob: object.required_string("include_glob"),
     exclude_glob: object.required_string("exclude_glob"),
     session_key: object.required_string("session_key"),
-    generation: require_text_search_non_negative(
-      object.required_int("generation"),
-      path.add_key("generation"),
-    ),
-    max_results: require_text_search_non_negative(
-      object.required_int("max_results"),
-      path.add_key("max_results"),
-    ),
+    generation: object.required_non_negative_int("generation"),
+    max_results: object.required_non_negative_int("max_results"),
   }
 }
 
@@ -78,10 +64,7 @@ pub impl FromJson for CancelSearchSemanticPayload with fn from_json(json, path) 
   )
   {
     session_key: object.required_string("session_key"),
-    generation: require_text_search_non_negative(
-      object.required_int("generation"),
-      path.add_key("generation"),
-    ),
+    generation: object.required_non_negative_int("generation"),
   }
 }
 
@@ -97,7 +80,7 @@ pub impl ToJson for CancelSearchSemanticPayload with fn to_json(self) {
 ///|
 pub impl FromJson for SemanticContextLine with fn from_json(json, path) {
   let object = JsonObject::decode(json, path, "semantic-search context line")
-  let line = sem_one_based_line(object.required_int("line"), path, "line")
+  let line = object.required_one_based("line", "line")
   {
     line,
     text: object.required_string("text"),
@@ -117,26 +100,10 @@ pub impl ToJson for SemanticContextLine with fn to_json(self) {
 ///|
 pub impl FromJson for SemanticSearchHit with fn from_json(json, path) {
   let object = JsonObject::decode(json, path, "semantic-search hit")
-  let start_line = sem_one_based_line(
-    object.required_int("start_line"),
-    path,
-    "start_line",
-  )
-  let start_column = sem_one_based_column(
-    object.required_int("start_column"),
-    path,
-    "start_column",
-  )
-  let end_line = sem_one_based_line(
-    object.required_int("end_line"),
-    path,
-    "end_line",
-  )
-  let end_column = sem_one_based_column(
-    object.required_int("end_column"),
-    path,
-    "end_column",
-  )
+  let start_line = object.required_one_based("start_line", "line")
+  let start_column = object.required_one_based("start_column", "column")
+  let end_line = object.required_one_based("end_line", "line")
+  let end_column = object.required_one_based("end_column", "column")
   if end_line < start_line ||
     (end_line == start_line && end_column < start_column) {
     raise JsonDecodeError((path, "semantic-search hit range must be forward"))
@@ -144,14 +111,7 @@ pub impl FromJson for SemanticSearchHit with fn from_json(json, path) {
   let context : Array[SemanticContextLine] = object.required_array_of(
     "source_context",
   )
-  let description = match object.fields.get("description") {
-    Some(String(value)) => Some(value)
-    Some(Null) | None => None
-    Some(_) =>
-      raise JsonDecodeError(
-        (path.add_key("description"), "expected string or null"),
-      )
-  }
+  let description = object.optional_string("description")
   {
     path: object.required_string("path"),
     rule_id: object.required_string("rule_id"),
@@ -179,9 +139,7 @@ pub impl ToJson for SemanticSearchHit with fn to_json(self) {
     "matched_source": self.matched_source.to_json(),
     "source_context": self.source_context.to_json(),
   }
-  if self.description is Some(description) {
-    fields["description"] = description.to_json()
-  }
+  set_optional(fields, "description", self.description)
   Json(fields)
 }
 
@@ -216,41 +174,13 @@ pub impl ToJson for SemanticSearchError with fn to_json(self) {
 ///|
 pub impl FromJson for SearchSemanticReply with fn from_json(json, path) {
   let object = JsonObject::decode(json, path, "semantic-search reply")
-  let generation = require_text_search_non_negative(
-    object.required_int("generation"),
-    path.add_key("generation"),
-  )
-  let match_count = require_text_search_non_negative(
-    object.required_int("match_count"),
-    path.add_key("match_count"),
-  )
-  let file_count = require_text_search_non_negative(
-    object.required_int("file_count"),
-    path.add_key("file_count"),
-  )
+  let generation = object.required_non_negative_int("generation")
+  let match_count = object.required_non_negative_int("match_count")
+  let file_count = object.required_non_negative_int("file_count")
   let hits : Array[SemanticSearchHit] = object.required_array_of("matches")
-  let error_code = object.optional_string("error_code")
-  let error_message = object.optional_string("error_message")
-  let error = match (error_code, error_message) {
-    (None, None) => None
-    (Some(code), Some(message)) => {
-      if code.is_empty() {
-        raise JsonDecodeError(
-          (path.add_key("error_code"), "expected non-empty error code"),
-        )
-      }
-      if message.is_empty() {
-        raise JsonDecodeError(
-          (path.add_key("error_message"), "expected non-empty error message"),
-        )
-      }
-      let pair : SemanticSearchError = { code, message, }
-      Some(pair)
-    }
-    _ =>
-      raise JsonDecodeError(
-        (path, "error_code and error_message must be present together"),
-      )
+  let error : SemanticSearchError? = match optional_error_pair(object) {
+    Some((code, message)) => Some({ code, message, })
+    None => None
   }
   {
     root: object.required_string("root"),
@@ -298,19 +228,10 @@ pub impl FromJson for SemanticSearchProgressPayload with fn from_json(
   {
     root: object.required_string("root"),
     session_key: object.required_string("session_key"),
-    generation: require_text_search_non_negative(
-      object.required_int("generation"),
-      path.add_key("generation"),
-    ),
+    generation: object.required_non_negative_int("generation"),
     matches,
-    match_count: require_text_search_non_negative(
-      object.required_int("match_count"),
-      path.add_key("match_count"),
-    ),
-    file_count: require_text_search_non_negative(
-      object.required_int("file_count"),
-      path.add_key("file_count"),
-    ),
+    match_count: object.required_non_negative_int("match_count"),
+    file_count: object.required_non_negative_int("file_count"),
   }
 }
 

--- a/desktop/internal/protocol/text_search_codec.mbt
+++ b/desktop/internal/protocol/text_search_codec.mbt
@@ -5,14 +5,52 @@
 ///|
 
 ///|
-fn require_text_search_non_negative(
-  value : Int,
-  path : @json.JsonPath,
+/// A count that only moves forward. Both search boundaries refuse a negative
+/// one at the field's own path, with the same message.
+fn JsonObject::required_non_negative_int(
+  self : JsonObject,
+  name : String,
 ) -> Int raise @json.JsonDecodeError {
+  let value = self.required_int(name)
   if value < 0 {
-    raise JsonDecodeError((path, "expected non-negative integer"))
+    raise JsonDecodeError(
+      (self.path.add_key(name), "expected non-negative integer"),
+    )
   }
   value
+}
+
+///|
+/// Both search boundaries carry a failure as a code/message pair that is
+/// wholly present or wholly absent, and refuse a blank half of one.
+fn optional_error_pair(
+  object : JsonObject,
+) -> (String, String)? raise @json.JsonDecodeError {
+  let error_code = object.optional_string("error_code")
+  let error_message = object.optional_string("error_message")
+  match (error_code, error_message) {
+    (None, None) => None
+    (Some(code), Some(message)) => {
+      if code.is_empty() {
+        raise JsonDecodeError(
+          (object.path.add_key("error_code"), "expected non-empty error code"),
+        )
+      }
+      if message.is_empty() {
+        raise JsonDecodeError(
+          (
+            object.path.add_key("error_message"),
+            "expected non-empty error message",
+          ),
+        )
+      }
+      Some((code, message))
+    }
+    _ =>
+      raise JsonDecodeError(
+        (object.path, "error_code and error_message must be present together"),
+      )
+  }
 }
 
 ///|
@@ -27,14 +65,8 @@ pub impl FromJson for SearchTextPayload with fn from_json(json, path) {
     include_glob: object.required_string("include_glob"),
     exclude_glob: object.required_string("exclude_glob"),
     session_key: object.required_string("session_key"),
-    generation: require_text_search_non_negative(
-      object.required_int("generation"),
-      path.add_key("generation"),
-    ),
-    max_results: require_text_search_non_negative(
-      object.required_int("max_results"),
-      path.add_key("max_results"),
-    ),
+    generation: object.required_non_negative_int("generation"),
+    max_results: object.required_non_negative_int("max_results"),
   }
 }
 
@@ -61,10 +93,7 @@ pub impl FromJson for CancelSearchTextPayload with fn from_json(json, path) {
   )
   {
     session_key: object.required_string("session_key"),
-    generation: require_text_search_non_negative(
-      object.required_int("generation"),
-      path.add_key("generation"),
-    ),
+    generation: object.required_non_negative_int("generation"),
   }
 }
 
@@ -140,41 +169,13 @@ pub impl ToJson for TextSearchMatch with fn to_json(self) {
 ///|
 pub impl FromJson for SearchTextReply with fn from_json(json, path) {
   let object = JsonObject::decode(json, path, "text-search reply")
-  let generation = require_text_search_non_negative(
-    object.required_int("generation"),
-    path.add_key("generation"),
-  )
-  let match_count = require_text_search_non_negative(
-    object.required_int("match_count"),
-    path.add_key("match_count"),
-  )
-  let file_count = require_text_search_non_negative(
-    object.required_int("file_count"),
-    path.add_key("file_count"),
-  )
+  let generation = object.required_non_negative_int("generation")
+  let match_count = object.required_non_negative_int("match_count")
+  let file_count = object.required_non_negative_int("file_count")
   let matches : Array[TextSearchMatch] = object.required_array_of("matches")
-  let error_code = object.optional_string("error_code")
-  let error_message = object.optional_string("error_message")
-  let error = match (error_code, error_message) {
-    (None, None) => None
-    (Some(code), Some(message)) => {
-      if code.is_empty() {
-        raise JsonDecodeError(
-          (path.add_key("error_code"), "expected non-empty error code"),
-        )
-      }
-      if message.is_empty() {
-        raise JsonDecodeError(
-          (path.add_key("error_message"), "expected non-empty error message"),
-        )
-      }
-      let pair : TextSearchError = { code, message, }
-      Some(pair)
-    }
-    _ =>
-      raise JsonDecodeError(
-        (path, "error_code and error_message must be present together"),
-      )
+  let error : TextSearchError? = match optional_error_pair(object) {
+    Some((code, message)) => Some({ code, message, })
+    None => None
   }
   {
     root: object.required_string("root"),

--- a/desktop/internal/worktree/worktree.mbt
+++ b/desktop/internal/worktree/worktree.mbt
@@ -1108,15 +1108,7 @@ pub async fn remove(
   let entry = {
     worktree_registry_lock.acquire()
     defer worktree_registry_lock.release()
-    let entries = read_worktrees_unlocked(dir)
-    let mut found : WorktreeEntry? = None
-    for entry in entries {
-      if entry.name == name {
-        found = Some(entry)
-        break
-      }
-    }
-    found
+    read_worktrees_unlocked(dir).iter().find_first(entry => entry.name == name)
   }
   guard entry is Some(entry) else {
     raise WorktreeError("no worktree named \{name} in this workspace")
@@ -1362,175 +1354,176 @@ async test "attach refuses a linked worktree, keeps main and non-git attachable"
 }
 
 ///|
+/// Runs `body` against a registered git workspace under a redirected HOME,
+/// tearing both down on either exit path, so no lifecycle test has to spell
+/// the setup out. The fixture root comes first, the repository second.
 #cfg(not(platform="windows"))
-async test "worktree create provisions checkout, branch, registry, exclusion" {
+async fn with_worktree_repo(
+  prefix : String,
+  body : async (@pathx.Absolute, @pathx.Absolute) -> Unit,
+) -> Unit {
   worktree_env_test_lock.acquire()
   defer worktree_env_test_lock.release()
   let previous = @sys.get_env_var("HOME")
-  let root = worktree_test_root("openseek-worktree-create-")
+  let root = worktree_test_root(prefix)
   defer @fs.rmdir(root.to_string(), recursive=true)
   @sys.set_env_var("HOME", root.join("global").to_string())
   defer restore_home_env(previous)
   let repo = root.join("repo")
   prepare_git_repo(repo)
   ignore(@workspaces.add(repo.to_string(), fn(_) {  }))
-  let host = test_host()
-  let committed : Ref[Int] = Ref(-1)
-  let reply = create(
-    host,
-    repo.to_string(),
-    WorktreeOwner::openseek("s-fix-auth"),
-    infos => committed.val = infos.length(),
-    name="fix-auth",
-  )
-  assert_eq(committed.val, 1)
-  assert_eq(reply.name, "fix-auth")
-  guard reply.worktrees is [info] else { fail("expected one worktree") }
-  assert_eq(info.name, "fix-auth")
-  // The minted branch is `openseek/<name>-<8 hex chars of salt>`.
-  assert_true(info.branch.has_prefix("openseek/fix-auth-"))
-  assert_eq(info.branch.length(), "openseek/fix-auth-".length() + 8)
-  assert_eq(info.base, @gitx.run(repo, ["rev-parse", "HEAD"]))
-  // Creation IS the binding: the entry carries its conversation from birth.
-  assert_eq(info.session, Some("s-fix-auth"))
-  assert_eq(tree_base(repo, "s-fix-auth"), Some(info.base))
-  assert_eq(tree_base(repo, "workspace-root"), None)
-  assert_eq(info.path, repo.join(".worktrees/fix-auth").to_string())
-  assert_true(info.present)
-  assert_true(@fsx.is_dir(repo.join(".worktrees/fix-auth").to_path()))
-  assert_true(
-    @gitx.probe(repo, [
-      "show-ref",
-      "--verify",
-      "--quiet",
-      "refs/heads/\{info.branch}",
-    ])
-    is Some(_),
-  )
-  // The new checkout sits on its own branch at the recorded base.
-  assert_eq(
-    @gitx.run(repo.join(".worktrees/fix-auth"), [
-      "rev-parse", "--abbrev-ref", "HEAD",
-    ]),
-    info.branch,
-  )
-  let exclude = @fsx.read_text(repo.join(".git/info/exclude").to_path())
-  assert_true(exclude.contains(".worktrees/"))
-  assert_true(exclude.contains(".openseek/"))
-  guard list(repo.to_string()).worktrees is [listed] else {
-    fail("expected one listed worktree")
-  }
-  assert_eq(listed.name, "fix-auth")
-  assert_true(listed.present)
+  body(root, repo)
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "worktree create provisions checkout, branch, registry, exclusion" {
+  with_worktree_repo("openseek-worktree-create-", async fn(_root, repo) {
+    let host = test_host()
+    let committed : Ref[Int] = Ref(-1)
+    let reply = create(
+      host,
+      repo.to_string(),
+      WorktreeOwner::openseek("s-fix-auth"),
+      infos => committed.val = infos.length(),
+      name="fix-auth",
+    )
+    assert_eq(committed.val, 1)
+    assert_eq(reply.name, "fix-auth")
+    guard reply.worktrees is [info] else { fail("expected one worktree") }
+    assert_eq(info.name, "fix-auth")
+    // The minted branch is `openseek/<name>-<8 hex chars of salt>`.
+    assert_true(info.branch.has_prefix("openseek/fix-auth-"))
+    assert_eq(info.branch.length(), "openseek/fix-auth-".length() + 8)
+    assert_eq(info.base, @gitx.run(repo, ["rev-parse", "HEAD"]))
+    // Creation IS the binding: the entry carries its conversation from birth.
+    assert_eq(info.session, Some("s-fix-auth"))
+    assert_eq(tree_base(repo, "s-fix-auth"), Some(info.base))
+    assert_eq(tree_base(repo, "workspace-root"), None)
+    assert_eq(info.path, repo.join(".worktrees/fix-auth").to_string())
+    assert_true(info.present)
+    assert_true(@fsx.is_dir(repo.join(".worktrees/fix-auth").to_path()))
+    assert_true(
+      @gitx.probe(repo, [
+        "show-ref",
+        "--verify",
+        "--quiet",
+        "refs/heads/\{info.branch}",
+      ])
+      is Some(_),
+    )
+    // The new checkout sits on its own branch at the recorded base.
+    assert_eq(
+      @gitx.run(repo.join(".worktrees/fix-auth"), [
+        "rev-parse", "--abbrev-ref", "HEAD",
+      ]),
+      info.branch,
+    )
+    let exclude = @fsx.read_text(repo.join(".git/info/exclude").to_path())
+    assert_true(exclude.contains(".worktrees/"))
+    assert_true(exclude.contains(".openseek/"))
+    guard list(repo.to_string()).worktrees is [listed] else {
+      fail("expected one listed worktree")
+    }
+    assert_eq(listed.name, "fix-auth")
+    assert_true(listed.present)
+  })
 }
 
 ///|
 #cfg(not(platform="windows"))
 async test "explicit registry removal can prune a vanished worktree" {
-  worktree_env_test_lock.acquire()
-  defer worktree_env_test_lock.release()
-  let previous = @sys.get_env_var("HOME")
-  let root = worktree_test_root("openseek-worktree-release-")
-  defer @fs.rmdir(root.to_string(), recursive=true)
-  @sys.set_env_var("HOME", root.join("global").to_string())
-  defer restore_home_env(previous)
-  let repo = root.join("repo")
-  prepare_git_repo(repo)
-  ignore(@workspaces.add(repo.to_string(), fn(_) {  }))
-  let host = test_host()
-  ignore(
-    create(
-      host,
-      repo.to_string(),
-      WorktreeOwner::openseek("s-release"),
-      fn(_) {  },
-      name="wt",
-    ),
-  )
-  @fs.rmdir(repo.join(".worktrees/wt").to_string(), recursive=true)
-  // The low-level protocol operation remains available for orphan cleanup.
-  // The bundled UI does not expose it for a conversation; Archive retains the
-  // row so a later Unarchive still requires explicit Repair.
-  let reply = remove(host, repo.to_string(), "wt", false, fn(_) {  })
-  assert_eq(reply.worktrees.length(), 0)
-  // Unbound, the conversation runs in the workspace again — no refusal.
-  assert_eq(run_dir(repo, "s-release").to_string(), repo.to_string())
+  with_worktree_repo("openseek-worktree-release-", async fn(_root, repo) {
+    let host = test_host()
+    ignore(
+      create(
+        host,
+        repo.to_string(),
+        WorktreeOwner::openseek("s-release"),
+        fn(_) {  },
+        name="wt",
+      ),
+    )
+    @fs.rmdir(repo.join(".worktrees/wt").to_string(), recursive=true)
+    // The low-level protocol operation remains available for orphan cleanup.
+    // The bundled UI does not expose it for a conversation; Archive retains the
+    // row so a later Unarchive still requires explicit Repair.
+    let reply = remove(host, repo.to_string(), "wt", false, fn(_) {  })
+    assert_eq(reply.worktrees.length(), 0)
+    // Unbound, the conversation runs in the workspace again — no refusal.
+    assert_eq(run_dir(repo, "s-release").to_string(), repo.to_string())
+  })
 }
 
 ///|
 #cfg(not(platform="windows"))
 async test "worktree names are host-generated and skip surviving branches" {
-  worktree_env_test_lock.acquire()
-  defer worktree_env_test_lock.release()
-  let previous = @sys.get_env_var("HOME")
-  let root = worktree_test_root("openseek-worktree-autoname-")
-  defer @fs.rmdir(root.to_string(), recursive=true)
-  @sys.set_env_var("HOME", root.join("global").to_string())
-  defer restore_home_env(previous)
-  let repo = root.join("repo")
-  prepare_git_repo(repo)
-  ignore(@workspaces.add(repo.to_string(), fn(_) {  }))
-  let host = test_host()
-  let first = create(host, repo.to_string(), WorktreeOwner::openseek("s-1"), fn(
-    _,
-  ) {
+  with_worktree_repo("openseek-worktree-autoname-", async fn(_root, repo) {
+    let host = test_host()
+    let first = create(host, repo.to_string(), WorktreeOwner::openseek("s-1"), fn(
+      _,
+    ) {
 
-  })
-  assert_eq(first.name, "wt-1")
-  // The session is the idempotency key: a replay (a retry after a lost
-  // reply) gets the existing binding back, never a second checkout.
-  let replay = create(host, repo.to_string(), WorktreeOwner::openseek("s-1"), fn(
-    _,
-  ) {
+    })
+    assert_eq(first.name, "wt-1")
+    // The session is the idempotency key: a replay (a retry after a lost
+    // reply) gets the existing binding back, never a second checkout.
+    let replay = create(
+      host,
+      repo.to_string(),
+      WorktreeOwner::openseek("s-1"),
+      fn(_) {  },
+    )
+    assert_eq(replay.name, "wt-1")
+    assert_eq(replay.worktrees.length(), 1)
+    let second = create(
+      host,
+      repo.to_string(),
+      WorktreeOwner::openseek("s-2"),
+      fn(_) {  },
+    )
+    assert_eq(second.name, "wt-2")
+    // Removal keeps the branch, so a fresh name never resurrects wt-1: the
+    // counter moves past every holder, branches included.
+    ignore(remove(host, repo.to_string(), "wt-1", false, fn(_) {  }))
+    let third = create(host, repo.to_string(), WorktreeOwner::openseek("s-3"), fn(
+      _,
+    ) {
 
+    })
+    assert_eq(third.name, "wt-3")
+    guard list(repo.to_string()).worktrees is [a, b] else {
+      fail("expected two registered worktrees")
+    }
+    assert_eq(a.name, "wt-2")
+    assert_eq(b.name, "wt-3")
+    // A bare `openseek/wt-4` left behind by a build that minted unsalted
+    // branches is history too: the counter moves past it instead of pairing
+    // the directory with a lookalike salted branch.
+    ignore(@gitx.run(repo, ["branch", "openseek/wt-4"]))
+    // Codex uses the same registry, name allocator, and idempotency contract,
+    // but its owner remains in a distinct field from OpenSeek sessions.
+    let codex = create(
+      host,
+      repo.to_string(),
+      WorktreeOwner::codex("thread-1"),
+      fn(_) {  },
+    )
+    assert_eq(codex.name, "wt-5")
+    let codex_replay = create(
+      host,
+      repo.to_string(),
+      WorktreeOwner::codex("thread-1"),
+      fn(_) {  },
+    )
+    assert_eq(codex_replay.name, "wt-5")
+    guard codex_replay.worktrees.iter().find_first(info => info.name == "wt-5")
+      is Some(codex_info) else {
+      fail("expected Codex-owned worktree row")
+    }
+    assert_eq(codex_info.session, None)
+    assert_eq(codex_info.codex_thread, Some("thread-1"))
   })
-  assert_eq(replay.name, "wt-1")
-  assert_eq(replay.worktrees.length(), 1)
-  let second = create(host, repo.to_string(), WorktreeOwner::openseek("s-2"), fn(
-    _,
-  ) {
-
-  })
-  assert_eq(second.name, "wt-2")
-  // Removal keeps the branch, so a fresh name never resurrects wt-1: the
-  // counter moves past every holder, branches included.
-  ignore(remove(host, repo.to_string(), "wt-1", false, fn(_) {  }))
-  let third = create(host, repo.to_string(), WorktreeOwner::openseek("s-3"), fn(
-    _,
-  ) {
-
-  })
-  assert_eq(third.name, "wt-3")
-  guard list(repo.to_string()).worktrees is [a, b] else {
-    fail("expected two registered worktrees")
-  }
-  assert_eq(a.name, "wt-2")
-  assert_eq(b.name, "wt-3")
-  // A bare `openseek/wt-4` left behind by a build that minted unsalted
-  // branches is history too: the counter moves past it instead of pairing
-  // the directory with a lookalike salted branch.
-  ignore(@gitx.run(repo, ["branch", "openseek/wt-4"]))
-  // Codex uses the same registry, name allocator, and idempotency contract,
-  // but its owner remains in a distinct field from OpenSeek sessions.
-  let codex = create(host, repo.to_string(), WorktreeOwner::codex("thread-1"), fn(
-    _,
-  ) {
-
-  })
-  assert_eq(codex.name, "wt-5")
-  let codex_replay = create(
-    host,
-    repo.to_string(),
-    WorktreeOwner::codex("thread-1"),
-    fn(_) {  },
-  )
-  assert_eq(codex_replay.name, "wt-5")
-  guard codex_replay.worktrees.iter().find_first(info => info.name == "wt-5")
-    is Some(codex_info) else {
-    fail("expected Codex-owned worktree row")
-  }
-  assert_eq(codex_info.session, None)
-  assert_eq(codex_info.codex_thread, Some("thread-1"))
 }
 
 ///|
@@ -1562,116 +1555,113 @@ async fn create_refusal(
 ///|
 #cfg(not(platform="windows"))
 async test "worktree create names the holder in every refusal" {
-  worktree_env_test_lock.acquire()
-  defer worktree_env_test_lock.release()
-  let previous = @sys.get_env_var("HOME")
-  let root = worktree_test_root("openseek-worktree-refuse-")
-  defer @fs.rmdir(root.to_string(), recursive=true)
-  @sys.set_env_var("HOME", root.join("global").to_string())
-  defer restore_home_env(previous)
-  let repo = root.join("repo")
-  prepare_git_repo(repo)
-  ignore(@workspaces.add(repo.to_string(), fn(_) {  }))
-  let host = test_host()
-  assert_true(
-    create_refusal(host, root.join("unregistered").to_string(), "s", "x").contains(
-      "not a registered workspace",
-    ),
-  )
-  assert_true(
-    create_refusal(host, repo.to_string(), "s", "-x").contains("worktree names"),
-  )
-  assert_true(
-    create_refusal(host, repo.to_string(), "a/b", "x").contains(
-      "session id invalid",
-    ),
-  )
-  // Binding is for new conversations: one with durable history keeps the
-  // tree it grew up in.
-  @fsx.ensure_dir(
-    @workspaces.store_root(repo).join("sessions").join("s-old").to_path(),
-  )
-  assert_true(
-    create_refusal(host, repo.to_string(), "s-old", "x").contains(
-      "already has history",
-    ),
-  )
-  // The session must be new EVERYWHERE: history in the global store, a
-  // binding in another workspace's registry, and an in-flight first turn
-  // all refuse — any of them would fork the conversation's routing.
-  guard @workspaces.global_store_root() is Some(global) else {
-    fail("expected a global store under HOME")
-  }
-  @fsx.ensure_dir(global.join("sessions/s-global").to_path())
-  assert_true(
-    create_refusal(host, repo.to_string(), "s-global", "x").contains(
-      "already has history",
-    ),
-  )
-  let elsewhere = root.join("elsewhere")
-  @fsx.ensure_dir(elsewhere.to_path())
-  ignore(@workspaces.add(elsewhere.to_string(), fn(_) {  }))
-  write_worktrees(elsewhere, [
-    {
-      name: "wt-e",
-      branch: "openseek/wt-e",
-      base: "abc",
-      session: Some("s-elsewhere"),
-      codex_thread: None,
-    },
-  ])
-  assert_true(
-    create_refusal(host, repo.to_string(), "s-elsewhere", "x").contains(
-      "already runs in worktree wt-e",
-    ),
-  )
-  // A conversation the host already holds a slot for is mid-first-turn; its
-  // durable record has not landed yet, so only the host can say so.
-  assert_true(
-    create_refusal(test_host(live=["s-live"]), repo.to_string(), "s-live", "x").contains(
-      "already starting",
-    ),
-  )
-  ignore(
-    create(
-      host,
-      repo.to_string(),
-      WorktreeOwner::openseek("s-dup"),
-      fn(_) {  },
-      name="dup",
-    ),
-  )
-  assert_true(
-    create_refusal(host, repo.to_string(), "s-2", "dup").contains(
-      "already exists",
-    ),
-  )
-  @fsx.ensure_dir(repo.join(".worktrees/held").to_path())
-  assert_true(
-    create_refusal(host, repo.to_string(), "s-3", "held").contains(
-      "already exists on disk",
-    ),
-  )
-  // A workspace that is not a git repository cannot host worktrees; a linked
-  // worktree registered before the attach guard existed is refused too.
-  let plain = root.join("plain")
-  @fsx.ensure_dir(plain.to_path())
-  ignore(@workspaces.add(plain.to_string(), fn(_) {  }))
-  assert_true(
-    create_refusal(host, plain.to_string(), "s", "x").contains(
-      "not a git repository",
-    ),
-  )
-  // A repository SUBDIRECTORY stays attachable but cannot host worktrees:
-  // the checkout would land inside it as untracked noise at the wrong depth.
-  let sub = repo.join("sub")
-  @fsx.ensure_dir(sub.to_path())
-  ignore(@workspaces.add(sub.to_string(), fn(_) {  }))
-  assert_true(
-    create_refusal(host, sub.to_string(), "s-sub", "x").contains(
-      "repository subdirectory",
-    ),
-  )
+  with_worktree_repo("openseek-worktree-refuse-", async fn(root, repo) {
+    let host = test_host()
+    assert_true(
+      create_refusal(host, root.join("unregistered").to_string(), "s", "x").contains(
+        "not a registered workspace",
+      ),
+    )
+    assert_true(
+      create_refusal(host, repo.to_string(), "s", "-x").contains(
+        "worktree names",
+      ),
+    )
+    assert_true(
+      create_refusal(host, repo.to_string(), "a/b", "x").contains(
+        "session id invalid",
+      ),
+    )
+    // Binding is for new conversations: one with durable history keeps the
+    // tree it grew up in.
+    @fsx.ensure_dir(
+      @workspaces.store_root(repo).join("sessions").join("s-old").to_path(),
+    )
+    assert_true(
+      create_refusal(host, repo.to_string(), "s-old", "x").contains(
+        "already has history",
+      ),
+    )
+    // The session must be new EVERYWHERE: history in the global store, a
+    // binding in another workspace's registry, and an in-flight first turn
+    // all refuse — any of them would fork the conversation's routing.
+    guard @workspaces.global_store_root() is Some(global) else {
+      fail("expected a global store under HOME")
+    }
+    @fsx.ensure_dir(global.join("sessions/s-global").to_path())
+    assert_true(
+      create_refusal(host, repo.to_string(), "s-global", "x").contains(
+        "already has history",
+      ),
+    )
+    let elsewhere = root.join("elsewhere")
+    @fsx.ensure_dir(elsewhere.to_path())
+    ignore(@workspaces.add(elsewhere.to_string(), fn(_) {  }))
+    write_worktrees(elsewhere, [
+      {
+        name: "wt-e",
+        branch: "openseek/wt-e",
+        base: "abc",
+        session: Some("s-elsewhere"),
+        codex_thread: None,
+      },
+    ])
+    assert_true(
+      create_refusal(host, repo.to_string(), "s-elsewhere", "x").contains(
+        "already runs in worktree wt-e",
+      ),
+    )
+    // A conversation the host already holds a slot for is mid-first-turn; its
+    // durable record has not landed yet, so only the host can say so.
+    assert_true(
+      create_refusal(
+        test_host(live=["s-live"]),
+        repo.to_string(),
+        "s-live",
+        "x",
+      ).contains("already starting"),
+    )
+    ignore(
+      create(
+        host,
+        repo.to_string(),
+        WorktreeOwner::openseek("s-dup"),
+        fn(_) {  },
+        name="dup",
+      ),
+    )
+    assert_true(
+      create_refusal(host, repo.to_string(), "s-2", "dup").contains(
+        "already exists",
+      ),
+    )
+    @fsx.ensure_dir(repo.join(".worktrees/held").to_path())
+    assert_true(
+      create_refusal(host, repo.to_string(), "s-3", "held").contains(
+        "already exists on disk",
+      ),
+    )
+    // A workspace that is not a git repository cannot host worktrees; a linked
+    // worktree registered before the attach guard existed is refused too.
+    let plain = root.join("plain")
+    @fsx.ensure_dir(plain.to_path())
+    ignore(@workspaces.add(plain.to_string(), fn(_) {  }))
+    assert_true(
+      create_refusal(host, plain.to_string(), "s", "x").contains(
+        "not a git repository",
+      ),
+    )
+    // A repository SUBDIRECTORY stays attachable but cannot host worktrees:
+    // the checkout would land inside it as untracked noise at the wrong depth.
+    let sub = repo.join("sub")
+    @fsx.ensure_dir(sub.to_path())
+    ignore(@workspaces.add(sub.to_string(), fn(_) {  }))
+    assert_true(
+      create_refusal(host, sub.to_string(), "s-sub", "x").contains(
+        "repository subdirectory",
+      ),
+    )
+  })
 }
 
 ///|
@@ -1695,114 +1685,98 @@ async fn remove_refusal(
 ///|
 #cfg(not(platform="windows"))
 async test "worktree remove enforces the dirty check and keeps the branch" {
-  worktree_env_test_lock.acquire()
-  defer worktree_env_test_lock.release()
-  let previous = @sys.get_env_var("HOME")
-  let root = worktree_test_root("openseek-worktree-remove-")
-  defer @fs.rmdir(root.to_string(), recursive=true)
-  @sys.set_env_var("HOME", root.join("global").to_string())
-  defer restore_home_env(previous)
-  let repo = root.join("repo")
-  prepare_git_repo(repo)
-  ignore(@workspaces.add(repo.to_string(), fn(_) {  }))
-  let host = test_host()
-  assert_true(
-    remove_refusal(host, repo.to_string(), "nope", false).contains(
-      "no worktree named",
-    ),
-  )
-  let w1 = create(
-    host,
-    repo.to_string(),
-    WorktreeOwner::openseek("s-w1"),
-    fn(_) {  },
-    name="w1",
-  )
-  @fs.write_file(
-    repo.join(".worktrees/w1/junk.txt").to_string(),
-    b"x",
-    create_mode=CreateOrTruncate,
-  )
-  assert_true(
-    remove_refusal(host, repo.to_string(), "w1", false).contains(
-      "uncommitted changes",
-    ),
-  )
-  assert_eq(list(repo.to_string()).worktrees.length(), 1)
-  let committed : Ref[Int] = Ref(-1)
-  let forced = remove(host, repo.to_string(), "w1", true, infos => {
-    committed.val = infos.length()
+  with_worktree_repo("openseek-worktree-remove-", async fn(_root, repo) {
+    let host = test_host()
+    assert_true(
+      remove_refusal(host, repo.to_string(), "nope", false).contains(
+        "no worktree named",
+      ),
+    )
+    let w1 = create(
+      host,
+      repo.to_string(),
+      WorktreeOwner::openseek("s-w1"),
+      fn(_) {  },
+      name="w1",
+    )
+    @fs.write_file(
+      repo.join(".worktrees/w1/junk.txt").to_string(),
+      b"x",
+      create_mode=CreateOrTruncate,
+    )
+    assert_true(
+      remove_refusal(host, repo.to_string(), "w1", false).contains(
+        "uncommitted changes",
+      ),
+    )
+    assert_eq(list(repo.to_string()).worktrees.length(), 1)
+    let committed : Ref[Int] = Ref(-1)
+    let forced = remove(host, repo.to_string(), "w1", true, infos => {
+      committed.val = infos.length()
+    })
+    assert_eq(committed.val, 0)
+    assert_eq(forced.worktrees.length(), 0)
+    assert_false(@fsx.exists(repo.join(".worktrees/w1").to_path()))
+    guard w1.worktrees is [w1_info] else { fail("expected one worktree") }
+    // Committed work is never lost: the branch survives every removal.
+    assert_true(
+      @gitx.probe(repo, [
+        "show-ref",
+        "--verify",
+        "--quiet",
+        "refs/heads/\{w1_info.branch}",
+      ])
+      is Some(_),
+    )
+    let w2 = create(
+      host,
+      repo.to_string(),
+      WorktreeOwner::openseek("s-w2"),
+      fn(_) {  },
+      name="w2",
+    )
+    ignore(remove(host, repo.to_string(), "w2", false, fn(_) {  }))
+    assert_eq(list(repo.to_string()).worktrees.length(), 0)
+    guard w2.worktrees is [w2_info] else { fail("expected one worktree") }
+    assert_true(
+      @gitx.probe(repo, [
+        "show-ref",
+        "--verify",
+        "--quiet",
+        "refs/heads/\{w2_info.branch}",
+      ])
+      is Some(_),
+    )
   })
-  assert_eq(committed.val, 0)
-  assert_eq(forced.worktrees.length(), 0)
-  assert_false(@fsx.exists(repo.join(".worktrees/w1").to_path()))
-  guard w1.worktrees is [w1_info] else { fail("expected one worktree") }
-  // Committed work is never lost: the branch survives every removal.
-  assert_true(
-    @gitx.probe(repo, [
-      "show-ref",
-      "--verify",
-      "--quiet",
-      "refs/heads/\{w1_info.branch}",
-    ])
-    is Some(_),
-  )
-  let w2 = create(
-    host,
-    repo.to_string(),
-    WorktreeOwner::openseek("s-w2"),
-    fn(_) {  },
-    name="w2",
-  )
-  ignore(remove(host, repo.to_string(), "w2", false, fn(_) {  }))
-  assert_eq(list(repo.to_string()).worktrees.length(), 0)
-  guard w2.worktrees is [w2_info] else { fail("expected one worktree") }
-  assert_true(
-    @gitx.probe(repo, [
-      "show-ref",
-      "--verify",
-      "--quiet",
-      "refs/heads/\{w2_info.branch}",
-    ])
-    is Some(_),
-  )
 }
 
 ///|
 #cfg(not(platform="windows"))
 async test "worktree remove prunes an externally deleted checkout" {
-  worktree_env_test_lock.acquire()
-  defer worktree_env_test_lock.release()
-  let previous = @sys.get_env_var("HOME")
-  let root = worktree_test_root("openseek-worktree-prune-")
-  defer @fs.rmdir(root.to_string(), recursive=true)
-  @sys.set_env_var("HOME", root.join("global").to_string())
-  defer restore_home_env(previous)
-  let repo = root.join("repo")
-  prepare_git_repo(repo)
-  ignore(@workspaces.add(repo.to_string(), fn(_) {  }))
-  let host = test_host()
-  ignore(
-    create(
-      host,
-      repo.to_string(),
-      WorktreeOwner::openseek("s-gone"),
-      fn(_) {  },
-      name="gone",
-    ),
-  )
-  @fs.rmdir(repo.join(".worktrees/gone").to_string(), recursive=true)
-  guard list(repo.to_string()).worktrees is [listed] else {
-    fail("expected the deleted worktree to stay listed")
-  }
-  assert_false(listed.present)
-  ignore(remove(host, repo.to_string(), "gone", false, fn(_) {  }))
-  assert_eq(list(repo.to_string()).worktrees.length(), 0)
-  assert_false(
-    @gitx.run(repo, ["worktree", "list", "--porcelain"]).contains(
-      ".worktrees/gone",
-    ),
-  )
+  with_worktree_repo("openseek-worktree-prune-", async fn(_root, repo) {
+    let host = test_host()
+    ignore(
+      create(
+        host,
+        repo.to_string(),
+        WorktreeOwner::openseek("s-gone"),
+        fn(_) {  },
+        name="gone",
+      ),
+    )
+    @fs.rmdir(repo.join(".worktrees/gone").to_string(), recursive=true)
+    guard list(repo.to_string()).worktrees is [listed] else {
+      fail("expected the deleted worktree to stay listed")
+    }
+    assert_false(listed.present)
+    ignore(remove(host, repo.to_string(), "gone", false, fn(_) {  }))
+    assert_eq(list(repo.to_string()).worktrees.length(), 0)
+    assert_false(
+      @gitx.run(repo, ["worktree", "list", "--porcelain"]).contains(
+        ".worktrees/gone",
+      ),
+    )
+  })
 }
 
 ///|


### PR DESCRIPTION
**This half needs a careful read.** Every hunk here adds or removes something
SHARED, so correctness depends on code outside the hunk you are looking at. The
purely in-function rewrites this was mixed with have moved to a separate pull
request, so what is left is all shared-surface change.

What to check, hardest first:

1. **An extracted helper must be equivalent at every call site it replaced.**
   The trap is a call site that passed a different argument, or read state at a
   different moment, than its neighbours.
2. **A merged or-pattern arm must have had identical bodies.** Where the arms
   differed and the difference moved inside the arm, the fold buys less than it
   appears to.
3. **A reshaped loop must keep its iteration order and its early exits.**

Scope: `desktop/`. The largest pieces are the protocol codec readers and writers each boundary had copied, the engine's shared refusal and run-actor fixtures, and the frontend's repeated update transitions.

### Review comment addressed

**`[for key, _ in ... if !desired_keys.contains => key]`** — applied. The stale
editor keys are filtered in the comprehension, so the intermediate array of
every editor key is gone. The predicate is named rather than inline because
`moon fmt` wraps the longer form, and a wrapped comprehension whose body is a
bare identifier becomes `{ key }`, which the compiler reads as a struct literal.

### Verified on this branch alone

`moon fmt --check`, `moon check --target native --deny-warn`, `moon check
--target js --deny-warn`, and both full test suites, with no other part of the
refactor applied. No `.mbti` changed.

---

The refactor is split so each pull request asks one kind of question. Every file
appears in exactly one of them, each was verified on its own branch with no
other part applied, so they merge in any order.

| | easy to review | needs a careful read |
| --- | --- | --- |
| root | #1330 | this one (#1325) |
| `desktop/` | #1331 | #1326 |
| `editor/` | #1332 | #1327 |
| tests | #1333 | #1328 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JiBNGzCsZpN6e5Y4p9pXdn
