### PR TITLE
feat(desktop): add on-demand moon.mod dependency graphs

### DIFF
--- a/desktop/e2e/tests/rabbita_dom.spec.js
+++ b/desktop/e2e/tests/rabbita_dom.spec.js
@@ -344,7 +344,7 @@ test('ordinary MBTI files render as UML and reviews keep source surfaces', async
   expect(app.pageErrors).toEqual([]);
 });
 
-test('ordinary moon.mod defaults to its package graph and round-trips to source', async ({ page }) => {
+test('ordinary moon.mod defaults to source and loads its package graph on demand', async ({ page }) => {
   const app = new DesktopBrowserHarness(page);
   const path = 'moon.mod';
   const working = [
@@ -361,6 +361,20 @@ test('ordinary moon.mod defaults to its package graph and round-trips to source'
   await app.openQuickOpen();
   await page.getByRole('option', { name: /moon\.mod/ }).click();
 
+  const diagram = page.locator('#package-diagram-host');
+  const view = page.getByRole('group', { name: 'Moon module view' });
+  await expect(page.locator('#viewer-host')).toBeVisible();
+  await expect(page.locator('#viewer-host')).toContainText('example/app');
+  await expect(view.getByRole('button', { name: 'Source' })).toHaveAttribute(
+    'aria-pressed',
+    'true',
+  );
+  await expect(diagram).toBeHidden();
+  expect(app.requests.filter(
+    request => request.method === 'moon.package_graph',
+  )).toHaveLength(0);
+  await view.getByRole('button', { name: 'Dependency graph' }).click();
+
   await expect.poll(() => app.requests.find(
     request => request.method === 'moon.package_graph',
   )).toMatchObject({
@@ -370,7 +384,6 @@ test('ordinary moon.mod defaults to its package graph and round-trips to source'
       path: 'moon.mod',
     },
   });
-  const diagram = page.locator('#package-diagram-host');
   await expect(diagram).toBeVisible();
   await expect(diagram.locator('svg')).toBeVisible();
   await expect(diagram.locator('svg')).toContainText('main');
@@ -387,7 +400,6 @@ test('ordinary moon.mod defaults to its package graph and round-trips to source'
     diagram.getByRole('separator', { name: 'Resize diagram' }),
   ).toHaveCount(0);
 
-  const view = page.getByRole('group', { name: 'Moon module view' });
   await expect(view.getByRole('button')).toHaveText(['Dependency graph', 'Source']);
   await expect(
     view.getByRole('button', { name: 'Dependency graph' }),

--- a/desktop/e2e/tests/rabbita_dom.spec.js
+++ b/desktop/e2e/tests/rabbita_dom.spec.js
@@ -1,6 +1,23 @@
 import { test, expect } from '@playwright/test';
 import { DesktopBrowserHarness } from './support/desktop_browser_harness.js';
 
+async function diagramViewportFillsHost(host) {
+  return host.evaluate((element) => {
+    const viewport = element.querySelector(
+      ':scope > .moonbit-viewer-markdown-diagram-viewport',
+    );
+    if (!viewport) return false;
+    const hostRect = element.getBoundingClientRect();
+    const viewportRect = viewport.getBoundingClientRect();
+    return [
+      viewportRect.left - hostRect.left,
+      viewportRect.top - hostRect.top,
+      viewportRect.right - hostRect.right,
+      viewportRect.bottom - hostRect.bottom,
+    ].every((delta) => Math.abs(delta) <= 1);
+  });
+}
+
 test('workspace search supports toggles and keyboard navigation', async ({ page }) => {
   const app = new DesktopBrowserHarness(page);
   await app.install();
@@ -283,6 +300,16 @@ test('ordinary MBTI files render as UML and reviews keep source surfaces', async
   await expect(diagram).toBeVisible();
   await expect(diagram.locator('svg')).toBeVisible();
   await expect(diagram.locator('svg')).toContainText('Point');
+  await expect(
+    diagram.getByRole('toolbar', { name: 'UML diagram controls' }),
+  ).toBeVisible();
+  await expect(
+    diagram.getByRole('button', { name: 'Zoom in' }),
+  ).toBeVisible();
+  await expect.poll(() => diagramViewportFillsHost(diagram)).toBe(true);
+  await expect(
+    diagram.getByRole('separator', { name: 'Resize diagram' }),
+  ).toHaveCount(0);
   const view = page.getByRole('group', { name: 'MBTI view' });
   await expect(view.getByRole('button')).toHaveText(['Diagram', 'Source']);
   await expect(view.getByRole('button', { name: 'Diagram' })).toHaveAttribute(
@@ -314,6 +341,72 @@ test('ordinary MBTI files render as UML and reviews keep source surfaces', async
   await expect(page.locator('#viewer-host')).toBeVisible();
   await expect(page.locator('#viewer-host')).toContainText('Point');
   await expect(diagram).toBeHidden();
+  expect(app.pageErrors).toEqual([]);
+});
+
+test('ordinary moon.mod defaults to its package graph and round-trips to source', async ({ page }) => {
+  const app = new DesktopBrowserHarness(page);
+  const path = 'moon.mod';
+  const working = [
+    'name = "example/app"',
+    'version = "0.1.0"',
+    '',
+  ].join('\n');
+  app.searchFiles = [path];
+  app.workingFiles[path] = working;
+
+  await app.install();
+  await app.goto();
+  await app.openSession();
+  await app.openQuickOpen();
+  await page.getByRole('option', { name: /moon\.mod/ }).click();
+
+  await expect.poll(() => app.requests.find(
+    request => request.method === 'moon.package_graph',
+  )).toMatchObject({
+    params: {
+      session: 'session-1',
+      root: '/workspace',
+      path: 'moon.mod',
+    },
+  });
+  const diagram = page.locator('#package-diagram-host');
+  await expect(diagram).toBeVisible();
+  await expect(diagram.locator('svg')).toBeVisible();
+  await expect(diagram.locator('svg')).toContainText('main');
+  await expect(diagram.locator('svg')).toContainText('core');
+  await expect(diagram.locator('svg')).toContainText('util');
+  await expect(
+    diagram.getByRole('toolbar', { name: 'UML diagram controls' }),
+  ).toBeVisible();
+  await expect(
+    diagram.getByRole('button', { name: 'Fit diagram' }),
+  ).toBeVisible();
+  await expect.poll(() => diagramViewportFillsHost(diagram)).toBe(true);
+  await expect(
+    diagram.getByRole('separator', { name: 'Resize diagram' }),
+  ).toHaveCount(0);
+
+  const view = page.getByRole('group', { name: 'Moon module view' });
+  await expect(view.getByRole('button')).toHaveText(['Dependency graph', 'Source']);
+  await expect(
+    view.getByRole('button', { name: 'Dependency graph' }),
+  ).toHaveAttribute('aria-pressed', 'true');
+
+  await view.getByRole('button', { name: 'Source' }).click();
+  await expect(diagram).toBeHidden();
+  await expect(page.locator('#viewer-host')).toBeVisible();
+  await expect(page.locator('#viewer-host')).toContainText('example/app');
+  await expect(view.getByRole('button', { name: 'Source' })).toHaveAttribute(
+    'aria-pressed',
+    'true',
+  );
+
+  await view.getByRole('button', { name: 'Dependency graph' }).click();
+  await expect(diagram.locator('svg')).toBeVisible();
+  expect(app.requests.filter(
+    request => request.method === 'moon.package_graph',
+  )).toHaveLength(1);
   expect(app.pageErrors).toEqual([]);
 });
 

--- a/desktop/e2e/tests/support/desktop_browser_harness.js
+++ b/desktop/e2e/tests/support/desktop_browser_harness.js
@@ -94,6 +94,40 @@ export class DesktopBrowserHarness {
       ].join('\n'),
     };
     this.searchFiles = ['src/main.mbt', 'README.md'];
+    // `moon.package_graph` returns the command's JSON verbatim. The default
+    // UML filter keeps branching nodes, so the fixture has one package with
+    // two source dependencies and exercises the real renderer path.
+    this.packageGraphSource = JSON.stringify({
+      version: 2,
+      status: 'success',
+      error: null,
+      root: [0],
+      nodes: [
+        {
+          module: 'example/app',
+          version: '0.1.0',
+          source: { kind: 'local', path: '/workspace/app' },
+          rel: 'main',
+        },
+        {
+          module: 'example/lib',
+          version: '0.1.0',
+          source: { kind: 'local', path: '/workspace/lib' },
+          rel: 'core',
+        },
+        {
+          module: 'example/lib',
+          version: '0.1.0',
+          source: { kind: 'local', path: '/workspace/lib' },
+          rel: 'util',
+        },
+      ],
+      edges: [
+        { from: 0, to: 1, alias: 'core', kinds: ['source'] },
+        { from: 0, to: 2, alias: 'util', kinds: ['source'] },
+      ],
+      logs: [],
+    });
     // Transcript images use the same fs.read_file RPC as text files, but the
     // real host returns bytes plus a verified media type. Tests opt into that
     // response per path instead of bypassing the product image loader.
@@ -767,6 +801,8 @@ export class DesktopBrowserHarness {
         };
       case 'git.original_file':
         return this.gitOriginalFile(request.params || {});
+      case 'moon.package_graph':
+        return { kind: 'source', source: this.packageGraphSource };
       case 'fs.read_directory':
         return { entries: this.directoryEntries[request.params?.path] || [] };
       case 'fs.read_file':

--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -2,7 +2,8 @@
 // no escape hatch for a foreign DOM widget, so the source viewer and Line
 // full-file comparison each own a stable, never-diffed host element. The view
 // renders those hosts empty, and after the first paint each widget attaches its
-// imperative DOM. Token/Tree uses a fourth stable sibling containing keyed,
+// imperative DOM. Diagrams use their own stable siblings, and Token/Tree uses
+// another stable sibling containing keyed,
 // empty per-section hosts; each receives a real DiffEditor. Every top-level
 // stays independent, so no global monotonic line mapping is synthesized.
 
@@ -22,6 +23,12 @@ const MarkdownViewerHostId = "markdown-viewer-host"
 /// MoonBit interface. The code Viewer keeps the same source model mounted
 /// behind it so switching back to source is non-destructive.
 const MbtiDiagramHostId = "mbti-diagram-host"
+
+///|
+/// The stable sibling host for a `moon.mod` package-dependency graph. Its
+/// source is produced asynchronously by the Desktop Host, while the ordinary
+/// code Viewer keeps the manifest model mounted behind it.
+const PackageDiagramHostId = "package-diagram-host"
 
 ///|
 /// The stable sibling host reserved for the switchable DiffEditor.
@@ -76,11 +83,20 @@ priv struct ViewerHost {
   // inside the code Viewer. It shares product services but owns its own model
   // and view-state lifetime.
   mut markdown_viewer : @viewer.MarkdownViewer?
-  // The MBTI host is plain generated SVG rather than another editor widget.
-  // Cache the rendered input so unrelated app updates do not repeat UML
-  // layout while its stable host remains mounted.
+  // The MBTI host uses the same interactive SVG viewport as diagrams rendered
+  // in Markdown. Cache the rendered input so unrelated app updates do not
+  // repeat UML layout while its stable host remains mounted, and retain the
+  // viewport handle so every borrowed listener and DOM node is released before
+  // replacing that SVG.
   mut mbti_resource : String?
   mut mbti_source : String?
+  mut mbti_diagram_viewports : @diagram_viewport.DiagramViewports?
+  // Package graph layout is also imperative. Cache the complete presentation
+  // so root-level sync messages cannot recreate a loading/error live region or
+  // make a screen reader announce the same status repeatedly. Its generated
+  // SVG has an independent Markdown diagram viewport lifetime.
+  mut package_graph : PackageGraphState?
+  mut package_diagram_viewports : @diagram_viewport.DiagramViewports?
   // Desired full-comparison layout survives a pre-mount command in the same
   // way font settings do for the source Viewer.
   mut diff_options : @viewer.DiffEditorOptions
@@ -140,6 +156,9 @@ let viewer_state : ViewerHost = {
   markdown_viewer: None,
   mbti_resource: None,
   mbti_source: None,
+  mbti_diagram_viewports: None,
+  package_graph: None,
+  package_diagram_viewports: None,
   diff_options: @viewer.DiffEditorOptions(
     editor_options=@viewer.ViewerOptions(
       theme="light",
@@ -316,6 +335,13 @@ fn uses_markdown_presentation(name : String) -> Bool {
 ///|
 fn uses_mbti_presentation(name : String) -> Bool {
   name.to_lower().has_suffix(".mbti")
+}
+
+///|
+/// Only the module manifest itself owns the dependency-graph presentation;
+/// similarly named files and legacy JSON manifests remain ordinary source.
+fn uses_moon_mod_presentation(name : String) -> Bool {
+  name == "moon.mod"
 }
 
 ///|
@@ -1019,6 +1045,23 @@ fn dispose_source_model(model : @model.TextModel?) -> Unit {
 }
 
 ///|
+/// Put one trusted generated SVG behind the same interaction surface used by
+/// Markdown diagrams. The wrapper is the shared component's DOM contract; the
+/// returned lifetime owns its controls, resize observer, and input listeners.
+fn mount_generated_svg_viewport(
+  host : @dom.Element,
+  svg : String,
+) -> @diagram_viewport.DiagramViewports {
+  host.set_inner_html("")
+  let wrapper = @dom.document().create_element("div")
+  wrapper.set_attribute("class", "moonbit-viewer-markdown-diagram")
+  wrapper.set_attribute("data-diagram-language", "uml")
+  wrapper.set_inner_html(svg)
+  host.append_child(wrapper.as_node())
+  @diagram_viewport.DiagramViewports(host, () => (), fill_container=true)
+}
+
+///|
 /// Render a generated interface into the stable MBTI host at most once per
 /// resource/content pair. The UML module returns generated SVG at this trusted
 /// insertion boundary; a malformed interface gets an explicit error surface
@@ -1035,8 +1078,15 @@ fn show_mbti_diagram(resource : @common.Uri, source : String) -> Unit {
   }
   viewer_state.mbti_resource = Some(resource_key)
   viewer_state.mbti_source = Some(source)
+  if viewer_state.mbti_diagram_viewports is Some(viewports) {
+    viewports.dispose()
+  }
+  viewer_state.mbti_diagram_viewports = None
   match @viewer.render_mbti_diagram_svg(source) {
-    Some(svg) => host.set_inner_html(svg)
+    Some(svg) =>
+      viewer_state.mbti_diagram_viewports = Some(
+        mount_generated_svg_viewport(host, svg),
+      )
     None => {
       let message =
         #|<div class="mbti-diagram-error" role="status">This interface could not be rendered as a UML diagram. View the source for details.</div>
@@ -1049,7 +1099,83 @@ fn show_mbti_diagram(resource : @common.Uri, source : String) -> Unit {
 fn clear_mbti_diagram() -> Unit {
   viewer_state.mbti_resource = None
   viewer_state.mbti_source = None
+  if viewer_state.mbti_diagram_viewports is Some(viewports) {
+    viewports.dispose()
+  }
+  viewer_state.mbti_diagram_viewports = None
   if @dom.document().get_element_by_id(MbtiDiagramHostId).to_option()
+    is Some(host) {
+    host.set_inner_html("")
+  }
+}
+
+///|
+/// Replace the package graph host with a status node without interpreting any
+/// Host-provided text as HTML. Only SVG returned by the pinned UML renderer is
+/// inserted through the trusted `innerHTML` boundary below.
+fn show_package_diagram_status(host : @dom.Element, message : String) -> Unit {
+  if viewer_state.package_diagram_viewports is Some(viewports) {
+    viewports.dispose()
+  }
+  viewer_state.package_diagram_viewports = None
+  host.set_inner_html("")
+  let status = @dom.document().create_element("div")
+  status.set_attribute("class", "package-diagram-status")
+  status.set_attribute("role", "status")
+  status.append_child(@dom.document().create_text_node(message).as_node())
+  host.append_child(status.as_node())
+}
+
+///|
+/// Reconcile one asynchronous `moon tree --package --json` result into the
+/// stable package-diagram host after Rabbita has exposed it. Every complete
+/// presentation is applied at most once; a new loading or failure state still
+/// retires the preceding graph so switching tabs can never display stale SVG.
+fn show_package_graph_in_viewer(state : PackageGraphState) -> @cmd.Cmd {
+  after_render_effect(() => {
+    guard @dom.document().get_element_by_id(PackageDiagramHostId).to_option()
+      is Some(host) else {
+      return
+    }
+    if viewer_state.package_graph == Some(state) {
+      return
+    }
+    viewer_state.package_graph = Some(state)
+    match state {
+      PackageGraphLoading(_) =>
+        show_package_diagram_status(host, "Loading dependency graph…")
+      PackageGraphReady(_, source) =>
+        match @viewer.render_package_dep_diagram_svg(source) {
+          Some(svg) => {
+            if viewer_state.package_diagram_viewports is Some(viewports) {
+              viewports.dispose()
+            }
+            viewer_state.package_diagram_viewports = Some(
+              mount_generated_svg_viewport(host, svg),
+            )
+          }
+          None =>
+            show_package_diagram_status(
+              host, "This dependency graph could not be rendered. View the source for details.",
+            )
+        }
+      PackageGraphFailed(_, message) =>
+        show_package_diagram_status(
+          host,
+          "Could not load dependency graph: \{message}",
+        )
+    }
+  })
+}
+
+///|
+fn clear_package_graph() -> Unit {
+  viewer_state.package_graph = None
+  if viewer_state.package_diagram_viewports is Some(viewports) {
+    viewports.dispose()
+  }
+  viewer_state.package_diagram_viewports = None
+  if @dom.document().get_element_by_id(PackageDiagramHostId).to_option()
     is Some(host) {
     host.set_inner_html("")
   }
@@ -1126,6 +1252,9 @@ fn show_file_in_viewer(
     }
     if uses_mbti_presentation(name) {
       show_mbti_diagram(uri, content)
+    }
+    if !uses_moon_mod_presentation(name) {
+      clear_package_graph()
     }
     // Whether anything needs redrawing is decided here, against the document
     // the viewer really shows — the update loop only says "show this", it
@@ -1433,6 +1562,7 @@ fn clear_viewer() -> @cmd.Cmd {
     viewer_state.relative = None
     viewer_state.navigation = None
     clear_mbti_diagram()
+    clear_package_graph()
     clear_diff_comparison()
     clear_semantic_review_editors()
   })
@@ -1471,6 +1601,7 @@ fn clear_document() -> @cmd.Cmd {
     viewer_state.relative = None
     viewer_state.navigation = None
     clear_mbti_diagram()
+    clear_package_graph()
   })
 }
 

--- a/desktop/frontend/fileeditor/files.mbt
+++ b/desktop/frontend/fileeditor/files.mbt
@@ -163,6 +163,68 @@ fn read_file(
 }
 
 ///|
+/// Ask the owning Desktop Host to run `moon tree --package --json` beside an
+/// exact `moon.mod`. This auxiliary failure is kept separate from the source
+/// read so the editable manifest remains available when Moon cannot render it.
+fn read_package_graph(
+  dispatch : @cmd.Emit[Msg],
+  owner : @interop.ConversationKey,
+  epoch : Int,
+  path : @pathx.Relative,
+  generation : Int,
+  root~ : @common.Uri?,
+) -> @cmd.Cmd {
+  guard root is Some(root) && @resource.belongs_to(root, owner.channel) else {
+    return dispatch(
+      PackageGraphRequestFailed(
+        owner~,
+        epoch~,
+        path~,
+        generation~,
+        message="file root moved to another host before package graph request",
+      ),
+    )
+  }
+  @cmd.custom_cmd(scheduler => {
+    @js.async_run(() => {
+      let reply = @interop.bridge_request(
+        owner.channel,
+        @commands.moon_package_graph,
+        { session: owner.session, root: root.path, path: path.0, },
+      ) catch {
+        error => {
+          scheduler.add(
+            dispatch(
+              PackageGraphRequestFailed(
+                owner~,
+                epoch~,
+                path~,
+                generation~,
+                message=@interop.bridge_error_text(error),
+              ),
+            ),
+          )
+          return
+        }
+      }
+      let message = match reply {
+        @protocol.PackageGraphSource(source~) =>
+          PackageGraphRequestLoaded(owner~, epoch~, path~, generation~, source~)
+        @protocol.PackageGraphError(message~) =>
+          PackageGraphRequestFailed(
+            owner~,
+            epoch~,
+            path~,
+            generation~,
+            message~,
+          )
+      }
+      scheduler.add(dispatch(message))
+    })
+  })
+}
+
+///|
 /// A workspace-relative path's final `/`-segment, for a mention chip's jump
 /// target — it carries only the path, not a display name.
 pub fn basename(path : @pathx.Relative) -> String {

--- a/desktop/frontend/fileeditor/moon.pkg
+++ b/desktop/frontend/fileeditor/moon.pkg
@@ -10,6 +10,7 @@ import {
   "moonbitlang/editor/language",
   "moonbitlang/editor/viewer/diff_provider/moondiff" @moon_diff_provider,
   "moonbitlang/editor/viewer",
+  "moonbitlang/editor/viewer/browser/diagram_viewport",
   "moonbitlang/editor/viewer/common/agent_feedback_api",
   "moonbitlang/editor/viewer/common/languages",
   "moonbitlang/editor/viewer/common/markers",

--- a/desktop/frontend/fileeditor/moon_mod_presentation_wbtest.mbt
+++ b/desktop/frontend/fileeditor/moon_mod_presentation_wbtest.mbt
@@ -1,0 +1,266 @@
+///|
+fn moon_mod_test_state() -> (State, Ctx, @pathx.Relative) raise {
+  let path = @pathx.Relative("moon.mod")
+  let docs = owned_state().docs.copy()
+  docs[path] = loaded_doc(path.0)
+  let state = { ..owned_state(), docs, }
+  let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path), }
+  (state, ctx, path)
+}
+
+///|
+test "ordinary moon.mod defaults to one generation-fenced dependency request" {
+  let (state, ctx, path) = moon_mod_test_state()
+  assert_true(moon_mod_view_available(state, ctx))
+  assert_true(uses_package_diagram_surface(state, ctx))
+  assert_true(state.moon_mod_view_mode(path) is MoonModDependencies)
+
+  let (loading, _) = sync(test_emit(), state, ctx)
+  guard loading.package_graphs.get(path)
+    is Some(PackageGraphLoading(generation)) else {
+    fail("expected the default dependency graph request")
+  }
+  assert_eq(generation, 1)
+  let (still_loading, _) = sync(test_emit(), loading, ctx)
+  assert_true(
+    still_loading.package_graphs.get(path) ==
+    Some(PackageGraphLoading(generation)),
+  )
+  assert_eq(still_loading.package_graph_generation, generation)
+}
+
+///|
+test "package graph replies accept only the current owner epoch path and generation" {
+  let (state, ctx, path) = moon_mod_test_state()
+  let (loading, _) = sync(test_emit(), state, ctx)
+  let stale = PackageGraphRequestLoaded(
+    owner=ctx.owner,
+    epoch=ctx.request_epoch,
+    path~,
+    generation=0,
+    source="stale",
+  )
+  let (_, after_stale) = update(test_emit(), stale, loading, ctx)
+  assert_true(after_stale == loading)
+
+  let wrong_owner = PackageGraphRequestLoaded(
+    owner={ ..ctx.owner, session: "another-session", },
+    epoch=ctx.request_epoch,
+    path~,
+    generation=1,
+    source="wrong-owner",
+  )
+  let (_, after_wrong_owner) = update(test_emit(), wrong_owner, loading, ctx)
+  assert_true(after_wrong_owner == loading)
+  let wrong_epoch = PackageGraphRequestLoaded(
+    owner=ctx.owner,
+    epoch=ctx.request_epoch + 1,
+    path~,
+    generation=1,
+    source="wrong-epoch",
+  )
+  let (_, after_wrong_epoch) = update(test_emit(), wrong_epoch, loading, ctx)
+  assert_true(after_wrong_epoch == loading)
+  let wrong_path = PackageGraphRequestLoaded(
+    owner=ctx.owner,
+    epoch=ctx.request_epoch,
+    path=@pathx.Relative("nested/moon.mod"),
+    generation=1,
+    source="wrong-path",
+  )
+  let (_, after_wrong_path) = update(test_emit(), wrong_path, loading, ctx)
+  assert_true(after_wrong_path == loading)
+
+  let current = PackageGraphRequestLoaded(
+    owner=ctx.owner,
+    epoch=ctx.request_epoch,
+    path~,
+    generation=1,
+    source="graph-json",
+  )
+  let (_, ready) = update(test_emit(), current, loading, ctx)
+  assert_true(
+    ready.package_graphs.get(path) == Some(PackageGraphReady(1, "graph-json")),
+  )
+
+  let late_failure = PackageGraphRequestFailed(
+    owner=ctx.owner,
+    epoch=ctx.request_epoch,
+    path~,
+    generation=1,
+    message="late",
+  )
+  let (_, after_late_failure) = update(test_emit(), late_failure, ready, ctx)
+  assert_true(after_late_failure == ready)
+}
+
+///|
+test "source preserves a ready graph and failed dependency view retries explicitly" {
+  let (state, ctx, path) = moon_mod_test_state()
+  let package_graphs = state.package_graphs.copy()
+  package_graphs[path] = PackageGraphReady(4, "cached")
+  let ready = { ..state, package_graphs, package_graph_generation: 4, }
+  let (_, source) = update(
+    test_emit(),
+    MoonModViewModeSelected(MoonModSource),
+    ready,
+    ctx,
+  )
+  assert_true(source.moon_mod_view_mode(path) is MoonModSource)
+  assert_false(uses_package_diagram_surface(source, ctx))
+  assert_true(
+    source.package_graphs.get(path) == Some(PackageGraphReady(4, "cached")),
+  )
+
+  let (_, dependencies) = update(
+    test_emit(),
+    MoonModViewModeSelected(MoonModDependencies),
+    source,
+    ctx,
+  )
+  assert_true(uses_package_diagram_surface(dependencies, ctx))
+  assert_true(
+    dependencies.package_graphs.get(path) ==
+    Some(PackageGraphReady(4, "cached")),
+  )
+
+  let failed_graphs = dependencies.package_graphs.copy()
+  failed_graphs[path] = PackageGraphFailed(5, "moon failed")
+  let failed = {
+    ..dependencies,
+    package_graphs: failed_graphs,
+    package_graph_generation: 5,
+  }
+  let (_, source_after_failure) = update(
+    test_emit(),
+    MoonModViewModeSelected(MoonModSource),
+    failed,
+    ctx,
+  )
+  assert_true(source_after_failure.moon_mod_view_mode(path) is MoonModSource)
+  assert_true(
+    source_after_failure.package_graphs.get(path) ==
+    Some(PackageGraphFailed(5, "moon failed")),
+  )
+  let (_, retrying) = update(
+    test_emit(),
+    MoonModViewModeSelected(MoonModDependencies),
+    source_after_failure,
+    ctx,
+  )
+  assert_true(retrying.package_graphs.get(path) is None)
+  let (loading, _) = sync(test_emit(), retrying, ctx)
+  assert_true(loading.package_graphs.get(path) == Some(PackageGraphLoading(6)))
+}
+
+///|
+test "positioned moon.mod opens source and close forgets all graph state" {
+  let (state, ctx, path) = moon_mod_test_state()
+  let (_, positioned) = open_document(
+    test_emit(),
+    state,
+    ctx,
+    path,
+    name="moon.mod",
+    range=Some(@common.Range(1, 1, 1, 5)),
+    had_active=true,
+  )
+  assert_true(positioned.moon_mod_view_mode(path) is MoonModSource)
+
+  let graphs = positioned.package_graphs.copy()
+  graphs[path] = PackageGraphReady(1, "cached")
+  let positioned = { ..positioned, package_graphs: graphs, }
+  let (_, closed) = close_document(
+    test_emit(),
+    positioned,
+    { ..ctx, open_files: [], active_file: None, },
+    path,
+    next=None,
+    was_active=true,
+  )
+  assert_true(closed.moon_mod_view_modes.get(path) is None)
+  assert_true(closed.package_graphs.get(path) is None)
+  assert_true(closed.moon_mod_view_mode(path) is MoonModDependencies)
+}
+
+///|
+test "reviewed and historical moon.mod views remain source-only" {
+  let (state, ctx, path) = moon_mod_test_state()
+  let docs = state.docs.copy()
+  docs[path] = {
+    ..docs[path],
+    review: Some({
+      generation: 1,
+      working_generation: 1,
+      baseline: ReviewContent("name = \"old/app\""),
+      view_mode: ReviewSource,
+      selected: test_modified_change(path),
+    }),
+  }
+  let reviewed = { ..state, docs, }
+  assert_false(moon_mod_view_available(reviewed, ctx))
+  assert_false(uses_package_diagram_surface(reviewed, ctx))
+  let (_, after_toggle) = update(
+    test_emit(),
+    MoonModViewModeSelected(MoonModSource),
+    reviewed,
+    ctx,
+  )
+  assert_true(after_toggle == reviewed)
+  let (after_sync, _) = sync(test_emit(), reviewed, ctx)
+  assert_true(after_sync.package_graphs.get(path) is None)
+
+  let history = {
+    ..ctx,
+    active_file: None,
+    active_history_diff: Some({
+      commit: "commit",
+      parent: Some("parent"),
+      path,
+      original_path: None,
+      status: "M",
+      kind: "modified",
+    }),
+  }
+  assert_false(moon_mod_view_available(state, history))
+  assert_false(uses_package_diagram_surface(state, history))
+}
+
+///|
+test "package graph invalidation covers manifests but not source edits" {
+  assert_true(Modified(@pathx.Relative("moon.mod")).package_graph_relevant())
+  assert_true(
+    Modified(@pathx.Relative("nested/moon.pkg")).package_graph_relevant(),
+  )
+  assert_true(
+    Renamed(
+      old=@pathx.Relative("old/moon.work"),
+      new=@pathx.Relative("new/moon.work"),
+    ).package_graph_relevant(),
+  )
+  assert_false(
+    Modified(@pathx.Relative("src/main.mbt")).package_graph_relevant(),
+  )
+  assert_false(
+    Modified(@pathx.Relative("notes/moon.mod.bak")).package_graph_relevant(),
+  )
+}
+
+///|
+test "watcher baseline invalidates a graph cached across its observation gap" {
+  let (state, ctx, path) = moon_mod_test_state()
+  let package_graphs = state.package_graphs.copy()
+  package_graphs[path] = PackageGraphReady(3, "cached")
+  let state = { ..state, package_graphs, package_graph_generation: 3, }
+  let (_, invalidated) = update(
+    test_emit(),
+    FsChanged(
+      root=ctx.test_root(),
+      generation=ctx.watch_identity(state.watch_generation),
+      changes=None,
+    ),
+    state,
+    ctx,
+  )
+  assert_true(invalidated.package_graphs.get(path) is None)
+}

--- a/desktop/frontend/fileeditor/moon_mod_presentation_wbtest.mbt
+++ b/desktop/frontend/fileeditor/moon_mod_presentation_wbtest.mbt
@@ -9,16 +9,27 @@ fn moon_mod_test_state() -> (State, Ctx, @pathx.Relative) raise {
 }
 
 ///|
-test "ordinary moon.mod defaults to one generation-fenced dependency request" {
+test "ordinary moon.mod defaults to source and requests its graph only when selected" {
   let (state, ctx, path) = moon_mod_test_state()
   assert_true(moon_mod_view_available(state, ctx))
+  assert_false(uses_package_diagram_surface(state, ctx))
+  assert_true(state.moon_mod_view_mode(path) is MoonModSource)
+
+  let (source, _) = sync(test_emit(), state, ctx)
+  assert_true(source.package_graphs.get(path) is None)
+  assert_eq(source.package_graph_generation, 0)
+  let (_, state) = update(
+    test_emit(),
+    MoonModViewModeSelected(MoonModDependencies),
+    source,
+    ctx,
+  )
   assert_true(uses_package_diagram_surface(state, ctx))
-  assert_true(state.moon_mod_view_mode(path) is MoonModDependencies)
 
   let (loading, _) = sync(test_emit(), state, ctx)
   guard loading.package_graphs.get(path)
     is Some(PackageGraphLoading(generation)) else {
-    fail("expected the default dependency graph request")
+    fail("expected the explicitly selected dependency graph request")
   }
   assert_eq(generation, 1)
   let (still_loading, _) = sync(test_emit(), loading, ctx)
@@ -32,6 +43,12 @@ test "ordinary moon.mod defaults to one generation-fenced dependency request" {
 ///|
 test "package graph replies accept only the current owner epoch path and generation" {
   let (state, ctx, path) = moon_mod_test_state()
+  let (_, state) = update(
+    test_emit(),
+    MoonModViewModeSelected(MoonModDependencies),
+    state,
+    ctx,
+  )
   let (loading, _) = sync(test_emit(), state, ctx)
   let stale = PackageGraphRequestLoaded(
     owner=ctx.owner,
@@ -97,6 +114,12 @@ test "package graph replies accept only the current owner epoch path and generat
 ///|
 test "source preserves a ready graph and failed dependency view retries explicitly" {
   let (state, ctx, path) = moon_mod_test_state()
+  let (_, state) = update(
+    test_emit(),
+    MoonModViewModeSelected(MoonModDependencies),
+    state,
+    ctx,
+  )
   let package_graphs = state.package_graphs.copy()
   package_graphs[path] = PackageGraphReady(4, "cached")
   let ready = { ..state, package_graphs, package_graph_generation: 4, }
@@ -156,6 +179,12 @@ test "source preserves a ready graph and failed dependency view retries explicit
 ///|
 test "positioned moon.mod opens source and close forgets all graph state" {
   let (state, ctx, path) = moon_mod_test_state()
+  let (_, state) = update(
+    test_emit(),
+    MoonModViewModeSelected(MoonModDependencies),
+    state,
+    ctx,
+  )
   let (_, positioned) = open_document(
     test_emit(),
     state,
@@ -180,12 +209,18 @@ test "positioned moon.mod opens source and close forgets all graph state" {
   )
   assert_true(closed.moon_mod_view_modes.get(path) is None)
   assert_true(closed.package_graphs.get(path) is None)
-  assert_true(closed.moon_mod_view_mode(path) is MoonModDependencies)
+  assert_true(closed.moon_mod_view_mode(path) is MoonModSource)
 }
 
 ///|
 test "reviewed and historical moon.mod views remain source-only" {
   let (state, ctx, path) = moon_mod_test_state()
+  let (_, state) = update(
+    test_emit(),
+    MoonModViewModeSelected(MoonModDependencies),
+    state,
+    ctx,
+  )
   let docs = state.docs.copy()
   docs[path] = {
     ..docs[path],

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -93,6 +93,25 @@ pub(all) enum MbtiViewMode {
 } derive(Eq)
 
 ///|
+/// The presentation selected for an ordinary `moon.mod`. The dependency
+/// graph is the default, while positioned navigation, reviews, and history
+/// keep the source surface.
+pub(all) enum MoonModViewMode {
+  MoonModDependencies
+  MoonModSource
+} derive(Eq)
+
+///|
+/// One package-graph request cached for an open `moon.mod` tab. Every state
+/// carries the request generation so closing/reopening or invalidating a graph
+/// cannot accept a late Host reply from its predecessor.
+pub(all) enum PackageGraphState {
+  PackageGraphLoading(Int)
+  PackageGraphReady(Int, String)
+  PackageGraphFailed(Int, String)
+} derive(Eq)
+
+///|
 /// The layout shared by Line and sectioned semantic comparison. This
 /// panel-level preference is independent from `ReviewViewMode`: returning to
 /// source keeps it for the next review and the next changed file.
@@ -524,6 +543,13 @@ pub(all) struct State {
   // so a closed and later reopened interface starts rendered again. Special
   // source-bearing opens record `MbtiSource` while that tab remains open.
   mbti_view_modes : Map[@pathx.Relative, MbtiViewMode]
+  // Per-tab moon.mod presentation and the Host-produced package graph JSON.
+  // Absence from `moon_mod_view_modes` defaults to the dependency graph;
+  // absence from `package_graphs` means the next active rendered view starts
+  // one request. The generation is page-lifetime state used to fence replies.
+  moon_mod_view_modes : Map[@pathx.Relative, MoonModViewMode]
+  package_graphs : Map[@pathx.Relative, PackageGraphState]
+  package_graph_generation : Int
   // The directory whose immediate children are open in the breadcrumb's
   // VS Code-style picker. The legacy field and message names remain so this
   // presentation change does not grow the package's public API.
@@ -585,6 +611,9 @@ pub fn State::empty() -> State {
     children: Map([]),
     docs: Map([]),
     mbti_view_modes: Map([]),
+    moon_mod_view_modes: Map([]),
+    package_graphs: Map([]),
+    package_graph_generation: 0,
     highlighted: None,
     index: IndexEmpty,
     error: None,
@@ -597,6 +626,16 @@ pub fn State::empty() -> State {
 /// lifetime.
 fn State::mbti_view_mode(self : State, path : @pathx.Relative) -> MbtiViewMode {
   self.mbti_view_modes.get(path).unwrap_or(MbtiDiagram)
+}
+
+///|
+/// An open `moon.mod` defaults to its dependency graph without storing a map
+/// entry. Explicit source/graph selections live only for that tab's lifetime.
+fn State::moon_mod_view_mode(
+  self : State,
+  path : @pathx.Relative,
+) -> MoonModViewMode {
+  self.moon_mod_view_modes.get(path).unwrap_or(MoonModDependencies)
 }
 
 ///|
@@ -634,6 +673,7 @@ pub fn State::prepare_owner(
     request_epoch: self.request_epoch + 1,
     file_link_generation: self.file_link_generation,
     review_generation: self.review_generation,
+    package_graph_generation: self.package_graph_generation + 1,
     watch_generation: self.watch_generation,
     // Preserve the old host configuration until `sync` can explicitly retire
     // or replace it against the newly resolved checkout placement.
@@ -877,6 +917,25 @@ pub(all) enum Msg {
   // Select the ordinary `.mbti` tab's rendered diagram or source. Reviews,
   // history comparisons, and non-MBTI documents ignore the action.
   MbtiViewModeSelected(MbtiViewMode)
+  // Select an ordinary `moon.mod` tab's package dependency graph or source.
+  // Reviews, history comparisons, and non-manifest documents ignore it.
+  MoonModViewModeSelected(MoonModViewMode)
+  // One Host-side `moon tree --package --json` request settled. The complete
+  // owner/epoch/path/generation tuple fences checkout and close/reopen races.
+  PackageGraphRequestLoaded(
+    owner~ : @interop.ConversationKey,
+    epoch~ : Int,
+    path~ : @pathx.Relative,
+    generation~ : Int,
+    source~ : String
+  )
+  PackageGraphRequestFailed(
+    owner~ : @interop.ConversationKey,
+    epoch~ : Int,
+    path~ : @pathx.Relative,
+    generation~ : Int,
+    message~ : String
+  )
   // One `git.original_file` request settled. `path` is always the current
   // changed path (the dock/document key), even when the host read its rename
   // source from `original_path`.
@@ -1104,6 +1163,12 @@ pub extend ReviewBaseline with Eq::{equal, not_equal}
 
 ///|
 pub extend MbtiViewMode with Eq::{equal, not_equal}
+
+///|
+pub extend MoonModViewMode with Eq::{equal, not_equal}
+
+///|
+pub extend PackageGraphState with Eq::{equal, not_equal}
 
 ///|
 pub extend ReviewDiffLayout with Eq::{equal, not_equal}

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -544,7 +544,7 @@ pub(all) struct State {
   // source-bearing opens record `MbtiSource` while that tab remains open.
   mbti_view_modes : Map[@pathx.Relative, MbtiViewMode]
   // Per-tab moon.mod presentation and the Host-produced package graph JSON.
-  // Absence from `moon_mod_view_modes` defaults to the dependency graph;
+  // Absence from `moon_mod_view_modes` defaults to source;
   // absence from `package_graphs` means the next active rendered view starts
   // one request. The generation is page-lifetime state used to fence replies.
   moon_mod_view_modes : Map[@pathx.Relative, MoonModViewMode]
@@ -629,13 +629,13 @@ fn State::mbti_view_mode(self : State, path : @pathx.Relative) -> MbtiViewMode {
 }
 
 ///|
-/// An open `moon.mod` defaults to its dependency graph without storing a map
+/// An open `moon.mod` defaults to source without storing a map
 /// entry. Explicit source/graph selections live only for that tab's lifetime.
 fn State::moon_mod_view_mode(
   self : State,
   path : @pathx.Relative,
 ) -> MoonModViewMode {
-  self.moon_mod_view_modes.get(path).unwrap_or(MoonModDependencies)
+  self.moon_mod_view_modes.get(path).unwrap_or(MoonModSource)
 }
 
 ///|

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -426,6 +426,14 @@ pub fn open_document(
   } else {
     state
   }
+  let state = if uses_moon_mod_presentation(name) &&
+    (range is Some(_) || annotation is Some(_)) {
+    let moon_mod_view_modes = state.moon_mod_view_modes.copy()
+    moon_mod_view_modes[path] = MoonModSource
+    { ..state, moon_mod_view_modes, }
+  } else {
+    state
+  }
   let clear_review = if ctx.active_file == Some(path) {
     // Always clear the displayed resource, even when this path has no cached
     // `Doc`: a reviewed tab can be closed while another dock kind is active,
@@ -1096,7 +1104,11 @@ pub fn close_document(
   docs.remove(path)
   let mbti_view_modes = state.mbti_view_modes.copy()
   mbti_view_modes.remove(path)
-  let state = { ..state, mbti_view_modes, }
+  let moon_mod_view_modes = state.moon_mod_view_modes.copy()
+  moon_mod_view_modes.remove(path)
+  let package_graphs = state.package_graphs.copy()
+  package_graphs.remove(path)
+  let state = { ..state, mbti_view_modes, moon_mod_view_modes, package_graphs, }
   // Closing a tab is useful local state even while placement is parked, but
   // promoting its neighbor must not address the missing checkout. Recovery's
   // sync pass restores whichever surviving tab the dock made active.
@@ -1237,6 +1249,30 @@ fn FileChange::moonbit_relevant(self : FileChange) -> Bool {
     Modified(path) | Created(path) | Removed(path) => moonbit_check_input(path)
     Renamed(old~, new~) => moonbit_check_input(old) || moonbit_check_input(new)
   }
+}
+
+///|
+/// Whether this event can change the package graph produced by Moon. Source
+/// contents do not: package edges come from module/workspace/package manifests.
+fn FileChange::package_graph_relevant(self : FileChange) -> Bool {
+  match self {
+    Modified(path) | Created(path) | Removed(path) => package_graph_input(path)
+    Renamed(old~, new~) => package_graph_input(old) || package_graph_input(new)
+  }
+}
+
+///|
+fn package_graph_input(path : @pathx.Relative) -> Bool {
+  let text = path.0
+  for
+    name in [
+      "moon.pkg", "moon.mod", "moon.work", "moon.pkg.json", "moon.mod.json", "moon.lock",
+    ] {
+    if text == name || text.has_suffix("/" + name) {
+      return true
+    }
+  }
+  false
 }
 
 ///|
@@ -1762,6 +1798,55 @@ fn refresh_changes(
 }
 
 ///|
+/// Keep the active ordinary `moon.mod` paired with one Host-produced package
+/// graph. The post-dispatch sync is the common path for fresh opens, restored
+/// tabs, view-mode changes, invalidations, and replies, so the request remains
+/// idempotent without duplicating lifecycle logic in each transition.
+fn sync_package_graph(
+  dispatch : @cmd.Emit[Msg],
+  state : State,
+  ctx : Ctx,
+) -> (State, @cmd.Cmd) {
+  guard ctx.checkout_ready() &&
+    ctx.panel_open &&
+    ctx.active_history_diff is None &&
+    ctx.active_file is Some(path) &&
+    state.docs.get(path) is Some(doc) &&
+    doc.review is None &&
+    uses_moon_mod_presentation(doc.name) &&
+    doc.state is (TabLoading | TabLoaded(..)) else {
+    return (state, @cmd.none)
+  }
+  match state.moon_mod_view_mode(path) {
+    MoonModSource => (state, @cmd.none)
+    MoonModDependencies =>
+      match state.package_graphs.get(path) {
+        Some(graph) => (state, show_package_graph_in_viewer(graph))
+        None => {
+          let generation = state.package_graph_generation + 1
+          let graph = PackageGraphLoading(generation)
+          let package_graphs = state.package_graphs.copy()
+          package_graphs[path] = graph
+          (
+            { ..state, package_graphs, package_graph_generation: generation, },
+            @cmd.batch([
+              show_package_graph_in_viewer(graph),
+              read_package_graph(
+                dispatch,
+                ctx.owner,
+                ctx.request_epoch,
+                path,
+                generation,
+                root=ctx.root(),
+              ),
+            ]),
+          )
+        }
+      }
+  }
+}
+
+///|
 /// Reconcile the file subsystem with the active conversation after every
 /// message: rebuild the document table and drop the tree cache when the
 /// conversation changed (the dock parks/restores strip identities; this side
@@ -1936,6 +2021,7 @@ pub fn sync(
           state.file_link_generation
         },
         review_generation: state.review_generation,
+        package_graph_generation: state.package_graph_generation + 1,
         git_graph_generation: if owner_changed || placement_identity_changed {
           state.git_graph_generation + 1
         } else {
@@ -2007,6 +2093,8 @@ pub fn sync(
       git_commit_files: GitCommitFilesIdle,
       history_docs: Map([]),
       history_generation: state.history_generation + 1,
+      package_graphs: Map([]),
+      package_graph_generation: state.package_graph_generation + 1,
       placement: state.placement.reconcile(ctx.placement),
       request_epoch,
     }
@@ -2144,6 +2232,7 @@ pub fn sync(
     (@cmd.none, state)
   }
   let state = state.sync_semantic_review(ctx)
+  let (state, package_graph_cmd) = sync_package_graph(dispatch, state, ctx)
   let pending_cmd = @cmd.batch([
     retire_index_cmd,
     reroot_cmd,
@@ -2151,6 +2240,7 @@ pub fn sync(
     changes_cmd,
     graph_cmd,
     history_cmd,
+    package_graph_cmd,
     sync_semantic_review_editors(state),
   ])
   // A closed panel re-roots (above) and keeps the watcher placed, but the tree
@@ -2285,6 +2375,53 @@ pub fn update(
         { ..state, mbti_view_modes, },
       )
     }
+    MoonModViewModeSelected(mode) => {
+      guard ctx.active_history_diff is None &&
+        ctx.active_file is Some(path) &&
+        state.docs.get(path)
+        is Some({ name, state: TabLoaded(..), review: None, .. }) &&
+        uses_moon_mod_presentation(name) else {
+        return (@cmd.none, state)
+      }
+      let retry_failed = mode is MoonModDependencies &&
+        state.package_graphs.get(path) is Some(PackageGraphFailed(_, _))
+      if state.moon_mod_view_mode(path) == mode && !retry_failed {
+        return (@cmd.none, state)
+      }
+      let moon_mod_view_modes = state.moon_mod_view_modes.copy()
+      moon_mod_view_modes[path] = mode
+      let package_graphs = state.package_graphs.copy()
+      if mode is MoonModDependencies &&
+        package_graphs.get(path) is Some(PackageGraphFailed(_, _)) {
+        package_graphs.remove(path)
+      }
+      (
+        request_viewer_remeasure(),
+        { ..state, moon_mod_view_modes, package_graphs, },
+      )
+    }
+    PackageGraphRequestLoaded(owner~, epoch~, path~, generation~, source~) =>
+      if state.owner == Some(owner) &&
+        state.request_epoch == epoch &&
+        state.package_graphs.get(path) is Some(PackageGraphLoading(current)) &&
+        current == generation {
+        let package_graphs = state.package_graphs.copy()
+        package_graphs[path] = PackageGraphReady(generation, source)
+        (@cmd.none, { ..state, package_graphs, })
+      } else {
+        (@cmd.none, state)
+      }
+    PackageGraphRequestFailed(owner~, epoch~, path~, generation~, message~) =>
+      if state.owner == Some(owner) &&
+        state.request_epoch == epoch &&
+        state.package_graphs.get(path) is Some(PackageGraphLoading(current)) &&
+        current == generation {
+        let package_graphs = state.package_graphs.copy()
+        package_graphs[path] = PackageGraphFailed(generation, message)
+        (@cmd.none, { ..state, package_graphs, })
+      } else {
+        (@cmd.none, state)
+      }
     DiffLoadingDue(owner~, path~, generation~) =>
       if state.owner == Some(owner) &&
         ctx.active_file == Some(path) &&
@@ -3270,7 +3407,17 @@ pub fn update(
         } else {
           state.watching
         }
-        let state = { ..state, reviewed_changes: [], index, watching, }
+        let state = {
+          ..state,
+          reviewed_changes: [],
+          index,
+          watching,
+          // Agent runs can alter unopened package manifests outside the
+          // pruned watcher. Retire every cached graph at this settled boundary;
+          // post-dispatch sync immediately refreshes the visible dependency
+          // view while Source remains cheap.
+          package_graphs: Map([]),
+        }
         let index_cmd = if start_index_refresh {
           list_files(dispatch, owner, state.request_epoch, root=ctx.root())
         } else {
@@ -3332,10 +3479,14 @@ pub fn update(
         let relist : Array[@pathx.Relative] = []
         let mut refresh_index = false
         let mut moonbit_changed = false
+        let mut package_graph_changed = false
         if changes is Some(changes) {
           for change in changes {
             if change.moonbit_relevant() {
               moonbit_changed = true
+            }
+            if change.package_graph_relevant() {
+              package_graph_changed = true
             }
             for path in ctx.open_files {
               if change.touches(path) && !stat_paths.contains(path) {
@@ -3359,6 +3510,10 @@ pub fn update(
             }
           }
         } else {
+          // A watcher baseline closes the unobserved replacement gap. Any
+          // package manifest may have changed while the old watcher was gone,
+          // so a cached dependency graph cannot cross this boundary.
+          package_graph_changed = true
           for path in ctx.open_files {
             stat_paths.push(path)
           }
@@ -3439,7 +3594,18 @@ pub fn update(
             list_files(dispatch, owner, state.request_epoch, root=ctx.root()),
           )
         }
-        let next = { ..state, loading, reviewed_changes, index, }
+        let package_graphs = if package_graph_changed {
+          Map([])
+        } else {
+          state.package_graphs
+        }
+        let next = {
+          ..state,
+          loading,
+          reviewed_changes,
+          index,
+          package_graphs,
+        }
         // Any content event can change Git status, not just a structural one.
         // Refresh only after Changes has been requested and while its explorer
         // or a review is live; reopening performs its own full refresh. The

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -298,7 +298,7 @@ pub fn resize_handle_view() -> @html.Html {
 /// always rooted at the workspace root) as a toggleable pane on
 /// the viewer's right. Always rendered so the viewer's host element
 /// (`viewer-host`, `markdown-viewer-host`, `mbti-diagram-host`,
-/// `diff-editor-host`, and `semantic-review-host`) stay put
+/// `package-diagram-host`, `diff-editor-host`, and `semantic-review-host`) stay put
 /// across renders and screen
 /// switches; CSS hides the inactive surface and the tree pane when toggled off,
 /// and collapses the whole panel to zero width when it is closed. The children's
@@ -342,6 +342,10 @@ pub fn body_view(
   let use_mbti_surface = !use_diff_surface &&
     !use_markdown_surface &&
     uses_mbti_diagram_surface(state, ctx)
+  let use_package_surface = !use_diff_surface &&
+    !use_markdown_surface &&
+    !use_mbti_surface &&
+    uses_package_diagram_surface(state, ctx)
   let use_semantic_surface = use_diff_surface &&
     state.review_diff_mode != ReviewDiffLine &&
     (match ctx.active_history_diff {
@@ -353,7 +357,10 @@ pub fn body_view(
     attrs=@html.Attrs::build()
       .id(ViewerHostId)
       .class(
-        if use_diff_surface || use_markdown_surface || use_mbti_surface {
+        if use_diff_surface ||
+          use_markdown_surface ||
+          use_mbti_surface ||
+          use_package_surface {
           "viewer-host editor-shell moonbit-viewer-surface-hidden"
         } else {
           "viewer-host editor-shell"
@@ -383,6 +390,19 @@ pub fn body_view(
           "viewer-host editor-shell mbti-diagram-host"
         } else {
           "viewer-host editor-shell mbti-diagram-host moonbit-viewer-surface-hidden"
+        },
+      )
+      .data_set("theme", if ctx.dark_mode { "dark" } else { "light" }),
+    ([] : Array[@html.Html]),
+  )
+  let package_diagram_host = @html.div(
+    attrs=@html.Attrs::build()
+      .id(PackageDiagramHostId)
+      .class(
+        if use_package_surface {
+          "viewer-host editor-shell package-diagram-host"
+        } else {
+          "viewer-host editor-shell package-diagram-host moonbit-viewer-surface-hidden"
         },
       )
       .data_set("theme", if ctx.dark_mode { "dark" } else { "light" }),
@@ -426,6 +446,7 @@ pub fn body_view(
       viewer_host,
       markdown_viewer_host,
       mbti_diagram_host,
+      package_diagram_host,
       diff_editor_host,
       semantic_review_host,
       viewer_notice(state, ctx),
@@ -1805,6 +1826,9 @@ pub fn breadcrumb_view(
   if mbti_view_available(state, ctx) {
     path_row.push(mbti_view_toolbar(dispatch, state, ctx))
   }
+  if moon_mod_view_available(state, ctx) {
+    path_row.push(moon_mod_view_toolbar(dispatch, state, ctx))
+  }
   path_row.push(
     @html.button(
       class="panel-toggle",
@@ -1906,6 +1930,72 @@ fn mbti_view_toolbar(
     [
       mbti_view_button(dispatch, selected, MbtiDiagram, "Diagram"),
       mbti_view_button(dispatch, selected, MbtiSource, "Source"),
+    ],
+  )
+}
+
+///|
+/// A package dependency graph belongs only to an ordinary, loaded file whose
+/// exact basename is `moon.mod`. Reviews and historical comparisons retain
+/// their source/diff surfaces even if their path names a module manifest.
+fn moon_mod_view_available(state : State, ctx : Ctx) -> Bool {
+  guard ctx.active_history_diff is None && ctx.active_file is Some(path) else {
+    return false
+  }
+  state.docs.get(path) is Some({ name, state: TabLoaded(..), review: None, .. }) &&
+  uses_moon_mod_presentation(name)
+}
+
+///|
+fn uses_package_diagram_surface(state : State, ctx : Ctx) -> Bool {
+  guard moon_mod_view_available(state, ctx) && ctx.active_file is Some(path) else {
+    return false
+  }
+  state.moon_mod_view_mode(path) == MoonModDependencies
+}
+
+///|
+fn moon_mod_view_button(
+  dispatch : @cmd.Emit[Msg],
+  selected : MoonModViewMode,
+  mode : MoonModViewMode,
+  label : String,
+) -> @html.Html {
+  let active = selected == mode
+  @html.button(
+    type_="button",
+    class=if active {
+      "review-mode-button active"
+    } else {
+      "review-mode-button"
+    },
+    // An already-selected failed dependency view treats another click as an
+    // explicit retry; the update loop leaves every other same-mode click inert.
+    on_click=dispatch(MoonModViewModeSelected(mode)),
+    attrs=@html.Attrs::build().aria_pressed(active.to_string()),
+    label,
+  )
+}
+
+///|
+fn moon_mod_view_toolbar(
+  dispatch : @cmd.Emit[Msg],
+  state : State,
+  ctx : Ctx,
+) -> @html.Html {
+  guard ctx.active_file is Some(path) else { return @html.nothing }
+  let selected = state.moon_mod_view_mode(path)
+  @html.div(
+    class="review-mode-toolbar moon-mod-view-toolbar",
+    attrs=@html.Attrs::build().role("group").aria_label("Moon module view"),
+    [
+      moon_mod_view_button(
+        dispatch,
+        selected,
+        MoonModDependencies,
+        "Dependency graph",
+      ),
+      moon_mod_view_button(dispatch, selected, MoonModSource, "Source"),
     ],
   )
 }

--- a/desktop/internal/commands/commands.mbt
+++ b/desktop/internal/commands/commands.mbt
@@ -508,6 +508,17 @@ pub let terminal_close : Command[
 ] = Command("terminal.close")
 
 ///|
+pub let moon_package_graph : Command[
+  @protocol.MoonPackageGraphPayload,
+  @protocol.MoonPackageGraphReply,
+] = Command("moon.package_graph")
+
+///|
+test "package graph command keeps its remote wire name" {
+  assert_eq(moon_package_graph.name(), "moon.package_graph")
+}
+
+///|
 pub let lsp_open : Command[
   @protocol.LspOpenPayload,
   @protocol.LspDiagnosticsReply,

--- a/desktop/internal/commands/pkg.generated.mbti
+++ b/desktop/internal/commands/pkg.generated.mbti
@@ -171,6 +171,8 @@ pub let lsp_open : Command[@protocol.LspOpenPayload, @protocol.LspDiagnosticsRep
 
 pub let lsp_workspace_symbols : Command[@protocol.WorkspaceSymbolsPayload, @protocol.WorkspaceSymbolsReply]
 
+pub let moon_package_graph : Command[@protocol.MoonPackageGraphPayload, @protocol.MoonPackageGraphReply]
+
 pub let moonide_definition : Command[@protocol.MoonIdeNavigationPayload, @protocol.MoonIdeLocationsReply]
 
 pub let moonide_references : Command[@protocol.MoonIdeNavigationPayload, @protocol.MoonIdeLocationsReply]

--- a/desktop/internal/host/host.mbt
+++ b/desktop/internal/host/host.mbt
@@ -283,6 +283,9 @@ pub fn endpoints(
       terminal_close_op(connection.terminal, payload)
       Acknowledged
     }),
+    @endpoint.Endpoint::remote(@commands.moon_package_graph, async fn(payload) {
+      moon_package_graph_op(state.moon, payload)
+    }),
     @endpoint.Endpoint::remote(@commands.lsp_open, async fn(payload) {
       lsp_open_op(state.moon, payload)
     }),

--- a/desktop/internal/host/package_graph_ops.mbt
+++ b/desktop/internal/host/package_graph_ops.mbt
@@ -1,0 +1,266 @@
+// Host-owned package dependency graphs. Unlike source-only editor renderers,
+// this view must ask the selected Moon toolchain to resolve the module from
+// the concrete checkout that owns the opened `moon.mod`.
+
+///|
+/// The argv passed directly to Moon. Keeping it as an array prevents a path or
+/// manifest value from ever becoming shell syntax.
+fn moon_package_graph_args() -> Array[String] {
+  ["tree", "--package", "--json"]
+}
+
+///|
+/// Resolve the opened manifest through the same ownership and physical
+/// containment boundary used by language operations, then return its parent
+/// directory as Moon's cwd.
+async fn moon_package_graph_cwd(
+  payload : MoonPackageGraphPayload,
+) -> @pathx.Absolute {
+  let location = LanguagePath::resolve(
+    payload.session,
+    payload.root,
+    payload.path,
+  )
+  let manifest = location.physical_root.join(location.physical_relative)
+  guard manifest.to_path().basename() == "moon.mod" else {
+    raise PayloadError("path must name moon.mod")
+  }
+  let kind = @fs.kind(manifest.to_string()) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => raise HostError("moon.mod is unavailable")
+  }
+  guard kind is Regular else {
+    raise PayloadError("path must name a moon.mod file")
+  }
+  guard manifest.to_path().dirname().to_absolute() is Some(cwd) else {
+    raise HostError("moon.mod parent is not an absolute path")
+  }
+  cwd.normalize()
+}
+
+///|
+/// Extract Moon's useful message from a failed structured result. Current
+/// output carries an error string; accepting `{message}` as well preserves the
+/// diagnostic if Moon evolves the field into a structured error.
+fn moon_tree_error_message(error : Json) -> String? {
+  let message = match error {
+    String(message) => message
+    Object(fields) =>
+      match fields.get("message") {
+        Some(String(message)) => message
+        _ => return None
+      }
+    _ => return None
+  }
+  let message = message.trim().to_owned()
+  if message.is_empty() {
+    None
+  } else {
+    Some(message)
+  }
+}
+
+///|
+/// Recognize Moon's JSON failure envelope independently of the process exit
+/// code. This second check is deliberate: a tool that accidentally exits zero
+/// with `status: "failed"` still must not feed that JSON to the UML renderer.
+fn moon_tree_failure_message(output : String) -> String? {
+  let json = @json.parse(output.trim()) catch { _ => return None }
+  guard json is Object(fields) &&
+    fields.get("status") is Some(String(status)) &&
+    status != "success" else {
+    return None
+  }
+  if fields.get("error") is Some(error) &&
+    moon_tree_error_message(error) is Some(message) {
+    return Some(message)
+  }
+  Some("moon tree reported status “\{status}”")
+}
+
+///|
+/// Validate only the stable package-graph envelope before preserving Moon's
+/// source verbatim for `uml.render_package_dep_svg`. A non-null `error` or a
+/// non-success status is never a graph, even if it happens to contain arrays
+/// named `nodes` and `edges`.
+fn is_moon_package_graph_source(source : String) -> Bool {
+  let json = @json.parse(source.trim()) catch { _ => return false }
+  guard json is Object(fields) &&
+    fields.get("nodes") is Some(Array(_)) &&
+    fields.get("edges") is Some(Array(_)) else {
+    return false
+  }
+  let status_ok = match fields.get("status") {
+    None | Some(String("success")) => true
+    _ => false
+  }
+  let error_clear = match fields.get("error") {
+    None | Some(Null) => true
+    _ => false
+  }
+  status_ok && error_clear
+}
+
+///|
+/// Classify one completed Moon process without losing its best diagnostic.
+/// Nonzero exits prefer the structured stdout error, then stderr, raw stdout,
+/// and finally the exit code. Zero exits still require a successful graph
+/// envelope so failed or malformed JSON cannot masquerade as source.
+fn moon_package_graph_process_reply(
+  code : Int,
+  stdout : String,
+  stderr : String,
+) -> MoonPackageGraphReply {
+  let stdout_detail = stdout.trim().to_owned()
+  let stderr_detail = stderr.trim().to_owned()
+  if code != 0 {
+    if moon_tree_failure_message(stdout_detail) is Some(message) {
+      return PackageGraphError(message~)
+    }
+    if !stderr_detail.is_empty() {
+      return PackageGraphError(message=stderr_detail)
+    }
+    if !stdout_detail.is_empty() {
+      return PackageGraphError(message=stdout_detail)
+    }
+    return PackageGraphError(
+      message="moon tree --package --json exited with code \{code}",
+    )
+  }
+  if moon_tree_failure_message(stdout_detail) is Some(message) {
+    return PackageGraphError(message~)
+  }
+  if stdout_detail.is_empty() {
+    return PackageGraphError(
+      message="moon tree --package --json returned empty output",
+    )
+  }
+  guard is_moon_package_graph_source(stdout_detail) else {
+    return PackageGraphError(
+      message="moon tree --package --json returned invalid package graph JSON",
+    )
+  }
+  PackageGraphSource(source=stdout)
+}
+
+///|
+/// Run the package graph query in the opened manifest's directory. Toolchain
+/// resolution, spawn, text decoding, and timeout failures are reported as an
+/// explicit reply variant so the editor can retain and display the source
+/// view while explaining why the graph is unavailable.
+async fn moon_package_graph_op(
+  state : MoonCliState,
+  payload : MoonPackageGraphPayload,
+) -> MoonPackageGraphReply {
+  let cwd = moon_package_graph_cwd(payload)
+  guard state.run_moon(moon_package_graph_args(), cwd)
+    is Some((code, stdout, stderr)) else {
+    return PackageGraphError(message="could not run moon tree --package --json")
+  }
+  moon_package_graph_process_reply(code, stdout, stderr)
+}
+
+///|
+test "package graph invokes Moon with the exact argv" {
+  assert_eq(moon_package_graph_args(), ["tree", "--package", "--json"])
+}
+
+///|
+test "package graph accepts only successful graph JSON" {
+  let graph = "{\"version\":2,\"status\":\"success\",\"error\":null,\"nodes\":[],\"edges\":[]}"
+  assert_eq(
+    moon_package_graph_process_reply(0, graph, "ignored stderr"),
+    PackageGraphSource(source=graph),
+  )
+  assert_eq(
+    moon_package_graph_process_reply(
+      0, "{\"status\":\"failed\",\"error\":\"manifest failed\",\"nodes\":[],\"edges\":[]}",
+      "",
+    ),
+    PackageGraphError(message="manifest failed"),
+  )
+  assert_eq(
+    moon_package_graph_process_reply(0, "{\"nodes\":[]}", ""),
+    PackageGraphError(
+      message="moon tree --package --json returned invalid package graph JSON",
+    ),
+  )
+  assert_eq(
+    moon_package_graph_process_reply(0, "  \n", ""),
+    PackageGraphError(
+      message="moon tree --package --json returned empty output",
+    ),
+  )
+}
+
+///|
+test "package graph process errors retain Moon's best diagnostic" {
+  assert_eq(
+    moon_package_graph_process_reply(
+      2, "{\"status\":\"failed\",\"error\":{\"message\":\"bad dependency\"}}", "less useful stderr",
+    ),
+    PackageGraphError(message="bad dependency"),
+  )
+  assert_eq(
+    moon_package_graph_process_reply(2, "unstructured stdout", " stderr wins "),
+    PackageGraphError(message="stderr wins"),
+  )
+  assert_eq(
+    moon_package_graph_process_reply(2, " stdout fallback ", ""),
+    PackageGraphError(message="stdout fallback"),
+  )
+  assert_eq(
+    moon_package_graph_process_reply(2, "", ""),
+    PackageGraphError(message="moon tree --package --json exited with code 2"),
+  )
+}
+
+///|
+async test "package graph cwd is the authorized moon.mod parent" {
+  let root = @fs.tmpdir(prefix="openseek-package-graph-root-")
+  defer (@fs.rmdir(root, recursive=true) catch { _ => () })
+  defer (@work_dir.revoke_host_workspace("package-graph-test") catch {
+    _ => ()
+  })
+  @fs.mkdir("\{root}/nested/module", recursive=true)
+  @fs.write_file(
+    "\{root}/nested/module/moon.mod",
+    "{}",
+    create_mode=CreateOrTruncate,
+  )
+  @fs.write_file(
+    "\{root}/nested/module/README.md",
+    "not a manifest",
+    create_mode=CreateOrTruncate,
+  )
+  guard @pathx.Path(root).to_absolute() is Some(root_absolute) &&
+    root_absolute.to_uri_path() is Some(root_resource) else {
+    fail("test root could not be represented as a frontend resource")
+  }
+  @work_dir.authorize_host_workspace("package-graph-test", root)
+  let cwd = moon_package_graph_cwd({
+    session: "package-graph-test",
+    root: root_resource,
+    path: "nested/module/moon.mod",
+  })
+  let expected_text = @fs.realpath("\{root}/nested/module")
+  guard @pathx.Path(expected_text).to_absolute() is Some(expected) else {
+    fail("test module root is not absolute")
+  }
+  assert_eq(cwd, expected.normalize())
+  let wrong_name_rejected = try {
+    ignore(
+      moon_package_graph_cwd({
+        session: "package-graph-test",
+        root: root_resource,
+        path: "nested/module/README.md",
+      }),
+    )
+    false
+  } catch {
+    _ => true
+  } noraise {
+    rejected => rejected
+  }
+  assert_true(wrong_name_rejected)
+}

--- a/desktop/internal/host/protocol.mbt
+++ b/desktop/internal/host/protocol.mbt
@@ -355,6 +355,18 @@ type MoonIdeLocation = @protocol.MoonIdeLocation
 type MoonIdeLocationsReply = @protocol.MoonIdeLocationsReply
 
 ///|
+/// Request a package dependency graph for one `moon.mod`. The manifest path
+/// is relative to the explicit editor root and is revalidated against the
+/// conversation's host workspace before Moon is invoked.
+type MoonPackageGraphPayload = @protocol.MoonPackageGraphPayload
+
+///|
+/// A successful `moon tree --package --json` source or an in-band operational
+/// error. Keeping the variants distinct prevents failed Moon JSON from being
+/// interpreted as graph input.
+type MoonPackageGraphReply = @protocol.MoonPackageGraphReply
+
+///|
 /// `lsp_open` tells the host the editor is now showing `path` relative to the
 /// explicit absolute `root`, so it runs `moon check` over the file's module.
 /// The reply carries the file's diagnostics from that run; other files'

--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -724,6 +724,34 @@ pub impl ToJson for TerminalClosePayload with fn to_json(self) {
 }
 
 ///|
+/// Request the package dependency graph for one concrete `moon.mod` shown by
+/// the file editor. `root` is the owning conversation checkout and `path` is
+/// relative to it; the Host revalidates both before invoking Moon.
+pub(all) struct MoonPackageGraphPayload {
+  session : String
+  root : String
+  path : String
+} derive(Debug, Eq)
+
+///|
+pub impl FromJson for MoonPackageGraphPayload with fn from_json(json, path) {
+  guard json is Object(fields) else {
+    raise JsonDecodeError((path, "expected Moon package-graph payload"))
+  }
+  let object = JsonObject::of(fields, path)
+  {
+    session: object.required_string("session"),
+    root: object.required_string("root"),
+    path: object.required_string("path"),
+  }
+}
+
+///|
+pub impl ToJson for MoonPackageGraphPayload with fn to_json(self) {
+  { "session": self.session, "root": self.root, "path": self.path }
+}
+
+///|
 pub(all) struct LspOpenPayload {
   session : String
   root : String
@@ -1791,6 +1819,18 @@ pub extend MoonIdeNavigationPayload with Eq::{equal, not_equal}
 
 ///|
 pub extend MoonIdeNavigationPayload with ToJson::{to_json}
+
+///|
+pub extend MoonPackageGraphPayload with Debug::{to_repr}
+
+///|
+pub extend MoonPackageGraphPayload with FromJson::{from_json}
+
+///|
+pub extend MoonPackageGraphPayload with Eq::{equal, not_equal}
+
+///|
+pub extend MoonPackageGraphPayload with ToJson::{to_json}
 
 ///|
 pub extend OpenSeekThinking with Debug::{to_repr}

--- a/desktop/internal/protocol/desktop_replies.mbt
+++ b/desktop/internal/protocol/desktop_replies.mbt
@@ -1611,6 +1611,53 @@ pub(all) struct MoonIdeLocationsReply {
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
+/// The result of asking the Host to run `moon tree --package --json` for an
+/// opened module manifest. Operational failures stay in-band so the local
+/// Proton bridge cannot replace the useful Moon error with a generic rejected
+/// command message, and the already-loaded manifest source remains usable.
+pub(all) enum MoonPackageGraphReply {
+  PackageGraphSource(source~ : String)
+  PackageGraphError(message~ : String)
+} derive(Debug, Eq)
+
+///|
+pub impl ToJson for MoonPackageGraphReply with fn to_json(self) {
+  match self {
+    PackageGraphSource(source~) => { "kind": "source", "source": source }
+    PackageGraphError(message~) => { "kind": "error", "message": message }
+  }
+}
+
+///|
+pub impl FromJson for MoonPackageGraphReply with fn from_json(json, path) {
+  guard json is Object(fields) && fields.get("kind") is Some(String(kind_)) else {
+    raise JsonDecodeError((path, "expected Moon package-graph reply"))
+  }
+  match kind_ {
+    "source" => {
+      guard fields.get("source") is Some(String(source)) else {
+        raise JsonDecodeError(
+          (path.add_key("source"), "package-graph source must be a string"),
+        )
+      }
+      PackageGraphSource(source~)
+    }
+    "error" => {
+      guard fields.get("message") is Some(String(message)) else {
+        raise JsonDecodeError(
+          (path.add_key("message"), "package-graph error must be a string"),
+        )
+      }
+      PackageGraphError(message~)
+    }
+    _ =>
+      raise JsonDecodeError(
+        (path.add_key("kind"), "unknown Moon package-graph reply kind"),
+      )
+  }
+}
+
+///|
 pub(all) struct LspPosition {
   line : Int
   character : Int
@@ -2355,6 +2402,18 @@ pub extend MoonIdeLocationsReply with Eq::{equal, not_equal}
 
 ///|
 pub extend MoonIdeLocationsReply with ToJson::{to_json}
+
+///|
+pub extend MoonPackageGraphReply with Debug::{to_repr}
+
+///|
+pub extend MoonPackageGraphReply with FromJson::{from_json}
+
+///|
+pub extend MoonPackageGraphReply with Eq::{equal, not_equal}
+
+///|
+pub extend MoonPackageGraphReply with ToJson::{to_json}
 
 ///|
 pub extend OpenExternalReply with Debug::{to_repr}

--- a/desktop/internal/protocol/desktop_replies_test.mbt
+++ b/desktop/internal/protocol/desktop_replies_test.mbt
@@ -905,6 +905,71 @@ test "language payload codecs require every routing coordinate" {
 }
 
 ///|
+test "Moon package-graph codecs keep routing and outcome explicit" {
+  let payload : @protocol.MoonPackageGraphPayload = @json.from_json({
+    "session": "thread-1",
+    "root": "/work/project",
+    "path": "nested/moon.mod",
+    "future_metadata": true,
+  })
+  @debug.assert_eq(payload.to_json(), {
+    "session": "thread-1",
+    "root": "/work/project",
+    "path": "nested/moon.mod",
+  })
+  let missing_path = try {
+    let _ : @protocol.MoonPackageGraphPayload = @json.from_json({
+      "session": "thread-1",
+      "root": "/work/project",
+    })
+    false
+  } catch {
+    _ => true
+  }
+  assert_true(missing_path)
+  let source : @protocol.MoonPackageGraphReply = PackageGraphSource(
+    source="{\"status\":\"success\"}",
+  )
+  @debug.assert_eq(source.to_json(), {
+    "kind": "source",
+    "source": "{\"status\":\"success\"}",
+  })
+  let decoded_source : @protocol.MoonPackageGraphReply = @json.from_json(
+    source.to_json(),
+  )
+  assert_eq(decoded_source, source)
+  let failure : @protocol.MoonPackageGraphReply = PackageGraphError(
+    message="moon tree failed",
+  )
+  @debug.assert_eq(failure.to_json(), {
+    "kind": "error",
+    "message": "moon tree failed",
+  })
+  let decoded_failure : @protocol.MoonPackageGraphReply = @json.from_json(
+    failure.to_json(),
+  )
+  assert_eq(decoded_failure, failure)
+  let missing_source = try {
+    let _ : @protocol.MoonPackageGraphReply = @json.from_json({
+      "kind": "source",
+    })
+    false
+  } catch {
+    _ => true
+  }
+  assert_true(missing_source)
+  let unknown_kind = try {
+    let _ : @protocol.MoonPackageGraphReply = @json.from_json({
+      "kind": "cancelled",
+    })
+    false
+  } catch {
+    _ => true
+  }
+  assert_true(unknown_kind)
+}
+
+///|
 test "worktree replies omit absent owners and reject ambiguous ownership" {
   let openseek : @protocol.WorktreeInfo = @json.from_json({
     "name": "wt-1",

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -1418,6 +1418,31 @@ pub fn MoonIdeNavigationPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for MoonIdeNavigationPayload
 pub impl @json.FromJson for MoonIdeNavigationPayload
 
+pub(all) struct MoonPackageGraphPayload {
+  session : String
+  root : String
+  path : String
+} derive(Eq, @debug.Debug)
+pub fn MoonPackageGraphPayload::equal(Self, Self) -> Bool
+pub fn MoonPackageGraphPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn MoonPackageGraphPayload::not_equal(Self, Self) -> Bool
+pub fn MoonPackageGraphPayload::to_json(Self) -> Json
+pub fn MoonPackageGraphPayload::to_repr(Self) -> @debug.Repr
+pub impl ToJson for MoonPackageGraphPayload
+pub impl @json.FromJson for MoonPackageGraphPayload
+
+pub(all) enum MoonPackageGraphReply {
+  PackageGraphSource(source~ : String)
+  PackageGraphError(message~ : String)
+} derive(Eq, @debug.Debug)
+pub fn MoonPackageGraphReply::equal(Self, Self) -> Bool
+pub fn MoonPackageGraphReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn MoonPackageGraphReply::not_equal(Self, Self) -> Bool
+pub fn MoonPackageGraphReply::to_json(Self) -> Json
+pub fn MoonPackageGraphReply::to_repr(Self) -> @debug.Repr
+pub impl ToJson for MoonPackageGraphReply
+pub impl @json.FromJson for MoonPackageGraphReply
+
 pub(all) enum Notification {
   AgentConnected(ConnectedPayload)
   AgentStarted(StartedPayload)

--- a/desktop/styles/file_panel.css
+++ b/desktop/styles/file_panel.css
@@ -169,26 +169,46 @@ button.panel-toggle:not(:disabled):hover {
 .viewer-stack > .viewer-host {
   flex: 1 1 auto;
 }
-.viewer-host.mbti-diagram-host {
+.viewer-host.mbti-diagram-host,
+.viewer-host.package-diagram-host {
   box-sizing: border-box;
-  align-items: safe center;
-  justify-content: safe center;
-  padding: 24px;
-  overflow: auto;
+  align-items: stretch;
+  justify-content: stretch;
+  padding: 0;
+  overflow: hidden;
   color: var(--vscode-editor-foreground, var(--color-text-primary));
   background: var(--vscode-editor-background, var(--color-bg-surface));
   overscroll-behavior: contain;
 }
-.mbti-diagram-host:not(.moonbit-viewer-surface-hidden) {
+.mbti-diagram-host:not(.moonbit-viewer-surface-hidden),
+.package-diagram-host:not(.moonbit-viewer-surface-hidden) {
   display: flex;
 }
-.mbti-diagram-host > svg {
-  display: block;
-  flex: 0 0 auto;
-  margin: auto;
+.mbti-diagram-host > .moonbit-viewer-markdown-diagram,
+.package-diagram-host > .moonbit-viewer-markdown-diagram {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  border-radius: 0;
 }
-.mbti-diagram-error {
+/* The shared viewport must measure the generated SVG at its intrinsic size.
+   Its reusable Markdown rule caps SVG width before measurement, which turns a
+   very wide package graph into a few-pixel-tall viewport. The controller owns
+   fitting and clipping once mounted, so disable only that inherited cap here. */
+:is(.mbti-diagram-host, .package-diagram-host)
+  .moonbit-viewer-markdown-diagram-content
+  > svg {
+  max-width: none;
+}
+.mbti-diagram-error,
+.package-diagram-status {
+  box-sizing: border-box;
   max-width: 420px;
+  margin: auto;
+  padding: 24px;
   color: var(--color-text-secondary);
   font-size: var(--font-size-md);
   line-height: var(--line-height-relaxed);

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -564,6 +564,25 @@ Notifications:
 | `terminal.output` | `{id, sequence, data}` — `data` is base64 of the raw PTY bytes |
 | `terminal.exit` | `{id, code}` |
 
+### moon.* — MoonBit project views
+
+`moon.package_graph` is an explicit Host operation because its input cannot be
+derived from the open manifest text alone. The Host verifies that `root` is the
+checkout owned by `session`, resolves the root-relative `path` with physical
+symlink containment, requires it to name `moon.mod`, and runs the selected
+toolchain's `moon` with argv exactly `tree --package --json` in that manifest's
+parent directory.
+
+The reply is tagged on both paths. A nonzero process exit first extracts the
+message from Moon's JSON `status`/`error` stdout when available, then falls back
+to stderr, stdout, and finally the exit code. Malformed output and JSON with a
+failure status also return `kind: "error"`; they are never passed to the UML
+renderer as package-graph source.
+
+| method | params | result |
+|---|---|---|
+| `moon.package_graph` | `{session, root, path}` (`root` absolute, `path` root-relative and naming `moon.mod`) | `{kind: "source", source}` where `source` is successful `moon tree` JSON, or `{kind: "error", message}` |
+
 ### lsp.*
 
 | method | params | result |

--- a/editor/internal/viewer/markdown/diagram_code_block.mbt
+++ b/editor/internal/viewer/markdown/diagram_code_block.mbt
@@ -67,6 +67,18 @@ pub fn render_mbti_diagram_svg(source : String) -> String? {
 }
 
 ///|
+/// Compile the JSON emitted by `moon tree --package --json` to a package
+/// dependency SVG. The command remains the host's responsibility; this pure
+/// boundary only renders its successful output and keeps malformed graphs on
+/// the caller's fallback path.
+pub fn render_package_dep_diagram_svg(source : String) -> String? {
+  let color_scheme = viewer_uml_color_scheme()
+  Some(@uml.render_package_dep_svg(source, color_scheme~)) catch {
+    _ => None
+  }
+}
+
+///|
 /// Keep every synchronous UML surface on the same CSS-backed palette. SVGs
 /// can then follow a host theme change without recompiling their source.
 fn viewer_uml_color_scheme() -> @uml_style.ColorScheme {

--- a/editor/internal/viewer/markdown/pkg.generated.mbti
+++ b/editor/internal/viewer/markdown/pkg.generated.mbti
@@ -21,6 +21,8 @@ pub fn render_markdown(String, language_id? : String, code_block_renderer? : (Ma
 
 pub fn render_mbti_diagram_svg(String) -> String?
 
+pub fn render_package_dep_diagram_svg(String) -> String?
+
 pub fn render_tokenized_code_block(MarkdownCodeBlock, String?) -> String
 
 pub fn render_uml_diagram_svg(String) -> String?

--- a/editor/viewer/browser/diagram_viewport/README.mbt.md
+++ b/editor/viewer/browser/diagram_viewport/README.mbt.md
@@ -12,5 +12,11 @@ may have been inserted or replaced, and call `dispose` before removing or
 replacing the borrowed root. `dispose` restores the attributes, inline styles,
 and direct SVG structure that the package borrowed.
 
+Standalone image panels can construct `DiagramViewports` with
+`fill_container=true`. In that mode the owning host supplies the viewport
+dimensions, the SVG is initially fitted into the complete surface, and the
+inline-only height resize handle is omitted. Markdown callers keep the default
+intrinsic-height behavior.
+
 The stylesheet beside this document is part of the package's presentation
 contract and must be included by each browser host.

--- a/editor/viewer/browser/diagram_viewport/diagram_viewport.mbt
+++ b/editor/viewer/browser/diagram_viewport/diagram_viewport.mbt
@@ -82,6 +82,7 @@ priv struct MarkdownDiagramViewport {
   resize_handle : @rdom.Element
   owner_document : @rdom.Document
   owner_window : @rdom.Window
+  fill_container : Bool
   saved_tabindex : SavedAttribute
   saved_aria_label : SavedAttribute
   saved_height : SavedStyle
@@ -121,6 +122,7 @@ priv struct MarkdownDiagramViewportLifetime {
   target : @rdom.Element
   on_size_changed : () -> Unit
   schedule_frame : (() -> Unit) -> () -> Unit
+  fill_container : Bool
   controllers : Array[MarkdownDiagramViewport]
   mut active : Bool
 }
@@ -148,6 +150,10 @@ struct DiagramViewports {
 /// commits or replaces a direct SVG.
 /// `on_size_changed` invalidates the owning presentation whenever this
 /// component writes a new inline viewport height.
+/// `fill_container` keeps each viewport at the size supplied by its owning
+/// container and initially fits the SVG into that complete surface. It is
+/// intended for standalone image panels; inline Markdown diagrams retain their
+/// intrinsic, user-resizable height by default.
 ///
 /// ```d2
 /// direction: right
@@ -171,6 +177,7 @@ struct DiagramViewports {
 pub fn DiagramViewports::DiagramViewports(
   target : @rdom.Element,
   on_size_changed : () -> Unit,
+  fill_container? : Bool = false,
 ) -> DiagramViewports {
   let schedule_frame = (callback : () -> Unit) => {
     let registration = @base_browser.schedule_at_next_animation_frame(callback)
@@ -180,6 +187,7 @@ pub fn DiagramViewports::DiagramViewports(
     target,
     on_size_changed,
     schedule_frame,
+    fill_container,
     controllers: [],
     active: true,
   }
@@ -222,6 +230,7 @@ fn MarkdownDiagramViewportLifetime::refresh(
         self.target,
         self.on_size_changed,
         self.schedule_frame,
+        self.fill_container,
       ) {
       Mounted(controller) => self.controllers.push(controller)
       Skipped => ()
@@ -288,6 +297,7 @@ fn mount_diagram_viewport(
   fallback_target : @rdom.Element,
   on_size_changed : () -> Unit,
   schedule_frame : (() -> Unit) -> () -> Unit,
+  fill_container : Bool,
 ) -> DiagramViewportMountResult {
   guard direct_svg_child(wrapper) is Some(svg) else { return Skipped }
   let result : Ref[DiagramViewportMountResult] = Ref(Skipped)
@@ -297,6 +307,7 @@ fn mount_diagram_viewport(
   ) => {
     result.val = mount_diagram_viewport_in_environment(
       wrapper, svg, owner_document, owner_window, on_size_changed, schedule_frame,
+      fill_container,
     )
   })
   if found {
@@ -314,6 +325,7 @@ fn mount_diagram_viewport_in_environment(
   owner_window : @rdom.Window,
   on_size_changed : () -> Unit,
   schedule_frame : (() -> Unit) -> () -> Unit,
+  fill_container : Bool,
 ) -> DiagramViewportMountResult {
   let content = owner_document.create_element("div")
   content.set_attribute("class", diagram_content_class)
@@ -366,6 +378,7 @@ fn mount_diagram_viewport_in_environment(
     resize_handle,
     owner_document,
     owner_window,
+    fill_container,
     saved_tabindex: save_element_attribute(wrapper, "tabindex"),
     saved_aria_label: save_element_attribute(wrapper, "aria-label"),
     saved_height: save_element_style(wrapper, "height"),
@@ -417,7 +430,9 @@ fn mount_diagram_viewport_in_environment(
   )
   content.append_child(svg.as_node())
   wrapper.append_child(controls.as_node())
-  wrapper.append_child(resize_handle.as_node())
+  if !fill_container {
+    wrapper.append_child(resize_handle.as_node())
+  }
   controller.install_listeners()
   controller.observer = @base_browser.observe_element_resize(wrapper, () => {
     if controller.active {
@@ -899,6 +914,16 @@ fn MarkdownDiagramViewport::center_natural_content(
   self : MarkdownDiagramViewport,
 ) -> Bool {
   guard self.measure_svg() is Some(svg_size) else { return false }
+  if self.fill_container {
+    let rect = self.viewport_rect()
+    if !is_positive_finite(rect.get_width()) ||
+      !is_positive_finite(rect.get_height()) ||
+      !self.fit_content_to_rect(svg_size, rect) {
+      return false
+    }
+    self.initialized = true
+    return true
+  }
   let before = self.viewport_rect()
   if !is_positive_finite(before.get_width()) {
     return false
@@ -954,11 +979,13 @@ fn MarkdownDiagramViewport::preserve_visible_origin(
     0.0
   }
   guard self.measure_svg() is Some(svg_size) else { return false }
-  let height = self.height_for_svg(svg_size)
-  if !is_positive_finite(height) {
-    return false
+  if !self.fill_container {
+    let height = self.height_for_svg(svg_size)
+    if !is_positive_finite(height) {
+      return false
+    }
+    self.write_height(height) |> ignore
   }
-  self.write_height(height) |> ignore
   let rect = self.viewport_rect()
   if !is_positive_finite(rect.get_width()) ||
     !is_positive_finite(rect.get_height()) {
@@ -1059,7 +1086,7 @@ fn MarkdownDiagramViewport::resize_to_height(
   self : MarkdownDiagramViewport,
   height : Double,
 ) -> Bool {
-  if !is_finite(height) {
+  if self.fill_container || !is_finite(height) {
     return false
   }
   let next_height = diagram_minimum_height.max(height)

--- a/editor/viewer/browser/diagram_viewport/diagram_viewport_reference_wbtest.mbt
+++ b/editor/viewer/browser/diagram_viewport/diagram_viewport_reference_wbtest.mbt
@@ -360,6 +360,8 @@ extern "js" fn diagram_viewport_test_target(
   #|     add('diago', true, 400, 400, 800, 400);
   #|   } else if (mode === 'tall') {
   #|     add('diago', true, 400, 800, 200, 800);
+  #|   } else if (mode === 'panel') {
+  #|     add('diago', true, 600, 500, 200, 100);
   #|   } else {
   #|     add('diago', true, 400, 100, 200, 100);
   #|   }
@@ -945,6 +947,46 @@ test "mounts synchronous UML SVGs with UML accessibility labels" {
     "UML diagram controls",
   )
   diagram_viewport_test_flush_frame(harness)
+}
+
+///|
+test "fill-container mode occupies owner geometry and omits inline resizing" {
+  let harness = install_diagram_viewport_test_dom()
+  defer harness.dispose()
+  let target = diagram_viewport_test_target(harness, "panel")
+  let changes = Ref(0)
+  let viewports = DiagramViewports(
+    target,
+    () => changes.val += 1,
+    fill_container=true,
+  )
+  defer viewports.dispose()
+  diagram_viewport_test_flush_frame(harness)
+
+  assert_eq(diagram_viewport_test_wrapper_height(viewports.lifetime, 0), "")
+  assert_eq(
+    diagram_viewport_test_child_classes(viewports.lifetime, 0),
+    "moonbit-viewer-markdown-diagram-content|moonbit-viewer-markdown-diagram-controls",
+  )
+  assert_eq(diagram_viewport_test_scale(viewports.lifetime, 0), 1.0)
+  assert_eq(diagram_viewport_test_translate_x(viewports.lifetime, 0), 200.0)
+  assert_eq(diagram_viewport_test_translate_y(viewports.lifetime, 0), 200.0)
+  assert_eq(changes.val, 0)
+
+  diagram_viewport_test_set_geometry(
+    viewports.lifetime,
+    0,
+    800.0,
+    600.0,
+    200.0,
+    100.0,
+  )
+  diagram_viewport_test_trigger_observer(harness, 0)
+  assert_eq(diagram_viewport_test_translate_x(viewports.lifetime, 0), 300.0)
+  assert_eq(diagram_viewport_test_translate_y(viewports.lifetime, 0), 250.0)
+  assert_false(viewports.lifetime.controllers[0].resize_to_height(320.0))
+  assert_eq(diagram_viewport_test_wrapper_height(viewports.lifetime, 0), "")
+  assert_eq(changes.val, 0)
 }
 
 ///|

--- a/editor/viewer/browser/diagram_viewport/pkg.generated.mbti
+++ b/editor/viewer/browser/diagram_viewport/pkg.generated.mbti
@@ -11,7 +11,7 @@ import {
 
 // Types and methods
 type DiagramViewports
-pub fn DiagramViewports::DiagramViewports(@dom.Element, () -> Unit) -> Self
+pub fn DiagramViewports::DiagramViewports(@dom.Element, () -> Unit, fill_container? : Bool) -> Self
 pub fn DiagramViewports::dispose(Self) -> Unit
 pub fn DiagramViewports::refresh(Self) -> Unit
 

--- a/editor/viewer/markdown_diagrams.mbt
+++ b/editor/viewer/markdown_diagrams.mbt
@@ -15,3 +15,11 @@ pub fn render_uml_diagram_svg(source : String) -> String? {
 pub fn render_mbti_diagram_svg(source : String) -> String? {
   @markdown_core.render_mbti_diagram_svg(source)
 }
+
+///|
+/// Compile the JSON emitted by `moon tree --package --json` to a theme-aware
+/// package dependency SVG. Invalid graph JSON returns `None` so hosts can keep
+/// the manifest source available as a fallback.
+pub fn render_package_dep_diagram_svg(source : String) -> String? {
+  @markdown_core.render_package_dep_diagram_svg(source)
+}

--- a/editor/viewer/markdown_diagrams_test.mbt
+++ b/editor/viewer/markdown_diagrams_test.mbt
@@ -36,3 +36,36 @@ test "public Viewer MBTI renderer accepts a bare generated interface" {
   assert_true(svg.contains("--vscode-editor-foreground"))
   assert_true(render_mbti_diagram_svg("pub struct MissingPackage") is None)
 }
+
+///|
+test "public Viewer package dependency renderer accepts moon tree JSON" {
+  // The UML renderer's default filter selects nodes with in/out degree above
+  // one, so this fixture deliberately branches at `main` and exercises the
+  // default rather than overriding product behavior in the test.
+  let source =
+    #|{
+    #|  "version": 2,
+    #|  "status": "success",
+    #|  "error": null,
+    #|  "root": [0],
+    #|  "nodes": [
+    #|    {"module":"example/app","version":"0.1.0","source":{"kind":"local","path":"/workspace/app"},"rel":"main"},
+    #|    {"module":"example/lib","version":"0.1.0","source":{"kind":"local","path":"/workspace/lib"},"rel":"core"},
+    #|    {"module":"example/lib","version":"0.1.0","source":{"kind":"local","path":"/workspace/lib"},"rel":"util"}
+    #|  ],
+    #|  "edges": [
+    #|    {"from":0,"to":1,"alias":"core","kinds":["source"]},
+    #|    {"from":0,"to":2,"alias":"util","kinds":["source"]}
+    #|  ],
+    #|  "logs": []
+    #|}
+  guard render_package_dep_diagram_svg(source) is Some(svg) else {
+    fail("expected package dependency SVG")
+  }
+  assert_true(svg.contains("<svg"))
+  assert_true(svg.contains("main"))
+  assert_true(svg.contains("core"))
+  assert_true(svg.contains("util"))
+  assert_true(svg.contains("--vscode-editor-foreground"))
+  assert_true(render_package_dep_diagram_svg("{\"nodes\":[]}") is None)
+}

--- a/editor/viewer/pkg.generated.mbti
+++ b/editor/viewer/pkg.generated.mbti
@@ -25,6 +25,8 @@ pub fn overlay_widget(String, @dom.Element) -> @browser.OverlayWidget
 
 pub fn render_mbti_diagram_svg(String) -> String?
 
+pub fn render_package_dep_diagram_svg(String) -> String?
+
 pub fn render_uml_diagram_svg(String) -> String?
 
 pub fn view_zone(Int, @dom.Element, after_column? : Int, after_column_affinity? : @model.PositionAffinity, show_in_hidden_areas? : Bool, ignore_hidden_area_source? : String, ordinal? : Int, suppress_mouse_down? : Bool, height_in_lines? : Double, height_in_px? : Double, min_width_in_px? : Double, margin_dom_node? : @dom.Element, on_dom_node_top? : (Double) -> Unit raise, on_dom_node_layout? : (Bool, Double) -> Unit raise, on_computed_height? : (Double) -> Unit raise) -> @browser.ViewZone


### PR DESCRIPTION
Opening `moon.mod` shows Source by default. Selecting **Dependency graph** asks the desktop host to run `moon tree --package --json` in the owning module and renders the result. No graph request runs until selected; closing and reopening the tab resets it to Source. Review, historical, and position-targeted opens remain source-only.

Module graphs and MBTI diagrams use the shared SVG viewport to fill the file panel, with Fit, pan, zoom, and view-state preservation across Source round trips. MBTI retains its default Diagram view. Graph requests use the typed desktop protocol with generation fencing, cache invalidation, explicit errors, and retry behavior.

Validation:

- `moon info && moon fmt`, `just check`, `just test` (3227 native, 3206 JS, 24 cram), and `just build` passed.
- Desktop browser suite: 45 passed, including Source selected on open, zero initial graph requests, and graph loading on selection.
- Editor tests: 1083 wasm, 1866 JS, 1217 native; editor browser suite: 103 passed. These cover the shared viewport implementation; the subsequent default-mode change touches only desktop code.
- Release macOS app rebuilt and strict recursive codesign verification passed. Real Proton/CEF app checks confirmed Source on open, host-backed graph loading on selection, and Source round trips. MBTI types, Fit, pan, zoom, and full-panel layout were also visually checked.

Known rendering limitations: large dependency graphs become too small to read at Fit, and MBTI files containing only functions currently show an empty diagram without an empty-state message.
