### PR TITLE
refactor(desktop): in-function rewrites

### DIFF
--- a/desktop/frontend/composer/component.mbt
+++ b/desktop/frontend/composer/component.mbt
@@ -142,54 +142,33 @@ fn Entry::reconciled(self : Entry, input : Input) -> Entry {
   let root_changed = input.root != self.root
   let context_changed = self.context_generation != input.context_generation
   let skills_changed = self.installed_skills != input.installed_skills
-  match self.pending_submission {
+  let acknowledged : Draft? = match self.pending_submission {
     Some(PromptSubmission(sequence_before~, _)) if input.submission_sequence >
-      sequence_before =>
-      return {
-        ..self,
-        source: incoming,
-        draft: incoming,
-        source_goal: incoming_goal,
-        goal_draft: incoming_goal,
-        completion: None,
-        symbol_cache: if root_changed {
-          SymbolCache()
-        } else {
-          self.symbol_cache
-        },
-        file_completion: self.file_completion_for(
-          input,
-          incoming.task,
-          input.root,
-        ),
-        root: input.root,
-        installed_skills: input.installed_skills,
-        context_generation: input.context_generation,
-        pending_submission: None,
-      }
+      sequence_before => Some(incoming)
     Some(GoalSubmission(sequence_before~, _)) if input.submission_sequence >
-      sequence_before => {
-      let draft = self.draft.reconciled(source=self.source, incoming~)
-      return {
-        ..self,
-        source: incoming,
-        draft,
-        source_goal: incoming_goal,
-        goal_draft: incoming_goal,
-        completion: None,
-        symbol_cache: if root_changed {
-          SymbolCache()
-        } else {
-          self.symbol_cache
-        },
-        file_completion: self.file_completion_for(input, draft.task, input.root),
-        root: input.root,
-        installed_skills: input.installed_skills,
-        context_generation: input.context_generation,
-        pending_submission: None,
-      }
+      sequence_before =>
+      Some(self.draft.reconciled(source=self.source, incoming~))
+    _ => None
+  }
+  if acknowledged is Some(draft) {
+    return {
+      ..self,
+      source: incoming,
+      draft,
+      source_goal: incoming_goal,
+      goal_draft: incoming_goal,
+      completion: None,
+      symbol_cache: if root_changed {
+        SymbolCache()
+      } else {
+        self.symbol_cache
+      },
+      file_completion: self.file_completion_for(input, draft.task, input.root),
+      root: input.root,
+      installed_skills: input.installed_skills,
+      context_generation: input.context_generation,
+      pending_submission: None,
     }
-    _ => ()
   }
   let draft = self.draft.reconciled(source=self.source, incoming~)
   let goal_draft = if incoming_goal == self.source_goal {
@@ -318,13 +297,10 @@ fn Model::active(self : Model, input : Input) -> Entry {
 ///|
 fn Model::with_entry(self : Model, entry : Entry) -> Model {
   let entries = self.entries.copy()
-  for index, existing in entries {
-    if existing.owner == entry.owner {
-      entries[index] = entry
-      return { ..self, entries, }
-    }
+  match entries.search_by(existing => existing.owner == entry.owner) {
+    Some(index) => entries[index] = entry
+    None => entries.push(entry)
   }
-  entries.push(entry)
   { ..self, entries, }
 }
 
@@ -433,9 +409,9 @@ fn Entry::accept_completion(
   guard self.completion is Some(completion) else {
     return ({ ..self, completion: None, }, @cmd.none)
   }
-  match completion.kind {
+  let mention : Mention? = match completion.kind {
     SlashCommands =>
-      (
+      return (
         {
           ..self,
           draft: { ..self.draft, task: completion.menu.draft_without_token(), },
@@ -446,61 +422,41 @@ fn Entry::accept_completion(
         ),
       )
     SkillMentions =>
-      (
-        {
-          ..self,
-          draft: {
-            ..self.draft.with_mention({
-              ref_: @mention_context.Skill(name=item.insert.trim().to_owned()),
-              range: None,
-            }),
-            task: completion.menu.draft_without_token(),
-          },
-          completion: None,
-        },
-        @cmd.none,
-      )
+      Some({
+        ref_: @mention_context.Skill(name=item.insert.trim().to_owned()),
+        range: None,
+      })
     Symbols => {
       let (file, line) = if item.path is Some(path) && item.range is Some(range) {
         (path, range.start_line_number)
       } else {
         ("", 0)
       }
-      (
-        {
-          ..self,
-          draft: {
-            ..self.draft.with_mention({
-              ref_: @mention_context.Symbol(name=item.label, file~, line~),
-              range: item.range,
-            }),
-            task: completion.menu.draft_without_token(),
-          },
-          completion: None,
-        },
-        @cmd.none,
-      )
+      Some({
+        ref_: @mention_context.Symbol(name=item.label, file~, line~),
+        range: item.range,
+      })
     }
     Files =>
-      if item.path is Some(path) {
-        (
-          {
-            ..self,
-            draft: {
-              ..self.draft.with_mention({
-                ref_: @mention_context.File(path~),
-                range: None,
-              }),
-              task: completion.menu.draft_without_token(),
-            },
-            completion: None,
-          },
-          @cmd.none,
-        )
-      } else {
-        ({ ..self, completion: None, }, @cmd.none)
-      }
+      item.path.map(path => Mention::{
+        ref_: @mention_context.File(path~),
+        range: None,
+      })
   }
+  guard mention is Some(mention) else {
+    return ({ ..self, completion: None, }, @cmd.none)
+  }
+  (
+    {
+      ..self,
+      draft: {
+        ..self.draft.with_mention(mention),
+        task: completion.menu.draft_without_token(),
+      },
+      completion: None,
+    },
+    @cmd.none,
+  )
 }
 
 ///|
@@ -773,31 +729,15 @@ fn Model::update(
       )
     }
     FilesLoaded(owner~, root~, query~, epoch~, files~) => {
-      guard entry.settled_file_completion(
-          input,
-          owner,
-          root,
-          query,
-          epoch,
-          Some(files),
-        )
-        is Some(next) else {
-        return (self.with_entry(entry), @cmd.none)
-      }
+      let next = entry
+        .settled_file_completion(input, owner, root, query, epoch, Some(files))
+        .unwrap_or(entry)
       (self.with_entry(next), @cmd.none)
     }
     FilesFailed(owner~, root~, query~, epoch~) => {
-      guard entry.settled_file_completion(
-          input,
-          owner,
-          root,
-          query,
-          epoch,
-          None,
-        )
-        is Some(next) else {
-        return (self.with_entry(entry), @cmd.none)
-      }
+      let next = entry
+        .settled_file_completion(input, owner, root, query, epoch, None)
+        .unwrap_or(entry)
       (self.with_entry(next), @cmd.none)
     }
   }

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -2677,12 +2677,7 @@ fn Model::device_state(
   self : Model,
   channel : @interop.ChannelId,
 ) -> DeviceState? {
-  for dev in self.devices {
-    if dev.channel == channel {
-      return Some(dev)
-    }
-  }
-  None
+  self.devices.iter().find_first(dev => dev.channel == channel)
 }
 
 ///|
@@ -2996,12 +2991,9 @@ fn Model::find_conversation(
   channel : @interop.ChannelId,
   session_id : String,
 ) -> Conversation? {
-  for conv in self.conversations {
-    if conv.device == channel && conv.session_id == session_id {
-      return Some(conv)
-    }
-  }
-  None
+  self.conversations
+  .iter()
+  .find_first(conv => conv.device == channel && conv.session_id == session_id)
 }
 
 ///|
@@ -3190,12 +3182,10 @@ fn DeviceState::archive_override(
   self : DeviceState,
   key : ArchiveRecordKey,
 ) -> ArchiveDisposition? {
-  for fact in self.archive_overrides {
-    if fact.key == key {
-      return Some(fact.disposition)
-    }
-  }
-  None
+  self.archive_overrides
+  .iter()
+  .find_first(fact => fact.key == key)
+  .map(fact => fact.disposition)
 }
 
 ///|
@@ -3271,12 +3261,10 @@ fn Model::remembered_model(
   session : String,
 ) -> EngineModel? {
   let key = conversation_model_key(channel, session)
-  for entry in self.conversation_models {
-    if entry.key == key {
-      return Some(entry.model)
-    }
-  }
-  None
+  self.conversation_models
+  .iter()
+  .find_first(entry => entry.key == key)
+  .map(entry => entry.model)
 }
 
 ///|
@@ -3401,12 +3389,9 @@ fn Model::conversation_is_new_chat(self : Model, conv : Conversation) -> Bool {
     return false
   }
   guard self.device_state(conv.device) is Some(dev) else { return true }
-  for item in dev.sessions {
-    if item.id == conv.session_id && item.workspace == conv.project() {
-      return false
-    }
-  }
-  true
+  !dev.sessions
+  .iter()
+  .any(item => item.id == conv.session_id && item.workspace == conv.project())
 }
 
 ///|
@@ -3432,12 +3417,13 @@ fn Model::conversation_by_run(
   channel : @interop.ChannelId,
   run_id : String,
 ) -> Conversation? {
-  for conv in self.conversations.filter(conv => conv.device == channel) {
-    if conv.run is Open(run_id=active, ..) && active == run_id {
-      return Some(conv)
-    }
-  }
-  None
+  self.conversations
+  .iter()
+  .find_first(conv => {
+    conv.device == channel &&
+    conv.run is Open(run_id=active, ..) &&
+    active == run_id
+  })
 }
 
 ///|
@@ -3449,12 +3435,11 @@ fn Model::conversation_by_last_run(
   channel : @interop.ChannelId,
   run_id : String,
 ) -> Conversation? {
-  for conv in self.conversations.filter(conv => conv.device == channel) {
-    if conv.last_run_id is Some(last) && last == run_id {
-      return Some(conv)
-    }
-  }
-  None
+  self.conversations
+  .iter()
+  .find_first(conv => {
+    conv.device == channel && conv.last_run_id is Some(last) && last == run_id
+  })
 }
 
 ///|
@@ -4082,45 +4067,27 @@ fn Model::begin_transcript_reload(
   self : Model,
   conv : Conversation,
 ) -> (Model, Int?) {
-  match conv.sync {
-    Reloading(..) => (self.replace_conversation(conv), None)
-    Synced => {
-      let generation = self.transcript_request_generation + 1
-      (
-        {
-          ..self.replace_conversation({
-            ..conv,
-            sync: Reloading(
-              generation~,
-              attempt=1,
-              buffered=[],
-              reload_after_current=false,
-            ),
-          }),
-          transcript_request_generation: generation,
-        },
-        Some(generation),
-      )
-    }
-    ReloadFailed(buffered~, ..) => {
-      let generation = self.transcript_request_generation + 1
-      (
-        {
-          ..self.replace_conversation({
-            ..conv,
-            sync: Reloading(
-              generation~,
-              attempt=1,
-              buffered=buffered.copy(),
-              reload_after_current=false,
-            ),
-          }),
-          transcript_request_generation: generation,
-        },
-        Some(generation),
-      )
-    }
+  let buffered : Array[BufferedCommit] = match conv.sync {
+    Reloading(..) => return (self.replace_conversation(conv), None)
+    Synced => []
+    ReloadFailed(buffered~, ..) => buffered.copy()
   }
+  let generation = self.transcript_request_generation + 1
+  (
+    {
+      ..self.replace_conversation({
+        ..conv,
+        sync: Reloading(
+          generation~,
+          attempt=1,
+          buffered~,
+          reload_after_current=false,
+        ),
+      }),
+      transcript_request_generation: generation,
+    },
+    Some(generation),
+  )
 }
 
 ///|

--- a/desktop/frontend/transcript/component/tool_tabs.mbt
+++ b/desktop/frontend/transcript/component/tool_tabs.mbt
@@ -81,28 +81,26 @@ fn tool_arguments_tabbed_view(
   name : String,
   arguments : String?,
 ) -> @html.Html? {
+  guard arguments is Some(arguments) else { return None }
+  let trimmed = arguments.trim()
+  guard !trimmed.is_empty() && trimmed != "{}" else { return None }
   let tabs : Array[ToolCallTab] = []
-  if arguments is Some(arguments) {
-    let trimmed = arguments.trim()
-    if !trimmed.is_empty() && trimmed != "{}" {
-      match custom_card(name, arguments) {
-        Some((label, card)) => {
-          tabs.push({ label, body: card, })
-          tabs.push({
-            label: "Original JSON",
-            body: original_json_content(arguments),
-          })
-        }
-        None => {
-          let content = json_arguments_content(arguments)
-          tabs.push({ label: "Arguments", body: content.body, })
-          if content.has_distinct_original {
-            tabs.push({
-              label: "Original JSON",
-              body: original_json_content(arguments),
-            })
-          }
-        }
+  match custom_card(name, arguments) {
+    Some((label, card)) => {
+      tabs.push({ label, body: card, })
+      tabs.push({
+        label: "Original JSON",
+        body: original_json_content(arguments),
+      })
+    }
+    None => {
+      let content = json_arguments_content(arguments)
+      tabs.push({ label: "Arguments", body: content.body, })
+      if content.has_distinct_original {
+        tabs.push({
+          label: "Original JSON",
+          body: original_json_content(arguments),
+        })
       }
     }
   }
@@ -124,34 +122,24 @@ fn tool_output_tabs(
   if output.is_blank() {
     return []
   }
-  match (name, arguments) {
-    ("read", Some(arguments)) =>
-      match @read_html.moonbit_output(arguments, output) {
-        Some(rendered) =>
-          [
-            {
-              label: "Output",
-              body: @html.pre(class="tool-call-output", [rendered]),
-            },
-            {
-              label: "Original output",
-              body: @html.pre(class="tool-card-original-json", output),
-            },
-          ]
-        None =>
-          [
-            {
-              label: "Output",
-              body: @html.pre(class="tool-call-output", truncate_output(output)),
-            },
-          ]
-      }
-    _ =>
-      [
-        {
-          label: "Output",
-          body: @html.pre(class="tool-call-output", truncate_output(output)),
-        },
-      ]
+  if name == "read" &&
+    arguments is Some(arguments) &&
+    @read_html.moonbit_output(arguments, output) is Some(rendered) {
+    return [
+      {
+        label: "Output",
+        body: @html.pre(class="tool-call-output", [rendered]),
+      },
+      {
+        label: "Original output",
+        body: @html.pre(class="tool-card-original-json", output),
+      },
+    ]
   }
+  [
+    {
+      label: "Output",
+      body: @html.pre(class="tool-call-output", truncate_output(output)),
+    },
+  ]
 }

--- a/desktop/frontend/transcript/sessions.mbt
+++ b/desktop/frontend/transcript/sessions.mbt
@@ -527,18 +527,12 @@ fn SessionTerminalProjection::append_to(
   ts? : Double,
   sequence? : Int,
 ) -> Bool {
-  let (kind, message) = match self.0 {
-    @desktop_protocol.Finished(message) => ("finished", message)
-    @desktop_protocol.Aborted(message) => ("aborted", message)
-    @desktop_protocol.Interrupted(message) => ("interrupted", message)
-    @desktop_protocol.Failed(message) => ("failed", message)
-  }
-  let message = message.trim().to_owned()
-  match kind {
+  let failure = match self.0 {
     // A current no-tool final is already the last provider response. Mark
     // that response finished instead of duplicating its prose; it keeps its
     // own stamp and sequence, so the settled bubble stays the same keyed node.
-    "finished" =>
+    @desktop_protocol.Finished(message) => {
+      let message = message.trim().to_owned()
       if !message.is_empty() &&
         items is [.., last] &&
         last.kind
@@ -560,53 +554,33 @@ fn SessionTerminalProjection::append_to(
             finished=true,
           ),
         }
-        true
-      } else {
-        if !message.is_empty() {
-          // A differing terminal message, such as a completion-tool answer,
-          // remains a new final bubble.
-          items.push({ kind: Answer(message), ts, sequence, })
-        }
-        false
+        return true
       }
-    "aborted" => {
-      items.push({
-        kind: Failure(
-          if message.is_empty() {
-            "aborted"
-          } else {
-            "aborted: \{message}"
-          },
-        ),
-        ts,
-        sequence,
-      })
-      false
+      if !message.is_empty() {
+        // A differing terminal message, such as a completion-tool answer,
+        // remains a new final bubble.
+        items.push({ kind: Answer(message), ts, sequence, })
+      }
+      return false
     }
-    "interrupted" => {
-      items.push({
-        kind: Failure(
-          if message.is_empty() {
-            "cancelled"
-          } else {
-            "cancelled: \{message}"
-          },
-        ),
-        ts,
-        sequence,
-      })
-      false
-    }
-    "failed" => {
-      items.push({
-        kind: Failure(if message.is_empty() { "failed" } else { message }),
-        ts,
-        sequence,
-      })
-      false
-    }
-    _ => false
+    @desktop_protocol.Aborted(message) =>
+      match message.trim().to_owned() {
+        "" => "aborted"
+        message => "aborted: \{message}"
+      }
+    @desktop_protocol.Interrupted(message) =>
+      match message.trim().to_owned() {
+        "" => "cancelled"
+        message => "cancelled: \{message}"
+      }
+    @desktop_protocol.Failed(message) =>
+      match message.trim().to_owned() {
+        "" => "failed"
+        message => message
+      }
   }
+  items.push({ kind: Failure(failure), ts, sequence, })
+  false
 }
 
 ///|

--- a/desktop/internal/host/update_check.mbt
+++ b/desktop/internal/host/update_check.mbt
@@ -35,16 +35,8 @@ fn SelfUpdate::SelfUpdate(
 ) -> SelfUpdate {
   {
     app_version,
-    work_dir: if runtime_dir is Some(dir) {
-      Some(dir.to_string())
-    } else {
-      None
-    },
-    bundle_path: if executable is Some(exe) {
-      app_bundle_path(exe)
-    } else {
-      None
-    },
+    work_dir: runtime_dir.map(dir => dir.to_string()),
+    bundle_path: executable.bind(app_bundle_path),
     downloads: Queue(kind=Blocking(1)),
     staged: None,
     busy: false,
@@ -96,17 +88,14 @@ async fn SelfUpdate::check(self : SelfUpdate) -> CheckUpdateReply {
     error => raise error
   }
   guard info is Some(info) else { return UpToDate }
-  let unavailable_reason = if info.artifact is Some(_) &&
+  let (installable, unavailable_reason) = if info.artifact is Some(_) &&
     self.work_dir is Some(_) &&
     self.bundle_path is Some(bundle) {
-    @update.self_update_unavailable_reason(bundle_path=bundle)
+    let reason = @update.self_update_unavailable_reason(bundle_path=bundle)
+    (reason is None, reason)
   } else {
-    None
+    (false, None)
   }
-  let installable = info.artifact is Some(_) &&
-    self.work_dir is Some(_) &&
-    self.bundle_path is Some(_) &&
-    unavailable_reason is None
   Available(version=info.version, installable~, unavailable_reason~)
 }
 

--- a/desktop/internal/moonbit/toolchain_paths.mbt
+++ b/desktop/internal/moonbit/toolchain_paths.mbt
@@ -152,26 +152,20 @@ fn moonbit_wasm_gc_bundle_probe_path(moon_home : @pathx.Path) -> @pathx.Path {
 async fn write_fake_seed(root : @pathx.Absolute) -> Unit {
   @fs.mkdir(root.join("bin").to_string(), recursive=true)
   @fs.mkdir(root.join("lib/core").to_string(), recursive=true)
-  @fs.write_file(
-    root.join("bin/moon").to_string(),
-    "",
-    create_mode=CreateOrTruncate,
-  )
-  @fs.write_file(
-    root.join("bin/moonc").to_string(),
-    "",
-    create_mode=CreateOrTruncate,
-  )
-  @fs.write_file(
-    root.join("lib/core/moon.mod").to_string(),
-    "{}",
-    create_mode=CreateOrTruncate,
-  )
-  @fs.write_file(
-    root.join(MoonbitSeedVersionFile).to_string(),
-    "test-version",
-    create_mode=CreateOrTruncate,
-  )
+  let files = [
+    ("bin/moon", ""),
+    ("bin/moonc", ""),
+    ("lib/core/moon.mod", "{}"),
+    (MoonbitSeedVersionFile, "test-version"),
+  ]
+  for file in files {
+    let (path, content) = file
+    @fs.write_file(
+      root.join(path).to_string(),
+      content,
+      create_mode=CreateOrTruncate,
+    )
+  }
 }
 
 ///|


### PR DESCRIPTION
**Every hunk stays inside one function.** Nothing shared is added, removed or
re-signatured, so each hunk can be judged by reading it — there is no other code
to go check.

The shapes used, all of them:

| before | after |
| --- | --- |
| an `if`/`else` ladder | one `match` with guards or nested patterns |
| a nested `match` on options | a `guard ... is Some(..)` chain |
| a manual index loop | a comprehension, `fold`, `any`, `find_first`, `search_by` |
| two identical `match` arms | one or-pattern arm |
| `match o { Some(v) => ...; None => ... }` | an Option combinator |
| duplicated branches in one function | a local binding or a closure used only there |

The helper extractions these were mixed with are in the paired pull request, so
nothing here crosses a call site.

Scope: the frontend composer, model, transcript components, and the host's update check and toolchain paths.

### Verified on this branch alone

`moon fmt --check`, `moon check --target native --deny-warn`, `moon check
--target js --deny-warn`, and both full test suites, with no other part of the
refactor applied. No `.mbti` changed.

---

The refactor is split so each pull request asks one kind of question. Every file
appears in exactly one of them, each was verified on its own branch with no
other part applied, so they merge in any order.

| | easy to review | needs a careful read |
| --- | --- | --- |
| root | `simplify/local-root` | `simplify/structural-root` (#1325) |
| `desktop/` | `simplify/local-desktop` | `simplify/structural-desktop` (#1326) |
| `editor/` | `simplify/local-editor` | `simplify/structural-editor` (#1327) |
| tests | `simplify/tests-local` | `simplify/tests` (#1328) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JiBNGzCsZpN6e5Y4p9pXdn
