### PR TITLE
fix(desktop): clear OpenSeek sidebar selection on page switches

### DIFF
--- a/desktop/frontend/conversation_rename.mbt
+++ b/desktop/frontend/conversation_rename.mbt
@@ -21,6 +21,9 @@ fn Model::decorate_conversation_input(
   }
   let selected = match input.id.source() {
     @conversation.OpenSeekLive | @conversation.OpenSeekArchived =>
+      // Remembered OpenSeek selection survives page switches, but its row
+      // must stop highlighting while Codex or another page is on screen.
+      self.screen is Chat &&
       self
       .conversation_selection()
       .map_or(false, selection => selection.matches_id(input.id))

--- a/desktop/frontend/view_wbtest.mbt
+++ b/desktop/frontend/view_wbtest.mbt
@@ -45,4 +45,12 @@ test "a fresh chat selects its project and materializes on first send" {
     "Explain the sidebar state",
   )
   assert_true(submitted_project.conversations[0].active)
+
+  // Opening Codex preserves the OpenSeek conversation for returning to it,
+  // but must clear its sidebar highlight while the Codex page is visible.
+  let (_, codex_page) = update(test_dispatch(), OpenCodex, submitted)
+  assert_true(!sidebar_project_for_test(codex_page).conversations[0].active)
+  assert_true(
+    codex_page.conversation_selection() == submitted.conversation_selection(),
+  )
 }


### PR DESCRIPTION
Switching from an OpenSeek conversation to Codex could leave both sidebar rows highlighted. The row decoration reapplied the remembered OpenSeek selection without checking which page was visible.

Require the Chat page when highlighting OpenSeek rows, while preserving the remembered selection. Extend the existing sidebar test to check that opening Codex clears the old highlight without losing that selection.

Validation on the rebased commit:
- `moon test desktop/frontend --target js`: 461 passed.
- `just check`: passed.
- `just test`: 3,202 native tests, 3,184 JS tests, and 24 cram cases passed. Live API smoke tests were skipped where credentials were absent.
- `just build`: native and JS builds passed.
- `moon info` and `moon fmt`: passed; no generated interface changes.

No application-window validation was performed.
