### PR TITLE
refactor: in-function rewrites in the root module

### DIFF
--- a/agent/turn_loop.mbt
+++ b/agent/turn_loop.mbt
@@ -876,10 +876,9 @@ async fn AgentLoop::salvage_control_calls_at_ceiling(
   }) else {
     return None
   }
-  let session = for index = from, session = session, spent = spent_result_chars {
-    if index >= response.tool_calls.length() {
-      break session
-    }
+  let session = for
+    index in from..<response.tool_calls.length()
+    session = session, spent = spent_result_chars {
     let call = response.tool_calls[index]
     let is_control_call = self.tools.find(call.name) is Some(definition) &&
       definition.is_control()
@@ -905,7 +904,7 @@ async fn AgentLoop::salvage_control_calls_at_ceiling(
             // size its compact-on-finish decision against stale usage
             // while the reserved checkpoint headroom is already spent.
             ContinueToolBatch(next) =>
-              continue index + 1, next, spent + recorded_result_chars(next)
+              continue next, spent + recorded_result_chars(next)
             // The control already closed the batch remainder and prepared a
             // continuation (e.g. a control finish converted into a goal
             // check): re-scanning the same calls would duplicate results
@@ -922,13 +921,14 @@ async fn AgentLoop::salvage_control_calls_at_ceiling(
         None => ()
       }
     }
-    continue index + 1,
-      self.close_skipped_tool_calls(
+    continue self.close_skipped_tool_calls(
         session,
         response.tool_calls[index:index + 1],
         note=ceiling_skip_note,
       ),
       spent
+  } nobreak {
+    session
   }
   // Controls ran but none sealed or continued the turn: every call is
   // closed (executed or skip-noted), so yield at the ceiling with the

--- a/agent_tool/write/write.mbt
+++ b/agent_tool/write/write.mbt
@@ -123,13 +123,13 @@ async fn write_file(
   file_state~ : @agent_tool.FileStateMap,
   write_scope? : @write_scope.WriteScope,
 ) -> @agent_tool.ToolAction {
-  // Every failure names the file it tried to write, as `edit`/`remove` do.
-  let fail_brief = "write \{@agent_tool.brief_basename(path)}"
   fn err(message : String) -> @agent_tool.ToolAction {
+    // Every failure names the file it tried to write, as `edit`/`remove` do.
+    // Built here rather than once per call: the success path never needs it.
     @agent_tool.respond(
       "error writing \{path}: \{message}",
       is_error=true,
-      brief=fail_brief,
+      brief="write \{@agent_tool.brief_basename(path)}",
     )
   }
 

--- a/agent_tool/write/write.mbt
+++ b/agent_tool/write/write.mbt
@@ -123,12 +123,18 @@ async fn write_file(
   file_state~ : @agent_tool.FileStateMap,
   write_scope? : @write_scope.WriteScope,
 ) -> @agent_tool.ToolAction {
-  if @manifest_error.write_error(path, input.content) is Some(message) {
-    return @agent_tool.respond(
+  // Every failure names the file it tried to write, as `edit`/`remove` do.
+  let fail_brief = "write \{@agent_tool.brief_basename(path)}"
+  fn err(message : String) -> @agent_tool.ToolAction {
+    @agent_tool.respond(
       "error writing \{path}: \{message}",
       is_error=true,
-      brief="write \{@agent_tool.brief_basename(path)}",
+      brief=fail_brief,
     )
+  }
+
+  if @manifest_error.write_error(path, input.content) is Some(message) {
+    return err(message)
   }
   // Resolve symlinks once, up front: the realpath decides both whether this
   // is an existing-source overwrite to reject and — for the syntax gate below
@@ -147,10 +153,8 @@ async fn write_file(
   // stops a link named `x.txt` pointing at `lib.mbt` from slipping past the
   // suffix check and truncating the source through CreateOrTruncate below.
   if @fs.exists(path) && (is_mbt_source(path) || is_mbt_source(target)) {
-    return @agent_tool.respond(
-      "error writing \{path}: existing source file — use edit or multi_edit to change it (an empty old_string inserts new code); write is for creating new files",
-      is_error=true,
-      brief="write \{@agent_tool.brief_basename(path)}",
+    return err(
+      "existing source file — use edit or multi_edit to change it (an empty old_string inserts new code); write is for creating new files",
     )
   }
   // Pre-write syntax gate for syncheck inputs (`.mbt`, `.mbt.md`, `moon.mod`,
@@ -183,11 +187,7 @@ async fn write_file(
   // are created for the target): the early gate decided on filesystem state
   // that awaits ago may have changed underneath the tool.
   if write_scope is Some(scope) && scope.deny_reason(path) is Some(reason) {
-    return @agent_tool.respond(
-      "error writing \{path}: write blocked: \{reason}",
-      is_error=true,
-      brief="write \{@agent_tool.brief_basename(path)}",
-    )
+    return err("write blocked: \{reason}")
   }
   create_parent_dirs(path)
   // Probe before writing so the result can tell the model whether it created a
@@ -233,12 +233,7 @@ async fn write_file(
   let lines = if input.content == "" {
     0
   } else {
-    let newlines = for ch in input.content; newlines = 0 {
-      continue if ch == '\n' { newlines + 1 } else { newlines }
-    } nobreak {
-      newlines
-    }
-    newlines + 1
+    input.content.iter().count_if(ch => ch == '\n') + 1
   }
   let line_word = if lines == 1 { "line" } else { "lines" }
   let summary = if existed {

--- a/eval/prompt_task/harness/analyzer.mbt
+++ b/eval/prompt_task/harness/analyzer.mbt
@@ -522,32 +522,20 @@ fn probe_output_result(
         summarize(combined),
     )
   }
-  if spec.output_contains != "" &&
-    !contains_expected_text(combined, spec.output_contains) {
-    return ProbeResult(
-      name=spec.name,
-      passed=false,
-      reason="missing output text `\{spec.output_contains}`: " +
-        summarize(combined),
-    )
-  }
-  if spec.stdout_contains != "" &&
-    !contains_expected_text(stdout, spec.stdout_contains) {
-    return ProbeResult(
-      name=spec.name,
-      passed=false,
-      reason="missing stdout text `\{spec.stdout_contains}`: " +
-        summarize(stdout),
-    )
-  }
-  if spec.stderr_contains != "" &&
-    !contains_expected_text(stderr, spec.stderr_contains) {
-    return ProbeResult(
-      name=spec.name,
-      passed=false,
-      reason="missing stderr text `\{spec.stderr_contains}`: " +
-        summarize(stderr),
-    )
+  let text_checks = [
+    ("output", spec.output_contains, combined),
+    ("stdout", spec.stdout_contains, stdout),
+    ("stderr", spec.stderr_contains, stderr),
+  ]
+  for check in text_checks {
+    let (label, expected, haystack) = check
+    if expected != "" && !contains_expected_text(haystack, expected) {
+      return ProbeResult(
+        name=spec.name,
+        passed=false,
+        reason="missing \{label} text `\{expected}`: " + summarize(haystack),
+      )
+    }
   }
   if spec.stdout_json {
     let trimmed = stdout.trim().to_owned()

--- a/eval/report/report.mbt
+++ b/eval/report/report.mbt
@@ -84,20 +84,17 @@ pub fn Report::markdown(self : Report) -> String {
   for row in self.rows {
     lines.push(row.markdown_row(self.metric_columns))
   }
-  let detail_lines = detail_section_lines(self.rows)
-  if detail_lines.length() > 0 {
-    lines.push("")
-    lines.push("## Trial Details")
-    lines.push("")
-    lines.append(detail_lines)
+  fn section(title : String, body : Array[String]) -> Unit {
+    if body.length() > 0 {
+      lines.push("")
+      lines.push("## \{title}")
+      lines.push("")
+      lines.append(body)
+    }
   }
-  let log_lines = log_section_lines(self.rows)
-  if log_lines.length() > 0 {
-    lines.push("")
-    lines.push("## Logs")
-    lines.push("")
-    lines.append(log_lines)
-  }
+
+  section("Trial Details", detail_section_lines(self.rows))
+  section("Logs", log_section_lines(self.rows))
   "\{lines.join("\n")}\n"
 }
 


### PR DESCRIPTION
**Every hunk stays inside one function.** Nothing shared is added, removed or
re-signatured, so each hunk can be judged by reading it — there is no other code
to go check.

The shapes used, all of them:

| before | after |
| --- | --- |
| an `if`/`else` ladder | one `match` with guards or nested patterns |
| a nested `match` on options | a `guard ... is Some(..)` chain |
| a manual index loop | a comprehension, `fold`, `any`, `find_first`, `search_by` |
| two identical `match` arms | one or-pattern arm |
| `match o { Some(v) => ...; None => ... }` | an Option combinator |
| duplicated branches in one function | a local binding or a closure used only there |

The helper extractions these were mixed with are in the paired pull request, so
nothing here crosses a call site.

Scope: `agent/turn_loop.mbt`, `agent_tool/write`, and two `eval/` harness files.

### Verified on this branch alone

`moon fmt --check`, `moon check --target native --deny-warn`, `moon check
--target js --deny-warn`, and both full test suites, with no other part of the
refactor applied. No `.mbti` changed.

---

The refactor is split so each pull request asks one kind of question. Every file
appears in exactly one of them, each was verified on its own branch with no
other part applied, so they merge in any order.

| | easy to review | needs a careful read |
| --- | --- | --- |
| root | `simplify/local-root` | `simplify/structural-root` (#1325) |
| `desktop/` | `simplify/local-desktop` | `simplify/structural-desktop` (#1326) |
| `editor/` | `simplify/local-editor` | `simplify/structural-editor` (#1327) |
| tests | `simplify/tests-local` | `simplify/tests` (#1328) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JiBNGzCsZpN6e5Y4p9pXdn
