### PR TITLE
chore(desktop): upgrade Proton to 0.2.9

### DIFF
--- a/desktop/internal/extension/browser_views.mbt
+++ b/desktop/internal/extension/browser_views.mbt
@@ -63,9 +63,10 @@ pub fn browser_view_id(name : String) -> Int? {
 
 ///|
 /// A view event as the `browser.event` notification payload the frontend
-/// decodes.
-pub fn view_event_json(id : Int, event : @proton.ViewEvent) -> Json {
-  match event {
+/// decodes. Lifecycle notifications without a frontend consumer are omitted.
+pub fn view_event_json(id : Int, event : @proton.ViewEvent) -> Json? {
+  let payload : Json = match event {
+    DidStartLoading | DidFinishLoad => return None
     Navigated(url~) =>
       { "id": id.to_json(), "kind": "navigated", "url": url.to_json() }
     LoadingChanged(is_loading~) =>
@@ -95,6 +96,7 @@ pub fn view_event_json(id : Int, event : @proton.ViewEvent) -> Json {
       }
     Closed => { "id": id.to_json(), "kind": "closed" }
   }
+  Some(payload)
 }
 
 ///|

--- a/desktop/internal/extension/pkg.generated.mbti
+++ b/desktop/internal/extension/pkg.generated.mbti
@@ -14,7 +14,7 @@ pub async fn open_external(@protocol.ExternalLinkPayload) -> @protocol.OpenExter
 
 pub fn openseek_capability(@api.ApiState, DesktopBridgeActor, BrowserViews) -> @moonbit-community/proton/extension.RendererCapability
 
-pub fn view_event_json(Int, @proton.ViewEvent) -> Json
+pub fn view_event_json(Int, @proton.ViewEvent) -> Json?
 
 // Errors
 

--- a/desktop/main.mbt
+++ b/desktop/main.mbt
@@ -225,10 +225,12 @@ async fn main {
     .on_view_event(async fn(view, event) noraise {
       match @extension.browser_view_id(view.id()) {
         Some(id) =>
-          bridge.notify_browser_event(@extension.view_event_json(id, event)) catch {
-            // Only cancellation can interrupt the queue put — the app is
-            // shutting down, so the event has nowhere to go anyway.
-            _ => ()
+          if @extension.view_event_json(id, event) is Some(payload) {
+            bridge.notify_browser_event(payload) catch {
+              // Only cancellation can interrupt the queue put — the app is
+              // shutting down, so the event has nowhere to go anyway.
+              _ => ()
+            }
           }
         None => ()
       }

--- a/desktop/moon.mod
+++ b/desktop/moon.mod
@@ -12,15 +12,15 @@ import {
   "moonbit-community/rabbita@0.15.4",
   "moonbitlang/x@0.4.50",
   "moonbitlang/async@0.21.0",
-  "moonbit-community/proton@0.2.8",
-  "moonbit-community/proton_ext@0.2.8",
+  "moonbit-community/proton@0.2.9",
+  "moonbit-community/proton_ext@0.2.9",
   "tonyfettes/platform@0.1.1",
   "tonyfettes/xlog@0.4.0",
   "moonbitlang/editor@0.4.5",
-  "moonbit-community/proton_contract@0.2.8",
+  "moonbit-community/proton_contract@0.2.9",
   "bobzhang/openseek@0.2.2",
-  "moonbit-community/proton_cefsetup@0.2.8",
-  "moonbit-community/proton_config@0.2.8",
+  "moonbit-community/proton_cefsetup@0.2.9",
+  "moonbit-community/proton_config@0.2.9",
 }
 
 readme = "README.md"


### PR DESCRIPTION
Upgrade the desktop Proton dependencies (`proton`, `proton_ext`, `proton_contract`, `proton_cefsetup`, and `proton_config`) from 0.2.8 to 0.2.9. Packaging and CI already derive the Proton CLI version from this manifest.

Proton 0.2.9 adds `DidStartLoading` and `DidFinishLoad` view events. Omit these events from desktop notifications because the frontend continues to use `LoadingChanged` for loading state; preserve all existing event payloads.

Validation:
- `moon info && moon fmt`
- `just check`
- `just test`: 3,202 native tests, 3,184 JS tests, and 24 offline CLI cram cases passed.
- `just build`

The macOS linker reported deployment-target warnings for local object files built for macOS 26.0 while linking for 12.0. No packaged GUI exit reproduction was run, so this upgrade does not establish that the intermittent macOS exit dialog is fixed.
