### PR TITLE
refactor(editor): share the repeated viewer and contribution helpers

### DIFF
--- a/editor/base/common/monaco_range.mbt
+++ b/editor/base/common/monaco_range.mbt
@@ -53,14 +53,8 @@ fn Range::is_empty_range(range : Range) -> Bool {
 
 ///|
 /// Test if position is in this range. If the position is at the edges, returns true.
-fn Range::contains_position_impl(self : Range, position : Position) -> Bool {
-  Range::contains_position_in(self, position)
-}
-
-///|
-/// Test if position is in this range. If the position is at the edges, returns true.
 pub fn Range::contains_position(self : Range, position : Position) -> Bool {
-  self.contains_position_impl(position)
+  Range::contains_position_in(self, position)
 }
 
 ///|
@@ -136,91 +130,60 @@ fn Range::strict_contains_range_in(range : Range, other_range : Range) -> Bool {
 
 ///|
 /// A reunion of the two ranges (smallest start, largest end).
-fn Range::plus_range_impl(self : Range, other : Range) -> Range {
+pub fn Range::plus_range(self : Range, other : Range) -> Range {
   Range::plus_range_of(self, other)
 }
 
 ///|
-/// A reunion of the two ranges (smallest start, largest end).
-pub fn Range::plus_range(self : Range, other : Range) -> Range {
-  self.plus_range_impl(other)
-}
-
-///|
 fn Range::plus_range_of(a : Range, b : Range) -> Range {
-  let mut start_line_number = 0
-  let mut start_column = 0
-  let mut end_line_number = 0
-  let mut end_column = 0
-  if b.start_line_number < a.start_line_number {
-    start_line_number = b.start_line_number
-    start_column = b.start_column
+  let (start_line_number, start_column) = if b.start_line_number <
+    a.start_line_number {
+    (b.start_line_number, b.start_column)
   } else if b.start_line_number == a.start_line_number {
-    start_line_number = b.start_line_number
-    start_column = b.start_column.min(a.start_column)
+    (b.start_line_number, b.start_column.min(a.start_column))
   } else {
-    start_line_number = a.start_line_number
-    start_column = a.start_column
+    (a.start_line_number, a.start_column)
   }
-  if b.end_line_number > a.end_line_number {
-    end_line_number = b.end_line_number
-    end_column = b.end_column
+  let (end_line_number, end_column) = if b.end_line_number > a.end_line_number {
+    (b.end_line_number, b.end_column)
   } else if b.end_line_number == a.end_line_number {
-    end_line_number = b.end_line_number
-    end_column = b.end_column.max(a.end_column)
+    (b.end_line_number, b.end_column.max(a.end_column))
   } else {
-    end_line_number = a.end_line_number
-    end_column = a.end_column
+    (a.end_line_number, a.end_column)
   }
   Range(start_line_number, start_column, end_line_number, end_column)
 }
 
 ///|
 /// An intersection of the two ranges, or `None` if they do not intersect.
-fn Range::intersect_ranges_impl(self : Range, other : Range) -> Range? {
+pub fn Range::intersect_ranges(self : Range, other : Range) -> Range? {
   Range::intersect_ranges_of(self, other)
 }
 
 ///|
-/// An intersection of the two ranges, or `None` if they do not intersect.
-pub fn Range::intersect_ranges(self : Range, other : Range) -> Range? {
-  self.intersect_ranges_impl(other)
-}
-
-///|
 fn Range::intersect_ranges_of(a : Range, b : Range) -> Range? {
-  let mut result_start_line_number = a.start_line_number
-  let mut result_start_column = a.start_column
-  let mut result_end_line_number = a.end_line_number
-  let mut result_end_column = a.end_column
-  let other_start_line_number = b.start_line_number
-  let other_start_column = b.start_column
-  let other_end_line_number = b.end_line_number
-  let other_end_column = b.end_column
-  if result_start_line_number < other_start_line_number {
-    result_start_line_number = other_start_line_number
-    result_start_column = other_start_column
-  } else if result_start_line_number == other_start_line_number {
-    result_start_column = result_start_column.max(other_start_column)
+  let (start_line_number, start_column) = if a.start_line_number <
+    b.start_line_number {
+    (b.start_line_number, b.start_column)
+  } else if a.start_line_number == b.start_line_number {
+    (a.start_line_number, a.start_column.max(b.start_column))
+  } else {
+    (a.start_line_number, a.start_column)
   }
-  if result_end_line_number > other_end_line_number {
-    result_end_line_number = other_end_line_number
-    result_end_column = other_end_column
-  } else if result_end_line_number == other_end_line_number {
-    result_end_column = result_end_column.min(other_end_column)
+  let (end_line_number, end_column) = if a.end_line_number > b.end_line_number {
+    (b.end_line_number, b.end_column)
+  } else if a.end_line_number == b.end_line_number {
+    (a.end_line_number, a.end_column.min(b.end_column))
+  } else {
+    (a.end_line_number, a.end_column)
   }
-  if result_start_line_number > result_end_line_number {
+  if start_line_number > end_line_number {
     return None
   }
-  if result_start_line_number == result_end_line_number &&
-    result_start_column > result_end_column {
+  if start_line_number == end_line_number && start_column > end_column {
     return None
   }
-  Some(
-    Range(
-      result_start_line_number, result_start_column, result_end_line_number, result_end_column,
-    ),
-  )
+  Some(Range(start_line_number, start_column, end_line_number, end_column))
 }
 
 ///|

--- a/editor/base/common/path.mbt
+++ b/editor/base/common/path.mbt
@@ -602,14 +602,14 @@ fn Win32::relative_impl(from : String, to : String) -> String {
       return to_orig
     } else if i == length {
       if to_len > length {
-        return join_range(to_split[:], i, "\\")
+        return to_split[i:].join("\\")
       }
       if from_len > length {
         return "\{"..\\".repeat(from_len - 1 - i)}.."
       }
       return ""
     }
-    return "..\\".repeat(from_len - i) + join_range(to_split[:], i, "\\")
+    return "..\\".repeat(from_len - i) + to_split[i:].join("\\")
   }
 
   // Trim any leading backslashes
@@ -709,19 +709,6 @@ fn Win32::relative_impl(from : String, to : String) -> String {
     to_start += 1
   }
   js_slice(to_orig, to_start, end=to_end)
-}
-
-///|
-/// `toSplit.slice(i).join('\\')` helper for `Win32::relative`.
-fn join_range(parts : ArrayView[String], start : Int, sep : String) -> String {
-  let sb = StringBuilder()
-  for i in start..<parts.length() {
-    if i > start {
-      sb.write_string(sep)
-    }
-    sb.write_string(parts[i])
-  }
-  sb.to_string()
 }
 
 ///|
@@ -1086,7 +1073,7 @@ fn Posix::join_impl(paths : Array[String]) -> String {
   if path is [] {
     return "."
   }
-  Posix::normalize(join_range(path[:], 0, "/"))
+  Posix::normalize(path.join("/"))
 }
 
 ///|

--- a/editor/base/common/strings.mbt
+++ b/editor/base/common/strings.mbt
@@ -351,16 +351,7 @@ fn starts_with_ignore_case_impl(str : String, candidate : String) -> Bool {
 /// `"` alone, matching Monaco's `_tokenizeToString`; use `escape_html` for text
 /// that can also land in an attribute value.
 pub fn escape(text : String) -> String {
-  let sb = StringBuilder()
-  for ch in text {
-    match ch {
-      '&' => sb.write_string("&amp;")
-      '<' => sb.write_string("&lt;")
-      '>' => sb.write_string("&gt;")
-      _ => sb.write_char(ch)
-    }
-  }
-  sb.to_string()
+  escape_impl(text, quote=false)
 }
 
 ///|
@@ -368,13 +359,20 @@ pub fn escape(text : String) -> String {
 /// three characters plus `"`. Callers that build markup by concatenation and
 /// may quote the result need this variant.
 pub fn escape_html(text : String) -> String {
+  escape_impl(text, quote=true)
+}
+
+///|
+/// Shared body of `escape` and `escape_html`; `quote` adds the
+/// attribute-value `"` escape.
+fn escape_impl(text : String, quote~ : Bool) -> String {
   let sb = StringBuilder()
   for ch in text {
     match ch {
       '&' => sb.write_string("&amp;")
       '<' => sb.write_string("&lt;")
       '>' => sb.write_string("&gt;")
-      '"' => sb.write_string("&quot;")
+      '"' if quote => sb.write_string("&quot;")
       _ => sb.write_char(ch)
     }
   }

--- a/editor/internal/shell/workbench/document_source.mbt
+++ b/editor/internal/shell/workbench/document_source.mbt
@@ -135,27 +135,21 @@ fn reload_active_document_cmd(
 
 ///|
 fn close_active_document_source() -> Unit {
-  match active_document_watch.val {
-    Some(watch) => watch.dispose()
-    None => ()
+  if active_document_watch.val is Some(watch) {
+    watch.dispose()
   }
   active_document_watch.val = None
-  match active_document_uri.val {
-    Some(uri) =>
-      if !preview_resource_retains_remote_document(uri) {
-        document_provider.close(uri)
-      }
-    None => ()
+  if active_document_uri.val is Some(uri) &&
+    !preview_resource_retains_remote_document(uri) {
+    document_provider.close(uri)
   }
   active_document_uri.val = None
 }
 
 ///|
 fn is_active_document_resource(uri : @base_common.Uri) -> Bool {
-  match active_document_uri.val {
-    Some(current) => current.to_string() == uri.to_string()
-    None => false
-  }
+  active_document_uri.val is Some(current) &&
+  current.to_string() == uri.to_string()
 }
 
 ///|
@@ -179,13 +173,8 @@ fn read_active_document(
 
 ///|
 fn is_active_document(uri : @base_common.Uri, generation : Int) -> Bool {
-  if generation != active_document_generation.val {
-    return false
-  }
-  match active_document_uri.val {
-    Some(current) => current.to_string() == uri.to_string()
-    None => false
-  }
+  generation == active_document_generation.val &&
+  is_active_document_resource(uri)
 }
 
 ///|
@@ -196,9 +185,8 @@ fn route_watched_document_cmd(
   payload : @remote_protocol.DocumentPayload,
 ) -> @rabbita.Cmd {
   @cmd.custom_cmd(_ => {
-    match watch_listeners.get(payload.document.uri.to_string()) {
-      Some(listener) => listener(DocumentUpdated(payload.document))
-      None => ()
+    if watch_listeners.get(payload.document.uri.to_string()) is Some(listener) {
+      listener(DocumentUpdated(payload.document))
     }
   })
 }

--- a/editor/internal/shell/workbench/protocol_client.mbt
+++ b/editor/internal/shell/workbench/protocol_client.mbt
@@ -28,9 +28,8 @@ let protocol_send : Ref[((@remote_protocol.ClientPacket) -> Unit)?] = Ref(None)
 
 ///|
 fn send_protocol_packet(packet : @remote_protocol.ClientPacket) -> Unit {
-  match protocol_send.val {
-    Some(send) => send(packet)
-    None => ()
+  if protocol_send.val is Some(send) {
+    send(packet)
   }
 }
 
@@ -102,24 +101,25 @@ fn cancelled_protocol_response(id : String) -> @remote_protocol.ServerPacket {
 }
 
 ///|
-fn cancel_pending_request(id : String) -> Unit {
-  match pending_requests.get(id) {
-    Some(pending) => {
-      pending_requests.remove(id)
-      if pending.sent {
-        cancelled_request_ids[id] = ()
-      }
-      match pending.cancellation_subscription {
-        Some(subscription) => {
-          pending.cancellation_subscription = None
-          subscription.dispose()
-        }
-        None => ()
-      }
-      (pending.resolve)(cancelled_protocol_response(id))
-    }
-    None => ()
+/// Removes the pending entry for `id` and releases its cancellation
+/// subscription, returning the entry when one was still registered.
+fn take_pending_request(id : String) -> PendingProtocolRequest? {
+  guard pending_requests.get(id) is Some(pending) else { return None }
+  pending_requests.remove(id)
+  if pending.cancellation_subscription is Some(subscription) {
+    pending.cancellation_subscription = None
+    subscription.dispose()
   }
+  Some(pending)
+}
+
+///|
+fn cancel_pending_request(id : String) -> Unit {
+  guard take_pending_request(id) is Some(pending) else { return }
+  if pending.sent {
+    cancelled_request_ids[id] = ()
+  }
+  (pending.resolve)(cancelled_protocol_response(id))
 }
 
 ///|
@@ -130,27 +130,15 @@ fn resolve_pending_response(packet : @remote_protocol.ServerPacket) -> Bool {
   if id == "" {
     return false
   }
-  match pending_requests.get(id) {
-    Some(pending) => {
-      pending_requests.remove(id)
-      match pending.cancellation_subscription {
-        Some(subscription) => {
-          pending.cancellation_subscription = None
-          subscription.dispose()
-        }
-        None => ()
-      }
-      (pending.resolve)(packet)
-      true
-    }
-    None =>
-      if cancelled_request_ids.contains(id) {
-        cancelled_request_ids.remove(id)
-        true
-      } else {
-        false
-      }
+  if take_pending_request(id) is Some(pending) {
+    (pending.resolve)(packet)
+    return true
   }
+  if cancelled_request_ids.contains(id) {
+    cancelled_request_ids.remove(id)
+    return true
+  }
+  false
 }
 
 ///|
@@ -158,28 +146,14 @@ fn resolve_pending_response(packet : @remote_protocol.ServerPacket) -> Bool {
 /// providers resolve instead of leaking.
 fn fail_pending_requests(message : String) -> Unit {
   cancelled_request_ids.clear()
-  let ids : Array[String] = []
-  for id, _pending in pending_requests {
-    ids.push(id)
-  }
+  let ids = [ for id, _pending in pending_requests => id ]
   for id in ids {
-    match pending_requests.get(id) {
-      Some(pending) => {
-        pending_requests.remove(id)
-        match pending.cancellation_subscription {
-          Some(subscription) => {
-            pending.cancellation_subscription = None
-            subscription.dispose()
-          }
-          None => ()
-        }
-        (pending.resolve)(
-          RemoteError(
-            ProtocolError(ProtocolProviderError, message, request_id=id),
-          ),
-        )
-      }
-      None => ()
+    if take_pending_request(id) is Some(pending) {
+      (pending.resolve)(
+        RemoteError(
+          ProtocolError(ProtocolProviderError, message, request_id=id),
+        ),
+      )
     }
   }
 }

--- a/editor/internal/viewer/browser/view/view_events.mbt
+++ b/editor/internal/viewer/browser/view/view_events.mbt
@@ -12,7 +12,7 @@ pub fn ViewConfigurationChangedEvent::from_changed_options(
 ) -> ViewConfigurationChangedEvent {
   let result : Array[ViewConfigurationOption] = []
   for option in changed_options {
-    if !view_configuration_options_contain(result, option) {
+    if !result.contains(option) {
       result.push(option)
     }
   }
@@ -24,20 +24,7 @@ fn ViewConfigurationChangedEvent::has_changed(
   self : ViewConfigurationChangedEvent,
   option : ViewConfigurationOption,
 ) -> Bool {
-  view_configuration_options_contain(self.changed_options, option)
-}
-
-///|
-fn view_configuration_options_contain(
-  options : Array[ViewConfigurationOption],
-  expected : ViewConfigurationOption,
-) -> Bool {
-  for option in options {
-    if option == expected {
-      return true
-    }
-  }
-  false
+  self.changed_options.contains(option)
 }
 
 ///|

--- a/editor/internal/viewer/code_editor_widget/cursor_commands.mbt
+++ b/editor/internal/viewer/code_editor_widget/cursor_commands.mbt
@@ -598,15 +598,11 @@ fn CodeEditorWidget::run_move_to_core_command(
   in_selection_mode : Bool,
 ) -> Bool {
   let id = if in_selection_mode { "_moveToSelect" } else { "_moveTo" }
-  let core_args : CursorCoreCommandArgs? = match args {
-    Some(args) => Some(MoveCommandArguments(args))
-    None => None
-  }
   editor_registry().run_core_editor_command(
     self,
     view_model,
     id,
-    args?=core_args,
+    args?=args.map(value => MoveCommandArguments(value)),
   )
 }
 
@@ -618,15 +614,11 @@ fn CodeEditorWidget::run_word_core_command(
   in_selection_mode : Bool,
 ) -> Bool {
   let id = if in_selection_mode { "_wordSelectDrag" } else { "_wordSelect" }
-  let core_args : CursorCoreCommandArgs? = match args {
-    Some(args) => Some(MoveCommandArguments(args))
-    None => None
-  }
   editor_registry().run_core_editor_command(
     self,
     view_model,
     id,
-    args?=core_args,
+    args?=args.map(value => MoveCommandArguments(value)),
   )
 }
 
@@ -638,15 +630,11 @@ fn CodeEditorWidget::run_line_core_command(
   in_selection_mode : Bool,
 ) -> Bool {
   let id = if in_selection_mode { "_lineSelectDrag" } else { "_lineSelect" }
-  let core_args : CursorCoreCommandArgs? = match args {
-    Some(args) => Some(MoveCommandArguments(args))
-    None => None
-  }
   editor_registry().run_core_editor_command(
     self,
     view_model,
     id,
-    args?=core_args,
+    args?=args.map(value => MoveCommandArguments(value)),
   )
 }
 
@@ -656,15 +644,11 @@ fn CodeEditorWidget::run_set_selection_core_command(
   args : CursorSetSelectionCommandArgs?,
 ) -> Bool {
   guard self.get_view_model() is Some(view_model) else { return false }
-  let core_args : CursorCoreCommandArgs? = match args {
-    Some(args) => Some(SetSelectionCommandArguments(args))
-    None => None
-  }
   editor_registry().run_core_editor_command(
     self,
     view_model,
     "setSelection",
-    args?=core_args,
+    args?=args.map(value => SetSelectionCommandArguments(value)),
   )
 }
 
@@ -777,113 +761,53 @@ fn register_cursor_navigation_commands(
       in_selection_mode=true,
     ).as_core_editor_command(),
   )
-  register_cursor_key_command(
+  register_cursor_move_key_pair(
     registry,
-    CursorMoveBasedCommand::CursorMoveBasedCommand(
-      "cursorLeft",
-      SimpleMoveArguments(Left, None, false, 1),
-    ).as_core_editor_command(),
+    "cursorLeft",
     "ArrowLeft",
-    shift=false,
+    Left,
+    None,
+    1,
   )
-  register_cursor_key_command(
+  register_cursor_move_key_pair(
     registry,
-    CursorMoveBasedCommand::CursorMoveBasedCommand(
-      "cursorLeftSelect",
-      SimpleMoveArguments(Left, None, true, 1),
-    ).as_core_editor_command(),
-    "ArrowLeft",
-    shift=true,
-  )
-  register_cursor_key_command(
-    registry,
-    CursorMoveBasedCommand::CursorMoveBasedCommand(
-      "cursorRight",
-      SimpleMoveArguments(Right, None, false, 1),
-    ).as_core_editor_command(),
+    "cursorRight",
     "ArrowRight",
-    shift=false,
+    Right,
+    None,
+    1,
   )
-  register_cursor_key_command(
+  register_cursor_move_key_pair(
     registry,
-    CursorMoveBasedCommand::CursorMoveBasedCommand(
-      "cursorRightSelect",
-      SimpleMoveArguments(Right, None, true, 1),
-    ).as_core_editor_command(),
-    "ArrowRight",
-    shift=true,
-  )
-  register_cursor_key_command(
-    registry,
-    CursorMoveBasedCommand::CursorMoveBasedCommand(
-      "cursorUp",
-      SimpleMoveArguments(Up, WrappedLine, false, 1),
-    ).as_core_editor_command(),
+    "cursorUp",
     "ArrowUp",
-    shift=false,
+    Up,
+    WrappedLine,
+    1,
   )
-  register_cursor_key_command(
+  register_cursor_move_key_pair(
     registry,
-    CursorMoveBasedCommand::CursorMoveBasedCommand(
-      "cursorUpSelect",
-      SimpleMoveArguments(Up, WrappedLine, true, 1),
-    ).as_core_editor_command(),
-    "ArrowUp",
-    shift=true,
-  )
-  register_cursor_key_command(
-    registry,
-    CursorMoveBasedCommand::CursorMoveBasedCommand(
-      "cursorPageUp",
-      SimpleMoveArguments(Up, WrappedLine, false, -1),
-    ).as_core_editor_command(),
+    "cursorPageUp",
     "PageUp",
-    shift=false,
+    Up,
+    WrappedLine,
+    -1,
   )
-  register_cursor_key_command(
+  register_cursor_move_key_pair(
     registry,
-    CursorMoveBasedCommand::CursorMoveBasedCommand(
-      "cursorPageUpSelect",
-      SimpleMoveArguments(Up, WrappedLine, true, -1),
-    ).as_core_editor_command(),
-    "PageUp",
-    shift=true,
-  )
-  register_cursor_key_command(
-    registry,
-    CursorMoveBasedCommand::CursorMoveBasedCommand(
-      "cursorDown",
-      SimpleMoveArguments(Down, WrappedLine, false, 1),
-    ).as_core_editor_command(),
+    "cursorDown",
     "ArrowDown",
-    shift=false,
+    Down,
+    WrappedLine,
+    1,
   )
-  register_cursor_key_command(
+  register_cursor_move_key_pair(
     registry,
-    CursorMoveBasedCommand::CursorMoveBasedCommand(
-      "cursorDownSelect",
-      SimpleMoveArguments(Down, WrappedLine, true, 1),
-    ).as_core_editor_command(),
-    "ArrowDown",
-    shift=true,
-  )
-  register_cursor_key_command(
-    registry,
-    CursorMoveBasedCommand::CursorMoveBasedCommand(
-      "cursorPageDown",
-      SimpleMoveArguments(Down, WrappedLine, false, -1),
-    ).as_core_editor_command(),
+    "cursorPageDown",
     "PageDown",
-    shift=false,
-  )
-  register_cursor_key_command(
-    registry,
-    CursorMoveBasedCommand::CursorMoveBasedCommand(
-      "cursorPageDownSelect",
-      SimpleMoveArguments(Down, WrappedLine, true, -1),
-    ).as_core_editor_command(),
-    "PageDown",
-    shift=true,
+    Down,
+    WrappedLine,
+    -1,
   )
   register_cursor_key_command(
     registry,
@@ -941,6 +865,37 @@ fn register_cursor_key_command(
       (key, false, false),
     ])
   }
+}
+
+///|
+/// Registers one cursor-key pair: the plain command on the bare key and its
+/// `…Select` twin on Shift, in that order.
+fn register_cursor_move_key_pair(
+  registry : EditorContributionRegistry,
+  id : String,
+  key : String,
+  direction : @view_model.SimpleMoveDirection,
+  unit : @view_model.CursorMoveUnit,
+  value : Int,
+) -> Unit {
+  register_cursor_key_command(
+    registry,
+    CursorMoveBasedCommand::CursorMoveBasedCommand(
+      id,
+      SimpleMoveArguments(direction, unit, false, value),
+    ).as_core_editor_command(),
+    key,
+    shift=false,
+  )
+  register_cursor_key_command(
+    registry,
+    CursorMoveBasedCommand::CursorMoveBasedCommand(
+      id + "Select",
+      SimpleMoveArguments(direction, unit, true, value),
+    ).as_core_editor_command(),
+    key,
+    shift=true,
+  )
 }
 
 ///|

--- a/editor/internal/viewer/code_editor_widget/definition_contribution.mbt
+++ b/editor/internal/viewer/code_editor_widget/definition_contribution.mbt
@@ -239,10 +239,9 @@ fn CodeEditorWidget::symbol_navigation_anchor_is_current(
 }
 
 ///|
-/// Surface-owned preparation shared by Definition and References actions.
-/// Populated Peek sessions remain independently usable; only unresolved
-/// queries are superseded by the new navigation intent.
-fn CodeEditorWidget::prepare_symbol_navigation_intent(
+/// Closes a Peek session that is still resolving its definitions or
+/// references; a populated session stays open.
+fn CodeEditorWidget::close_loading_references_peek(
   self : CodeEditorWidget,
 ) -> Unit {
   match self.references_contribution() {
@@ -254,6 +253,16 @@ fn CodeEditorWidget::prepare_symbol_navigation_intent(
       }
     None => ()
   }
+}
+
+///|
+/// Surface-owned preparation shared by Definition and References actions.
+/// Populated Peek sessions remain independently usable; only unresolved
+/// queries are superseded by the new navigation intent.
+fn CodeEditorWidget::prepare_symbol_navigation_intent(
+  self : CodeEditorWidget,
+) -> Unit {
+  self.close_loading_references_peek()
   match self.definition_contribution() {
     Some(state) => state.reset_link_gesture()
     None => ()
@@ -324,15 +333,7 @@ fn CodeEditorWidget::on_definition_cursor_selection_changed(
   } else {
     state.reset_link_gesture()
   }
-  match self.references_contribution() {
-    Some(references) =>
-      match references.controller.phase() {
-        PeekLoadingDefinitions(_) | PeekLoadingReferences(_) =>
-          self.close_references_peek(restore_focus=false)
-        _ => ()
-      }
-    None => ()
-  }
+  self.close_loading_references_peek()
   self.clear_definition_message()
 }
 
@@ -473,15 +474,7 @@ fn CodeEditorWidget::commit_plain_definition_pointer_target(
 ) -> Unit {
   guard self.definition_contribution() is Some(state) else { return }
   state.navigation_action.cancel()
-  match self.references_contribution() {
-    Some(references) =>
-      match references.controller.phase() {
-        PeekLoadingDefinitions(_) | PeekLoadingReferences(_) =>
-          self.close_references_peek(restore_focus=false)
-        _ => ()
-      }
-    None => ()
-  }
+  self.close_loading_references_peek()
   state.last_pointer_target = match target {
     Some(target) if self.definition_link_target_is_current(target) =>
       Some(target)
@@ -800,35 +793,35 @@ fn CodeEditorWidget::show_definition_message(
       self.reveal_position_in_center_if_outside_viewport(position)
       widget.set_message(message)
       widget.show_at(position)
-      match self.current_code_view() {
-        Some(view) => {
-          view.content_widgets.set_widget_position(
-            widget.content_widget_handle(),
-          )
-          self.schedule_render()
-        }
-        None => ()
-      }
+      self.reposition_definition_message_widget(widget)
       state.message_hide = Some(
         @base_browser.schedule_timeout(
           () => {
             if !state.disposed {
               widget.hide()
-              match self.current_code_view() {
-                Some(view) => {
-                  view.content_widgets.set_widget_position(
-                    widget.content_widget_handle(),
-                  )
-                  self.schedule_render()
-                }
-                None => ()
-              }
+              self.reposition_definition_message_widget(widget)
               state.message_hide = None
             }
           },
           2500,
         ),
       )
+    }
+    None => ()
+  }
+}
+
+///|
+/// Re-publishes the definition message widget's position on the current view
+/// and schedules the repaint; a no-op without a view.
+fn CodeEditorWidget::reposition_definition_message_widget(
+  self : CodeEditorWidget,
+  widget : @definition_browser.DefinitionMessageWidget,
+) -> Unit {
+  match self.current_code_view() {
+    Some(view) => {
+      view.content_widgets.set_widget_position(widget.content_widget_handle())
+      self.schedule_render()
     }
     None => ()
   }
@@ -847,15 +840,7 @@ fn CodeEditorWidget::clear_definition_message(self : CodeEditorWidget) -> Unit {
       match state.message_widget {
         Some(widget) => {
           widget.hide()
-          match self.current_code_view() {
-            Some(view) => {
-              view.content_widgets.set_widget_position(
-                widget.content_widget_handle(),
-              )
-              self.schedule_render()
-            }
-            None => ()
-          }
+          self.reposition_definition_message_widget(widget)
         }
         None => ()
       }
@@ -893,10 +878,7 @@ fn CodeEditorWidget::dispose_definition_message(
 fn CodeEditorWidget::definition_message_for_test(
   self : CodeEditorWidget,
 ) -> String? {
-  match self.definition_contribution() {
-    Some(state) => state.last_message
-    None => None
-  }
+  self.definition_contribution().bind(state => state.last_message)
 }
 
 ///|

--- a/editor/internal/viewer/code_editor_widget/editor_extensions.mbt
+++ b/editor/internal/viewer/code_editor_widget/editor_extensions.mbt
@@ -157,6 +157,17 @@ fn EditorContributionEntry::typed_lookup_available(
 }
 
 ///|
+/// Disposes every retained subscription in `listeners` and empties the list.
+fn dispose_and_clear_listeners(
+  listeners : Array[@base_common.Disposable],
+) -> Unit {
+  for listener in listeners {
+    listener.dispose()
+  }
+  listeners.clear()
+}
+
+///|
 /// Direct typed lifecycle dispatch. The complete CodeEditorWidget map remains installed
 /// while every row tears down, so feature cleanup can still use typed central
 /// accessors. The explicit lifecycle state rejects recursive/repeated teardown
@@ -169,55 +180,32 @@ fn EditorContributionEntry::dispose(
   guard self.lifecycle == ContributionLive else { return }
   self.lifecycle = ContributionDisposing
   match self.instance {
-    AgentFeedbackInput(_) => {
-      for listener in self.listeners {
-        listener.dispose()
-      }
-      self.listeners.clear()
-    }
+    AgentFeedbackInput(_) => dispose_and_clear_listeners(self.listeners)
     AgentFeedbackWidget(controller) => {
       viewer.clear_agent_feedback_widgets_from(controller) |> ignore
-      for listener in self.listeners {
-        listener.dispose()
-      }
-      self.listeners.clear()
+      dispose_and_clear_listeners(self.listeners)
     }
     Folding(controller) => {
       controller.clear_local()
-      for listener in self.listeners {
-        listener.dispose()
-      }
-      self.listeners.clear()
+      dispose_and_clear_listeners(self.listeners)
     }
     ContentHover(state) => state.dispose_behavior()
     QuickDiff(state) => {
       state.collection.clear()
-      for listener in state.listeners {
-        listener.dispose()
-      }
-      state.listeners.clear()
+      dispose_and_clear_listeners(state.listeners)
     }
     MarkdownComments(state) => state.dispose(viewer)
     ContextMenu(state) => {
       state.dispose()
-      for listener in self.listeners {
-        listener.dispose()
-      }
-      self.listeners.clear()
+      dispose_and_clear_listeners(self.listeners)
     }
     Definition(state) => {
       state.dispose(viewer)
-      for listener in self.listeners {
-        listener.dispose()
-      }
-      self.listeners.clear()
+      dispose_and_clear_listeners(self.listeners)
     }
     References(state) => {
       state.dispose(viewer)
-      for listener in self.listeners {
-        listener.dispose()
-      }
-      self.listeners.clear()
+      dispose_and_clear_listeners(self.listeners)
     }
   }
   self.lifecycle = ContributionDisposed
@@ -458,6 +446,22 @@ fn EditorContributionRegistry::register_editor_contribution(
 }
 
 ///|
+/// Adds one keybinding rule per `(key, alt, ctrl_cmd)` row, all sharing the
+/// command id and live `when` predicate.
+fn EditorContributionRegistry::push_keybinding_rules(
+  self : EditorContributionRegistry,
+  bindings : Array[(String, Bool, Bool)],
+  command_id : String,
+  when : (CodeEditorWidget) -> Bool,
+  shift~ : Bool,
+) -> Unit {
+  for binding in bindings {
+    let (key, alt, ctrl_cmd) = binding
+    self.keybindings.push({ key, alt, ctrl_cmd, shift, command_id, when, })
+  }
+}
+
+///|
 /// `registerEditorCommand` + the keybinding rows of `Command.register`
 /// (`editorExtensions.ts:528-531`, `:124-156`).
 fn EditorContributionRegistry::register_editor_command(
@@ -481,28 +485,8 @@ fn EditorContributionRegistry::register_editor_command(
     run,
   }
   self.commands.set(command.id, RegisteredEditor(command))
-  for binding in keybindings {
-    let (key, alt, ctrl_cmd) = binding
-    self.keybindings.push({
-      key,
-      alt,
-      ctrl_cmd,
-      shift: false,
-      command_id: id,
-      when: precondition,
-    })
-  }
-  for binding in shift_keybindings {
-    let (key, alt, ctrl_cmd) = binding
-    self.keybindings.push({
-      key,
-      alt,
-      ctrl_cmd,
-      shift: true,
-      command_id: id,
-      when: precondition,
-    })
-  }
+  self.push_keybinding_rules(keybindings, id, precondition, shift=false)
+  self.push_keybinding_rules(shift_keybindings, id, precondition, shift=true)
 }
 
 ///|
@@ -579,28 +563,18 @@ fn EditorContributionRegistry::register_core_editor_command(
   shift_keybindings? : Array[(String, Bool, Bool)] = [],
 ) -> Unit {
   self.commands.set(command.id, RegisteredCore(command))
-  for binding in keybindings {
-    let (key, alt, ctrl_cmd) = binding
-    self.keybindings.push({
-      key,
-      alt,
-      ctrl_cmd,
-      shift: false,
-      command_id: command.id,
-      when: keybinding_when,
-    })
-  }
-  for binding in shift_keybindings {
-    let (key, alt, ctrl_cmd) = binding
-    self.keybindings.push({
-      key,
-      alt,
-      ctrl_cmd,
-      shift: true,
-      command_id: command.id,
-      when: keybinding_when,
-    })
-  }
+  self.push_keybinding_rules(
+    keybindings,
+    command.id,
+    keybinding_when,
+    shift=false,
+  )
+  self.push_keybinding_rules(
+    shift_keybindings,
+    command.id,
+    keybinding_when,
+    shift=true,
+  )
 }
 
 ///|

--- a/editor/internal/viewer/contrib/hover/hover_participants.mbt
+++ b/editor/internal/viewer/contrib/hover/hover_participants.mbt
@@ -279,13 +279,9 @@ pub fn ContentHoverComputer::create_loading_message(
   anchor : HoverAnchor,
 ) -> HoverPart? {
   for participant in self.participants {
-    match participant.create_loading_message {
-      Some(create_loading_message) =>
-        match create_loading_message(anchor) {
-          Some(message) => return Some(message)
-          None => ()
-        }
-      None => ()
+    if participant.create_loading_message is Some(create_loading_message) &&
+      create_loading_message(anchor) is Some(message) {
+      return Some(message)
     }
   }
   None
@@ -407,25 +403,17 @@ fn computed_hover_from_parts(
     return None
   }
   let sorted = sort_hover_parts_stably(parts)
-  let range = for part in sorted; range = fallback_range {
-    continue union_range(range, hover_part_range(part))
-  } nobreak {
-    range
-  }
-  Some({ range, parts: sorted, })
+  Some({ range: hover_parts_range(sorted, fallback_range), parts: sorted, })
 }
 
 ///|
-/// JavaScript's source sort is stable while MoonBit's `Array::sort_by` is not.
-/// Carry the arrival index as the final comparator key so equal participant
-/// ordinal/range-start parts retain provider completion order on every target.
-fn sort_hover_parts_stably(parts : Array[HoverPart]) -> Array[HoverPart] {
-  let indexed : Array[(Int, HoverPart)] = []
-  for index, part in parts {
-    indexed.push((index, part))
-  }
+/// Stable sort over an unstable `Array::sort_by`: decorate with the arrival
+/// index and use it as the final comparator key, so equal-key items retain
+/// input order on every target.
+fn[T] sort_stably(items : Array[T], compare : (T, T) -> Int) -> Array[T] {
+  let indexed : Array[(Int, T)] = [ for index, item in items => (index, item) ]
   indexed.sort_by((left, right) => {
-    let order = compare_hover_parts(left.1, right.1)
+    let order = compare(left.1, right.1)
     if order != 0 {
       order
     } else {
@@ -433,6 +421,14 @@ fn sort_hover_parts_stably(parts : Array[HoverPart]) -> Array[HoverPart] {
     }
   })
   indexed.map(item => item.1)
+}
+
+///|
+/// JavaScript's source sort is stable while MoonBit's `Array::sort_by` is not.
+/// Carry the arrival index as the final comparator key so equal participant
+/// ordinal/range-start parts retain provider completion order on every target.
+fn sort_hover_parts_stably(parts : Array[HoverPart]) -> Array[HoverPart] {
+  sort_stably(parts, compare_hover_parts)
 }
 
 ///|

--- a/editor/internal/viewer/contrib/hover/hover_registry.mbt
+++ b/editor/internal/viewer/contrib/hover/hover_registry.mbt
@@ -34,19 +34,7 @@ fn HoverParticipantRegistry::build_all(
   // MoonBit's Array::sort_by is unstable, while JavaScript's source sort is
   // stable. Carry the registration index as an explicit tie-break so equal
   // ordinals retain registration order on every backend.
-  let indexed : Array[(Int, HoverParticipantHandle)] = []
-  for index, participant in participants {
-    indexed.push((index, participant))
-  }
-  indexed.sort_by((left, right) => {
-    let by_ordinal = left.1.ordinal - right.1.ordinal
-    if by_ordinal != 0 {
-      by_ordinal
-    } else {
-      left.0 - right.0
-    }
-  })
-  indexed.map(entry => entry.1)
+  sort_stably(participants, (left, right) => left.ordinal - right.ordinal)
 }
 
 ///|

--- a/editor/internal/viewer/diff_editor/overview_projection.mbt
+++ b/editor/internal/viewer/diff_editor/overview_projection.mbt
@@ -32,39 +32,35 @@ fn diff_overview_viewport_geometry(
 }
 
 ///|
-fn original_diff_overview_ruler_entries(
+fn diff_overview_ruler_entries(
   diff_state : DiffState,
+  color : String,
+  range_of : (@diff.DetailedLineRangeMapping) -> @base_common.LineRange,
 ) -> Array[@code_widget.CodeEditorOverviewRulerEntry] {
   let entries : Array[@code_widget.CodeEditorOverviewRulerEntry] = []
   for change_index, mapping in diff_state.mappings {
-    let range = mapping.line_range_mapping.original
+    let range = range_of(mapping.line_range_mapping)
     if !range.is_empty() {
-      entries.push({
-        id: change_index,
-        range,
-        color: diff_overview_removed_color,
-        lane: Full,
-      })
+      entries.push({ id: change_index, range, color, lane: Full, })
     }
   }
   entries
 }
 
 ///|
+fn original_diff_overview_ruler_entries(
+  diff_state : DiffState,
+) -> Array[@code_widget.CodeEditorOverviewRulerEntry] {
+  diff_overview_ruler_entries(diff_state, diff_overview_removed_color, mapping => {
+    mapping.original
+  })
+}
+
+///|
 fn modified_diff_overview_ruler_entries(
   diff_state : DiffState,
 ) -> Array[@code_widget.CodeEditorOverviewRulerEntry] {
-  let entries : Array[@code_widget.CodeEditorOverviewRulerEntry] = []
-  for change_index, mapping in diff_state.mappings {
-    let range = mapping.line_range_mapping.modified
-    if !range.is_empty() {
-      entries.push({
-        id: change_index,
-        range,
-        color: diff_overview_inserted_color,
-        lane: Full,
-      })
-    }
-  }
-  entries
+  diff_overview_ruler_entries(diff_state, diff_overview_inserted_color, mapping => {
+    mapping.modified
+  })
 }

--- a/editor/internal/viewer/markdown_viewer/markdown_viewer.mbt
+++ b/editor/internal/viewer/markdown_viewer/markdown_viewer.mbt
@@ -270,11 +270,9 @@ fn MarkdownViewerWidget::is_current_attachment(
   generation : Int,
 ) -> Bool {
   guard !self.disposed && self.generation == generation else { return false }
-  match self.current {
-    Some(current) =>
-      current.generation == generation && current.model.model.same(model)
-    None => false
-  }
+  self.current is Some(current) &&
+  current.generation == generation &&
+  current.model.model.same(model)
 }
 
 ///|
@@ -368,15 +366,40 @@ fn MarkdownViewerWidget::attach_model(
   }
   self.current = Some(attachment)
   attachment.initialize_folding()
-  match hover_bridge {
-    Some(bridge) => bridge.activate()
-    None => ()
+  if hover_bridge is Some(bridge) {
+    bridge.activate()
   }
-  match definition_bridge {
-    Some(bridge) => bridge.activate()
-    None => ()
+  if definition_bridge is Some(bridge) {
+    bridge.activate()
   }
   self.layout()
+}
+
+///|
+/// The bridge quiesce shared by `replace_source` and `apply_theme`:
+/// definition first on the way down, hover first on the way back up.
+fn MarkdownViewerWidgetAttachment::before_projection_replaced(
+  self : MarkdownViewerWidgetAttachment,
+) -> Unit {
+  if self.definition_bridge is Some(bridge) {
+    bridge.before_projection_replaced()
+  }
+  if self.hover_bridge is Some(bridge) {
+    bridge.before_projection_replaced()
+  }
+}
+
+///|
+/// The rebind half of `MarkdownViewerWidgetAttachment::before_projection_replaced`.
+fn MarkdownViewerWidgetAttachment::after_projection_replaced(
+  self : MarkdownViewerWidgetAttachment,
+) -> Unit {
+  if self.hover_bridge is Some(bridge) {
+    bridge.after_projection_replaced()
+  }
+  if self.definition_bridge is Some(bridge) {
+    bridge.after_projection_replaced()
+  }
 }
 
 ///|
@@ -386,24 +409,10 @@ fn MarkdownViewerWidgetAttachment::replace_source(
   source_model_version : Int,
 ) -> Unit {
   guard !self.disposed && self.view is Some(view) else { return }
-  match self.definition_bridge {
-    Some(bridge) => bridge.before_projection_replaced()
-    None => ()
-  }
-  match self.hover_bridge {
-    Some(bridge) => bridge.before_projection_replaced()
-    None => ()
-  }
+  self.before_projection_replaced()
   view.replace_source(source, source_model_version)
   self.reconcile_folding(source)
-  match self.hover_bridge {
-    Some(bridge) => bridge.after_projection_replaced()
-    None => ()
-  }
-  match self.definition_bridge {
-    Some(bridge) => bridge.after_projection_replaced()
-    None => ()
-  }
+  self.after_projection_replaced()
 }
 
 ///|
@@ -412,37 +421,21 @@ fn MarkdownViewerWidgetAttachment::apply_theme(
   theme : String,
 ) -> Unit {
   guard !self.disposed && self.view is Some(view) else { return }
-  match self.definition_bridge {
-    Some(bridge) => bridge.before_projection_replaced()
-    None => ()
-  }
-  match self.hover_bridge {
-    Some(bridge) => bridge.before_projection_replaced()
-    None => ()
-  }
+  self.before_projection_replaced()
   view.apply_theme(theme)
   self.reconcile_folding(self.fold.source)
-  match self.hover_bridge {
-    Some(bridge) => bridge.after_projection_replaced()
-    None => ()
-  }
-  match self.definition_bridge {
-    Some(bridge) => bridge.after_projection_replaced()
-    None => ()
-  }
+  self.after_projection_replaced()
 }
 
 ///|
 fn MarkdownViewerWidgetAttachment::layout_changed(
   self : MarkdownViewerWidgetAttachment,
 ) -> Unit {
-  match self.hover_bridge {
-    Some(bridge) => bridge.layout_changed()
-    None => ()
+  if self.hover_bridge is Some(bridge) {
+    bridge.layout_changed()
   }
-  match self.definition_bridge {
-    Some(bridge) => bridge.layout_changed()
-    None => ()
+  if self.definition_bridge is Some(bridge) {
+    bridge.layout_changed()
   }
 }
 
@@ -454,17 +447,14 @@ fn MarkdownViewerWidgetAttachment::dispose(
     return
   }
   self.disposed = true
-  match self.definition_bridge {
-    Some(bridge) => bridge.dispose()
-    None => ()
+  if self.definition_bridge is Some(bridge) {
+    bridge.dispose()
   }
-  match self.hover_bridge {
-    Some(bridge) => bridge.dispose()
-    None => ()
+  if self.hover_bridge is Some(bridge) {
+    bridge.dispose()
   }
-  match self.view {
-    Some(view) => view.dispose()
-    None => ()
+  if self.view is Some(view) {
+    view.dispose()
   }
   while self.listeners.length() > 0 {
     self.listeners.remove(self.listeners.length() - 1).dispose()
@@ -479,14 +469,10 @@ fn MarkdownViewerWidget::detach_model(
   self.generation += 1
   self.current = None
   self.focused = false
-  let root = match current.view {
-    Some(view) => Some(view.root())
-    None => None
-  }
+  let root = current.view.map(view => view.root())
   current.dispose()
-  match root {
-    Some(root) => @base_browser.remove_element(root)
-    None => ()
+  if root is Some(root) {
+    @base_browser.remove_element(root)
   }
   if !self.disposed {
     self.restore_placeholder()
@@ -497,9 +483,8 @@ fn MarkdownViewerWidget::detach_model(
 
 ///|
 fn MarkdownViewerWidget::hide_placeholder(self : MarkdownViewerWidget) -> Unit {
-  match self.placeholder {
-    Some(placeholder) => @base_browser.remove_element(placeholder.root)
-    None => ()
+  if self.placeholder is Some(placeholder) {
+    @base_browser.remove_element(placeholder.root)
   }
 }
 
@@ -507,12 +492,10 @@ fn MarkdownViewerWidget::hide_placeholder(self : MarkdownViewerWidget) -> Unit {
 fn MarkdownViewerWidget::restore_placeholder(
   self : MarkdownViewerWidget,
 ) -> Unit {
-  match (self.host, self.placeholder) {
-    (Some(host), Some(placeholder)) =>
-      if !@base_browser.element_contains(host, placeholder.root) {
-        host.append_child(placeholder.root.as_node())
-      }
-    _ => ()
+  if self.host is Some(host) &&
+    self.placeholder is Some(placeholder) &&
+    !@base_browser.element_contains(host, placeholder.root) {
+    host.append_child(placeholder.root.as_node())
   }
 }
 
@@ -532,18 +515,11 @@ pub fn MarkdownViewerWidget::set_model(
     (Some(current), Some(next)) if current.model.same(next) => return None
     _ => ()
   }
-  let old_model_url = match self.current {
-    Some(current) => Some(current.model.model.uri)
-    None => None
-  }
-  let new_model_url = match model {
-    Some(next) => Some(next.model.uri)
-    None => None
-  }
+  let old_model_url = self.current.map(current => current.model.model.uri)
+  let new_model_url = model.map(next => next.model.uri)
   let old = self.detach_model()
-  match model {
-    Some(next) => self.attach_model(next)
-    None => ()
+  if model is Some(next) {
+    self.attach_model(next)
   }
   self.did_change_model.fire({ old_model_url, new_model_url, })
   old
@@ -553,10 +529,7 @@ pub fn MarkdownViewerWidget::set_model(
 pub fn MarkdownViewerWidget::get_model(
   self : MarkdownViewerWidget,
 ) -> MarkdownViewerWidgetModel? {
-  match self.current {
-    Some(current) => Some(current.model)
-    None => None
-  }
+  self.current.map(current => current.model)
 }
 
 ///|
@@ -629,23 +602,16 @@ pub fn MarkdownViewerWidget::update_options(
   }
   let previous = self.options
   self.options = options
-  match self.placeholder {
-    Some(placeholder) => placeholder.update(options)
-    None => ()
+  if self.placeholder is Some(placeholder) {
+    placeholder.update(options)
   }
-  match self.current {
-    Some(current) => {
-      if previous.theme != options.theme {
-        current.apply_theme(options.theme)
-      }
-      if previous.show_unused != options.show_unused {
-        match current.view {
-          Some(view) => view.apply_marker_unused_visibility(options.show_unused)
-          None => ()
-        }
-      }
+  if self.current is Some(current) {
+    if previous.theme != options.theme {
+      current.apply_theme(options.theme)
     }
-    None => ()
+    if previous.show_unused != options.show_unused && current.view is Some(view) {
+      view.apply_marker_unused_visibility(options.show_unused)
+    }
   }
 }
 
@@ -676,9 +642,8 @@ pub fn MarkdownViewerWidget::get_container_dom_node(
 
 ///|
 pub fn MarkdownViewerWidget::focus(self : MarkdownViewerWidget) -> Unit {
-  match self.get_dom_node() {
-    Some(root) => @base_browser.focus_prevent_scroll(root)
-    None => ()
+  if self.get_dom_node() is Some(root) {
+    @base_browser.focus_prevent_scroll(root)
   }
 }
 
@@ -769,9 +734,8 @@ pub fn MarkdownViewerWidget::dispose(self : MarkdownViewerWidget) -> Unit {
     return
   }
   self.disposed = true
-  match self.resize_observer {
-    Some(observer) => observer.dispose()
-    None => ()
+  if self.resize_observer is Some(observer) {
+    observer.dispose()
   }
   self.resize_observer = None
   self.detach_model() |> ignore

--- a/editor/server/host/language_provider.mbt
+++ b/editor/server/host/language_provider.mbt
@@ -252,22 +252,7 @@ fn parse_moon_definition_range(raw : String) -> @base_common.Range? {
 
 ///|
 fn parse_positive_position(raw : StringView) -> @base_common.Position? {
-  guard raw.find(":") is Some(colon) else { return None }
-  let parsed = Some(
-    (
-      @string.parse_int(raw[0:colon], base=10),
-      @string.parse_int(raw[colon + 1:], base=10),
-    ),
-  ) catch {
-    _ => None
-  }
-  match parsed {
-    Some((line, column)) =>
-      if line >= 1 && column >= 1 {
-        Some(Position(line, column))
-      } else {
-        None
-      }
-    None => None
-  }
+  parse_check_position(raw).filter(position => {
+    position.line_number >= 1 && position.column >= 1
+  })
 }

--- a/editor/server/host/moon_check.mbt
+++ b/editor/server/host/moon_check.mbt
@@ -139,18 +139,17 @@ async fn MoonCheckDiagnostics::run_once(self : MoonCheckDiagnostics) -> Unit {
   // raced the switch discards its results below.
   let root = normalize_host_path(self.root.val)
   let generation = self.sync_generation.val
-  let documents = copy_synced_documents(self.documents)
+  let documents = self.documents.copy()
   let before = capture_native_disk_snapshots(root, documents)
   let raw = (self.collect_check)()
   let after = capture_native_disk_snapshots(root, documents)
-  if self.sync_generation.val != generation ||
-    !same_native_disk_snapshot_map(before, after) {
+  if self.sync_generation.val != generation || before != after {
     self.dirty.val = true
     return
   }
   guard raw is Some(raw) else { return }
   let next = parse_moon_check_diagnostics(root, raw)
-  let accepted = copy_published_diagnostic_sets(self.published.val)
+  let accepted = self.published.val.copy()
   for key, document in documents {
     // A stable disk/model mismatch is not a clear for the last accepted model.
     // Preserve that key and continue so historical entries cannot suppress
@@ -189,28 +188,6 @@ fn MoonCheckDiagnostics::emit(
 }
 
 ///|
-fn copy_synced_documents(
-  documents : Map[String, SyncedDocumentStamp],
-) -> Map[String, SyncedDocumentStamp] {
-  let copy : Map[String, SyncedDocumentStamp] = Map([])
-  for key, document in documents {
-    copy.set(key, document)
-  }
-  copy
-}
-
-///|
-fn copy_published_diagnostic_sets(
-  published : Map[String, PublishedDiagnosticSet],
-) -> Map[String, PublishedDiagnosticSet] {
-  let copy : Map[String, PublishedDiagnosticSet] = Map([])
-  for key, diagnostic_set in published {
-    copy.set(key, diagnostic_set)
-  }
-  copy
-}
-
-///|
 async fn capture_native_disk_snapshots(
   root : String,
   documents : Map[String, SyncedDocumentStamp],
@@ -229,22 +206,6 @@ async fn capture_native_disk_snapshots(
     }
   }
   snapshots
-}
-
-///|
-fn same_native_disk_snapshot_map(
-  left : Map[String, NativeDiskSnapshot],
-  right : Map[String, NativeDiskSnapshot],
-) -> Bool {
-  if left.length() != right.length() {
-    return false
-  }
-  for key, snapshot in left {
-    guard right.get(key) is Some(other) && other == snapshot else {
-      return false
-    }
-  }
-  true
 }
 
 ///|
@@ -323,43 +284,26 @@ fn check_level_severity(level : String) -> @language.DiagnosticSeverity {
 /// Parses a `moon check` location: `line:col-line:col`, or a bare `line:col`
 /// which degrades to an empty range at that position.
 fn parse_moon_loc(loc : String) -> @base_common.Range? {
-  match loc.find("-") {
-    Some(dash) =>
-      match
-        (
-          parse_check_position(loc[0:dash]),
-          parse_check_position(loc[dash + 1:]),
-        ) {
-        (Some(start), Some(end)) =>
-          Some(@base_common.Range::from_positions(start, end))
-        _ => None
-      }
-    None =>
-      match parse_check_position(loc[:]) {
-        Some(position) =>
-          Some(@base_common.Range::from_positions(position, position))
-        None => None
-      }
+  guard loc.find("-") is Some(dash) else {
+    guard parse_check_position(loc[:]) is Some(position) else { return None }
+    return Some(@base_common.Range::from_positions(position, position))
   }
+  guard parse_check_position(loc[0:dash]) is Some(start) else { return None }
+  guard parse_check_position(loc[dash + 1:]) is Some(end) else { return None }
+  Some(@base_common.Range::from_positions(start, end))
 }
 
 ///|
 fn parse_check_position(view : StringView) -> @base_common.Position? {
-  match view.find(":") {
-    Some(colon) => {
-      let parsed = Some(
-        (
-          @string.parse_int(view[0:colon], base=10),
-          @string.parse_int(view[colon + 1:], base=10),
-        ),
-      ) catch {
-        _ => None
-      }
-      match parsed {
-        Some((line, column)) => Some(Position(line, column))
-        None => None
-      }
-    }
-    None => None
+  guard view.find(":") is Some(colon) else { return None }
+  let parsed = Some(
+    (
+      @string.parse_int(view[0:colon], base=10),
+      @string.parse_int(view[colon + 1:], base=10),
+    ),
+  ) catch {
+    _ => None
   }
+  guard parsed is Some((line, column)) else { return None }
+  Some(Position(line, column))
 }

--- a/editor/shell/remote_protocol/host_browse.mbt
+++ b/editor/shell/remote_protocol/host_browse.mbt
@@ -102,28 +102,19 @@ fn decode_host_directory_listed_payload(
   id : String,
 ) -> ServerPacketDecodeResult {
   match json_string_field(packet, "path") {
-    Some(path) => {
-      let entries : Array[HostDirectoryEntry] = []
-      match json_field(packet, "entries") {
-        Some(Array(items)) =>
-          for item in items {
-            if parse_host_directory_entry(item) is Some(entry) {
-              entries.push(entry)
-            }
-          }
-        _ => ()
-      }
+    Some(path) =>
       DecodedServerPacket(
         HostDirectoryListed({
           id,
           listing: {
             path,
             parent: json_string_field(packet, "parent"),
-            entries,
+            entries: json_array_field(
+              packet, "entries", parse_host_directory_entry,
+            ),
           },
         }),
       )
-    }
     None =>
       ServerPacketDecodeError(
         ProtocolError(

--- a/editor/shell/remote_protocol/protocol.mbt
+++ b/editor/shell/remote_protocol/protocol.mbt
@@ -546,25 +546,14 @@ fn decode_directory_resolved_payload(
 ///|
 fn decode_diagnostics_payload(packet : Json) -> ServerPacketDecodeResult {
   match parse_uri_field(packet, "uri", "") {
-    ParsedProtocolUri(uri) => {
-      let diagnostics = []
-      match json_field(packet, "diagnostics") {
-        Some(Array(items)) =>
-          for item in items {
-            if parse_diagnostic(item) is Some(diagnostic) {
-              diagnostics.push(diagnostic)
-            }
-          }
-        _ => ()
-      }
+    ParsedProtocolUri(uri) =>
       DecodedServerPacket(
         Diagnostics({
           uri,
           revision: json_string_field(packet, "documentRevision").unwrap_or(""),
-          diagnostics,
+          diagnostics: json_array_field(packet, "diagnostics", parse_diagnostic),
         }),
       )
-    }
     ProtocolUriError(error) => ServerPacketDecodeError(error)
   }
 }
@@ -575,20 +564,15 @@ fn decode_hover_result_payload(
   id : String,
 ) -> ServerPacketDecodeResult {
   match parse_uri_field(packet, "uri", id) {
-    ParsedProtocolUri(uri) => {
-      let hover = match json_field(packet, "hover") {
-        Some(value) => parse_hover(value)
-        None => None
-      }
+    ParsedProtocolUri(uri) =>
       DecodedServerPacket(
         HoverResult({
           id,
           uri,
           revision: json_string_field(packet, "documentRevision").unwrap_or(""),
-          hover,
+          hover: json_field(packet, "hover").bind(parse_hover),
         }),
       )
-    }
     ProtocolUriError(error) => ServerPacketDecodeError(error)
   }
 }
@@ -599,26 +583,15 @@ fn decode_definition_result_payload(
   id : String,
 ) -> ServerPacketDecodeResult {
   match parse_uri_field(packet, "uri", id) {
-    ParsedProtocolUri(uri) => {
-      let locations = []
-      match json_field(packet, "locations") {
-        Some(Array(items)) =>
-          for item in items {
-            if parse_location(item) is Some(location) {
-              locations.push(location)
-            }
-          }
-        _ => ()
-      }
+    ParsedProtocolUri(uri) =>
       DecodedServerPacket(
         DefinitionResult({
           id,
           uri,
           revision: json_string_field(packet, "documentRevision").unwrap_or(""),
-          locations,
+          locations: json_array_field(packet, "locations", parse_location),
         }),
       )
-    }
     ProtocolUriError(error) => ServerPacketDecodeError(error)
   }
 }
@@ -629,26 +602,17 @@ fn decode_references_result_payload(
   id : String,
 ) -> ServerPacketDecodeResult {
   match parse_uri_field(packet, "uri", id) {
-    ParsedProtocolUri(uri) => {
-      let references = []
-      match json_field(packet, "references") {
-        Some(Array(items)) =>
-          for item in items {
-            if parse_reference_item(item) is Some(reference) {
-              references.push(reference)
-            }
-          }
-        _ => ()
-      }
+    ParsedProtocolUri(uri) =>
       DecodedServerPacket(
         ReferencesResult({
           id,
           uri,
           revision: json_string_field(packet, "documentRevision").unwrap_or(""),
-          references,
+          references: json_array_field(
+            packet, "references", parse_reference_item,
+          ),
         }),
       )
-    }
     ProtocolUriError(error) => ServerPacketDecodeError(error)
   }
 }
@@ -659,26 +623,15 @@ fn decode_document_symbols_result_payload(
   id : String,
 ) -> ServerPacketDecodeResult {
   match parse_uri_field(packet, "uri", id) {
-    ParsedProtocolUri(uri) => {
-      let symbols = []
-      match json_field(packet, "symbols") {
-        Some(Array(items)) =>
-          for item in items {
-            if parse_document_symbol(item) is Some(symbol) {
-              symbols.push(symbol)
-            }
-          }
-        _ => ()
-      }
+    ParsedProtocolUri(uri) =>
       DecodedServerPacket(
         DocumentSymbolsResult({
           id,
           uri,
           revision: json_string_field(packet, "documentRevision").unwrap_or(""),
-          symbols,
+          symbols: json_array_field(packet, "symbols", parse_document_symbol),
         }),
       )
-    }
     ProtocolUriError(error) => ServerPacketDecodeError(error)
   }
 }
@@ -907,15 +860,7 @@ fn parse_workspace_stat(value : Json) -> @workspace.WorkspaceStat? {
     return None
   }
   let children = match json_field(value, "children") {
-    Some(Array(items)) => {
-      let resolved = []
-      for item in items {
-        if parse_workspace_stat(item) is Some(stat) {
-          resolved.push(stat)
-        }
-      }
-      Some(resolved)
-    }
+    Some(Array(items)) => Some(items.filter_map(parse_workspace_stat))
     _ => None
   }
   Some({
@@ -1095,26 +1040,17 @@ fn parse_range(value : Json) -> @base_common.Range? {
 
 ///|
 fn parse_diagnostic(value : Json) -> @language.Diagnostic? {
-  match value {
-    Object(_) =>
-      match json_field(value, "range") {
-        Some(range_json) =>
-          match parse_range(range_json) {
-            Some(range) =>
-              Some({
-                range,
-                severity: diagnostic_severity(
-                  json_string_field(value, "severity").unwrap_or("Info"),
-                ),
-                message: json_string_field(value, "message").unwrap_or(""),
-                tags: parse_diagnostic_tags(value),
-              })
-            None => None
-          }
-        None => None
-      }
-    _ => None
-  }
+  guard value is Object(_) else { return None }
+  guard json_field(value, "range") is Some(range_json) else { return None }
+  guard parse_range(range_json) is Some(range) else { return None }
+  Some({
+    range,
+    severity: diagnostic_severity(
+      json_string_field(value, "severity").unwrap_or("Info"),
+    ),
+    message: json_string_field(value, "message").unwrap_or(""),
+    tags: parse_diagnostic_tags(value),
+  })
 }
 
 ///|
@@ -1141,26 +1077,15 @@ fn parse_diagnostic_tags(value : Json) -> Array[@language.DiagnosticTag]? {
 
 ///|
 fn parse_hover(value : Json) -> @language.Hover? {
-  match value {
-    Null => None
-    Object(_) =>
-      match (json_field(value, "range"), json_field(value, "contents")) {
-        (Some(range_json), Some(contents_json)) =>
-          match parse_range(range_json) {
-            Some(range) => {
-              let contents = parse_hover_contents(contents_json)
-              if contents.length() == 0 {
-                None
-              } else {
-                Some({ range, contents, })
-              }
-            }
-            None => None
-          }
-        _ => None
-      }
-    _ => None
+  guard value is Object(_) else { return None }
+  guard json_field(value, "range") is Some(range_json) else { return None }
+  guard json_field(value, "contents") is Some(contents_json) else {
+    return None
   }
+  guard parse_range(range_json) is Some(range) else { return None }
+  let contents = parse_hover_contents(contents_json)
+  guard contents.length() != 0 else { return None }
+  Some({ range, contents, })
 }
 
 ///|
@@ -1194,10 +1119,7 @@ fn parse_hover_content(value : Json) -> @language.HoverContent? {
         _ => None
       }
     Object(_) => {
-      let text = match json_string_field(value, "value") {
-        Some(text) => text
-        None => return None
-      }
+      guard json_string_field(value, "value") is Some(text) else { return None }
       if text == "" {
         return None
       }
@@ -1221,63 +1143,40 @@ fn parse_hover_plaintext(text : String) -> Array[@language.HoverContent] {
 
 ///|
 fn parse_location(value : Json) -> @language.Location? {
-  match value {
-    Null => None
-    Object(_) =>
-      match (json_string_field(value, "uri"), json_field(value, "range")) {
-        (Some(raw_uri), Some(range_json)) =>
-          match (try_parse_uri(raw_uri), parse_range(range_json)) {
-            (Some(uri), Some(range)) => Some({ uri, range, })
-            _ => None
-          }
-        _ => None
-      }
-    _ => None
-  }
+  guard value is Object(_) else { return None }
+  guard json_string_field(value, "uri") is Some(raw_uri) else { return None }
+  guard json_field(value, "range") is Some(range_json) else { return None }
+  guard try_parse_uri(raw_uri) is Some(uri) else { return None }
+  guard parse_range(range_json) is Some(range) else { return None }
+  Some({ uri, range, })
 }
 
 ///|
 fn parse_reference_item(value : Json) -> ReferenceItem? {
-  match value {
-    Object(_) =>
-      match (json_string_field(value, "uri"), json_field(value, "range")) {
-        (Some(raw_uri), Some(range_json)) =>
-          match (try_parse_uri(raw_uri), parse_range(range_json)) {
-            (Some(uri), Some(range)) =>
-              Some({
-                uri,
-                range,
-                line: json_int_field(value, "line").unwrap_or(0),
-                column: json_int_field(value, "column").unwrap_or(0),
-                line_text: json_string_field(value, "lineText").unwrap_or(""),
-              })
-            _ => None
-          }
-        _ => None
-      }
-    _ => None
-  }
+  guard value is Object(_) else { return None }
+  guard json_string_field(value, "uri") is Some(raw_uri) else { return None }
+  guard json_field(value, "range") is Some(range_json) else { return None }
+  guard try_parse_uri(raw_uri) is Some(uri) else { return None }
+  guard parse_range(range_json) is Some(range) else { return None }
+  Some({
+    uri,
+    range,
+    line: json_int_field(value, "line").unwrap_or(0),
+    column: json_int_field(value, "column").unwrap_or(0),
+    line_text: json_string_field(value, "lineText").unwrap_or(""),
+  })
 }
 
 ///|
 fn parse_document_symbol(value : Json) -> @language.DocumentSymbol? {
-  match value {
-    Object(_) =>
-      match json_field(value, "range") {
-        Some(range_json) =>
-          match parse_range(range_json) {
-            Some(range) =>
-              Some({
-                name: json_string_field(value, "name").unwrap_or(""),
-                kind: json_string_field(value, "kind").unwrap_or(""),
-                range,
-              })
-            None => None
-          }
-        None => None
-      }
-    _ => None
-  }
+  guard value is Object(_) else { return None }
+  guard json_field(value, "range") is Some(range_json) else { return None }
+  guard parse_range(range_json) is Some(range) else { return None }
+  Some({
+    name: json_string_field(value, "name").unwrap_or(""),
+    kind: json_string_field(value, "kind").unwrap_or(""),
+    range,
+  })
 }
 
 ///|
@@ -1318,6 +1217,20 @@ fn json_int_field(value : Json, key : String) -> Int? {
   match json_field(value, key) {
     Some(Number(number, repr=_)) => Some(number.to_int())
     _ => None
+  }
+}
+
+///|
+/// Every element of the JSON array at `key`, dropping the ones `parse`
+/// rejects. A missing or non-array field yields an empty array.
+fn[T] json_array_field(
+  value : Json,
+  key : String,
+  parse : (Json) -> T?,
+) -> Array[T] {
+  match json_field(value, key) {
+    Some(Array(items)) => items.filter_map(parse)
+    _ => []
   }
 }
 

--- a/editor/shell/workspace/document.mbt
+++ b/editor/shell/workspace/document.mbt
@@ -199,23 +199,7 @@ pub impl ToJson for DocumentSnapshot with fn to_json(self) {
 ///|
 /// JSON shape for document errors.
 pub impl ToJson for DocumentError with fn to_json(self) {
-  let fields : Map[String, Json] = {
-    "code": self.code.to_string().to_json(),
-    "message": self.message.to_json(),
-    "status": self.status().to_json(),
-  }
-  if self.uri is Some(uri) {
-    fields["uri"] = uri.to_string().to_json()
-    fields["displayName"] = @base_common.basename_or_authority(uri).to_json()
-  }
-  Json(fields)
-}
-
-///|
-/// HTTP-like status used by the reference server when serializing document
-/// failures.
-fn DocumentError::status(self : DocumentError) -> Int {
-  self.to_file_system_error().status()
+  ToJson::to_json(self.to_file_system_error())
 }
 
 ///|

--- a/editor/viewer/common/diff/advanced_diff.mbt
+++ b/editor/viewer/common/diff/advanced_diff.mbt
@@ -120,19 +120,6 @@ priv struct ReadabilitySequence {
 }
 
 ///|
-fn reverse_sequence_diffs(
-  reversed : Array[SequenceDiff],
-) -> Array[SequenceDiff] {
-  let result : Array[SequenceDiff] = []
-  let mut index = reversed.length() - 1
-  while index >= 0 {
-    result.push(reversed[index])
-    index -= 1
-  }
-  result
-}
-
-///|
 // Port of DynamicProgrammingDiffing.compute. In particular, the direction
 // order, diagonal tie preference, and consecutive-diagonal bonus match the
 // pinned source.
@@ -223,7 +210,7 @@ fn weighted_sequence_diffs(
     }
   }
   report_alignment(-1, -1)
-  reverse_sequence_diffs(reversed)
+  reversed.rev()
 }
 
 ///|
@@ -434,24 +421,16 @@ fn shift_sequence_diffs(
       None
     }
     let sequence1_valid : DiffOffsetRange = {
-      start: match previous {
-        Some(value) => value.original.end_exclusive + 1
-        None => 0
-      },
-      end_exclusive: match next {
-        Some(value) => value.original.start - 1
-        None => sequence1.values.length()
-      },
+      start: previous.map_or(0, value => value.original.end_exclusive + 1),
+      end_exclusive: next.map_or(sequence1.values.length(), value => {
+        value.original.start - 1
+      }),
     }
     let sequence2_valid : DiffOffsetRange = {
-      start: match previous {
-        Some(value) => value.modified.end_exclusive + 1
-        None => 0
-      },
-      end_exclusive: match next {
-        Some(value) => value.modified.start - 1
-        None => sequence2.values.length()
-      },
+      start: previous.map_or(0, value => value.modified.end_exclusive + 1),
+      end_exclusive: next.map_or(sequence2.values.length(), value => {
+        value.modified.start - 1
+      }),
     }
     let current = result[index]
     if current.original.is_empty() {
@@ -485,19 +464,51 @@ fn optimize_sequence_diffs(
 }
 
 ///|
+// One left-to-right pass that folds each diff into the one accumulated before
+// it whenever `should_join` accepts the pair.
+fn join_adjacent_sequence_diffs(
+  sequence_diffs : Array[SequenceDiff],
+  should_join : (SequenceDiff, SequenceDiff) -> Bool,
+) -> Array[SequenceDiff] {
+  let result : Array[SequenceDiff] = []
+  for diff in sequence_diffs {
+    let last_index = result.length() - 1
+    if last_index >= 0 && should_join(result[last_index], diff) {
+      result[last_index] = result[last_index].join(diff)
+    } else {
+      result.push(diff)
+    }
+  }
+  result
+}
+
+///|
+// Repeat that pass until it stops merging, at most eleven times. Every join
+// drops one diff, so a pass that returns as many diffs as it received made no
+// join and the sequence is stable.
+fn join_adjacent_sequence_diffs_until_stable(
+  sequence_diffs : Array[SequenceDiff],
+  should_join : (SequenceDiff, SequenceDiff) -> Bool,
+) -> Array[SequenceDiff] {
+  let mut diffs = sequence_diffs
+  for _ in 0..<11 {
+    let joined = join_adjacent_sequence_diffs(diffs, should_join)
+    let stable = joined.length() == diffs.length()
+    diffs = joined
+    if stable {
+      break
+    }
+  }
+  diffs
+}
+
+///|
 fn remove_short_matches(
   original_values : Array[Int],
   modified_values : Array[Int],
   sequence_diffs : Array[SequenceDiff],
 ) -> Array[SequenceDiff] {
-  let result : Array[SequenceDiff] = []
-  for diff in sequence_diffs {
-    if result.is_empty() {
-      result.push(diff)
-      continue
-    }
-    let last_index = result.length() - 1
-    let last = result[last_index]
+  join_adjacent_sequence_diffs(sequence_diffs, (last, diff) => {
     let original_gap : DiffOffsetRange = {
       start: last.original.end_exclusive,
       end_exclusive: diff.original.start,
@@ -506,14 +517,9 @@ fn remove_short_matches(
       start: last.modified.end_exclusive,
       end_exclusive: diff.modified.start,
     }
-    if scalar_range_utf16_length(original_values, original_gap) <= 2 ||
-      scalar_range_utf16_length(modified_values, modified_gap) <= 2 {
-      result[last_index] = last.join(diff)
-    } else {
-      result.push(diff)
-    }
-  }
-  result
+    scalar_range_utf16_length(original_values, original_gap) <= 2 ||
+    scalar_range_utf16_length(modified_values, modified_gap) <= 2
+  })
 }
 
 ///|
@@ -742,31 +748,14 @@ fn remove_very_short_matching_text_between_long_diffs(
   modified_values : Array[Int],
   sequence_diffs : Array[SequenceDiff],
 ) -> Array[SequenceDiff] {
-  let mut diffs = sequence_diffs
-  if diffs.is_empty() {
-    return diffs
-  }
-  let mut pass = 0
-  let mut repeat = true
-  while repeat && pass < 11 {
-    repeat = false
-    let joined : Array[SequenceDiff] = [diffs[0]]
-    for index in 1..<diffs.length() {
-      let current = diffs[index]
-      let last_index = joined.length() - 1
-      let previous = joined[last_index]
-      if should_join_long_scalar_diffs(
-          original_values, modified_values, previous, current,
-        ) {
-        joined[last_index] = previous.join(current)
-        repeat = true
-      } else {
-        joined.push(current)
-      }
-    }
-    diffs = joined
-    pass += 1
-  }
+  let diffs = join_adjacent_sequence_diffs_until_stable(sequence_diffs, (
+    previous,
+    current,
+  ) => {
+    should_join_long_scalar_diffs(
+      original_values, modified_values, previous, current,
+    )
+  })
   mark_short_trim_as_changed(original_values, modified_values, diffs)
 }
 
@@ -774,22 +763,10 @@ fn remove_very_short_matching_text_between_long_diffs(
 fn merge_touching_sequence_diffs(
   sequence_diffs : Array[SequenceDiff],
 ) -> Array[SequenceDiff] {
-  let result : Array[SequenceDiff] = []
-  for diff in sequence_diffs {
-    if result.is_empty() {
-      result.push(diff)
-      continue
-    }
-    let last_index = result.length() - 1
-    let last = result[last_index]
-    if last.original.end_exclusive >= diff.original.start ||
-      last.modified.end_exclusive >= diff.modified.start {
-      result[last_index] = last.join(diff)
-    } else {
-      result.push(diff)
-    }
-  }
-  result
+  join_adjacent_sequence_diffs(sequence_diffs, (last, diff) => {
+    last.original.end_exclusive >= diff.original.start ||
+    last.modified.end_exclusive >= diff.modified.start
+  })
 }
 
 ///|
@@ -898,10 +875,13 @@ fn include_strict_whitespace_line_diffs(
     return sequence_diffs
   }
   let result : Array[SequenceDiff] = []
-  let mut original_start = 0
-  let mut modified_start = 0
-  for diff in sequence_diffs {
-    let equal_count = diff.original.start - original_start
+  // Emit a one-line diff for every line of an equal run whose two sides still
+  // differ once whitespace is no longer ignored.
+  fn push_strict_whitespace_diffs(
+    original_start : Int,
+    modified_start : Int,
+    equal_count : Int,
+  ) -> Unit {
     for offset in 0..<equal_count {
       let original_offset = original_start + offset
       let modified_offset = modified_start + offset
@@ -918,27 +898,25 @@ fn include_strict_whitespace_line_diffs(
         })
       }
     }
+  }
+
+  let mut original_start = 0
+  let mut modified_start = 0
+  for diff in sequence_diffs {
+    push_strict_whitespace_diffs(
+      original_start,
+      modified_start,
+      diff.original.start - original_start,
+    )
     result.push(diff)
     original_start = diff.original.end_exclusive
     modified_start = diff.modified.end_exclusive
   }
-  let equal_count = original_lines.length() - original_start
-  for offset in 0..<equal_count {
-    let original_offset = original_start + offset
-    let modified_offset = modified_start + offset
-    if original_lines[original_offset] != modified_lines[modified_offset] {
-      result.push({
-        original: {
-          start: original_offset,
-          end_exclusive: original_offset + 1,
-        },
-        modified: {
-          start: modified_offset,
-          end_exclusive: modified_offset + 1,
-        },
-      })
-    }
-  }
+  push_strict_whitespace_diffs(
+    original_start,
+    modified_start,
+    original_lines.length() - original_start,
+  )
   merge_touching_sequence_diffs(result)
 }
 
@@ -966,40 +944,19 @@ fn remove_very_short_matching_lines_between_diffs(
   original_lines : Array[String],
   sequence_diffs : Array[SequenceDiff],
 ) -> Array[SequenceDiff] {
-  let mut diffs = sequence_diffs
-  if diffs.is_empty() {
-    return diffs
-  }
-  let mut pass = 0
-  let mut repeat = true
-  while repeat && pass < 11 {
-    repeat = false
-    let result : Array[SequenceDiff] = [diffs[0]]
-    for index in 1..<diffs.length() {
-      let current = diffs[index]
-      let last_index = result.length() - 1
-      let previous = result[last_index]
-      let short_unchanged = line_non_whitespace_length(
-          original_lines,
-          previous.original.end_exclusive,
-          current.original.start,
-        ) <=
-        4
-      let substantial_side = previous.original.length() +
-        previous.modified.length() >
-        5 ||
-        current.original.length() + current.modified.length() > 5
-      if short_unchanged && substantial_side {
-        result[last_index] = previous.join(current)
-        repeat = true
-      } else {
-        result.push(current)
-      }
-    }
-    diffs = result
-    pass += 1
-  }
-  diffs
+  join_adjacent_sequence_diffs_until_stable(sequence_diffs, (previous, current) => {
+    let short_unchanged = line_non_whitespace_length(
+        original_lines,
+        previous.original.end_exclusive,
+        current.original.start,
+      ) <=
+      4
+    let substantial_side = previous.original.length() +
+      previous.modified.length() >
+      5 ||
+      current.original.length() + current.modified.length() > 5
+    short_unchanged && substantial_side
+  })
 }
 
 ///|
@@ -1139,7 +1096,7 @@ fn merge_sequence_diff_sets(
   first : Array[SequenceDiff],
   second : Array[SequenceDiff],
 ) -> Array[SequenceDiff] {
-  let result : Array[SequenceDiff] = []
+  let merged : Array[SequenceDiff] = []
   let mut first_index = 0
   let mut second_index = 0
   while first_index < first.length() || second_index < second.length() {
@@ -1156,15 +1113,11 @@ fn merge_sequence_diff_sets(
       second_index += 1
       value
     }
-    if !result.is_empty() &&
-      result[result.length() - 1].original.end_exclusive >= next.original.start {
-      let last_index = result.length() - 1
-      result[last_index] = result[last_index].join(next)
-    } else {
-      result.push(next)
-    }
+    merged.push(next)
   }
-  result
+  join_adjacent_sequence_diffs(merged, (last, next) => {
+    last.original.end_exclusive >= next.original.start
+  })
 }
 
 ///|
@@ -1255,40 +1208,23 @@ fn extend_diffs_to_parent_if_appropriate(
     if equal_mapping.original.is_empty() {
       continue
     }
-    let (next_index, next_original, next_modified) = scan_parent_for_word_extension(
-      sequence1,
-      sequence2,
-      equal_mappings,
-      index,
-      equal_mapping.original.start,
-      equal_mapping.modified.start,
-      equal_mapping,
-      last_original,
-      last_modified,
-      find_parent,
-      force,
-      additional,
-    )
-    index = next_index
-    last_original = next_original
-    last_modified = next_modified
-    let (next_index, next_original, next_modified) = scan_parent_for_word_extension(
-      sequence1,
-      sequence2,
-      equal_mappings,
-      index,
-      equal_mapping.original.end_exclusive - 1,
-      equal_mapping.modified.end_exclusive - 1,
-      equal_mapping,
-      last_original,
-      last_modified,
-      find_parent,
-      force,
-      additional,
-    )
-    index = next_index
-    last_original = next_original
-    last_modified = next_modified
+    let anchors = [
+      (equal_mapping.original.start, equal_mapping.modified.start),
+      (
+        equal_mapping.original.end_exclusive - 1,
+        equal_mapping.modified.end_exclusive - 1,
+      ),
+    ]
+    for anchor in anchors {
+      let (pair_original, pair_modified) = anchor
+      let (next_index, next_original, next_modified) = scan_parent_for_word_extension(
+        sequence1, sequence2, equal_mappings, index, pair_original, pair_modified,
+        equal_mapping, last_original, last_modified, find_parent, force, additional,
+      )
+      index = next_index
+      last_original = next_original
+      last_modified = next_modified
+    }
   }
   merge_sequence_diff_sets(sequence_diffs, additional)
 }

--- a/editor/viewer/common/languages/languages.mbt
+++ b/editor/viewer/common/languages/languages.mbt
@@ -48,9 +48,7 @@ fn[T] LanguageFeatureRegistry::register(
   self.entries.push(entry)
   @base_common.Disposable::from(() => {
     active.val = false
-    let retained = self.entries.filter(item => item.active.val)
-    self.entries.clear()
-    self.entries.append(retained)
+    self.entries.retain(item => item.active.val)
   })
 }
 
@@ -393,46 +391,54 @@ async fn Languages::hover_at_with_log_handle(
     if !entry.active.val {
       continue
     }
-    match
-      (entry.provider.provide_hover(model, position, token) catch {
-        _ => {
-          if !token.is_cancellation_requested() {
-            log_provider_failure(
-              log_service,
-              "language.hover",
-              model,
-              captured.provider_index,
-            )
-          }
-          None
+    let hover = entry.provider.provide_hover(model, position, token) catch {
+      _ => {
+        if !token.is_cancellation_requested() {
+          log_provider_failure(
+            log_service,
+            "language.hover",
+            model,
+            captured.provider_index,
+          )
         }
-      }) {
-      Some(hover) =>
-        if token.is_cancellation_requested() {
-          return None
-        } else if entry.active.val && hover.contents.length() > 0 {
-          return Some(hover)
-        }
-      None => ()
+        None
+      }
+    }
+    if hover is Some(hover) {
+      if token.is_cancellation_requested() {
+        return None
+      } else if entry.active.val && hover.contents.length() > 0 {
+        return Some(hover)
+      }
     }
   }
   None
 }
 
 ///|
-async fn Languages::definition_at_with_log_handle(
-  self : Languages,
+/// Shared body of `definition_at_with_log_handle` and
+/// `references_at_with_log_handle`: fans one position out to every matching
+/// live provider, then concatenates the surviving results in registry order.
+async fn[T] locations_at_with_log_handle(
+  registry : LanguageFeatureRegistry[T],
   model : @model.TextModel,
   offset : Int,
   log_service : @log.LogHandle,
-  token? : @language.CancellationToken = @language.CancellationToken::none(),
-  run_tasks? : async (Array[async () -> Unit]) -> Unit = @base_common.run_async_tasks_sequentially,
+  category : String,
+  token : @language.CancellationToken,
+  run_tasks : async (Array[async () -> Unit]) -> Unit,
+  provide : async (
+    T,
+    @model.TextModel,
+    @base_common.Position,
+    @language.CancellationToken,
+  ) -> Array[@language.Location],
 ) -> Array[@language.Location] noraise {
   if token.is_cancellation_requested() {
     return []
   }
   let position = model.get_position_at(offset)
-  let providers = self.definition_provider.snapshot_matching(model)
+  let providers = registry.snapshot_matching(model)
   let provider_results : Array[Array[@language.Location]?] = [
     for _ in 0..<providers.length() => None
   ]
@@ -443,12 +449,12 @@ async fn Languages::definition_at_with_log_handle(
       if token.is_cancellation_requested() || !entry.active.val {
         return
       }
-      let result = entry.provider.provide_definition(model, position, token) catch {
+      let result = provide(entry.provider, model, position, token) catch {
         _ => {
           if !token.is_cancellation_requested() {
             log_provider_failure(
               log_service,
-              "language.definition",
+              category,
               model,
               captured.provider_index,
             )
@@ -467,15 +473,34 @@ async fn Languages::definition_at_with_log_handle(
   }
   let locations : Array[@language.Location] = []
   for index, result in provider_results {
-    match result {
-      Some(result) =>
-        if providers[index].entry.active.val {
-          locations.append(result)
-        }
-      None => ()
+    if result is Some(result) && providers[index].entry.active.val {
+      locations.append(result)
     }
   }
   locations
+}
+
+///|
+async fn Languages::definition_at_with_log_handle(
+  self : Languages,
+  model : @model.TextModel,
+  offset : Int,
+  log_service : @log.LogHandle,
+  token? : @language.CancellationToken = @language.CancellationToken::none(),
+  run_tasks? : async (Array[async () -> Unit]) -> Unit = @base_common.run_async_tasks_sequentially,
+) -> Array[@language.Location] noraise {
+  locations_at_with_log_handle(
+    self.definition_provider,
+    model,
+    offset,
+    log_service,
+    "language.definition",
+    token,
+    run_tasks,
+    (provider, model, position, token) => {
+      provider.provide_definition(model, position, token)
+    },
+  )
 }
 
 ///|
@@ -497,54 +522,18 @@ async fn Languages::references_at_with_log_handle(
   token? : @language.CancellationToken = @language.CancellationToken::none(),
   run_tasks? : async (Array[async () -> Unit]) -> Unit = @base_common.run_async_tasks_sequentially,
 ) -> Array[@language.Location] noraise {
-  if token.is_cancellation_requested() {
-    return []
-  }
-  let position = model.get_position_at(offset)
-  let providers = self.references_provider.snapshot_matching(model)
-  let provider_results : Array[Array[@language.Location]?] = [
-    for _ in 0..<providers.length() => None
-  ]
-  let tasks : Array[async () -> Unit] = []
-  for result_index, captured in providers {
-    tasks.push(() => {
-      let entry = captured.entry
-      if token.is_cancellation_requested() || !entry.active.val {
-        return
-      }
-      let result = entry.provider.provide_references(model, position, token) catch {
-        _ => {
-          if !token.is_cancellation_requested() {
-            log_provider_failure(
-              log_service,
-              "language.references",
-              model,
-              captured.provider_index,
-            )
-          }
-          []
-        }
-      }
-      provider_results[result_index] = Some(result)
-    })
-  }
-  run_tasks(tasks) catch {
-    _ => ()
-  }
-  if token.is_cancellation_requested() {
-    return []
-  }
-  let locations : Array[@language.Location] = []
-  for index, result in provider_results {
-    match result {
-      Some(result) =>
-        if providers[index].entry.active.val {
-          locations.append(result)
-        }
-      None => ()
-    }
-  }
-  locations
+  locations_at_with_log_handle(
+    self.references_provider,
+    model,
+    offset,
+    log_service,
+    "language.references",
+    token,
+    run_tasks,
+    (provider, model, position, token) => {
+      provider.provide_references(model, position, token)
+    },
+  )
 }
 
 ///|

--- a/editor/viewer/common/markers/squiggly_theme.mbt
+++ b/editor/viewer/common/markers/squiggly_theme.mbt
@@ -16,10 +16,10 @@
 fn encode_uri_component(text : String) -> String {
   let sb = StringBuilder()
   for ch in text {
-    let code = ch.to_int()
-    if is_unreserved(code) {
+    if is_unreserved(ch) {
       sb.write_char(ch)
     } else {
+      let code = ch.to_int()
       sb.write_char('%')
       sb.write_char(hex_digit_char((code >> 4) & 0xF))
       sb.write_char(hex_digit_char(code & 0xF))
@@ -29,19 +29,12 @@ fn encode_uri_component(text : String) -> String {
 }
 
 ///|
-fn is_unreserved(code : Int) -> Bool {
-  (code >= '0'.to_int() && code <= '9'.to_int()) ||
-  (code >= 'A'.to_int() && code <= 'Z'.to_int()) ||
-  (code >= 'a'.to_int() && code <= 'z'.to_int()) ||
-  code == '-'.to_int() ||
-  code == '_'.to_int() ||
-  code == '.'.to_int() ||
-  code == '!'.to_int() ||
-  code == '~'.to_int() ||
-  code == '*'.to_int() ||
-  code == '\''.to_int() ||
-  code == '('.to_int() ||
-  code == ')'.to_int()
+fn is_unreserved(ch : Char) -> Bool {
+  match ch {
+    '0'..='9' | 'A'..='Z' | 'a'..='z' => true
+    '-' | '_' | '.' | '!' | '~' | '*' | '\'' | '(' | ')' => true
+    _ => false
+  }
 }
 
 ///|
@@ -94,23 +87,17 @@ pub(all) struct SquigglyThemeColors {
 /// in this viewer consumes those custom properties (deviation, no dead state).
 pub fn squiggly_theme_css(colors : SquigglyThemeColors) -> String {
   let sb = StringBuilder()
-  match colors.error {
-    Some(color) =>
-      write_squiggly_rule(sb, "error", squiggly_svg_data_uri(color))
-    None => ()
+  if colors.error is Some(color) {
+    write_squiggly_rule(sb, "error", squiggly_svg_data_uri(color))
   }
-  match colors.warning {
-    Some(color) =>
-      write_squiggly_rule(sb, "warning", squiggly_svg_data_uri(color))
-    None => ()
+  if colors.warning is Some(color) {
+    write_squiggly_rule(sb, "warning", squiggly_svg_data_uri(color))
   }
-  match colors.info {
-    Some(color) => write_squiggly_rule(sb, "info", squiggly_svg_data_uri(color))
-    None => ()
+  if colors.info is Some(color) {
+    write_squiggly_rule(sb, "info", squiggly_svg_data_uri(color))
   }
-  match colors.hint {
-    Some(color) => write_dotdotdot_rule(sb, dotdotdot_svg_data_uri(color))
-    None => ()
+  if colors.hint is Some(color) {
+    write_dotdotdot_rule(sb, dotdotdot_svg_data_uri(color))
   }
   sb.to_string()
 }

--- a/editor/viewer/common/view_layout/render_line_renderer.mbt
+++ b/editor/viewer/common/view_layout/render_line_renderer.mbt
@@ -269,6 +269,18 @@ fn transform_and_remove_overflowing(
 }
 
 ///|
+/// A copy of `token` cut short at `end_index`, keeping its CSS class, metadata
+/// and RTL flag.
+fn line_part_with_end_index(token : LinePart, end_index : Int) -> LinePart {
+  {
+    end_index,
+    class_name: token.class_name,
+    metadata: token.metadata,
+    contains_rtl: token.contains_rtl,
+  }
+}
+
+///|
 fn split_large_tokens(
   line_content : String,
   tokens : Array[LinePart],
@@ -281,9 +293,6 @@ fn split_large_tokens(
     for token in tokens {
       let token_end_index = token.end_index
       if last_token_end_index + long_token < token_end_index {
-        let token_type = token.class_name
-        let token_metadata = token.metadata
-        let token_contains_rtl = token.contains_rtl
         let mut last_space_offset = -1
         let mut curr_token_start = last_token_end_index
         for j in last_token_end_index..<token_end_index {
@@ -291,23 +300,13 @@ fn split_large_tokens(
             last_space_offset = j
           }
           if last_space_offset != -1 && j - curr_token_start >= long_token {
-            result.push({
-              end_index: last_space_offset + 1,
-              class_name: token_type,
-              metadata: token_metadata,
-              contains_rtl: token_contains_rtl,
-            })
+            result.push(line_part_with_end_index(token, last_space_offset + 1))
             curr_token_start = last_space_offset + 1
             last_space_offset = -1
           }
         }
         if curr_token_start != token_end_index {
-          result.push({
-            end_index: token_end_index,
-            class_name: token_type,
-            metadata: token_metadata,
-            contains_rtl: token_contains_rtl,
-          })
+          result.push(line_part_with_end_index(token, token_end_index))
         }
       } else {
         result.push(token)
@@ -319,25 +318,12 @@ fn split_large_tokens(
       let token_end_index = token.end_index
       let diff = token_end_index - last_token_end_index
       if diff > long_token {
-        let token_type = token.class_name
-        let token_metadata = token.metadata
-        let token_contains_rtl = token.contains_rtl
         let pieces_count = (diff + long_token - 1) / long_token
         for j in 1..<pieces_count {
           let piece_end_index = last_token_end_index + j * long_token
-          result.push({
-            end_index: piece_end_index,
-            class_name: token_type,
-            metadata: token_metadata,
-            contains_rtl: token_contains_rtl,
-          })
+          result.push(line_part_with_end_index(token, piece_end_index))
         }
-        result.push({
-          end_index: token_end_index,
-          class_name: token_type,
-          metadata: token_metadata,
-          contains_rtl: token_contains_rtl,
-        })
+        result.push(line_part_with_end_index(token, token_end_index))
       } else {
         result.push(token)
       }
@@ -421,12 +407,7 @@ fn extract_control_characters(
       if is_control_character(charcode) {
         if char_offset > last_end_index {
           last_end_index = char_offset
-          result.push({
-            end_index: char_offset,
-            class_name: token.class_name,
-            metadata: token.metadata,
-            contains_rtl: token.contains_rtl,
-          })
+          result.push(line_part_with_end_index(token, char_offset))
         }
         last_end_index = char_offset + 1
         result.push({
@@ -440,12 +421,7 @@ fn extract_control_characters(
     }
     if char_offset > last_end_index {
       last_end_index = token_end_index
-      result.push({
-        end_index: token_end_index,
-        class_name: token.class_name,
-        metadata: token.metadata,
-        contains_rtl: token.contains_rtl,
-      })
+      result.push(line_part_with_end_index(token, token_end_index))
     }
   }
   result
@@ -663,12 +639,7 @@ fn apply_inline_decorations(
       let decoration = decorations[decoration_index]
       if decoration.start_offset > last_result_end_index {
         last_result_end_index = decoration.start_offset
-        result.push({
-          end_index: last_result_end_index,
-          class_name: token_type,
-          metadata: token_metadata,
-          contains_rtl: token_contains_rtl,
-        })
+        result.push(line_part_with_end_index(token, last_result_end_index))
       }
       if decoration.end_offset + 1 <= token_end_index {
         last_result_end_index = decoration.end_offset + 1
@@ -692,12 +663,7 @@ fn apply_inline_decorations(
     }
     if token_end_index > last_result_end_index {
       last_result_end_index = token_end_index
-      result.push({
-        end_index: last_result_end_index,
-        class_name: token_type,
-        metadata: token_metadata,
-        contains_rtl: token_contains_rtl,
-      })
+      result.push(line_part_with_end_index(token, last_result_end_index))
     }
   }
   let last_token_end_index = tokens[tokens.length() - 1].end_index
@@ -974,21 +940,7 @@ fn write_css_px(html : StringBuilder, value : Double) -> Unit {
 
 ///|
 fn to_4_char_hex(n : Int) -> String {
-  let sb = StringBuilder()
-  append_code(sb, hex_digit((n >> 12) & 0xF))
-  append_code(sb, hex_digit((n >> 8) & 0xF))
-  append_code(sb, hex_digit((n >> 4) & 0xF))
-  append_code(sb, hex_digit(n & 0xF))
-  sb.to_string()
-}
-
-///|
-fn hex_digit(value : Int) -> Int {
-  if value < 10 {
-    0x30 + value
-  } else {
-    0x41 + value - 10
-  }
+  (n & 0xFFFF).to_string(radix=16).to_upper().pad_start(4, '0')
 }
 
 ///|


### PR DESCRIPTION
**This half needs a careful read.** Every hunk here adds or removes something
SHARED, so correctness depends on code outside the hunk you are looking at. The
purely in-function rewrites this was mixed with have moved to a separate pull
request, so what is left is all shared-surface change.

What to check, hardest first:

1. **An extracted helper must be equivalent at every call site it replaced.**
   The trap is a call site that passed a different argument, or read state at a
   different moment, than its neighbours.
2. **A merged or-pattern arm must have had identical bodies.** Where the arms
   differed and the difference moved inside the arm, the fold buys less than it
   appears to.
3. **A reshaped loop must keep its iteration order and its early exits.**

Scope: `editor/`. The largest pieces are the cursor-key registration pairs, the shared listener disposal sweep, the repeated Option ladders in the code editor widget, and the shared decode helpers in the remote protocol.

### Verified on this branch alone

`moon fmt --check`, the native and JS workspace checks with `--deny-warn`, both
full test suites, and from `editor/` `moon check --target all --warn-list +73
--deny-warn` plus `moon test --target all`, with no other part of the refactor
applied. No `.mbti` changed.

---

The refactor is split so each pull request asks one kind of question. Every file
appears in exactly one of them, each was verified on its own branch with no
other part applied, so they merge in any order.

| | easy to review | needs a careful read |
| --- | --- | --- |
| root | #1330 | this one (#1325) |
| `desktop/` | #1331 | #1326 |
| `editor/` | #1332 | #1327 |
| tests | #1333 | #1328 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JiBNGzCsZpN6e5Y4p9pXdn
