### PR TITLE
fix(desktop): clarify transcript work and tool disclosures

### DIFF
--- a/desktop/e2e/tests/rabbita_dom.spec.js
+++ b/desktop/e2e/tests/rabbita_dom.spec.js
@@ -767,10 +767,10 @@ test('tool-call tabs keep focus-driven scrolling inside the transcript', async (
   await app.openSession();
 
   const transcript = page.locator('#transcript');
-  await expect(transcript.locator('.tool-call-summary')).toContainText('Print <browser> fixture');
+  await expect(transcript.locator('.tool-toggle')).toContainText('Print <browser> fixture');
   const tabs = transcript.locator('.tool-call-tabs');
   const originalJson = tabs.getByText('Original JSON', { exact: true });
-  await transcript.locator('.tool-call-summary').click();
+  await transcript.locator('.tool-toggle').click();
   await transcript.evaluate(node => {
     node.scrollTop = node.scrollHeight;
   });
@@ -828,8 +828,9 @@ test('runtime notices keep the compact result-row presentation', async ({ page }
   expect(app.pageErrors).toEqual([]);
 });
 
-test('a model step shows its thought, then its prose, then its tool rows', async ({ page }) => {
+test('work groups commentary with independent thinking and paired tool disclosures', async ({ page }) => {
   const app = new DesktopBrowserHarness(page);
+  const reasoning = '🔎 first thought with supporting evidence. '.repeat(200) + 'End of reasoning.';
   app.sessionEvents = [
     {
       sequence: 1,
@@ -844,7 +845,7 @@ test('a model step shows its thought, then its prose, then its tool rows', async
         kind: 'assistant',
         payload: {
           content: 'I will inspect the project.',
-          reasoning_content: 'first thought',
+          reasoning_content: reasoning,
           tool_calls: [{ id: 'c1', name: 'read', arguments: '{"path":"moon.mod"}' }],
         },
       },
@@ -867,14 +868,110 @@ test('a model step shows its thought, then its prose, then its tool rows', async
   await app.goto();
   await app.openSession();
 
-  // One durable response is one step, whose parts keep the model's order:
-  // the thought it had, the prose it said, then the calls that prose announced.
-  const step = page.locator('.step');
-  await expect(step).toHaveCount(1);
-  await expect(step.locator(':scope > *')).toHaveClass(['activity-row', 'msg', 'activity-row']);
-  await expect(step.locator('.activity-row').first().locator('.activity-text')).toHaveText('#1 · Thought');
-  await expect(step.locator('.msg .msg-content.markdown')).toContainText('I will inspect the project.');
-  await expect(step.locator('.activity-row').last().locator('.tool-call-text')).toHaveText('read moon.mod');
+  const work = page.locator('.work-group');
+  const summary = work.locator(':scope > summary');
+  await expect(summary).toHaveAccessibleName('Work · 1 step · 1 tool call');
+  await expect(summary).not.toContainText('first thought');
+  const thought = work.locator('.work-thinking-body');
+  const thinking = work.locator('.work-thinking > summary');
+  const prose = work.locator('.msg .msg-content.markdown');
+  const tool = work.locator('.tool-toggle');
+  await expect(thinking).toHaveAccessibleName('Thinking');
+  await expect(thought).not.toBeVisible();
+  await expect(prose).toHaveText('I will inspect the project.');
+  await expect(prose).toBeVisible();
+  await expect(tool).toHaveAccessibleName('Read · moon.mod — Result available');
+  await thinking.press('Enter');
+  await expect(thought).toHaveText(reasoning);
+  await expect(thinking).toHaveAccessibleName('Thinking');
+  await tool.click();
+  await expect(work.getByText('moon.mod', { exact: true })).toBeVisible();
+  await expect(work.getByText('module contents', { exact: true })).toBeVisible();
+  await expect(work.locator('details.tool-result')).toHaveCount(0);
+  await summary.press('Enter');
+  await expect(prose).not.toBeVisible();
+  await summary.press('Enter');
+  await expect(thought).toBeVisible();
+  await expect(work.getByText('module contents', { exact: true })).toBeVisible();
+  expect(app.pageErrors).toEqual([]);
+});
+
+test('work commentary stays ordinary selectable text and file links keep work open', async ({ page }) => {
+  const app = new DesktopBrowserHarness(page);
+  app.sessionEvents = [
+    { sequence: 1, item: { kind: 'user', payload: { content: 'Show the browser fixture activity controls' } } },
+    { sequence: 2, item: { kind: 'assistant', payload: {
+      content: 'I will inspect the project.\n\n[Source](src/main.mbt:12)',
+      tool_calls: [{ id: 'c1', name: 'read', arguments: '{"path":"src/main.mbt"}' }],
+    } } },
+  ];
+  await app.install();
+  await app.goto();
+  await app.openSession();
+  const activity = page.locator('.work-group');
+  const text = activity.getByText('I will inspect the project.', { exact: true });
+  await expect(text).toBeVisible();
+  await text.click();
+  await expect(activity).toHaveAttribute('open', '');
+
+  // Drag across ordinary prose: the resulting click must preserve the selection.
+  const box = await text.boundingBox();
+  await page.mouse.move(box.x + 2, box.y + box.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(box.x + 100, box.y + box.height / 2, { steps: 8 });
+  await page.mouse.up();
+  await expect(activity).toHaveAttribute('open', '');
+  expect(await page.evaluate(() => document.getSelection().toString())).not.toBe('');
+  await page.evaluate(() => document.getSelection().removeAllRanges());
+
+  await activity.getByTitle('Open src/main.mbt:12').click();
+  await expect(activity).toHaveAttribute('open', '');
+  await expect.poll(() => app.requests.some(request =>
+    request.method === 'host.open_path' && request.params?.path === 'src/main.mbt:12'))
+    .toBe(true);
+  expect(app.pageErrors).toEqual([]);
+});
+
+test('reasoning-enabled answer text stays visible while streaming', async ({ page }) => {
+  const app = new DesktopBrowserHarness(page);
+  app.sessionEvents = [{
+    sequence: 1,
+    item: { kind: 'user', payload: { content: 'Show the browser fixture reasoning stream' } },
+  }];
+  await app.install();
+  await app.goto();
+  await app.openSession();
+  app.notify('agent.started', {
+    run_id: 'reasoning-run', session: 'session-1',
+    session_root: '/workspace/.openseek', model: 'deepseek-v4-pro', max_steps: 1000,
+  });
+  app.notify('agent.event', {
+    run_id: 'reasoning-run', session: 'session-1',
+    event: { event: 'reasoning_delta', content: 'Consider the evidence first.' },
+  });
+  const activity = page.locator('.work-group');
+  await expect(activity.locator(':scope > summary')).toHaveAccessibleName('Work · Thinking');
+  await activity.locator(':scope > summary').click();
+  await expect(activity).not.toHaveAttribute('open', '');
+  app.notify('agent.event', {
+    run_id: 'reasoning-run', session: 'session-1',
+    event: { event: 'assistant_delta', content: 'The answer is arriving' },
+  });
+  const answer = page.locator('.msg.streaming .msg-content');
+  await expect(answer).toHaveText('The answer is arriving');
+  await expect(answer).toBeVisible();
+  await expect(activity).not.toHaveAttribute('open', '');
+  app.notify('agent.event', {
+    run_id: 'reasoning-run', session: 'session-1',
+    event: { event: 'assistant_delta', content: ' in two chunks.' },
+  });
+  await expect(answer).toHaveText('The answer is arriving in two chunks.');
+  await expect(answer).toBeVisible();
+  await expect(page.locator('.msg.streaming .assistant-message-actions')).toHaveCount(0);
+  await activity.locator(':scope > summary').click();
+  await activity.locator('.work-thinking > summary').click();
+  await expect(activity.locator('.work-thinking-body')).toHaveText('Consider the evidence first.');
+  await expect(answer).toBeVisible();
   expect(app.pageErrors).toEqual([]);
 });
 
@@ -2004,10 +2101,58 @@ test('pending job waits show descriptions from earlier tool rows', async ({ page
   await app.goto();
   await app.openSession();
   const wait = page.locator('details.tool-call').filter({ hasText: 'Waiting for' });
+  // The expanded Work group exposes pending targets while tool bodies stay folded.
+  const activity = page.locator('details.work-group').filter({ has: wait.first() });
+  await expect(activity).toHaveAttribute('open', '');
+  await expect(wait.first()).toBeVisible();
   await expect(wait.locator('.tool-call-text')).toHaveText(
     ['Waiting for bg-10: Watch CI on rebased PR 27, bg-11', 'Waiting for bg-11']);
   await expect(wait.first()).not.toHaveAttribute('open', '');
   await wait.first().locator('summary').click();
   await expect(wait.first()).toContainText('"job_ids"');
+  expect(app.pageErrors).toEqual([]);
+});
+
+test('paired tool results preserve disclosure and tab state when results arrive out of order', async ({ page }) => {
+  const app = new DesktopBrowserHarness(page);
+  app.sessionEvents = [
+    { sequence: 1, item: { kind: 'user', payload: { content: 'Show the browser fixture with two file reads' } } },
+    { sequence: 2, item: { kind: 'assistant', payload: {
+      content: 'I will inspect both files.', reasoning_content: 'Compare the two files.',
+      tool_calls: ['a', 'b'].map(id => ({ id, name: 'read', arguments: JSON.stringify({ path: `${id}.mbt` }) })),
+    } } },
+  ];
+  await app.install();
+  await app.goto();
+  await app.openSession();
+  const work = page.locator('.work-group');
+  const tools = work.locator('details.tool-call');
+  await expect(tools).toHaveCount(2);
+  await tools.first().locator(':scope > summary').click();
+  const json = tools.first().getByText('Original JSON', { exact: true });
+  await json.click();
+  const commit = (sequence, kind, payload) => app.notify('session.event', {
+    session: 'session-1', session_root: '/workspace/.openseek', sequence,
+    event: { sequence, item: { kind, payload } },
+  });
+  commit(3, 'tool_result', { tool_call_id: 'b', tool_name: 'read', content: 'B output', is_error: false });
+  await expect(tools.nth(1).locator('.tool-status')).toHaveAccessibleName('Result available');
+  await expect(tools.nth(1)).not.toHaveAttribute('open', '');
+  await expect(tools.first().locator('.tool-card-original-json')).toBeVisible();
+  commit(4, 'tool_result', { tool_call_id: 'a', tool_name: 'read', content: 'A failed', is_error: true });
+  await expect(tools.first().locator('.tool-status')).toHaveAccessibleName('Tool failed');
+  await expect(work.locator(':scope > summary')).toContainText('Tool failed');
+  await expect(tools.first()).toHaveAttribute('open', '');
+  await expect(tools.first().locator('.tool-card-original-json')).toBeVisible();
+  await expect(tools.first().getByText('A failed', { exact: true })).toBeVisible();
+  await expect(tools.locator('.tool-call-text')).toHaveText(['Read · a.mbt', 'Read · b.mbt']);
+  await work.locator(':scope > summary').click();
+  commit(5, 'terminal', { kind: 'finished', message: 'One file could not be read.' });
+  await expect(work).not.toHaveAttribute('open', '');
+  const answer = page.getByText('One file could not be read.', { exact: true });
+  await expect(answer).toBeVisible();
+  await expect(work.getByText('One file could not be read.', { exact: true })).toHaveCount(0);
+  await work.locator(':scope > summary').click();
+  await expect(tools.first().locator('.tool-card-original-json')).toBeVisible();
   expect(app.pageErrors).toEqual([]);
 });

--- a/desktop/frontend/transcript/component/rendering.mbt
+++ b/desktop/frontend/transcript/component/rendering.mbt
@@ -422,6 +422,8 @@ fn Input::empty_content(self : Input) -> EmptyContent {
 
 ///|
 priv enum BlockContent {
+  /// Contiguous work; its native disclosure is keyed by the preceding boundary.
+  Work(Array[Block])
   /// Nothing to show: no durable items and nothing streaming.
   Empty(EmptyContent)
   /// One transcript item. `step_label` is the ordinal an OpenSeek provider
@@ -529,7 +531,7 @@ fn stream_blocks(input : Input) -> @vector.Vector[Block] {
       ),
     })
   }
-  @vector.from_array(blocks)
+  @vector.from_array(group_work_blocks(blocks))
 }
 
 ///|
@@ -544,15 +546,9 @@ fn Block::branch_key(self : Block) -> String {
 fn Block::render(self : Block, actions : Actions) -> @html.Html {
   let on_open = path => (actions.open)(path)
   match self.content {
+    Work(blocks) => work_view(blocks, actions)
     Empty(empty) => empty.render(actions)
-    Item(
-      item~,
-      anchor~,
-      step_label~,
-      assistant_name~,
-      subrun_parent~,
-      wait_labels~
-    ) =>
+    Item(item~, anchor~, assistant_name~, subrun_parent~, wait_labels~, ..) =>
       transcript_item_view(
         item,
         on_open,
@@ -560,19 +556,17 @@ fn Block::render(self : Block, actions : Actions) -> @html.Html {
         anchor?,
         on_jump=target => (actions.jump)(target),
         assistant_name~,
-        step_label?,
         subrun?=subrun_parent.map(parent => SubrunLink::{
           parent,
           open: session => (actions.open_session)(session),
         }),
       )
     TurnRule(ts~) => turn_rule_view(ts?)
-    Live(prose~, reasoning~, reasoning_complete~, step_label~, assistant_name~) =>
+    Live(prose~, reasoning~, reasoning_complete~, assistant_name~, ..) =>
       assistant_view(
         on_open,
         prose?,
         reasoning?,
-        step_label?,
         assistant_name~,
         live=true,
         reasoning_complete~,

--- a/desktop/frontend/transcript/component/tool_exchange.mbt
+++ b/desktop/frontend/transcript/component/tool_exchange.mbt
@@ -1,0 +1,190 @@
+// Recorded inputs and output share one invocation and one disclosure.
+
+///|
+fn tool_exchange_view(
+  call : @transcript.ToolCall,
+  sequence? : Int,
+  subrun? : SubrunLink,
+  wait_label? : String,
+) -> @html.Html {
+  let name = call.name
+  let key = tool_call_tabs_key(call.call_id, sequence)
+  let (status, is_error, brief, output) = match call.outcome {
+    Pending(output~) =>
+      (
+        if output is Some(_) {
+          "Output arriving"
+        } else {
+          "Awaiting result"
+        },
+        false,
+        None,
+        output,
+      )
+    Done(is_error~, brief~, content~) =>
+      (
+        if is_error {
+          "Tool failed"
+        } else {
+          "Result available"
+        },
+        is_error,
+        brief,
+        Some(content),
+      )
+  }
+  let label = if wait_label is Some(label) {
+    label
+  } else if pending_job_wait_label(call) is Some(label) {
+    label
+  } else if name == "read" &&
+    call.arguments is Some(arguments) &&
+    card_fields(arguments) is Some(fields) &&
+    fields.get("path") is Some(String(path)) {
+    "Read · " + path
+  } else {
+    let label = match brief {
+      Some(text) if !text.is_blank() => text
+      _ => name
+    }
+    if name == "mbtx" &&
+      call.arguments is Some(arguments) &&
+      card_fields(arguments) is Some(fields) &&
+      fields.get("description") is Some(String(description)) &&
+      !description.is_blank() {
+      label + " · " + description
+    } else {
+      label
+    }
+  }
+  // Bound the actual focus label, not only its visual paint. The complete
+  // caption remains readable in the body when it exceeds this compact label.
+  let cut = String::from_iter(label.iter().take(120))
+  let caption = if cut.length() < label.length() { cut + "…" } else { cut }
+  let body : Array[@html.Html] = []
+  if call.arguments is Some(arguments) {
+    // A `plan` call shows the checklist it recorded rather than its JSON, in
+    // every state where that checklist is what the model asked for. A pending
+    // call qualifies: the card is a record of the call, and the missing Output
+    // section already marks it unfinished. A rejected one does not — the
+    // malformed arguments are what the reader needs, and dressing them up as a
+    // checklist would report a plan that never took effect.
+    if @plan.classify(call) is Some(Applied(steps) | Pending(steps)) {
+      body.push(@html.div(class="tool-call-section", [@plan.card(steps)]))
+    } else if tool_arguments_tabbed_view(
+        tool_call_tabs_key(call.call_id, sequence),
+        name,
+        Some(arguments),
+      )
+      is Some(tabs) {
+      body.push(@html.div(class="tool-call-section", [tabs]))
+    } else if custom_card(name, arguments) is Some((label, card)) {
+      // Some tools' arguments have a shape JSON hides, such as an `edit` split
+      // across two blobs whose difference is the whole point. Those get a card.
+      // A payload the card cannot read falls through to the generic rendering
+      // below, so nothing is ever shown as a change that is not one.
+      body.push(
+        @html.div(class="tool-call-section", [
+          @html.div(class="tool-call-section-label", label),
+          card,
+        ]),
+      )
+    } else {
+      let trimmed = arguments.trim()
+      if !trimmed.is_empty() && trimmed != "{}" {
+        body.push(
+          @html.div(class="tool-call-section", [
+            @html.div(class="tool-call-section-label", "Arguments"),
+            json_arguments_content(arguments).body,
+          ]),
+        )
+      }
+    }
+  }
+  if body.is_empty() {
+    body.push(
+      @html.div(class="tool-call-section", [
+        @html.div(class="tool-call-section-label", "Arguments"),
+        @html.div(
+          class="tool-empty",
+          if call.arguments is None {
+            "No arguments recorded."
+          } else {
+            "No arguments."
+          },
+        ),
+      ]),
+    )
+  }
+  if caption != label {
+    body.insert(0, @html.div(class="tool-caption", truncate_output(label)))
+  }
+  let inputs = @html.div(class="tool-input", body)
+  let output_sections = tool_output_sections(
+    name,
+    call.arguments,
+    brief,
+    output,
+    key,
+    subrun?,
+  )
+  if output_sections.is_empty() {
+    output_sections.push(
+      @html.div(class="tool-call-section", [
+        @html.div(class="tool-call-section-label", "Output"),
+        @html.div(
+          class="tool-empty",
+          if output is None {
+            "Waiting for a result…"
+          } else {
+            "No output returned."
+          },
+        ),
+      ]),
+    )
+  }
+  let status_icon = match call.outcome {
+    Pending(..) => @icons.icon_circle
+    Done(is_error=true, ..) => @icons.icon_error
+    Done(..) => @icons.icon_check
+  }
+  @html.details(
+    class="tool-call" +
+      (if is_error { " error" } else { "" }) +
+      failure_stage_class(name, brief, is_error, call.arguments),
+    [
+      @html.summary(
+        class="work-toggle tool-toggle",
+        attrs=@html.Attrs::build().aria_label(caption + " — " + status),
+        [
+          @html.span(class="work-chevron", @icons.icon_chevron_down()),
+          @html.span(class="tool-call-text", caption),
+          @plan.fold_progress(call),
+          match
+            failure_marker(
+              name,
+              brief,
+              is_error,
+              call.arguments,
+              brief_shown=brief is Some(text) && caption.contains(text),
+            ) {
+            Some(marker) => marker
+            None => @html.nothing
+          },
+          @html.span(
+            class="tool-status",
+            attrs=@html.Attrs::build()
+              .role("img")
+              .aria_label(status)
+              .title(status),
+            @icons.icon(status_icon),
+          ),
+        ],
+      ),
+      @html.div(class="tool-body", {
+        "input": inputs,
+        "output": @html.div(class="tool-output", output_sections),
+      }),
+    ],
+  )
+}

--- a/desktop/frontend/transcript/component/tool_tabs.mbt
+++ b/desktop/frontend/transcript/component/tool_tabs.mbt
@@ -71,8 +71,7 @@ fn tool_call_tabs_key(call_id : String, sequence : Int?) -> String {
 /// custom card supplies the first semantic view for tools such as `mbtx` and
 /// `edit`; other tools use the readable generic arguments view. Exact JSON is
 /// a separate tab only when the first view is a derived reading rather than
-/// the recording itself. The result deliberately does not join this tab set:
-/// like the viz HTML renderer, the transcript renders it as its own row.
+/// the recording itself. Output follows below in the same tool disclosure.
 ///
 /// `None` when there is only one useful view: the existing labeled fallback is
 /// clearer than a one-entry tab strip.

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -1,24 +1,5 @@
 ///|
-/// One provider response as the transcript shows it: its thought behind a
-/// fold, its prose as a bubble, and every tool call on display as its own
-/// one-line row (`tool_request_view`), expandable to that call's arguments and
-/// output — in the order the model produced them, so a step that ran ten
-/// tools reads as ten scannable rows after the narration that announced them.
-/// Only reasoning stays behind a fold: a step that opens with a thought
-/// carries the ordinal and commit instant on that fold's summary
-/// ("#2 14:32:10 · Thought"), and a numbered step that goes straight to
-/// tools puts the same columns on a plain heading line instead. The open
-/// state of every disclosure is the browser's (`<details>`), so a reader's
-/// toggle survives re-renders and the run growing while live.
-///
-/// The response still streaming renders through this same view (`live`), so
-/// nothing shown live restyles when its durable event lands: the thought
-/// stays plain text until it completes, and the prose bubble is marked
-/// streaming until the commit replaces it.
-///
-/// Failures need no badge up here: a failed call's own row is visible and
-/// carries its own literal `failed` marker. Its potentially large arguments
-/// and output stay folded by default, like every other call.
+/// Render commentary directly, with independent disclosures for reasoning and tools.
 fn assistant_view(
   on_open : (String) -> @cmd.Cmd,
   wait_labels? : Map[Int, String] = Map([]),
@@ -27,92 +8,41 @@ fn assistant_view(
   calls? : Array[@transcript.ToolCall] = [],
   sequence? : Int,
   ts? : Double,
-  step_label? : String,
   assistant_name? : String = "OpenSeek",
   finished? : Bool = false,
   live? : Bool = false,
   reasoning_complete? : Bool = true,
   subrun? : SubrunLink,
 ) -> @html.Html {
-  // The step ordinal is its own span so it can carry the accent and a fixed
-  // numeral column, then the instant in a second fixed column: the run reads
-  // as a table. The instant belongs beside the ordinal rather than out at the
-  // row's right edge — the reason to show it at all is the gap to the step
-  // above and below, and comparing a column is the eye's job only when
-  // nothing variable-width sits between its entries and their anchor.
-  let header : Array[@html.Html] = []
-  let stamp = step_stamp(ts?)
-  if step_label is Some(label) {
-    header.push(@html.span(class="activity-step", label))
-    // A real space, not a CSS margin, and only when the instant follows it: the
-    // gap has to exist in the text as well, or the accessible name and anything
-    // copied out of the row read "#1Committed 14:32:10".
-    if stamp is Some(_) {
-      header.push(@html.text(" "))
-    }
-  }
-  if stamp is Some(stamp) {
-    header.push(stamp)
-  }
-  // The header rides the thought fold's summary when the step opens with
-  // reasoning, keeping the common step's one-line "#2 · Thought" lead. A step
-  // that goes straight to tools gets a plain heading line instead: a call
-  // row's summary belongs to that call alone. Prose alone carries no heading.
-  let lead : Array[@html.Html] = []
-  if reasoning is Some(text) {
-    let thinking = live && !reasoning_complete
-    let label = if thinking { "Thinking…" } else { "Thought" }
-    let summary : Array[@html.Html] = []
-    if header.is_empty() {
-      // The separator introduces the label only when something precedes it:
-      // a Codex thought with no ordinal and no stamp is the label alone.
-      summary.push(@html.text(label))
-    } else {
-      summary.append(header)
-      summary.push(@html.text(" · \{label}"))
-    }
-    let body = if thinking {
-      // Do not parse an unfinished Markdown document on every provider token.
-      // Newlines are preserved by CSS while fragments are still arriving.
-      @html.div(
-        class="msg-content activity-thinking activity-thinking-live",
-        @html.text(text),
-      )
-    } else {
-      @html.div(
-        class="msg-content markdown activity-thinking",
-        @markdown.markdown_nodes(text, open_file=on_open),
-      )
-    }
-    lead.push(
-      @html.details(class="activity", open=live, [
-        @html.summary(class="activity-summary", [
-          @html.span(class="activity-text", summary),
+  let content : Map[String, @html.Html] = Map([])
+  if reasoning is Some(text) && !text.is_blank() {
+    content.set(
+      "thinking",
+      @html.details(class="work-thinking", [
+        @html.summary(class="work-toggle", [
+          @html.span(class="work-chevron", @icons.icon_chevron_down()),
+          @html.text(
+            if live && !reasoning_complete {
+              "Thinking · in progress"
+            } else {
+              "Thinking"
+            },
+          ),
         ]),
-        @html.div(class="activity-body", [body]),
+        @html.div(
+          class="work-thinking-body msg-content markdown",
+          if live && !reasoning_complete {
+            [@html.text(text)]
+          } else {
+            @markdown.markdown_nodes(text, open_file=on_open)
+          },
+        ),
       ]),
     )
-  } else if !header.is_empty() && !calls.is_empty() {
-    lead.push(@html.div(class="activity-heading", header))
   }
-  let work = if calls.is_empty() {
-    None
-  } else {
-    Some(
-      @html.div(
-        class="activity-work",
-        tool_run_views(calls, sequence?, subrun?, wait_labels~),
-      ),
-    )
-  }
-  // The prose bubble separates the thought from the work it announced; a
-  // response without prose keeps both under one quiet guide line.
-  let parts : Array[@html.Html] = []
   if prose is Some(text) {
-    if !lead.is_empty() {
-      parts.push(@html.div(class="activity-row", lead))
-    }
-    parts.push(
+    content.set(
+      "message",
       assistant_message_view(
         text,
         on_open,
@@ -123,18 +53,20 @@ fn assistant_view(
         streaming=live,
       ),
     )
-    if work is Some(work) {
-      parts.push(@html.div(class="activity-row", [work]))
-    }
-  } else {
-    if work is Some(work) {
-      lead.push(work)
-    }
-    if !lead.is_empty() {
-      parts.push(@html.div(class="activity-row", lead))
-    }
   }
-  @html.div(class="step", parts)
+  if !calls.is_empty() {
+    content.set(
+      "tools",
+      @html.div(
+        class="work-tools",
+        tool_run_views(calls, sequence?, subrun?, wait_labels~),
+      ),
+    )
+  }
+  if finished || (live && reasoning is None) {
+    return @html.div(class="step", content)
+  }
+  @html.div(class="work-step", content)
 }
 
 ///|
@@ -168,11 +100,9 @@ fn notice_view(
 }
 
 ///|
-/// Render one response's tool calls. Several calls of one provider response
-/// are a parallel burst: show every request first and every result after it,
-/// exactly as the viz HTML renderer's Assistant card followed by result cards
-/// makes a burst readable. A lone call — every Codex item, and a notice —
-/// keeps its request beside its own result instead of implying concurrency.
+/// Pair each invocation's inputs and output under one stable disclosure. The
+/// index disambiguates malformed histories with duplicate call ids; results
+/// update in place without changing the request order or browser-owned state.
 fn tool_run_views(
   calls : Array[@transcript.ToolCall],
   sequence? : Int,
@@ -180,57 +110,15 @@ fn tool_run_views(
   wait_labels? : Map[Int, String] = Map([]),
 ) -> Map[String, @html.Html] {
   let rows : Map[String, @html.Html] = Map([])
-  let burst = calls.length() > 1 && calls.all(call => call.arguments is Some(_))
-  if burst {
-    for index, call in calls {
-      rows[tool_run_row_key(call, index, "request")] = tool_request_view(
-        call,
-        sequence?,
-        wait_label?=wait_labels.get(index),
-      )
-    }
-    for index, call in calls {
-      if tool_result_row_is_visible(call) {
-        rows[tool_run_row_key(call, index, "result")] = tool_result_view(
-          call,
-          sequence?,
-          subrun?,
-        )
-      }
-    }
-  } else {
-    for index, call in calls {
-      if call.arguments is Some(_) {
-        rows[tool_run_row_key(call, index, "request")] = tool_request_view(
-          call,
-          sequence?,
-          wait_label?=wait_labels.get(index),
-        )
-      }
-      if tool_result_row_is_visible(call) {
-        rows[tool_run_row_key(call, index, "result")] = tool_result_view(
-          call,
-          sequence?,
-          subrun?,
-        )
-      }
-    }
+  for index, call in calls {
+    rows["call\u{0}\{call.call_id}\u{0}\{index}"] = tool_exchange_view(
+      call,
+      sequence?,
+      subrun?,
+      wait_label?=wait_labels.get(index),
+    )
   }
   rows
-}
-
-///|
-/// Stable VDOM identity for one side of a tool exchange. Results can arrive
-/// after later calls are already visible, so keyed children keep browser-owned
-/// disclosure and radio state attached to the same call instead of the same
-/// array position. The index disambiguates malformed logs with duplicate ids;
-/// call order itself is stable in the transcript projection.
-fn tool_run_row_key(
-  call : @transcript.ToolCall,
-  index : Int,
-  side : String,
-) -> String {
-  "\{side}\u{0}\{call.call_id}\u{0}\{index}"
 }
 
 ///|
@@ -262,171 +150,6 @@ fn subrun_chip(child : String, open : (String) -> @cmd.Cmd) -> @html.Html {
       "↳ subagent transcript",
     ),
   ])
-}
-
-///|
-/// A completed result always gets its own row, including an empty one. Codex
-/// command items can also stream output while still in progress; surface that
-/// stream immediately, with the row still labelled pending until the
-/// completed item arrives.
-fn tool_result_row_is_visible(call : @transcript.ToolCall) -> Bool {
-  match call.outcome {
-    Done(..) => true
-    Pending(output~) => output is Some(_)
-  }
-}
-
-///|
-/// One recorded tool request, always on display as its own row. Its brief is
-/// the result-derived caption the viz renderer also promotes onto the call;
-/// expanding reveals only what the model sent. Failed calls read red and carry
-/// a literal marker, while their separate result row owns the output.
-fn tool_request_view(
-  call : @transcript.ToolCall,
-  sequence? : Int,
-  wait_label? : String,
-) -> @html.Html {
-  guard call.arguments is Some(arguments) else { return @html.nothing }
-  let name = call.name
-  // A pending call has no result to be wrong about, and no brief yet.
-  let (is_error, brief) = match call.outcome {
-    Done(is_error~, brief~, ..) => (is_error, brief)
-    Pending(..) => (false, None)
-  }
-  let label = if brief is Some(brief) && !brief.is_blank() {
-    brief
-  } else if wait_label is Some(label) {
-    label
-  } else if pending_job_wait_label(call) is Some(label) {
-    label
-  } else {
-    name
-  }
-  let label = if name == "mbtx" &&
-    card_fields(arguments) is Some(fields) &&
-    fields.get("description") is Some(String(description)) &&
-    !description.is_blank() {
-    "\{label} · \{description}"
-  } else {
-    label
-  }
-  let error_class = (if is_error { " error" } else { "" }) +
-    failure_stage_class(name, brief, is_error, Some(arguments))
-  // The row's always-visible line: the brief, a literal marker when the
-  // result errored and the brief does not already carry the state in words
-  // (see `failure_marker`), and — for an applied `plan` call — the compact
-  // progress meter. `fold_progress` renders nothing for every other call.
-  let line : Array[@html.Html] = [
-    @html.span(class="tool-flow", "→"),
-    @html.span(class="tool-call-text", label),
-  ]
-  if failure_marker(
-      name,
-      brief,
-      is_error,
-      Some(arguments),
-      // The request row's label is the brief whenever one exists.
-      brief_shown=brief is Some(brief) && !brief.is_blank(),
-    )
-    is Some(marker) {
-    line.push(marker)
-  }
-  line.push(@plan.fold_progress(call))
-  let body : Array[@html.Html] = []
-  // A `plan` call shows the checklist it recorded rather than its JSON, in
-  // every state where that checklist is what the model asked for. A pending
-  // call qualifies: the card is a record of the call, and the missing Output
-  // section already marks it unfinished. A rejected one does not — the
-  // malformed arguments are what the reader needs, and dressing them up as a
-  // checklist would report a plan that never took effect.
-  if @plan.classify(call) is Some(Applied(steps) | Pending(steps)) {
-    body.push(@html.div(class="tool-call-section", [@plan.card(steps)]))
-  } else if tool_arguments_tabbed_view(
-      tool_call_tabs_key(call.call_id, sequence),
-      name,
-      Some(arguments),
-    )
-    is Some(tabs) {
-    body.push(@html.div(class="tool-call-section", [tabs]))
-  } else if custom_card(name, arguments) is Some((label, card)) {
-    // Some tools' arguments have a shape JSON hides, such as an `edit` split
-    // across two blobs whose difference is the whole point. Those get a card.
-    // A payload the card cannot read falls through to the generic rendering
-    // below, so nothing is ever shown as a change that is not one.
-    body.push(
-      @html.div(class="tool-call-section", [
-        @html.div(class="tool-call-section-label", label),
-        card,
-      ]),
-    )
-  } else {
-    let trimmed = arguments.trim()
-    if !trimmed.is_empty() && trimmed != "{}" {
-      body.push(
-        @html.div(class="tool-call-section", [
-          @html.div(class="tool-call-section-label", "Arguments"),
-          json_arguments_content(arguments).body,
-        ]),
-      )
-    }
-  }
-  if body.is_empty() {
-    @html.div(class="tool-call-label" + error_class, line)
-  } else {
-    @html.details(
-      class="tool-call" + error_class,
-      [
-        // The full label as the row's tooltip: a brief longer than the pane
-        // is ellipsized by the stylesheet, and the body holds the arguments
-        // but not the brief — hover (or opening the row, which the
-        // stylesheet un-clamps) is how the whole text stays reachable.
-        @html.summary(class="tool-call-summary", title=label, line),
-        ..body,
-      ],
-    )
-  }
-}
-
-///|
-/// One tool result, separate from the request that produced it as in the viz
-/// HTML renderer. A completed row remains visible even when empty; a pending
-/// Codex command gets a row only after it has streamed output, and its label
-/// deliberately says "output" rather than claiming completion.
-fn tool_result_view(
-  call : @transcript.ToolCall,
-  sequence? : Int,
-  subrun? : SubrunLink,
-) -> @html.Html {
-  let key = tool_call_tabs_key(call.call_id, sequence)
-  match call.outcome {
-    Pending(output~) =>
-      result_row_view(
-        call.name,
-        call.arguments,
-        pending=true,
-        is_error=false,
-        brief=None,
-        output,
-        key,
-        subrun?,
-      )
-    Done(content~, is_error~, brief~) =>
-      result_row_view(
-        call.name,
-        call.arguments,
-        pending=false,
-        is_error~,
-        brief~,
-        // An empty result still gets its row; it just has nothing to expand.
-        if content.is_blank() {
-          None
-        } else {
-          Some(content)
-        },
-        key,
-        subrun?,
-      )
-  }
 }
 
 ///|
@@ -470,6 +193,27 @@ fn result_row_view(
     is Some(marker) {
     line.push(marker)
   }
+  let body = tool_output_sections(name, arguments, brief, output, key, subrun?)
+  if body.is_empty() {
+    @html.div(class="tool-result-label" + error_class + pending_class, line)
+  } else {
+    @html.details(
+      class="tool-result" + error_class + pending_class,
+      [@html.summary(class="tool-result-summary", title=label, line), ..body],
+    )
+  }
+}
+
+///|
+/// Exact output and child-transcript links, reusable inside a notice or call.
+fn tool_output_sections(
+  name : String,
+  arguments : String?,
+  brief : String?,
+  output : String?,
+  key : String,
+  subrun? : SubrunLink,
+) -> Array[@html.Html] {
   let body : Array[@html.Html] = []
   // A sub-run result names the child session it spawned in its brief. The
   // result owns the child report and therefore owns the way into its transcript.
@@ -500,14 +244,7 @@ fn result_row_view(
       )
     }
   }
-  if body.is_empty() {
-    @html.div(class="tool-result-label" + error_class + pending_class, line)
-  } else {
-    @html.details(
-      class="tool-result" + error_class + pending_class,
-      [@html.summary(class="tool-result-summary", title=label, line), ..body],
-    )
-  }
+  body
 }
 
 ///|
@@ -697,7 +434,12 @@ fn user_message_view(
       body.push(@html.div(class="msg-content", inline_code_nodes(content)))
   }
   // The overview rail and scroll watcher share this stable turn anchor.
-  @html.div(class="msg user", id?=anchor, [@html.div(class="user-bubble", body)])
+  @html.div(
+    class="msg user",
+    id?=anchor,
+    attrs=@html.Attrs::build().tabindex(0),
+    [@html.div(class="user-bubble", body)],
+  )
 }
 
 ///|
@@ -816,9 +558,7 @@ fn turn_rule_view(ts? : Double) -> @html.Html {
 }
 
 ///|
-/// One transcript item as its own stream child. `step_label` is the ordinal an
-/// OpenSeek provider response carries ("#3"); every other source and kind
-/// has none.
+/// Render one normalized transcript item; the work grouping owns its placement.
 fn transcript_item_view(
   item : @transcript.TranscriptItem,
   on_open : (String) -> @cmd.Cmd,
@@ -826,7 +566,6 @@ fn transcript_item_view(
   anchor? : String,
   on_jump? : (@mention_context.Target) -> @cmd.Cmd,
   assistant_name? : String = "OpenSeek",
-  step_label? : String,
   subrun? : SubrunLink,
 ) -> @html.Html {
   match item.kind {
@@ -840,7 +579,6 @@ fn transcript_item_view(
         wait_labels~,
         sequence?=item.sequence,
         ts?=item.ts,
-        step_label?,
         assistant_name~,
         finished~,
         subrun?,

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -797,12 +797,8 @@ fn step_time_label(unix_ms : Double) -> String {
 }
 
 ///|
-/// The hairline closing a user's turn: everything below it until the next
-/// bubble is the agent's answer. Drawn after the bubble rather than before it
-/// because that is the boundary a reader needs — the bubble's own alignment
-/// already separates it from the answer above. The rule carries the prompt's
-/// send time at its right end, under the bubble it dates; a turn replayed
-/// from an unstamped store keeps the bare rule.
+/// The prompt's send time, aligned beneath its bubble. Unstamped history
+/// leaves this row empty; styling removes it from the layout.
 fn turn_rule_view(ts? : Double) -> @html.Html {
   let children : Array[@html.Html] = []
   if ts is Some(ts) {

--- a/desktop/frontend/transcript/component/view_wbtest.mbt
+++ b/desktop/frontend/transcript/component/view_wbtest.mbt
@@ -49,7 +49,9 @@ test "transcript stream children use stable typed keys in display order" {
     streaming_identity="r7",
   )
   let keys = stream_keys(input)
-  assert_eq(keys, ["row\u{0}s41", "rule\u{0}s41", "row\u{0}s42", "live\u{0}r7"])
+  assert_eq(keys, [
+    "row\u{0}s41", "rule\u{0}s41", "work\u{0}rule\u{0}s41", "live\u{0}r7",
+  ])
   // The result filling the call, and the durable reasoning the same event
   // turns out to carry, change the response's node, never its identity: the
   // browser-owned disclosures inside it survive both.
@@ -81,7 +83,7 @@ test "transcript stream children use stable typed keys in display order" {
 }
 
 ///|
-test "the live response is one node, replaced by the durable one" {
+test "work identity survives live reasoning committing while prose stays outside" {
   let user : VisibleRow = {
     item: { kind: User("question"), ts: None, sequence: Some(1), },
     identity: "s1",
@@ -102,11 +104,11 @@ test "the live response is one node, replaced by the durable one" {
     streaming_identity="r7",
   )
   let live_keys = stream_keys(live_input)
-  assert_eq(live_keys, ["row\u{0}s1", "rule\u{0}s1", "live\u{0}r7"])
-  // The answer streaming after the thought joins the same node.
+  assert_eq(live_keys, ["row\u{0}s1", "rule\u{0}s1", "work\u{0}rule\u{0}s1"])
+  // Streaming prose remains a separate visible node beside folded reasoning.
   let answering = { ..live_input, streaming_response: Some("partial"), }
-  assert_eq(stream_keys(answering), live_keys)
-  // The durable commit is its own node; the preview is gone with the run.
+  assert_eq(stream_keys(answering), [..live_keys, "live\u{0}r7"])
+  // The durable step replaces the provisional evidence inside the same group.
   let settled = {
     ..live_input,
     items: [
@@ -128,7 +130,7 @@ test "the live response is one node, replaced by the durable one" {
     ],
     streaming_reasoning: None,
   }
-  assert_eq(stream_keys(settled), ["row\u{0}s1", "rule\u{0}s1", "row\u{0}s2"])
+  assert_eq(stream_keys(settled), live_keys)
 }
 
 ///|
@@ -237,4 +239,109 @@ test "tool output truncation keeps the head and tail around a skip marker" {
   assert_true(bounded.has_prefix("x".repeat(12_000)))
   assert_true(bounded.has_suffix("x".repeat(8_000)))
   assert_true(bounded.contains("10000 UTF-16 code units skipped"))
+}
+
+///|
+test "finished evidence folds separately from the answer for both providers" {
+  for source in [OpenSeek, Codex] {
+    let input = {
+      ..base_input(),
+      source,
+      items: VisibleRow::history([
+        { kind: User("question"), ts: None, sequence: Some(1), },
+        {
+          kind: Assistant(
+            reasoning=Some("evidence"),
+            prose=Some("final answer"),
+            calls=[],
+            replay=false,
+            finished=true,
+          ),
+          ts: None,
+          sequence: Some(2),
+        },
+      ]),
+    }
+    let blocks = stream_blocks(input).to_array()
+    assert_eq(blocks.length(), 4)
+    guard blocks[2].content is Work([evidence]) else { fail("missing work") }
+    assert_true(
+      evidence.content
+      is Item(
+        item={
+          kind: Assistant(
+            reasoning=Some("evidence"),
+            prose=None,
+            finished=false,
+            ..
+          ),
+          ..
+        },
+        ..
+      ),
+    )
+    assert_true(
+      blocks[3].content
+      is Item(
+        item={
+          kind: Assistant(
+            reasoning=None,
+            prose=Some("final answer"),
+            finished=true,
+            calls=[],
+            ..
+          ),
+          ..
+        },
+        ..
+      ),
+    )
+  }
+}
+
+///|
+test "work grouping preserves notices checkpoints failures and prompt boundaries" {
+  let activity : @transcript.ItemKind = Assistant(
+    reasoning=None,
+    prose=Some("activity"),
+    calls=[],
+    replay=false,
+    finished=false,
+  )
+  for
+    boundary in [
+      @transcript.ItemKind::User("next prompt"),
+      Summary("checkpoint"),
+      Notice(
+        label="notice",
+        brief=None,
+        is_error=false,
+        body=Some("background result"),
+      ),
+      Failure("failed"),
+      Answer("answer"),
+      Assistant(
+        reasoning=None,
+        prose=Some("replayed answer"),
+        calls=[],
+        replay=true,
+        finished=false,
+      ),
+    ] {
+    let input = {
+      ..base_input(),
+      items: VisibleRow::history([
+        { kind: activity, ts: None, sequence: Some(1), },
+        { kind: boundary, ts: None, sequence: Some(2), },
+        { kind: activity, ts: None, sequence: Some(3), },
+      ]),
+    }
+    let blocks = stream_blocks(input).to_array()
+    assert_true(blocks[0].content is Work([_]))
+    assert_true(
+      blocks[1].content is Item(item={ kind, .. }, ..) && kind == boundary,
+    )
+    assert_true(blocks.last().unwrap().content is Work([_]))
+    assert_true(blocks[0].key != blocks.last().unwrap().key)
+  }
 }

--- a/desktop/frontend/transcript/component/work.mbt
+++ b/desktop/frontend/transcript/component/work.mbt
@@ -1,0 +1,183 @@
+///|
+/// Group contiguous work without crossing prompts, checkpoints or notices.
+/// The preceding boundary owns the group key: replacing the first live thought
+/// with a durable response must not reset the reader's disclosure choice.
+/// Final-answer evidence joins the work; final and live prose remain outside.
+fn group_work_blocks(blocks : Array[Block]) -> Array[Block] {
+  let output : Array[Block] = []
+  let mut work : Array[Block] = []
+  let mut boundary = TranscriptRenderKey::empty()
+  for block in blocks {
+    let (evidence, remainder) = match block.content {
+      Item(
+        item~,
+        anchor~,
+        step_label~,
+        assistant_name~,
+        subrun_parent~,
+        wait_labels~
+      ) =>
+        match item.kind {
+          Assistant(replay=false, finished=false, ..) => (Some(block), None)
+          Assistant(replay=false, finished=true, reasoning~, prose~, calls~) if (
+              reasoning is Some(text) && !text.is_blank()
+            ) ||
+            !calls.is_empty() => {
+            let evidence = {
+              ..block,
+              content: Item(
+                item={
+                  ..item,
+                  kind: Assistant(
+                    reasoning~,
+                    prose=None,
+                    calls~,
+                    replay=false,
+                    finished=false,
+                  ),
+                },
+                anchor~,
+                step_label~,
+                assistant_name~,
+                subrun_parent~,
+                wait_labels~,
+              ),
+            }
+            let answer = {
+              ..block,
+              content: Item(
+                item={
+                  ..item,
+                  kind: Assistant(
+                    reasoning=None,
+                    prose~,
+                    calls=[],
+                    replay=false,
+                    finished=true,
+                  ),
+                },
+                anchor~,
+                step_label~,
+                assistant_name~,
+                subrun_parent~,
+                wait_labels~,
+              ),
+            }
+            (Some(evidence), Some(answer))
+          }
+          _ => (None, Some(block))
+        }
+      Live(
+        prose~,
+        reasoning~,
+        reasoning_complete~,
+        step_label~,
+        assistant_name~
+      ) => {
+        let evidence = match reasoning {
+          Some(text) if !text.is_blank() =>
+            Some({
+              ..block,
+              content: Live(
+                prose=None,
+                reasoning=Some(text),
+                reasoning_complete~,
+                step_label~,
+                assistant_name~,
+              ),
+            })
+          _ => None
+        }
+        let answer = prose.map(text => {
+          ..block,
+          content: Live(
+            prose=Some(text),
+            reasoning=None,
+            reasoning_complete~,
+            step_label~,
+            assistant_name~,
+          ),
+        })
+        (evidence, answer)
+      }
+      _ => (None, Some(block))
+    }
+    if evidence is Some(part) {
+      work.push(part)
+    }
+    if remainder is Some(part) {
+      if work.get(0) is Some(first) {
+        output.push({
+          ..first,
+          key: { value: "work\u{0}" + boundary.wire(), },
+          content: Work(work),
+        })
+        work = []
+      }
+      output.push(part)
+      boundary = part.key
+    }
+  }
+  if work.get(0) is Some(first) {
+    output.push({
+      ..first,
+      key: { value: "work\u{0}" + boundary.wire(), },
+      content: Work(work),
+    })
+  }
+  output
+}
+
+///|
+/// A factual, bounded navigation label. Only OpenSeek response ordinals count
+/// as steps; Codex may split one response across several transcript items.
+fn work_view(blocks : Array[Block], actions : Actions) -> @html.Html {
+  let children : Map[String, @html.Html] = Map([])
+  let mut steps = 0
+  let mut tools = 0
+  let mut failed = false
+  let mut pending = false
+  let mut thinking = false
+  for block in blocks {
+    children[block.branch_key()] = block.render(actions)
+    match block.content {
+      Item(item~, step_label~, ..) => {
+        if step_label is Some(_) {
+          steps += 1
+        }
+        if item.kind is Assistant(calls~, ..) {
+          tools += calls.length()
+          failed = failed ||
+            calls.any(call => call.outcome is Done(is_error=true, ..))
+          pending = pending || calls.any(call => call.outcome is Pending(..))
+        }
+      }
+      Live(reasoning_complete~, ..) => thinking = !reasoning_complete
+      _ => ()
+    }
+  }
+  let mut label = "Work"
+  if steps > 0 {
+    label += " · \{steps} " + (if steps == 1 { "step" } else { "steps" })
+  }
+  if tools > 0 {
+    label += " · \{tools} " +
+      (if tools == 1 { "tool call" } else { "tool calls" })
+  }
+  if failed {
+    label += " · Tool failed"
+  }
+  if pending {
+    label += " · Awaiting result"
+  }
+  if thinking {
+    label += " · Thinking"
+  }
+  @html.details(class="work-group", attrs=@html.Attrs::build().open(true), [
+    @html.summary(class="work-toggle work-summary", [
+      @html.span(class="work-chevron", @icons.icon_chevron_down()),
+      @html.text(label),
+    ]),
+    @html.div(class="work-body", children),
+  ])
+}

--- a/desktop/styles/composer.css
+++ b/desktop/styles/composer.css
@@ -1,7 +1,6 @@
 
 /* ---------- composer ---------- */
 .composer {
-  border-top: 1px solid var(--color-separator);
   background: var(--color-bg-canvas);
   padding: 16px 24px 18px;
 }

--- a/desktop/styles/transcript.css
+++ b/desktop/styles/transcript.css
@@ -26,7 +26,7 @@
      the message off the right. minmax(0, …) lets it shrink so the
      pre's own `overflow: auto` scrolls and plain text wraps instead. */
   grid-template-columns: minmax(0, 1fr);
-  gap: 20px;
+  gap: 14px;
   max-width: 820px;
   margin: 0 auto;
 }
@@ -461,6 +461,9 @@
    used to. */
 .msg.user {
   justify-content: flex-end;
+  margin-top: 18px;
+}
+.stream > .msg.user:first-child {
   margin-top: 8px;
 }
 .user-bubble {
@@ -486,21 +489,16 @@
   white-space: nowrap;
 }
 
-/* Closes the user's turn: a hairline running to the right edge, where a
-   trailing label (the send time) can sit under the bubble it belongs
-   to. Empty of children it is simply the full-width rule. */
+/* Send time belongs beneath the prompt, without separating its answer. */
 .turn-rule {
   display: flex;
-  align-items: center;
-  gap: 10px;
+  justify-content: flex-end;
+  margin-top: -8px;
   color: var(--color-text-faint);
   font-size: var(--font-size-xs);
 }
-.turn-rule::before {
-  content: "";
-  flex: 1;
-  height: 1px;
-  background: var(--color-border);
+.turn-rule:empty {
+  display: none;
 }
 
 .msg-body {
@@ -508,8 +506,8 @@
   min-width: 0;
 }
 
-/* A completed assistant answer closes with a left-aligned metadata row: the
-   raw-Markdown action first, followed by the durable event's completion time.
+/* A completed assistant answer closes with the raw-Markdown action on the
+   left and the durable event's completion time on the right.
    The icon stays visible instead of relying on hover so touch and keyboard
    users can discover it. */
 .assistant-message-actions {
@@ -518,6 +516,13 @@
   justify-content: flex-start;
   gap: 8px;
   margin-top: 4px;
+}
+/* Actions lead; metadata trails the quiet end-of-exchange boundary. */
+.assistant-message-actions::after {
+  content: "";
+  height: 1px;
+  flex: 1;
+  background: var(--color-border-subtle);
 }
 .assistant-message-copy {
   --icon-size: var(--icon-md);
@@ -533,6 +538,7 @@
   cursor: pointer;
 }
 .assistant-message-time {
+  order: 1;
   color: var(--color-text-muted);
   font-size: var(--font-size-xs);
   font-variant-numeric: tabular-nums;
@@ -778,19 +784,7 @@
   color: var(--color-text-secondary);
 }
 
-/* live streaming bubble: a blinking caret after the latest text */
-.msg.streaming .msg-content::after {
-  content: "▍";
-  margin-left: 2px;
-  color: var(--color-text-secondary);
-  animation: caretBlink 1s steps(1) infinite;
-}
 
-@keyframes caretBlink {
-  50% {
-    opacity: 0;
-  }
-}
 
 
 .inline-code {

--- a/desktop/styles/transcript.css
+++ b/desktop/styles/transcript.css
@@ -491,14 +491,32 @@
 
 /* Send time belongs beneath the prompt, without separating its answer. */
 .turn-rule {
-  display: flex;
-  justify-content: flex-end;
+  position: relative;
+  height: 0;
   margin-top: -8px;
   color: var(--color-text-faint);
   font-size: var(--font-size-xs);
 }
 .turn-rule:empty {
   display: none;
+}
+
+.turn-rule .turn-time {
+  position: absolute;
+  right: 0;
+  top: 0;
+  opacity: 0;
+}
+.msg.user:hover + .turn-rule .turn-time,
+.msg.user:focus-within + .turn-rule .turn-time,
+.turn-rule:hover .turn-time { opacity: 1; }
+.msg.user:focus-visible {
+  outline: 1px solid var(--color-focus-ring);
+  outline-offset: 3px;
+}
+/* Touch users cannot hover to inspect a prompt's send time. */
+@media (hover: none) {
+  .turn-rule .turn-time { opacity: 1; }
 }
 
 .msg-body {
@@ -839,12 +857,7 @@
   gap: 20px;
 }
 
-/* One model step's work: a heading (or thought fold) carrying the ordinal
-   and commit instant, then every tool call on display as its own row. Flush
-   with the agent's prose, not indented: the work is the agent's, and an
-   indent under a user bubble would read as the user's. Only reasoning sits
-   behind a fold; a quiet guide line groups the call rows without turning
-   them into a card. */
+/* Runtime notices retain their position in the transcript. */
 .activity-row {
   min-width: 0;
   display: grid;
@@ -853,116 +866,16 @@
   animation: riseIn 0.34s cubic-bezier(0.2, 0.7, 0.2, 1) both;
 }
 
-.activity-summary,
-.tool-call-summary,
-.tool-result-summary {
-  cursor: pointer;
-  list-style: none;
-  user-select: none;
-}
-.activity-summary::-webkit-details-marker,
-.tool-call-summary::-webkit-details-marker,
-.tool-result-summary::-webkit-details-marker {
-  display: none;
-}
-
-/* The visible guide belongs to the body, while this empty part of the native
-   summary extends its hit area over the guide. A click therefore toggles only
-   the details element that owns that line, including when disclosures nest. */
-.activity {
-  position: relative;
-}
-.activity[open] > .activity-summary::before {
-  content: "";
-  position: absolute;
-  z-index: 1;
-  top: 1.5em;
-  bottom: 0;
-  left: -5px;
-  width: 12px;
-  cursor: pointer;
-}
-
-.activity-summary {
-  display: flex;
-  align-items: baseline;
-  gap: 10px;
-  color: var(--color-text-muted);
-  font-size: var(--font-size-sm);
-}
-.activity-summary:hover {
-  color: var(--color-text-secondary);
-}
-.activity-text {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.activity-text::before {
-  content: "▸ ";
-}
-.activity[open] > .activity-summary .activity-text::before {
-  content: "▾ ";
-}
-
-/* The model-step ordinal stays in the transcript's neutral hierarchy so step
-   status does not compete with selection, primary actions, or failures. Tabular
-   numerals in a fixed right-aligned column hold every `·` on the same x as the
-   count crosses #9 → #10. */
-.activity-step {
-  display: inline-block;
-  min-width: 3ch;
-  text-align: right;
-  font-variant-numeric: tabular-nums;
-  color: var(--color-text-muted);
-  transition: color 0.15s ease;
-}
-
-/* Hover and disclosure raise contrast without introducing another blue state. */
-.activity-summary:hover .activity-step,
-.activity[open] > .activity-summary .activity-step {
-  color: var(--color-text-secondary);
-}
-.activity:has(> .activity-summary .activity-step) > .activity-body {
-  border-left-color: var(--color-border);
-}
-
-/* The step heading when the step went straight to tools: the same ordinal and
-   instant columns the thought fold's summary carries, on a plain line — there
-   is nothing to disclose, every call below is already on display. The hidden
-   marker reserves exactly the lead the summary's `▸ ` takes (same font, same
-   text), so `#N` and the instant line up in one column across both header
-   forms; the gap between them is the markup's real space, as in the summary. */
 .activity-heading {
   color: var(--color-text-muted);
   font-size: var(--font-size-sm);
 }
-.activity-heading::before {
-  content: "▸ ";
-  visibility: hidden;
-}
 
-/* When the step committed, in the summary's second fixed column, right after
-   the ordinal — which a real space in the markup separates it from, not a
-   margin here, so the gap survives being copied or read aloud. No color of its
-   own: it inherits the summary's, so it is exactly as legible as the line it
-   belongs to and brightens with it on hover. Setting one would only have
-   restated the same token, or made the row's least important item its highest
-   contrast. Tabular numerals so the seconds digits do not shift against the
-   rows above and below — reading the gaps between steps is the whole point of
-   showing them. */
+/* Runtime notice commit time; tool activity deliberately omits this clock. */
 .activity-time {
   color: var(--color-text-faint);
   font-size: var(--font-size-xs);
   font-variant-numeric: tabular-nums;
-}
-
-.activity-body {
-  display: grid;
-  gap: 14px;
-  padding: 12px 0 4px 16px;
-  border-left: 2px solid var(--color-border);
 }
 
 /* compaction checkpoint between turns: a quiet labeled fold with the
@@ -1001,23 +914,7 @@
   color: var(--color-text-secondary);
 }
 
-/* Reasoning inside the work log — and the live stream before it commits
-   (`assistant_view`): full-width muted prose, never a labelled
-   "Thinking" row of its own. */
-.activity-thinking {
-  color: var(--color-text-secondary);
-  font-size: var(--font-size-md);
-}
-.activity-thinking-live {
-  white-space: pre-wrap;
-  overflow-wrap: anywhere;
-}
-
-/* A step's tool exchanges, always on display: one row per request and result,
-   with every request in a proven parallel burst preceding its result rows.
-   They hang behind
-   the same quiet guide line an expanded fold used to draw, so the step still
-   reads as one block under its heading or thought fold. */
+/* Runtime notices remain separate from the work disclosure. */
 .activity-work {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
@@ -1026,17 +923,7 @@
   border-left: 2px solid var(--color-border);
 }
 
-.tool-exchange {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  gap: 4px;
-}
-
-/* One tool request/result row: the request expands to recorded arguments and
-   the result expands to output. Same muted line treatment as the summaries —
-   depth is carried by the guide line, not a size step. */
-.tool-call-label,
-.tool-call-summary,
+/* Standalone runtime-notice rows keep their compact disclosure. */
 .tool-result-label,
 .tool-result-summary {
   display: flex;
@@ -1050,18 +937,10 @@
   color: var(--color-text-faint);
   text-align: center;
 }
-.tool-call-summary:hover,
 .tool-result-summary:hover {
   color: var(--color-text-secondary);
 }
-/* One line per expandable call, whatever the brief's length: a long brief
-   (a Codex command string, a full shell invocation) truncates with an
-   ellipsis instead of wrapping or forcing the pane wider — the row list
-   stays scannable, and the full text is one click away inside the fold.
-   Only summaries get this: a bodyless `.tool-call-label` row (a goal
-   notice, a pending call) holds the sole copy of its text, so it wraps
-   rather than losing what an ellipsis would clip. */
-.tool-call-summary .tool-call-text,
+/* Keep a long notice caption compact until its disclosure is opened. */
 .tool-result-summary .tool-result-text {
   min-width: 0;
   overflow: hidden;
@@ -1073,7 +952,6 @@
    keeps a clipped brief reachable — including where there is no hover.
    `anywhere` breaks an unbroken token (a Codex command string), so the
    revealed text wraps instead of painting past the pane. */
-.tool-call[open] > .tool-call-summary .tool-call-text,
 .tool-result[open] > .tool-result-summary .tool-result-text {
   white-space: normal;
   overflow: visible;
@@ -1082,25 +960,20 @@
 /* A bodyless label wraps its whole text (see above — it is the sole copy),
    and the same `anywhere` break keeps an unbroken token, such as a long URL
    in a one-line goal, from pushing the transcript wide. */
-.tool-call-label .tool-call-text,
 .tool-result-label .tool-result-text {
   min-width: 0;
   overflow-wrap: anywhere;
 }
-/* The trailing marker belongs to rows that own a fold; `.tool-call-label`
+/* The trailing marker belongs to rows that own a fold; `.tool-result-label`
    rows have nothing to disclose and stay bare. It is the summary's own last
    flex item rather than part of the text span, so a truncated brief cannot
    ellipsize it away. */
-.tool-call-summary::after,
 .tool-result-summary::after {
   content: "▸";
 }
-.tool-call[open] > .tool-call-summary::after,
 .tool-result[open] > .tool-result-summary::after {
   content: "▾";
 }
-.tool-call-label.error,
-.tool-call.error > .tool-call-summary,
 .tool-result-label.error,
 .tool-result.error > .tool-result-summary {
   color: var(--color-danger);
@@ -1117,8 +990,6 @@
    failed", "build timeout"), so the row appends no marker — appending one
    repeated the brief verbatim. Runtime failures keep the red row plus the
    "runtime error" marker, which does add a word the brief lacks. */
-.tool-call-label.error.stage-build,
-.tool-call.error.stage-build > .tool-call-summary,
 .tool-result-label.error.stage-build,
 .tool-result.error.stage-build > .tool-result-summary {
   color: var(--color-warning);
@@ -1185,9 +1056,8 @@
   background: var(--color-danger-soft);
 }
 
-/* Alternate views of one request or one result share a compact radio-backed
-   tab set. Requests and results never share a strip: the separate rows retain
-   the call/result chronology exposed by the viz HTML renderer. */
+/* Alternate views share a compact radio-backed tab set. Input and output
+   have independent tabs within the same invocation disclosure. */
 .tool-call-tabs {
   display: flex;
   flex-wrap: wrap;
@@ -1521,4 +1391,223 @@
   color: var(--color-text-muted);
   font-size: var(--font-size-sm);
   font-style: italic;
+}
+
+.tool-result-summary { cursor: pointer; list-style: none; }
+.tool-result-summary::-webkit-details-marker { display: none; }
+
+/* Work disclosures: shared typography, compact spacing and a single reading
+   alignment. Direct commentary leads; reasoning and tool evidence recede. */
+.work-group, .work-thinking, .tool-call,
+.tool-input, .tool-output {
+  min-width: 0;
+}
+
+.work-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 28px;
+  cursor: pointer;
+  list-style: none;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  font-weight: 400;
+  line-height: 1.5;
+}
+
+.work-toggle::-webkit-details-marker {
+  display: none;
+}
+
+.work-toggle::marker {
+  content: "";
+}
+
+.work-toggle:hover {
+  color: var(--color-text-primary);
+}
+
+.work-toggle:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 3px;
+  border-radius: 3px;
+}
+
+.work-chevron {
+  flex: none;
+  --icon-size: var(--icon-sm);
+  width: var(--icon-sm);
+  height: var(--icon-sm);
+  display: inline-flex;
+  transform: rotate(-90deg);
+  color: var(--color-text-muted);
+}
+
+details[open] > .work-toggle > .work-chevron {
+  transform: none;
+}
+
+.work-summary {
+  color: var(--color-text-muted);
+}
+
+.work-body, .work-step, .work-tools, .tool-body {
+  display: grid;
+  grid-template-columns: minmax(0,1fr);
+  min-width: 0;
+}
+
+.work-body {
+  gap: 16px;
+  padding: 8px 0 0 20px;
+}
+
+.work-step {
+  gap: 8px;
+}
+
+.work-thinking-body {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-relaxed);
+  padding: 8px 0 0 20px;
+}
+
+.work-thinking-body p:first-child {
+  margin-top: 0;
+}
+
+.work-thinking-body p:last-child {
+  margin-bottom: 0;
+}
+
+.work-tools {
+  gap: 4px;
+}
+
+.work-step > .msg {
+  margin: 0;
+}
+
+/* Direct commentary leads; disclosed reasoning and tool evidence are secondary. */
+.work-step > .msg .msg-content {
+  color: var(--color-text-primary);
+}
+
+.tool-call-text {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.tool-status {
+  margin-left: auto;
+  flex: none;
+  display: inline-flex;
+  --icon-size: var(--icon-lg);
+  width: var(--icon-lg);
+  height: var(--icon-lg);
+  color: var(--color-text-muted);
+}
+
+.tool-call.error .tool-status,
+.tool-call.error .tool-output,
+.tool-call.error .tool-call-output {
+  color: var(--color-danger);
+}
+
+.tool-body {
+  padding: 8px 0 0 20px;
+  gap: 16px;
+}
+
+/* These child margins previously stacked with the parent's grid gap. */
+.tool-body .tool-call-section {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+}
+
+.tool-body .tool-call-section-label,
+.tool-body .tool-call-tabs,
+.tool-body .tool-call-arguments-friendly,
+.tool-body pre {
+  margin: 0;
+}
+
+/* Input and output share one reading rail and type scale. Tabs still identify
+   alternate input views; their labels use the same treatment as Output. */
+.tool-body .tool-call-tabs {
+  gap: 0 16px;
+}
+
+.tool-body .tool-call-tab-label,
+.tool-body .tool-call-section-label {
+  padding: 4px 0;
+  border-bottom: 2px solid transparent;
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-normal);
+  font-weight: 400;
+  letter-spacing: normal;
+  text-transform: none;
+}
+
+.tool-body .tool-call-section-label {
+  color: var(--color-text-secondary);
+}
+
+.tool-body .tool-call-tab-panel {
+  padding-top: 8px;
+}
+
+.tool-body .tool-call-arguments-friendly,
+.tool-body pre {
+  max-width: 100%;
+  padding: 0;
+  border-radius: 0;
+  background: transparent;
+  color: var(--color-text-secondary);
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-sm);
+  font-weight: 400;
+  line-height: var(--line-height-relaxed);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.tool-body .tool-argument-field {
+  margin: 0;
+}
+
+.tool-body .tool-argument-key,
+.tool-body .tool-argument-value {
+  font-family: inherit;
+  font-weight: inherit;
+}
+
+.tool-body .tool-argument-key {
+  color: var(--color-text-secondary);
+}
+
+.tool-empty {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.tool-call[open] > .tool-toggle .tool-call-text {
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
+.tool-call.error.stage-build .tool-status {
+  color: var(--color-warning);
+}
+
+.tool-caption {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  overflow-wrap: anywhere;
 }


### PR DESCRIPTION
Repeated step metadata and separate tool request/result folds make a conversation harder to scan. This change groups routine work while keeping direct commentary, final answers, and consequential tool states clear.

- One **Work** disclosure groups contiguous activity. It starts expanded, with commentary visible and independent **Thinking** and tool disclosures. Per-step captions, ambiguous commit clocks, and text-preview summaries are removed.
- Each tool has one section for its arguments and output. Shared status icons distinguish pending, available, and failed results; input/output share typography and alignment. Reasoning and tool evidence use secondary text beneath direct commentary.
- Live prose and final answers remain outside Work, including when a final answer carries reasoning. Existing Copy scope stays on the final message, with a quiet end line and completion time. User send times appear on hover or keyboard focus, and stay visible without hover. The competing composer border and blinking stream cursor are removed.

Work is keyed by its preceding transcript boundary, and tool details by invocation identity. This preserves disclosure and selected-tab state as live reasoning commits or parallel results arrive out of order. Prompts, checkpoints, runtime notices, and terminal errors retain their order outside the group. Collapsed labels keep pending/failure state discoverable; tool captions are bounded before entering the accessible name, with longer captions available in the body.

The shared renderer applies to both providers. Existing job-wait descriptions, plan progress, specialized arguments/output, failure stages, and subagent transcript links are retained. Event decoding, approvals, stored history, and final-answer eligibility are unchanged. No generated summaries, inferred durations, or new dependencies are introduced.

The PR contains the renderer, styles, and regression coverage for these transitions. The [interactive replay and screenshot fixture](https://github.com/moonbitlang/openseek/tree/61c678b5110492d674033980d6febcba1427b494/desktop/frontend/replay) remain on the separate replay branch.

## Before and after

Real production components, identical synthetic events and timestamps, and a 1280 × 850 viewport. Before is main at `635dc44`; after is this PR at `a4734b7`. Thinking and tool details are closed on both sides; Work starts expanded. These images demonstrate presentation, not real tool execution.

| Before — main | After — this PR |
| --- | --- |
| ![Main: numbered thoughts and separate requests/results](https://raw.githubusercontent.com/moonbitlang/openseek/61c678b5110492d674033980d6febcba1427b494/desktop/frontend/replay/screenshots/main-before.jpg) | ![PR: one Work group with paired tools and quieter evidence](https://raw.githubusercontent.com/moonbitlang/openseek/61c678b5110492d674033980d6febcba1427b494/desktop/frontend/replay/screenshots/current-after.jpg) |

<details>
<summary>Expanded Thinking and tool details</summary>

![Arguments and output together with aligned typography](https://raw.githubusercontent.com/moonbitlang/openseek/61c678b5110492d674033980d6febcba1427b494/desktop/frontend/replay/screenshots/current-details.jpg)

[Dark appearance](https://raw.githubusercontent.com/moonbitlang/openseek/61c678b5110492d674033980d6febcba1427b494/desktop/frontend/replay/screenshots/current-dark.jpg) · [390px layout](https://raw.githubusercontent.com/moonbitlang/openseek/61c678b5110492d674033980d6febcba1427b494/desktop/frontend/replay/screenshots/current-narrow.jpg)

</details>
