### PR TITLE
refactor(editor): use rev_iter for last-boundary scan

### DIFF
--- a/editor/internal/viewer/contrib/contextmenu/browser/context_menu_widget.mbt
+++ b/editor/internal/viewer/contrib/contextmenu/browser/context_menu_widget.mbt
@@ -942,9 +942,9 @@ fn context_menu_boundary_index(
       }
     }
   } else {
-    for index = nodes.length() - 1; index >= 0; index = index - 1 {
-      if nodes[index] is Some(_) {
-        return index
+    for index, node in nodes.rev_iter() {
+      if node is Some(_) {
+        return nodes.length() - 1 - index
       }
     }
   }


### PR DESCRIPTION
Follow-up to #1332: the last-boundary scan in `context_menu_boundary_index`
used a manual descending index loop. Switch it to the lazy `Array::rev_iter()`
(stdlib reverse iteration), which is allocation-free.

`for index, node in nodes.rev_iter()` yields the element and a *reversed*
position (0-based from the end), so the original index is recovered with
`nodes.length() - 1 - index`.

Verified: `moon fmt` and `moon check` in `editor/` are clean.

Generated with SeekMoon