### PR TITLE
refactor: drop two allocations and two one-line indirections (review of #1322)

### DIFF
--- a/agent_subtask/geometry.mbt
+++ b/agent_subtask/geometry.mbt
@@ -51,7 +51,7 @@ pub async fn resolve_geometry(
   let worktree_roots : Array[String] = []
   for record in listing.output.split("\u{0}") {
     if record.strip_prefix("worktree ") is Some(root) {
-      worktree_roots.push(canonical(root.to_owned()))
+      worktree_roots.push(canonical(root))
     }
   }
   guard !worktree_roots.is_empty() else {
@@ -84,10 +84,10 @@ pub fn Geometry::is_integration_target_for(
 ///|
 /// realpath when possible; lexical normalization otherwise (a nonexistent
 /// path cannot be part of live geometry, but error messages still read).
-async fn canonical(path : String) -> String {
+async fn canonical(path : StringView) -> String {
   let real = @fs.realpath(path) catch {
     error if @async.is_being_cancelled() => raise error
-    _ => path
+    _ => path.to_owned()
   }
   @workspace_path.strip_trailing_slash(real)
 }

--- a/agent_subtask/registry.mbt
+++ b/agent_subtask/registry.mbt
@@ -144,13 +144,6 @@ fn components(prefix : String) -> Array[String] {
 }
 
 ///|
-/// Whether `shorter` is a component-wise prefix of `longer` (equal counts as
-/// covered).
-fn one_covers(shorter : Array[String], longer : Array[String]) -> Bool {
-  longer.starts_with(shorter)
-}
-
-///|
 /// Component-wise prefix overlap between two allowed-path sets: `src`
 /// overlaps `src/lexer` and `src`, never `src2`.
 fn paths_overlap(a : Array[String], b : Array[String]) -> Bool {
@@ -158,7 +151,9 @@ fn paths_overlap(a : Array[String], b : Array[String]) -> Bool {
     b.any(right => {
       let l = components(left)
       let r = components(right)
-      one_covers(l, r) || one_covers(r, l)
+      // Either component list being a prefix of the other is an overlap;
+      // equal lists count as covered.
+      r.starts_with(l) || l.starts_with(r)
     })
   })
 }

--- a/agent_subtask/scope.mbt
+++ b/agent_subtask/scope.mbt
@@ -79,7 +79,7 @@ fn scope_violations(
   let violations : Array[String] = []
   for change in changes {
     let parts = components(change.path)
-    let admitted = allowed.any(prefix => one_covers(prefix, parts))
+    let admitted = allowed.any(prefix => parts.starts_with(prefix))
     if !admitted && !violations.contains(change.path) {
       violations.push(change.path)
     }

--- a/agent_tool/read/html/read_output.mbt
+++ b/agent_tool/read/html/read_output.mbt
@@ -30,7 +30,7 @@ pub fn moonbit_output(arguments : String, content : String) -> @rhtml.Html? {
 
 ///|
 /// Render a numbered result when `path` has a MoonBit source extension.
-fn moonbit_output_for_path(path : String, content : String) -> @rhtml.Html? {
+fn moonbit_output_for_path(path : StringView, content : String) -> @rhtml.Html? {
   // The read body is capped by its canonical decoder. Leave room for the
   // short status footer; older unbounded records use the host's plain fallback.
   guard is_moonbit_source(path) &&
@@ -78,14 +78,14 @@ pub fn moonbit_output_for_brief(
 ) -> @rhtml.Html? {
   guard brief.strip_prefix("read ") is Some(path_view) else { return None }
   let path = path_view.strip_suffix(" (truncated)").unwrap_or(path_view)
-  moonbit_output_for_path(path.to_owned(), content)
+  moonbit_output_for_path(path, content)
 }
 
 ///|
 /// Source/interface/script extensions tokenized by the MoonBit lexer. Markdown
 /// files such as `.mbt.md` deliberately stay plain: their outer grammar is
 /// Markdown even though fenced snippets may contain MoonBit.
-fn is_moonbit_source(path : String) -> Bool {
+fn is_moonbit_source(path : StringView) -> Bool {
   let lower = path.to_lower()
   lower.has_suffix(".mbt") ||
   lower.has_suffix(".mbti") ||

--- a/agent_tool/shell/internal/decode/decode.mbt
+++ b/agent_tool/shell/internal/decode/decode.mbt
@@ -43,7 +43,7 @@ fn parse_fields(fields : Map[String, Json]) -> ShellInput raise {
     cmd,
     cwd,
     timeout_ms,
-    max_output_chars: cap_max_output_chars(max_output_chars),
+    max_output_chars: max_output_chars.min(hard_max_output_chars),
     run_in_background,
   }
 }
@@ -91,11 +91,6 @@ fn optional_positive_int(
     Some(Null) | None => None
     _ => fail("arguments.\{name} to be a number")
   }
-}
-
-///|
-fn cap_max_output_chars(value : Int) -> Int {
-  value.min(hard_max_output_chars)
 }
 
 ///|


### PR DESCRIPTION
Addresses the review comments left on #1322 after it merged. Four of the five
are applied; the fifth is answered below.

### Allocations the caller did not need

**`canonical` takes a `StringView`** (`agent_subtask/geometry.mbt`).
`@fs.realpath` already accepts a `StringView`, so `canonical(root.to_owned())`
at the worktree-list site copied a path only to hand it straight through. The
fallback arm still owns its result, but that is the error path, not the scan.

**`moonbit_output_for_path` and `is_moonbit_source` take a `StringView`**
(`agent_tool/read/html/read_output.mbt`). Rendering from a read brief no longer
copies the path out of its `strip_prefix` view just to check the extension.

### Indirections that stopped paying for themselves

**`one_covers` is inlined** as `longer.starts_with(shorter)`. Note it has two
call sites, not one: the overlap test in `registry.mbt` and the admission test
in `scope.mbt`. Inlining still wins, because at each site the stdlib call reads
as what it means, where `one_covers(prefix, parts)` made the reader resolve an
argument order first.

**`cap_max_output_chars` is inlined** as `max_output_chars.min(hard_max_output_chars)`
at its single call site.

### The one not applied: `count.count_if?`

`total_line_count` in `agent_tool/edit/edit.mbt` reads:

```moonbit
let count = content.iter().count_if(ch => ch == '\n')
```

I could not find a shorter true form. `String` has no `count_if`, so the
`.iter()` hop is what reaches `Iter::count_if`; the only other counting method
is `Iter::count`, which takes no predicate. If the intent was to drop the
intermediate binding, it has to stay — the result is used twice, once per branch
of the trailing `has_suffix` test. Happy to change it if you meant something
else.

### Verified

`moon fmt --check`, native and JS checks with `--deny-warn`, and both full test
suites: 3202 native, 3184 JS. No `.mbti` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JiBNGzCsZpN6e5Y4p9pXdn
