### PR TITLE
lint: gate repo on moongrep and fix some-catch-none-unwrap call sites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,37 @@ jobs:
         if: matrix.target == 'native'
         run: moon cram test tests/cram
 
+  # Structural lint via moongrep. The `.moongrep/rules/*.yaml` files are the
+  # source of truth; this gate keeps new code from reintroducing the patterns
+  # they forbid. `scan` streams one JSON Lines finding per match on stdout and
+  # exits 0 whether or not it matches, so gate on an empty stdout.
+  moongrep:
+    name: moongrep lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up MoonBit
+        run: |
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
+          echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
+
+      - name: Update MoonBit package registry
+        run: moon update
+
+      - name: Run moongrep scan
+        run: |
+          findings="$(moonx moonbit-community/moongrep@0.1.18 -- scan --output-json)"
+          if [ -n "$findings" ]; then
+            printf '%s\n' "$findings"
+            count="$(printf '%s\n' "$findings" | wc -l | tr -d ' ')"
+            echo "::error::moongrep reported $count finding(s)"
+            exit 1
+          fi
+
   # cmd/viz_app is a separate MoonBit module and owns its browser test runner.
   # Keep it out of Desktop's recipe so either application can be tested alone.
   viz-e2e:

--- a/.moongrep/rules/some-catch-none-unwrap.yaml
+++ b/.moongrep/rules/some-catch-none-unwrap.yaml
@@ -1,0 +1,8 @@
+id: some-catch-none-unwrap
+description: >-
+  A raising call is wrapped in `Some(...) catch { _ => None }` and then
+  immediately unwrapped with `is Some(...)`. Replace the pair with a
+  `try ... catch ... noraise` expression so the success value is used directly
+  and the failure branch carries the actual control flow.
+patterns:
+  - shape: '(Some($(e:exp)) catch { _ => None }) is Some($(x:id))'

--- a/desktop/internal/codex/transport.mbt
+++ b/desktop/internal/codex/transport.mbt
@@ -37,8 +37,10 @@ pub impl @jsonrpc.Transport for StdioTransport with fn recv(self) {
     }
     // A non-JSON stdout line violates app-server framing. Ignore it instead of
     // killing unrelated in-flight requests; EOF still closes the connection.
-    if (Some(@json.parse(trimmed)) catch { _ => None }) is Some(message) {
-      return Some(message)
+    try @json.parse(trimmed) catch {
+      _ => continue
+    } noraise {
+      message => return Some(message)
     }
   }
 }

--- a/editor/server/host/language_provider.mbt
+++ b/editor/server/host/language_provider.mbt
@@ -155,9 +155,7 @@ fn parse_moon_hover_output_impl(
   raw : String,
   position : @base_common.Position,
 ) -> @language.Hover? {
-  guard (Some(@json.parse(raw)) catch { _ => None }) is Some(json) else {
-    return None
-  }
+  let json = @json.parse(raw) catch { _ => return None }
   let contents : Array[@language.HoverContent] = match json {
     { "contents": Array(items), .. } =>
       [

--- a/editor/server/host/native_host.mbt
+++ b/editor/server/host/native_host.mbt
@@ -149,12 +149,8 @@ async fn read_native_disk_snapshot(
   guard validate_native_file(root, target) is None else { return None }
   let before = native_file_signature(target)
   guard before != "missing" else { return None }
-  guard (Some(@fs.read_file(target)) catch { _ => None }) is Some(data) else {
-    return None
-  }
-  guard (Some(data.text()) catch { _ => None }) is Some(text) else {
-    return None
-  }
+  let data = @fs.read_file(target) catch { _ => return None }
+  let text = data.text() catch { _ => return None }
   guard !text.contains("\u{0}") else { return None }
   let after = native_file_signature(target)
   guard before == after else { return None }

--- a/mcp/stdio/ndjson.mbt
+++ b/mcp/stdio/ndjson.mbt
@@ -52,8 +52,10 @@ pub impl @jsonrpc.Transport for NdjsonTransport with fn recv(self) {
     if trimmed == "" {
       continue
     }
-    if (Some(@json.parse(trimmed)) catch { _ => None }) is Some(message) {
-      return Some(message)
+    try @json.parse(trimmed) catch {
+      _ => continue
+    } noraise {
+      message => return Some(message)
     }
   }
 }

--- a/mcp/streamhttp/transport.mbt
+++ b/mcp/streamhttp/transport.mbt
@@ -430,14 +430,18 @@ async fn read_sse_stream(
         let text = data.to_string()
         data.reset()
         has_data = false
-        if (Some(@json.parse(text)) catch { _ => None }) is Some(message) {
-          deliver(message)
-          // The spec has the server close the stream after the reply; a server
-          // that keeps it open instead would pin this exchange's cap slot, so
-          // once our request is answered we close from this side (allowed at
-          // any time) rather than read to EOF.
-          if answered() {
-            break
+        try @json.parse(text) catch {
+          _ => ()
+        } noraise {
+          message => {
+            deliver(message)
+            // The spec has the server close the stream after the reply; a server
+            // that keeps it open instead would pin this exchange's cap slot, so
+            // once our request is answered we close from this side (allowed at
+            // any time) rather than read to EOF.
+            if answered() {
+              break
+            }
           }
         }
       }
@@ -454,9 +458,12 @@ async fn read_sse_stream(
     // event:/id:/retry:/comments are irrelevant to the message layer.
   }
   // A final event unterminated by a blank line still counts.
-  if has_data &&
-    (Some(@json.parse(data.to_string())) catch { _ => None }) is Some(message) {
-    deliver(message)
+  if has_data {
+    try @json.parse(data.to_string()) catch {
+      _ => ()
+    } noraise {
+      message => deliver(message)
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Adds a [moongrep](https://github.com/moonbit-community/moongrep) structural lint rule, wires it into CI, and fixes the seven existing call sites it flags.

## What changed

- **Rule** (`.moongrep/rules/some-catch-none-unwrap.yaml`): flags the `(Some(x) catch { _ => None }) is Some(y)` antipattern, where a raising call is wrapped in `Some` only to be immediately unwrapped.
- **Fixes**: rewrites the seven matches to use `try ... catch ... noraise` (for skip/continue flow) or a direct `catch` with an early return (for `guard ... else return None` flow), so the success value is used directly.
- **CI** (`.github/workflows/ci.yml`): a new lightweight `moongrep` job runs `moonx moonbit-community/moongrep@0.1.18 -- scan --output-json` and fails on any finding, making `.moongrep/rules` a CI-enforced contract.

## Files touched

- `mcp/stdio/ndjson.mbt`
- `mcp/streamhttp/transport.mbt`
- `desktop/internal/codex/transport.mbt`
- `editor/server/host/native_host.mbt`
- `editor/server/host/language_provider.mbt`

## Validation

- `moon check` clean for the affected modules (root, `editor/server`, `desktop`).
- `moon test mcp/stdio mcp/streamhttp`: 9/9 pass.
- `moon fmt --check` clean on all changed files.
- moongrep scan reports 0 findings after the fixes.