### PR TITLE
deps: upgrade rabbita to 0.15.7

### DIFF
--- a/cmd/viz_app/moon.mod
+++ b/cmd/viz_app/moon.mod
@@ -4,7 +4,7 @@ version = "0.1.0"
 
 import {
   "bobzhang/openseek@0.2.2",
-  "moonbit-community/rabbita@0.15.4",
+  "moonbit-community/rabbita@0.15.7",
 }
 
 preferred_target = "js"

--- a/desktop/frontend/action_menu/action_menu.mbt
+++ b/desktop/frontend/action_menu/action_menu.mbt
@@ -152,7 +152,10 @@ pub fn context_attrs(target : String) -> @html.Attrs {
     event.prevent_default()
     dispatch_open({
       target,
-      anchor: Pointer(event.get_client_x(), event.get_client_y()),
+      anchor: Pointer(
+        event.get_client_x().to_int(),
+        event.get_client_y().to_int(),
+      ),
       restore_focus_id: remembered_context_focus(event),
     })
   })
@@ -193,7 +196,7 @@ fn focus_element(id : String, after_render : Bool) -> @cmd.Cmd {
     if @dom.document().get_element_by_id(id).to_option() is Some(element) {
       let _ : @js.Value = @js.Value::cast_from(element).apply_with_string(
         "focus",
-        ([] : Array[@js.Value]),
+        ([] : FixedArray[@js.Value]),
       )
       if element.get_attribute(TemporaryFocusAttribute) == Some(id) {
         element.remove_attribute(TemporaryFocusAttribute)
@@ -241,8 +244,8 @@ fn position(target : String, anchor : Anchor) -> @cmd.Cmd {
       let window = @dom.window()
       let mut viewport_left = 0.0
       let mut viewport_top = 0.0
-      let mut viewport_width = window.inner_width().to_double()
-      let mut viewport_height = window.inner_height().to_double()
+      let mut viewport_width = window.inner_width()
+      let mut viewport_height = window.inner_height()
       if window.get_visual_viewport() is Some(viewport) {
         viewport_left = viewport.get_offset_left()
         viewport_top = viewport.get_offset_top()

--- a/desktop/frontend/action_menu/context_menu.mbt
+++ b/desktop/frontend/action_menu/context_menu.mbt
@@ -200,8 +200,8 @@ fn install_context_menu_listener(
       event_element(event) is Some(element) else {
       return
     }
-    let x = mouse.get_client_x()
-    let y = mouse.get_client_y()
+    let x = mouse.get_client_x().to_int()
+    let y = mouse.get_client_y().to_int()
     remembered_selection = Some((x, y, selected_at(element, x, y, false)))
   }
   // Capture closes the previous menu even when another owner stops bubbling.
@@ -223,8 +223,8 @@ fn install_context_menu_listener(
       return
     }
     event.prevent_default()
-    let x = mouse.get_client_x()
-    let y = mouse.get_client_y()
+    let x = mouse.get_client_x().to_int()
+    let y = mouse.get_client_y().to_int()
     let keyboard = x == 0 && y == 0
     let mut selected_text = selected_at(element, x, y, keyboard)
     if selected_text is None &&

--- a/desktop/frontend/boot.mbt
+++ b/desktop/frontend/boot.mbt
@@ -390,7 +390,7 @@ pub fn boot() -> Unit {
       subscriptions=(model, emit) => {
         let subs : Array[@sub.Sub] = [
           @sub.on_resize(
-            emit.map(viewport => ViewportResized(width=viewport.width)),
+            emit.map(viewport => ViewportResized(width=viewport.width.to_int())),
           ),
           app_shortcut_subscription(emit),
           // Host event sources follow the device roster. Removing a device

--- a/desktop/frontend/bridge.mbt
+++ b/desktop/frontend/bridge.mbt
@@ -1610,7 +1610,7 @@ fn close_window() -> @cmd.Cmd {
   @cmd.custom_cmd(_ => {
     let _ : @js.Value = @js.globalThis.apply_with_string(
       "close",
-      ([] : Array[@js.Value]),
+      ([] : FixedArray[@js.Value]),
     )
   })
 }

--- a/desktop/frontend/bridge/local.mbt
+++ b/desktop/frontend/bridge/local.mbt
@@ -175,6 +175,6 @@ fn LocalBridgeSub::update_dispatch(
 fn LocalBridgeSub::unload(self : LocalBridgeSub) -> Unit {
   self.active = false
   for unsubscribe in self.unsubscribers {
-    let _ : @js.Value = unsubscribe.apply(([] : Array[@js.Value]))
+    let _ : @js.Value = unsubscribe.apply(([] : FixedArray[@js.Value]))
   }
 }

--- a/desktop/frontend/browser_ops.mbt
+++ b/desktop/frontend/browser_ops.mbt
@@ -243,7 +243,7 @@ fn focus_browser_address() -> @cmd.Cmd {
         Some(element) => {
           let _ : @js.Value = @js.Cast::from(element).apply_with_string(
             "focus",
-            ([] : Array[@js.Value]),
+            ([] : FixedArray[@js.Value]),
           )
         }
         None => ()

--- a/desktop/frontend/conversation_rename.mbt
+++ b/desktop/frontend/conversation_rename.mbt
@@ -66,11 +66,11 @@ fn focus_conversation_rename() -> @cmd.Cmd {
         is Some(input) {
         let _ : @js.Value = @js.Value::cast_from(input).apply_with_string(
           "focus",
-          ([] : Array[@js.Value]),
+          ([] : FixedArray[@js.Value]),
         )
         let _ : @js.Value = @js.Value::cast_from(input).apply_with_string(
           "select",
-          ([] : Array[@js.Value]),
+          ([] : FixedArray[@js.Value]),
         )
       }
     },

--- a/desktop/frontend/fileeditor/editor_resize.mbt
+++ b/desktop/frontend/fileeditor/editor_resize.mbt
@@ -98,7 +98,7 @@ fn on_resize_move(event : @dom.Event) -> Unit {
   let rect = content.get_bounding_client_rect()
   set_editor_width(
     drag_size(
-      rect.get_right() - mouse.get_client_x().to_double(),
+      rect.get_right() - mouse.get_client_x(),
       floor=MinEditorWidth.to_double(),
       max=rect.get_width() - MinChatWidth.to_double(),
     ),

--- a/desktop/frontend/fileeditor/git_graph_resize.mbt
+++ b/desktop/frontend/fileeditor/git_graph_resize.mbt
@@ -61,7 +61,7 @@ fn request_git_graph_resize_mount() -> @cmd.Cmd {
         }
         let rect = layout.get_bounding_client_rect()
         let height = drag_size(
-          mouse.get_client_y().to_double() - rect.get_top(),
+          mouse.get_client_y() - rect.get_top(),
           floor=MinReviewSectionHeight.to_double(),
           max=rect.get_height() - MinReviewSectionHeight.to_double(),
         )

--- a/desktop/frontend/fileeditor/tree_resize.mbt
+++ b/desktop/frontend/fileeditor/tree_resize.mbt
@@ -112,7 +112,7 @@ fn on_tree_resize_move(event : @dom.Event) -> Unit {
   if tree_docked_right() {
     set_tree_width(
       drag_size(
-        rect.get_right() - mouse.get_client_x().to_double(),
+        rect.get_right() - mouse.get_client_x(),
         floor=MinTreeWidth.to_double(),
         max=rect.get_width() - MinViewerWidth.to_double(),
       ),
@@ -120,7 +120,7 @@ fn on_tree_resize_move(event : @dom.Event) -> Unit {
   } else {
     set_tree_height(
       drag_size(
-        rect.get_bottom() - mouse.get_client_y().to_double(),
+        rect.get_bottom() - mouse.get_client_y(),
         floor=MinTreeHeight.to_double(),
         max=rect.get_height() - MinViewerHeight.to_double(),
       ),

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -126,7 +126,7 @@ fn focus_breadcrumb_entry_after_render(index : Int) -> @cmd.Cmd {
         is Some(row) {
         let _ : @js.Value = @js.Value::cast_from(row).apply_with_string(
           "focus",
-          ([] : Array[@js.Value]),
+          ([] : FixedArray[@js.Value]),
         )
       }
     },
@@ -141,7 +141,7 @@ fn focus_explorer_tab_after_render(id : String) -> @cmd.Cmd {
       if @dom.document().get_element_by_id(id).to_option() is Some(tab) {
         let _ : @js.Value = @js.Value::cast_from(tab).apply_with_string(
           "focus",
-          ([] : Array[@js.Value]),
+          ([] : FixedArray[@js.Value]),
         )
       }
     },
@@ -239,7 +239,7 @@ fn focus_changed_file_after_render(index : Int) -> @cmd.Cmd {
         is Some(row) {
         let _ : @js.Value = @js.Value::cast_from(row).apply_with_string(
           "focus",
-          ([] : Array[@js.Value]),
+          ([] : FixedArray[@js.Value]),
         )
       }
     },
@@ -837,7 +837,7 @@ fn focus_git_commit_after_render(index : Int) -> @cmd.Cmd {
         is Some(row) {
         let _ : @js.Value = @js.Value::cast_from(row).apply_with_string(
           "focus",
-          ([] : Array[@js.Value]),
+          ([] : FixedArray[@js.Value]),
         )
       }
     },

--- a/desktop/frontend/grep_search/view.mbt
+++ b/desktop/frontend/grep_search/view.mbt
@@ -9,7 +9,7 @@ pub fn focus_query_after_render() -> @cmd.Cmd {
         is Some(input) {
         let _ : @js.Value = @js.Value::cast_from(input).apply_with_string(
           "focus",
-          ([] : Array[@js.Value]),
+          ([] : FixedArray[@js.Value]),
         )
       }
     },

--- a/desktop/frontend/interop/interop.mbt
+++ b/desktop/frontend/interop/interop.mbt
@@ -54,7 +54,7 @@ pub fn page_has_focus() -> Bool {
   }
   let focused : Bool = document.apply_with_string(
     "hasFocus",
-    ([] : Array[@js.Value]),
+    ([] : FixedArray[@js.Value]),
   )
   let hidden : Bool = js_prop(document, "hidden")
     .map(value => value.cast())
@@ -68,7 +68,7 @@ pub fn page_has_focus() -> Bool {
 /// agreement with the host's — does not matter.
 pub fn now_ms() -> Double {
   let date_constructor : @js.Value = @js.globalThis.get_with_string("Date")
-  date_constructor.apply_with_string("now", ([] : Array[@js.Value]))
+  date_constructor.apply_with_string("now", ([] : FixedArray[@js.Value]))
 }
 
 ///|

--- a/desktop/frontend/interop/ws.mbt
+++ b/desktop/frontend/interop/ws.mbt
@@ -122,7 +122,7 @@ pub fn ws_close(channel : ChannelId) -> Unit {
   reject_all(session, "SeekMoon connection closed")
   let _ : @js.Value = session.socket.apply_with_string(
     "close",
-    ([] : Array[@js.Value]),
+    ([] : FixedArray[@js.Value]),
   )
 }
 

--- a/desktop/frontend/quick_open/view.mbt
+++ b/desktop/frontend/quick_open/view.mbt
@@ -22,7 +22,7 @@ fn focus_after_render() -> @cmd.Cmd {
       if @dom.document().get_element_by_id(InputId).to_option() is Some(input) {
         let _ : @js.Value = @js.Value::cast_from(input).apply_with_string(
           "focus",
-          ([] : Array[@js.Value]),
+          ([] : FixedArray[@js.Value]),
         )
       }
     },

--- a/desktop/frontend/select_control/view.mbt
+++ b/desktop/frontend/select_control/view.mbt
@@ -122,7 +122,7 @@ fn Control::focus(
     if @dom.document().get_element_by_id(id).to_option() is Some(element) {
       let _ : @js.Value = @js.Value::cast_from(element).apply_with_string(
         "focus",
-        ([] : Array[@js.Value]),
+        ([] : FixedArray[@js.Value]),
       )
     }
   }

--- a/desktop/frontend/session.mbt
+++ b/desktop/frontend/session.mbt
@@ -67,9 +67,9 @@ fn new_codex_chat(
 /// separate conversations.
 fn generated_session_id() -> String {
   let date_constructor : @js.Value = @js.globalThis.get_with_string("Date")
-  let now : @js.Value = date_constructor.new(([] : Array[@js.Value]))
+  let now : @js.Value = date_constructor.new(([] : FixedArray[@js.Value]))
   fn utc(name : String) -> Int {
-    now.apply_with_string(name, ([] : Array[@js.Value]))
+    now.apply_with_string(name, ([] : FixedArray[@js.Value]))
   }
 
   let date = pad(utc("getUTCFullYear"), 4) +
@@ -84,7 +84,10 @@ fn generated_session_id() -> String {
 ///|
 fn random_salt() -> String {
   let math : @js.Value = @js.globalThis.get_with_string("Math")
-  let value : Double = math.apply_with_string("random", ([] : Array[@js.Value]))
+  let value : Double = math.apply_with_string(
+    "random",
+    ([] : FixedArray[@js.Value]),
+  )
   pad((value * 1_000_000_000.0).to_int(), 9)
 }
 

--- a/desktop/frontend/sidebar_resize.mbt
+++ b/desktop/frontend/sidebar_resize.mbt
@@ -98,7 +98,7 @@ fn on_sidebar_resize_move(event : @dom.Event) -> Unit {
   let rect = app.get_bounding_client_rect()
   set_sidebar_width(
     drag_width(
-      mouse.get_client_x().to_double() - rect.get_left(),
+      mouse.get_client_x() - rect.get_left(),
       ceiling=rect.get_width() - MinContentWidth.to_double(),
     ),
   )

--- a/desktop/frontend/terminal/host.mbt
+++ b/desktop/frontend/terminal/host.mbt
@@ -123,7 +123,7 @@ fn terminal_style() -> @js.Value {
 }
 
 ///|
-fn no_args() -> Array[@js.Value] {
+fn no_args() -> FixedArray[@js.Value] {
   []
 }
 

--- a/desktop/frontend/terminal/resize.mbt
+++ b/desktop/frontend/terminal/resize.mbt
@@ -98,7 +98,7 @@ fn TerminalResizer::track(self : TerminalResizer, event : @dom.Event) -> Unit {
   let floor = MinTerminalHeight.to_double()
   let max = rect.get_height() - MinConversationHeight.to_double()
   let ceiling = max.max(floor)
-  let raw = rect.get_bottom() - mouse.get_client_y().to_double()
+  let raw = rect.get_bottom() - mouse.get_client_y()
   let height = raw.clamp(min=floor, max=ceiling)
   guard @dom.document().query_selector("html").to_option() is Some(root) else {
     return

--- a/desktop/frontend/transcript/component/component.mbt
+++ b/desktop/frontend/transcript/component/component.mbt
@@ -334,7 +334,7 @@ fn show_empty_project_menu_after_render() -> @cmd.Cmd {
         is Some(search) {
         let _ : @js.Value = @js.Value::cast_from(search).apply_with_string(
           "focus",
-          ([] : Array[@js.Value]),
+          ([] : FixedArray[@js.Value]),
         )
       }
     },
@@ -350,7 +350,7 @@ fn focus_empty_project_trigger_after_render() -> @cmd.Cmd {
         is Some(trigger) {
         let _ : @js.Value = @js.Value::cast_from(trigger).apply_with_string(
           "focus",
-          ([] : Array[@js.Value]),
+          ([] : FixedArray[@js.Value]),
         )
       }
     },
@@ -457,7 +457,12 @@ fn visible_turn_anchor(transcript : @dom.Element) -> String? {
   let mut found : Int? = None
   while low <= high {
     let middle = low + (high - low) / 2
-    if bubbles[middle].get_bounding_client_rect().get_top() <= reference {
+    if bubbles
+      .item(middle.to_double())
+      .unwrap()
+      .get_bounding_client_rect()
+      .get_top() <=
+      reference {
       found = Some(middle)
       low = middle + 1
     } else {
@@ -465,7 +470,7 @@ fn visible_turn_anchor(transcript : @dom.Element) -> String? {
     }
   }
   guard found is Some(index) else { return None }
-  bubbles[index].get_attribute("id")
+  bubbles.item(index.to_double()).unwrap().get_attribute("id")
 }
 
 ///|

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -713,7 +713,7 @@ fn clock_label(unix_ms : Double) -> String {
     return ""
   }
   let at : @js.Value = date_constructor.new([@js.Value::cast_from(unix_ms)])
-  let now : @js.Value = date_constructor.new(([] : Array[@js.Value]))
+  let now : @js.Value = date_constructor.new(([] : FixedArray[@js.Value]))
   let locales = @js.Value::cast_from(([] : Array[String]))
   let time_options = @js.Object::new()
   time_options["hour"] = "2-digit"
@@ -724,11 +724,11 @@ fn clock_label(unix_ms : Double) -> String {
   ])
   let at_date : String = at.apply_with_string(
     "toDateString",
-    ([] : Array[@js.Value]),
+    ([] : FixedArray[@js.Value]),
   )
   let today : String = now.apply_with_string(
     "toDateString",
-    ([] : Array[@js.Value]),
+    ([] : FixedArray[@js.Value]),
   )
   if at_date == today {
     return clock

--- a/desktop/frontend/window_titlebar.mbt
+++ b/desktop/frontend/window_titlebar.mbt
@@ -142,7 +142,7 @@ fn window_titlebar_sub_loader(
         unload: _ => {
           let _ : @js.Value = geometry.apply_with_string(
             "dispose",
-            ([] : Array[@js.Value]),
+            ([] : FixedArray[@js.Value]),
           )
           target.remove_event_listener_with_options(
             "dblclick",

--- a/desktop/moon.mod
+++ b/desktop/moon.mod
@@ -9,7 +9,7 @@ import {
   "moonbit-community/pty@0.4.1",
   "moonbit-community/fuzzy_match@0.2.6",
   "moonbit-community/flate@0.7.1",
-  "moonbit-community/rabbita@0.15.4",
+  "moonbit-community/rabbita@0.15.7",
   "moonbitlang/x@0.4.50",
   "moonbitlang/async@0.21.0",
   "moonbit-community/proton@0.2.9",

--- a/editor/base/browser/mouse_event.mbt
+++ b/editor/base/browser/mouse_event.mbt
@@ -56,8 +56,8 @@ pub fn StandardMouseEvent::StandardMouseEvent(
     } else {
       detail
     },
-    posx: e.get_page_x().to_double(),
-    posy: e.get_page_y().to_double(),
+    posx: e.get_page_x(),
+    posy: e.get_page_y(),
     ctrl_key: e.get_ctrl_key(),
     shift_key: e.get_shift_key(),
     alt_key: e.get_alt_key(),

--- a/editor/internal/viewer/browser/controller/scrollbar_input.mbt
+++ b/editor/internal/viewer/browser/controller/scrollbar_input.mbt
@@ -88,7 +88,7 @@ pub fn MouseHandler::delegate_vertical_scrollbar_pointer_down(
   let scrollable = self.view_helper.editor_scrollable
   let track_rect = scrollable.track(true).get_bounding_client_rect()
   let state = scrollable.state(true)
-  let pointer_position = mouse.get_client_y().to_double()
+  let pointer_position = mouse.get_client_y()
   let slider_start = track_rect.get_top() + state.slider_position()
   let slider_end = slider_start + state.slider_size()
   event.prevent_default()
@@ -265,9 +265,9 @@ fn scrollbar_drag_orthogonal_coord(
   vertical : Bool,
 ) -> Double {
   if vertical {
-    mouse.get_client_x().to_double()
+    mouse.get_client_x()
   } else {
-    mouse.get_client_y().to_double()
+    mouse.get_client_y()
   }
 }
 

--- a/editor/internal/viewer/browser/markdown/markdown_wbtest.mbt
+++ b/editor/internal/viewer/browser/markdown/markdown_wbtest.mbt
@@ -4,6 +4,11 @@
 /// policy remains product code in `install_markdown_dom`.
 extern "js" fn install_markdown_test_dom() -> Unit =
   #| () => {
+  #|   // rabbita reads DOM collections through `item(index)`, so the fake ones
+  #|   // are arrays carrying that method rather than bare arrays.
+  #|   const collection = (items) => Object.assign(items, {
+  #|     item: (index) => items[index] ?? null,
+  #|   });
   #|   const voidTags = new Set(["AREA", "BASE", "BR", "COL", "EMBED", "HR", "IMG", "INPUT", "LINK", "META", "PARAM", "SOURCE", "TRACK", "WBR"]);
   #|   const decode = (value) => value
   #|     .replaceAll("&quot;", "\"")
@@ -68,7 +73,7 @@ extern "js" fn install_markdown_test_dom() -> Unit =
   #|         }
   #|       };
   #|       visit(this);
-  #|       return result;
+  #|       return collection(result);
   #|     }
   #|     get textContent() { return this.childNodes.map((child) => child.textContent).join(""); }
   #|   }
@@ -126,7 +131,7 @@ extern "js" fn install_markdown_test_dom() -> Unit =
   #|     removeAttribute(name) { this.attributes.delete(name.toLowerCase()); }
   #|     remove() { this.parentNode?.removeChild(this); }
   #|     set innerHTML(value) { parseInto(this.tagName === "TEMPLATE" ? this.content : this, value, this.ownerDocument); }
-  #|     get children() { return this.childNodes.filter((child) => child.nodeType === 1); }
+  #|     get children() { return collection(this.childNodes.filter((child) => child.nodeType === 1)); }
   #|   }
   #|
   #|   class FakeDocument extends FakeTree {

--- a/editor/internal/viewer/browser/markdown_document/markdown_document.mbt
+++ b/editor/internal/viewer/browser/markdown_document/markdown_document.mbt
@@ -450,7 +450,7 @@ fn MarkdownDocumentView::post_render(self : MarkdownDocumentView) -> Unit {
       element_index < children.length() else {
       continue
     }
-    let element = children[element_index]
+    let element = children.item(element_index.to_double()).unwrap()
     element.set_attribute(
       "data-markdown-block-anchor",
       anchor.index.to_string(),
@@ -680,7 +680,8 @@ pub fn MarkdownDocumentView::set_hidden_root_elements(
   // `display:none`, so the view never owns or clobbers an element's `style`
   // attribute, and no `aria-hidden` bookkeeping is needed: `display:none`
   // already removes the subtree from the accessibility tree.
-  for index, child in children {
+  for index in 0..<children.length() {
+    let child = children.item(index.to_double()).unwrap()
     if hidden.contains(index) {
       child.set_attribute(markdown_hidden_element_attribute, "true")
     } else if child.has_attribute(markdown_hidden_element_attribute) {
@@ -731,7 +732,8 @@ pub fn MarkdownDocumentView::install_section_fold_controls(
       wanted[control.heading_element_index] = control
     }
   }
-  for index, child in children {
+  for index in 0..<children.length() {
+    let child = children.item(index.to_double()).unwrap()
     let existing = child.query_selector(markdown_fold_toggle_selector)
     match wanted.get(index) {
       Some(control) => {
@@ -790,7 +792,7 @@ let markdown_fold_toggle_selector : String = ".moonbit-viewer-markdown-fold-togg
 
 ///|
 fn markdown_first_child(element : @rdom.Element) -> @rdom.Node? {
-  element.get_children().get(0).map(first => first.as_node())
+  element.get_children().item(0).to_option().map(first => first.as_node())
 }
 
 ///|
@@ -946,7 +948,7 @@ fn MarkdownDocumentView::element_for_source_offset(
     }
     match anchor.rendered_element_index {
       Some(index) if index >= 0 && index < children.length() =>
-        return Some(children[index])
+        return Some(children.item(index.to_double()).unwrap())
       _ => ()
     }
   }
@@ -958,7 +960,7 @@ fn MarkdownDocumentView::element_for_source_offset(
       index < children.length() else {
       continue
     }
-    let element = children[index]
+    let element = children.item(index.to_double()).unwrap()
     if first_mapped is None {
       first_mapped = Some(element)
     }
@@ -1059,7 +1061,10 @@ pub fn MarkdownDocumentView::visible_source_ranges(
       index < children.length() else {
       continue
     }
-    let rect = children[index].get_bounding_client_rect()
+    let rect = children
+      .item(index.to_double())
+      .unwrap()
+      .get_bounding_client_rect()
     if rect.get_bottom() > viewport_top && rect.get_top() < viewport_bottom {
       result.push(anchor.source_range)
     }
@@ -1123,7 +1128,7 @@ pub fn MarkdownDocumentView::set_toc_entries(
   // Re-read the first child every pass: the underlying collection is live in
   // a real browser, so removing while iterating a snapshot hands the DOM an
   // undefined mid-loop.
-  while self.toc_list.get_children() is [stale, ..] {
+  while self.toc_list.get_children().item(0).to_option() is Some(stale) {
     self.toc_list.as_node().remove_child(stale.as_node())
   }
   for entry in entries {

--- a/editor/internal/viewer/code_editor_widget/overview_ruler.mbt
+++ b/editor/internal/viewer/code_editor_widget/overview_ruler.mbt
@@ -358,8 +358,7 @@ fn CodeEditorOverviewRuler::handle_pointer_down(
   }
   let rect = self.root.get_bounding_client_rect()
   let pixel_ratio = @base_browser.device_pixel_ratio().max(1.0)
-  let offset = ((mouse.get_client_y().to_double() - rect.get_top()) *
-    pixel_ratio)
+  let offset = ((mouse.get_client_y() - rect.get_top()) * pixel_ratio)
     .round()
     .to_int()
   guard closest_code_editor_overview_ruler_entry(self.bands, offset) is Some(id) else {

--- a/editor/internal/viewer/contrib/contextmenu/browser/context_menu_widget.mbt
+++ b/editor/internal/viewer/contrib/contextmenu/browser/context_menu_widget.mbt
@@ -225,7 +225,7 @@ fn ContextMenuWidget::rebuild_menu_shell(self : ContextMenuWidget) -> Unit {
 fn ContextMenuWidget::root_actions_node(
   self : ContextMenuWidget,
 ) -> @rdom.Element {
-  self.menu.get_children()[0].get_children()[0]
+  self.menu.get_children().item(0).unwrap().get_children().item(0).unwrap()
 }
 
 ///|

--- a/editor/internal/viewer/contrib/hover/browser/content_hover_widget.mbt
+++ b/editor/internal/viewer/contrib/hover/browser/content_hover_widget.mbt
@@ -212,10 +212,7 @@ pub fn ContentHoverWidget::ContentHoverWidget(
   wrapper.add_event_listener("mouseleave", event => {
     match event.to_mouse_event() {
       Some(mouse) =>
-        (host.handle_mouseleave)(
-          mouse.get_client_x().to_double(),
-          mouse.get_client_y().to_double(),
-        )
+        (host.handle_mouseleave)(mouse.get_client_x(), mouse.get_client_y())
       None => ()
     }
     event.stop_propagation()
@@ -845,8 +842,7 @@ fn hover_prefer_above(
 /// Monaco `dom.getDomNodePagePosition(editorDomNode).top`: client-rect top
 /// plus the window's vertical scroll.
 fn dom_node_page_top(node : @rdom.Element) -> Double {
-  node.get_bounding_client_rect().get_top() +
-  @rdom.window().scroll_y().to_double()
+  node.get_bounding_client_rect().get_top() + @rdom.window().scroll_y()
 }
 
 ///|

--- a/editor/internal/viewer/contrib/hover/browser/markdown_document_hover.mbt
+++ b/editor/internal/viewer/contrib/hover/browser/markdown_document_hover.mbt
@@ -426,10 +426,7 @@ fn MarkdownDocumentHoverBridge::bind_semantic_dom(
       self.invalidate_pointer_request()
       return
     }
-    self.on_pointer_move(
-      mouse.get_client_x().to_double(),
-      mouse.get_client_y().to_double(),
-    )
+    self.on_pointer_move(mouse.get_client_x(), mouse.get_client_y())
   })
 }
 

--- a/editor/internal/viewer/diff_editor/widget.mbt
+++ b/editor/internal/viewer/diff_editor/widget.mbt
@@ -504,9 +504,7 @@ fn DiffEditorWidget::install_event_bridges(self : DiffEditorWidget) -> Unit {
           .get_bounding_client_rect()
           .get_width()
           .max(1.0)
-        let state_relative_offset = (
-            Double::from_int(pointer_event.get_client_x()) - root_left
-          ) /
+        let state_relative_offset = (pointer_event.get_client_x() - root_left) /
           pane_width *
           self.layout_state.width
         if self.layout_state.set_split_from_pointer(state_relative_offset) {

--- a/editor/internal/viewer/markdown_viewer/markdown_viewer_definition.mbt
+++ b/editor/internal/viewer/markdown_viewer/markdown_viewer_definition.mbt
@@ -492,8 +492,8 @@ fn MarkdownViewerWidgetDefinitionBridge::bind_semantic_dom(
       self.cancel_link_preview()
       return
     }
-    self.last_client_x = mouse.get_client_x().to_double()
-    self.last_client_y = mouse.get_client_y().to_double()
+    self.last_client_x = mouse.get_client_x()
+    self.last_client_y = mouse.get_client_y()
     let target = self.target_at(self.last_client_x, self.last_client_y)
     self.last_target = target
     if mouse.get_buttons() == 0 &&
@@ -514,17 +514,13 @@ fn MarkdownViewerWidgetDefinitionBridge::bind_semantic_dom(
   self.view.listen_semantic_dom("contextmenu", event => {
     guard self.is_current() &&
       event.to_mouse_event() is Some(mouse) &&
-      self.target_at(
-        mouse.get_client_x().to_double(),
-        mouse.get_client_y().to_double(),
-      )
-      is Some(target) else {
+      self.target_at(mouse.get_client_x(), mouse.get_client_y()) is Some(target) else {
       return
     }
     if self.show_context_menu(
         target,
-        mouse.get_client_x().to_double(),
-        mouse.get_client_y().to_double(),
+        mouse.get_client_x(),
+        mouse.get_client_y(),
       ) {
       event.prevent_default()
       event.stop_propagation()
@@ -538,8 +534,8 @@ fn MarkdownViewerWidgetDefinitionBridge::bind_semantic_dom(
     guard standard.left_button && standard.detail <= 1 else { return }
     self.viewer.focus()
     self.mouse_down_target = self.target_at(
-      mouse.get_client_x().to_double(),
-      mouse.get_client_y().to_double(),
+      mouse.get_client_x(),
+      mouse.get_client_y(),
     )
     self.last_target = self.mouse_down_target
   })
@@ -548,10 +544,7 @@ fn MarkdownViewerWidgetDefinitionBridge::bind_semantic_dom(
       return
     }
     let standard = @base_browser.StandardMouseEvent(mouse)
-    let target = self.target_at(
-      mouse.get_client_x().to_double(),
-      mouse.get_client_y().to_double(),
-    )
+    let target = self.target_at(mouse.get_client_x(), mouse.get_client_y())
     let down = self.mouse_down_target
     self.mouse_down_target = None
     guard standard.left_button &&

--- a/editor/internal/viewer/ui/scrollbar/native_scrollable_element_input.mbt
+++ b/editor/internal/viewer/ui/scrollbar/native_scrollable_element_input.mbt
@@ -225,9 +225,9 @@ fn native_scrollbar_orthogonal_coord(
   vertical : Bool,
 ) -> Double {
   if vertical {
-    mouse.get_client_x().to_double()
+    mouse.get_client_x()
   } else {
-    mouse.get_client_y().to_double()
+    mouse.get_client_y()
   }
 }
 

--- a/editor/internal/viewer/ui/scrollbar/scrollable_element.mbt
+++ b/editor/internal/viewer/ui/scrollbar/scrollable_element.mbt
@@ -465,9 +465,9 @@ pub fn ScrollableElementDom::desired_position_from_track(
 ) -> Double {
   let rect = self.track(vertical).get_bounding_client_rect()
   let offset = if vertical {
-    mouse.get_client_y().to_double() - rect.get_top()
+    mouse.get_client_y() - rect.get_top()
   } else {
-    mouse.get_client_x().to_double() - rect.get_left()
+    mouse.get_client_x() - rect.get_left()
   }
   self.state(vertical).desired_position_from_offset(offset)
 }
@@ -586,8 +586,8 @@ fn away_from_zero(value : Double) -> Double {
 ///|
 pub fn drag_coord(mouse : @rdom.MouseEvent, vertical : Bool) -> Double {
   if vertical {
-    mouse.get_client_y().to_double()
+    mouse.get_client_y()
   } else {
-    mouse.get_client_x().to_double()
+    mouse.get_client_x()
   }
 }

--- a/editor/moon.mod
+++ b/editor/moon.mod
@@ -22,7 +22,7 @@ import {
   "moonbit-community/cmark@0.4.5",
   "moonbit-community/moondiff@0.0.7",
   "moonbitlang/async@0.21.0",
-  "moonbit-community/rabbita@0.15.4",
+  "moonbit-community/rabbita@0.15.7",
   "Milky2018/diago@0.3.0",
   "moonbitlang/x@0.4.50",
   "kokic/uml@0.2.2",

--- a/editor/viewer/browser/diagram_viewport/diagram_viewport.mbt
+++ b/editor/viewer/browser/diagram_viewport/diagram_viewport.mbt
@@ -553,8 +553,8 @@ fn MarkdownDiagramViewport::install_listeners(
     self.is_panning = true
     self.has_dragged = false
     self.pan_pointer_id = Some(@base_browser.mouse_event_pointer_id(mouse))
-    let client_x = Double::from_int(mouse.get_client_x())
-    let client_y = Double::from_int(mouse.get_client_y())
+    let client_x = mouse.get_client_x()
+    let client_y = mouse.get_client_y()
     self.start_x = client_x - self.translate_x
     self.start_y = client_y - self.translate_y
     self.previous_move_x = client_x
@@ -588,8 +588,8 @@ fn MarkdownDiagramViewport::install_listeners(
       } else {
         1.25
       },
-      Double::from_int(mouse.get_client_x()) - rect.get_left(),
-      Double::from_int(mouse.get_client_y()) - rect.get_top(),
+      mouse.get_client_x() - rect.get_left(),
+      mouse.get_client_y() - rect.get_top(),
     )
     |> ignore
   })
@@ -617,8 +617,8 @@ fn MarkdownDiagramViewport::install_listeners(
       let delta = -delta_y * diagram_zoom_factor * multiplier
       self.zoom_at_point(
         1.0 + delta,
-        Double::from_int(wheel.get_client_x()) - rect.get_left(),
-        Double::from_int(wheel.get_client_y()) - rect.get_top(),
+        wheel.get_client_x() - rect.get_left(),
+        wheel.get_client_y() - rect.get_top(),
       )
       |> ignore
     },
@@ -667,7 +667,7 @@ fn MarkdownDiagramViewport::install_listeners(
     }
     self.is_resizing = true
     self.resize_pointer_id = Some(@base_browser.mouse_event_pointer_id(mouse))
-    self.resize_start_y = Double::from_int(mouse.get_client_y())
+    self.resize_start_y = mouse.get_client_y()
     self.resize_start_height = rect.get_height()
   })
   self.listen(self.owner_window.as_event_target(), "pointermove", event => {
@@ -683,8 +683,8 @@ fn MarkdownDiagramViewport::install_listeners(
       }
       event.prevent_default()
       event.stop_propagation()
-      let client_x = Double::from_int(mouse.get_client_x())
-      let client_y = Double::from_int(mouse.get_client_y())
+      let client_x = mouse.get_client_x()
+      let client_y = mouse.get_client_y()
       let dx = client_x - self.previous_move_x
       let dy = client_y - self.previous_move_y
       if dx.abs() > diagram_drag_threshold || dy.abs() > diagram_drag_threshold {
@@ -705,9 +705,7 @@ fn MarkdownDiagramViewport::install_listeners(
       event.prevent_default()
       event.stop_propagation()
       self.resize_to_height(
-        self.resize_start_height +
-        Double::from_int(mouse.get_client_y()) -
-        self.resize_start_y,
+        self.resize_start_height + mouse.get_client_y() - self.resize_start_y,
       )
       |> ignore
     }

--- a/editor/viewer/browser/diagram_viewport/diagram_viewport_reference_wbtest.mbt
+++ b/editor/viewer/browser/diagram_viewport/diagram_viewport_reference_wbtest.mbt
@@ -22,6 +22,11 @@ type DiagramViewportTestHarness
 ///|
 extern "js" fn install_diagram_viewport_test_dom() -> DiagramViewportTestHarness =
   #| () => {
+  #|   // rabbita reads DOM collections through `item(index)`, so the fake ones
+  #|   // are arrays carrying that method rather than bare arrays.
+  #|   const collection = (items) => Object.assign(items, {
+  #|     item: (index) => items[index] ?? null,
+  #|   });
   #|   const harness = {
   #|     restored: false,
   #|     originals: {
@@ -164,7 +169,7 @@ extern "js" fn install_diagram_viewport_test_dom() -> DiagramViewportTestHarness
   #|     removeAttribute(name) { this.attributes.delete(String(name).toLowerCase()); }
   #|     get children() {
   #|       harness.childReads += 1;
-  #|       return this.childNodes.filter(child => child.nodeType === 1);
+  #|       return collection(this.childNodes.filter(child => child.nodeType === 1));
   #|     }
   #|     get firstChild() { return this.childNodes[0] ?? null; }
   #|     get nextSibling() {
@@ -218,7 +223,7 @@ extern "js" fn install_diagram_viewport_test_dom() -> DiagramViewportTestHarness
   #|         }
   #|       };
   #|       visit(this);
-  #|       return result;
+  #|       return collection(result);
   #|     }
   #|     getBoundingClientRect() {
   #|       if (this.tagName === 'SVG' &&

--- a/moon.mod
+++ b/moon.mod
@@ -7,7 +7,7 @@ import {
   "moonbitlang/x@0.4.50",
   "moonbitlang/jsonl@0.2.0",
   "bobzhang/openseek_protocol@0.1.1",
-  "moonbit-community/rabbita@0.15.4",
+  "moonbit-community/rabbita@0.15.7",
   "moonbitlang/editor@0.4.5",
   "moonbitlang/workflow@0.7.0",
 }


### PR DESCRIPTION
Upgrade Rabbita from 0.15.4 to 0.15.7 in the root, Desktop, editor, and viz modules. This removes the old `core/strconv` dependency that broke the editor check with nightly MoonBit.

Adapt callers to the current API: DOM coordinates return `Double`, JavaScript calls take `FixedArray` arguments, and DOM collections expose `item()` access. Convert coordinates to `Int` only at existing integer boundaries, and update the existing editor DOM fixtures to implement the collection contract.

Rebased onto `main` at `10b1f5b27`, preserving main's removal of the repeated titlebar `refreshDom` scan. No public interface changes.

Validation on macOS with MoonBit 0.1.20260904:

- `just check`, `just build`, `moon info`, and `moon fmt`.
- `just test`: 3248 native and 3217 JS tests; 24 cram cases; CLI turn-finish integration test.
- `just editor-test`: 1090 Wasm, 1875 JS, and 1224 native tests.
- Editor all-target check with `--warn-list +73 --deny-warn`.
- Browser suites: editor 107, Desktop 58, and viz 13 tests.
- `git diff --check` and `git range-diff`; one commit above main, no merge commits.
