### PR TITLE
fix(desktop): animate panel toggles independently of resizing

### DIFF
--- a/desktop/e2e/tests/rabbita_dom.spec.js
+++ b/desktop/e2e/tests/rabbita_dom.spec.js
@@ -1016,6 +1016,32 @@ test('new chat materializes on send, and archive and restore update the sidebar'
   expect(app.pageErrors).toEqual([]);
 });
 
+test('sidebar sizes update immediately between toggles', async ({ page }) => {
+  const app = new DesktopBrowserHarness(page);
+  await page.emulateMedia({ reducedMotion: 'no-preference' });
+  await app.install();
+  await app.goto();
+  await expect(page.getByRole('button', { name: 'Hide sidebar', exact: true }))
+    .toBeVisible();
+
+  // No drag class is set: any requested size must take effect immediately,
+  // while the separate toggle test continues to exercise open/close motion.
+  const samples = await page.locator('.app').evaluate(async element => {
+    const sidebar = element.querySelector(':scope > aside');
+    const samples = [];
+    for (const width of [300, 360, 420, 280]) {
+      document.documentElement.style.setProperty('--sidebar-width', `${width}px`);
+      samples.push({ requested: width, actual: sidebar.getBoundingClientRect().width });
+      await new Promise(resolve => requestAnimationFrame(resolve));
+    }
+    return samples;
+  });
+  for (const sample of samples) {
+    expect(Math.abs(sample.actual - sample.requested)).toBeLessThan(0.5);
+  }
+  expect(app.pageErrors).toEqual([]);
+});
+
 test('sidebar toggle stays fixed throughout the sidebar animation', async ({ page }) => {
   const app = new DesktopBrowserHarness(page);
   await app.install();

--- a/desktop/styles/base.css
+++ b/desktop/styles/base.css
@@ -290,12 +290,42 @@ html {
   }
 }
 
+/* Opening progress runs from 0 (no layout space) to 1 (the requested size).
+   Only open/close state changes animate it; dragging or window resizing
+   changes the requested size directly. These local numbers do not inherit
+   into nested panes. */
+@property --sidebar-open-progress {
+  syntax: "<number>";
+  inherits: false;
+  initial-value: 1;
+}
+
+@property --editor-open-progress {
+  syntax: "<number>";
+  inherits: false;
+  initial-value: 0;
+}
+
+@property --editor-expand-progress {
+  syntax: "<number>";
+  inherits: false;
+  initial-value: 0;
+}
+
+@property --terminal-open-progress {
+  syntax: "<number>";
+  inherits: false;
+  initial-value: 0;
+}
+
 .app {
   /* Vertical and horizontal resize handles share one hit-area size per axis.
      Component styles consume the dimension that matches their seam. */
   --resize-handle-width: 6px;
   --resize-handle-height: 6px;
-  --sidebar-column-width: clamp(220px, var(--sidebar-width, 264px), 480px);
+  --sidebar-column-width: calc(
+    clamp(220px, var(--sidebar-width, 264px), 480px) * var(--sidebar-open-progress)
+  );
   --sidebar-drawer-width: min(320px, 86vw);
   --sidebar-toggle-size: 28px;
   --topbar-inline-padding: 18px;
@@ -325,7 +355,7 @@ html {
      rather than 100vh, so the two height bases can't disagree. */
   height: 100%;
   min-height: 0;
-  transition: grid-template-columns var(--drawer-duration)
+  transition: --sidebar-open-progress var(--drawer-duration)
     var(--drawer-easing);
 }
 
@@ -333,8 +363,7 @@ html {
    takes the full width. The aside stays in the DOM (merely unmounted
    from layout) so reopening keeps its scroll position. */
 .app.sidebar-collapsed {
-  --sidebar-column-width: 0px;
-  grid-template-columns: 0 minmax(0, 1fr);
+  --sidebar-open-progress: 0;
 }
 .app.sidebar-collapsed > aside {
   visibility: hidden;
@@ -398,31 +427,34 @@ html.native-titlebar-overlay .app .window-titlebar-drag-strip {
    opens, so the viewer host element stays in the DOM but takes no
    space. */
 .content {
+  --editor-restored-width: clamp(360px, var(--editor-width, 50%), calc(100% - 240px));
+  /* Expansion fills the remainder beyond the saved width. Closing scales
+     the resulting column to zero without changing the saved drag size. */
+  --editor-column-width: calc(
+    (var(--editor-restored-width) +
+      (100% - var(--editor-restored-width)) * var(--editor-expand-progress)) *
+      var(--editor-open-progress)
+  );
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 0;
-  grid-template-rows: minmax(0, 1fr) 0;
+  grid-template-columns: minmax(0, 1fr) var(--editor-column-width);
+  grid-template-rows:
+    minmax(0, 1fr)
+    calc(
+      clamp(180px, var(--terminal-height, 38%), calc(100% - 180px)) *
+        var(--terminal-open-progress)
+    );
   min-width: 0;
   min-height: 0;
   transition:
-    grid-template-columns var(--drawer-duration) var(--drawer-easing),
-    grid-template-rows var(--drawer-duration) var(--drawer-easing);
-}
-
-/* A drag continuously changes the target size. Restarting the drawer
-   transition on every move makes the seam lag behind the pointer. The drag
-   classes last until mouseup, so ordinary open/close motion stays animated. */
-html.is-resizing .app,
-html.is-resizing .content,
-html.is-resizing-terminal .content {
-  transition: none;
+    --editor-open-progress var(--drawer-duration) var(--drawer-easing),
+    --editor-expand-progress var(--drawer-duration) var(--drawer-easing),
+    --terminal-open-progress var(--drawer-duration) var(--drawer-easing);
 }
 
 /* Opening the terminal carves a resizable second row out of the conversation
    column. The editor keeps the full height in its own column. */
 .content.terminal-open {
-  grid-template-rows:
-    minmax(0, 1fr)
-    clamp(180px, var(--terminal-height, 38%), calc(100% - 180px));
+  --terminal-open-progress: 1;
 }
 .content > main {
   grid-row: 1;
@@ -440,16 +472,14 @@ html.is-resizing-terminal .content {
    editor floors at 360px while the conversation keeps at least 240px. The
    clamp also re-fits the panel on window resize without any script. */
 .content.panel-open {
-  grid-template-columns:
-    minmax(0, 1fr)
-    clamp(360px, var(--editor-width, 50%), calc(100% - 240px));
+  --editor-open-progress: 1;
 }
 
 /* Expanded: keep the conversation mounted in a zero-width track and hand the
    whole content area to the editor. The saved --editor-width is untouched, so
    restoring returns to the user's previous split. */
 .content.panel-open.panel-expanded {
-  grid-template-columns: 0 minmax(0, 1fr);
+  --editor-expand-progress: 1;
 }
 
 /* The expanded editor occupies the main column and inherits its reservation. */

--- a/desktop/styles/base.css
+++ b/desktop/styles/base.css
@@ -408,6 +408,15 @@ html.native-titlebar-overlay .app .window-titlebar-drag-strip {
     grid-template-rows var(--drawer-duration) var(--drawer-easing);
 }
 
+/* A drag continuously changes the target size. Restarting the drawer
+   transition on every move makes the seam lag behind the pointer. The drag
+   classes last until mouseup, so ordinary open/close motion stays animated. */
+html.is-resizing .app,
+html.is-resizing .content,
+html.is-resizing-terminal .content {
+  transition: none;
+}
+
 /* Opening the terminal carves a resizable second row out of the conversation
    column. The editor keeps the full height in its own column. */
 .content.terminal-open {

--- a/desktop/styles/base.css
+++ b/desktop/styles/base.css
@@ -290,10 +290,12 @@ html {
   }
 }
 
-/* Opening progress runs from 0 (no layout space) to 1 (the requested size).
-   Only open/close state changes animate it; dragging or window resizing
-   changes the requested size directly. These local numbers do not inherit
-   into nested panes. */
+/* Register progress as a number so CSS can interpolate between 0 and 1.
+   Layout size = requested size * opening progress: a 320px pane occupies
+   0px when closed, 160px at progress 0.5, and 320px when fully open.
+   Only toggling or expanding a pane animates progress. A resize changes the
+   requested size directly, without starting a new transition. These local
+   numbers do not inherit into nested panes. */
 @property --sidebar-open-progress {
   syntax: "<number>";
   inherits: false;

--- a/desktop/styles/file_panel.css
+++ b/desktop/styles/file_panel.css
@@ -222,22 +222,32 @@ button.panel-toggle:not(:disabled):hover {
    clamped so the panel floors at 96px while the viewer keeps at
    least 120px. The clamp also re-fits the panel on window resize
    without any script. */
+/* Only opening/closing changes this progress. The drag size stays outside
+   the transition, so both tree orientations follow size changes directly. */
+@property --tree-open-progress {
+  syntax: "<number>";
+  inherits: false;
+  initial-value: 1;
+}
+
 .file-tree-pane {
   position: relative;
   display: flex;
   flex-direction: column;
-  flex: 0 0 clamp(96px, var(--tree-height, 32%), calc(100% - 120px));
+  flex: 0 0 calc(
+    clamp(96px, var(--tree-height, 32%), calc(100% - 120px)) * var(--tree-open-progress)
+  );
   min-height: 0;
   overflow: hidden;
   border-top: 1px solid var(--color-separator);
   background: var(--color-bg-surface);
   visibility: visible;
   transition:
-    flex-basis var(--drawer-duration) var(--drawer-easing),
+    --tree-open-progress var(--drawer-duration) var(--drawer-easing),
     visibility 0s linear;
 }
 .editor:not(.tree-open) .file-tree-pane {
-  flex-basis: 0;
+  --tree-open-progress: 0;
   visibility: hidden;
   pointer-events: none;
   transition-delay: 0s, var(--drawer-duration);
@@ -252,20 +262,12 @@ button.panel-toggle:not(:disabled):hover {
   flex-direction: row;
 }
 .editor.tree-right .file-tree-pane {
-  flex: 0 0 clamp(180px, var(--tree-width, 260px), calc(100% - 240px));
+  flex: 0 0 calc(
+    clamp(180px, var(--tree-width, 260px), calc(100% - 240px)) * var(--tree-open-progress)
+  );
   min-width: 0;
   border-top: none;
   border-left: 1px solid var(--color-separator);
-}
-.editor.tree-right:not(.tree-open) .file-tree-pane {
-  flex-basis: 0;
-}
-
-/* Follow the pointer immediately while dragging either tree axis. Resizing
-   the sidebar or editor can also change the tree's clamped size; animate its
-   open/close changes again once the drag ends. */
-html:is(.is-resizing, .is-resizing-row, .is-resizing-col) .file-tree-pane {
-  transition: none;
 }
 
 /* Drag-to-resize handle on the panel's viewer-facing seam — the

--- a/desktop/styles/file_panel.css
+++ b/desktop/styles/file_panel.css
@@ -261,6 +261,13 @@ button.panel-toggle:not(:disabled):hover {
   flex-basis: 0;
 }
 
+/* Follow the pointer immediately while dragging either tree axis. Resizing
+   the sidebar or editor can also change the tree's clamped size; animate its
+   open/close changes again once the drag ends. */
+html:is(.is-resizing, .is-resizing-row, .is-resizing-col) .file-tree-pane {
+  transition: none;
+}
+
 /* Drag-to-resize handle on the panel's viewer-facing seam — the
    row-resize twin of .editor-resize-handle in the bottom layout, a
    col-resize strip on the left seam in the sidebar layout. */


### PR DESCRIPTION
Continuously resizing a pane restarted the 180 ms transition on its grid track or flex basis, leaving the divider behind the pointer and still moving after input stopped.

Animate registered numeric open/close progress instead, and calculate layout from that progress and the requested size. Only panel state changes start a transition; dragging, programmatic size changes, and window resizing apply immediately without drag-specific animation overrides. Preserve sidebar, editor, terminal, and file-tree toggles, editor expansion/restoration, and reduced-motion behavior.

Add a browser regression that changes the sidebar size without setting any drag class and checks that each requested width takes effect immediately.

Validation:
- Desktop browser bundle built; all 42 desktop Playwright tests passed.
- Headless Chromium probes with the real CSS: all five resize paths show no trailing size animation; resizing during opening preserves the existing toggle animation deadline.
- Compared settled layouts with the previous implementation across 288 viewport/panel combinations; geometry and visibility matched. Checked ten toggle/expand transitions with normal and reduced motion.
- `just check`, `just test` (3,202 native tests, 3,184 JS tests, and 24 offline cram tests), `just build`, `moon info`, and `moon fmt` passed; generated interfaces unchanged.

Validation used headless Chromium; no running desktop app window was operated.
