### PR TITLE
feat(desktop): run one host per application identity

### DIFF
--- a/desktop/.gitignore
+++ b/desktop/.gitignore
@@ -19,6 +19,11 @@ e2e/node_modules/
 e2e/playwright-report/
 e2e/test-results/
 
+# Project config a development package is built from, derived from the
+# checked-in one at packaging time. It has to live here rather than under
+# target/, because a project config's relative paths resolve against its own
+# directory.
+/proton.project.dev.json
 # The empty file redirected into one-shot child runs as stdin. It normally
 # lives in the per-user runtime dir; with no runtime dir (tests, and any bare
 # invocation) `prepare_engine_stdin` falls back to `<program>.stdin` beside the

--- a/desktop/main.mbt
+++ b/desktop/main.mbt
@@ -56,46 +56,6 @@ async fn main {
       .map(p => p.to_string())
       .unwrap_or("(inherited environment)"),
     }
-  // A fresh install has no workspaces at all. Attach the default one before
-  // anything can serve a workspace list, so the first page to connect
-  // already has somewhere to work. This runs exactly once per registry: a
-  // user who later detaches it does not get it back.
-  let default_workspace = @workspaces.initialize() catch {
-    error => {
-      // An unwritable Documents folder must not stop the app — the user can
-      // still attach a project by hand.
-      @xlog.error() <?
-        {
-          "message": "default workspace setup failed",
-          "error": @debug.render(Repr(error)),
-        }
-      None
-    }
-  }
-  if default_workspace is Some(dir) {
-    @xlog.info() <?
-      { "message": "default workspace attached", "path": dir.to_string() }
-  }
-  // Conversations the desktop used to keep in the global store predate
-  // workspaces owning every record. Move them into the default workspace so
-  // they stay listed; a failure leaves them where they are for a later launch.
-  let migrated = @engine.migrate_global_store() catch {
-    error => {
-      @xlog.error() <?
-        {
-          "message": "global store migration failed",
-          "error": @debug.render(Repr(error)),
-        }
-      0
-    }
-  }
-  if migrated > 0 {
-    @xlog.info() <?
-      {
-        "message": "migrated conversations from the global store",
-        "count": migrated,
-      }
-  }
   // The relay sign-in store: a persisted session from auth.json, unless the
   // environment override pins the connector config directly (development).
   let auth = @auth.AuthStore::load(
@@ -123,8 +83,17 @@ async fn main {
   // entry serves from. The window is bridge-only: it makes no HTTP requests
   // at all. Remote browsers use the same method catalog over the relay
   // WebSocket instead (docs/remote-protocol.md).
+  // The identity this process answers to. A development build never answers
+  // to the shipped one: `package/build.mjs` generates a project config
+  // carrying its own, and `proton dev` hands that config on to the host
+  // through PROTON_PROJECT_CONFIG, so this call picks it up either way.
+  let app = app.load_config()
+  // One host per identity, for the shipped application: `single_instance`
+  // hands a later launch to the process already holding that identity's lock,
+  // and that process brings its window to the front.
+  let single_instance = single_instance_wanted(app)
+  let app = if single_instance { app.single_instance() } else { app }
   let app = app
-    .load_config()
     // Let the page palette paint the native titlebar area. The default macOS
     // titlebar follows the system appearance, so an explicit in-app dark theme
     // otherwise leaves a bright strip above the dark application shell.
@@ -139,19 +108,15 @@ async fn main {
     // the system opener until Proton exposes the disposition.
     .on_new_window_request(async fn(_, request) noraise {
       if request.user_gesture {
-        ignore(
-          Some(@extension.open_external({ url: request.url, })) catch {
-            error => {
-              @xlog.error() <?
-                {
-                  "event": "external_link_open_failed",
-                  "url": request.url,
-                  "error": @debug.render(Repr(error)),
-                }
-              None
-            }
-          },
-        )
+        ignore(@extension.open_external({ url: request.url, })) catch {
+          error =>
+            @xlog.error() <?
+              {
+                "event": "external_link_open_failed",
+                "url": request.url,
+                "error": @debug.render(Repr(error)),
+              }
+        }
       }
       Deny
     })
@@ -235,49 +200,77 @@ async fn main {
         None => ()
       }
     })
+  // Set by the application lifecycle hook, which only the process that kept
+  // this launch reaches. A forwarded launch returns from
+  // `app.run()` having done nothing, and must not go on to act on state
+  // that belongs to the host still running.
+  let mut is_primary = false
   @async.with_task_group(group => {
-    // The bridge actor, engine actor, and host actors run for the app's
-    // lifetime — they feed every page/client rather than borrowing a
-    // `host.connect` request task as their owner.
-    group.spawn_bg(allow_failure=true, () => bridge.run())
-    group.spawn_bg(allow_failure=true, () => {
-      state
-      .codex_actor()
-      .run((method_, params) => {
-        if @protocol.Notification::from_wire(method_, params)
-          is Some(notification) {
+    // Everything that acts on state belonging to whoever owns the runtime
+    // directory starts here and nowhere earlier: the hook runs only in the
+    // process that kept the launch, and before its window opens. A launch
+    // handed to another host returns from `app.run()` without ever reaching
+    // it, so it neither spawns a Codex app-server or engine of its own, nor
+    // registers with the relay under the running host's device identity.
+    //
+    // The actors run for the app's lifetime on this group — they feed every
+    // page/client rather than borrowing a `host.connect` request task as
+    // their owner — and stop when the run loop returns.
+    let app = app.app_lifecycle(
+      on_start=async fn(_) {
+        is_primary = true
+        prepare_workspaces()
+        group.spawn_bg(allow_failure=true, () => bridge.run())
+        group.spawn_bg(allow_failure=true, () => {
+          state
+          .codex_actor()
+          .run((method_, params) => {
+            if @protocol.Notification::from_wire(method_, params)
+              is Some(notification) {
+              state.publish(notification)
+            }
+          })
+        })
+        group.spawn_bg(allow_failure=true, () => {
+          state
+          .engine_actor()
+          .run(state.sink(), message => {
+            state.publish(
+              AgentError({
+                run_id: None,
+                message: Some(message),
+                exit_code: None,
+                diagnostics: None,
+              }),
+            )
+          })
+        })
+        @host.spawn_host_pumps(group, state.host_state(), notification => {
           state.publish(notification)
-        }
-      })
-    })
-    group.spawn_bg(allow_failure=true, () => {
-      state
-      .engine_actor()
-      .run(state.sink(), message => {
-        state.publish(
-          AgentError({
-            run_id: None,
-            message: Some(message),
-            exit_code: None,
-            diagnostics: None,
-          }),
-        )
-      })
-    })
-    @host.spawn_host_pumps(group, state.host_state(), notification => {
-      state.publish(notification)
-    })
-    // The relay actor runs for the app's lifetime: it registers
-    // this host whenever a sign-in (or the environment override) says so,
-    // and idles otherwise.
-    group.spawn_bg(allow_failure=true, () => relay.run())
-    @xlog.info() <? { "event": "desktop_app_run_start" }
+        })
+        // The relay actor registers this host whenever a sign-in (or the
+        // environment override) says so, and idles otherwise.
+        group.spawn_bg(allow_failure=true, () => relay.run())
+      },
+      on_shutdown=fn(_) {  },
+    )
+    @xlog.info() <?
+      { "event": "desktop_app_run_start", "single_instance": single_instance }
     try {
       app.run()
+      if !is_primary {
+        // Nothing else tells a `moon run` user what happened: Proton notes
+        // the forwarding in its own log, the running instance's window comes
+        // to the front, and this process ends.
+        println(
+          "SeekMoon is already running; its window was brought to the front. Quit it first, or set OPENSEEK_DESKTOP_MULTI_INSTANCE=1 to start another instance.",
+        )
+      }
       @xlog.info() <?
         {
           "event": "desktop_app_run_return",
           "result": "ok",
+          "primary": is_primary,
           "message": "host process exit ok",
         }
     } catch {
@@ -298,20 +291,129 @@ async fn main {
   // relaunch marker: reopen the new version now that the run loop is done.
   // `open -n` hands the launch to LaunchServices, so the new instance is
   // not our child and this process can exit right after.
-  if runtime_dir is Some(dir) &&
-    @update.take_relaunch_target(work_dir=dir.to_string()) is Some(target) {
-    @xlog.info() <? { "message": "relaunch after update", "path": target }
-    let code = @process.run("open", ["-n", target]) catch {
-      error => {
-        @xlog.error() <? { "message": "relaunch failed", "error": "\{error}" }
-        return
+  //
+  // Only the host that ran the loop may take that marker. A forwarded
+  // launch reaches here too, having done nothing, and taking the marker
+  // there would consume the still-running primary's relaunch: the bundle
+  // would reopen, hand itself straight back to that primary, exit — and
+  // when the primary finally closed, its marker would be gone and the
+  // update would never be entered. The nesting is deliberate; a `&&` chain
+  // would take the marker while deciding whether it was allowed to.
+  if is_primary {
+    if runtime_dir is Some(dir) {
+      if @update.take_relaunch_target(work_dir=dir.to_string()) is Some(target) {
+        @xlog.info() <? { "message": "relaunch after update", "path": target }
+        let code = @process.run("open", ["-n", target]) catch {
+          error => {
+            @xlog.error() <?
+              { "message": "relaunch failed", "error": "\{error}" }
+            return
+          }
+        }
+        if code != 0 {
+          @xlog.error() <? { "message": "relaunch failed", "code": code }
+        }
       }
     }
-    if code != 0 {
-      @xlog.error() <? { "message": "relaunch failed", "code": code }
+  }
+  @xlog.info() <? { "event": "desktop_main_return", "primary": is_primary }
+}
+
+///|
+/// The identity suffix `package/build.mjs` appends when it generates the
+/// project config a development build runs under. Spelled there too; this is
+/// the shared half of that convention.
+const DevelopmentSuffix = ".dev"
+
+///|
+/// Whether this launch takes part in single instance at all.
+///
+/// Only the shipped application does. A development build is a second copy of
+/// the same program on the same machine, and being told "one is already
+/// running" is never what its author wanted: a rebuilt one has to start, not
+/// hand its launch to the binary it just replaced. Standing outside also
+/// costs it nothing it had, since Proton only grants a persistent browser
+/// profile to an application that owns a single-instance identity.
+///
+/// `OPENSEEK_DESKTOP_MULTI_INSTANCE` takes the shipped application out too,
+/// for a harness driving several hosts or a second copy of one build.
+///
+/// The identity is read back through `data_dir`, whose last segment is the
+/// identity Proton resolved from the manifest or the project config. Proton
+/// has no public accessor for it, and reading it here rather than trusting
+/// the build mode means the two always agree.
+fn single_instance_wanted(app : @proton.App) -> Bool {
+  if @envx.get("OPENSEEK_DESKTOP_MULTI_INSTANCE") is Some(_) {
+    @xlog.info() <?
+      {
+        "event": "desktop_instance_opt_out",
+        "message": "OPENSEEK_DESKTOP_MULTI_INSTANCE is set; starting beside any running host",
+      }
+    return false
+  }
+  let identity = app.data_dir() catch {
+    error => {
+      // Without an identity there is nothing to lock on, and guessing one
+      // could silence a launch that belongs to the installed application.
+      @xlog.warn() <?
+        {
+          "event": "desktop_instance_identity_unknown",
+          "message": "could not resolve this application's identity; starting beside any running host",
+          "error": @debug.render(Repr(error)),
+        }
+      return false
     }
   }
-  @xlog.info() <? { "event": "desktop_main_return" }
+  // A path separator cannot appear inside an identity, so a data directory
+  // ending in the suffix is one whose identity does.
+  !identity.has_suffix(DevelopmentSuffix)
+}
+
+///|
+/// First-launch and migration work on the workspace registry. The primary
+/// runs this before it serves any client, so the first `workspace.list` a
+/// page sees already reflects it.
+async fn prepare_workspaces() -> Unit {
+  // A fresh install has no workspaces at all. Attach the default one before
+  // anything can serve a workspace list, so the first page to connect
+  // already has somewhere to work. This runs exactly once per registry: a
+  // user who later detaches it does not get it back.
+  let default_workspace = @workspaces.initialize() catch {
+    error => {
+      // An unwritable Documents folder must not stop the app — the user can
+      // still attach a project by hand.
+      @xlog.error() <?
+        {
+          "message": "default workspace setup failed",
+          "error": @debug.render(Repr(error)),
+        }
+      None
+    }
+  }
+  if default_workspace is Some(dir) {
+    @xlog.info() <?
+      { "message": "default workspace attached", "path": dir.to_string() }
+  }
+  // Conversations the desktop used to keep in the global store predate
+  // workspaces owning every record. Move them into the default workspace so
+  // they stay listed; a failure leaves them where they are for a later launch.
+  let migrated = @engine.migrate_global_store() catch {
+    error => {
+      @xlog.error() <?
+        {
+          "message": "global store migration failed",
+          "error": @debug.render(Repr(error)),
+        }
+      0
+    }
+  }
+  if migrated > 0 {
+    @xlog.info() <?
+      {
+        "message": "migrated conversations from the global store",
+        "count": migrated,
+      }
+  }
 }
 
 ///|

--- a/desktop/package/build.mjs
+++ b/desktop/package/build.mjs
@@ -32,6 +32,22 @@ const Hosts = {
 
 const EsbuildVersion = "0.28.1";
 
+// A development build must not answer to the shipped application's identity.
+// Proton derives the macOS permission grants and the application data
+// directory from it, and locks the operating system's single-instance slot on
+// it, so sharing the identity means a locally built app and the installed one
+// hand each other their launches.
+//
+// A packaged app cannot choose its identity at startup the way an unbundled
+// host can: Proton reads it from the manifest inside the bundle and rejects
+// any disagreement. So a development build is stamped here instead, from a
+// generated copy of the project config. The suffix is what the host looks for
+// when deciding whether to take part in single instance, so it is spelled in
+// `desktop/main.mbt` too.
+const DevelopmentSuffix = ".dev";
+const DevelopmentConfig = "proton.project.dev.json";
+const DevelopmentProduct = "SeekMoon Dev";
+
 // These archives already contain browser-ready distributions. Fetching the
 // exact tarballs avoids installing a package manager or recreating its
 // dependency graph during an application build.
@@ -345,6 +361,34 @@ class Build {
     }
   }
 
+  // Derive the project config a development build runs under: the checked-in
+  // one with its own identity and product name, and everything else — the
+  // signing list above all — carried over rather than duplicated.
+  //
+  // The output directory is deliberately left alone. The product name already
+  // keeps a development bundle from overwriting a release one, and moving the
+  // output would strand every consumer that knows where packaging writes.
+  //
+  // One identity covers every development build. It only has to differ from
+  // the shipped one, because a development build does not take part in single
+  // instance at all: nothing is competing for the identity, so nothing has to
+  // tell one development build from the next.
+  //
+  // `proton dev` passes this path on to the host as PROTON_PROJECT_CONFIG and
+  // the host reads its identity from there, so an unbundled run and a
+  // development package pick it up the same way.
+  async developmentConfig() {
+    const config = JSON.parse(await readFile(join(this.desktop, "proton.project.json"), "utf8"));
+    config.identifier = `${config.identifier}${DevelopmentSuffix}`;
+    config.package.product_name = DevelopmentProduct;
+    // The generated config has to sit beside the one it derives from: every
+    // relative path in a project config — the backend package, icons, staged
+    // resources, the signing list, the output directory — resolves against the
+    // directory holding the config itself.
+    await writeFile(join(this.desktop, DevelopmentConfig), `${JSON.stringify(config, null, 2)}\n`);
+    return DevelopmentConfig;
+  }
+
   async package(options) {
     if (!this.host || this.host.command !== this.command) throw new Error(`${this.command} packaging cannot run on ${process.platform}/${process.arch}`);
     if ((this.command === "macos" && process.arch !== "arm64") || (this.command !== "macos" && process.arch !== "x64")) {
@@ -360,7 +404,8 @@ class Build {
       : this.command === "windows"
         ? options.targets.map(target => target === "installer" ? "nsis" : target)
         : ["appimage"];
-    const args = ["-C", ".", "package", "--config", "proton.project.json"];
+    const config = options.release ? "proton.project.json" : await this.developmentConfig();
+    const args = ["-C", ".", "package", "--config", config];
     for (const format of [...new Set(formats)]) args.push("--format", format);
     if (options.release) args.push("--release");
     if (options.sign) args.push("--sign");
@@ -378,7 +423,8 @@ class Build {
       env.APPIMAGE_EXTRACT_AND_RUN = "1";
     }
     await this.proton(args, env);
-    if (this.command === "macos" && options.open) await this.commandRun("open", [join(this.desktop, "dist/SeekMoon.app")]);
+    const bundle = `dist/${options.release ? "SeekMoon" : DevelopmentProduct}.app`;
+    if (this.command === "macos" && options.open) await this.commandRun("open", [join(this.desktop, bundle)]);
   }
 
   async run() {
@@ -391,7 +437,10 @@ class Build {
     if (this.command === "dev") {
       await this.web("debug");
       await this.commandRun("moon", ["build", "cmd/openseek", "--target", "native"], { cwd: this.repo });
-      return await this.proton(["-C", ".", "dev", "--config", "proton.project.json", "--no-frontend", "--setup"]);
+      // The same development identity a packaged development build gets, for
+      // the same reason: never the shipped one.
+      const config = await this.developmentConfig();
+      return await this.proton(["-C", ".", "dev", "--config", config, "--no-frontend", "--setup"]);
     }
     await this.package(options);
   }


### PR DESCRIPTION
Proton's `single_instance` hands a later launch to the process already holding the identity's operating-system lock, which brings its window to the front instead of opening a second one. Enabling it also gives CEF a persistent browser profile, so logins in the dock's browser tabs survive a restart.

## Only the shipped application takes part

A development build is a second copy of the same program on the same machine, and being told "one is already running" is never what its author wanted: a rebuilt one has to start, not hand its launch to the binary it just replaced.

Standing outside still needs an identity of its own, because Proton derives the macOS permission grants and the application data directory from it too. The host cannot pick one: a packaged application takes its identity from the manifest inside the bundle and Proton rejects any disagreement. So `package/build.mjs` generates a project config carrying a `.dev` identity for every non-release build, and `proton dev` passes that config on to an unbundled host through `PROTON_PROJECT_CONFIG`. The host reads the identity back through `data_dir` and takes part only when it is not that one.

One identity covers every development build. Nothing is competing for it, so nothing has to tell one development build from the next.

## A forwarded launch must have no side effects

Every actor, the default workspace setup, and the global store migration now start in `app_lifecycle(on_start)`, which only the process that kept the launch reaches, and which runs before its window opens. Previously a second launch spawned its own Codex app-server and engine, and registered with the relay under the running host's device identity, before being forwarded.

## The relaunch marker belongs to the host that ran the loop

A forwarded launch reaching it would consume the primary's relaunch: the new bundle would reopen, hand itself back, and exit, leaving no marker for the update to resume from. The nesting is deliberate — a `&&` chain would take the marker while deciding whether it was allowed to, since `&&` evaluates async operands eagerly.

`OPENSEEK_DESKTOP_MULTI_INSTANCE` takes the shipped application out too, for a harness driving several hosts or a second copy of one build.

## What this does not do

No heartbeat. A host stuck in `cef_shutdown` keeps the instance lock forever, and a launch handed to it is accepted by its listener thread and never acted on, so the app stops opening until that process is killed. That is proton's bug to fix (a watchdog around `cef_shutdown`), not something to work around in every host. Until then the escape is `OPENSEEK_DESKTOP_MULTI_INSTANCE=1` or killing the ~100% CPU process.

Development builds get no persistent browser profile, since Proton grants one only to an application that owns a single-instance identity.

## CI

Untouched. Every packaging step in `desktop-release.yml` passes `--release`, so it keeps `proton.project.json`, the shipped identity, and `dist/SeekMoon.app`. The Windows smoke job in `desktop.yml` builds without `--release`, so its artifact is now named `SeekMoon Dev` and carries the `.dev` identity; it stays in `dist/`, the upload glob still matches, and the packaging mechanics are identical. The output directory is deliberately left alone for exactly this reason — the product name already keeps the two from overwriting each other.

## Verification

`moon check` clean on native and js, `moon test --target native` 3209 passing, `node --check package/build.mjs`.

Not yet exercised by hand, and worth doing before merge:

- `open -n dist/SeekMoon.app` twice: the second launch should focus the first rather than open a window, and print a line saying so.
- A non-release package should land at `dist/SeekMoon Dev.app` and run beside an installed SeekMoon.
- `moon run ./desktop/package/dev` should still start, and should not be silenced by either of the above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149X43kNM9UGQS9cJfGRrC2
