### PR TITLE
fix(desktop): show a static Steer label

### DIFF
--- a/desktop/frontend/composer/view.mbt
+++ b/desktop/frontend/composer/view.mbt
@@ -338,7 +338,7 @@ pub fn ContextComponent::render(
           @html.div(class="pending-steer-row", title=shown, [
             @html.span(class="pending-steer-icon", "⤷"),
             @html.span(class="pending-steer-text", shown),
-            @html.span(class="pending-steer-state", "steering…"),
+            @html.span(class="pending-steer-state", "Steer"),
           ]),
         )
       }

--- a/desktop/styles/composer.css
+++ b/desktop/styles/composer.css
@@ -499,7 +499,6 @@
   flex: none;
   color: var(--color-text-muted);
   font-size: var(--font-size-xs);
-  animation: caretBlink 1.4s steps(1) infinite;
 }
 
 /* Queued follow-ups are composer state until the engine promotes them into


### PR DESCRIPTION
Pending steering input now shows a static `Steer` label instead of blinking `steering…` text. Removes the blink animation and ellipsis from the composer status.

Validation: `just check`, `just test` (3,209 native tests, 3,189 JavaScript tests, and 24 cram cases), `just build`, and `moon info && moon fmt` all passed. No public API changes.
