### PR TITLE
fix(deepseek): include request context in streaming failures

### DIFF
--- a/deepseek/client/client.mbt
+++ b/deepseek/client/client.mbt
@@ -111,11 +111,13 @@ fn retryable_status(code : Int) -> Bool {
 }
 
 ///|
-/// Marks an attempt failure the retry loop may absorb. Carries the
-/// already-formatted public failure message so the final attempt re-raises
-/// the same text a non-retrying client would have produced.
-priv suberror RetryableApiError {
-  RetryableApiError(String)
+/// Provider errors stay typed through retries and diagnostic construction.
+/// The public chat boundary formats them as Failure messages.
+priv suberror ApiError {
+  HttpStatusError(Int, String)
+  IdleTimeout(String, Int)
+  StreamEnded
+  ResponseError(String)
 }
 
 ///|
@@ -129,23 +131,21 @@ let max_backoff_ms : Int = 60_000
 /// (exponential backoff doubling from `retry_backoff_ms`, capped at
 /// `max_backoff_ms`; `max_retry` counts restarts, hence the -1).
 ///
-/// The `fatal_error` classification: cancellations, plain failures (our own
-/// final verdicts — non-retryable HTTP statuses, malformed response bodies,
-/// truncated streams), and malformed-api_url parse errors (which fail
-/// identically every time, before any network I/O) propagate immediately;
+/// Cancellations, non-retryable HTTP statuses, malformed responses, plain
+/// failures, and malformed-api_url parse errors propagate immediately;
 /// anything else is transport-shaped (connect refused, reset, DNS) and
 /// retries within budget. `bail` lets an attempt declare later retries
 /// pointless — streaming chat sets it once the stream has produced any event,
 /// since replaying a half-consumed completion would duplicate content (or
 /// regenerate tool calls) downstream.
 ///
-/// A `RetryableApiError` that survives the budget (or bail) re-raises as a
-/// plain failure carrying the same text a non-retrying client would have
-/// produced, so the private marker type never escapes the package.
+/// Errors propagate with their types intact. The chat boundary observes the
+/// final cause before adding request context for the caller.
 async fn[T] Client::with_retries(
   self : Client,
   attempt : async () -> T,
   bail : () -> Bool,
+  progress? : RequestProgress,
 ) -> T {
   @async.retry(
     ExponentialDelay(
@@ -155,17 +155,27 @@ async fn[T] Client::with_retries(
     ),
     max_retry=self.retry_attempts - 1,
     fatal_error=error => {
-      bail() ||
-      @async.is_cancellation_error(error) ||
-      error is Failure::Failure(_) ||
-      error is @http.URIParseError::InvalidFormat ||
-      error is @http.URIParseError::UnsupportedProtocol(_)
+      let streamed = bail()
+      let fatal = streamed ||
+        (error is HttpStatusError(code, _) && !retryable_status(code)) ||
+        error is ResponseError(_) ||
+        @async.is_cancellation_error(error) ||
+        error is Failure::Failure(_) ||
+        error is @http.URIParseError::InvalidFormat ||
+        error is @http.URIParseError::UnsupportedProtocol(_)
+      if progress is Some(progress) {
+        progress.stop_reason = if streamed {
+          StreamStarted
+        } else if fatal {
+          NotRetryable
+        } else {
+          AttemptsExhausted
+        }
+      }
+      fatal
     },
     attempt,
-  ) catch {
-    RetryableApiError(message) => fail(message)
-    error => raise error
-  }
+  )
 }
 
 ///|
@@ -176,6 +186,8 @@ async fn[T] Client::with_retries(
 /// be constrained to a JSON object. Pass `stream=StreamHandler(...)` to send
 /// the request in SSE streaming mode while still receiving the accumulated
 /// response as the return value.
+/// Streaming failures include request progress in the Failure message after
+/// retries stop. Cancellation propagates unchanged.
 pub async fn Client::chat(
   self : Client,
   messages : Array[@deepseek.ChatMessage],
@@ -191,27 +203,44 @@ pub async fn Client::chat(
     stream=is_streaming,
     response_format?,
   ) <| messages
-  match stream {
-    None => self.with_retries(() => self.chat_attempt(body), () => false)
-    Some(stream) => {
-      // Once the server has produced any complete SSE event the completion is
-      // running and billed — text deltas, tool-call deltas, and usage alike,
-      // even though only text reaches the callbacks. A retry past that point
-      // could duplicate content or generate a different tool call, so the
-      // first event (not just the first text delta) bails the retry loop and
-      // failures surface instead (Codex review).
-      let mut streamed = false
-      self.with_retries(
-        () => {
-          self.chat_stream_attempt(
-            body,
-            on_stream_event=() => streamed = true,
-            stream,
-          )
-        },
-        () => streamed,
-      )
+  try {
+    match stream {
+      None => self.with_retries(() => self.chat_attempt(body), () => false)
+      Some(stream) => {
+        // Once the server has produced any complete SSE event the completion is
+        // running and billed — text deltas, tool-call deltas, and usage alike,
+        // even though only text reaches the callbacks. A retry past that point
+        // could duplicate content or generate a different tool call, so the
+        // first event (not just the first text delta) bails the retry loop and
+        // failures surface instead (Codex review).
+        let progress = RequestProgress()
+        self.with_retries(
+          () => {
+            progress.begin_attempt()
+            self.chat_stream_attempt(body, progress, stream)
+          },
+          () => {
+            match progress.phase {
+              Sse(sse) => sse.event_count > 0 || sse.buffered_data
+              Decode(event_count~, ..) => event_count > 0
+              Connect | WriteRequest | ResponseHeaders | ResponseBody => false
+            }
+          },
+          progress~,
+        ) catch {
+          error if @async.is_being_cancelled() ||
+            @async.is_cancellation_error(error) => raise error
+          error => fail(progress.failure_message(self, error))
+        }
+      }
     }
+  } catch {
+    HttpStatusError(code, body) => fail("DeepSeek API error \{code}: \{body}")
+    IdleTimeout(context, timeout_ms) =>
+      fail("\{context} idle for \{timeout_ms}ms")
+    StreamEnded => fail("DeepSeek stream ended before [DONE]")
+    ResponseError(message) => fail(message)
+    error => raise error
   }
 }
 
@@ -226,21 +255,22 @@ async fn Client::chat_attempt(
   })
   let text = data.text()
   guard resp.code >= 200 && resp.code < 300 else {
-    let message = "DeepSeek API error \{resp.code}: \{text}"
-    if retryable_status(resp.code) {
-      raise RetryableApiError(message)
-    }
-    fail(message)
+    raise HttpStatusError(resp.code, text)
   }
   // A 2xx body that fails to parse or decode is a final verdict, not a
   // transport error: the completion already ran (and billed), so retrying
   // would duplicate it for the same bad payload.
-  @json.from_json(
-    @json.parse(text) catch {
-      error => fail("DeepSeek response is not JSON: \{error}; body: \{text}")
-    },
-  ) catch {
-    error => fail("DeepSeek response decode error: \{error}; body: \{text}")
+  let json = @json.parse(text) catch {
+    error =>
+      raise ResponseError(
+        "DeepSeek response is not JSON: \{error}; body: \{text}",
+      )
+  }
+  @json.from_json(json) catch {
+    error =>
+      raise ResponseError(
+        "DeepSeek response decode error: \{error}; body: \{text}",
+      )
   }
 }
 
@@ -248,7 +278,7 @@ async fn Client::chat_attempt(
 async fn Client::chat_stream_attempt(
   self : Client,
   body : Json,
-  on_stream_event~ : () -> Unit,
+  progress : RequestProgress,
   stream : StreamHandler,
 ) -> @deepseek.ChatResponse {
   let client = @http.post_stream(self.api_url, headers={
@@ -261,23 +291,23 @@ async fn Client::chat_stream_attempt(
     "Accept-Encoding": "identity",
   })
   defer client.close()
+  progress.phase = WriteRequest
   client.write(body.stringify())
   // Bound the wait for response headers the same way the SSE loop bounds the
   // wait between events: a peer that accepts the connection then never sends a
   // status line would otherwise block here forever, before any event, with no
   // error for the retry loop to see.
+  progress.phase = ResponseHeaders
   let resp = with_idle_timeout(
     self.idle_timeout_ms,
     "DeepSeek response headers",
     () => client.end_request(),
   )
+  progress.http_status = Some(resp.code)
   guard resp.code >= 200 && resp.code < 300 else {
+    progress.phase = ResponseBody
     let text = client.read_all().text()
-    let message = "DeepSeek API error \{resp.code}: \{text}"
-    if retryable_status(resp.code) {
-      raise RetryableApiError(message)
-    }
-    fail(message)
+    raise HttpStatusError(resp.code, text)
   }
   // The stream reader finalizes malformed SSE payloads at its parse site
   // (see decode_sse_data in stream.mbt), so a mid-stream transport error
@@ -285,8 +315,8 @@ async fn Client::chat_stream_attempt(
   // decides whether retrying is allowed.
   read_chat_stream(
     client,
+    progress,
     idle_timeout_ms=self.idle_timeout_ms,
-    on_stream_event~,
     on_content_delta=stream.on_content_delta,
     on_reasoning_delta=stream.on_reasoning_delta,
   )

--- a/deepseek/client/client.mbt
+++ b/deepseek/client/client.mbt
@@ -111,13 +111,12 @@ fn retryable_status(code : Int) -> Bool {
 }
 
 ///|
-/// Provider errors stay typed through retries and diagnostic construction.
+/// These failures may be retried before any response data is received.
 /// The public chat boundary formats them as Failure messages.
-priv suberror ApiError {
+priv suberror RetryableApiError {
   HttpStatusError(Int, String)
   IdleTimeout(String, Int)
   StreamEnded
-  ResponseError(String)
 }
 
 ///|
@@ -157,8 +156,6 @@ async fn[T] Client::with_retries(
     fatal_error=error => {
       let streamed = bail()
       let fatal = streamed ||
-        (error is HttpStatusError(code, _) && !retryable_status(code)) ||
-        error is ResponseError(_) ||
         @async.is_cancellation_error(error) ||
         error is Failure::Failure(_) ||
         error is @http.URIParseError::InvalidFormat ||
@@ -239,7 +236,6 @@ pub async fn Client::chat(
     IdleTimeout(context, timeout_ms) =>
       fail("\{context} idle for \{timeout_ms}ms")
     StreamEnded => fail("DeepSeek stream ended before [DONE]")
-    ResponseError(message) => fail(message)
     error => raise error
   }
 }
@@ -255,22 +251,19 @@ async fn Client::chat_attempt(
   })
   let text = data.text()
   guard resp.code >= 200 && resp.code < 300 else {
-    raise HttpStatusError(resp.code, text)
+    if retryable_status(resp.code) {
+      raise HttpStatusError(resp.code, text)
+    }
+    fail("DeepSeek API error \{resp.code}: \{text}")
   }
   // A 2xx body that fails to parse or decode is a final verdict, not a
   // transport error: the completion already ran (and billed), so retrying
   // would duplicate it for the same bad payload.
   let json = @json.parse(text) catch {
-    error =>
-      raise ResponseError(
-        "DeepSeek response is not JSON: \{error}; body: \{text}",
-      )
+    error => fail("DeepSeek response is not JSON: \{error}; body: \{text}")
   }
   @json.from_json(json) catch {
-    error =>
-      raise ResponseError(
-        "DeepSeek response decode error: \{error}; body: \{text}",
-      )
+    error => fail("DeepSeek response decode error: \{error}; body: \{text}")
   }
 }
 
@@ -307,7 +300,10 @@ async fn Client::chat_stream_attempt(
   guard resp.code >= 200 && resp.code < 300 else {
     progress.phase = ResponseBody
     let text = client.read_all().text()
-    raise HttpStatusError(resp.code, text)
+    if retryable_status(resp.code) {
+      raise HttpStatusError(resp.code, text)
+    }
+    fail("DeepSeek API error \{resp.code}: \{text}")
   }
   // The stream reader finalizes malformed SSE payloads at its parse site
   // (see decode_sse_data in stream.mbt), so a mid-stream transport error

--- a/deepseek/client/diagnostics.mbt
+++ b/deepseek/client/diagnostics.mbt
@@ -1,0 +1,109 @@
+///|
+priv enum RequestPhase {
+  Connect
+  WriteRequest
+  ResponseHeaders
+  ResponseBody
+  Sse(SseProgress)
+  Decode(event_count~ : Int, last_event_at~ : Int64?)
+}
+
+///|
+priv struct SseProgress {
+  mut event_count : Int
+  mut last_event_at : Int64?
+  mut buffered_data : Bool
+}
+
+///|
+priv enum RetryStopReason {
+  StreamStarted
+  NotRetryable
+  AttemptsExhausted
+}
+
+///|
+/// Per-request observations used to enrich the final error message. The
+/// elapsed clock spans all attempts and backoff. Never retain request contents.
+priv struct RequestProgress {
+  started_at : Int64
+  mut attempts : Int
+  mut phase : RequestPhase
+  mut http_status : Int?
+  mut stop_reason : RetryStopReason
+}
+
+///|
+fn RequestProgress::RequestProgress() -> RequestProgress {
+  {
+    started_at: @async.now(),
+    attempts: 0,
+    phase: Connect,
+    http_status: None,
+    stop_reason: AttemptsExhausted,
+  }
+}
+
+///|
+fn RequestProgress::begin_attempt(self : Self) -> Unit {
+  self.attempts += 1
+  self.phase = Connect
+  self.http_status = None
+  self.stop_reason = AttemptsExhausted
+}
+
+///|
+fn RequestProgress::failure_message(
+  self : Self,
+  client : Client,
+  error : Error,
+) -> String {
+  // Preserve the original payload, including errors not classified here.
+  let detail = match error {
+    IdleTimeout(context, timeout_ms) =>
+      "Request idle for \{timeout_ms} ms: \{context}"
+    HttpStatusError(code, body) => "HTTP \{code}: \{body}"
+    StreamEnded => "Stream ended before [DONE]"
+    ResponseError(message) => "Invalid model response: \{message}"
+    @http.IncorrectBodyLength => "HTTP response body length mismatch"
+    error => "\{@debug.Repr(error)}"
+  }
+  let reason = match self.stop_reason {
+    StreamStarted => "Not retried because response data was already received."
+    NotRetryable => "This error cannot be retried automatically."
+    AttemptsExhausted => "The retry limit was reached."
+  }
+  let phase = match self.phase {
+    Connect => "connect"
+    WriteRequest => "write_request"
+    ResponseHeaders => "response_headers"
+    ResponseBody => "response_body"
+    Sse(_) => "sse_read"
+    Decode(..) => "decode"
+  }
+  let message = StringBuilder()
+  message.write_string("Model request failed: \{detail}. \{reason}")
+  message.write_string(
+    " Model: \{client.model}; stage: \{phase}; attempts: \{self.attempts}/\{client.retry_attempts.max(1)}; elapsed: \{(@async.now() - self.started_at).max(0)} ms",
+  )
+  if self.http_status is Some(status) {
+    message.write_string("; HTTP status: \{status}")
+  }
+  let last_event_at = match self.phase {
+    Sse(sse) => {
+      message.write_string(
+        "; stream events: \{sse.event_count}; buffered event: \{sse.buffered_data}",
+      )
+      sse.last_event_at
+    }
+    Decode(event_count~, last_event_at~) => {
+      message.write_string("; stream events: \{event_count}")
+      last_event_at
+    }
+    Connect | WriteRequest | ResponseHeaders | ResponseBody => None
+  }
+  if last_event_at is Some(at) {
+    message.write_string("; last event: \{(@async.now() - at).max(0)} ms ago")
+  }
+  message.to_string()
+}

--- a/deepseek/client/diagnostics.mbt
+++ b/deepseek/client/diagnostics.mbt
@@ -64,7 +64,6 @@ fn RequestProgress::failure_message(
       "Request idle for \{timeout_ms} ms: \{context}"
     HttpStatusError(code, body) => "HTTP \{code}: \{body}"
     StreamEnded => "Stream ended before [DONE]"
-    ResponseError(message) => "Invalid model response: \{message}"
     @http.IncorrectBodyLength => "HTTP response body length mismatch"
     error => "\{@debug.Repr(error)}"
   }

--- a/deepseek/client/diagnostics_test.mbt
+++ b/deepseek/client/diagnostics_test.mbt
@@ -53,11 +53,11 @@ async test "idle stream delivers partial output once without retrying" {
   @async.with_task_group() <| group => {
     let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     defer server.close()
-    let hits = Ref(0)
+    let mut hits = 0
     group.spawn_bg(no_wait=true) <| () => {
       server.run_forever((_request, body, conn) => {
         ignore(body.read_all())
-        hits.val += 1
+        hits += 1
         conn.send_response(200, "OK", extra_headers={
           "Content-Type": "text/event-stream",
         })
@@ -84,7 +84,7 @@ async test "idle stream delivers partial output once without retrying" {
     } noraise {
       _ => fail("expected timeout")
     }
-    assert_eq(hits.val, 1)
+    assert_eq(hits, 1)
     assert_eq(deltas, ["partial"])
   }
 }
@@ -94,12 +94,12 @@ async test "a thrown body read after a buffered data line cannot replay the requ
   @async.with_task_group() <| group => {
     let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     defer server.close()
-    let hits = Ref(0)
+    let mut hits = 0
     group.spawn_bg(no_wait=true) <| () => {
       server.run_forever(
         (_request, body, conn) => {
           ignore(body.read_all())
-          hits.val += 1
+          hits += 1
           conn.send_response(200, "OK", extra_headers={
             "Content-Type": "text/event-stream",
             "Content-Length": "10000",
@@ -128,7 +128,7 @@ async test "a thrown body read after a buffered data line cannot replay the requ
     } noraise {
       _ => fail("expected body read failure")
     }
-    assert_eq(hits.val, 1)
+    assert_eq(hits, 1)
   }
 }
 
@@ -161,11 +161,11 @@ async test "idle flush preserves malformed response payload without retrying" {
   @async.with_task_group() <| group => {
     let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     defer server.close()
-    let hits = Ref(0)
+    let mut hits = 0
     group.spawn_bg(no_wait=true) <| () => {
       server.run_forever((_request, body, conn) => {
         ignore(body.read_all())
-        hits.val += 1
+        hits += 1
         conn.send_response(200, "OK", extra_headers={
           "Content-Type": "text/event-stream",
         })
@@ -191,7 +191,7 @@ async test "idle flush preserves malformed response payload without retrying" {
     } noraise {
       _ => fail("expected invalid response")
     }
-    assert_eq(hits.val, 1)
+    assert_eq(hits, 1)
   }
 }
 

--- a/deepseek/client/diagnostics_test.mbt
+++ b/deepseek/client/diagnostics_test.mbt
@@ -229,7 +229,7 @@ async test "malformed buffered response is not mislabeled as the idle timeout th
     assert_eq(hits.val, 1)
     assert_eq(failures.length(), 1)
     let text = failures[0]
-    assert_true(text.contains("Invalid model response"))
+    assert_true(text.contains("DeepSeek stream decode error"))
     assert_true(
       text.contains("Not retried because response data was already received."),
     )

--- a/deepseek/client/diagnostics_test.mbt
+++ b/deepseek/client/diagnostics_test.mbt
@@ -5,7 +5,6 @@ async test "stream failure diagnostics preserve HTTP error payload after exhaust
       is Some((url, hits)) else {
       return
     }
-    let failures : Array[String] = []
     let client = @client.Client(
       api_key="private-key",
       api_url=url,
@@ -18,56 +17,39 @@ async test "stream failure diagnostics preserve HTTP error payload after exhaust
         stream=StreamHandler(on_content_delta=_ => ()),
       )
     catch {
-      Failure(message) => failures.push(message)
+      Failure(message) => assert_true(message.contains("synthetic failure"))
       error => raise error
     } noraise {
       _ => fail("expected failure")
     }
     assert_eq(hits.val, 2)
-    assert_eq(failures.length(), 1)
-    let text = failures[0]
-    assert_true(text.contains("attempts: 2/2"))
-    assert_true(text.contains("HTTP 503"))
-    assert_true(text.contains("The retry limit was reached."))
-    assert_true(text.contains("stage: response_body"))
-    assert_false(text.contains("last event:"))
-    assert_false(text.contains("stream events:"))
-    assert_false(text.contains("buffered event:"))
-    assert_false(text.contains("private"))
-    assert_true(text.contains("synthetic failure"))
-    assert_false(text.contains(url))
   }
 }
 
 ///|
-async test "stream diagnostics distinguish non-retryable HTTP errors" {
+async test "stream never retries a non-retryable HTTP error" {
   @async.with_task_group() <| group => {
     guard flaky_server(group, failures=99, status=400, sse=true)
       is Some((url, hits)) else {
       return
     }
-    let failures : Array[String] = []
     try
       @client.Client(api_key="test", api_url=url).chat(
         [ChatMessage(User, content="hello")],
         stream=StreamHandler(on_content_delta=_ => ()),
       )
     catch {
-      Failure(message) => failures.push(message)
+      Failure(_) => ()
       error => raise error
     } noraise {
       _ => fail("expected failure")
     }
     assert_eq(hits.val, 1)
-    assert_eq(failures.length(), 1)
-    assert_true(
-      failures[0].contains("This error cannot be retried automatically."),
-    )
   }
 }
 
 ///|
-async test "idle stream diagnostics report partial output without retrying" {
+async test "idle stream delivers partial output once without retrying" {
   @async.with_task_group() <| group => {
     let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     defer server.close()
@@ -86,7 +68,7 @@ async test "idle stream diagnostics report partial output without retrying" {
         @async.sleep(3000)
       })
     }
-    let failures : Array[String] = []
+    let deltas : Array[String] = []
     try
       @client.Client(
         api_key="test",
@@ -94,25 +76,16 @@ async test "idle stream diagnostics report partial output without retrying" {
         idle_timeout_ms=100,
       ).chat(
         [ChatMessage(User, content="hello")],
-        stream=StreamHandler(on_content_delta=_ => ()),
+        stream=StreamHandler(on_content_delta=delta => deltas.push(delta)),
       )
     catch {
-      Failure(message) => failures.push(message)
+      Failure(_) => ()
       error => raise error
     } noraise {
       _ => fail("expected timeout")
     }
     assert_eq(hits.val, 1)
-    assert_eq(failures.length(), 1)
-    let text = failures[0]
-    assert_true(text.contains("Request idle for 100 ms"))
-    assert_true(text.contains("stage: sse_read"))
-    assert_true(text.contains("stream events: 1"))
-    assert_true(
-      text.contains("Not retried because response data was already received."),
-    )
-    assert_true(text.contains("last event:"))
-    assert_true(text.contains("elapsed:"))
+    assert_eq(deltas, ["partial"])
   }
 }
 
@@ -140,7 +113,6 @@ async test "a thrown body read after a buffered data line cannot replay the requ
         allow_failure=true,
       )
     }
-    let failures : Array[String] = []
     try
       @client.Client(
         api_key="test",
@@ -151,18 +123,12 @@ async test "a thrown body read after a buffered data line cannot replay the requ
         stream=StreamHandler(on_content_delta=_ => ()),
       )
     catch {
-      Failure(message) => failures.push(message)
+      Failure(_) => ()
       error => raise error
     } noraise {
       _ => fail("expected body read failure")
     }
     assert_eq(hits.val, 1)
-    assert_eq(failures.length(), 1)
-    assert_true(
-      failures[0].contains(
-        "Not retried because response data was already received.",
-      ),
-    )
   }
 }
 
@@ -191,7 +157,7 @@ async test "cancellation is not wrapped as a request failure" {
 }
 
 ///|
-async test "malformed buffered response is not mislabeled as the idle timeout that flushed it" {
+async test "idle flush preserves malformed response payload without retrying" {
   @async.with_task_group() <| group => {
     let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
     defer server.close()
@@ -210,7 +176,6 @@ async test "malformed buffered response is not mislabeled as the idle timeout th
         @async.sleep(3000)
       })
     }
-    let failures : Array[String] = []
     try
       @client.Client(
         api_key="test",
@@ -221,21 +186,12 @@ async test "malformed buffered response is not mislabeled as the idle timeout th
         stream=StreamHandler(on_content_delta=_ => ()),
       )
     catch {
-      Failure(message) => failures.push(message)
+      Failure(message) => assert_true(message.contains("private-invalid-json"))
       error => raise error
     } noraise {
       _ => fail("expected invalid response")
     }
     assert_eq(hits.val, 1)
-    assert_eq(failures.length(), 1)
-    let text = failures[0]
-    assert_true(text.contains("DeepSeek stream decode error"))
-    assert_true(
-      text.contains("Not retried because response data was already received."),
-    )
-    assert_true(text.contains("stream events: 1"))
-    assert_false(text.contains("Request idle"))
-    assert_true(text.contains("private-invalid-json"))
   }
 }
 
@@ -245,7 +201,7 @@ suberror StreamCallbackError {
 } derive(Debug)
 
 ///|
-async test "fallback diagnostics preserve error representation and payload" {
+async test "fallback diagnostics preserve the original error payload" {
   @async.with_task_group() <| group => {
     guard flaky_server(group, failures=0, status=200, sse=true)
       is Some((url, hits)) else {
@@ -259,11 +215,8 @@ async test "fallback diagnostics preserve error representation and payload" {
         }),
       )
     catch {
-      Failure(message) => {
-        assert_true(message.contains("StreamCallbackError"))
+      Failure(message) =>
         assert_true(message.contains("callback error payload"))
-        assert_false(message.contains("omitted"))
-      }
       error => raise error
     } noraise {
       _ => fail("expected callback failure")

--- a/deepseek/client/diagnostics_test.mbt
+++ b/deepseek/client/diagnostics_test.mbt
@@ -1,0 +1,273 @@
+///|
+async test "stream failure diagnostics preserve HTTP error payload after exhausted retries" {
+  @async.with_task_group() <| group => {
+    guard flaky_server(group, failures=99, status=503, sse=true)
+      is Some((url, hits)) else {
+      return
+    }
+    let failures : Array[String] = []
+    let client = @client.Client(
+      api_key="private-key",
+      api_url=url,
+      retry_attempts=2,
+      retry_backoff_ms=1,
+    )
+    try
+      client.chat(
+        [ChatMessage(User, content="private prompt")],
+        stream=StreamHandler(on_content_delta=_ => ()),
+      )
+    catch {
+      Failure(message) => failures.push(message)
+      error => raise error
+    } noraise {
+      _ => fail("expected failure")
+    }
+    assert_eq(hits.val, 2)
+    assert_eq(failures.length(), 1)
+    let text = failures[0]
+    assert_true(text.contains("attempts: 2/2"))
+    assert_true(text.contains("HTTP 503"))
+    assert_true(text.contains("The retry limit was reached."))
+    assert_true(text.contains("stage: response_body"))
+    assert_false(text.contains("last event:"))
+    assert_false(text.contains("stream events:"))
+    assert_false(text.contains("buffered event:"))
+    assert_false(text.contains("private"))
+    assert_true(text.contains("synthetic failure"))
+    assert_false(text.contains(url))
+  }
+}
+
+///|
+async test "stream diagnostics distinguish non-retryable HTTP errors" {
+  @async.with_task_group() <| group => {
+    guard flaky_server(group, failures=99, status=400, sse=true)
+      is Some((url, hits)) else {
+      return
+    }
+    let failures : Array[String] = []
+    try
+      @client.Client(api_key="test", api_url=url).chat(
+        [ChatMessage(User, content="hello")],
+        stream=StreamHandler(on_content_delta=_ => ()),
+      )
+    catch {
+      Failure(message) => failures.push(message)
+      error => raise error
+    } noraise {
+      _ => fail("expected failure")
+    }
+    assert_eq(hits.val, 1)
+    assert_eq(failures.length(), 1)
+    assert_true(
+      failures[0].contains("This error cannot be retried automatically."),
+    )
+  }
+}
+
+///|
+async test "idle stream diagnostics report partial output without retrying" {
+  @async.with_task_group() <| group => {
+    let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
+    defer server.close()
+    let hits = Ref(0)
+    group.spawn_bg(no_wait=true) <| () => {
+      server.run_forever((_request, body, conn) => {
+        ignore(body.read_all())
+        hits.val += 1
+        conn.send_response(200, "OK", extra_headers={
+          "Content-Type": "text/event-stream",
+        })
+        conn.write(
+          "data: {\"choices\":[{\"delta\":{\"content\":\"partial\"}}]}\n\n",
+        )
+        conn.flush()
+        @async.sleep(3000)
+      })
+    }
+    let failures : Array[String] = []
+    try
+      @client.Client(
+        api_key="test",
+        api_url="http://127.0.0.1:\{server.addr.port()}/",
+        idle_timeout_ms=100,
+      ).chat(
+        [ChatMessage(User, content="hello")],
+        stream=StreamHandler(on_content_delta=_ => ()),
+      )
+    catch {
+      Failure(message) => failures.push(message)
+      error => raise error
+    } noraise {
+      _ => fail("expected timeout")
+    }
+    assert_eq(hits.val, 1)
+    assert_eq(failures.length(), 1)
+    let text = failures[0]
+    assert_true(text.contains("Request idle for 100 ms"))
+    assert_true(text.contains("stage: sse_read"))
+    assert_true(text.contains("stream events: 1"))
+    assert_true(
+      text.contains("Not retried because response data was already received."),
+    )
+    assert_true(text.contains("last event:"))
+    assert_true(text.contains("elapsed:"))
+  }
+}
+
+///|
+async test "a thrown body read after a buffered data line cannot replay the request" {
+  @async.with_task_group() <| group => {
+    let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
+    defer server.close()
+    let hits = Ref(0)
+    group.spawn_bg(no_wait=true) <| () => {
+      server.run_forever(
+        (_request, body, conn) => {
+          ignore(body.read_all())
+          hits.val += 1
+          conn.send_response(200, "OK", extra_headers={
+            "Content-Type": "text/event-stream",
+            "Content-Length": "10000",
+          })
+          conn.write(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"partial\"}}]}\n",
+          )
+          conn.flush()
+          conn.close()
+        },
+        allow_failure=true,
+      )
+    }
+    let failures : Array[String] = []
+    try
+      @client.Client(
+        api_key="test",
+        api_url="http://127.0.0.1:\{server.addr.port()}/",
+        retry_backoff_ms=1,
+      ).chat(
+        [ChatMessage(User, content="hello")],
+        stream=StreamHandler(on_content_delta=_ => ()),
+      )
+    catch {
+      Failure(message) => failures.push(message)
+      error => raise error
+    } noraise {
+      _ => fail("expected body read failure")
+    }
+    assert_eq(hits.val, 1)
+    assert_eq(failures.length(), 1)
+    assert_true(
+      failures[0].contains(
+        "Not retried because response data was already received.",
+      ),
+    )
+  }
+}
+
+///|
+async test "cancellation is not wrapped as a request failure" {
+  @async.with_task_group() <| group => {
+    let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
+    defer server.close()
+    group.spawn_bg(no_wait=true) <| () => {
+      server.run_forever((_request, body, _conn) => {
+        ignore(body.read_all())
+        @async.sleep(3000)
+      })
+    }
+    let result = @async.with_timeout_opt(100, () => {
+      @client.Client(
+        api_key="test",
+        api_url="http://127.0.0.1:\{server.addr.port()}/",
+      ).chat(
+        [ChatMessage(User, content="hello")],
+        stream=StreamHandler(on_content_delta=_ => ()),
+      )
+    })
+    assert_true(result is None)
+  }
+}
+
+///|
+async test "malformed buffered response is not mislabeled as the idle timeout that flushed it" {
+  @async.with_task_group() <| group => {
+    let server = @http.Server(@socket.Addr::parse("127.0.0.1:0"))
+    defer server.close()
+    let hits = Ref(0)
+    group.spawn_bg(no_wait=true) <| () => {
+      server.run_forever((_request, body, conn) => {
+        ignore(body.read_all())
+        hits.val += 1
+        conn.send_response(200, "OK", extra_headers={
+          "Content-Type": "text/event-stream",
+        })
+        // No blank-line terminator. The idle handler will flush this payload;
+        // its parse error, not the timeout, is the actual failure cause.
+        conn.write("data: private-invalid-json\n")
+        conn.flush()
+        @async.sleep(3000)
+      })
+    }
+    let failures : Array[String] = []
+    try
+      @client.Client(
+        api_key="test",
+        api_url="http://127.0.0.1:\{server.addr.port()}/",
+        idle_timeout_ms=100,
+      ).chat(
+        [ChatMessage(User, content="hello")],
+        stream=StreamHandler(on_content_delta=_ => ()),
+      )
+    catch {
+      Failure(message) => failures.push(message)
+      error => raise error
+    } noraise {
+      _ => fail("expected invalid response")
+    }
+    assert_eq(hits.val, 1)
+    assert_eq(failures.length(), 1)
+    let text = failures[0]
+    assert_true(text.contains("Invalid model response"))
+    assert_true(
+      text.contains("Not retried because response data was already received."),
+    )
+    assert_true(text.contains("stream events: 1"))
+    assert_false(text.contains("Request idle"))
+    assert_true(text.contains("private-invalid-json"))
+  }
+}
+
+///|
+suberror StreamCallbackError {
+  StreamCallbackError(String)
+} derive(Debug)
+
+///|
+async test "fallback diagnostics preserve error representation and payload" {
+  @async.with_task_group() <| group => {
+    guard flaky_server(group, failures=0, status=200, sse=true)
+      is Some((url, hits)) else {
+      return
+    }
+    try
+      @client.Client(api_key="test", api_url=url).chat(
+        [ChatMessage(User, content="hello")],
+        stream=StreamHandler(on_content_delta=_ => {
+          raise StreamCallbackError("callback error payload")
+        }),
+      )
+    catch {
+      Failure(message) => {
+        assert_true(message.contains("StreamCallbackError"))
+        assert_true(message.contains("callback error payload"))
+        assert_false(message.contains("omitted"))
+      }
+      error => raise error
+    } noraise {
+      _ => fail("expected callback failure")
+    }
+    assert_eq(hits.val, 1)
+  }
+}

--- a/deepseek/client/moon.pkg
+++ b/deepseek/client/moon.pkg
@@ -4,6 +4,7 @@ import {
   "moonbitlang/async/http",
   "moonbitlang/async/io",
   "moonbitlang/core/json",
+  "moonbitlang/core/debug",
 }
 
 import {

--- a/deepseek/client/stream.mbt
+++ b/deepseek/client/stream.mbt
@@ -186,12 +186,9 @@ async fn flush_sse_event(
     acc,
     // A malformed payload on an established 2xx stream is a final verdict:
     // the completion already ran (and billed), so the retry loop must not
-    // re-run it. Keep that verdict typed until retry classification finishes.
+    // re-run it. Failure marks the parse error as non-retryable.
     @json.parse(data) catch {
-      error =>
-        raise ResponseError(
-          "DeepSeek stream decode error: \{error}; data: \{data}",
-        )
+      error => fail("DeepSeek stream decode error: \{error}; data: \{data}")
     },
     on_content_delta~,
     on_reasoning_delta~,
@@ -265,7 +262,8 @@ async fn read_chat_stream(
     // is model output already produced (and billed), so flushing fires
     // on_stream_event and keeps the retry loop from replaying a half-consumed
     // completion. EOF and timeout differ only in the retry reason.
-    let error : ApiError = match read_stream_line(reader, idle_timeout_ms) {
+    let error : RetryableApiError = match
+      read_stream_line(reader, idle_timeout_ms) {
       Some(Some(raw)) => {
         let trimmed = raw.trim()
         if trimmed.is_empty() {
@@ -307,7 +305,6 @@ async fn read_chat_stream(
     last_event_at=sse.last_event_at,
   )
   acc.response() catch {
-    error =>
-      raise ResponseError("DeepSeek stream response decode error: \{error}")
+    error => fail("DeepSeek stream response decode error: \{error}")
   }
 }

--- a/deepseek/client/stream.mbt
+++ b/deepseek/client/stream.mbt
@@ -186,9 +186,12 @@ async fn flush_sse_event(
     acc,
     // A malformed payload on an established 2xx stream is a final verdict:
     // the completion already ran (and billed), so the retry loop must not
-    // re-run it. fail() converts the parse error to the non-retryable class.
+    // re-run it. Keep that verdict typed until retry classification finishes.
     @json.parse(data) catch {
-      error => fail("DeepSeek stream decode error: \{error}; data: \{data}")
+      error =>
+        raise ResponseError(
+          "DeepSeek stream decode error: \{error}; data: \{data}",
+        )
     },
     on_content_delta~,
     on_reasoning_delta~,
@@ -197,7 +200,7 @@ async fn flush_sse_event(
 }
 
 ///|
-/// Runs `read` under an idle bound, raising `RetryableApiError` directly if it
+/// Runs `read` under an idle bound, raising `IdleTimeout` directly if it
 /// produces nothing within `idle_timeout_ms`. Use it only where a stall leaves
 /// no buffered state to reconcile — the response-header read, where nothing has
 /// been produced yet so retrying on a fresh connection is unconditionally safe.
@@ -214,7 +217,7 @@ async fn[T] with_idle_timeout(
   } else {
     match @async.with_timeout_opt(idle_timeout_ms, read) {
       Some(value) => value
-      None => raise RetryableApiError("\{what} idle for \{idle_timeout_ms}ms")
+      None => raise IdleTimeout(what, idle_timeout_ms)
     }
   }
 }
@@ -239,11 +242,21 @@ async fn read_stream_line(
 ///|
 async fn read_chat_stream(
   reader : @http.Client,
+  progress : RequestProgress,
   idle_timeout_ms~ : Int,
-  on_stream_event~ : () -> Unit,
   on_content_delta~ : async (String) -> Unit,
   on_reasoning_delta~ : async (String) -> Unit,
 ) -> @deepseek.ChatResponse {
+  let sse : SseProgress = {
+    event_count: 0,
+    last_event_at: None,
+    buffered_data: false,
+  }
+  progress.phase = Sse(sse)
+  let on_stream_event = () => {
+    sse.event_count += 1
+    sse.last_event_at = Some(@async.now())
+  }
   let acc = StreamAccumulator::StreamAccumulator()
   let data_lines : Array[String] = []
   for ;; {
@@ -252,10 +265,11 @@ async fn read_chat_stream(
     // is model output already produced (and billed), so flushing fires
     // on_stream_event and keeps the retry loop from replaying a half-consumed
     // completion. EOF and timeout differ only in the retry reason.
-    let reason = match read_stream_line(reader, idle_timeout_ms) {
+    let error : ApiError = match read_stream_line(reader, idle_timeout_ms) {
       Some(Some(raw)) => {
         let trimmed = raw.trim()
         if trimmed.is_empty() {
+          sse.buffered_data = false
           if flush_sse_event(
               acc,
               data_lines,
@@ -267,12 +281,16 @@ async fn read_chat_stream(
           }
         } else if sse_data_fragment(raw) is Some(data) {
           data_lines.push(data)
+          // A socket exception can bypass EOF flushing. Once a data line is
+          // buffered, retrying must not replay the partially received output.
+          sse.buffered_data = true
         }
         continue
       }
-      Some(None) => "DeepSeek stream ended before [DONE]"
-      None => "DeepSeek stream idle for \{idle_timeout_ms}ms"
+      Some(None) => StreamEnded
+      None => IdleTimeout("DeepSeek stream", idle_timeout_ms)
     }
+    sse.buffered_data = false
     if flush_sse_event(
         acc,
         data_lines,
@@ -282,7 +300,14 @@ async fn read_chat_stream(
       ) {
       break
     }
-    raise RetryableApiError(reason)
+    raise error
   }
-  acc.response()
+  progress.phase = Decode(
+    event_count=sse.event_count,
+    last_event_at=sse.last_event_at,
+  )
+  acc.response() catch {
+    error =>
+      raise ResponseError("DeepSeek stream response decode error: \{error}")
+  }
 }


### PR DESCRIPTION
Streaming failures such as `ConnectionClosed` or connection resets previously reached the transcript with little request context. Include the model, request stage, attempts, elapsed time, HTTP status, and SSE progress in the existing failure message, along with why retries stopped. Preserve all error payloads and format unclassified errors with `@debug.Repr(error)`.

Keep request stages and retry stop reasons typed, with SSE observations carried only by the relevant phase. A buffered SSE data line now prevents retrying a partially received response even when the body reader throws before the event is flushed. Final streaming errors become `Failure(message)` after retry classification; cancellation propagates unchanged. Session protocol and UI interfaces are unchanged.

Validation: `just check`, `just test` (3,209 native tests, 3,184 JS tests, 24 cram cases), `just build`, `moon info`, and `moon fmt` passed. Regression coverage includes retry exhaustion, non-retryable HTTP errors, idle timeouts, buffered-response interruption, malformed payloads, cancellation, and fallback error payloads.
