### PR TITLE
refactor(editor): in-function rewrites

### DIFF
--- a/editor/internal/shell/examples/embedded_viewer/main.mbt
+++ b/editor/internal/shell/examples/embedded_viewer/main.mbt
@@ -825,26 +825,17 @@ fn update_embed(
           { ..model, diff_visible: visible, },
         )
       }
-    ToggleDiffLayout =>
+    ToggleDiffLayout | ToggleDiffSash => {
       if model.status != "ready" || !model.diff_visible {
-        (@rabbita.none, model)
-      } else {
-        let inline_layout = !model.inline_layout
-        (
-          set_embed_diff_options(inline_layout, model.sash_enabled),
-          { ..model, inline_layout, },
-        )
+        return (@rabbita.none, model)
       }
-    ToggleDiffSash =>
-      if model.status != "ready" || !model.diff_visible {
-        (@rabbita.none, model)
+      let next = if msg is ToggleDiffLayout {
+        { ..model, inline_layout: !model.inline_layout, }
       } else {
-        let sash_enabled = !model.sash_enabled
-        (
-          set_embed_diff_options(model.inline_layout, sash_enabled),
-          { ..model, sash_enabled, },
-        )
+        { ..model, sash_enabled: !model.sash_enabled, }
       }
+      (set_embed_diff_options(next.inline_layout, next.sash_enabled), next)
+    }
   }
 }
 

--- a/editor/internal/viewer/browser/controller/mouse_target.mbt
+++ b/editor/internal/viewer/browser/controller/mouse_target.mbt
@@ -878,41 +878,17 @@ fn create_mouse_target_for_request(
     // overflowing content widgets
     return request.fulfill_unknown()
   }
-  match hit_test_content_widget(ctx, request) {
-    Some(result) => return result
-    None => ()
-  }
-  match hit_test_overlay_widget(ctx, request) {
-    Some(result) => return result
-    None => ()
-  }
-  match hit_test_minimap(ctx, request) {
-    Some(result) => return result
-    None => ()
-  }
-  match hit_test_scrollbar_slider(ctx, request) {
-    Some(result) => return result
-    None => ()
-  }
-  match hit_test_view_zone(ctx, request) {
-    Some(result) => return result
-    None => ()
-  }
-  match hit_test_margin(ctx, request) {
-    Some(result) => return result
-    None => ()
-  }
-  match hit_test_view_cursor(ctx, request) {
-    Some(result) => return result
-    None => ()
-  }
-  match hit_test_view_lines(ctx, request) {
-    Some(result) => return result
-    None => ()
-  }
-  match hit_test_scrollbar(ctx, request) {
-    Some(result) => return result
-    None => ()
+  let hit_tests : Array[
+    (HitTestContext, HitTestRequest) -> @editor_browser.MouseTarget?,
+  ] = [
+    hit_test_content_widget, hit_test_overlay_widget, hit_test_minimap, hit_test_scrollbar_slider,
+    hit_test_view_zone, hit_test_margin, hit_test_view_cursor, hit_test_view_lines,
+    hit_test_scrollbar,
+  ]
+  for hit_test in hit_tests {
+    if hit_test(ctx, request) is Some(result) {
+      return result
+    }
   }
   request.fulfill_unknown()
 }
@@ -1175,26 +1151,18 @@ fn hit_test_scrollbar_slider(
   ctx : HitTestContext,
   request : HitTestRequest,
 ) -> @editor_browser.MouseTarget? {
-  if ElementPath::is_child_of_scrollable_element(request.target_path()) {
-    match request.target() {
-      Some(target) => {
-        let class_name = controller_element_class_name(target)
-        if class_name_has_word(class_name, "slider") ||
-          class_name_has_word(class_name, "scrollbar") {
-          let possible_line_number = ctx.get_line_number_at_vertical_offset(
-            request.mouse_vertical_offset,
-          )
-          let max_column = ctx.view_model.get_line_max_column(
-            possible_line_number,
-          )
-          return Some(
-            request.fulfill_scrollbar(
-              Position(possible_line_number, max_column),
-            ),
-          )
-        }
-      }
-      None => ()
+  if ElementPath::is_child_of_scrollable_element(request.target_path()) &&
+    request.target() is Some(target) {
+    let class_name = controller_element_class_name(target)
+    if class_name_has_word(class_name, "slider") ||
+      class_name_has_word(class_name, "scrollbar") {
+      let possible_line_number = ctx.get_line_number_at_vertical_offset(
+        request.mouse_vertical_offset,
+      )
+      let max_column = ctx.view_model.get_line_max_column(possible_line_number)
+      return Some(
+        request.fulfill_scrollbar(Position(possible_line_number, max_column)),
+      )
     }
   }
   None
@@ -1290,30 +1258,18 @@ fn create_mouse_target_from_hit_test_position(
   // Let's define a, b, c and check if the offset is in between them...
   let points : Array[(Double, Int)] = [] // (offset, column)
   points.push((visible_range.left.to_double(), column))
-  if column > 1 {
-    match ctx.visible_range_for_position(line_number, column - 1) {
-      Some(visible_range) =>
-        points.push((visible_range.left.to_double(), column - 1))
-      None => ()
-    }
+  if column > 1 &&
+    ctx.visible_range_for_position(line_number, column - 1)
+    is Some(visible_range) {
+    points.push((visible_range.left.to_double(), column - 1))
   }
   let line_max_column = ctx.view_model.get_line_max_column(line_number)
-  if column < line_max_column {
-    match ctx.visible_range_for_position(line_number, column + 1) {
-      Some(visible_range) =>
-        points.push((visible_range.left.to_double(), column + 1))
-      None => ()
-    }
+  if column < line_max_column &&
+    ctx.visible_range_for_position(line_number, column + 1)
+    is Some(visible_range) {
+    points.push((visible_range.left.to_double(), column + 1))
   }
-  points.sort_by((a, b) => {
-    if a.0 < b.0 {
-      -1
-    } else if a.0 > b.0 {
-      1
-    } else {
-      0
-    }
-  })
+  points.sort_by_key(p => p.0)
   let mouse_coordinates = request.pos.to_client_coordinates()
   let span_node_client_rect = span_node.get_bounding_client_rect()
   let mouse_is_over_span_node = span_node_client_rect.get_left() <=
@@ -1420,18 +1376,11 @@ fn actual_do_hit_test_with_caret_range_from_point(
   if node_is_text(start_container) {
     // startContainer is expected to be the token text
     let parent1 = node_parent_element(start_container) // the token span
-    let parent2 = match parent1 {
-      Some(el) => controller_parent_element(el) // the view line container span
-      None => None
-    }
-    let parent3 = match parent2 {
-      Some(el) => controller_parent_element(el) // the view line div
-      None => None
-    }
-    let parent3_class_name = match parent3 {
-      Some(el) => controller_element_class_name(el)
-      None => ""
-    }
+    // the view line container span
+    let parent2 = parent1.bind(controller_parent_element)
+    // the view line div
+    let parent3 = parent2.bind(controller_parent_element)
+    let parent3_class_name = parent3.map_or("", controller_element_class_name)
     if parent3_class_name == @view.VIEW_LINE_CLASS_NAME {
       return hit_test_result_from_dom_info(
         ctx,
@@ -1447,14 +1396,9 @@ fn actual_do_hit_test_with_caret_range_from_point(
     // startContainer is expected to be the token span
     let start_element = start_container.to_element().unwrap()
     let parent1 = controller_parent_element(start_element) // the view line container span
-    let parent2 = match parent1 {
-      Some(el) => controller_parent_element(el) // the view line div
-      None => None
-    }
-    let parent2_class_name = match parent2 {
-      Some(el) => controller_element_class_name(el)
-      None => ""
-    }
+    // the view line div
+    let parent2 = parent1.bind(controller_parent_element)
+    let parent2_class_name = parent2.map_or("", controller_element_class_name)
     if parent2_class_name == @view.VIEW_LINE_CLASS_NAME {
       return hit_test_result_from_dom_info(
         ctx,
@@ -1487,18 +1431,11 @@ fn do_hit_test_with_caret_position_from_point(
   if node_is_text(offset_node) {
     // offsetNode is expected to be the token text
     let parent1 = node_parent_element(offset_node) // the token span
-    let parent2 = match parent1 {
-      Some(el) => controller_parent_element(el) // the view line container span
-      None => None
-    }
-    let parent3 = match parent2 {
-      Some(el) => controller_parent_element(el) // the view line div
-      None => None
-    }
-    let parent3_class_name = match parent3 {
-      Some(el) => controller_element_class_name(el)
-      None => ""
-    }
+    // the view line container span
+    let parent2 = parent1.bind(controller_parent_element)
+    // the view line div
+    let parent3 = parent2.bind(controller_parent_element)
+    let parent3_class_name = parent3.map_or("", controller_element_class_name)
     if parent3_class_name == @view.VIEW_LINE_CLASS_NAME {
       return hit_test_result_from_dom_info(
         ctx,
@@ -1515,29 +1452,17 @@ fn do_hit_test_with_caret_position_from_point(
   if node_is_element(offset_node) {
     let offset_element = offset_node.to_element().unwrap()
     let parent1 = controller_parent_element(offset_element)
-    let parent1_class_name = match parent1 {
-      Some(el) => controller_element_class_name(el)
-      None => ""
-    }
-    let parent2 = match parent1 {
-      Some(el) => controller_parent_element(el)
-      None => None
-    }
-    let parent2_class_name = match parent2 {
-      Some(el) => controller_element_class_name(el)
-      None => ""
-    }
+    let parent1_class_name = parent1.map_or("", controller_element_class_name)
+    let parent2 = parent1.bind(controller_parent_element)
+    let parent2_class_name = parent2.map_or("", controller_element_class_name)
     if parent1_class_name == @view.VIEW_LINE_CLASS_NAME {
       // it returned the `<span>` of the line and the offset is the `<span>`
       // with the inline decoration
       let child_count = offset_node.get_child_count()
       let child_index = native_caret_hit_offset(hit).min(child_count - 1)
-      if child_index >= 0 {
-        match offset_node.get_child(child_index).to_element() {
-          Some(token_span) =>
-            return hit_test_result_from_dom_info(ctx, token_span, 0)
-          None => ()
-        }
+      if child_index >= 0 &&
+        offset_node.get_child(child_index).to_element() is Some(token_span) {
+        return hit_test_result_from_dom_info(ctx, token_span, 0)
       }
     } else if parent2_class_name == @view.VIEW_LINE_CLASS_NAME {
       // it returned the `<span>` with the inline decoration

--- a/editor/internal/viewer/browser/controller/scrollbar_input.mbt
+++ b/editor/internal/viewer/browser/controller/scrollbar_input.mbt
@@ -41,60 +41,34 @@ pub fn MouseHandler::hook_scrollable_scrollbar_input(
   self.add_dom_listener(scrollable.wrapper(), "mouseleave", _ => {
     scrollable.mouse_left()
   })
-  let vertical_slider = scrollable.slider(true)
-  self.add_dom_listener(vertical_slider, "pointerdown", event => {
-    match event.to_mouse_event() {
-      Some(mouse) if mouse.get_button() == 0 => {
+  let hook_slider = (vertical : Bool) => {
+    let slider = scrollable.slider(vertical)
+    self.add_dom_listener(slider, "pointerdown", event => {
+      if event.to_mouse_event() is Some(mouse) && mouse.get_button() == 0 {
         event.prevent_default()
         event.stop_propagation()
-        self.start_scrollable_drag(scrollable, owner, vertical=true, mouse)
+        self.start_scrollable_drag(scrollable, owner, vertical~, mouse)
       }
-      _ => ()
-    }
-  })
-  self.add_dom_listener(vertical_slider, "click", event => {
-    match event.to_mouse_event() {
-      Some(mouse) if mouse.get_button() == 0 => event.stop_propagation()
-      _ => ()
-    }
-  })
-  let horizontal_slider = scrollable.slider(false)
-  self.add_dom_listener(horizontal_slider, "pointerdown", event => {
-    match event.to_mouse_event() {
-      Some(mouse) if mouse.get_button() == 0 => {
+    })
+    self.add_dom_listener(slider, "click", event => {
+      if event.to_mouse_event() is Some(mouse) && mouse.get_button() == 0 {
+        event.stop_propagation()
+      }
+    })
+  }
+  hook_slider(true)
+  hook_slider(false)
+  let hook_track = (vertical : Bool) => {
+    self.add_dom_listener(scrollable.track(vertical), "pointerdown", event => {
+      if event.to_mouse_event() is Some(mouse) {
         event.prevent_default()
         event.stop_propagation()
-        self.start_scrollable_drag(scrollable, owner, vertical=false, mouse)
+        self.scrollable_track_jump(scrollable, owner, vertical~, mouse)
       }
-      _ => ()
-    }
-  })
-  self.add_dom_listener(horizontal_slider, "click", event => {
-    match event.to_mouse_event() {
-      Some(mouse) if mouse.get_button() == 0 => event.stop_propagation()
-      _ => ()
-    }
-  })
-  self.add_dom_listener(scrollable.track(true), "pointerdown", event => {
-    match event.to_mouse_event() {
-      Some(mouse) => {
-        event.prevent_default()
-        event.stop_propagation()
-        self.scrollable_track_jump(scrollable, owner, vertical=true, mouse)
-      }
-      None => ()
-    }
-  })
-  self.add_dom_listener(scrollable.track(false), "pointerdown", event => {
-    match event.to_mouse_event() {
-      Some(mouse) => {
-        event.prevent_default()
-        event.stop_propagation()
-        self.scrollable_track_jump(scrollable, owner, vertical=false, mouse)
-      }
-      None => ()
-    }
-  })
+    })
+  }
+  hook_track(true)
+  hook_track(false)
 }
 
 ///|
@@ -242,16 +216,10 @@ fn MouseHandler::start_scrollable_drag(
 /// disposal.
 fn MouseHandler::end_scrollable_drag(self : MouseHandler) -> Unit {
   self.scrollbar_drag_monitor.stop_monitoring(false)
-  match self.drag {
-    Some(drag) =>
-      match self.scrollable_for_drag(drag.owner) {
-        Some(scrollable) => {
-          scrollable.set_slider_active(vertical=drag.vertical, false)
-          scrollable.drag_ended()
-        }
-        None => ()
-      }
-    None => ()
+  if self.drag is Some(drag) &&
+    self.scrollable_for_drag(drag.owner) is Some(scrollable) {
+    scrollable.set_slider_active(vertical=drag.vertical, false)
+    scrollable.drag_ended()
   }
   self.drag = None
 }
@@ -338,19 +306,17 @@ fn MouseHandler::apply_scrollable_position(
 ) -> Unit {
   match owner {
     EditorScrollableElement =>
-      match (self.view_helper.view_layout)() {
-        Some(view_layout) =>
-          if vertical {
-            view_layout.scroll_to(scroll_top=desired) |> ignore
-          } else {
-            let position = view_layout.position()
-            view_layout.scroll_to(
-              scroll_top=position.scroll_top,
-              scroll_left=desired,
-            )
-            |> ignore
-          }
-        None => ()
+      if (self.view_helper.view_layout)() is Some(view_layout) {
+        if vertical {
+          view_layout.scroll_to(scroll_top=desired) |> ignore
+        } else {
+          let position = view_layout.position()
+          view_layout.scroll_to(
+            scroll_top=position.scroll_top,
+            scroll_left=desired,
+          )
+          |> ignore
+        }
       }
     HoverScrollableElement => scrollable.native_scroll_to(vertical~, desired)
   }
@@ -428,10 +394,8 @@ fn MouseHandler::handle_browser_desperate_reveal(
     }
   }
   if delta_top != 0.0 || delta_left != 0.0 {
-    match (self.view_helper.view_layout)() {
-      Some(view_layout) =>
-        view_layout.scroll_by(delta_left~, delta_top~) |> ignore
-      None => ()
+    if (self.view_helper.view_layout)() is Some(view_layout) {
+      view_layout.scroll_by(delta_left~, delta_top~) |> ignore
     }
   }
 }

--- a/editor/internal/viewer/browser/view/view_zones.mbt
+++ b/editor/internal/viewer/browser/view/view_zones.mbt
@@ -381,11 +381,9 @@ fn ViewZones::recompute_whitespace_props(self : ViewZones) -> Bool {
 
 ///|
 fn ViewZones::zone_keys_snapshot(self : ViewZones) -> Array[String] {
-  let keys : Array[String] = []
-  for id, _ in self.zones {
-    keys.push(id)
-  }
-  keys
+  [
+    for id, _ in self.zones => id
+  ]
 }
 
 ///|
@@ -401,17 +399,15 @@ fn ViewZones::layout_infos(self : ViewZones) -> Array[(String, Int, Double)] {
   for whitespace in context.view_model.get_whitespaces() {
     layout_heights.set(whitespace.id, whitespace.height.to_double())
   }
-  let result : Array[(String, Int, Double)] = []
-  for _, zone in self.zones {
-    result.push(
+  [
+    for _, zone in self.zones => {
       (
         zone.whitespace_id,
         zone.delegate.after_line_number,
         layout_heights.get(zone.whitespace_id).unwrap_or(0.0),
-      ),
-    )
-  }
-  result
+      )
+    }
+  ]
 }
 
 ///|
@@ -419,10 +415,7 @@ fn ViewZones::zone_ordinal(
   _self : ViewZones,
   zone : @editor_browser.ViewZone,
 ) -> Int {
-  match zone.ordinal {
-    Some(ordinal) => ordinal
-    None => zone.after_column.unwrap_or(10000)
-  }
+  zone.ordinal.unwrap_or(zone.after_column.unwrap_or(10000))
 }
 
 ///|
@@ -430,15 +423,7 @@ fn ViewZones::compute_whitespace_props(
   self : ViewZones,
   zone : @editor_browser.ViewZone,
 ) -> ComputedViewZoneProps {
-  if zone.after_line_number == 0 {
-    return {
-      is_in_hidden_area: false,
-      after_view_line_number: 0,
-      height_in_px: self.height_in_pixels(zone),
-      min_width_in_px: self.min_width_in_pixels(zone),
-    }
-  }
-  guard self.context is Some(context) else {
+  guard zone.after_line_number != 0 && self.context is Some(context) else {
     return {
       is_in_hidden_area: false,
       after_view_line_number: 0,
@@ -533,10 +518,7 @@ fn ViewZones::add_zone(
     is_in_hidden_area: props.is_in_hidden_area,
     is_visible: false,
     dom_node: FastViewZoneDomNode(zone.dom_node),
-    margin_dom_node: match zone.margin_dom_node {
-      Some(node) => Some(FastViewZoneDomNode(node))
-      None => None
-    },
+    margin_dom_node: zone.margin_dom_node.map(node => FastViewZoneDomNode(node)),
     caller_aria_hidden_present,
     caller_aria_hidden_value,
   }
@@ -553,15 +535,12 @@ fn ViewZones::add_zone(
   registered.dom_node.element.set_attribute("monaco-view-zone", whitespace_id)
   registered.dom_node.element.set_attribute("aria-hidden", "true")
   self.dom_node.append_child(registered.dom_node.element.as_node())
-  match registered.margin_dom_node {
-    Some(margin_dom_node) => {
-      margin_dom_node.set_position("absolute")
-      @base_browser.set_style_property(margin_dom_node.element, "width", "100%")
-      margin_dom_node.set_display("none")
-      margin_dom_node.element.set_attribute("monaco-view-zone", whitespace_id)
-      self.margin_dom_node.append_child(margin_dom_node.element.as_node())
-    }
-    None => ()
+  if registered.margin_dom_node is Some(margin_dom_node) {
+    margin_dom_node.set_position("absolute")
+    @base_browser.set_style_property(margin_dom_node.element, "width", "100%")
+    margin_dom_node.set_display("none")
+    margin_dom_node.element.set_attribute("monaco-view-zone", whitespace_id)
+    self.margin_dom_node.append_child(margin_dom_node.element.as_node())
   }
   self.zones.set(whitespace_id, registered)
   self.should_render = true
@@ -582,13 +561,10 @@ fn ViewZones::remove_zone(
   zone.dom_node.element.remove_attribute("monaco-view-zone")
   restore_view_zone_aria_hidden(zone)
   @base_browser.remove_element(zone.dom_node.element)
-  match zone.margin_dom_node {
-    Some(margin_dom_node) => {
-      margin_dom_node.element.remove_attribute("monaco-visible-view-zone")
-      margin_dom_node.element.remove_attribute("monaco-view-zone")
-      @base_browser.remove_element(margin_dom_node.element)
-    }
-    None => ()
+  if zone.margin_dom_node is Some(margin_dom_node) {
+    margin_dom_node.element.remove_attribute("monaco-visible-view-zone")
+    margin_dom_node.element.remove_attribute("monaco-view-zone")
+    @base_browser.remove_element(margin_dom_node.element)
   }
   self.should_render = true
   true
@@ -633,10 +609,10 @@ fn ViewZones::should_suppress_mouse_down_on_view_zone(
   self : ViewZones,
   id : String,
 ) -> Bool {
-  match self.zones.get(id) {
-    Some(zone) => zone.delegate.suppress_mouse_down.unwrap_or(false)
-    None => false
-  }
+  self.zones
+  .get(id)
+  .bind(zone => zone.delegate.suppress_mouse_down)
+  .unwrap_or(false)
 }
 
 ///|
@@ -797,13 +773,10 @@ fn ViewZones::render(
     zone.dom_node.set_top(css_pixels_double(new_top))
     zone.dom_node.set_height(css_pixels(new_height))
     zone.dom_node.set_display(new_display)
-    match zone.margin_dom_node {
-      Some(margin_dom_node) => {
-        margin_dom_node.set_top(css_pixels_double(new_top))
-        margin_dom_node.set_height(css_pixels(new_height))
-        margin_dom_node.set_display(new_display)
-      }
-      None => ()
+    if zone.margin_dom_node is Some(margin_dom_node) {
+      margin_dom_node.set_top(css_pixels_double(new_top))
+      margin_dom_node.set_height(css_pixels(new_height))
+      margin_dom_node.set_display(new_display)
     }
   }
 

--- a/editor/internal/viewer/contrib/contextmenu/browser/context_menu_widget.mbt
+++ b/editor/internal/viewer/contrib/contextmenu/browser/context_menu_widget.mbt
@@ -126,9 +126,8 @@ pub fn ContextMenuWidget::show(
   self.focused_entry_index = -1
   self.theme = theme
   self.container.set_attribute("data-theme", theme)
-  match theme_source {
-    Some(source) => copy_context_menu_theme(self.container, source)
-    None => ()
+  if theme_source is Some(source) {
+    copy_context_menu_theme(self.container, source)
   }
   self.rebuild_root_menu()
   self.install_show_listeners()
@@ -180,11 +179,8 @@ pub fn ContextMenuWidget::hide(
   self.entries = []
   self.item_nodes = []
   self.focused_entry_index = -1
-  if restore_focus {
-    match self.focus_to_return {
-      Some(element) => @base_browser.focus_prevent_scroll(element)
-      None => ()
-    }
+  if restore_focus && self.focus_to_return is Some(element) {
+    @base_browser.focus_prevent_scroll(element)
   }
   self.focus_to_return = None
   (self.callbacks.on_hide)(was_cancelled)
@@ -287,57 +283,36 @@ fn ContextMenuWidget::install_show_listeners(self : ContextMenuWidget) -> Unit {
     event.prevent_default()
     event.stop_propagation()
   })
+  let listen_document = (event_type : String, listener : @rdom.Listener) => {
+    @rdom.document().add_event_listener(event_type, listener)
+    self.show_listeners.push(
+      @base_common.Disposable::from(() => {
+        @rdom.document().remove_event_listener(event_type, listener)
+      }),
+    )
+  }
+  let hide_when_outside : @rdom.Listener = event => {
+    guard self.visible else { return }
+    if !context_menu_event_inside(event, self.container) &&
+      !self.event_inside_submenu(event) {
+      self.hide(was_cancelled=true)
+    }
+  }
   // An eligible editor target stops propagation and replaces this menu in its
   // own handler. A native-fallback target does not, so the document event
   // closes the stale custom menu before the browser presents its own surface.
-  let context_menu_listener : @rdom.Listener = event => {
-    guard self.visible else { return }
-    if !context_menu_event_inside(event, self.container) &&
-      !self.event_inside_submenu(event) {
-      self.hide(was_cancelled=true)
-    }
-  }
-  @rdom.document().add_event_listener("contextmenu", context_menu_listener)
-  self.show_listeners.push(
-    @base_common.Disposable::from(() => {
-      @rdom.document().remove_event_listener(
-        "contextmenu", context_menu_listener,
-      )
-    }),
-  )
+  listen_document("contextmenu", hide_when_outside)
   self.listen_show(self.container, "keydown", event => {
     self.handle_keydown(event)
   })
-  let document_listener : @rdom.Listener = event => {
+  listen_document("mousedown", event => {
     guard self.visible else { return }
-    match event.to_mouse_event() {
-      Some(mouse) if mouse.get_button() == 2 => return
-      _ => ()
+    if event.to_mouse_event() is Some(mouse) && mouse.get_button() == 2 {
+      return
     }
-    if !context_menu_event_inside(event, self.container) &&
-      !self.event_inside_submenu(event) {
-      self.hide(was_cancelled=true)
-    }
-  }
-  @rdom.document().add_event_listener("mousedown", document_listener)
-  self.show_listeners.push(
-    @base_common.Disposable::from(() => {
-      @rdom.document().remove_event_listener("mousedown", document_listener)
-    }),
-  )
-  let focus_listener : @rdom.Listener = event => {
-    guard self.visible else { return }
-    if !context_menu_event_inside(event, self.container) &&
-      !self.event_inside_submenu(event) {
-      self.hide(was_cancelled=true)
-    }
-  }
-  @rdom.document().add_event_listener("focusin", focus_listener)
-  self.show_listeners.push(
-    @base_common.Disposable::from(() => {
-      @rdom.document().remove_event_listener("focusin", focus_listener)
-    }),
-  )
+    hide_when_outside(event)
+  })
+  listen_document("focusin", hide_when_outside)
   let blur_listener = () => self.hide(was_cancelled=true)
   context_menu_add_window_blur_listener(self.container, blur_listener)
   self.show_listeners.push(
@@ -591,7 +566,7 @@ fn ContextMenuWidget::handle_keydown(
         self.focus_relative_root(-1)
       }
     }
-    "Home" => {
+    "Home" | "PageUp" => {
       event.prevent_default()
       if self.submenu_owns_focus() {
         self.focus_submenu_boundary(first=true)
@@ -605,14 +580,6 @@ fn ContextMenuWidget::handle_keydown(
         self.focus_submenu_boundary(first=false)
       } else {
         self.focus_root_boundary(first=false)
-      }
-    }
-    "PageUp" => {
-      event.prevent_default()
-      if self.submenu_owns_focus() {
-        self.focus_submenu_boundary(first=true)
-      } else {
-        self.focus_root_boundary(first=true)
       }
     }
     "ArrowRight" =>
@@ -689,9 +656,8 @@ fn ContextMenuWidget::close_submenu(
   self.cancel_submenu_timers()
   if submenu.parent_entry_index >= 0 &&
     submenu.parent_entry_index < self.item_nodes.length() {
-    match self.item_nodes[submenu.parent_entry_index] {
-      Some(parent) => parent.action.set_attribute("aria-expanded", "false")
-      None => ()
+    if self.item_nodes[submenu.parent_entry_index] is Some(parent) {
+      parent.action.set_attribute("aria-expanded", "false")
     }
   }
   dispose_context_submenu(submenu)
@@ -731,9 +697,8 @@ fn ContextMenuWidget::event_inside_submenu(
 fn ContextMenuWidget::cancel_submenu_show_timer(
   self : ContextMenuWidget,
 ) -> Unit {
-  match self.submenu_show_timer {
-    Some(timer) => timer.dispose()
-    None => ()
+  if self.submenu_show_timer is Some(timer) {
+    timer.dispose()
   }
   self.submenu_show_timer = None
 }
@@ -742,9 +707,8 @@ fn ContextMenuWidget::cancel_submenu_show_timer(
 fn ContextMenuWidget::cancel_submenu_hide_timer(
   self : ContextMenuWidget,
 ) -> Unit {
-  match self.submenu_hide_timer {
-    Some(timer) => timer.dispose()
-    None => ()
+  if self.submenu_hide_timer is Some(timer) {
+    timer.dispose()
   }
   self.submenu_hide_timer = None
 }
@@ -877,15 +841,12 @@ fn build_context_menu_item(entry : ContextMenuEntry) -> ContextMenuItemNode {
       action.set_attribute("data-context-menu-command", id)
       label.append_child(document.create_text_node(title).as_node())
       action.append_child(label.as_node())
-      match keybinding_label {
-        Some(binding) => {
-          let keybinding = document.create_element("span")
-          keybinding.set_attribute("class", "keybinding")
-          keybinding.set_attribute("aria-hidden", "true")
-          keybinding.append_child(document.create_text_node(binding).as_node())
-          action.append_child(keybinding.as_node())
-        }
-        None => ()
+      if keybinding_label is Some(binding) {
+        let keybinding = document.create_element("span")
+        keybinding.set_attribute("class", "keybinding")
+        keybinding.set_attribute("aria-hidden", "true")
+        keybinding.append_child(document.create_text_node(binding).as_node())
+        action.append_child(keybinding.as_node())
       }
     }
     ContextMenuSubmenu(label=title, ..) => {
@@ -926,27 +887,20 @@ fn update_context_menu_focus(
   pointer_driven : Bool,
 ) -> Unit {
   for index, maybe_node in nodes {
-    match maybe_node {
-      Some(node) => {
-        let focused = index == focused_index
-        node.wrapper.set_attribute(
-          "class",
-          if focused {
-            "action-item focused"
-          } else {
-            "action-item"
-          },
-        )
-        node.action.set_attribute(
-          "data-pointer-focus",
-          if focused && pointer_driven {
-            "true"
-          } else {
-            "false"
-          },
-        )
-      }
-      None => ()
+    if maybe_node is Some(node) {
+      let focused = index == focused_index
+      node.wrapper.set_attribute(
+        "class",
+        if focused {
+          "action-item focused"
+        } else {
+          "action-item"
+        },
+      )
+      node.action.set_attribute(
+        "data-pointer-focus",
+        (focused && pointer_driven).to_string(),
+      )
     }
   }
 }
@@ -981,21 +935,11 @@ fn context_menu_boundary_index(
   nodes : Array[ContextMenuItemNode?],
   first : Bool,
 ) -> Int {
-  if first {
-    for index, node in nodes {
-      if node is Some(_) {
-        return index
-      }
-    }
-  } else {
-    for offset in 0..<nodes.length() {
-      let index = nodes.length() - 1 - offset
-      if nodes[index] is Some(_) {
-        return index
-      }
-    }
+  match [ for index, node in nodes if node is Some(_) => index ] {
+    [] => -1
+    [head, ..] if first => head
+    [.., last] => last
   }
-  -1
 }
 
 ///|

--- a/editor/internal/viewer/contrib/contextmenu/browser/context_menu_widget.mbt
+++ b/editor/internal/viewer/contrib/contextmenu/browser/context_menu_widget.mbt
@@ -935,11 +935,16 @@ fn context_menu_boundary_index(
   nodes : Array[ContextMenuItemNode?],
   first : Bool,
 ) -> Int {
-  match [ for index, node in nodes if node is Some(_) => index ] {
-    [] => -1
-    [head, ..] if first => head
-    [.., last] => last
+  let mut result = -1
+  for index, node in nodes {
+    if node is Some(_) {
+      if first {
+        return index
+      }
+      result = index
+    }
   }
+  result
 }
 
 ///|

--- a/editor/internal/viewer/contrib/contextmenu/browser/context_menu_widget.mbt
+++ b/editor/internal/viewer/contrib/contextmenu/browser/context_menu_widget.mbt
@@ -935,16 +935,20 @@ fn context_menu_boundary_index(
   nodes : Array[ContextMenuItemNode?],
   first : Bool,
 ) -> Int {
-  let mut result = -1
-  for index, node in nodes {
-    if node is Some(_) {
-      if first {
+  if first {
+    for index, node in nodes {
+      if node is Some(_) {
         return index
       }
-      result = index
+    }
+  } else {
+    for index = nodes.length() - 1; index >= 0; index = index - 1 {
+      if nodes[index] is Some(_) {
+        return index
+      }
     }
   }
-  result
+  -1
 }
 
 ///|

--- a/editor/internal/viewer/contrib/folding/browser/folding_model.mbt
+++ b/editor/internal/viewer/contrib/folding/browser/folding_model.mbt
@@ -466,44 +466,35 @@ pub fn FoldingModel::get_regions_inside(
     Some(region) => region.end_line_number()
     None => 0x7FFFFFFF // Number.MAX_VALUE
   }
-  match filter {
-    Some({ with_level: Some(filter), .. }) => {
-      let level_stack : Array[FoldingRegion] = []
-      for i in index..<self.regions.length() {
-        let current = self.regions.to_region(i)
-        if self.regions.get_start_line_number(i) < end_line_number {
-          while level_stack.length() > 0 &&
-                !current.contained_by({
-                  start_line_number: level_stack[level_stack.length() - 1].start_line_number(),
-                  end_line_number: level_stack[level_stack.length() - 1].end_line_number(),
-                }) {
-            level_stack.pop() |> ignore
-          }
-          level_stack.push(current)
-          if filter(current, level_stack.length()) {
-            result.push(current)
-          }
-        } else {
-          break
+  let with_level_filter = match filter {
+    Some({ with_level: Some(filter), .. }) => Some(filter)
+    _ => None
+  }
+  let plain_filter = match filter {
+    Some({ plain: Some(f), .. }) => Some(f)
+    _ => None
+  }
+  let level_stack : Array[FoldingRegion] = []
+  for i in index..<self.regions.length() {
+    guard self.regions.get_start_line_number(i) < end_line_number else { break }
+    let current = self.regions.to_region(i)
+    let keep = match (with_level_filter, plain_filter) {
+      (Some(filter), _) => {
+        while level_stack.length() > 0 &&
+              !current.contained_by({
+                start_line_number: level_stack[level_stack.length() - 1].start_line_number(),
+                end_line_number: level_stack[level_stack.length() - 1].end_line_number(),
+              }) {
+          level_stack.pop() |> ignore
         }
+        level_stack.push(current)
+        filter(current, level_stack.length())
       }
+      (None, Some(f)) => f(current)
+      (None, None) => true
     }
-    _ => {
-      let plain_filter = match filter {
-        Some({ plain: Some(f), .. }) => Some(f)
-        _ => None
-      }
-      for i in index..<self.regions.length() {
-        let current = self.regions.to_region(i)
-        if self.regions.get_start_line_number(i) < end_line_number {
-          match plain_filter {
-            Some(f) => if f(current) { result.push(current) }
-            None => result.push(current)
-          }
-        } else {
-          break
-        }
-      }
+    if keep {
+      result.push(current)
     }
   }
   result
@@ -520,36 +511,28 @@ pub fn set_collapse_state_levels_down(
   line_numbers? : Array[Int],
 ) -> Unit {
   let to_toggle : Array[FoldingRegion] = []
+  let inside_filter = region_filter_with_level((r, level) => {
+    r.is_collapsed() != do_collapse && level < levels
+  })
   match line_numbers {
     Some(line_numbers) if line_numbers.length() > 0 =>
       for line_number in line_numbers {
-        match folding_model.get_region_at_line(line_number) {
-          Some(region) => {
-            if region.is_collapsed() != do_collapse {
-              to_toggle.push(region)
-            }
-            if levels > 1 {
-              let regions_inside = folding_model.get_regions_inside(
-                Some(region),
-                filter=region_filter_with_level((r, level) => {
-                  r.is_collapsed() != do_collapse && level < levels
-                }),
-              )
-              to_toggle.append(regions_inside)
-            }
-          }
-          None => ()
+        guard folding_model.get_region_at_line(line_number) is Some(region) else {
+          continue
+        }
+        if region.is_collapsed() != do_collapse {
+          to_toggle.push(region)
+        }
+        if levels > 1 {
+          to_toggle.append(
+            folding_model.get_regions_inside(Some(region), filter=inside_filter),
+          )
         }
       }
-    _ => {
-      let regions_inside = folding_model.get_regions_inside(
-        None,
-        filter=region_filter_with_level((r, level) => {
-          r.is_collapsed() != do_collapse && level < levels
-        }),
+    _ =>
+      to_toggle.append(
+        folding_model.get_regions_inside(None, filter=inside_filter),
       )
-      to_toggle.append(regions_inside)
-    }
   }
   folding_model.toggle_collapse_state(to_toggle)
 }

--- a/editor/internal/viewer/contrib/hover/browser/content_hover_widget.mbt
+++ b/editor/internal/viewer/contrib/hover/browser/content_hover_widget.mbt
@@ -241,7 +241,7 @@ pub fn ContentHoverWidget::ContentHoverWidget(
   wrapper.add_event_listener("contextmenu", event => event.stop_propagation())
   wrapper.add_event_listener("focusin", event => event.stop_propagation())
   wrapper.add_event_listener("focusout", event => event.stop_propagation())
-  wrapper.add_event_listener("wheel", event => {
+  let on_wheel = (event : @rdom.Event) => {
     match event.to_wheel_event() {
       Some(wheel) => {
         event.prevent_default()
@@ -250,19 +250,9 @@ pub fn ContentHoverWidget::ContentHoverWidget(
       }
       None => event.stop_propagation()
     }
-  })
-  scrollable
-  .content()
-  .add_event_listener("wheel", event => {
-    match event.to_wheel_event() {
-      Some(wheel) => {
-        event.prevent_default()
-        event.stop_propagation()
-        widget.handle_wheel(wheel)
-      }
-      None => event.stop_propagation()
-    }
-  })
+  }
+  wrapper.add_event_listener("wheel", on_wheel)
+  scrollable.content().add_event_listener("wheel", on_wheel)
   scrollable
   .content()
   .add_event_listener("scroll", _ => scrollable.update_from_native_content())

--- a/editor/internal/viewer/contrib/markdown_comments/markdown_comments.mbt
+++ b/editor/internal/viewer/contrib/markdown_comments/markdown_comments.mbt
@@ -11,102 +11,85 @@ fn detect_markdown_comments_in_snapshot(
   while line_index < line_count {
     // Line comments deliberately take precedence when configured delimiters
     // overlap. A whole consecutive run is consumed by this branch.
-    match rule.line_comment {
-      Some(line_rule) =>
-        match
-          line_comment_content(
+    if rule.line_comment is Some(line_rule) &&
+      line_comment_content(
+        snapshot.get_line_content(line_index + 1),
+        line_rule.comment,
+      )
+      is Some(first_content) {
+      let contents = [first_content]
+      let start_line_number = line_index + 1
+      line_index += 1
+      while line_index < line_count {
+        guard line_comment_content(
             snapshot.get_line_content(line_index + 1),
             line_rule.comment,
-          ) {
-          Some(first_content) => {
-            let contents = [first_content]
-            let start_line_number = line_index + 1
-            line_index += 1
-            while line_index < line_count {
-              match
-                line_comment_content(
-                  snapshot.get_line_content(line_index + 1),
-                  line_rule.comment,
-                ) {
-                Some(content) => {
-                  contents.push(content)
-                  line_index += 1
-                }
-                None => break
-              }
-            }
-            result.push({
-              line_range: LineRange(start_line_number, line_index + 1),
-              markdown: contents.join("\n"),
-            })
-            continue
-          }
-          None => ()
+          )
+          is Some(content) else {
+          break
         }
-      None => ()
+        contents.push(content)
+        line_index += 1
+      }
+      result.push({
+        line_range: LineRange(start_line_number, line_index + 1),
+        markdown: contents.join("\n"),
+      })
+      continue
     }
-
-    match rule.block_comment {
-      Some(pair) => {
-        let first_line = snapshot.get_line_content(line_index + 1)
-        let opening_offset = leading_indent_end(first_line)
-        if matches_at(first_line, opening_offset, pair.open) {
-          let start_line_index = line_index
-          let after_open = opening_offset + pair.open.length()
-          let mut closing_line_index = line_index
-          let mut closing_offset = -1
-          while closing_line_index < line_count {
-            let line = snapshot.get_line_content(closing_line_index + 1)
-            let search_start = if closing_line_index == start_line_index {
-              after_open
-            } else {
-              0
-            }
-            closing_offset = find_from(line, pair.close, search_start)
-            if closing_offset >= 0 {
-              break
-            }
-            closing_line_index += 1
+    if rule.block_comment is Some(pair) {
+      let first_line = snapshot.get_line_content(line_index + 1)
+      let opening_offset = leading_indent_end(first_line)
+      if matches_at(first_line, opening_offset, pair.open) {
+        let start_line_index = line_index
+        let after_open = opening_offset + pair.open.length()
+        let mut closing_line_index = line_index
+        let mut closing_offset = -1
+        while closing_line_index < line_count {
+          let line = snapshot.get_line_content(closing_line_index + 1)
+          let search_start = if closing_line_index == start_line_index {
+            after_open
+          } else {
+            0
           }
-          if closing_line_index == line_count {
-            // The unmatched opening delimiter owns the remaining source as a
-            // block comment, but cannot produce a renderable whole-line block.
-            line_index = line_count
-            continue
+          closing_offset = find_from(line, pair.close, search_start)
+          if closing_offset >= 0 {
+            break
           }
-          let closing_line = snapshot.get_line_content(closing_line_index + 1)
-          let closes_at_boundary = closing_offset + pair.close.length() ==
-            trailing_content_end(closing_line)
-          if closes_at_boundary {
-            let body_lines : Array[String] = []
-            if start_line_index == closing_line_index {
-              body_lines.push(slice(first_line, after_open, closing_offset))
-            } else {
-              body_lines.push(
-                slice(first_line, after_open, first_line.length()),
-              )
-              let mut interior_line = start_line_index + 1
-              while interior_line < closing_line_index {
-                body_lines.push(snapshot.get_line_content(interior_line + 1))
-                interior_line += 1
-              }
-              body_lines.push(slice(closing_line, 0, closing_offset))
-            }
-            result.push({
-              line_range: LineRange(
-                start_line_index + 1,
-                closing_line_index + 2,
-              ),
-              markdown: normalize_block_body(body_lines),
-            })
-          }
-          // The first closing delimiter ends the language block even when
-          // trailing source makes the whole-line candidate invalid.
-          line_index = closing_line_index + 1
+          closing_line_index += 1
+        }
+        if closing_line_index == line_count {
+          // The unmatched opening delimiter owns the remaining source as a
+          // block comment, but cannot produce a renderable whole-line block.
+          line_index = line_count
           continue
         }
+        let closing_line = snapshot.get_line_content(closing_line_index + 1)
+        let closes_at_boundary = closing_offset + pair.close.length() ==
+          trailing_content_end(closing_line)
+        if closes_at_boundary {
+          let body_lines : Array[String] = []
+          if start_line_index == closing_line_index {
+            body_lines.push(slice(first_line, after_open, closing_offset))
+          } else {
+            body_lines.push(slice(first_line, after_open, first_line.length()))
+            let mut interior_line = start_line_index + 1
+            while interior_line < closing_line_index {
+              body_lines.push(snapshot.get_line_content(interior_line + 1))
+              interior_line += 1
+            }
+            body_lines.push(slice(closing_line, 0, closing_offset))
+          }
+          result.push({
+            line_range: LineRange(start_line_index + 1, closing_line_index + 2),
+            markdown: normalize_block_body(body_lines),
+          })
+        }
+        // The first closing delimiter ends the language block even when
+        // trailing source makes the whole-line candidate invalid.
+        line_index = closing_line_index + 1
+        continue
       }
-      None => ()
     }
     line_index += 1
   }

--- a/editor/internal/viewer/contrib/references/browser/references_controller.mbt
+++ b/editor/internal/viewer/contrib/references/browser/references_controller.mbt
@@ -726,13 +726,15 @@ fn ReferencesController::schedule_preview(
   model : @model.TextModel,
   reference : @navigation_api.TextModelReference?,
 ) -> Unit {
+  let dispose_reference = () => {
+    if reference is Some(current) {
+      current.dispose()
+    }
+  }
   guard !model.is_disposed() &&
     self.session_is_current(generation) &&
     self.preview_generation == preview_generation else {
-    match reference {
-      Some(reference) => reference.dispose()
-      None => ()
-    }
+    dispose_reference()
     return
   }
   let task = self.launch_async_task
@@ -748,34 +750,30 @@ fn ReferencesController::schedule_preview(
         result_model,
         widget,
       ) else {
-      match reference {
-        Some(reference) => reference.dispose()
-        None => ()
-      }
+      dispose_reference()
       return
+    }
+    let commit_is_current = () => {
+      self.preview_commit_is_current(
+        generation,
+        preview_generation,
+        location.uri.to_string(),
+        model,
+        result_model,
+        widget,
+      )
     }
     let restore_preview_focus = self.clear_installed_preview()
-    guard self.preview_commit_is_current(
-      generation,
-      preview_generation,
-      location.uri.to_string(),
-      model,
-      result_model,
-      widget,
-    ) else {
-      match reference {
-        Some(reference) => reference.dispose()
-        None => ()
-      }
+    guard commit_is_current() else {
+      dispose_reference()
       return
     }
-    let matches : Array[@base_common.Range] = []
     let uri = model.uri.to_string()
-    for item in result_model.references {
-      if item.uri_string == uri {
-        matches.push(model.validate_range(item.range))
+    let matches : Array[@base_common.Range] = [
+      for item in result_model.references if item.uri_string == uri => {
+        model.validate_range(item.range)
       }
-    }
+    ]
     let preview = (self.preview_factory.create)(
       widget.get_preview_host(),
       model,
@@ -784,62 +782,29 @@ fn ReferencesController::schedule_preview(
       mode,
     )
     guard preview is Some(preview) else {
-      match reference {
-        Some(reference) => reference.dispose()
-        None => ()
-      }
+      dispose_reference()
       self.show_preview_unavailable(
         generation, preview_generation, "No preview available",
       )
       return
     }
-    if !self.preview_commit_is_current(
-        generation,
-        preview_generation,
-        location.uri.to_string(),
-        model,
-        result_model,
-        widget,
-      ) {
+    if !commit_is_current() {
       preview.dispose()
-      match reference {
-        Some(reference) => reference.dispose()
-        None => ()
-      }
+      dispose_reference()
       return
     }
     widget.show_preview_ready()
-    if !self.preview_commit_is_current(
-        generation,
-        preview_generation,
-        location.uri.to_string(),
-        model,
-        result_model,
-        widget,
-      ) {
+    if !commit_is_current() {
       preview.dispose()
-      match reference {
-        Some(reference) => reference.dispose()
-        None => ()
-      }
+      dispose_reference()
       return
     }
     if restore_preview_focus {
       preview.focus()
     }
-    if !self.preview_commit_is_current(
-        generation,
-        preview_generation,
-        location.uri.to_string(),
-        model,
-        result_model,
-        widget,
-      ) {
+    if !commit_is_current() {
       preview.dispose()
-      match reference {
-        Some(reference) => reference.dispose()
-        None => ()
-      }
+      dispose_reference()
       return
     }
     self.preview = Some(preview)

--- a/editor/internal/viewer/diff_editor/view_model.mbt
+++ b/editor/internal/viewer/diff_editor/view_model.mbt
@@ -125,34 +125,24 @@ pub fn DiffEditorViewModel::set_model(
       self.state = Pending
       let original_identity = model.original.identity()
       let modified_identity = model.modified.identity()
+      let invalidate_content = () => {
+        self.invalidate_content_for_model_pair(
+          original_identity, modified_identity,
+        )
+      }
+      let clear_pair = () => {
+        self.clear_model_pair_on_will_dispose(
+          original_identity, modified_identity,
+        )
+      }
       self.model_subscriptions.push(
-        model.original.on_did_change_content(_ => {
-          self.invalidate_content_for_model_pair(
-            original_identity, modified_identity,
-          )
-        }),
+        model.original.on_did_change_content(_ => invalidate_content()),
       )
       self.model_subscriptions.push(
-        model.modified.on_did_change_content(_ => {
-          self.invalidate_content_for_model_pair(
-            original_identity, modified_identity,
-          )
-        }),
+        model.modified.on_did_change_content(_ => invalidate_content()),
       )
-      self.model_subscriptions.push(
-        model.original.on_will_dispose(() => {
-          self.clear_model_pair_on_will_dispose(
-            original_identity, modified_identity,
-          )
-        }),
-      )
-      self.model_subscriptions.push(
-        model.modified.on_will_dispose(() => {
-          self.clear_model_pair_on_will_dispose(
-            original_identity, modified_identity,
-          )
-        }),
-      )
+      self.model_subscriptions.push(model.original.on_will_dispose(clear_pair))
+      self.model_subscriptions.push(model.modified.on_will_dispose(clear_pair))
       self.schedule_immediate_compute()
     }
   }

--- a/editor/server/host/native_host.mbt
+++ b/editor/server/host/native_host.mbt
@@ -588,15 +588,10 @@ async fn write_static_response_body(
   content : Bytes,
 ) -> Unit {
   let chunk_size = 16384
-  let mut start = 0
-  while start < content.length() {
-    let end = if start + chunk_size < content.length() {
-      start + chunk_size
-    } else {
-      content.length()
-    }
+  for start = 0; start < content.length(); {
+    let end = (start + chunk_size).min(content.length())
     conn.write(content[start:end])
-    start = end
+    continue end
   }
 }
 

--- a/editor/viewer/browser/editor_dom.mbt
+++ b/editor/viewer/browser/editor_dom.mbt
@@ -274,19 +274,8 @@ pub fn EditorMouseEventFactory::on_pointer_down(
   target : @rdom.Element,
   callback : (EditorDomMouseEvent, Int) -> Unit,
 ) -> @base_common.Disposable {
-  let handler = (event : @rdom.Event) => {
-    match event.to_mouse_event() {
-      Some(mouse) =>
-        callback(
-          EditorDomMouseEvent(mouse, false, self.editor_view_dom_node),
-          @base_browser.mouse_event_pointer_id(mouse),
-        )
-      None => ()
-    }
-  }
-  target.add_event_listener("pointerdown", handler)
-  @base_common.Disposable::from(() => {
-    target.remove_event_listener("pointerdown", handler)
+  self.listen(target, "pointerdown", event => {
+    callback(event, @base_browser.mouse_event_pointer_id(event.browser_event))
   })
 }
 
@@ -335,9 +324,8 @@ pub fn GlobalEditorPointerMoveMonitor::GlobalEditorPointerMoveMonitor(
 fn GlobalEditorPointerMoveMonitor::dispose_keydown_listener(
   self : GlobalEditorPointerMoveMonitor,
 ) -> Unit {
-  match self.keydown_listener {
-    Some(listener) => listener.dispose()
-    None => ()
+  if self.keydown_listener is Some(listener) {
+    listener.dispose()
   }
   self.keydown_listener = None
 }

--- a/editor/viewer/common/languages/text_to_html_tokenizer.mbt
+++ b/editor/viewer/common/languages/text_to_html_tokenizer.mbt
@@ -50,16 +50,26 @@ pub fn tokenize_line_to_html(
         char_index += 1
         continue
       }
-      if char_code == 9 { // Tab
-        let remainder = width % tab_size
-        let insert_spaces_count = if remainder == 0 {
-          tab_size
-        } else {
-          tab_size - remainder
+      match char_code {
+        9 => { // Tab
+          let remainder = width % tab_size
+          let insert_spaces_count = if remainder == 0 {
+            tab_size
+          } else {
+            tab_size - remainder
+          }
+          width += insert_spaces_count
+          for _ in 0..<insert_spaces_count {
+            if use_nbsp && prev_is_space {
+              part.write_string("&#160;")
+              prev_is_space = false
+            } else {
+              part.write_string(" ")
+              prev_is_space = true
+            }
+          }
         }
-        width += insert_spaces_count
-        let mut spaces_remaining = insert_spaces_count
-        while spaces_remaining > 0 {
+        32 => // Space
           if use_nbsp && prev_is_space {
             part.write_string("&#160;")
             prev_is_space = false
@@ -67,41 +77,21 @@ pub fn tokenize_line_to_html(
             part.write_string(" ")
             prev_is_space = true
           }
-          spaces_remaining -= 1
-        }
-      } else if char_code == 60 { // <
-        part.write_string("&lt;")
-        prev_is_space = false
-      } else if char_code == 62 { // >
-        part.write_string("&gt;")
-        prev_is_space = false
-      } else if char_code == 38 { // &
-        part.write_string("&amp;")
-        prev_is_space = false
-      } else if char_code == 0 { // Null
-        part.write_string("&#00;")
-        prev_is_space = false
-      } else if char_code == 65279 ||
-        char_code == 8232 ||
-        char_code == 8233 ||
-        char_code == 133 {
-        // UTF8_BOM, LINE_SEPARATOR, PARAGRAPH_SEPARATOR, NEXT_LINE
-        part.write_string("\u{FFFD}")
-        prev_is_space = false
-      } else if char_code == 13 { // CarriageReturn (zero-width space)
-        part.write_string("&#8203")
-        prev_is_space = false
-      } else if char_code == 32 { // Space
-        if use_nbsp && prev_is_space {
-          part.write_string("&#160;")
+        _ => {
+          part.write_string(
+            match char_code {
+              60 => "&lt;" // <
+              62 => "&gt;" // >
+              38 => "&amp;" // &
+              0 => "&#00;" // Null
+              // UTF8_BOM, LINE_SEPARATOR, PARAGRAPH_SEPARATOR, NEXT_LINE
+              65279 | 8232 | 8233 | 133 => "\u{FFFD}"
+              13 => "&#8203" // CarriageReturn (zero-width space)
+              _ => text[char_index:char_index + 1].to_owned()
+            },
+          )
           prev_is_space = false
-        } else {
-          part.write_string(" ")
-          prev_is_space = true
         }
-      } else {
-        part.write_string(text[char_index:char_index + 1].to_owned())
-        prev_is_space = false
       }
       char_index += 1
     }

--- a/editor/viewer/common/markers/marker_decorations_service.mbt
+++ b/editor/viewer/common/markers/marker_decorations_service.mbt
@@ -93,19 +93,12 @@ pub fn MarkerDecorationsService::dispose(
   // Block both marker-service and outward-emitter ingress before any owner can
   // reenter through a model-decoration callback.
   self.disposed = true
-  match self.subscription {
-    Some(d) => {
-      self.subscription = None
-      d.dispose()
-    }
-    None => ()
+  if self.subscription is Some(d) {
+    self.subscription = None
+    d.dispose()
   }
   self.did_change_marker_decorations.dispose()
-  let registrations : Array[ModelMarkerRegistration] = []
-  for _, registration in self.model_registrations {
-    registrations.push(registration)
-  }
-  for registration in registrations {
+  for registration in self.model_registrations.values().to_array() {
     self.finalize_registration(registration, ServiceDisposed)
   }
   // These are the two ownership indexes. They intentionally survive until
@@ -229,19 +222,13 @@ fn MarkerDecorationsService::finalize_registration(
   }
   registration.update_requested = false
   registration.reset_requested = false
-  match registration.content_subscription {
-    Some(subscription) => {
-      registration.content_subscription = None
-      subscription.dispose()
-    }
-    None => ()
+  if registration.content_subscription is Some(subscription) {
+    registration.content_subscription = None
+    subscription.dispose()
   }
-  match registration.dispose_subscription {
-    Some(subscription) => {
-      registration.dispose_subscription = None
-      subscription.dispose()
-    }
-    None => ()
+  if registration.dispose_subscription is Some(subscription) {
+    registration.dispose_subscription = None
+    subscription.dispose()
   }
   registration.marker_decorations.dispose()
 }
@@ -253,17 +240,12 @@ fn MarkerDecorationsService::remove_model_from_uri_index(
   model_id : Int,
 ) -> Unit {
   let uri_key = uri.to_string()
-  match self.model_ids_by_uri.get(uri_key) {
-    Some(model_ids) => {
-      match model_ids.search(model_id) {
-        Some(index) => model_ids.remove(index) |> ignore
-        None => ()
-      }
-      if model_ids.length() == 0 {
-        self.model_ids_by_uri.remove(uri_key)
-      }
-    }
-    None => ()
+  guard self.model_ids_by_uri.get(uri_key) is Some(model_ids) else { return }
+  if model_ids.search(model_id) is Some(index) {
+    model_ids.remove(index) |> ignore
+  }
+  if model_ids.length() == 0 {
+    self.model_ids_by_uri.remove(uri_key)
   }
 }
 
@@ -298,18 +280,15 @@ fn MarkerDecorationsService::handle_marker_change(
     if self.disposed {
       return
     }
-    match self.model_ids_by_uri.get(resource.to_string()) {
-      Some(model_ids) =>
-        for model_id in model_ids.copy() {
-          if self.disposed {
-            return
-          }
-          match self.model_registrations.get(model_id) {
-            Some(registration) => self.update_decorations(registration)
-            None => ()
-          }
+    if self.model_ids_by_uri.get(resource.to_string()) is Some(model_ids) {
+      for model_id in model_ids.copy() {
+        if self.disposed {
+          return
         }
-      None => ()
+        if self.model_registrations.get(model_id) is Some(registration) {
+          self.update_decorations(registration)
+        }
+      }
     }
   }
 }
@@ -389,17 +368,16 @@ fn MarkerDecorationsService::update_decorations_once(
     MarkerReadOptions(resource=marker_decorations.model.uri, take=500),
   )
   // filter markers from suppressed ranges
-  match self.suppressed_ranges.get(marker_decorations.model.uri.to_string()) {
-    Some(suppressed_ranges) =>
-      markers = markers.filter(marker => {
-        !suppressed_ranges.any(candidate => {
-          @base_common.Range::are_intersecting_or_touching(
-            candidate,
-            marker.range(),
-          )
-        })
+  if self.suppressed_ranges.get(marker_decorations.model.uri.to_string())
+    is Some(suppressed_ranges) {
+    markers = markers.filter(marker => {
+      !suppressed_ranges.any(candidate => {
+        @base_common.Range::are_intersecting_or_touching(
+          candidate,
+          marker.range(),
+        )
       })
-    None => ()
+    })
   }
   if marker_decorations.update(markers) && !self.disposed && registration.active {
     self.did_change_marker_decorations.fire(marker_decorations.model)
@@ -481,16 +459,10 @@ fn create_decoration_option(marker : Marker) -> @model.ModelDecorationOptions {
       minimap = Some({ color: minimap_error, position: Inline, })
     }
   }
-  match marker.tags {
-    Some(tags) => {
-      if tags.contains(Unnecessary) {
-        inline_class_name = Some("squiggly-inline-unnecessary")
-      }
-      if tags.contains(Deprecated) {
-        inline_class_name = Some("squiggly-inline-deprecated")
-      }
-    }
-    None => ()
+  if marker.has_tag(Deprecated) {
+    inline_class_name = Some("squiggly-inline-deprecated")
+  } else if marker.has_tag(Unnecessary) {
+    inline_class_name = Some("squiggly-inline-unnecessary")
   }
   ModelDecorationOptions(
     class_name,
@@ -543,15 +515,13 @@ fn create_decoration_range(
       // keep the range as is, it will be rendered 1ch wide
       return ret
     }
-    match model.get_word_at_position(ret.get_start_position()) {
-      Some(word) =>
-        ret = Range(
-          ret.start_line_number,
-          word.start_column,
-          ret.end_line_number,
-          word.end_column,
-        )
-      None => ()
+    if model.get_word_at_position(ret.get_start_position()) is Some(word) {
+      ret = Range(
+        ret.start_line_number,
+        word.start_column,
+        ret.end_line_number,
+        word.end_column,
+      )
     }
   } else if raw_marker.end_column == max_value_column &&
     raw_marker.start_column == 1 &&

--- a/editor/viewer/common/model/abstract_syntax_token_backend.mbt
+++ b/editor/viewer/common/model/abstract_syntax_token_backend.mbt
@@ -139,14 +139,7 @@ fn AttachedViews::detach_view(
   self : AttachedViews,
   view : AttachedViewImpl,
 ) -> Unit {
-  let found = for i, candidate in self.views {
-    if candidate.same(view) {
-      break i
-    }
-  } nobreak {
-    -1
-  }
-  if found >= 0 {
+  if self.views.search_by(candidate => candidate.same(view)) is Some(found) {
     self.views.remove(found) |> ignore
   }
   self.did_change_visible_ranges.fire({ view, state: None, })
@@ -309,15 +302,7 @@ fn line_range_arrays_equal(
   left : ArrayView[@base_common.LineRange],
   right : ArrayView[@base_common.LineRange],
 ) -> Bool {
-  if left.length() != right.length() {
-    return false
-  }
-  for i in 0..<left.length() {
-    if !left[i].equals(right[i]) {
-      return false
-    }
-  }
-  true
+  left == right
 }
 
 ///|

--- a/editor/viewer/common/model/tokenizer_syntax_token_backend.mbt
+++ b/editor/viewer/common/model/tokenizer_syntax_token_backend.mbt
@@ -80,24 +80,19 @@ fn TokenizerSyntaxTokenBackend::handle_attached_view_state_change(
   self : TokenizerSyntaxTokenBackend,
   change : AttachedViewStateChange,
 ) -> Unit {
+  let existing = self.attached_view_states.search_by(entry => {
+    entry.view.same(change.view)
+  })
   match change.state {
     Some(state) => {
-      let index = for i, entry in self.attached_view_states {
-        if entry.view.same(change.view) {
-          break i
-        }
-      } nobreak {
-        -1
-      }
-      let handler = if index >= 0 {
+      let handler = if existing is Some(index) {
         self.attached_view_states[index].handler
       } else {
         let holder : Ref[AttachedViewHandler?] = Ref(None)
         let handler = AttachedViewHandler(
           () => {
-            match holder.val {
-              Some(current) => self.refresh_ranges(current.line_ranges())
-              None => ()
+            if holder.val is Some(current) {
+              self.refresh_ranges(current.line_ranges())
             }
           },
           () => self.model_state.scheduler.val,
@@ -108,19 +103,11 @@ fn TokenizerSyntaxTokenBackend::handle_attached_view_state_change(
       }
       handler.handle_state_change(state)
     }
-    None => {
-      let index = for i, entry in self.attached_view_states {
-        if entry.view.same(change.view) {
-          break i
-        }
-      } nobreak {
-        -1
-      }
-      if index >= 0 {
+    None =>
+      if existing is Some(index) {
         self.attached_view_states[index].handler.dispose()
         self.attached_view_states.remove(index) |> ignore
       }
-    }
   }
 }
 

--- a/editor/viewer/common/view_layout/scrollable.mbt
+++ b/editor/viewer/common/view_layout/scrollable.mbt
@@ -342,12 +342,9 @@ fn init_scroll_animation(
 pub fn SmoothScrollingOperation::dispose(
   self : SmoothScrollingOperation,
 ) -> Unit {
-  match self.animation_frame_disposable {
-    Some(disposable) => {
-      disposable.dispose()
-      self.animation_frame_disposable = None
-    }
-    None => ()
+  if self.animation_frame_disposable is Some(disposable) {
+    disposable.dispose()
+    self.animation_frame_disposable = None
   }
 }
 
@@ -524,9 +521,8 @@ pub fn Scrollable::set_scroll_dimensions(
     new_state,
     in_smooth_scrolling=self.smooth_scrolling is Some(_),
   )
-  match self.smooth_scrolling {
-    Some(operation) => operation.accept_scroll_dimensions(self.state)
-    None => ()
+  if self.smooth_scrolling is Some(operation) {
+    operation.accept_scroll_dimensions(self.state)
   }
   change
 }
@@ -708,9 +704,8 @@ fn Scrollable::set_state(
 
 ///|
 fn Scrollable::cancel_smooth_scrolling(self : Scrollable) -> Unit {
-  match self.smooth_scrolling {
-    Some(operation) => operation.dispose()
-    None => ()
+  if self.smooth_scrolling is Some(operation) {
+    operation.dispose()
   }
   self.operation_generation += 1
   self.smooth_scrolling = None
@@ -930,24 +925,11 @@ pub fn EditorScrollable::dispose(self : EditorScrollable) -> Unit {
 ///|
 fn truncate_double(value : Double) -> Double {
   // JavaScript's `value | 0` performs ToInt32, not a saturating Double->Int
-  // conversion. Keep the modulo/wrap explicit so the common package has the
-  // same result on every MoonBit target, including the signed-32-bit edges.
-  let modulus = 4294967296.0
-  let signed_boundary = 2147483648.0
-  let mut wrapped = value.trunc() % modulus
-  // NaN and both infinities become zero under ToInt32. Normalize negative zero
-  // too, so the retained dimensions have one canonical zero representation.
-  if wrapped.is_nan() || wrapped == 0.0 {
-    return 0.0
-  }
-  if wrapped < 0.0 {
-    wrapped += modulus
-  }
-  if wrapped >= signed_boundary {
-    wrapped - modulus
-  } else {
-    wrapped
-  }
+  // conversion. `javascript_to_int32` keeps that modulo/wrap explicit, so the
+  // common package has the same result on every MoonBit target, including the
+  // signed-32-bit edges: NaN and both infinities become zero, and negative zero
+  // is normalized, so the retained dimensions have one canonical zero.
+  javascript_to_int32(value).to_double()
 }
 
 ///|


### PR DESCRIPTION
**Every hunk stays inside one function.** Nothing shared is added, removed or
re-signatured, so each hunk can be judged by reading it — there is no other code
to go check.

The shapes used, all of them:

| before | after |
| --- | --- |
| an `if`/`else` ladder | one `match` with guards or nested patterns |
| a nested `match` on options | a `guard ... is Some(..)` chain |
| a manual index loop | a comprehension, `fold`, `any`, `find_first`, `search_by` |
| two identical `match` arms | one or-pattern arm |
| `match o { Some(v) => ...; None => ... }` | an Option combinator |
| duplicated branches in one function | a local binding or a closure used only there |

The helper extractions these were mixed with are in the paired pull request, so
nothing here crosses a call site.

Scope: the browser controller and view, the folding, hover, references and context-menu contributions, the markers service, the tokenizer backends, and the scrollable layout.

### Verified on this branch alone

`moon fmt --check`, the native and JS workspace checks with `--deny-warn`, both
full test suites, and from `editor/` `moon check --target all --warn-list +73
--deny-warn` plus `moon test --target all`, with no other part of the refactor
applied. No `.mbti` changed.

---

The refactor is split so each pull request asks one kind of question. Every file
appears in exactly one of them, each was verified on its own branch with no
other part applied, so they merge in any order.

| | easy to review | needs a careful read |
| --- | --- | --- |
| root | `simplify/local-root` | `simplify/structural-root` (#1325) |
| `desktop/` | `simplify/local-desktop` | `simplify/structural-desktop` (#1326) |
| `editor/` | `simplify/local-editor` | `simplify/structural-editor` (#1327) |
| tests | `simplify/tests-local` | `simplify/tests` (#1328) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JiBNGzCsZpN6e5Y4p9pXdn
