### PR TITLE
feat(syntax): highlight lexscan and lexmatch as MoonBit keywords

### DIFF
--- a/editor/syntax/lang_moonbit/lexer.mbt
+++ b/editor/syntax/lang_moonbit/lexer.mbt
@@ -75,7 +75,9 @@ fn classify_word(word : StringView) -> @syntax.HighlightTag {
     | "extern"
     | "declare"
     | "where"
-    | "nobreak" => Keyword
+    | "nobreak"
+    | "lexscan"
+    | "lexmatch" => Keyword
     "true" | "false" => Constant
     _ => if @syntax.is_capitalized(word) { Type } else { Identifier }
   }

--- a/editor/syntax/lang_moonbit/lexer_test.mbt
+++ b/editor/syntax/lang_moonbit/lexer_test.mbt
@@ -287,3 +287,19 @@ test "import classifies as a keyword in script import blocks" {
     ),
   )
 }
+
+///|
+test "lexscan and lexmatch classify as keywords" {
+  inspect(
+    render_tokens("lexscan lexmatch; let lexer = 0"),
+    content=(
+      #|0-7 Keyword lexscan
+      #|8-16 Keyword lexmatch
+      #|16-17 Delimiter ;
+      #|18-21 Keyword let
+      #|22-27 Identifier lexer
+      #|28-29 Operator =
+      #|30-31 Number 0
+    ),
+  )
+}


### PR DESCRIPTION
Add `lexscan` and `lexmatch` to the MoonBit word-classification keyword list in `editor/syntax/lang_moonbit/lexer.mbt`, so the `.mbt` syntax highlighter renders them as keywords instead of identifiers.

`lexscan` and `lexmatch` are MoonBit lexer keywords (e.g. `lexmatch view with longest { ... }`); previously they were classified as plain identifiers.

Changes:
- `editor/syntax/lang_moonbit/lexer.mbt`: add `"lexscan"` and `"lexmatch"` to `classify_word`.
- `editor/syntax/lang_moonbit/lexer_test.mbt`: add a golden token-stream test asserting both classify as `Keyword`.

Verified locally:
- `moon test editor/syntax` — 18 passed, 0 failed
- `moon fmt --check editor/syntax` — clean

Generated with SeekMoon