### PR TITLE
chore(editor): move packaging excludes into .moonignore

### DIFF
--- a/editor/.moonignore
+++ b/editor/.moonignore
@@ -1,0 +1,37 @@
+# Packaging ignore list for `moonbitlang/editor`.
+#
+# `.moonignore` overrides `.gitignore` in this directory, so the build and
+# dependency directories from `.gitignore` are repeated here; the second block
+# holds what used to live in `options(exclude: ...)` in `moon.mod`.
+
+_build/
+.mooncakes/
+node_modules/
+dist/
+playwright-report/
+test-results/
+target/
+web/generated/editor.mjs
+web/generated/editor.mjs.map
+web/generated/moonbit.d.ts
+web/generated/web.d.ts
+web/dist/
+.claude/
+
+/codemirror
+/vscode
+/internal/shell
+/server
+/moon.work
+/tests
+/scripts
+/internal/viewer/ui/scrollbar/mouse_wheel_classifier_reference_wbtest.mbt
+/AGENTS.md
+/justfile
+/package.json
+/package-lock.json
+/playwright.config.js
+/docs/exec-plans
+/docs/references
+/docs/notes
+/docs/styles.md

--- a/editor/moon.mod
+++ b/editor/moon.mod
@@ -27,25 +27,3 @@ import {
   "moonbitlang/x@0.4.50",
   "kokic/uml@0.2.2",
 }
-
-options(
-  exclude: [
-    "codemirror",
-    "vscode",
-    "internal/shell",
-    "server",
-    "moon.work",
-    "tests",
-    "scripts",
-    "internal/viewer/ui/scrollbar/mouse_wheel_classifier_reference_wbtest.mbt",
-    "AGENTS.md",
-    "justfile",
-    "package.json",
-    "package-lock.json",
-    "playwright.config.js",
-    "docs/exec-plans",
-    "docs/references",
-    "docs/notes",
-    "docs/styles.md",
-  ],
-)


### PR DESCRIPTION
`moon check` prints a deprecation warning on every run:

```
Warning: `exclude` in `/Users/dii/git/openseek/editor/moon.mod` is deprecated;
use `.gitignore` or `.moonignore` to control which files are packaged instead.
`.moonignore` overrides `.gitignore` in the same directory.
```

This moves the `options(exclude: ...)` list out of `editor/moon.mod` and into a new `editor/.moonignore`.

Two details worth reviewing:

- **Anchoring.** Every entry gets a leading `/` (`/tests`, `/server`, `/scripts`, …). Without it, gitignore semantics would match a directory of that name at *any* depth, which would silently drop far more than the old root-relative `exclude` did.
- **`.gitignore` is overridden, not merged.** Because `.moonignore` takes precedence over `.gitignore` in the same directory, the build/dependency entries from `editor/.gitignore` are repeated in the new file (the two `scripts/` entries are dropped as redundant — `/scripts` covers them).

## Verification

`moon package --list --frozen` produces an **identical 855-file package set** before and after the change (sorted diff is empty).

Negative control: appending `/LICENSE` to the new `.moonignore` drops `LICENSE` from that list, confirming the file is actually consulted and that anchored patterns match — so the identical-set result is not a vacuous pass from an ignored file.

`moon check` is clean at both the repo root and in `editor/`, with the warning gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmAS6CGdbp4hjf6UTVgzYP