### PR TITLE
refactor(desktop): drop the Iter hop and one wire-name copy (review of #1323)

### DIFF
--- a/desktop/frontend/agent_model.mbt
+++ b/desktop/frontend/agent_model.mbt
@@ -69,7 +69,7 @@ fn ModelChoice::parse(value : String) -> ModelChoice? {
     return Some(CodexUnavailablePick)
   }
   if value.strip_prefix(OpenSeekChoicePrefix) is Some(rest) {
-    return EngineModel::parse(rest.to_owned()).map(model => OpenSeekModel(model))
+    return EngineModel::parse(rest).map(model => OpenSeekModel(model))
   }
   if value.strip_prefix(CodexChoicePrefix) is Some(rest) {
     let id = rest.to_owned()

--- a/desktop/frontend/codex/model.mbt
+++ b/desktop/frontend/codex/model.mbt
@@ -1685,7 +1685,7 @@ fn State::with_thread_reply(
     runtime: active.runtime,
     updated_at_ms: reply_stamp_ms,
   }
-  let replaced = self.threads.iter().any(existing => existing.id == active.id)
+  let replaced = self.threads.any(existing => existing.id == active.id)
   let threads = self.threads.map(existing => {
     if existing.id == active.id {
       // A reply without a stamp must not erase the catalog's; keep the row
@@ -2033,9 +2033,7 @@ fn CodexThread::with_turn(self : CodexThread, turn : CodexTurn) -> CodexThread {
 /// the first submitted input. Item ids stay app-server-owned; the local
 /// preview needs only this semantic boundary and never tries to match text.
 fn CodexThread::has_user_item(self : CodexThread) -> Bool {
-  self.turns
-  .iter()
-  .any(turn => turn.items.iter().any(item => item.kind == "userMessage"))
+  self.turns.any(turn => turn.items.any(item => item.kind == "userMessage"))
 }
 
 ///|

--- a/desktop/frontend/console.mbt
+++ b/desktop/frontend/console.mbt
@@ -227,18 +227,18 @@ fn apply_roster(
   let devices = model.devices.filter(dev => {
     Some(dev.channel) == page_channel &&
     dev.channel is Remote(id) &&
-    metas.iter().any(meta => meta.id == id)
+    metas.any(meta => meta.id == id)
   })
   let conversations = model.conversations.filter(conv => {
-    devices.iter().any(dev => dev.channel == conv.device)
+    devices.any(dev => dev.channel == conv.device)
   })
   // Connect only the query-selected target when the roster reports it online.
   // A held target keeps its reconnect loop when the advisory `online` flag
   // drops; a page first opened while it is offline waits for a later refresh.
   if console.page_device is Some(id) &&
-    metas.iter().any(meta => meta.id == id && meta.online) {
+    metas.any(meta => meta.id == id && meta.online) {
     let channel : @interop.ChannelId = Remote(id)
-    if !devices.iter().any(dev => dev.channel == channel) {
+    if !devices.any(dev => dev.channel == channel) {
       websocket_epoch += 1
       devices.push({ ..empty_device_state(channel), websocket_epoch, })
     }
@@ -247,13 +247,13 @@ fn apply_roster(
   // has no channel. The full console frame is gated then, so no UI action can
   // accidentally treat Local as a usable browser device.
   let focused = if page_channel is Some(channel) &&
-    devices.iter().any(dev => dev.channel == channel) {
+    devices.any(dev => dev.channel == channel) {
     channel
   } else {
     @interop.ChannelId::Local
   }
   let refocused = focused != model.focused
-  let focus_held = devices.iter().any(dev => dev.channel == focused)
+  let focus_held = devices.any(dev => dev.channel == focused)
   // The deep link's `?workspace=` lands on the pinned device when it first
   // connects, so its initial conversation opens in that project.
   let mut preselect_project = console.preselect_project

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -28,14 +28,14 @@ fn EngineModel::wire(self : EngineModel) -> String {
 /// Read a wire name. A blank one is the absence of a model, not a tier, so it
 /// reads as `None` — stored preferences fall back to what they already had,
 /// and the event decoders treat it like the missing field it is.
-fn EngineModel::parse(value : String) -> EngineModel? {
-  match value.trim().to_owned() {
+fn EngineModel::parse(value : StringView) -> EngineModel? {
+  match value.trim() {
     "deepseek-v4-pro" => Some(DsPro)
     "deepseek-v4-flash" => Some(DsFlash)
     "glm-5.3" => Some(Glm53)
     "glm-5.3-flash" => Some(Glm53Flash)
     "" => None
-    name => Some(Other(name))
+    name => Some(Other(name.to_owned()))
   }
 }
 


### PR DESCRIPTION
Addresses the review comments left on #1323 after it merged. Both are applied.

### `metas.any(...)`

`Array` has `any` and `all`, so going through `iter()` built an iterator per
call for nothing.

- **`console.mbt`** — all six sites, over the device roster and the device
  list. Four of them predate the sweep; the one you flagged and its neighbour
  came from it, so this cleans up the function rather than just the new lines.
- **`codex/model.mbt`** — the thread-replacement scan, and the nested
  `has_user_item` walk over turns and their items, which built two iterators
  per turn.

**Not changed:** two `.iter().any(...)` sites over a `String`, in
`transcript/sessions.mbt` and `worktrees.mbt`. `String` has no `any`, so the
hop to `Iter` is what makes those compile at all.

### `take StringView to avoid allocation?`

`EngineModel::parse` takes a `StringView` now. Its body already trimmed and
matched against literals, and only the unknown-model arm needs an owned name,
so the copy happens once for a custom endpoint instead of on every parse.
`ModelChoice::parse` then hands its `strip_prefix` view straight through, which
removes the `to_owned()` you pointed at.

### Verified

`moon fmt --check`, native and JS checks with `--deny-warn`, and both full test
suites: 3202 native, 3184 JS. No `.mbti` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JiBNGzCsZpN6e5Y4p9pXdn
