### PR TITLE
fix(deepseek): increase retry_attempts to 5

### DIFF
--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -132,6 +132,8 @@ pub async fn run_turn_with_append(
   max_steps? : Int = unbounded_max_steps,
   thinking? : @deepseek.ThinkingMode = Max,
   api_url? : String,
+  retry_attempts? : Int,
+  retry_backoff_ms? : Int,
   workspace_root? : String = ".",
   approval? : @agent_runtime.ApprovalChannel,
 ) -> @agent_session.Session {
@@ -147,6 +149,8 @@ pub async fn run_turn_with_append(
       max_steps~,
       thinking~,
       api_url?,
+      retry_attempts?,
+      retry_backoff_ms?,
     )
   }
 }
@@ -235,8 +239,10 @@ async test "run_turn_with_append closes failed persisted turns" {
 ///
 /// `tools` should normally be a registry built once with `build_tools(runtime,
 /// scope)` for a long-lived engine. If `tools` is omitted, this function builds
-/// a fresh registry for this call only. `api_url` is forwarded to the DeepSeek
-/// client. The caller owns the lifetime of `runtime`, `scope`, and any shared
+/// a fresh registry for this call only. `api_url`, `retry_attempts` and
+/// `retry_backoff_ms` are forwarded to the DeepSeek clients this turn builds;
+/// omitting a retry argument leaves that client default in place.
+/// The caller owns the lifetime of `runtime`, `scope`, and any shared
 /// `tools` registry passed here. Provider reasoning fragments always join the
 /// transient event stream; consumers choose whether and how to present them.
 pub async fn[X] run_turn_in_scope(
@@ -251,11 +257,27 @@ pub async fn[X] run_turn_in_scope(
   max_steps? : Int = unbounded_max_steps,
   thinking? : @deepseek.ThinkingMode = Max,
   api_url? : String,
+  retry_attempts? : Int,
+  retry_backoff_ms? : Int,
   tools? : @agent_tool.Tools,
   on_goal_met? : async (String, @agent_session.GoalBaseline?) -> String?,
 ) -> @agent_session.Session {
-  let client = @client.Client(api_key~, model~, thinking~, api_url?)
-  let summary_client = @client.Client(api_key~, model~, api_url?, thinking=No)
+  let client = @client.Client(
+    api_key~,
+    model~,
+    thinking~,
+    api_url?,
+    retry_attempts?,
+    retry_backoff_ms?,
+  )
+  let summary_client = @client.Client(
+    api_key~,
+    model~,
+    api_url?,
+    thinking=No,
+    retry_attempts?,
+    retry_backoff_ms?,
+  )
   let session = session |> append_item(User(UserMessage(task, submission_id?)))
   let tools = try {
     match tools {

--- a/agent/exports.mbt
+++ b/agent/exports.mbt
@@ -30,7 +30,9 @@ pub let plan_reminder_after_steps : Int = 50
 /// `prompt` package. `thinking` defaults to `Max`. `workspace_root` defaults to
 /// `"."` and is passed into the per-turn `AgentRuntime`; local file and shell
 /// tools resolve relative paths against that root. `api_url` is forwarded to
-/// the DeepSeek client and is mainly useful for tests or compatible endpoints.
+/// the DeepSeek client and is mainly useful for tests or compatible endpoints,
+/// as are `retry_attempts` and `retry_backoff_ms`; omit either to keep the
+/// client's own default.
 ///
 /// Use `run_turn_with_append` when every committed event must be persisted as
 /// the turn progresses, or `run_turn_in_scope` when runtime/tool state must span
@@ -43,6 +45,8 @@ pub async fn run(
   max_steps? : Int = unbounded_max_steps,
   thinking? : @deepseek.ThinkingMode = Max,
   api_url? : String,
+  retry_attempts? : Int,
+  retry_backoff_ms? : Int,
   workspace_root? : String = ".",
 ) -> Unit {
   let session = @agent_session.Session(
@@ -59,6 +63,8 @@ pub async fn run(
       max_steps~,
       thinking~,
       api_url?,
+      retry_attempts?,
+      retry_backoff_ms?,
       workspace_root~,
     ),
   )

--- a/agent/pkg.generated.mbti
+++ b/agent/pkg.generated.mbti
@@ -14,11 +14,11 @@ pub async fn[X] build_tools(@agent_runtime.AgentRuntime, @agent_runtime.AgentTas
 
 pub let plan_reminder_after_steps : Int
 
-pub async fn run(api_key~ : String, model~ : @deepseek.Model, task~ : String, system_prompt_text~ : String, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String) -> Unit
+pub async fn run(api_key~ : String, model~ : @deepseek.Model, task~ : String, system_prompt_text~ : String, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, retry_attempts? : Int, retry_backoff_ms? : Int, workspace_root? : String) -> Unit
 
-pub async fn[X] run_turn_in_scope(runtime~ : @agent_runtime.AgentRuntime, scope~ : @agent_runtime.AgentTaskScope[X], api_key~ : String, model~ : @deepseek.Model, session~ : @agent_session.Session, task~ : String, submission_id? : String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, tools? : @agent_tool.Tools, on_goal_met? : async (String, @agent_session.GoalBaseline?) -> String?) -> @agent_session.Session
+pub async fn[X] run_turn_in_scope(runtime~ : @agent_runtime.AgentRuntime, scope~ : @agent_runtime.AgentTaskScope[X], api_key~ : String, model~ : @deepseek.Model, session~ : @agent_session.Session, task~ : String, submission_id? : String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, retry_attempts? : Int, retry_backoff_ms? : Int, tools? : @agent_tool.Tools, on_goal_met? : async (String, @agent_session.GoalBaseline?) -> String?) -> @agent_session.Session
 
-pub async fn run_turn_with_append(api_key~ : String, model~ : @deepseek.Model, session~ : @agent_session.Session, task~ : String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String, approval? : @agent_runtime.ApprovalChannel) -> @agent_session.Session
+pub async fn run_turn_with_append(api_key~ : String, model~ : @deepseek.Model, session~ : @agent_session.Session, task~ : String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, retry_attempts? : Int, retry_backoff_ms? : Int, workspace_root? : String, approval? : @agent_runtime.ApprovalChannel) -> @agent_session.Session
 
 pub let unbounded_max_steps : Int
 

--- a/agent_explore/child.mbt
+++ b/agent_explore/child.mbt
@@ -18,6 +18,8 @@ pub async fn run_child(
   max_steps~ : Int,
   thinking? : @deepseek.ThinkingMode = Max,
   api_url? : String,
+  retry_attempts? : Int,
+  retry_backoff_ms? : Int,
   workspace_root? : String = ".",
   session_id? : String = "explore",
   append_item? : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session,
@@ -47,6 +49,8 @@ pub async fn run_child(
     model~,
     thinking~,
     api_url?,
+    retry_attempts?,
+    retry_backoff_ms?,
     workspace_root~,
   )
 }

--- a/agent_explore/pkg.generated.mbti
+++ b/agent_explore/pkg.generated.mbti
@@ -11,7 +11,7 @@ import {
 // Values
 pub let default_explore_max_steps : Int
 
-pub async fn run_child(Json, api_key~ : String, model~ : @deepseek.Model, max_steps~ : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String, session_id? : String, append_item? : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, scratch_dir? : String) -> ExploreReport?
+pub async fn run_child(Json, api_key~ : String, model~ : @deepseek.Model, max_steps~ : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, retry_attempts? : Int, retry_backoff_ms? : Int, workspace_root? : String, session_id? : String, append_item? : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, scratch_dir? : String) -> ExploreReport?
 
 // Errors
 

--- a/agent_kind/kind.mbt
+++ b/agent_kind/kind.mbt
@@ -26,6 +26,8 @@ pub async fn[T] execute_kind(
   model~ : @deepseek.Model,
   thinking? : @deepseek.ThinkingMode = Max,
   api_url? : String,
+  retry_attempts? : Int,
+  retry_backoff_ms? : Int,
   workspace_root? : String = ".",
   append_item? : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session,
 ) -> T? {
@@ -54,6 +56,8 @@ pub async fn[T] execute_kind(
       max_steps~,
       thinking~,
       api_url?,
+      retry_attempts?,
+      retry_backoff_ms?,
       tools~,
     )
   }

--- a/agent_kind/pkg.generated.mbti
+++ b/agent_kind/pkg.generated.mbti
@@ -11,7 +11,7 @@ import {
 // Values
 pub fn[T] capture_tool(name~ : String, description~ : String, schema~ : @agent_tool.JsonSchema, parse~ : (Json) -> Result[T, Array[String]], @ref.Ref[T?], finished_note? : (T) -> String) -> @agent_tool.AgentToolDefinition
 
-pub async fn[T] execute_kind(session_id~ : String, system_prompt~ : String, task~ : String, tools~ : (@ref.Ref[T?]) -> @agent_tool.Tools raise, max_steps~ : Int, api_key~ : String, model~ : @deepseek.Model, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String, append_item? : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session) -> T?
+pub async fn[T] execute_kind(session_id~ : String, system_prompt~ : String, task~ : String, tools~ : (@ref.Ref[T?]) -> @agent_tool.Tools raise, max_steps~ : Int, api_key~ : String, model~ : @deepseek.Model, thinking? : @deepseek.ThinkingMode, api_url? : String, retry_attempts? : Int, retry_backoff_ms? : Int, workspace_root? : String, append_item? : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session) -> T?
 
 pub fn[T] validated(Result[T, String], (T) -> Array[String]) -> Result[T, Array[String]]
 

--- a/agent_pattern_repair/pkg.generated.mbti
+++ b/agent_pattern_repair/pkg.generated.mbti
@@ -8,7 +8,7 @@ import {
 }
 
 // Values
-pub async fn run(String, String, api_key~ : String, model~ : @deepseek.Model, max_steps~ : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String) -> PatternRepairReport?
+pub async fn run(String, String, api_key~ : String, model~ : @deepseek.Model, max_steps~ : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, retry_attempts? : Int, retry_backoff_ms? : Int, workspace_root? : String) -> PatternRepairReport?
 
 // Errors
 

--- a/agent_pattern_repair/submit.mbt
+++ b/agent_pattern_repair/submit.mbt
@@ -34,6 +34,8 @@ pub async fn run(
   max_steps~ : Int,
   thinking? : @deepseek.ThinkingMode = Max,
   api_url? : String,
+  retry_attempts? : Int,
+  retry_backoff_ms? : Int,
   workspace_root? : String = ".",
 ) -> PatternRepairReport? {
   @agent_kind.execute_kind(
@@ -46,6 +48,8 @@ pub async fn run(
     model~,
     thinking~,
     api_url?,
+    retry_attempts?,
+    retry_backoff_ms?,
     workspace_root~,
   )
 }

--- a/agent_review/audit.mbt
+++ b/agent_review/audit.mbt
@@ -75,6 +75,8 @@ pub async fn run_goal_audit(
   max_steps~ : Int,
   thinking? : @deepseek.ThinkingMode = Max,
   api_url? : String,
+  retry_attempts? : Int,
+  retry_backoff_ms? : Int,
   workspace_root? : String = ".",
   session_id? : String = "goal-audit",
   append_item? : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session,
@@ -97,6 +99,8 @@ pub async fn run_goal_audit(
     model~,
     thinking~,
     api_url?,
+    retry_attempts?,
+    retry_backoff_ms?,
     workspace_root~,
   )
 }

--- a/agent_review/engine.mbt
+++ b/agent_review/engine.mbt
@@ -35,6 +35,8 @@ pub async fn run_review(
   max_steps? : Int = default_review_max_steps,
   thinking? : @deepseek.ThinkingMode = Max,
   api_url? : String,
+  retry_attempts? : Int,
+  retry_backoff_ms? : Int,
   scratch_dir? : String,
 ) -> ReviewReport {
   let report = @agent_kind.execute_kind(
@@ -53,6 +55,8 @@ pub async fn run_review(
     model~,
     thinking~,
     api_url?,
+    retry_attempts?,
+    retry_backoff_ms?,
     workspace_root~,
   )
   match report {

--- a/agent_review/pkg.generated.mbti
+++ b/agent_review/pkg.generated.mbti
@@ -11,9 +11,9 @@ import {
 // Values
 pub let default_audit_max_steps : Int
 
-pub async fn run_goal_audit(goal~ : String, baseline~ : @agent_session.GoalBaseline?, api_key~ : String, model~ : @deepseek.Model, max_steps~ : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String, session_id? : String, append_item? : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, scratch_dir? : String) -> ReviewReport?
+pub async fn run_goal_audit(goal~ : String, baseline~ : @agent_session.GoalBaseline?, api_key~ : String, model~ : @deepseek.Model, max_steps~ : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, retry_attempts? : Int, retry_backoff_ms? : Int, workspace_root? : String, session_id? : String, append_item? : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, scratch_dir? : String) -> ReviewReport?
 
-pub async fn run_review(String, @deepseek.Model, String, workspace_root? : String, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, scratch_dir? : String) -> ReviewReport
+pub async fn run_review(String, @deepseek.Model, String, workspace_root? : String, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, retry_attempts? : Int, retry_backoff_ms? : Int, scratch_dir? : String) -> ReviewReport
 
 // Errors
 

--- a/agent_session/compact/compact.mbt
+++ b/agent_session/compact/compact.mbt
@@ -85,6 +85,8 @@ pub async fn compact_session(
   api_key~ : String,
   model~ : @deepseek.Model,
   api_url? : String,
+  retry_attempts? : Int,
+  retry_backoff_ms? : Int,
 ) -> @agent_session.Session {
   let from_sequence = 1
   let to_sequence = session.last_sequence()
@@ -92,7 +94,14 @@ pub async fn compact_session(
     fail("session compaction requires at least one event")
   }
   @emit.emit(CompactionStarted(from_sequence~, to_sequence~))
-  let client = @client.Client(api_key~, model~, api_url?, thinking=No)
+  let client = @client.Client(
+    api_key~,
+    model~,
+    api_url?,
+    thinking=No,
+    retry_attempts?,
+    retry_backoff_ms?,
+  )
   let summary = generate_compaction_summary(client~, session)
   let next = append_compaction_summary(
     store?,

--- a/agent_session/compact/pkg.generated.mbti
+++ b/agent_session/compact/pkg.generated.mbti
@@ -9,7 +9,7 @@ import {
 }
 
 // Values
-pub async fn compact_session(store? : @store.SessionStore, @agent_session.Session, api_key~ : String, model~ : @deepseek.Model, api_url? : String) -> @agent_session.Session
+pub async fn compact_session(store? : @store.SessionStore, @agent_session.Session, api_key~ : String, model~ : @deepseek.Model, api_url? : String, retry_attempts? : Int, retry_backoff_ms? : Int) -> @agent_session.Session
 
 pub async fn generate_compaction_summary(client~ : @client.Client, @agent_session.Session) -> String
 

--- a/agent_worker/pkg.generated.mbti
+++ b/agent_worker/pkg.generated.mbti
@@ -13,7 +13,7 @@ pub let default_worker_deadline_ms : Int
 
 pub let default_worker_max_steps : Int
 
-pub async fn run_child(Json, api_key~ : String, model~ : @deepseek.Model, max_steps~ : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, session_id? : String, append_item? : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session) -> Result[WorkerReport?, String]
+pub async fn run_child(Json, api_key~ : String, model~ : @deepseek.Model, max_steps~ : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, retry_attempts? : Int, retry_backoff_ms? : Int, session_id? : String, append_item? : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session) -> Result[WorkerReport?, String]
 
 // Errors
 

--- a/agent_worker/tool.mbt
+++ b/agent_worker/tool.mbt
@@ -123,6 +123,8 @@ pub async fn run_child(
   max_steps~ : Int,
   thinking? : @deepseek.ThinkingMode = Max,
   api_url? : String,
+  retry_attempts? : Int,
+  retry_backoff_ms? : Int,
   session_id? : String = "worker",
   append_item? : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session,
 ) -> Result[WorkerReport?, String] {
@@ -184,6 +186,8 @@ pub async fn run_child(
     model~,
     thinking~,
     api_url?,
+    retry_attempts?,
+    retry_backoff_ms?,
     workspace_root=input.worker_root,
   )
   Ok(report)

--- a/cli/options.mbt
+++ b/cli/options.mbt
@@ -1,9 +1,9 @@
 ///|
 /// Options shared by the agent-running mains (`cmd/openseek` here and the
 /// `openseek_tui` binary in `moonbitlang/openseek_tui`): `--api-key`,
-/// `--model`, `--api-url`, `--max-steps`,
-/// `--thinking`, `--session`, `--session-root`, plus the provider-specific key
-/// options.
+/// `--model`, `--api-url`, `--retry-attempts`, `--retry-backoff-ms`,
+/// `--max-steps`, `--thinking`, `--session`, `--session-root`, plus the
+/// provider-specific key options.
 ///
 /// `cmd/openseek` installs these on its root command with `global=true`, so
 /// they read the same value in any position — `openseek --api-key k run`,
@@ -65,6 +65,20 @@ pub fn agent_shared_options(
       default_values=[""],
       global~,
       about="OpenAI-compatible chat completions endpoint.",
+    ),
+    OptionArg(
+      "retry-attempts",
+      long="retry-attempts",
+      env="OPENSEEK_RETRY_ATTEMPTS",
+      global~,
+      about="Total tries per model request before giving up on a retryable failure (429, 5xx, or a transport error); 1 disables retrying. Omit for the client default.",
+    ),
+    OptionArg(
+      "retry-backoff-ms",
+      long="retry-backoff-ms",
+      env="OPENSEEK_RETRY_BACKOFF_MS",
+      global~,
+      about="Delay before the first model-request retry; it doubles per attempt, capped at 60s. Omit for the client default.",
     ),
     OptionArg(
       "max-steps",

--- a/cmd/openseek/concurrent.mbt
+++ b/cmd/openseek/concurrent.mbt
@@ -17,6 +17,7 @@ async fn run_fleet(matches : @argparse.Matches, concurrency~ : Int) -> Unit {
   guard model.api_key(matches.values) is Some(api_key) else {
     fail("an API key is required for \{model}: pass --api-key")
   }
+  let (retry_attempts, retry_backoff_ms) = retry_overrides(matches)
   let max_steps = max_steps(matches)
   // One desk for the whole fleet, not one per attempt: every attempt streams
   // to the same stdout, so one ask counter keeps that stream readable in ask
@@ -80,6 +81,8 @@ async fn run_fleet(matches : @argparse.Matches, concurrency~ : Int) -> Unit {
               thinking~,
               api_key,
               api_url,
+              retry_attempts,
+              retry_backoff_ms,
               approval?,
             ),
           )
@@ -168,6 +171,8 @@ async fn run_one_attempt(
   thinking~ : @deepseek.ThinkingMode,
   api_key : String,
   api_url : String?,
+  retry_attempts : Int?,
+  retry_backoff_ms : Int?,
   approval? : @agent_runtime.ApprovalChannel,
 ) -> AttemptOutcome {
   // Generated before the try so a failed attempt can still name its (partial)
@@ -196,6 +201,8 @@ async fn run_one_attempt(
       max_steps?,
       thinking~,
       api_url?,
+      retry_attempts?,
+      retry_backoff_ms?,
       workspace_root=run_dir,
       approval?,
     )

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -152,6 +152,7 @@ async fn run_task_command(matches : @argparse.Matches) -> Unit {
     guard model.api_key(matches.values) is Some(api_key) else {
       fail("an API key is required for \{model}: pass --api-key")
     }
+    let (retry_attempts, retry_backoff_ms) = retry_overrides(matches)
     let max_steps = max_steps(matches)
     let task = task_text(matches)
     match resolved_session_id(matches) {
@@ -177,6 +178,8 @@ async fn run_task_command(matches : @argparse.Matches) -> Unit {
           max_steps?,
           thinking~,
           api_url?,
+          retry_attempts?,
+          retry_backoff_ms?,
           workspace_root~,
           review_deadline_ms~,
         )
@@ -210,6 +213,8 @@ async fn run_task_command(matches : @argparse.Matches) -> Unit {
           max_steps?,
           thinking~,
           api_url?,
+          retry_attempts?,
+          retry_backoff_ms?,
           workspace_root~,
           review_deadline_ms~,
           child_session=ChildSession(
@@ -268,6 +273,8 @@ async fn run_task_turn(
   max_steps? : Int,
   thinking~ : @deepseek.ThinkingMode,
   api_url? : String,
+  retry_attempts? : Int,
+  retry_backoff_ms? : Int,
   workspace_root~ : String,
   review_deadline_ms~ : Int?,
   child_session? : @agent_subrun.ChildSession,
@@ -346,6 +353,8 @@ async fn run_task_turn(
         max_steps?,
         thinking~,
         api_url?,
+        retry_attempts?,
+        retry_backoff_ms?,
         tools~,
         on_goal_met?,
       ),
@@ -834,6 +843,29 @@ fn max_steps(matches : @argparse.Matches) -> Int? raise {
       Some(@cli.parse_positive_int(input, "--max-steps"))
     _ => None
   }
+}
+
+///|
+/// Model-request retry overrides. `None` for either half means the DeepSeek
+/// client keeps its own default, so the defaults live in exactly one place
+/// (`@client.Client`) and are never restated here.
+///
+/// The pair is forwarded as `retry_attempts?, retry_backoff_ms?` all the way
+/// down to every in-process `@client.Client`. Child processes (`subrun`, the
+/// review gate) inherit it through `$OPENSEEK_RETRY_ATTEMPTS` /
+/// `$OPENSEEK_RETRY_BACKOFF_MS` rather than argument injection.
+fn retry_overrides(matches : @argparse.Matches) -> (Int?, Int?) raise {
+  let attempts = match matches {
+    { values: { "retry-attempts": [input, ..], .. }, .. } =>
+      Some(@cli.parse_positive_int(input, "--retry-attempts"))
+    _ => None
+  }
+  let backoff_ms = match matches {
+    { values: { "retry-backoff-ms": [input, ..], .. }, .. } =>
+      Some(@cli.parse_positive_int(input, "--retry-backoff-ms"))
+    _ => None
+  }
+  (attempts, backoff_ms)
 }
 
 ///|
@@ -1367,6 +1399,8 @@ test "cli parses env backed options and task" {
     "OPENSEEK_MAX_STEPS": "120",
     "OPENSEEK_SYSTEM_PROMPT_FILE": "/tmp/prompt-a.md",
     "OPENSEEK_SYSTEM_PROMPT_ADDENDUM_FILE": "/tmp/prompt-b.md",
+    "OPENSEEK_RETRY_ATTEMPTS": "4",
+    "OPENSEEK_RETRY_BACKOFF_MS": "25",
   })
   let (model, _, api_url) = agent_settings(parsed)
   assert_true(model is Deepseek(V4Pro))
@@ -1383,6 +1417,7 @@ test "cli parses env backed options and task" {
   assert_false(parsed is { values: { "session": [_, ..], .. }, .. })
   assert_eq(session_root(parsed), ".openseek")
   assert_eq(task_text(parsed), "write MoonBit")
+  assert_eq(retry_overrides(parsed), (Some(4), Some(25)))
 }
 
 ///|
@@ -1399,6 +1434,34 @@ test "cli defaults model and max steps" {
   assert_true(max_steps(parsed) is None)
   assert_true(parsed is { values: { "session"? : None, .. }, .. })
   assert_eq(session_root(parsed), ".openseek")
+  // Absent on both halves: the DeepSeek client keeps its own defaults, which
+  // the CLI never restates.
+  assert_eq(retry_overrides(parsed), (None, None))
+}
+
+///|
+test "cli retry flags override the environment and reject non-positives" {
+  let parsed = run_matches(
+    argv=["--retry-attempts", "2", "--retry-backoff-ms", "7", "write"],
+    env={ "DEEPSEEK": "test-key", "OPENSEEK_RETRY_ATTEMPTS": "9" },
+  )
+  assert_eq(retry_overrides(parsed), (Some(2), Some(7)))
+  // Rejection is checked through the environment: argparse refuses a bare
+  // `-1` as a missing value before the parsed string ever reaches here.
+  for bad in ["0", "-1", "many"] {
+    let rejected = run_matches(argv=["write"], env={
+      "DEEPSEEK": "test-key",
+      "OPENSEEK_RETRY_ATTEMPTS": bad,
+    })
+    try ignore(retry_overrides(rejected)) catch {
+      err =>
+        assert_true(
+          "\{err}".contains("--retry-attempts must be a positive integer"),
+        )
+    } noraise {
+      _ => fail("expected --retry-attempts \{bad} to be rejected")
+    }
+  }
 }
 
 ///|

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -29,17 +29,25 @@ async fn main {
 /// `[env: OPENSEEK_*]` fallbacks would otherwise silently never fire.
 async fn dispatch() -> Unit {
   let matches = @argparse.parse(root_command(), env=@env.get_env_vars())
-  match matches.subcommand {
-    Some(("run", m)) => run_task_command(m)
-    Some(("serve", m)) => run_serve_command(m)
-    Some(("review", m)) => run_review_command(m)
-    Some(("subrun", m)) => run_subrun_command(m)
-    Some(("mcp", m)) => run_mcp_command(m)
-    Some(("sessions", m)) => run_sessions_command(m)
-    // argparse rejects unknown and missing subcommands during parse, so this is
-    // unreachable.
-    Some((name, _)) => fail("unhandled subcommand: \{name}")
-    None => fail("missing subcommand (argparse should have rejected this)")
+  // argparse rejects unknown and missing subcommands during parse, so the
+  // absent case is unreachable.
+  guard matches.subcommand is Some((name, m)) else {
+    fail("missing subcommand (argparse should have rejected this)")
+  }
+  // Only the agent-running commands spawn children, and only they read the
+  // setting at all: a malformed value must not break `sessions list`, for the
+  // same reason `--api-key` is not argparse-`required`.
+  if name is ("run" | "serve" | "review" | "subrun") {
+    export_retry_overrides(m)
+  }
+  match name {
+    "run" => run_task_command(m)
+    "serve" => run_serve_command(m)
+    "review" => run_review_command(m)
+    "subrun" => run_subrun_command(m)
+    "mcp" => run_mcp_command(m)
+    "sessions" => run_sessions_command(m)
+    name => fail("unhandled subcommand: \{name}")
   }
 }
 
@@ -850,10 +858,9 @@ fn max_steps(matches : @argparse.Matches) -> Int? raise {
 /// client keeps its own default, so the defaults live in exactly one place
 /// (`@client.Client`) and are never restated here.
 ///
-/// The pair is forwarded as `retry_attempts?, retry_backoff_ms?` all the way
-/// down to every in-process `@client.Client`. Child processes (`subrun`, the
-/// review gate) inherit it through `$OPENSEEK_RETRY_ATTEMPTS` /
-/// `$OPENSEEK_RETRY_BACKOFF_MS` rather than argument injection.
+/// The pair is forwarded as `retry_attempts?, retry_backoff_ms?` down to every
+/// in-process `@client.Client`; `export_retry_overrides` carries it to child
+/// processes.
 fn retry_overrides(matches : @argparse.Matches) -> (Int?, Int?) raise {
   let attempts = match matches {
     { values: { "retry-attempts": [input, ..], .. }, .. } =>
@@ -866,6 +873,32 @@ fn retry_overrides(matches : @argparse.Matches) -> (Int?, Int?) raise {
     _ => None
   }
   (attempts, backoff_ms)
+}
+
+///|
+/// Write the resolved retry overrides back into this process's environment, so
+/// that a child sees exactly what this process resolved.
+///
+/// `--retry-attempts 2` and `OPENSEEK_RETRY_ATTEMPTS=2` must mean the same
+/// thing to a subagent, and before this a child got only the second: nothing
+/// injects these on the child command line, and four separate spawn sites
+/// would each have to — the review gate, the model-callable review tool, and
+/// the workflow scout and worker runners, the last two reachable only through
+/// the `SubrunInjection` handoff an `mbtx` snippet receives. Children do
+/// inherit the environment (`@process.spawn(inherit_env=true)`), so writing
+/// the flag back closes all four at once. It is also the shape `--api-key`
+/// already has: argv carries what a child cannot otherwise know, and the
+/// environment carries the rest.
+///
+/// A value that arrived from the environment is rewritten unchanged.
+fn export_retry_overrides(matches : @argparse.Matches) -> Unit raise {
+  let (attempts, backoff_ms) = retry_overrides(matches)
+  if attempts is Some(attempts) {
+    @env.set_env_var("OPENSEEK_RETRY_ATTEMPTS", "\{attempts}")
+  }
+  if backoff_ms is Some(backoff_ms) {
+    @env.set_env_var("OPENSEEK_RETRY_BACKOFF_MS", "\{backoff_ms}")
+  }
 }
 
 ///|
@@ -1462,6 +1495,27 @@ test "cli retry flags override the environment and reject non-positives" {
       _ => fail("expected --retry-attempts \{bad} to be rejected")
     }
   }
+}
+
+///|
+/// The flag has to reach subagents, and they are handed the environment, not
+/// this process's argv — see `export_retry_overrides`.
+test "cli exports argv retry overrides into the environment for children" {
+  let parsed = run_matches(
+    argv=["--retry-attempts", "3", "--retry-backoff-ms", "11", "write"],
+    env={ "DEEPSEEK": "test-key" },
+  )
+  export_retry_overrides(parsed)
+  assert_eq(@env.get_env_var("OPENSEEK_RETRY_ATTEMPTS"), Some("3"))
+  assert_eq(@env.get_env_var("OPENSEEK_RETRY_BACKOFF_MS"), Some("11"))
+  @env.unset_env_var("OPENSEEK_RETRY_ATTEMPTS")
+  @env.unset_env_var("OPENSEEK_RETRY_BACKOFF_MS")
+  // Nothing to carry means nothing written: a child keeps falling back to the
+  // client default rather than being pinned to a value nobody asked for.
+  let bare = run_matches(argv=["write"], env={ "DEEPSEEK": "test-key" })
+  export_retry_overrides(bare)
+  assert_eq(@env.get_env_var("OPENSEEK_RETRY_ATTEMPTS"), None)
+  assert_eq(@env.get_env_var("OPENSEEK_RETRY_BACKOFF_MS"), None)
 }
 
 ///|

--- a/cmd/openseek/review.mbt
+++ b/cmd/openseek/review.mbt
@@ -13,6 +13,7 @@ async fn run_review_cli(
     fail("an API key is required for \{model}: pass --api-key")
   }
   let max_steps = max_steps(matches)
+  let (retry_attempts, retry_backoff_ms) = retry_overrides(matches)
   let (thinking, base, api_url) = match matches {
     {
       values: {
@@ -58,6 +59,8 @@ async fn run_review_cli(
     max_steps=max_steps.unwrap_or(@agent.unbounded_max_steps),
     thinking~,
     api_url?,
+    retry_attempts?,
+    retry_backoff_ms?,
   ) catch {
     error => {
       @stdio.stderr.write("review failed: \{error}\n")

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -553,6 +553,7 @@ async fn run_serve(
   guard model.api_key(matches.values) is Some(api_key) else {
     fail("an API key is required for \{model}: pass --api-key")
   }
+  let (retry_attempts, retry_backoff_ms) = retry_overrides(matches)
   let max_steps = max_steps(matches)
   let review_deadline_ms = review_deadline_ms(matches)
   let session_id = match matches {
@@ -753,7 +754,15 @@ async fn run_serve(
     async fn compact_and_report(
       current : @agent_session.Session,
     ) -> @agent_session.Session {
-      @compact.compact_session(store?, current, api_key~, model~, api_url?) catch {
+      @compact.compact_session(
+        store?,
+        current,
+        api_key~,
+        model~,
+        api_url?,
+        retry_attempts?,
+        retry_backoff_ms?,
+      ) catch {
         error if @async.is_being_cancelled() ||
           @async.is_cancellation_error(error) => raise error
         error => {
@@ -930,6 +939,8 @@ async fn run_serve(
           max_steps?,
           thinking~,
           api_url?,
+          retry_attempts?,
+          retry_backoff_ms?,
           tools~,
         ) catch {
           error => {

--- a/cmd/openseek/subrun.mbt
+++ b/cmd/openseek/subrun.mbt
@@ -267,6 +267,11 @@ async fn dispatch_kind(
   // items append as the turn runs. Without the flags the transcript stays
   // in-memory, exactly as before.
   let durable = child_durable_session(matches, workspace_root~)
+  // Read here rather than threaded in: like `step_ceiling` below, this is a
+  // pure read of the child's own already-parsed argv/env. The parent does not
+  // inject `--retry-attempts` on the child argv — the retry settings ride the
+  // inherited environment, exactly as the API key and `--thinking` do.
+  let (retry_attempts, retry_backoff_ms) = retry_overrides(matches)
   // A child spawned from a hosted snippet inherits that snippet's handoff
   // in its environment. One that arrives with the handoff but WITHOUT a
   // reserved session was launched around the library — a hand-rolled
@@ -308,6 +313,8 @@ async fn dispatch_kind(
         ),
         thinking~,
         api_url?,
+        retry_attempts?,
+        retry_backoff_ms?,
         workspace_root~,
         session_id?,
         append_item?,
@@ -342,6 +349,8 @@ async fn dispatch_kind(
         ),
         thinking~,
         api_url?,
+        retry_attempts?,
+        retry_backoff_ms?,
         workspace_root~,
         session_id?,
         append_item?,
@@ -373,6 +382,8 @@ async fn dispatch_kind(
           ),
           thinking~,
           api_url?,
+          retry_attempts?,
+          retry_backoff_ms?,
           session_id?,
           append_item?,
         ) {
@@ -410,6 +421,8 @@ async fn dispatch_kind(
         max_steps=step_ceiling(matches, ceiling, 8),
         thinking~,
         api_url?,
+        retry_attempts?,
+        retry_backoff_ms?,
         workspace_root~,
       )
       report.map(report => report.to_json())

--- a/deepseek/client/client.mbt
+++ b/deepseek/client/client.mbt
@@ -66,7 +66,7 @@ pub fn Client::Client(
   model? : @deepseek.Model = default_model,
   api_url? : String = default_api_url_for_model(model),
   thinking? : @deepseek.ThinkingMode = No,
-  retry_attempts? : Int = 3,
+  retry_attempts? : Int = 5,
   retry_backoff_ms? : Int = 500,
   idle_timeout_ms? : Int = 120_000,
 ) -> Client {
@@ -121,8 +121,10 @@ priv suberror RetryableApiError {
 
 ///|
 /// Ceiling on a single backoff sleep. The doubling sequence from
-/// `retry_backoff_ms` stops growing here, so a generous retry budget cannot
-/// accumulate minutes-long sleeps between attempts.
+/// `retry_backoff_ms` stops growing here — but this bounds each sleep, not
+/// their sum, which stays a geometric series: raising `retry_attempts` buys
+/// tries at superlinear wall-clock cost (from 500ms, 5 tries sleep 7.5s and
+/// 10 sleep 183.5s).
 let max_backoff_ms : Int = 60_000
 
 ///|

--- a/deepseek/client/client_test.mbt
+++ b/deepseek/client/client_test.mbt
@@ -22,7 +22,15 @@ test "client endpoint defaults follow selected model" {
 
 ///|
 test "client debug redacts api key" {
-  let client = @client.Client(api_key="test-key", thinking=Max)
+  let client = @client.Client(
+    api_key="test-key",
+    model=Deepseek(V4Pro),
+    api_url="https://api.deepseek.com/chat/completions",
+    thinking=Max,
+    retry_attempts=3,
+    retry_backoff_ms=500,
+    idle_timeout_ms=120000,
+  )
   debug_inspect(
     client,
     content=(

--- a/tests/cram/cli.md
+++ b/tests/cram/cli.md
@@ -33,14 +33,16 @@ Commands:
   sessions  Manage durable sessions.
 
 Options:
-  -h, --help                     Show help information.
-  --api-key <api-key>            API key for the selected chat provider. [default: ]
-  --model <model>                Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, kimi-k2.7-code-highspeed, glm-5.3, or glm-5.3-flash. [env: OPENSEEK_MODEL] [default: deepseek-v4-flash]
-  --api-url <api-url>            OpenAI-compatible chat completions endpoint. [env: OPENSEEK_API_URL] [default: ]
-  --max-steps <max-steps>        Maximum agent steps per turn; omit to bound turns by the model's context window instead (a checkpoint summary carries each turn into the next). [env: OPENSEEK_MAX_STEPS]
-  --thinking <thinking>          Model thinking mode: no, high, or max; GLM maps no to low effort. [env: OPENSEEK_THINKING] [default: high]
-  --session <session>            Create or resume this durable session id.
-  --session-root <session-root>  Directory containing durable OpenSeek sessions. [default: .openseek]
+  -h, --help                             Show help information.
+  --api-key <api-key>                    API key for the selected chat provider. [default: ]
+  --model <model>                        Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, kimi-k2.7-code-highspeed, glm-5.3, or glm-5.3-flash. [env: OPENSEEK_MODEL] [default: deepseek-v4-flash]
+  --api-url <api-url>                    OpenAI-compatible chat completions endpoint. [env: OPENSEEK_API_URL] [default: ]
+  --retry-attempts <retry-attempts>      Total tries per model request before giving up on a retryable failure (429, 5xx, or a transport error); 1 disables retrying. Omit for the client default. [env: OPENSEEK_RETRY_ATTEMPTS]
+  --retry-backoff-ms <retry-backoff-ms>  Delay before the first model-request retry; it doubles per attempt, capped at 60s. Omit for the client default. [env: OPENSEEK_RETRY_BACKOFF_MS]
+  --max-steps <max-steps>                Maximum agent steps per turn; omit to bound turns by the model's context window instead (a checkpoint summary carries each turn into the next). [env: OPENSEEK_MAX_STEPS]
+  --thinking <thinking>                  Model thinking mode: no, high, or max; GLM maps no to low effort. [env: OPENSEEK_THINKING] [default: high]
+  --session <session>                    Create or resume this durable session id.
+  --session-root <session-root>          Directory containing durable OpenSeek sessions. [default: .openseek]
 ```
 
 The root carries the engine-shared options (`--api-key`, `--model`, …) as
@@ -135,6 +137,8 @@ Options:
   --api-key <api-key>                                          API key for the selected chat provider. [default: ]
   --model <model>                                              Chat model: deepseek-v4-flash, deepseek-v4-pro, kimi-k2.7-code, kimi-k2.7-code-highspeed, glm-5.3, or glm-5.3-flash. [env: OPENSEEK_MODEL] [default: deepseek-v4-flash]
   --api-url <api-url>                                          OpenAI-compatible chat completions endpoint. [env: OPENSEEK_API_URL] [default: ]
+  --retry-attempts <retry-attempts>                            Total tries per model request before giving up on a retryable failure (429, 5xx, or a transport error); 1 disables retrying. Omit for the client default. [env: OPENSEEK_RETRY_ATTEMPTS]
+  --retry-backoff-ms <retry-backoff-ms>                        Delay before the first model-request retry; it doubles per attempt, capped at 60s. Omit for the client default. [env: OPENSEEK_RETRY_BACKOFF_MS]
   --max-steps <max-steps>                                      Maximum agent steps per turn; omit to bound turns by the model's context window instead (a checkpoint summary carries each turn into the next). [env: OPENSEEK_MAX_STEPS]
   --thinking <thinking>                                        Model thinking mode: no, high, or max; GLM maps no to low effort. [env: OPENSEEK_THINKING] [default: high]
   --session <session>                                          Create or resume this durable session id.
@@ -277,11 +281,15 @@ This example stays offline by pointing `--api-url` at a closed local port: the
 engine names its session, durably records the user prompt, and only then fails
 to reach the API. The generated id's timestamp is normalized for determinism.
 
+A refused connection is retryable, so every example below that targets the
+closed port pins `OPENSEEK_RETRY_ATTEMPTS=1`: none of them is testing the retry
+budget, and the suite's runtime should not track its default.
+
 ```mooncram
 $ sh <<'EOF'
 > tmp=$(mktemp -d)
 > cd "$tmp"
-> if env DEEPSEEK=test-key openseek.exe run --api-url "http://127.0.0.1:9/chat/completions" "say hi" > out.jsonl 2>/dev/null; then echo exit-zero; else echo exit-non-zero; fi
+> if env DEEPSEEK=test-key OPENSEEK_RETRY_ATTEMPTS=1 openseek.exe run --api-url "http://127.0.0.1:9/chat/completions" "say hi" > out.jsonl 2>/dev/null; then echo exit-zero; else echo exit-non-zero; fi
 > grep -c '"event":"session_started"' out.jsonl
 > env -u DEEPSEEK openseek.exe sessions list | cut -f1 | sed -E 's/cli-[0-9]{8}-[0-9]{6}-[0-9]{3}(-[A-Za-z0-9]+)?/cli-<stamp>/'
 > rm -rf "$tmp"
@@ -303,7 +311,7 @@ $ sh <<'EOF'
 > tmp=$(mktemp -d)
 > cd "$tmp"
 > for level in warn error; do
->   env DEEPSEEK=test-key MOON_XLOG=$level openseek.exe run --api-url "http://127.0.0.1:9/chat/completions" --dir "$tmp/$level" "say hi" > "out-$level.jsonl" 2>/dev/null
+>   env DEEPSEEK=test-key OPENSEEK_RETRY_ATTEMPTS=1 MOON_XLOG=$level openseek.exe run --api-url "http://127.0.0.1:9/chat/completions" --dir "$tmp/$level" "say hi" > "out-$level.jsonl" 2>/dev/null
 >   echo "$level: $(grep -c '"event":"agent_step"' "out-$level.jsonl")"
 > done
 > rm -rf "$tmp"
@@ -319,7 +327,7 @@ behind.
 $ sh <<'EOF'
 > tmp=$(mktemp -d)
 > cd "$tmp"
-> env DEEPSEEK=test-key openseek.exe run --no-session --api-url "http://127.0.0.1:9/chat/completions" "say hi" >/dev/null 2>&1
+> env DEEPSEEK=test-key OPENSEEK_RETRY_ATTEMPTS=1 openseek.exe run --no-session --api-url "http://127.0.0.1:9/chat/completions" "say hi" >/dev/null 2>&1
 > if test -d .openseek; then echo recorded; else echo ephemeral; fi
 > rm -rf "$tmp"
 > EOF
@@ -337,7 +345,7 @@ it.
 $ sh <<'EOF'
 > tmp=$(mktemp -d)
 > mkdir -p "$tmp/parent"
-> if env DEEPSEEK=test-key openseek.exe run --dir "$tmp/parent/new" --api-url "http://127.0.0.1:9/chat/completions" "say hi" > "$tmp/out.jsonl" 2>/dev/null; then echo exit-zero; else echo exit-non-zero; fi
+> if env DEEPSEEK=test-key OPENSEEK_RETRY_ATTEMPTS=1 openseek.exe run --dir "$tmp/parent/new" --api-url "http://127.0.0.1:9/chat/completions" "say hi" > "$tmp/out.jsonl" 2>/dev/null; then echo exit-zero; else echo exit-non-zero; fi
 > if test -d "$tmp/parent/new"; then echo dir-created; else echo dir-missing; fi
 > grep -c '"event":"workspace_created"' "$tmp/out.jsonl"
 > env -u DEEPSEEK openseek.exe sessions list --dir "$tmp/parent/new" | cut -f1 | sed -E 's/cli-[0-9]{8}-[0-9]{6}-[0-9]{3}(-[A-Za-z0-9]+)?/cli-<stamp>/'


### PR DESCRIPTION
This PR increase the default retry attempts to 10. This argument is not supplied in agent/, therefore increase the default value here will effectively increase the retry times in actual seekmoon application including the desktop.