### PR TITLE
test: share fixtures and fold repeated cases

### DIFF
--- a/agent/auto_compact_test.mbt
+++ b/agent/auto_compact_test.mbt
@@ -13,36 +13,29 @@ async fn auto_compact_test_server(
   group : @async.TaskGroup[Unit],
   handle : (Json) -> MockReply raise,
 ) -> String? {
-  guard bind_test_server(
-      "local TCP bind unavailable; skipping auto-compaction test",
-    )
-    is Some(server) else {
-    return None
-  }
-  group.spawn_bg(no_wait=true) <| () => {
-    server.run_forever(
-      (request, body, conn) => {
-        assert_eq(request.path, "/chat/completions")
-        match handle(@json.parse(body.read_all().text())) {
-          Sse(payload) => {
-            conn.send_response(200, "OK", extra_headers={
-              "Content-Type": "text/event-stream",
-            })
-            conn.write("data: \{payload}\n\n")
-            conn.write("data: [DONE]\n\n")
-          }
-          Body(json) => {
-            conn.send_response(200, "OK", extra_headers={
-              "Content-Type": "application/json",
-            })
-            conn.write(json.stringify())
-          }
+  serve_chat_completions(
+    group,
+    "local TCP bind unavailable; skipping auto-compaction test",
+    max_connections=8,
+    (request, body, conn) => {
+      assert_eq(request.path, "/chat/completions")
+      match handle(@json.parse(body)) {
+        Sse(payload) => {
+          conn.send_response(200, "OK", extra_headers={
+            "Content-Type": "text/event-stream",
+          })
+          conn.write("data: \{payload}\n\n")
+          conn.write("data: [DONE]\n\n")
         }
-      },
-      max_connections=8,
-    )
-  }
-  Some("http://127.0.0.1:\{server.addr.port()}/chat/completions")
+        Body(json) => {
+          conn.send_response(200, "OK", extra_headers={
+            "Content-Type": "application/json",
+          })
+          conn.write(json.stringify())
+        }
+      }
+    },
+  )
 }
 
 ///|
@@ -164,14 +157,10 @@ fn summary_before_terminal(
   result : @agent_session.Session,
   loc~ : SourceLoc,
 ) -> @agent_session.SessionSummary raise {
-  let events = result.events()
-  let mut found = None
-  for event in events {
-    if event.item() is Summary(summary) {
-      found = Some(summary)
-    }
-  }
-  guard found is Some(summary) else {
+  let summaries = [
+    for event in result.events() if event.item() is Summary(summary) => summary
+  ]
+  guard summaries.last() is Some(summary) else {
     fail("expected the checkpoint summary before the terminal", loc~)
   }
   summary
@@ -206,15 +195,7 @@ fn finish_definition() -> @agent_tool.AgentToolDefinition {
 
 ///|
 fn finish_and_probe_tools() -> @agent_tool.Tools raise {
-  Tools([
-    finish_definition(),
-    AgentToolDefinition(
-      name="probe",
-      description="Probe tool.",
-      schema=JsonSchema({ "type": "object" }),
-      execute=Sync(_args => @agent_tool.respond("result-1")),
-    ),
-  ])
+  Tools([finish_definition(), probe_definition(result="result-1")])
 }
 
 ///|
@@ -621,12 +602,7 @@ async test "a pressured custom control completion is salvaged at the ceiling" {
         execute=Sync(_args => @agent_tool.ToolAction::finish("report captured")),
         control=true,
       ),
-      AgentToolDefinition(
-        name="probe",
-        description="Probe tool.",
-        schema=JsonSchema({ "type": "object" }),
-        execute=Sync(_args => @agent_tool.respond("result-1")),
-      ),
+      probe_definition(result="result-1"),
     ])
     let session = @agent_session.Session(
       SessionId("custom-completion-pressure"),
@@ -690,12 +666,7 @@ async test "a lone control verdict without a finish executes then yields" {
         execute=Sync(_args => @agent_tool.respond("verdict recorded")),
         control=true,
       ),
-      AgentToolDefinition(
-        name="probe",
-        description="Probe tool.",
-        schema=JsonSchema({ "type": "object" }),
-        execute=Sync(_args => @agent_tool.respond("result-1")),
-      ),
+      probe_definition(result="result-1"),
     ])
     let session = @agent_session.Session(
       SessionId("control-verdict-pressure"),

--- a/agent/goal_check_test.mbt
+++ b/agent/goal_check_test.mbt
@@ -6,24 +6,19 @@ async fn goal_check_test_server(
   bodies : Array[String],
   responses : Array[String],
 ) -> String? {
-  guard bind_test_server("local TCP bind unavailable; skipping goal check test")
-    is Some(server) else {
-    return None
-  }
-  group.spawn_bg(no_wait=true) <| () => {
-    server.run_forever(
-      (_request, body, conn) => {
-        bodies.push(body.read_all().text())
-        conn.send_response(200, "OK", extra_headers={
-          "Content-Type": "text/event-stream",
-        })
-        conn.write("data: \{responses[bodies.length() - 1]}\n\n")
-        conn.write("data: [DONE]\n\n")
-      },
-      max_connections=2,
-    )
-  }
-  Some("http://127.0.0.1:\{server.addr.port()}/chat/completions")
+  serve_chat_completions(
+    group,
+    "local TCP bind unavailable; skipping goal check test",
+    max_connections=2,
+    (_request, body, conn) => {
+      bodies.push(body)
+      conn.send_response(200, "OK", extra_headers={
+        "Content-Type": "text/event-stream",
+      })
+      conn.write("data: \{responses[bodies.length() - 1]}\n\n")
+      conn.write("data: [DONE]\n\n")
+    },
+  )
 }
 
 ///|
@@ -36,35 +31,29 @@ async fn goal_ceiling_test_server(
   checkpoint_bodies : Array[String],
   responses : Array[String],
 ) -> String? {
-  guard bind_test_server("local TCP bind unavailable; skipping goal check test")
-    is Some(server) else {
-    return None
-  }
-  group.spawn_bg(no_wait=true) <| () => {
-    server.run_forever(
-      (_request, body, conn) => {
-        let text = body.read_all().text()
-        if text.contains("CONTEXT CHECKPOINT COMPACTION") {
-          checkpoint_bodies.push(text)
-          conn.send_response(200, "OK", extra_headers={
-            "Content-Type": "application/json",
-          })
-          conn.write(
-            "{\"choices\":[{\"message\":{\"role\":\"assistant\",\"content\":\"GOAL-CEILING-SUMMARY\"}}]}",
-          )
-        } else {
-          bodies.push(text)
-          conn.send_response(200, "OK", extra_headers={
-            "Content-Type": "text/event-stream",
-          })
-          conn.write("data: \{responses[bodies.length() - 1]}\n\n")
-          conn.write("data: [DONE]\n\n")
-        }
-      },
-      max_connections=4,
-    )
-  }
-  Some("http://127.0.0.1:\{server.addr.port()}/chat/completions")
+  serve_chat_completions(
+    group,
+    "local TCP bind unavailable; skipping goal check test",
+    max_connections=4,
+    (_request, text, conn) => {
+      if text.contains("CONTEXT CHECKPOINT COMPACTION") {
+        checkpoint_bodies.push(text)
+        conn.send_response(200, "OK", extra_headers={
+          "Content-Type": "application/json",
+        })
+        conn.write(
+          "{\"choices\":[{\"message\":{\"role\":\"assistant\",\"content\":\"GOAL-CEILING-SUMMARY\"}}]}",
+        )
+      } else {
+        bodies.push(text)
+        conn.send_response(200, "OK", extra_headers={
+          "Content-Type": "text/event-stream",
+        })
+        conn.write("data: \{responses[bodies.length() - 1]}\n\n")
+        conn.write("data: [DONE]\n\n")
+      }
+    },
+  )
 }
 
 ///|
@@ -286,16 +275,13 @@ async test "a check on the reminder boundary is not buried by a reminder" {
     // 30-request reminder boundary; the check resets the cadence, so the
     // post-check request carries the check as the tail instruction with no
     // fresh reminder after it.
-    let responses = []
-    for _ in 0..<29 {
-      responses.push(
-        (
-          #|{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_probe","function":{"name":"probe","arguments":"{}"}}]}}]}
-        ),
-      )
-    }
-    responses.push(final_answer_payload("premature answer"))
-    responses.push(final_answer_payload("really done"))
+    let probe_round =
+      #|{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_probe","function":{"name":"probe","arguments":"{}"}}]}}]}
+    let responses = Array::make(29, probe_round) +
+      [
+        final_answer_payload("premature answer"),
+        final_answer_payload("really done"),
+      ]
     guard goal_check_test_server(group, bodies, responses) is Some(url) else {
       return
     }

--- a/agent/goal_reminder_test.mbt
+++ b/agent/goal_reminder_test.mbt
@@ -9,46 +9,46 @@ async fn goal_test_server(
   bodies : Array[String],
   probe_calls~ : Int,
 ) -> String? {
-  guard bind_test_server(
-      "local TCP bind unavailable; skipping goal reminder test",
-    )
-    is Some(server) else {
-    return None
-  }
-  group.spawn_bg(no_wait=true) <| () => {
-    server.run_forever(
-      (_request, body, conn) => {
-        bodies.push(body.read_all().text())
-        conn.send_response(200, "OK", extra_headers={
-          "Content-Type": "text/event-stream",
-        })
-        if bodies.length() <= probe_calls {
-          conn.write(
-            "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_\{bodies.length()}\",\"function\":{\"name\":\"probe\",\"arguments\":\"{}\"}}]}}]}\n\n",
-          )
-        } else {
-          conn.write(
-            "data: {\"choices\":[{\"delta\":{\"content\":\"done\"}}]}\n\n",
-          )
-        }
-        conn.write("data: [DONE]\n\n")
-      },
-      max_connections=2,
-    )
-  }
-  Some("http://127.0.0.1:\{server.addr.port()}/chat/completions")
+  serve_chat_completions(
+    group,
+    "local TCP bind unavailable; skipping goal reminder test",
+    max_connections=2,
+    (_request, body, conn) => {
+      bodies.push(body)
+      conn.send_response(200, "OK", extra_headers={
+        "Content-Type": "text/event-stream",
+      })
+      if bodies.length() <= probe_calls {
+        conn.write(
+          "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_\{bodies.length()}\",\"function\":{\"name\":\"probe\",\"arguments\":\"{}\"}}]}}]}\n\n",
+        )
+      } else {
+        conn.write(
+          "data: {\"choices\":[{\"delta\":{\"content\":\"done\"}}]}\n\n",
+        )
+      }
+      conn.write("data: [DONE]\n\n")
+    },
+  )
+}
+
+///|
+/// A no-op probe tool answering `result`: the filler call scripted turns use
+/// to keep a batch or a turn alive.
+fn probe_definition(
+  result? : String = "probe-result",
+) -> @agent_tool.AgentToolDefinition {
+  AgentToolDefinition(
+    name="probe",
+    description="Probe tool.",
+    schema=JsonSchema({ "type": "object" }),
+    execute=Sync(_args => @agent_tool.respond(result)),
+  )
 }
 
 ///|
 fn goal_probe_tools() -> @agent_tool.Tools raise {
-  Tools([
-    AgentToolDefinition(
-      name="probe",
-      description="Probe tool.",
-      schema=JsonSchema({ "type": "object" }),
-      execute=Sync(_args => @agent_tool.respond("probe-result")),
-    ),
-  ])
+  Tools([probe_definition()])
 }
 
 ///|

--- a/agent/goal_tool_test.mbt
+++ b/agent/goal_tool_test.mbt
@@ -21,15 +21,7 @@ fn goal_tool_call_payload(arguments : String) -> String {
 
 ///|
 fn goal_tools_with_probe() -> @agent_tool.Tools raise {
-  Tools([
-    @goal.definition(),
-    AgentToolDefinition(
-      name="probe",
-      description="Probe tool.",
-      schema=JsonSchema({ "type": "object" }),
-      execute=Sync(_args => @agent_tool.respond("probe-result")),
-    ),
-  ])
+  Tools([@goal.definition(), probe_definition()])
 }
 
 ///|

--- a/agent/mock_server_test.mbt
+++ b/agent/mock_server_test.mbt
@@ -11,3 +11,24 @@ async fn bind_test_server(skip_message : String) -> @http.Server? {
   }
   Some(server)
 }
+
+///|
+/// Serve `/chat/completions` on a localhost mock for one test, returning its
+/// URL: `handle` runs per request with the request, its body read out as text,
+/// and the connection to answer on. Reports the skip and returns None where the
+/// sandbox forbids TCP binds.
+async fn serve_chat_completions(
+  group : @async.TaskGroup[Unit],
+  skip_message : String,
+  max_connections~ : Int,
+  handle : async (@http.Request, String, @http.ServerConnection) -> Unit,
+) -> String? {
+  guard bind_test_server(skip_message) is Some(server) else { return None }
+  group.spawn_bg(no_wait=true) <| () => {
+    server.run_forever(
+      (request, body, conn) => handle(request, body.read_all().text(), conn),
+      max_connections~,
+    )
+  }
+  Some("http://127.0.0.1:\{server.addr.port()}/chat/completions")
+}

--- a/agent/plan_reminder_test.mbt
+++ b/agent/plan_reminder_test.mbt
@@ -26,48 +26,41 @@ async fn plan_test_server(
   plan_calls~ : Int,
   record_first~ : Bool,
 ) -> String? {
-  guard bind_test_server(
-      "local TCP bind unavailable; skipping plan reminder test",
-    )
-    is Some(server) else {
-    return None
-  }
-  group.spawn_bg(no_wait=true) <| () => {
-    server.run_forever(
-      (_request, body, conn) => {
-        bodies.push(body.read_all().text())
-        conn.send_response(200, "OK", extra_headers={
-          "Content-Type": "text/event-stream",
-        })
-        if record_first && bodies.length() == 1 {
-          conn.write(
-            (
-              #|data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_plan","function":{"name":"plan","arguments":"{\"steps\":[{\"title\":\"fix the parser\",\"status\":\"in_progress\"}]}"}}]}}]}
-            ),
-          )
-          conn.write("\n\n")
-        } else if bodies.length() <= plan_calls {
-          conn.write(
-            (
-              #|data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_plan","function":{"name":"plan","arguments":"{\"steps\":[{\"title\":\"step\",\"status\":\"doing\"}]}"}}]}}]}
-            ),
-          )
-          conn.write("\n\n")
-        } else {
-          conn.write(
-            (
-              #|data: {"choices":[{"delta":{"content":"done"}}]}
-              #|
-              #|
-            ),
-          )
-        }
-        conn.write("data: [DONE]\n\n")
-      },
-      max_connections=2,
-    )
-  }
-  Some("http://127.0.0.1:\{server.addr.port()}/chat/completions")
+  serve_chat_completions(
+    group,
+    "local TCP bind unavailable; skipping plan reminder test",
+    max_connections=2,
+    (_request, body, conn) => {
+      bodies.push(body)
+      conn.send_response(200, "OK", extra_headers={
+        "Content-Type": "text/event-stream",
+      })
+      if record_first && bodies.length() == 1 {
+        conn.write(
+          (
+            #|data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_plan","function":{"name":"plan","arguments":"{\"steps\":[{\"title\":\"fix the parser\",\"status\":\"in_progress\"}]}"}}]}}]}
+          ),
+        )
+        conn.write("\n\n")
+      } else if bodies.length() <= plan_calls {
+        conn.write(
+          (
+            #|data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_plan","function":{"name":"plan","arguments":"{\"steps\":[{\"title\":\"step\",\"status\":\"doing\"}]}"}}]}}]}
+          ),
+        )
+        conn.write("\n\n")
+      } else {
+        conn.write(
+          (
+            #|data: {"choices":[{"delta":{"content":"done"}}]}
+            #|
+            #|
+          ),
+        )
+      }
+      conn.write("data: [DONE]\n\n")
+    },
+  )
 }
 
 ///|

--- a/agent/steer_test.mbt
+++ b/agent/steer_test.mbt
@@ -3,30 +3,24 @@
 /// carries both the original task and the steered text as user messages, then
 /// streams a plain content answer so the turn finishes without tool calls.
 async fn steer_test_server(group : @async.TaskGroup[Unit]) -> String? {
-  guard bind_test_server("local TCP bind unavailable; skipping steer test")
-    is Some(server) else {
-    return None
-  }
-  group.spawn_bg(no_wait=true) <| () => {
-    server.run_forever(
-      (request, body, conn) => {
-        assert_eq(request.path, "/chat/completions")
-        let request_body = body.read_all().text()
-        assert_true(request_body.contains("do the task"))
-        assert_true(request_body.contains("also rename the file"))
-        // The prebuilt registry reached the request: the standard tools ride
-        // along even though the caller, not the turn, constructed them.
-        assert_true(request_body.contains("\"name\":\"mbtx\""))
-        conn.send_response(200, "OK", extra_headers={
-          "Content-Type": "text/event-stream",
-        })
-        conn.write("data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\n")
-        conn.write("data: [DONE]\n\n")
-      },
-      max_connections=1,
-    )
-  }
-  Some("http://127.0.0.1:\{server.addr.port()}/chat/completions")
+  serve_chat_completions(
+    group,
+    "local TCP bind unavailable; skipping steer test",
+    max_connections=1,
+    (request, request_body, conn) => {
+      assert_eq(request.path, "/chat/completions")
+      assert_true(request_body.contains("do the task"))
+      assert_true(request_body.contains("also rename the file"))
+      // The prebuilt registry reached the request: the standard tools ride
+      // along even though the caller, not the turn, constructed them.
+      assert_true(request_body.contains("\"name\":\"mbtx\""))
+      conn.send_response(200, "OK", extra_headers={
+        "Content-Type": "text/event-stream",
+      })
+      conn.write("data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\n")
+      conn.write("data: [DONE]\n\n")
+    },
+  )
 }
 
 ///|
@@ -85,46 +79,55 @@ async test "queued steering is folded in at the next step boundary" {
 async fn override_test_server(
   group : @async.TaskGroup[Unit],
   runtime : @agent_runtime.AgentRuntime,
+  skip_message : String,
+  steer : @agent_runtime.SteerInput,
+  expected~ : Array[String],
+  final_answer~ : String,
 ) -> String? {
-  guard bind_test_server("local TCP bind unavailable; skipping override test")
-    is Some(server) else {
-    return None
-  }
   let mut requests = 0
-  group.spawn_bg(no_wait=true) <| () => {
-    server.run_forever(
-      (_request, body, conn) => {
-        requests += 1
-        let request_body = body.read_all().text()
-        conn.send_response(200, "OK", extra_headers={
-          "Content-Type": "text/event-stream",
-        })
-        if requests == 1 {
-          // The steer arrives while this "final" call is in flight.
-          runtime.queue_steer(Prompt("actually, make it rhyme"))
-          conn.write(
-            "data: {\"choices\":[{\"delta\":{\"content\":\"draft answer\"}}]}\n\n",
-          )
-        } else {
-          assert_true(request_body.contains("actually, make it rhyme"))
-          assert_true(request_body.contains("draft answer"))
-          conn.write(
-            "data: {\"choices\":[{\"delta\":{\"content\":\"rhymed answer\"}}]}\n\n",
-          )
-        }
-        conn.write("data: [DONE]\n\n")
-      },
-      max_connections=2,
-    )
-  }
-  Some("http://127.0.0.1:\{server.addr.port()}/chat/completions")
+  serve_chat_completions(group, skip_message, max_connections=2, (
+    _request,
+    request_body,
+    conn,
+  ) => {
+    requests += 1
+    conn.send_response(200, "OK", extra_headers={
+      "Content-Type": "text/event-stream",
+    })
+    if requests == 1 {
+      // The steer arrives while this "final" call is in flight.
+      runtime.queue_steer(steer)
+      conn.write(
+        "data: {\"choices\":[{\"delta\":{\"content\":\"draft answer\"}}]}\n\n",
+      )
+    } else {
+      for fragment in expected {
+        assert_true(request_body.contains(fragment), msg=fragment)
+      }
+      assert_true(request_body.contains("draft answer"))
+      conn.write(
+        "data: {\"choices\":[{\"delta\":{\"content\":\"\{final_answer}\"}}]}\n\n",
+      )
+    }
+    conn.write("data: [DONE]\n\n")
+  })
 }
 
 ///|
 async test "a steer racing the final call keeps the turn alive" {
   @async.with_task_group() <| group => {
     let runtime = @agent_runtime.AgentRuntime()
-    guard override_test_server(group, runtime) is Some(url) else { return }
+    guard override_test_server(
+        group,
+        runtime,
+        "local TCP bind unavailable; skipping override test",
+        Prompt("actually, make it rhyme"),
+        expected=["actually, make it rhyme"],
+        final_answer="rhymed answer",
+      )
+      is Some(url) else {
+      return
+    }
     let scope = @agent_runtime.AgentTaskScope(group)
     let session = @agent_session.Session(
       SessionId("steer-override"),
@@ -165,48 +168,6 @@ async test "a steer racing the final call keeps the turn alive" {
 }
 
 ///|
-async fn inject_override_test_server(
-  group : @async.TaskGroup[Unit],
-  runtime : @agent_runtime.AgentRuntime,
-  context : String,
-) -> String? {
-  guard bind_test_server("local TCP bind unavailable; skipping inject test")
-    is Some(server) else {
-    return None
-  }
-  let mut requests = 0
-  group.spawn_bg(no_wait=true) <| () => {
-    server.run_forever(
-      (_request, body, conn) => {
-        requests += 1
-        let request_body = body.read_all().text()
-        conn.send_response(200, "OK", extra_headers={
-          "Content-Type": "text/event-stream",
-        })
-        if requests == 1 {
-          runtime.queue_steer(Command(context))
-          conn.write(
-            "data: {\"choices\":[{\"delta\":{\"content\":\"draft answer\"}}]}\n\n",
-          )
-        } else {
-          assert_true(request_body.contains("<user_shell_command>"))
-          assert_true(request_body.contains("<command>"))
-          assert_true(request_body.contains("exit=0"))
-          assert_true(request_body.contains("_build"))
-          assert_true(request_body.contains("draft answer"))
-          conn.write(
-            "data: {\"choices\":[{\"delta\":{\"content\":\"contextual answer\"}}]}\n\n",
-          )
-        }
-        conn.write("data: [DONE]\n\n")
-      },
-      max_connections=2,
-    )
-  }
-  Some("http://127.0.0.1:\{server.addr.port()}/chat/completions")
-}
-
-///|
 async test "inject racing the final call keeps the turn alive" {
   @async.with_task_group() <| group => {
     let runtime = @agent_runtime.AgentRuntime()
@@ -220,7 +181,15 @@ async test "inject racing the final call keeps the turn alive" {
       #|_build
       #|</result>
       #|</user_shell_command>
-    guard inject_override_test_server(group, runtime, context) is Some(url) else {
+    guard override_test_server(
+        group,
+        runtime,
+        "local TCP bind unavailable; skipping inject test",
+        Command(context),
+        expected=["<user_shell_command>", "<command>", "exit=0", "_build"],
+        final_answer="contextual answer",
+      )
+      is Some(url) else {
       return
     }
     let scope = @agent_runtime.AgentTaskScope(group)
@@ -306,45 +275,33 @@ fn drain_emitted() -> Array[Json] raise {
 ///|
 fn log_event(entry : Json) -> String {
   match entry {
-    Object(object) =>
-      match object.get("event") {
-        Some(String(event)) => event
-        _ => ""
-      }
+    { "event": String(event), .. } => event
     _ => ""
   }
 }
 
 ///|
 async fn reasoning_log_test_server(group : @async.TaskGroup[Unit]) -> String? {
-  guard bind_test_server(
-      "local TCP bind unavailable; skipping reasoning log test",
-    )
-    is Some(server) else {
-    return None
-  }
-  group.spawn_bg(no_wait=true) <| () => {
-    server.run_forever(
-      (_request, body, conn) => {
-        let _ = body.read_all()
-        conn.send_response(200, "OK", extra_headers={
-          "Content-Type": "text/event-stream",
-        })
-        conn.write(
-          "data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"I\"}}]}\n\n",
-        )
-        conn.write(
-          "data: {\"choices\":[{\"delta\":{\"reasoning_content\":\" think\"}}]}\n\n",
-        )
-        conn.write(
-          "data: {\"choices\":[{\"delta\":{\"content\":\"done\"}}],\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":5,\"total_tokens\":8,\"prompt_cache_hit_tokens\":1,\"prompt_cache_miss_tokens\":2}}\n\n",
-        )
-        conn.write("data: [DONE]\n\n")
-      },
-      max_connections=1,
-    )
-  }
-  Some("http://127.0.0.1:\{server.addr.port()}/chat/completions")
+  serve_chat_completions(
+    group,
+    "local TCP bind unavailable; skipping reasoning log test",
+    max_connections=1,
+    (_request, _body, conn) => {
+      conn.send_response(200, "OK", extra_headers={
+        "Content-Type": "text/event-stream",
+      })
+      conn.write(
+        "data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"I\"}}]}\n\n",
+      )
+      conn.write(
+        "data: {\"choices\":[{\"delta\":{\"reasoning_content\":\" think\"}}]}\n\n",
+      )
+      conn.write(
+        "data: {\"choices\":[{\"delta\":{\"content\":\"done\"}}],\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":5,\"total_tokens\":8,\"prompt_cache_hit_tokens\":1,\"prompt_cache_miss_tokens\":2}}\n\n",
+      )
+      conn.write("data: [DONE]\n\n")
+    },
+  )
 }
 
 ///|
@@ -410,44 +367,38 @@ async fn notice_test_server(
   notice : String,
   finish_first? : Bool = false,
 ) -> String? {
-  guard bind_test_server("local TCP bind unavailable; skipping notice test")
-    is Some(server) else {
-    return None
-  }
   let mut requests = 0
-  group.spawn_bg(no_wait=true) <| () => {
-    server.run_forever(
-      (_request, body, conn) => {
-        requests += 1
-        let request_body = body.read_all().text()
-        conn.send_response(200, "OK", extra_headers={
-          "Content-Type": "text/event-stream",
-        })
-        if requests == 1 {
-          // A background job finishes mid-turn and pushes a notice.
-          runtime.queue_steer(Notice(notice))
-          if finish_first {
-            conn.write(
-              "data: \{sse_tool_call("call_finish", "finish_test", 100_000)}\n\n",
-            )
-          } else {
-            conn.write(
-              "data: {\"choices\":[{\"delta\":{\"content\":\"draft\"}}]}\n\n",
-            )
-          }
-        } else {
-          // The notice was delivered to the model as user-role content.
-          assert_true(request_body.contains(notice))
+  serve_chat_completions(
+    group,
+    "local TCP bind unavailable; skipping notice test",
+    max_connections=2,
+    (_request, request_body, conn) => {
+      requests += 1
+      conn.send_response(200, "OK", extra_headers={
+        "Content-Type": "text/event-stream",
+      })
+      if requests == 1 {
+        // A background job finishes mid-turn and pushes a notice.
+        runtime.queue_steer(Notice(notice))
+        if finish_first {
           conn.write(
-            "data: {\"choices\":[{\"delta\":{\"content\":\"done\"}}]}\n\n",
+            "data: \{sse_tool_call("call_finish", "finish_test", 100_000)}\n\n",
+          )
+        } else {
+          conn.write(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"draft\"}}]}\n\n",
           )
         }
-        conn.write("data: [DONE]\n\n")
-      },
-      max_connections=2,
-    )
-  }
-  Some("http://127.0.0.1:\{server.addr.port()}/chat/completions")
+      } else {
+        // The notice was delivered to the model as user-role content.
+        assert_true(request_body.contains(notice))
+        conn.write(
+          "data: {\"choices\":[{\"delta\":{\"content\":\"done\"}}]}\n\n",
+        )
+      }
+      conn.write("data: [DONE]\n\n")
+    },
+  )
 }
 
 ///|
@@ -525,12 +476,12 @@ async test "a runtime notice after a completion preserves the follow-up step" {
       tools~,
     )
     let events = result.events()
-    let mut completions = 0
-    for event in events {
-      if event.item() is Tool(tool) && tool.tool_name() == "finish_test" {
-        completions += 1
-      }
-    }
+    let completions = events
+      .iter()
+      .filter(event => {
+        event.item() is Tool(tool) && tool.tool_name() == "finish_test"
+      })
+      .count()
     assert_eq(completions, 1)
     guard events[events.length() - 2].item() is Assistant(message) else {
       fail("expected explicit follow-up step before its terminal")

--- a/agent/tool_batch_test.mbt
+++ b/agent/tool_batch_test.mbt
@@ -1,46 +1,40 @@
 ///|
 async fn tool_batch_test_server(group : @async.TaskGroup[Unit]) -> String? {
-  guard bind_test_server("local TCP bind unavailable; skipping tool batch test")
-    is Some(server) else {
-    return None
-  }
   let mut requests = 0
-  group.spawn_bg(no_wait=true) <| () => {
-    server.run_forever(
-      (request, body, conn) => {
-        requests += 1
-        assert_eq(request.path, "/chat/completions")
-        let request_body = body.read_all().text()
-        conn.send_response(200, "OK", extra_headers={
-          "Content-Type": "text/event-stream",
-        })
-        if requests == 1 {
-          assert_true(request_body.contains("\"name\":\"first_test\""))
-          assert_true(request_body.contains("\"name\":\"second_test\""))
-          conn.write(
-            (
-              #|data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_first","type":"function","function":{"name":"first_test","arguments":"{}"}},{"index":1,"id":"call_second","type":"function","function":{"name":"second_test","arguments":"{}"}}]}}]}
-              #|
-              #|
-            ),
-          )
-        } else {
-          assert_true(request_body.contains("first-result"))
-          assert_true(request_body.contains("second-result"))
-          conn.write(
-            (
-              #|data: {"choices":[{"delta":{"content":"done"}}]}
-              #|
-              #|
-            ),
-          )
-        }
-        conn.write("data: [DONE]\n\n")
-      },
-      max_connections=2,
-    )
-  }
-  Some("http://127.0.0.1:\{server.addr.port()}/chat/completions")
+  serve_chat_completions(
+    group,
+    "local TCP bind unavailable; skipping tool batch test",
+    max_connections=2,
+    (request, request_body, conn) => {
+      requests += 1
+      assert_eq(request.path, "/chat/completions")
+      conn.send_response(200, "OK", extra_headers={
+        "Content-Type": "text/event-stream",
+      })
+      if requests == 1 {
+        assert_true(request_body.contains("\"name\":\"first_test\""))
+        assert_true(request_body.contains("\"name\":\"second_test\""))
+        conn.write(
+          (
+            #|data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_first","type":"function","function":{"name":"first_test","arguments":"{}"}},{"index":1,"id":"call_second","type":"function","function":{"name":"second_test","arguments":"{}"}}]}}]}
+            #|
+            #|
+          ),
+        )
+      } else {
+        assert_true(request_body.contains("first-result"))
+        assert_true(request_body.contains("second-result"))
+        conn.write(
+          (
+            #|data: {"choices":[{"delta":{"content":"done"}}]}
+            #|
+            #|
+          ),
+        )
+      }
+      conn.write("data: [DONE]\n\n")
+    },
+  )
 }
 
 ///|
@@ -118,42 +112,42 @@ async test "agent executes each normal tool call in a response batch" {
 }
 
 ///|
-async fn max_step_exhaustion_test_server(
+/// A stand-in that answers every request with a single `tool_name` call
+/// (id `call_id`), after checking the request advertised that tool.
+async fn one_tool_call_server(
   group : @async.TaskGroup[Unit],
+  skip_message : String,
+  tool_name~ : String,
+  call_id~ : String,
 ) -> String? {
-  guard bind_test_server(
-      "local TCP bind unavailable; skipping max-step exhaustion test",
+  serve_chat_completions(group, skip_message, max_connections=1, (
+    _request,
+    request_body,
+    conn,
+  ) => {
+    assert_true(request_body.contains("\"name\":\"\{tool_name}\""))
+    conn.send_response(200, "OK", extra_headers={
+      "Content-Type": "text/event-stream",
+    })
+    conn.write(
+      "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"\{call_id}\",\"type\":\"function\",\"function\":{\"name\":\"\{tool_name}\",\"arguments\":\"{}\"}}]}}]}\n\n",
     )
-    is Some(server) else {
-    return None
-  }
-  group.spawn_bg(no_wait=true) <| () => {
-    server.run_forever(
-      (_request, body, conn) => {
-        let request_body = body.read_all().text()
-        assert_true(request_body.contains("\"name\":\"continue_test\""))
-        conn.send_response(200, "OK", extra_headers={
-          "Content-Type": "text/event-stream",
-        })
-        conn.write(
-          (
-            #|data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_continue","type":"function","function":{"name":"continue_test","arguments":"{}"}}]}}]}
-            #|
-            #|
-          ),
-        )
-        conn.write("data: [DONE]\n\n")
-      },
-      max_connections=1,
-    )
-  }
-  Some("http://127.0.0.1:\{server.addr.port()}/chat/completions")
+    conn.write("data: [DONE]\n\n")
+  })
 }
 
 ///|
 async test "max-step exhaustion preserves continued session state" {
   @async.with_task_group() <| group => {
-    guard max_step_exhaustion_test_server(group) is Some(url) else { return }
+    guard one_tool_call_server(
+        group,
+        "local TCP bind unavailable; skipping max-step exhaustion test",
+        tool_name="continue_test",
+        call_id="call_continue",
+      )
+      is Some(url) else {
+      return
+    }
     let runtime = @agent_runtime.AgentRuntime()
     let scope = @agent_runtime.AgentTaskScope(group)
     let session = @agent_session.Session(
@@ -200,40 +194,17 @@ async test "max-step exhaustion preserves continued session state" {
 }
 
 ///|
-async fn append_failure_test_server(group : @async.TaskGroup[Unit]) -> String? {
-  guard bind_test_server(
-      "local TCP bind unavailable; skipping append failure test",
-    )
-    is Some(server) else {
-    return None
-  }
-  group.spawn_bg(no_wait=true) <| () => {
-    server.run_forever(
-      (_request, body, conn) => {
-        let request_body = body.read_all().text()
-        assert_true(request_body.contains("\"name\":\"ok_test\""))
-        conn.send_response(200, "OK", extra_headers={
-          "Content-Type": "text/event-stream",
-        })
-        conn.write(
-          (
-            #|data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_ok","type":"function","function":{"name":"ok_test","arguments":"{}"}}]}}]}
-            #|
-            #|
-          ),
-        )
-        conn.write("data: [DONE]\n\n")
-      },
-      max_connections=1,
-    )
-  }
-  Some("http://127.0.0.1:\{server.addr.port()}/chat/completions")
-}
-
-///|
 async test "agent failure terminal uses the latest persisted session" {
   @async.with_task_group() <| group => {
-    guard append_failure_test_server(group) is Some(url) else { return }
+    guard one_tool_call_server(
+        group,
+        "local TCP bind unavailable; skipping append failure test",
+        tool_name="ok_test",
+        call_id="call_ok",
+      )
+      is Some(url) else {
+      return
+    }
     let runtime = @agent_runtime.AgentRuntime()
     let scope = @agent_runtime.AgentTaskScope(group)
     let initial = @agent_session.Session(

--- a/agent_tool/edit/edit_test.mbt
+++ b/agent_tool/edit/edit_test.mbt
@@ -231,28 +231,26 @@ async test "edit preserves surrounding multiline content" {
 }
 
 ///|
-async test "edit rejects missing old_string" {
+/// One test for the argument shapes `edit` refuses before touching a file:
+/// each row is the arguments and the field the error must name.
+async test "edit rejects malformed arguments and names the offending field" {
   @vfs.with_tmpdir(dir => {
-    let output = run_edit({ "path": "\{dir}/noop.txt" })
-    assert_eq(output.content, "error: edit requires arguments.old_string")
-    assert_true(output.is_error)
+    let cases : Array[(Json, String)] = [
+      ({ "path": "\{dir}/noop.txt" }, "arguments.old_string"),
+      ({ "path": "\{dir}/noop.txt", "old_string": "x" }, "arguments.new_string"),
+      (Json::null(), "object arguments"),
+    ]
+    for case in cases {
+      let (arguments, expected) = case
+      let output = run_edit(arguments)
+      assert_eq(
+        output.content,
+        "error: edit requires \{expected}",
+        msg=expected,
+      )
+      assert_true(output.is_error, msg=expected)
+    }
   })
-}
-
-///|
-async test "edit rejects missing new_string" {
-  @vfs.with_tmpdir(dir => {
-    let output = run_edit({ "path": "\{dir}/noop.txt", "old_string": "x" })
-    assert_eq(output.content, "error: edit requires arguments.new_string")
-    assert_true(output.is_error)
-  })
-}
-
-///|
-async test "edit rejects non-object arguments" {
-  let output = run_edit(Json::null())
-  assert_eq(output.content, "error: edit requires object arguments")
-  assert_true(output.is_error)
 }
 
 ///|

--- a/agent_tool/internal/manifest_error/manifest_error_test.mbt
+++ b/agent_tool/internal/manifest_error/manifest_error_test.mbt
@@ -1,4 +1,17 @@
 ///|
+/// Asserts that writing `content` to `path` is refused with exactly `expected`.
+async fn assert_write_error(
+  path : String,
+  content : String,
+  expected : String,
+) -> Unit {
+  guard @manifest_error.write_error(path, content) is Some(message) else {
+    fail("expected a manifest error for \{path}")
+  }
+  assert_eq(message, expected)
+}
+
+///|
 async test "manifest error allows ordinary files" {
   assert_true(@manifest_error.write_error("notes.json", "{}") is None)
   assert_true(@manifest_error.write_error("not-moon.mod", "{}") is None)
@@ -8,16 +21,8 @@ async test "manifest error allows ordinary files" {
 ///|
 async test "manifest error rejects generated mbti files" {
   let message = "*.generated.mbti files are generated; run moon info instead of editing them"
-  guard @manifest_error.write_error("lib/pkg.generated.mbti", "package x")
-    is Some(unix) else {
-    fail("expected generated mbti error")
-  }
-  assert_eq(unix, message)
-  guard @manifest_error.write_error("C:\\workspace\\pkg.generated.mbti", "")
-    is Some(windows) else {
-    fail("expected generated mbti error")
-  }
-  assert_eq(windows, message)
+  assert_write_error("lib/pkg.generated.mbti", "package x", message)
+  assert_write_error("C:\\workspace\\pkg.generated.mbti", "", message)
 }
 
 ///|
@@ -42,72 +47,45 @@ async test "manifest error allows existing moon.mod.json" {
 
 ///|
 async test "manifest error rejects invalid moon.mod content" {
-  guard @manifest_error.write_error("moon.mod", "") is Some(empty) else {
-    fail("expected empty moon.mod error")
-  }
-  assert_eq(empty, "moon.mod must not be empty")
-  guard @manifest_error.write_error("moon.mod", "{\"name\":\"demo\"}")
-    is Some(json) else {
-    fail("expected JSON moon.mod error")
-  }
-  assert_eq(json, "moon.mod uses current text syntax, not JSON")
-  guard @manifest_error.write_error("moon.mod", "version = \"0.1.0\"")
-    is Some(missing_name) else {
-    fail("expected missing name moon.mod error")
-  }
-  assert_eq(missing_name, "moon.mod should include a module `name = ...` entry")
+  assert_write_error("moon.mod", "", "moon.mod must not be empty")
+  assert_write_error(
+    "moon.mod", "{\"name\":\"demo\"}", "moon.mod uses current text syntax, not JSON",
+  )
+  assert_write_error(
+    "moon.mod", "version = \"0.1.0\"", "moon.mod should include a module `name = ...` entry",
+  )
 }
 
 ///|
 async test "manifest error checks invalid moon.pkg content" {
   assert_true(@manifest_error.write_error("moon.pkg", "x") is None)
-  guard @manifest_error.write_error("moon.pkg", "# comment") is Some(comment) else {
-    fail("expected moon.pkg comment syntax error")
-  }
-  assert_eq(comment, "moon.pkg use // for comment syntax, not #")
-  guard @manifest_error.write_error("moon.pkg", "{\"import\":[]}") is Some(json) else {
-    fail("expected JSON moon.pkg error")
-  }
-  assert_eq(json, "moon.pkg uses current text syntax, not JSON")
+  assert_write_error(
+    "moon.pkg", "# comment", "moon.pkg use // for comment syntax, not #",
+  )
+  assert_write_error(
+    "moon.pkg", "{\"import\":[]}", "moon.pkg uses current text syntax, not JSON",
+  )
 }
 
 ///|
 async test "manifest error accepts Windows path separators" {
-  guard @manifest_error.write_error(
-      "C:\\workspace\\moon.mod", "{\"name\":\"bad\"}",
-    )
-    is Some(moon_mod) else {
-    fail("expected moon.mod error")
-  }
-  assert_eq(moon_mod, "moon.mod uses current text syntax, not JSON")
+  assert_write_error(
+    "C:\\workspace\\moon.mod", "{\"name\":\"bad\"}", "moon.mod uses current text syntax, not JSON",
+  )
   assert_true(
     @manifest_error.write_error("C:\\workspace\\moon.pkg", "x") is None,
   )
-  guard @manifest_error.write_error("C:\\workspace\\moon.pkg", "# comment")
-    is Some(moon_pkg) else {
-    fail("expected moon.pkg comment syntax error")
-  }
-  assert_eq(moon_pkg, "moon.pkg use // for comment syntax, not #")
-  guard @manifest_error.write_error("C:\\workspace\\moon.mod.json", "{}")
-    is Some(moon_mod_json) else {
-    fail("expected moon.mod.json error")
-  }
-  assert_eq(
-    moon_mod_json, "moon.mod.json is legacy; create moon.mod for new MoonBit projects",
+  assert_write_error(
+    "C:\\workspace\\moon.pkg", "# comment", "moon.pkg use // for comment syntax, not #",
+  )
+  assert_write_error(
+    "C:\\workspace\\moon.mod.json", "{}", "moon.mod.json is legacy; create moon.mod for new MoonBit projects",
   )
 }
 
 ///|
 async test "manifest error rejects generated interfaces" {
   let message = "*.generated.mbti files are generated; run moon info instead of editing them"
-  guard @manifest_error.write_error("pkg.generated.mbti", "...")
-    is Some(root_error) else {
-    fail("expected generated interface error")
-  }
-  assert_eq(root_error, message)
-  guard @manifest_error.write_error("lib\\pkg.generated.mbti", "...")
-    is Some(windows_error) else {
-    fail("expected generated interface error")
-  }
-  assert_eq(windows_error, message)
+  assert_write_error("pkg.generated.mbti", "...", message)
+  assert_write_error("lib\\pkg.generated.mbti", "...", message)
 }

--- a/deepseek/client/client_retry_test.mbt
+++ b/deepseek/client/client_retry_test.mbt
@@ -47,17 +47,25 @@ async fn flaky_server(
 }
 
 ///|
+/// The retrying client these tests drive: the fake key, the flaky server's
+/// endpoint, and a 1ms backoff so a retry budget is exercised without real
+/// sleeps. Only the attempt budget varies per test.
+fn retry_client(url : String, attempts~ : Int) -> @client.Client {
+  Client(
+    api_key="test-key",
+    api_url=url,
+    retry_attempts=attempts,
+    retry_backoff_ms=1,
+  )
+}
+
+///|
 async test "chat retries transient 5xx and succeeds" {
   @async.with_task_group() <| group => {
     guard flaky_server(group, failures=2, status=503) is Some((url, hits)) else {
       return
     }
-    let client = @client.Client(
-      api_key="test-key",
-      api_url=url,
-      retry_attempts=3,
-      retry_backoff_ms=1,
-    )
+    let client = retry_client(url, attempts=3)
     let response = client.chat([ChatMessage(User, content="hello")])
     assert_eq(response.content, "ok")
     assert_eq(hits.val, 3)
@@ -70,12 +78,7 @@ async test "chat gives up after the retry budget with the API error" {
     guard flaky_server(group, failures=99, status=500) is Some((url, hits)) else {
       return
     }
-    let client = @client.Client(
-      api_key="test-key",
-      api_url=url,
-      retry_attempts=2,
-      retry_backoff_ms=1,
-    )
+    let client = retry_client(url, attempts=2)
     let _ = client.chat([ChatMessage(User, content="hello")]) catch {
       error => {
         assert_true("\{error}".contains("DeepSeek API error 500"))
@@ -93,12 +96,7 @@ async test "chat never retries a non-429 client error" {
     guard flaky_server(group, failures=99, status=400) is Some((url, hits)) else {
       return
     }
-    let client = @client.Client(
-      api_key="test-key",
-      api_url=url,
-      retry_attempts=3,
-      retry_backoff_ms=1,
-    )
+    let client = retry_client(url, attempts=3)
     let _ = client.chat([ChatMessage(User, content="hello")]) catch {
       error => {
         assert_true("\{error}".contains("DeepSeek API error 400"))
@@ -117,12 +115,7 @@ async test "streaming chat retries a pre-stream 429 and then streams" {
       is Some((url, hits)) else {
       return
     }
-    let client = @client.Client(
-      api_key="test-key",
-      api_url=url,
-      retry_attempts=3,
-      retry_backoff_ms=1,
-    )
+    let client = retry_client(url, attempts=3)
     let deltas : Array[String] = []
     let response = client.chat(
       [ChatMessage(User, content="hello")],
@@ -189,12 +182,7 @@ async test "streaming chat retries a pre-delta stream drop" {
       )
     }
     let url = "http://127.0.0.1:\{server.addr.port()}/chat/completions"
-    let client = @client.Client(
-      api_key="test-key",
-      api_url=url,
-      retry_attempts=3,
-      retry_backoff_ms=1,
-    )
+    let client = retry_client(url, attempts=3)
     let response = client.chat(
       [ChatMessage(User, content="hello")],
       stream=StreamHandler(on_content_delta=_ => ()),
@@ -233,12 +221,7 @@ async test "streaming chat never retries after the first delta" {
       )
     }
     let url = "http://127.0.0.1:\{server.addr.port()}/chat/completions"
-    let client = @client.Client(
-      api_key="test-key",
-      api_url=url,
-      retry_attempts=3,
-      retry_backoff_ms=1,
-    )
+    let client = retry_client(url, attempts=3)
     let deltas : Array[String] = []
     let _ = client.chat(
       [ChatMessage(User, content="hello")],
@@ -284,12 +267,7 @@ async test "streaming chat never retries after a tool-call-only delta" {
       )
     }
     let url = "http://127.0.0.1:\{server.addr.port()}/chat/completions"
-    let client = @client.Client(
-      api_key="test-key",
-      api_url=url,
-      retry_attempts=3,
-      retry_backoff_ms=1,
-    )
+    let client = retry_client(url, attempts=3)
     let _ = client.chat(
       [ChatMessage(User, content="hello")],
       stream=StreamHandler(on_content_delta=_ => ()),

--- a/desktop/frontend/fileeditor/diff_provider_policy_wbtest.mbt
+++ b/desktop/frontend/fileeditor/diff_provider_policy_wbtest.mbt
@@ -14,16 +14,7 @@ test "selecting a Moon semantic algorithm enters Diff view and retains policy" {
   let path = @pathx.Relative("src/main.mbt")
   let selected = test_modified_change(path)
   let docs = owned_state().docs.copy()
-  docs[path] = {
-    ..loaded_doc(path.0),
-    review: Some({
-      generation: 1,
-      working_generation: 1,
-      baseline: ReviewContent("old source"),
-      view_mode: ReviewSource,
-      selected,
-    }),
-  }
+  docs[path] = reviewed_doc(path, selected, view_mode=ReviewSource)
   let state = { ..owned_state(), docs, review_view_mode: ReviewSource, }
   let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path), }
   let (_, line_unchanged) = update(
@@ -84,16 +75,7 @@ test "non-MoonBit review parks the last semantic review preference" {
   let path = @pathx.Relative("README.md")
   let selected = test_modified_change(path)
   let docs = owned_state().docs.copy()
-  docs[path] = {
-    ..loaded_doc(path.0),
-    review: Some({
-      generation: 1,
-      working_generation: 1,
-      baseline: ReviewContent("old text"),
-      view_mode: ReviewDiff,
-      selected,
-    }),
-  }
+  docs[path] = reviewed_doc(path, selected, baseline="old text")
   let state = { ..owned_state(), docs, review_diff_mode: ReviewDiffTree, }
   let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path), }
   let (_, unchanged) = update(

--- a/desktop/frontend/fileeditor/mbti_presentation_wbtest.mbt
+++ b/desktop/frontend/fileeditor/mbti_presentation_wbtest.mbt
@@ -35,16 +35,12 @@ test "reviewed MBTI files keep source and reject the diagram toggle" {
   let path = @pathx.Relative("api/pkg.generated.mbti")
   let selected = test_modified_change(path)
   let docs = owned_state().docs.copy()
-  docs[path] = {
-    ..loaded_doc(path.0),
-    review: Some({
-      generation: 1,
-      working_generation: 1,
-      baseline: ReviewContent("package \"old\""),
-      view_mode: ReviewSource,
-      selected,
-    }),
-  }
+  docs[path] = reviewed_doc(
+    path,
+    selected,
+    baseline="package \"old\"",
+    view_mode=ReviewSource,
+  )
   let state = { ..owned_state(), docs, }
   let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path), }
 

--- a/desktop/frontend/fileeditor/review_progress_wbtest.mbt
+++ b/desktop/frontend/fileeditor/review_progress_wbtest.mbt
@@ -3,16 +3,7 @@ fn review_progress_state() -> (State, Ctx, ChangedFile) raise {
   let path = @pathx.Relative("src/main.mbt")
   let selected = test_modified_change(path)
   let docs = owned_state().docs.copy()
-  docs[path] = {
-    ..loaded_doc(path.0),
-    review: Some({
-      generation: 1,
-      working_generation: 1,
-      baseline: ReviewContent("old source"),
-      view_mode: ReviewDiff,
-      selected,
-    }),
-  }
+  docs[path] = reviewed_doc(path, selected)
   let state = {
     ..owned_state(),
     docs,

--- a/desktop/frontend/fileeditor/review_view_mode_wbtest.mbt
+++ b/desktop/frontend/fileeditor/review_view_mode_wbtest.mbt
@@ -1,4 +1,26 @@
 ///|
+/// One open changed-file review document: `path` loaded from the fixture
+/// workspace with `baseline` as its HEAD side, in the given presentation.
+fn reviewed_doc(
+  path : @pathx.Relative,
+  selected : ChangedFile,
+  baseline? : String = "old source",
+  view_mode? : ReviewViewMode = ReviewDiff,
+  generation? : Int = 1,
+) -> Doc raise {
+  {
+    ..loaded_doc(path.0),
+    review: Some({
+      generation,
+      working_generation: generation,
+      baseline: ReviewContent(baseline),
+      view_mode,
+      selected,
+    }),
+  }
+}
+
+///|
 test "new reviews default to the full diff" {
   let path = @pathx.Relative("src/main.mbt")
   let change = test_modified_change(path)
@@ -24,16 +46,7 @@ test "full diff change navigation is enabled only after a nonempty diff" {
   let path = @pathx.Relative("src/main.mbt")
   let selected = test_modified_change(path)
   let docs = owned_state().docs.copy()
-  docs[path] = {
-    ..loaded_doc(path.0),
-    review: Some({
-      generation: 1,
-      working_generation: 1,
-      baseline: ReviewContent("old source"),
-      view_mode: ReviewDiff,
-      selected,
-    }),
-  }
+  docs[path] = reviewed_doc(path, selected)
   let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path), }
   let state = { ..owned_state(), docs, }
   let (_, available) = update(
@@ -117,16 +130,7 @@ test "full diff layout toggles independently and source mode preserves it" {
   let path = @pathx.Relative("src/main.mbt")
   let selected = test_modified_change(path)
   let docs = owned_state().docs.copy()
-  docs[path] = {
-    ..loaded_doc(path.0),
-    review: Some({
-      generation: 1,
-      working_generation: 1,
-      baseline: ReviewContent("old source"),
-      view_mode: ReviewDiff,
-      selected,
-    }),
-  }
+  docs[path] = reviewed_doc(path, selected)
   let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path), }
   let (_, inline) = update(
     test_emit(),
@@ -159,16 +163,11 @@ test "full diff remains selected when opening another changed file" {
   let first_change = test_modified_change(first_path)
   let second_change = test_modified_change(second_path)
   let docs = owned_state().docs.copy()
-  docs[first_path] = {
-    ..loaded_doc(first_path.0),
-    review: Some({
-      generation: 1,
-      working_generation: 1,
-      baseline: ReviewContent("old source"),
-      view_mode: ReviewSource,
-      selected: first_change,
-    }),
-  }
+  docs[first_path] = reviewed_doc(
+    first_path,
+    first_change,
+    view_mode=ReviewSource,
+  )
   let first_ctx = {
     ..test_ctx(),
     open_files: [first_path],
@@ -204,16 +203,12 @@ test "full diff remains selected when opening another changed file" {
   )
 
   let loaded_docs = switched.docs.copy()
-  loaded_docs[second_path] = {
-    ..loaded_doc(second_path.0),
-    review: Some({
-      generation: switched.review_generation,
-      working_generation: switched.review_generation,
-      baseline: ReviewContent("second old source"),
-      view_mode: ReviewDiff,
-      selected: second_change,
-    }),
-  }
+  loaded_docs[second_path] = reviewed_doc(
+    second_path,
+    second_change,
+    baseline="second old source",
+    generation=switched.review_generation,
+  )
   let (_, source_again) = update(
     test_emit(),
     ToggleReviewDiff,

--- a/desktop/frontend/fileeditor/semantic_review_view_wbtest.mbt
+++ b/desktop/frontend/fileeditor/semantic_review_view_wbtest.mbt
@@ -27,19 +27,12 @@ test "semantic input follows active MoonBit review and ignores layout" {
   let selected = test_modified_change(path)
   let docs = owned_state().docs.copy()
   docs[path] = {
-    ..loaded_doc(path.0),
+    ..reviewed_doc(path, selected, baseline="fn value() { 1 }"),
     state: TabLoaded(
       content="fn value() { 2 }",
       absolute=test_ctx().test_resource("/work/src/main.mbt"),
       sig="working",
     ),
-    review: Some({
-      generation: 1,
-      working_generation: 1,
-      baseline: ReviewContent("fn value() { 1 }"),
-      view_mode: ReviewDiff,
-      selected,
-    }),
   }
   let state = {
     ..owned_state(),

--- a/desktop/frontend/terminal/terminal_xxtest.mbt
+++ b/desktop/frontend/terminal/terminal_xxtest.mbt
@@ -1,17 +1,27 @@
 ///|
+/// A connected local conversation at `placement`, in the light scheme: the
+/// context most cases below start from.
+fn local_ctx(session : String, placement : @interop.CheckoutPlacement) -> Ctx {
+  {
+    channel: @interop.ChannelId::Local,
+    session,
+    placement: Some(placement),
+    dark_mode: false,
+    connected: true,
+  }
+}
+
+///|
 test "Windows workspace paths use their final component as the tab label" {
   let emit : @cmd.Emit[Msg] = @cmd.Emit(_ => @cmd.none)
   guard @resource.of_path(@interop.ChannelId::Local, "/C:/Users/alice/project")
     is Some(workspace) else {
     fail("Windows resource fixture was invalid")
   }
-  let ctx : Ctx = {
-    channel: @interop.ChannelId::Local,
-    session: "windows-workspace",
-    placement: Some(@interop.WorkspaceRoot(root=workspace)),
-    dark_mode: false,
-    connected: true,
-  }
+  let ctx = local_ctx(
+    "windows-workspace",
+    @interop.WorkspaceRoot(root=workspace),
+  )
   let (_, state) = update(emit, ToggleTerminal, State::empty(), ctx)
   guard state.tabs.get(0) is Some(tab) else {
     fail("terminal tab was not opened")
@@ -26,13 +36,7 @@ test "an exit before the open reply cannot revive a dead terminal" {
     is Some(workspace) else {
     fail("workspace resource fixture was invalid")
   }
-  let ctx : Ctx = {
-    channel: @interop.ChannelId::Local,
-    session: "exit-race",
-    placement: Some(@interop.WorkspaceRoot(root=workspace)),
-    dark_mode: false,
-    connected: true,
-  }
+  let ctx = local_ctx("exit-race", @interop.WorkspaceRoot(root=workspace))
   let (_, opening) = update(emit, ToggleTerminal, State::empty(), ctx)
   let key = opening.tabs[0].key
   let terminal_id = "terminal-exit-race"
@@ -67,13 +71,7 @@ test "sync records color-scheme changes even when the shown tab is unchanged" {
     is Some(scratch_root) else {
     fail("scratch resource fixture was invalid")
   }
-  let light_ctx : Ctx = {
-    channel: @interop.ChannelId::Local,
-    session: "theme",
-    placement: Some(@interop.Scratch(root=Some(scratch_root))),
-    dark_mode: false,
-    connected: true,
-  }
+  let light_ctx = local_ctx("theme", @interop.Scratch(root=Some(scratch_root)))
   let (light, _) = sync(emit, State::empty(), light_ctx)
   assert_true(light.shown is None)
   assert_true(light.synced_dark_mode is Some(false))
@@ -89,13 +87,10 @@ test "terminal UUIDs route independently of the focused device" {
     is Some(local_workspace) else {
     fail("local workspace resource fixture was invalid")
   }
-  let local_ctx : Ctx = {
-    channel: @interop.ChannelId::Local,
-    session: "shared-session",
-    placement: Some(@interop.WorkspaceRoot(root=local_workspace)),
-    dark_mode: false,
-    connected: true,
-  }
+  let local_ctx = local_ctx(
+    "shared-session",
+    @interop.WorkspaceRoot(root=local_workspace),
+  )
   let remote : @interop.ChannelId = Remote("device-1")
   guard @resource.of_path(remote, "/work/project") is Some(remote_workspace) else {
     fail("remote workspace resource fixture was invalid")
@@ -245,15 +240,10 @@ test "a missing checkout refuses new PTYs and retires only its conversation" {
     is Some(worktree_root) else {
     fail("workspace resource fixture was invalid")
   }
-  let ctx : Ctx = {
-    channel: @interop.ChannelId::Local,
-    session: "missing",
-    placement: Some(
-      @interop.Worktree(project=workspace, name="wt", root=worktree_root),
-    ),
-    dark_mode: false,
-    connected: true,
-  }
+  let ctx = local_ctx(
+    "missing",
+    @interop.Worktree(project=workspace, name="wt", root=worktree_root),
+  )
   let (_, opening) = update(emit, ToggleTerminal, State::empty(), ctx)
   let opening_key = opening.tabs[0].key
   let (_, running) = update(
@@ -309,13 +299,7 @@ test "a worktree conversation never reuses the main checkout terminal group" {
     is Some(worktree_root) else {
     fail("workspace resource fixture was invalid")
   }
-  let main : Ctx = {
-    channel: @interop.ChannelId::Local,
-    session: "main-chat",
-    placement: Some(@interop.WorkspaceRoot(root=workspace)),
-    dark_mode: false,
-    connected: true,
-  }
+  let main = local_ctx("main-chat", @interop.WorkspaceRoot(root=workspace))
   let (_, main_opening) = update(emit, ToggleTerminal, State::empty(), main)
   let worktree = {
     ..main,
@@ -346,13 +330,7 @@ test "an unresolved placement cannot reveal or create a project terminal" {
     is Some(worktree_root) else {
     fail("workspace resource fixture was invalid")
   }
-  let main : Ctx = {
-    channel: @interop.ChannelId::Local,
-    session: "main-chat",
-    placement: Some(@interop.WorkspaceRoot(root=workspace)),
-    dark_mode: false,
-    connected: true,
-  }
+  let main = local_ctx("main-chat", @interop.WorkspaceRoot(root=workspace))
   let (_, project_opening) = update(emit, ToggleTerminal, State::empty(), main)
   let unresolved : Ctx = { ..main, session: "restored-chat", placement: None, }
   // The existing project tab stays alive for its owner, but the restored

--- a/desktop/internal/protocol/desktop_replies_test.mbt
+++ b/desktop/internal/protocol/desktop_replies_test.mbt
@@ -819,24 +819,18 @@ test "Git pull-request payload controls optional branch hints explicitly" {
     "session": "thread-2",
   })
   @debug.assert_eq(absent.to_json(), { "session": "thread-2" })
-  let missing_session = try {
+  let missing_session = refused(() => {
     let _ : @protocol.GitPullRequestPayload = @json.from_json({
       "branch_hint": "openseek/wt-1",
     })
-    false
-  } catch {
-    _ => true
-  }
+  })
   assert_true(missing_session)
-  let malformed_hint = try {
+  let malformed_hint = refused(() => {
     let _ : @protocol.GitPullRequestPayload = @json.from_json({
       "session": "thread-1",
       "branch_hint": 7,
     })
-    false
-  } catch {
-    _ => true
-  }
+  })
   assert_true(malformed_hint)
 }
 
@@ -891,17 +885,14 @@ test "language payload codecs require every routing coordinate" {
     "line": 8,
     "column": 13,
   })
-  let missing_root = try {
+  let missing_root = refused(() => {
     let _ : @protocol.LspOpenPayload = @json.from_json({
       "session": "thread-1",
       "path": "src/main.mbt",
     })
-    false
-  } catch {
-    _ => true
-  }
+  })
   assert_true(missing_root)
-  let malformed_position = try {
+  let malformed_position = refused(() => {
     let _ : @protocol.LspHoverPayload = @json.from_json({
       "session": "thread-1",
       "root": "/work/project",
@@ -909,10 +900,7 @@ test "language payload codecs require every routing coordinate" {
       "line": "eight",
       "character": 13,
     })
-    false
-  } catch {
-    _ => true
-  }
+  })
   assert_true(malformed_position)
 }
 
@@ -963,7 +951,7 @@ test "worktree replies omit absent owners and reject ambiguous ownership" {
   })
   assert_eq(ownerless.session, None)
   assert_eq(ownerless.codex_thread, None)
-  let ambiguous = try {
+  let ambiguous = refused(() => {
     let _ : @protocol.WorktreeInfo = @json.from_json({
       "name": "ambiguous",
       "branch": "openseek/ambiguous",
@@ -973,12 +961,9 @@ test "worktree replies omit absent owners and reject ambiguous ownership" {
       "path": "/work/project/.worktrees/ambiguous",
       "present": true,
     })
-    false
-  } catch {
-    _ => true
-  }
+  })
   assert_true(ambiguous)
-  let malformed_present = try {
+  let malformed_present = refused(() => {
     let _ : @protocol.WorktreeInfo = @json.from_json({
       "name": "wt-3",
       "branch": "openseek/wt-3",
@@ -986,10 +971,7 @@ test "worktree replies omit absent owners and reject ambiguous ownership" {
       "path": "/work/project/.worktrees/wt-3",
       "present": "yes",
     })
-    false
-  } catch {
-    _ => true
-  }
+  })
   assert_true(malformed_present)
 }
 
@@ -1156,48 +1138,36 @@ test "Git history codecs ignore unknown fields and omit absent optionals" {
 
 ///|
 test "Git history codecs reject missing, null, and malformed required data" {
-  let missing_session = try {
+  let missing_session = refused(() => {
     let _ : @protocol.GitHistoryPayload = @json.from_json({
       "skip": 0,
       "limit": 50,
     })
-    false
-  } catch {
-    _ => true
-  }
+  })
   assert_true(missing_session)
-  let null_commit = try {
+  let null_commit = refused(() => {
     let _ : @protocol.GitCommitChangesPayload = @json.from_json({
       "session": "s1",
       "commit": null,
     })
-    false
-  } catch {
-    _ => true
-  }
+  })
   assert_true(null_commit)
-  let malformed_ref = try {
+  let malformed_ref = refused(() => {
     let _ : @protocol.GitHistoryRef = @json.from_json({
       "name": "HEAD",
       "revision": "1111111111111111111111111111111111111111",
       "kind": 1,
     })
-    false
-  } catch {
-    _ => true
-  }
+  })
   assert_true(malformed_ref)
-  let null_refs = try {
+  let null_refs = refused(() => {
     let _ : @protocol.GitHistorySnapshot = @json.from_json({
       "refs": null,
       "tips": [],
     })
-    false
-  } catch {
-    _ => true
-  }
+  })
   assert_true(null_refs)
-  let malformed_parent = try {
+  let malformed_parent = refused(() => {
     let _ : @protocol.GitHistoryCommit = @json.from_json({
       "id": "1111111111111111111111111111111111111111",
       "parent_ids": [1],
@@ -1205,42 +1175,30 @@ test "Git history codecs reject missing, null, and malformed required data" {
       "author": "OpenSeek",
       "authored_at": "2026-08-19T10:00:00+08:00",
     })
-    false
-  } catch {
-    _ => true
-  }
+  })
   assert_true(malformed_parent)
-  let null_snapshot = try {
+  let null_snapshot = refused(() => {
     let _ : @protocol.GitHistoryReply = @json.from_json({
       "repository": true,
       "snapshot": null,
       "commits": [],
       "has_more": false,
     })
-    false
-  } catch {
-    _ => true
-  }
+  })
   assert_true(null_snapshot)
-  let missing_status = try {
+  let missing_status = refused(() => {
     let _ : @protocol.GitHistoricalChange = @json.from_json({
       "path": "README.md",
       "kind": "file",
     })
-    false
-  } catch {
-    _ => true
-  }
+  })
   assert_true(missing_status)
-  let malformed_change = try {
+  let malformed_change = refused(() => {
     let _ : @protocol.GitCommitChangesReply = @json.from_json({
       "commit": "1111111111111111111111111111111111111111",
       "changes": [{ "path": "README.md", "status": false, "kind": "file" }],
     })
-    false
-  } catch {
-    _ => true
-  }
+  })
   assert_true(malformed_change)
 }
 

--- a/desktop/internal/session_record/record_test.mbt
+++ b/desktop/internal/session_record/record_test.mbt
@@ -30,6 +30,19 @@ async fn append_record(path : @pathx.Path, text : String) -> Unit {
 }
 
 ///|
+/// The `Unreadable` detail one poll of `session` refuses with; "read" when the
+/// poll succeeded, and any other failure rendered as itself.
+async fn unreadable_detail(root : @pathx.Absolute, session : String) -> String {
+  try {
+    ignore(@session_record.Tail(root, session).poll())
+    "read"
+  } catch {
+    @session_record.Unreadable(detail) => detail
+    error => "\{error}"
+  }
+}
+
+///|
 async test "a record's header names the document its events belong to" {
   let (root, path) = record_fixture("s-1")
   write_record(path, header_line("s-1") + event_line(1, "one"))
@@ -108,13 +121,7 @@ async test "an absent record is not the same failure as an unreadable one" {
   }
   inspect(absent, content="absent")
   write_record(path, "not a header\n" + event_line(1, "one"))
-  let unreadable = try {
-    ignore(@session_record.Tail(root, "s-5").poll())
-    "read"
-  } catch {
-    @session_record.Unreadable(detail) => detail
-    error => "\{error}"
-  }
+  let unreadable = unreadable_detail(root, "s-5")
   inspect(
     unreadable,
     content=(
@@ -127,13 +134,7 @@ async test "an absent record is not the same failure as an unreadable one" {
 async test "a record holding another session is refused" {
   let (root, path) = record_fixture("s-6")
   write_record(path, header_line("s-other") + event_line(1, "one"))
-  let refusal = try {
-    ignore(@session_record.Tail(root, "s-6").poll())
-    "read"
-  } catch {
-    @session_record.Unreadable(detail) => detail
-    error => "\{error}"
-  }
+  let refusal = unreadable_detail(root, "s-6")
   inspect(refusal, content="the session record holds s-other, not s-6")
 }
 
@@ -145,13 +146,7 @@ async test "a header version this build does not read is refused" {
     "{\"version\":2,\"id\":\"s-7\",\"system_prompt\":\"\"}\n" +
     event_line(1, "one"),
   )
-  let refusal = try {
-    ignore(@session_record.Tail(root, "s-7").poll())
-    "read"
-  } catch {
-    @session_record.Unreadable(detail) => detail
-    error => "\{error}"
-  }
+  let refusal = unreadable_detail(root, "s-7")
   inspect(
     refusal,
     content="the session record uses session file version 2; this build reads version 1",
@@ -217,13 +212,7 @@ async test "a lock that cannot be taken is a failure, not an unlocked read" {
   let session_dir = @session_record.record_path(root, "s-14").dirname()
   @fsx.ensure_dir(session_dir.dirname())
   @fs.write_file(session_dir.to_string(), "file", create_mode=CreateOrTruncate)
-  let refusal = try {
-    ignore(@session_record.Tail(root, "s-14").poll())
-    "read"
-  } catch {
-    @session_record.Unreadable(detail) => detail
-    error => "\{error}"
-  }
+  let refusal = unreadable_detail(root, "s-14")
   // The message carries the temp path, so assert its stable halves: that the
   // lock is what failed — not the record read behind it — and why.
   assert_true(refusal.has_prefix("cannot take the session record's lock"))
@@ -239,13 +228,7 @@ async test "a line that is not UTF-8 is refused, not silently mangled" {
   @fsx.write_bytes(
     path, b"{\"version\":1,\"id\":\"s-13\",\"system_prompt\":\"\"}\n{\"sequence\":1,\"ts\":0,\"item\":{\"kind\":\"user\",\"payload\":{\"content\":\"\xff\"}}}\n",
   )
-  let refusal = try {
-    ignore(@session_record.Tail(root, "s-13").poll())
-    "read"
-  } catch {
-    @session_record.Unreadable(detail) => detail
-    error => "\{error}"
-  }
+  let refusal = unreadable_detail(root, "s-13")
   inspect(
     refusal,
     content=(

--- a/desktop/internal/shellenv/shellenv_test.mbt
+++ b/desktop/internal/shellenv/shellenv_test.mbt
@@ -1,71 +1,46 @@
 ///|
 test "path activation follows the target shell's syntax" {
-  assert_eq(
-    @shellenv.path_prepend_command(
+  let posix_dirs = ["/tmp/it's moon/bin", "/tmp/packaged tools/bin"]
+  let windows_dirs = [
+    "C:\\Users\\Moon User\\toolchain\\bin", "C:\\Program Files\\SeekMoon\\bin",
+  ]
+  // shell command, PATH entries, windows, the line the shell should receive
+  let cases = [
+    (
       "/bin/zsh",
       [
         "/Applications/Seek Moon/toolchain/bin", "/Applications/Seek Moon/packaged/bin",
       ],
-      windows=false,
-    ),
-    Some(
+      false,
       "export PATH='/Applications/Seek Moon/toolchain/bin':'/Applications/Seek Moon/packaged/bin':\"$PATH\"\r",
     ),
-  )
-  assert_eq(
-    @shellenv.path_prepend_command(
+    (
       "/opt/homebrew/bin/fish",
       ["/tmp/it's\\moon/bin", "/tmp/packaged tools/bin"],
-      windows=false,
-    ),
-    Some(
+      false,
       "set -gx PATH '/tmp/it\\'s\\\\moon/bin' '/tmp/packaged tools/bin' $PATH\r",
     ),
-  )
-  assert_eq(
-    @shellenv.path_prepend_command(
-      "/bin/tcsh",
-      ["/tmp/it's moon/bin", "/tmp/packaged tools/bin"],
-      windows=false,
+    (
+      "/bin/tcsh", posix_dirs, false, "setenv PATH '/tmp/it'\\''s moon/bin':'/tmp/packaged tools/bin':\"$PATH\"\r",
     ),
-    Some(
-      "setenv PATH '/tmp/it'\\''s moon/bin':'/tmp/packaged tools/bin':\"$PATH\"\r",
+    (
+      "/usr/local/bin/pwsh", posix_dirs, false, "$env:PATH = '/tmp/it''s moon/bin:/tmp/packaged tools/bin:' + $env:PATH\r",
     ),
-  )
-  assert_eq(
-    @shellenv.path_prepend_command(
-      "/usr/local/bin/pwsh",
-      ["/tmp/it's moon/bin", "/tmp/packaged tools/bin"],
-      windows=false,
+    (
+      "C:/Program Files/PowerShell/pwsh.exe", windows_dirs, true, "$env:Path = 'C:\\Users\\Moon User\\toolchain\\bin;C:\\Program Files\\SeekMoon\\bin;' + $env:Path\r",
     ),
-    Some(
-      "$env:PATH = '/tmp/it''s moon/bin:/tmp/packaged tools/bin:' + $env:PATH\r",
+    (
+      "C:\\Windows\\System32\\cmd.exe", windows_dirs, true, "set \"Path=C:\\Users\\Moon User\\toolchain\\bin;C:\\Program Files\\SeekMoon\\bin;%Path%\"\r",
     ),
-  )
-  assert_eq(
-    @shellenv.path_prepend_command(
-      "C:/Program Files/PowerShell/pwsh.exe",
-      [
-        "C:\\Users\\Moon User\\toolchain\\bin", "C:\\Program Files\\SeekMoon\\bin",
-      ],
-      windows=true,
-    ),
-    Some(
-      "$env:Path = 'C:\\Users\\Moon User\\toolchain\\bin;C:\\Program Files\\SeekMoon\\bin;' + $env:Path\r",
-    ),
-  )
-  assert_eq(
-    @shellenv.path_prepend_command(
-      "C:\\Windows\\System32\\cmd.exe",
-      [
-        "C:\\Users\\Moon User\\toolchain\\bin", "C:\\Program Files\\SeekMoon\\bin",
-      ],
-      windows=true,
-    ),
-    Some(
-      "set \"Path=C:\\Users\\Moon User\\toolchain\\bin;C:\\Program Files\\SeekMoon\\bin;%Path%\"\r",
-    ),
-  )
+  ]
+  for row in cases {
+    let (shell, bin_dirs, windows, expected) = row
+    assert_eq(
+      @shellenv.path_prepend_command(shell, bin_dirs, windows~),
+      Some(expected),
+      msg="shell: \{shell}",
+    )
+  }
 }
 
 ///|

--- a/desktop/internal/terminal/terminal_test.mbt
+++ b/desktop/internal/terminal/terminal_test.mbt
@@ -9,6 +9,22 @@ fn new_push_queue() -> @async.Queue[@terminal.TerminalPush] {
 }
 
 ///|
+/// The `TerminalError` message an open in the current directory refuses with;
+/// `None` when it opened, or when it failed some other way.
+async fn open_refusal(
+  state : @terminal.TerminalState,
+  command? : Array[String],
+) -> String? {
+  try {
+    let _ = @terminal.open_terminal(state, cwd=".", cols=80, rows=24, command?)
+    None
+  } catch {
+    @terminal.TerminalError(message) => Some(message)
+    _ => None
+  }
+}
+
+///|
 #cfg(not(platform="windows"))
 async fn wait_for_output(
   pushes : @async.Queue[@terminal.TerminalPush],
@@ -88,15 +104,8 @@ async test "a missing program fails while opening the session" {
     group.spawn_bg(allow_failure=true, () => {
       @terminal.run_terminal_pump(state, async fn(push) { pushes.put(push) })
     })
-    let failed = try {
-      let _ = @terminal.open_terminal(state, cwd=".", cols=80, rows=24, command=[
-        "openseek-terminal-test-program-that-does-not-exist",
-      ])
-      false
-    } catch {
-      @terminal.TerminalError(_) => true
-      _ => false
-    }
+    let missing = ["openseek-terminal-test-program-that-does-not-exist"]
+    let failed = open_refusal(state, command=missing) is Some(_)
     assert_true(failed)
   })
 }
@@ -104,13 +113,7 @@ async test "a missing program fails while opening the session" {
 ///|
 async test "an empty command is rejected before spawning" {
   let state = @terminal.new_terminal_state()
-  let failed = try {
-    let _ = @terminal.open_terminal(state, cwd=".", cols=80, rows=24, command=[])
-    false
-  } catch {
-    @terminal.TerminalError(_) => true
-    _ => false
-  }
+  let failed = open_refusal(state, command=[]) is Some(_)
   assert_true(failed)
 }
 
@@ -139,25 +142,14 @@ async test "shutdown rejects pending and later terminal opens" {
     let state = @terminal.new_terminal_state()
     let pending_rejected : @async.Queue[Bool] = Queue(kind=Blocking(1))
     group.spawn_bg(allow_failure=true, () => {
-      let rejected = try {
-        let _ = @terminal.open_terminal(state, cwd=".", cols=80, rows=24)
-        false
-      } catch {
-        @terminal.TerminalError("terminal service is closed") => true
-        _ => false
-      }
+      let rejected = open_refusal(state) is Some("terminal service is closed")
       pending_rejected.put(rejected)
     })
     @async.pause()
     state.shutdown()
     assert_true(@async.with_timeout(5000, () => pending_rejected.get()))
-    let later_rejected = try {
-      let _ = @terminal.open_terminal(state, cwd=".", cols=80, rows=24)
-      false
-    } catch {
-      @terminal.TerminalError("terminal service is closed") => true
-      _ => false
-    }
+    let later_rejected = open_refusal(state)
+      is Some("terminal service is closed")
     assert_true(later_rejected)
   })
 }
@@ -203,14 +195,8 @@ async test "close_all_terminals cancels queued opens from an older page" {
     let pushes = new_push_queue()
     let cancelled : @async.Queue[Bool] = Queue(kind=Blocking(1))
     group.spawn_bg(allow_failure=true, () => {
-      let was_cancelled = try {
-        let _ = @terminal.open_terminal(state, cwd=".", cols=80, rows=24)
-        false
-      } catch {
-        @terminal.TerminalError("terminal open was cancelled by reconnect") =>
-          true
-        _ => false
-      }
+      let was_cancelled = open_refusal(state)
+        is Some("terminal open was cancelled by reconnect")
       cancelled.put(was_cancelled)
     })
     // Let the opener enqueue its request and block on the reply before the

--- a/editor/internal/viewer/code_editor_widget/definition_navigation_wbtest.mbt
+++ b/editor/internal/viewer/code_editor_widget/definition_navigation_wbtest.mbt
@@ -97,6 +97,20 @@ fn definition_navigation_services(
 }
 
 ///|
+/// Installs a viewer over `model` whose definition async tasks land in a
+/// manually drained queue.
+fn definition_navigation_viewer(
+  services : CodeEditorServices,
+  model : @model.TextModel,
+) -> (CodeEditorWidget, ManualDefinitionTasks) {
+  let viewer = CodeEditorWidget(services~)
+  let tasks = ManualDefinitionTasks()
+  viewer.set_definition_host_for_test(task => tasks.schedule(task))
+  viewer.set_model(Some(model))
+  (viewer, tasks)
+}
+
+///|
 test "definition-link cancellation callbacks cannot clobber replacement owners" {
   let services = definition_navigation_services([])
   let viewer = CodeEditorWidget(services~)
@@ -135,10 +149,7 @@ async test "F12 reveals a same-resource definition without calling the opener" {
     true
   })
   let services = definition_navigation_services([location], opener~)
-  let viewer = CodeEditorWidget(services~)
-  let tasks = ManualDefinitionTasks()
-  viewer.set_definition_host_for_test(task => tasks.schedule(task))
-  viewer.set_model(Some(model))
+  let (viewer, tasks) = definition_navigation_viewer(services, model)
   viewer.set_position(Position(1, 5))
 
   assert_true(
@@ -182,10 +193,7 @@ async test "headless multiple definitions retain provider-first fallback" {
     ],
     opener~,
   )
-  let viewer = CodeEditorWidget(services~)
-  let tasks = ManualDefinitionTasks()
-  viewer.set_definition_host_for_test(task => tasks.schedule(task))
-  viewer.set_model(Some(model))
+  let (viewer, tasks) = definition_navigation_viewer(services, model)
   viewer.set_position(Position(1, 5))
   viewer.start_goto_definition()
   tasks.run_next()
@@ -208,10 +216,7 @@ async test "F12 sends a cross-resource request and preserves rejection feedback"
     false
   })
   let services = definition_navigation_services([location], opener~)
-  let viewer = CodeEditorWidget(services~)
-  let tasks = ManualDefinitionTasks()
-  viewer.set_definition_host_for_test(task => tasks.schedule(task))
-  viewer.set_model(Some(model))
+  let (viewer, tasks) = definition_navigation_viewer(services, model)
   viewer.set_position(Position(1, 5))
 
   assert_true(
@@ -254,10 +259,7 @@ async test "a superseded definition opener failure cannot overwrite a newer navi
     }
   })
   let services = definition_navigation_services([location], opener~)
-  let viewer = CodeEditorWidget(services~)
-  let tasks = ManualDefinitionTasks()
-  viewer.set_definition_host_for_test(task => tasks.schedule(task))
-  viewer.set_model(Some(model))
+  let (viewer, tasks) = definition_navigation_viewer(services, model)
   viewer.set_position(Position(1, 5))
 
   @async.with_task_group() <| group => {
@@ -298,10 +300,7 @@ async test "cursor movement suppresses late definition opener failure" {
     false
   })
   let services = definition_navigation_services([location], opener~)
-  let viewer = CodeEditorWidget(services~)
-  let tasks = ManualDefinitionTasks()
-  viewer.set_definition_host_for_test(task => tasks.schedule(task))
-  viewer.set_model(Some(model))
+  let (viewer, tasks) = definition_navigation_viewer(services, model)
   viewer.set_position(Position(1, 5))
 
   @async.with_task_group() <| group => {
@@ -330,10 +329,7 @@ async test "empty and stale definition actions cannot navigate" {
     true
   })
   let services = definition_navigation_services([location], opener~)
-  let viewer = CodeEditorWidget(services~)
-  let tasks = ManualDefinitionTasks()
-  viewer.set_definition_host_for_test(task => tasks.schedule(task))
-  viewer.set_model(Some(model))
+  let (viewer, tasks) = definition_navigation_viewer(services, model)
   viewer.start_goto_definition()
   viewer.set_value("let source = changed\n")
   tasks.run_next()
@@ -347,11 +343,10 @@ async test "empty and stale definition actions cannot navigate" {
   assert_eq(opener_calls.val, 0)
 
   let empty_services = definition_navigation_services([], opener~)
-  let empty_viewer = CodeEditorWidget(services=empty_services)
-  let empty_tasks = ManualDefinitionTasks()
-  empty_viewer.set_definition_host_for_test(task => empty_tasks.schedule(task))
   let empty_model = definition_navigation_test_model("file:///empty.mbt")
-  empty_viewer.set_model(Some(empty_model))
+  let (empty_viewer, empty_tasks) = definition_navigation_viewer(
+    empty_services, empty_model,
+  )
   empty_viewer.start_goto_definition()
   empty_tasks.run_next()
   assert_eq(
@@ -371,10 +366,7 @@ async test "empty and stale definition actions cannot navigate" {
 async test "empty definition-link result is cached silently for one gesture" {
   let model = definition_navigation_test_model("file:///source.mbt")
   let services = definition_navigation_services([])
-  let viewer = CodeEditorWidget(services~)
-  let tasks = ManualDefinitionTasks()
-  viewer.set_definition_host_for_test(task => tasks.schedule(task))
-  viewer.set_model(Some(model))
+  let (viewer, tasks) = definition_navigation_viewer(services, model)
   let position = @base_common.Position(1, 14)
   let word = model.get_word_at_position(position).unwrap()
   let target = @definition.DefinitionTargetFingerprint::from_model(
@@ -450,10 +442,7 @@ async test "definition-link arms only a fresh token and stale content clears it"
     range: Range(3, 2, 3, 8),
   }
   let services = definition_navigation_services([location])
-  let viewer = CodeEditorWidget(services~)
-  let tasks = ManualDefinitionTasks()
-  viewer.set_definition_host_for_test(task => tasks.schedule(task))
-  viewer.set_model(Some(model))
+  let (viewer, tasks) = definition_navigation_viewer(services, model)
   let position = @base_common.Position(1, 14)
   let word = model.get_word_at_position(position).unwrap()
   let target = @definition.DefinitionTargetFingerprint::from_model(
@@ -538,10 +527,7 @@ async test "definition-link caches by word and executes a fresh Definition actio
     location_opener=opener,
     log_service=log_service.log_handle(),
   )
-  let viewer = CodeEditorWidget(services~)
-  let tasks = ManualDefinitionTasks()
-  viewer.set_definition_host_for_test(task => tasks.schedule(task))
-  viewer.set_model(Some(model))
+  let (viewer, tasks) = definition_navigation_viewer(services, model)
   let first_position = @base_common.Position(1, 14)
   let second_position = @base_common.Position(1, 18)
   let first_target = @definition.DefinitionTargetFingerprint::from_model(
@@ -626,10 +612,7 @@ async test "definition-link click does not wait for preview resolution" {
     true
   })
   let services = definition_navigation_services([location], opener~)
-  let viewer = CodeEditorWidget(services~)
-  let tasks = ManualDefinitionTasks()
-  viewer.set_definition_host_for_test(task => tasks.schedule(task))
-  viewer.set_model(Some(model))
+  let (viewer, tasks) = definition_navigation_viewer(services, model)
   let position = @base_common.Position(1, 14)
   let target = @definition.DefinitionTargetFingerprint::from_model(
     model,
@@ -689,10 +672,7 @@ async test "drag selection cancels an unresolved definition-link click" {
     true
   })
   let services = definition_navigation_services([location], opener~)
-  let viewer = CodeEditorWidget(services~)
-  let tasks = ManualDefinitionTasks()
-  viewer.set_definition_host_for_test(task => tasks.schedule(task))
-  viewer.set_model(Some(model))
+  let (viewer, tasks) = definition_navigation_viewer(services, model)
   let position = @base_common.Position(1, 14)
   let target = @definition.DefinitionTargetFingerprint::from_model(
     model,
@@ -782,10 +762,7 @@ async test "plain definition click cancels the previous pointer-anchored action"
     [{ uri: target_uri, range: Range(3, 2, 3, 6), }],
     opener~,
   )
-  let viewer = CodeEditorWidget(services~)
-  let tasks = ManualDefinitionTasks()
-  viewer.set_definition_host_for_test(task => tasks.schedule(task))
-  viewer.set_model(Some(model))
+  let (viewer, tasks) = definition_navigation_viewer(services, model)
   let first_position = @base_common.Position(1, 5)
   let second_position = @base_common.Position(1, 14)
   let second_target = @definition.DefinitionTargetFingerprint::from_model(
@@ -812,10 +789,7 @@ async test "plain definition click cancels the previous pointer-anchored action"
 test "non-left definition mouseup does not replace the command anchor" {
   let model = definition_navigation_test_model("file:///source.mbt")
   let services = definition_navigation_services([])
-  let viewer = CodeEditorWidget(services~)
-  let tasks = ManualDefinitionTasks()
-  viewer.set_definition_host_for_test(task => tasks.schedule(task))
-  viewer.set_model(Some(model))
+  let (viewer, _tasks) = definition_navigation_viewer(services, model)
   let first_position = @base_common.Position(1, 5)
   let second_position = @base_common.Position(1, 14)
   let first_target = @definition.DefinitionTargetFingerprint::from_model(

--- a/editor/internal/viewer/code_editor_widget/folding_host_wbtest.mbt
+++ b/editor/internal/viewer/code_editor_widget/folding_host_wbtest.mbt
@@ -3,6 +3,21 @@
 // model into `CodeEditorWidget::set_hidden_areas` and the view axis.
 
 ///|
+/// The attached folding model for `viewer`, failing the test when the
+/// controller or its model is missing.
+fn attached_folding_model(
+  viewer : CodeEditorWidget,
+) -> @folding_browser.FoldingModel raise {
+  guard viewer.folding_controller() is Some(controller) else {
+    fail("expected a folding controller")
+  }
+  guard controller.folding_model is Some(folding_model) else {
+    fail("expected an attached folding model")
+  }
+  folding_model
+}
+
+///|
 test "folding: contribution computes indent regions on model attach" {
   with_test_viewer(
     (
@@ -13,12 +28,7 @@ test "folding: contribution computes indent regions on model attach" {
       #|  e
     ),
     viewer => {
-      guard viewer.folding_controller() is Some(controller) else {
-        fail("expected a folding controller")
-      }
-      guard controller.folding_model is Some(folding_model) else {
-        fail("expected an attached folding model")
-      }
+      let folding_model = attached_folding_model(viewer)
       let regions = folding_model.regions()
       let fold_regions = folding_model.get_regions_inside(None)
       assert_eq(regions.length(), 2)
@@ -43,12 +53,7 @@ test "folding: public fold_top_level collapses every outer region only" {
     ),
     viewer => {
       let view_model = viewer.test_view_model()
-      guard viewer.folding_controller() is Some(controller) else {
-        fail("expected a folding controller")
-      }
-      guard controller.folding_model is Some(folding_model) else {
-        fail("expected an attached folding model")
-      }
+      let folding_model = attached_folding_model(viewer)
       let regions = folding_model.regions()
       let fold_regions = folding_model.get_regions_inside(None)
       assert_eq(regions.length(), 3)
@@ -85,12 +90,7 @@ test "folding: MoonBit outline keeps the complete signature and opening brace" {
   viewer.set_position(Position(4, 3))
   viewer.fold_top_level()
   let view_model = viewer.test_view_model()
-  guard viewer.folding_controller() is Some(controller) else {
-    fail("expected a folding controller")
-  }
-  guard controller.folding_model is Some(folding_model) else {
-    fail("expected an attached folding model")
-  }
+  let folding_model = attached_folding_model(viewer)
   guard folding_model.get_region_at_line(3) is Some(region) else {
     fail("expected a folding region at line 3")
   }
@@ -439,12 +439,7 @@ test "folding: same-start provider ranges yield to the comment run" {
   let viewer = CodeEditorWidget::CodeEditorWidget()
   viewer.set_model(Some(test_model(text, language_id="moonbit")))
   viewer.fold_top_level()
-  guard viewer.folding_controller() is Some(controller) else {
-    fail("expected a folding controller")
-  }
-  guard controller.folding_model is Some(folding_model) else {
-    fail("expected an attached folding model")
-  }
+  let folding_model = attached_folding_model(viewer)
   let regions = folding_model.regions()
   let fold_regions = folding_model.get_regions_inside(None)
   assert_eq(regions.length(), 1)
@@ -465,12 +460,7 @@ test "folding: provider ranges containing a comment run are retained" {
   let viewer = CodeEditorWidget::CodeEditorWidget()
   viewer.set_model(Some(test_model(text, language_id="moonbit")))
   viewer.fold_top_level()
-  guard viewer.folding_controller() is Some(controller) else {
-    fail("expected a folding controller")
-  }
-  guard controller.folding_model is Some(folding_model) else {
-    fail("expected an attached folding model")
-  }
+  let folding_model = attached_folding_model(viewer)
   let regions = folding_model.regions()
   let fold_regions = folding_model.get_regions_inside(None)
   assert_eq(regions.length(), 2)
@@ -522,12 +512,7 @@ test "folding: MoonBit outline collapses a copyright header to its first line" {
   )
   assert_eq(view_model.lines().get_view_line_content(2), "")
   assert_eq(view_model.lines().get_view_line_content(3), "fn f() -> Int {")
-  guard viewer.folding_controller() is Some(controller) else {
-    fail("expected a folding controller")
-  }
-  guard controller.folding_model is Some(folding_model) else {
-    fail("expected an attached folding model")
-  }
+  let folding_model = attached_folding_model(viewer)
   let regions = folding_model.regions()
   let fold_regions = folding_model.get_regions_inside(None)
   assert_eq(regions.length(), 2)
@@ -578,12 +563,7 @@ test "folding: comment-only MoonBit file folds and survives option updates" {
   // ...and provider recomputation (an option change) retains the host fold
   // even though the file contributes no outline function bodies.
   viewer.update_options(CodeEditorOptions(show_folding_controls=Never))
-  guard viewer.folding_controller() is Some(controller) else {
-    fail("expected a folding controller")
-  }
-  guard controller.folding_model is Some(folding_model) else {
-    fail("expected an attached folding model")
-  }
+  let folding_model = attached_folding_model(viewer)
   let regions = folding_model.regions()
   let fold_regions = folding_model.get_regions_inside(None)
   assert_eq(regions.length(), 1)
@@ -668,12 +648,7 @@ test "folding: MoonBit outline survives folding decoration option updates" {
     ),
   )
   viewer.fold_top_level()
-  guard viewer.folding_controller() is Some(controller) else {
-    fail("expected a folding controller")
-  }
-  guard controller.folding_model is Some(folding_model) else {
-    fail("expected an attached folding model")
-  }
+  let folding_model = attached_folding_model(viewer)
   viewer.update_options(CodeEditorOptions(show_folding_controls=Never))
   let regions = folding_model.regions()
   let fold_regions = folding_model.get_regions_inside(None)
@@ -723,12 +698,7 @@ test "folding: MoonBit outline respects the configured folding limit" {
     ),
   )
   viewer.fold_top_level()
-  guard viewer.folding_controller() is Some(controller) else {
-    fail("expected a folding controller")
-  }
-  guard controller.folding_model is Some(folding_model) else {
-    fail("expected an attached folding model")
-  }
+  let folding_model = attached_folding_model(viewer)
   let regions = folding_model.regions()
   let fold_regions = folding_model.get_regions_inside(None)
   assert_eq(regions.length(), 1)
@@ -750,12 +720,7 @@ test "folding: MoonBit outline preserves signatures with same-line bodies" {
   let viewer = CodeEditorWidget::CodeEditorWidget()
   viewer.set_model(Some(test_model(text, language_id="moonbit")))
   viewer.fold_top_level()
-  guard viewer.folding_controller() is Some(controller) else {
-    fail("expected a folding controller")
-  }
-  guard controller.folding_model is Some(folding_model) else {
-    fail("expected an attached folding model")
-  }
+  let folding_model = attached_folding_model(viewer)
   assert_eq(folding_model.regions().length(), 0)
   let view_model = viewer.test_view_model()
   assert_eq(view_model.line_count(), 4)
@@ -782,12 +747,7 @@ test "folding: toggling a region folds its lines out of the view axis" {
     viewer => {
       let view_model = viewer.test_view_model()
       assert_eq(view_model.line_count(), 5)
-      guard viewer.folding_controller() is Some(controller) else {
-        fail("expected a folding controller")
-      }
-      guard controller.folding_model is Some(folding_model) else {
-        fail("expected an attached folding model")
-      }
+      let folding_model = attached_folding_model(viewer)
       guard folding_model.get_region_at_line(1) is Some(region) else {
         fail("expected a folding region at line 1")
       }

--- a/editor/shell/remote_protocol/protocol_test.mbt
+++ b/editor/shell/remote_protocol/protocol_test.mbt
@@ -7,15 +7,11 @@ test "encodes and decodes document client packets" {
   let encoded = packet.to_json().stringify()
   assert_true(encoded.contains("\"type\":\"OpenDocument\""))
   assert_true(encoded.contains("\"version\":6"))
-
-  match @remote_protocol.decode_client_packet(encoded) {
-    DecodedClientPacket(OpenDocument(request)) => {
-      assert_eq(request.id, "open-1")
-      assert_eq(request.uri.to_string(), uri.to_string())
-    }
-    DecodedClientPacket(_) => fail("unexpected client packet")
-    ClientPacketDecodeError(error) => fail(error.message)
+  guard expect_client_packet(encoded) is OpenDocument(request) else {
+    fail("unexpected client packet")
   }
+  assert_eq(request.id, "open-1")
+  assert_eq(request.uri.to_string(), uri.to_string())
 }
 
 ///|
@@ -27,62 +23,49 @@ test "encodes and decodes semantic client packets" {
     document_revision: "rev-4",
     offset: 17,
   })
-  match @remote_protocol.decode_client_packet(hover.to_json().stringify()) {
-    DecodedClientPacket(Hover(request)) => {
-      assert_eq(request.id, "hover-1")
-      assert_eq(request.document_revision, "rev-4")
-      assert_eq(request.offset, 17)
-    }
-    DecodedClientPacket(_) => fail("unexpected hover packet")
-    ClientPacketDecodeError(error) => fail(error.message)
+  guard expect_client_packet(hover.to_json().stringify())
+    is Hover(hover_request) else {
+    fail("unexpected hover packet")
   }
-
+  assert_eq(hover_request.id, "hover-1")
+  assert_eq(hover_request.document_revision, "rev-4")
+  assert_eq(hover_request.offset, 17)
   let definition = @remote_protocol.Definition({
     id: "def-1",
     uri,
     document_revision: "rev-4",
     offset: 18,
   })
-  match
-    @remote_protocol.decode_client_packet(definition.to_json().stringify()) {
-    DecodedClientPacket(Definition(request)) => {
-      assert_eq(request.id, "def-1")
-      assert_eq(request.offset, 18)
-    }
-    DecodedClientPacket(_) => fail("unexpected definition packet")
-    ClientPacketDecodeError(error) => fail(error.message)
+  guard expect_client_packet(definition.to_json().stringify())
+    is Definition(definition_request) else {
+    fail("unexpected definition packet")
   }
-
+  assert_eq(definition_request.id, "def-1")
+  assert_eq(definition_request.offset, 18)
   let references = @remote_protocol.References({
     id: "refs-1",
     uri,
     document_revision: "rev-4",
     offset: 19,
   })
-  match
-    @remote_protocol.decode_client_packet(references.to_json().stringify()) {
-    DecodedClientPacket(References(request)) => {
-      assert_eq(request.id, "refs-1")
-      assert_eq(request.document_revision, "rev-4")
-      assert_eq(request.offset, 19)
-    }
-    DecodedClientPacket(_) => fail("unexpected references packet")
-    ClientPacketDecodeError(error) => fail(error.message)
+  guard expect_client_packet(references.to_json().stringify())
+    is References(references_request) else {
+    fail("unexpected references packet")
   }
-
+  assert_eq(references_request.id, "refs-1")
+  assert_eq(references_request.document_revision, "rev-4")
+  assert_eq(references_request.offset, 19)
   let symbols = @remote_protocol.DocumentSymbols({
     id: "symbols-1",
     uri,
     document_revision: "rev-5",
   })
-  match @remote_protocol.decode_client_packet(symbols.to_json().stringify()) {
-    DecodedClientPacket(DocumentSymbols(request)) => {
-      assert_eq(request.id, "symbols-1")
-      assert_eq(request.document_revision, "rev-5")
-    }
-    DecodedClientPacket(_) => fail("unexpected document symbols packet")
-    ClientPacketDecodeError(error) => fail(error.message)
+  guard expect_client_packet(symbols.to_json().stringify())
+    is DocumentSymbols(symbols_request) else {
+    fail("unexpected document symbols packet")
   }
+  assert_eq(symbols_request.id, "symbols-1")
+  assert_eq(symbols_request.document_revision, "rev-5")
 }
 
 ///|
@@ -94,14 +77,11 @@ test "encodes and decodes directory resolve packets" {
   })
   let encoded = request.to_json().stringify()
   assert_true(encoded.contains("\"type\":\"ResolveDirectory\""))
-  match @remote_protocol.decode_client_packet(encoded) {
-    DecodedClientPacket(ResolveDirectory(decoded)) => {
-      assert_eq(decoded.id, "resolve-1")
-      assert_eq(decoded.uri.to_string(), "readonly-remote://workspace")
-    }
-    DecodedClientPacket(_) => fail("unexpected resolve directory packet")
-    ClientPacketDecodeError(error) => fail(error.message)
+  guard expect_client_packet(encoded) is ResolveDirectory(decoded) else {
+    fail("unexpected resolve directory packet")
   }
+  assert_eq(decoded.id, "resolve-1")
+  assert_eq(decoded.uri.to_string(), "readonly-remote://workspace")
   let src_uri = expect_uri("readonly-remote://workspace/src")
   let resolved = @remote_protocol.DirectoryResolved({
     id: "resolve-1",
@@ -120,31 +100,24 @@ test "encodes and decodes directory resolve packets" {
       ]),
     },
   })
-  match @remote_protocol.decode_server_packet(resolved.to_json().stringify()) {
-    DecodedServerPacket(DirectoryResolved(payload)) => {
-      assert_eq(payload.id, "resolve-1")
-      assert_eq(payload.stat.uri.to_string(), "readonly-remote://workspace")
-      assert_eq(payload.stat.name, "workspace")
-      assert_true(payload.stat.kind == Directory)
-      match payload.stat.children {
-        Some(children) => {
-          assert_eq(children.length(), 2)
-          assert_eq(children[0].name, "moon.mod")
-          assert_true(children[0].kind == File)
-          assert_true(children[0].children is None)
-          assert_eq(
-            children[1].uri.to_string(),
-            "readonly-remote://workspace/src",
-          )
-          assert_true(children[1].kind == Directory)
-          assert_true(children[1].children is None)
-        }
-        None => fail("expected resolved children")
-      }
-    }
-    DecodedServerPacket(_) => fail("unexpected directory resolved packet")
-    ServerPacketDecodeError(error) => fail(error.message)
+  guard expect_server_packet(resolved.to_json().stringify())
+    is DirectoryResolved(payload) else {
+    fail("unexpected directory resolved packet")
   }
+  assert_eq(payload.id, "resolve-1")
+  assert_eq(payload.stat.uri.to_string(), "readonly-remote://workspace")
+  assert_eq(payload.stat.name, "workspace")
+  assert_true(payload.stat.kind == Directory)
+  guard payload.stat.children is Some(children) else {
+    fail("expected resolved children")
+  }
+  assert_eq(children.length(), 2)
+  assert_eq(children[0].name, "moon.mod")
+  assert_true(children[0].kind == File)
+  assert_true(children[0].children is None)
+  assert_eq(children[1].uri.to_string(), "readonly-remote://workspace/src")
+  assert_true(children[1].kind == Directory)
+  assert_true(children[1].children is None)
 
   // An empty resolved directory stays Some([]) across the wire; only
   // unresolved children round-trip as None.
@@ -152,15 +125,14 @@ test "encodes and decodes directory resolve packets" {
     id: "resolve-2",
     stat: { uri: src_uri, name: "src", kind: Directory, children: Some([]), },
   })
-  match @remote_protocol.decode_server_packet(empty.to_json().stringify()) {
-    DecodedServerPacket(DirectoryResolved(payload)) =>
-      match payload.stat.children {
-        Some(children) => assert_eq(children.length(), 0)
-        None => fail("expected empty children")
-      }
-    DecodedServerPacket(_) => fail("unexpected empty directory packet")
-    ServerPacketDecodeError(error) => fail(error.message)
+  guard expect_server_packet(empty.to_json().stringify())
+    is DirectoryResolved(empty_payload) else {
+    fail("unexpected empty directory packet")
   }
+  guard empty_payload.stat.children is Some(empty_children) else {
+    fail("expected empty children")
+  }
+  assert_eq(empty_children.length(), 0)
 }
 
 ///|
@@ -172,16 +144,13 @@ test "encodes and decodes server document and language packets" {
     uri, "main.mbt", "moonbit", "rev-2", "pub fn main {}\n",
   )
   let loaded = @remote_protocol.DocumentLoaded({ id: "open-1", document, })
-  match @remote_protocol.decode_server_packet(loaded.to_json().stringify()) {
-    DecodedServerPacket(DocumentLoaded(payload)) => {
-      assert_eq(payload.id, "open-1")
-      assert_eq(payload.document.uri.to_string(), uri.to_string())
-      assert_eq(payload.document.revision, "rev-2")
-    }
-    DecodedServerPacket(_) => fail("unexpected server packet")
-    ServerPacketDecodeError(error) => fail(error.message)
+  guard expect_server_packet(loaded.to_json().stringify())
+    is DocumentLoaded(loaded_payload) else {
+    fail("unexpected server packet")
   }
-
+  assert_eq(loaded_payload.id, "open-1")
+  assert_eq(loaded_payload.document.uri.to_string(), uri.to_string())
+  assert_eq(loaded_payload.document.revision, "rev-2")
   let hover = @remote_protocol.HoverResult({
     id: "hover-1",
     uri,
@@ -191,22 +160,16 @@ test "encodes and decodes server document and language packets" {
       contents: [PlainText("fn main"), Markdown("**main**")],
     }),
   })
-  match @remote_protocol.decode_server_packet(hover.to_json().stringify()) {
-    DecodedServerPacket(HoverResult(payload)) =>
-      match payload.hover {
-        Some(item) => {
-          assert_eq(payload.revision, "rev-2")
-          assert_eq(item.contents.length(), 2)
-          assert_hover_plaintext(item, 0, "fn main")
-          assert_hover_markdown(item, 1, "**main**")
-          assert_true(item.range == Range(1, 8, 1, 12))
-        }
-        None => fail("missing hover")
-      }
-    DecodedServerPacket(_) => fail("unexpected hover result packet")
-    ServerPacketDecodeError(error) => fail(error.message)
+  guard expect_server_packet(hover.to_json().stringify())
+    is HoverResult(hover_payload) else {
+    fail("unexpected hover result packet")
   }
-
+  guard hover_payload.hover is Some(item) else { fail("missing hover") }
+  assert_eq(hover_payload.revision, "rev-2")
+  assert_eq(item.contents.length(), 2)
+  assert_hover_plaintext(item, 0, "fn main")
+  assert_hover_markdown(item, 1, "**main**")
+  assert_true(item.range == Range(1, 8, 1, 12))
   let definitions = @remote_protocol.DefinitionResult({
     id: "def-1",
     uri,
@@ -222,35 +185,29 @@ test "encodes and decodes server document and language packets" {
   let encoded_definitions = definitions.to_json().stringify()
   assert_true(encoded_definitions.contains("\"locations\":["))
   assert_true(!encoded_definitions.contains("\"location\":"))
-  match @remote_protocol.decode_server_packet(encoded_definitions) {
-    DecodedServerPacket(DefinitionResult(payload)) => {
-      assert_eq(payload.id, "def-1")
-      assert_eq(payload.revision, "rev-2")
-      assert_eq(payload.locations.length(), 2)
-      assert_true(payload.locations[0].range == Range(1, 8, 1, 12))
-      assert_eq(
-        payload.locations[1].uri.to_string(),
-        "readonly-remote://workspace/src/lib.mbt",
-      )
-    }
-    DecodedServerPacket(_) => fail("unexpected definition result packet")
-    ServerPacketDecodeError(error) => fail(error.message)
+  guard expect_server_packet(encoded_definitions)
+    is DefinitionResult(definition_payload) else {
+    fail("unexpected definition result packet")
   }
-
+  assert_eq(definition_payload.id, "def-1")
+  assert_eq(definition_payload.revision, "rev-2")
+  assert_eq(definition_payload.locations.length(), 2)
+  assert_true(definition_payload.locations[0].range == Range(1, 8, 1, 12))
+  assert_eq(
+    definition_payload.locations[1].uri.to_string(),
+    "readonly-remote://workspace/src/lib.mbt",
+  )
   let no_definitions = @remote_protocol.DefinitionResult({
     id: "def-2",
     uri,
     revision: "rev-3",
     locations: [],
   })
-  match
-    @remote_protocol.decode_server_packet(no_definitions.to_json().stringify()) {
-    DecodedServerPacket(DefinitionResult(payload)) =>
-      assert_eq(payload.locations.length(), 0)
-    DecodedServerPacket(_) => fail("unexpected empty definition result packet")
-    ServerPacketDecodeError(error) => fail(error.message)
+  guard expect_server_packet(no_definitions.to_json().stringify())
+    is DefinitionResult(empty_definition_payload) else {
+    fail("unexpected empty definition result packet")
   }
-
+  assert_eq(empty_definition_payload.locations.length(), 0)
   let references_result = @remote_protocol.ReferencesResult({
     id: "refs-1",
     uri,
@@ -272,40 +229,29 @@ test "encodes and decodes server document and language packets" {
       },
     ],
   })
-  match
-    @remote_protocol.decode_server_packet(
-      references_result.to_json().stringify(),
-    ) {
-    DecodedServerPacket(ReferencesResult(payload)) => {
-      assert_eq(payload.id, "refs-1")
-      assert_eq(payload.revision, "rev-2")
-      assert_eq(payload.references.length(), 2)
-      assert_eq(payload.references[0].line, 1)
-      assert_eq(payload.references[0].column, 8)
-      assert_eq(payload.references[0].line_text, "pub fn main {}")
-      assert_true(payload.references[1].range == Range(2, 1, 2, 5))
-    }
-    DecodedServerPacket(_) => fail("unexpected references result packet")
-    ServerPacketDecodeError(error) => fail(error.message)
+  guard expect_server_packet(references_result.to_json().stringify())
+    is ReferencesResult(references_payload) else {
+    fail("unexpected references result packet")
   }
-
+  assert_eq(references_payload.id, "refs-1")
+  assert_eq(references_payload.revision, "rev-2")
+  assert_eq(references_payload.references.length(), 2)
+  assert_eq(references_payload.references[0].line, 1)
+  assert_eq(references_payload.references[0].column, 8)
+  assert_eq(references_payload.references[0].line_text, "pub fn main {}")
+  assert_true(references_payload.references[1].range == Range(2, 1, 2, 5))
   let empty_references = @remote_protocol.ReferencesResult({
     id: "refs-2",
     uri,
     revision: "rev-3",
     references: [],
   })
-  match
-    @remote_protocol.decode_server_packet(
-      empty_references.to_json().stringify(),
-    ) {
-    DecodedServerPacket(ReferencesResult(payload)) => {
-      assert_eq(payload.references.length(), 0)
-      assert_eq(payload.revision, "rev-3")
-    }
-    DecodedServerPacket(_) => fail("unexpected empty references packet")
-    ServerPacketDecodeError(error) => fail(error.message)
+  guard expect_server_packet(empty_references.to_json().stringify())
+    is ReferencesResult(empty_references_payload) else {
+    fail("unexpected empty references packet")
   }
+  assert_eq(empty_references_payload.references.length(), 0)
+  assert_eq(empty_references_payload.revision, "rev-3")
 
   // Diagnostics packets are server pushes: no request id on the wire.
   let diagnostics = @remote_protocol.ServerPacket::Diagnostics({
@@ -322,17 +268,14 @@ test "encodes and decodes server document and language packets" {
   })
   let encoded_diagnostics = diagnostics.to_json().stringify()
   assert_true(!encoded_diagnostics.contains("\"id\""))
-  match @remote_protocol.decode_server_packet(encoded_diagnostics) {
-    DecodedServerPacket(Diagnostics(payload)) => {
-      assert_eq(payload.uri.to_string(), uri.to_string())
-      assert_eq(payload.revision, "rev-2")
-      assert_eq(payload.diagnostics.length(), 1)
-      assert_eq(payload.diagnostics[0].message, "check me")
-    }
-    DecodedServerPacket(_) => fail("unexpected diagnostics packet")
-    ServerPacketDecodeError(error) => fail(error.message)
+  guard expect_server_packet(encoded_diagnostics)
+    is Diagnostics(diagnostics_payload) else {
+    fail("unexpected diagnostics packet")
   }
-
+  assert_eq(diagnostics_payload.uri.to_string(), uri.to_string())
+  assert_eq(diagnostics_payload.revision, "rev-2")
+  assert_eq(diagnostics_payload.diagnostics.length(), 1)
+  assert_eq(diagnostics_payload.diagnostics[0].message, "check me")
   let hint_diagnostics = @remote_protocol.ServerPacket::Diagnostics({
     uri,
     revision: "rev-3",
@@ -345,35 +288,27 @@ test "encodes and decodes server document and language packets" {
       },
     ],
   })
-  match
-    @remote_protocol.decode_server_packet(
-      hint_diagnostics.to_json().stringify(),
-    ) {
-    DecodedServerPacket(Diagnostics(payload)) => {
-      assert_eq(payload.diagnostics.length(), 1)
-      assert_true(payload.diagnostics[0].severity == Hint)
-      assert_true(
-        payload.diagnostics[0].tags == Some([Unnecessary, Deprecated]),
-      )
-    }
-    DecodedServerPacket(_) => fail("unexpected diagnostics packet")
-    ServerPacketDecodeError(error) => fail(error.message)
+  guard expect_server_packet(hint_diagnostics.to_json().stringify())
+    is Diagnostics(hint_payload) else {
+    fail("unexpected diagnostics packet")
   }
-
+  assert_eq(hint_payload.diagnostics.length(), 1)
+  assert_true(hint_payload.diagnostics[0].severity == Hint)
+  assert_true(
+    hint_payload.diagnostics[0].tags == Some([Unnecessary, Deprecated]),
+  )
   let symbols = @remote_protocol.DocumentSymbolsResult({
     id: "symbols-1",
     uri,
     revision: "rev-2",
     symbols: [{ name: "main", kind: "function", range: Range(1, 8, 1, 12), }],
   })
-  match @remote_protocol.decode_server_packet(symbols.to_json().stringify()) {
-    DecodedServerPacket(DocumentSymbolsResult(payload)) => {
-      assert_eq(payload.symbols.length(), 1)
-      assert_eq(payload.symbols[0].name, "main")
-    }
-    DecodedServerPacket(_) => fail("unexpected document symbols result packet")
-    ServerPacketDecodeError(error) => fail(error.message)
+  guard expect_server_packet(symbols.to_json().stringify())
+    is DocumentSymbolsResult(symbols_payload) else {
+    fail("unexpected document symbols result packet")
   }
+  assert_eq(symbols_payload.symbols.length(), 1)
+  assert_eq(symbols_payload.symbols[0].name, "main")
 }
 
 ///|
@@ -387,12 +322,11 @@ test "round-trips document text containing control characters" {
     uri, "control.mbt", "moonbit", "rev-1", text,
   )
   let loaded = @remote_protocol.DocumentLoaded({ id: "open-ctl", document, })
-  match @remote_protocol.decode_server_packet(loaded.to_json().stringify()) {
-    DecodedServerPacket(DocumentLoaded(payload)) =>
-      assert_eq(payload.document.text, text)
-    DecodedServerPacket(_) => fail("unexpected server packet")
-    ServerPacketDecodeError(error) => fail(error.message)
+  guard expect_server_packet(loaded.to_json().stringify())
+    is DocumentLoaded(payload) else {
+    fail("unexpected server packet")
   }
+  assert_eq(payload.document.text, text)
 }
 
 ///|
@@ -444,35 +378,29 @@ test "encodes and decodes host browse client packets" {
   })
   let encoded = list.to_json().stringify()
   assert_true(encoded.contains("\"type\":\"ListHostDirectory\""))
-  match @remote_protocol.decode_client_packet(encoded) {
-    DecodedClientPacket(ListHostDirectory(request)) => {
-      assert_eq(request.id, "list-1")
-      assert_eq(request.path, "/repos")
-    }
-    DecodedClientPacket(_) => fail("unexpected client packet")
-    ClientPacketDecodeError(error) => fail(error.message)
+  guard expect_client_packet(encoded) is ListHostDirectory(request) else {
+    fail("unexpected client packet")
   }
+  assert_eq(request.id, "list-1")
+  assert_eq(request.path, "/repos")
 
   // An empty path means "start from the current workspace root".
   let start = @remote_protocol.ListHostDirectory({ id: "list-2", path: "", })
-  match @remote_protocol.decode_client_packet(start.to_json().stringify()) {
-    DecodedClientPacket(ListHostDirectory(request)) =>
-      assert_eq(request.path, "")
-    DecodedClientPacket(_) => fail("unexpected client packet")
-    ClientPacketDecodeError(error) => fail(error.message)
+  guard expect_client_packet(start.to_json().stringify())
+    is ListHostDirectory(start_request) else {
+    fail("unexpected client packet")
   }
+  assert_eq(start_request.path, "")
   let switch = @remote_protocol.SwitchWorkspace({
     id: "switch-1",
     path: "/repos/demo",
   })
-  match @remote_protocol.decode_client_packet(switch.to_json().stringify()) {
-    DecodedClientPacket(SwitchWorkspace(request)) => {
-      assert_eq(request.id, "switch-1")
-      assert_eq(request.path, "/repos/demo")
-    }
-    DecodedClientPacket(_) => fail("unexpected client packet")
-    ClientPacketDecodeError(error) => fail(error.message)
+  guard expect_client_packet(switch.to_json().stringify())
+    is SwitchWorkspace(switch_request) else {
+    fail("unexpected client packet")
   }
+  assert_eq(switch_request.id, "switch-1")
+  assert_eq(switch_request.path, "/repos/demo")
 }
 
 ///|
@@ -490,46 +418,40 @@ test "encodes and decodes host browse server packets" {
   })
   let encoded = listed.to_json().stringify()
   assert_true(encoded.contains("\"isWorkspace\":true"))
-  match @remote_protocol.decode_server_packet(encoded) {
-    DecodedServerPacket(HostDirectoryListed(payload)) => {
-      assert_eq(payload.id, "list-1")
-      assert_eq(payload.listing.path, "/repos")
-      assert_eq(payload.listing.parent, Some("/"))
-      assert_eq(payload.listing.entries.length(), 2)
-      assert_eq(payload.listing.entries[0].name, "demo")
-      assert_eq(payload.listing.entries[0].path, "/repos/demo")
-      assert_true(payload.listing.entries[0].is_workspace)
-      assert_true(!payload.listing.entries[1].is_workspace)
-    }
-    DecodedServerPacket(_) => fail("unexpected server packet")
-    ServerPacketDecodeError(error) => fail(error.message)
+  guard expect_server_packet(encoded) is HostDirectoryListed(payload) else {
+    fail("unexpected server packet")
   }
+  assert_eq(payload.id, "list-1")
+  assert_eq(payload.listing.path, "/repos")
+  assert_eq(payload.listing.parent, Some("/"))
+  assert_eq(payload.listing.entries.length(), 2)
+  assert_eq(payload.listing.entries[0].name, "demo")
+  assert_eq(payload.listing.entries[0].path, "/repos/demo")
+  assert_true(payload.listing.entries[0].is_workspace)
+  assert_true(!payload.listing.entries[1].is_workspace)
 
   // The filesystem root omits `parent`.
   let rooted = @remote_protocol.HostDirectoryListed({
     id: "list-2",
     listing: { path: "/", parent: None, entries: [], },
   })
-  match @remote_protocol.decode_server_packet(rooted.to_json().stringify()) {
-    DecodedServerPacket(HostDirectoryListed(payload)) =>
-      assert_true(payload.listing.parent is None)
-    DecodedServerPacket(_) => fail("unexpected server packet")
-    ServerPacketDecodeError(error) => fail(error.message)
+  guard expect_server_packet(rooted.to_json().stringify())
+    is HostDirectoryListed(rooted_payload) else {
+    fail("unexpected server packet")
   }
+  assert_true(rooted_payload.listing.parent is None)
   let switched = @remote_protocol.WorkspaceSwitched({
     id: "switch-1",
     root: "/repos/demo",
     name: "demo",
   })
-  match @remote_protocol.decode_server_packet(switched.to_json().stringify()) {
-    DecodedServerPacket(WorkspaceSwitched(payload)) => {
-      assert_eq(payload.id, "switch-1")
-      assert_eq(payload.root, "/repos/demo")
-      assert_eq(payload.name, "demo")
-    }
-    DecodedServerPacket(_) => fail("unexpected server packet")
-    ServerPacketDecodeError(error) => fail(error.message)
+  guard expect_server_packet(switched.to_json().stringify())
+    is WorkspaceSwitched(switched_payload) else {
+    fail("unexpected server packet")
   }
+  assert_eq(switched_payload.id, "switch-1")
+  assert_eq(switched_payload.root, "/repos/demo")
+  assert_eq(switched_payload.name, "demo")
 
   // A broadcast push carries no id and never resolves a pending request.
   let push = @remote_protocol.WorkspaceSwitched({
@@ -537,11 +459,11 @@ test "encodes and decodes host browse server packets" {
     root: "/repos/demo",
     name: "demo",
   })
-  match @remote_protocol.decode_server_packet(push.to_json().stringify()) {
-    DecodedServerPacket(WorkspaceSwitched(payload)) => assert_eq(payload.id, "")
-    DecodedServerPacket(_) => fail("unexpected server packet")
-    ServerPacketDecodeError(error) => fail(error.message)
+  guard expect_server_packet(push.to_json().stringify())
+    is WorkspaceSwitched(push_payload) else {
+    fail("unexpected server packet")
   }
+  assert_eq(push_payload.id, "")
 }
 
 ///|
@@ -573,4 +495,28 @@ fn assert_hover_markdown(
 ///|
 fn expect_uri(raw : String) -> @base_common.Uri raise {
   @base_common.Uri::parse(raw)
+}
+
+///|
+/// Decodes a client packet, failing the test with the decoder's own message
+/// when the wire form is rejected.
+fn expect_client_packet(
+  encoded : String,
+) -> @remote_protocol.ClientPacket raise {
+  match @remote_protocol.decode_client_packet(encoded) {
+    DecodedClientPacket(packet) => packet
+    ClientPacketDecodeError(error) => fail(error.message)
+  }
+}
+
+///|
+/// Decodes a server packet, failing the test with the decoder's own message
+/// when the wire form is rejected.
+fn expect_server_packet(
+  encoded : String,
+) -> @remote_protocol.ServerPacket raise {
+  match @remote_protocol.decode_server_packet(encoded) {
+    DecodedServerPacket(packet) => packet
+    ServerPacketDecodeError(error) => fail(error.message)
+  }
 }

--- a/jsonrpc/client_wbtest.mbt
+++ b/jsonrpc/client_wbtest.mbt
@@ -72,6 +72,18 @@ fn[X] spawn_client(group : @async.TaskGroup[X], client : Client) -> Unit {
 }
 
 ///|
+/// The client most tests below start from: a queue transport plus the two
+/// standing tasks (reader and writer) the client requires, spawned on `group`.
+/// Tests that must install a handler before the reader starts, or that own the
+/// pump handle themselves, build their client inline instead.
+fn[X] new_client(group : @async.TaskGroup[X]) -> (FakeTransport, Client) {
+  let transport = new_transport()
+  let client = Client::Client(transport)
+  spawn_client(group, client)
+  (transport, client)
+}
+
+///|
 /// The raw id of a request, or `Null` if it somehow has none.
 fn id_of(request : Json) -> Json {
   match request {
@@ -121,9 +133,7 @@ async fn request_outcome(client : Client, method_ : String) -> String {
 ///|
 async test "concurrent requests each get their own reply even when answered out of order" {
   @async.with_task_group(group => {
-    let transport = new_transport()
-    let client = Client::Client(transport)
-    spawn_client(group, client)
+    let (transport, client) = new_client(group)
     // Fake peer: take both requests, then answer them in reverse arrival order.
     group.spawn_bg(no_wait=true, allow_failure=true, () => {
       let first_seen = transport.outbound.get()
@@ -147,9 +157,7 @@ async test "concurrent requests each get their own reply even when answered out 
 /// the answered request's reply must come back promptly (no read-lock starving).
 async test "a delivered reply never waits behind other outstanding requests" {
   @async.with_task_group(group => {
-    let transport = new_transport()
-    let client = Client::Client(transport)
-    spawn_client(group, client)
+    let (transport, client) = new_client(group)
     group.spawn_bg(no_wait=true, allow_failure=true, () => {
       client.request(method_="first", params=Json::null()) |> ignore
     })
@@ -174,9 +182,7 @@ async test "a delivered reply never waits behind other outstanding requests" {
 ///|
 async test "a request raises Failed on a JSON-RPC error reply" {
   @async.with_task_group(group => {
-    let transport = new_transport()
-    let client = Client::Client(transport)
-    spawn_client(group, client)
+    let (transport, client) = new_client(group)
     group.spawn_bg(no_wait=true, allow_failure=true, () => {
       transport.inbound.put(error_for(transport.outbound.get(), -32601, "nope"))
     })
@@ -190,9 +196,7 @@ async test "a request raises Failed on a JSON-RPC error reply" {
 /// must win so a failure is never masked as success.
 async test "a reply with both result and error surfaces the error" {
   @async.with_task_group(group => {
-    let transport = new_transport()
-    let client = Client::Client(transport)
-    spawn_client(group, client)
+    let (transport, client) = new_client(group)
     group.spawn_bg(no_wait=true, allow_failure=true, () => {
       let request = transport.outbound.get()
       transport.inbound.put({
@@ -211,9 +215,7 @@ async test "a reply with both result and error surfaces the error" {
 /// A reply carrying `error: null` next to a result is a success, not a failure.
 async test "a reply with a null error alongside a result succeeds" {
   @async.with_task_group(group => {
-    let transport = new_transport()
-    let client = Client::Client(transport)
-    spawn_client(group, client)
+    let (transport, client) = new_client(group)
     group.spawn_bg(no_wait=true, allow_failure=true, () => {
       let request = transport.outbound.get()
       transport.inbound.put({
@@ -233,9 +235,7 @@ async test "a reply with a null error alongside a result succeeds" {
 /// correlated requests.
 async test "a batched array reply routes each element" {
   @async.with_task_group(group => {
-    let transport = new_transport()
-    let client = Client::Client(transport)
-    spawn_client(group, client)
+    let (transport, client) = new_client(group)
     group.spawn_bg(no_wait=true, allow_failure=true, () => {
       let first = transport.outbound.get()
       let second = transport.outbound.get()
@@ -279,9 +279,7 @@ async test "peer notifications reach the installed handler" {
 /// usable for the real request.
 async test "a reply for an unknown id is dropped and the client stays usable" {
   @async.with_task_group(group => {
-    let transport = new_transport()
-    let client = Client::Client(transport)
-    spawn_client(group, client)
+    let (transport, client) = new_client(group)
     group.spawn_bg(no_wait=true, allow_failure=true, () => {
       let request = transport.outbound.get()
       transport.inbound.put({
@@ -301,9 +299,7 @@ async test "a reply for an unknown id is dropped and the client stays usable" {
 /// no other method).
 async test "a peer ping is answered with an empty success" {
   @async.with_task_group(group => {
-    let transport = new_transport()
-    let client = Client::Client(transport)
-    spawn_client(group, client)
+    let (transport, _) = new_client(group)
     transport.inbound.put({ "jsonrpc": "2.0", "id": 42, "method": "ping" })
     let reply = transport.outbound.get()
     assert_true(reply is { "id": Number(42, ..), "result": _, .. })
@@ -314,9 +310,7 @@ async test "a peer ping is answered with an empty success" {
 ///|
 async test "a peer method has no owner until a request handler is installed" {
   @async.with_task_group(group => {
-    let transport = new_transport()
-    let client = Client::Client(transport)
-    spawn_client(group, client)
+    let (transport, _) = new_client(group)
     transport.inbound.put({
       "jsonrpc": "2.0",
       "id": 41,
@@ -431,9 +425,7 @@ async test "a failing peer request handler receives internal error and keeps rou
 ///|
 async test "a request fails with Closed when the transport ends without a reply" {
   @async.with_task_group(group => {
-    let transport = new_transport()
-    let client = Client::Client(transport)
-    spawn_client(group, client)
+    let (transport, client) = new_client(group)
     // The peer consumes the request but ends the stream without answering.
     group.spawn_bg(no_wait=true, allow_failure=true, () => {
       transport.outbound.get() |> ignore
@@ -510,9 +502,7 @@ async test "a request after close raises Closed and notify is a no-op" {
 ///|
 async test "notify enqueues an id-less message the writer sends" {
   @async.with_task_group(group => {
-    let transport = new_transport()
-    let client = Client::Client(transport)
-    spawn_client(group, client)
+    let (transport, client) = new_client(group)
     client.notify(
       method_="notifications/initialized",
       params=Json::empty_object(),

--- a/mcp/config/config_wbtest.mbt
+++ b/mcp/config/config_wbtest.mbt
@@ -122,21 +122,8 @@ test "decode rejects a server with both command and url" {
 
 ///|
 test "decode rejects mistyped http fields" {
-  let bad_url = try {
-    decode({ "mcpServers": { "x": { "url": 7 } } }) |> ignore
-    "no error"
-  } catch {
-    Invalid(_) => "invalid"
-    _ => "other"
-  }
-  assert_eq(bad_url, "invalid")
-  let bad_headers = try {
-    decode({ "mcpServers": { "x": { "url": "http://h/mcp", "headers": [] } } })
-    |> ignore
-    "no error"
-  } catch {
-    Invalid(_) => "invalid"
-    _ => "other"
-  }
-  assert_eq(bad_headers, "invalid")
+  assert_invalid({ "mcpServers": { "x": { "url": 7 } } })
+  assert_invalid({
+    "mcpServers": { "x": { "url": "http://h/mcp", "headers": [] } },
+  })
 }

--- a/mcp/types_wbtest.mbt
+++ b/mcp/types_wbtest.mbt
@@ -1,6 +1,22 @@
 // Pure decoder and rendering tests — no transport.
 
 ///|
+/// Assert that `decode` raises `Protocol`. The three tests below differ only in
+/// the call; the chain that turns the raise into a comparable string — and the
+/// `_ => "other"` arm that keeps an unexpected error from reading as a pass —
+/// was copied into each of them.
+fn assert_protocol(decode : () -> Unit raise) -> Unit raise {
+  let outcome = try {
+    decode()
+    "no error"
+  } catch {
+    Protocol(_) => "protocol"
+    _ => "other"
+  }
+  assert_eq(outcome, "protocol")
+}
+
+///|
 test "decode_tool reads all fields" {
   let tool = decode_tool({
     "name": "search",
@@ -22,14 +38,7 @@ test "decode_tool defaults a missing description and schema" {
 
 ///|
 test "decode_tool raises Protocol when name is missing" {
-  let outcome = try {
-    decode_tool({ "description": "no name" }) |> ignore
-    "no error"
-  } catch {
-    Protocol(_) => "protocol"
-    _ => "other"
-  }
-  assert_eq(outcome, "protocol")
+  assert_protocol(() => decode_tool({ "description": "no name" }) |> ignore)
 }
 
 ///|
@@ -66,14 +75,7 @@ test "decode_content_block reads each block kind" {
 
 ///|
 test "decode_content_block raises Protocol without a type" {
-  let outcome = try {
-    decode_content_block({ "text": "orphan" }) |> ignore
-    "no error"
-  } catch {
-    Protocol(_) => "protocol"
-    _ => "other"
-  }
-  assert_eq(outcome, "protocol")
+  assert_protocol(() => decode_content_block({ "text": "orphan" }) |> ignore)
 }
 
 ///|
@@ -104,14 +106,9 @@ test "decode_initialize_result reads identity and defaults" {
 
 ///|
 test "decode_initialize_result raises without a protocol version" {
-  let outcome = try {
+  assert_protocol(() => {
     decode_initialize_result({ "serverInfo": { "name": "srv" } }) |> ignore
-    "no error"
-  } catch {
-    Protocol(_) => "protocol"
-    _ => "other"
-  }
-  assert_eq(outcome, "protocol")
+  })
 }
 
 ///|


### PR DESCRIPTION
**Test-only, and shared.** Fixtures introduced or shared across tests, and a few
near-identical cases folded into tables. The in-place test rewrites this was
mixed with have moved to #1333.

The fold is the thing to weigh: a folded test stops at its first failing row,
where separate tests each reported independently. Assertion counts are preserved
and every row carries `msg=` naming its input. Two are worth a second look on
that basis — the `edit` tool's malformed-argument cases, and the four
per-severity squiggly rules.

No production file changes here.

Scope: test files across all three modules.

### Verified on this branch alone

`moon fmt --check`, the native and JS workspace checks with `--deny-warn`, both
full test suites, and from `editor/` `moon check --target all --warn-list +73
--deny-warn` plus `moon test --target all`, with no other part of the refactor
applied. No `.mbti` changed.

---

The refactor is split so each pull request asks one kind of question. Every file
appears in exactly one of them, each was verified on its own branch with no
other part applied, so they merge in any order.

| | easy to review | needs a careful read |
| --- | --- | --- |
| root | #1330 | this one (#1325) |
| `desktop/` | #1331 | #1326 |
| `editor/` | #1332 | #1327 |
| tests | #1333 | #1328 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JiBNGzCsZpN6e5Y4p9pXdn
