### PR TITLE
docs(editor): fix comment/code inconsistencies from audit

### DIFF
--- a/editor/internal/viewer/browser/controller/mouse_target.mbt
+++ b/editor/internal/viewer/browser/controller/mouse_target.mbt
@@ -874,8 +874,8 @@ fn create_mouse_target_for_request(
   if !ElementPath::is_child_of_overflow_guard(path) &&
     !ElementPath::is_child_of_overflowing_content_widgets(path) &&
     !ElementPath::is_child_of_overflowing_overlay_widgets(path) {
-    // We only render dom nodes inside the overflow guard or in the
-    // overflowing content widgets
+    // We only render dom nodes inside the overflow guard, or in the
+    // overflowing content or overlay widgets
     return request.fulfill_unknown()
   }
   let hit_tests : Array[

--- a/editor/internal/viewer/contrib/folding/browser/folding_model.mbt
+++ b/editor/internal/viewer/contrib/folding/browser/folding_model.mbt
@@ -273,7 +273,7 @@ fn FoldingModel::current_folded_or_manual_ranges(
               dec_range.start_line_number + 1,
               dec_range.end_line_number,
             ) {
-            is_collapsed = false // uncollapse is the range is blocked
+            is_collapsed = false // uncollapse if the range is blocked
           }
           folded_ranges.push({
             start_line_number: dec_range.start_line_number,

--- a/editor/internal/viewer/contrib/hover/browser/content_hover_widget.mbt
+++ b/editor/internal/viewer/contrib/hover/browser/content_hover_widget.mbt
@@ -202,9 +202,6 @@ pub fn ContentHoverWidget::ContentHoverWidget(
     position_preference: None,
     hover_rows: None,
   }
-  // Content widgets swallow pointer motion, but a hover may overlap source
-  // text; non-interactive mousedown should still start editor selection at
-  // the underlying coordinate.
   wrapper.add_event_listener("mousemove", event => {
     // The pointer is on the hover widget: keep it open. The editor never
     // sees this move (stop_propagation), so the controller's grace timer

--- a/editor/viewer/common/markers/marker_decorations_service.mbt
+++ b/editor/viewer/common/markers/marker_decorations_service.mbt
@@ -101,9 +101,9 @@ pub fn MarkerDecorationsService::dispose(
   for registration in self.model_registrations.values().to_array() {
     self.finalize_registration(registration, ServiceDisposed)
   }
-  // These are the two ownership indexes. They intentionally survive until
-  // every watch/owner is inert so teardown callbacks cannot observe a partial
-  // service as live ingress.
+  // Drop watches/leases/ranges first, then the two ownership indexes
+  // (model_registrations and model_ids_by_uri) last, so teardown callbacks
+  // cannot observe a partial service as live ingress.
   self.blocked_model_ids.clear()
   self.legacy_leases.clear()
   self.suppressed_ranges.clear()
@@ -311,9 +311,11 @@ fn MarkerDecorationsService::refresh_model_registration(
 }
 
 ///|
-/// `_updateDecorations` (`markerDecorationsService.ts:114`): read the first 500
-/// markers, drop ones inside suppressed ranges, push them through `update`, and
-/// fire the change event when something changed.
+/// `_updateDecorations` (`markerDecorationsService.ts:114`): drain a
+/// registration's pending update/reset requests. A drain already in flight
+/// only gets the flags set; otherwise loop, applying a pending reset and
+/// running one stable marker read + owner update per pass
+/// (`update_decorations_once`), until reentrant callbacks request no more.
 fn MarkerDecorationsService::update_decorations(
   self : MarkerDecorationsService,
   registration : ModelMarkerRegistration,


### PR DESCRIPTION
Comment-consistency fixes found by an audit of the editor (three read-only
scouts over the 17 files rewritten by #1332). All findings are pre-existing;
the #1332 in-function refactor itself was comment-neutral (verified hunk by
hunk). Five fixes across four files:

- `content_hover_widget.mbt`: removed a stale comment stranded above the
  mousemove listener that asserted non-interactive mousedown "should start
  editor selection" — contradicted by the mousedown handler's own comment
  ("classifies it CONTENT_WIDGET … starts no selection") and by Monaco's
  contentHoverWidget.ts, which registers no mousedown listener and forwards
  nothing.
- `marker_decorations_service.mbt`: the doc above `update_decorations`
  described the read-500/filter/update/fire steps, which the code split out
  into `update_decorations_once`; the doc now describes the actual drain
  loop.
- `marker_decorations_service.mbt`: "These are the two ownership indexes"
  headed a block clearing five maps; it now names the two indexes
  (`model_registrations`, `model_ids_by_uri`) and states they are cleared
  last.
- `mouse_target.mbt`: the overflow comment named two of the three regions
  the guard keeps; added overflowing overlay widgets.
- `folding_model.mbt`: comment typo "is" -> "if".

Verified: `moon fmt` and `moon check` in `editor/` are clean.

Generated with SeekMoon