### PR TITLE
docs(prompt): teach @fs.kind FileKind enum usage in the default prompt

### DIFF
--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -125,6 +125,15 @@ where the binaries do not exist:
 | rm/mv/cp    | the `remove` and `write` tools; a snippet cannot write the workspace, and `remove` refuses files it did not create — a refusal there is an answer, not an obstacle to route past |
 | sh -c, xargs, make | write the logic as MoonBit statements |
 
+`@fs.kind(p)` returns a `FileKind` enum — `Directory`, `Regular`, `SymLink`,
+`BlockDevice`, `CharDevice`, `Pipe`, `Socket`, `Unknown` — which does **not**
+implement `Show`, so never interpolate or `println` it directly:
+`"\{@fs.kind(p)}"` is a type error. Test it with `is`
+(`@fs.kind(p) is Directory`, `@fs.kind(p) is Regular`); `match` it only when
+you need the full set. To print one for debugging, use `repr(k)` (prelude) or
+`@debug.render(@debug.Repr(k))` (import `moonbitlang/core/debug`) — never
+interpolation.
+
 If a refused command is genuinely what the task needs, say so rather than
 working around it — the `mbtx` tool description states the refusal and
 escalation rules.

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -130,6 +130,15 @@ fn default_prompt() -> String {
     #|| rm/mv/cp    | the `remove` and `write` tools; a snippet cannot write the workspace, and `remove` refuses files it did not create — a refusal there is an answer, not an obstacle to route past |
     #|| sh -c, xargs, make | write the logic as MoonBit statements |
     #|
+    #|`@fs.kind(p)` returns a `FileKind` enum — `Directory`, `Regular`, `SymLink`,
+    #|`BlockDevice`, `CharDevice`, `Pipe`, `Socket`, `Unknown` — which does **not**
+    #|implement `Show`, so never interpolate or `println` it directly:
+    #|`"\{@fs.kind(p)}"` is a type error. Test it with `is`
+    #|(`@fs.kind(p) is Directory`, `@fs.kind(p) is Regular`); `match` it only when
+    #|you need the full set. To print one for debugging, use `repr(k)` (prelude) or
+    #|`@debug.render(@debug.Repr(k))` (import `moonbitlang/core/debug`) — never
+    #|interpolation.
+    #|
     #|If a refused command is genuinely what the task needs, say so rather than
     #|working around it — the `mbtx` tool description states the refusal and
     #|escalation rules.


### PR DESCRIPTION
## What

Add a short guidance block to the default system prompt right after the
command-alternatives table (where `test -d → @fs.kind(p) is Directory`
lives), teaching the correct way to use `@fs.kind`:

- `@fs.kind(p)` returns a `FileKind` enum (`Directory`, `Regular`, `SymLink`,
  `BlockDevice`, `CharDevice`, `Pipe`, `Socket`, `Unknown`) that has no usable
  `Show`, so `"\\{@fs.kind(p)}"` interpolation is a compile error (4018).
- Test it with `is` (`@fs.kind(p) is Directory`, `is Regular`) and `match` for
  the full set.
- To print one while debugging: `repr(k)` or `@debug.render(@debug.Repr(k))`
  (import `moonbitlang/core/debug`).

Source of truth is `prompt/default_prompt.mbt.md`; `generated_default_prompt.mbt`
was regenerated via the `md_to_mbt_string` dev-build rule.

## Why

Agents frequently wrote `println("\\{@fs.kind(p)}")` in quick mbtx probes to
inspect a path's kind and bounced off a `FileKind does not implement Show`
compile error, then fixed it. In an A/B eval on a realistic
directory-classifying task (tidy-downloads), that error occurred 4 times across
2/3 trials with the old prompt vs 1 time with the new one — the guidance cuts
those moon-check recovery cycles. Outcome metrics (success rate, steps) were
unchanged; this is a compile-error-hygiene change.

## Verified

- `moon check` clean on the prompt package
- `moon fmt --check prompt` passes
- regeneration of `generated_default_prompt.mbt` is idempotent

Generated with SeekMoon