### PR TITLE
[draft] feat(desktop): choose steer or queue beside the send button

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -88,7 +88,15 @@ a finish cannot outrun the canonical row. The UI likewise renders
 `assistant_delta` as a live answer bubble, while durable `session.event`
 commits remain the only permanent transcript source.
 
-Submitting while a turn runs steers it instead of starting a new prompt: the
+While a turn runs, the composer exposes a **Steer now / Queue next** selector
+beside Send. It starts from Settings → Interface → Follow-up messages, applies
+only to this message, and resets to that default after submission. Enter and
+the send button use the same selection. Queue keeps the follow-up editable
+and deletable above the composer until its turn starts; its Steer button can
+apply it to the current turn instead. Editing a queued message exposes Save
+and hides the selector. Codex mode currently retains its steer-only action.
+
+Steer adds input to the current turn instead of starting a new prompt: the
 text rides the serve engine's lossless steering queue and is folded into the
 running turn at its next step boundary. The composer's action group grows
 while a turn runs — the interrupt (■) stays available throughout, and typed

--- a/desktop/e2e/tests/rabbita_dom.spec.js
+++ b/desktop/e2e/tests/rabbita_dom.spec.js
@@ -1796,3 +1796,41 @@ test('workspace settings open and persist per-workspace choices', async ({ page 
 
   expect(app.pageErrors).toEqual([]);
 });
+
+
+test('composer selects queue for one message and preserves queued controls', async ({ page }) => {
+  const app = new DesktopBrowserHarness(page);
+  await app.install();
+  await app.goto();
+  await app.openSession();
+  const composer = page.locator('#task');
+  await composer.fill('Start a turn');
+  await page.getByTitle('Send', { exact: true }).click();
+  const choice = page.getByRole('button', { name: 'Follow-up action', exact: true });
+  await expect(choice).toContainText('Steer now');
+  await composer.fill('Do this after the turn');
+  await choice.click();
+  await page.getByRole('option', { name: 'Queue next', exact: true }).click();
+  await expect(choice).toContainText('Queue next');
+  await expect(page.getByTitle('Queue for the next turn', { exact: true })).toBeVisible();
+  await composer.press('Enter');
+  await expect.poll(() => app.requests.find(r => r.method === 'agent.queue'))
+    .toMatchObject({ params: { action: 'add', text: 'Do this after the turn', run_id: 'run-e2e' } });
+  await expect(choice).toContainText('Steer now');
+  const queued = page.locator('.queued-input-row');
+  await expect(queued).toContainText('Do this after the turn');
+  await queued.getByTitle('Edit', { exact: true }).click();
+  await expect(choice).toBeHidden();
+  await composer.fill('Edited follow-up');
+  await page.getByTitle('Save queued message', { exact: true }).click();
+  await expect(queued).toContainText('Edited follow-up');
+  await expect(choice).toContainText('Steer now');
+  await queued.getByTitle('Delete', { exact: true }).click();
+  await expect(queued).toHaveCount(0);
+  await composer.fill('An immediate correction');
+  await page.getByTitle('Steer the running task', { exact: true }).click();
+  await expect.poll(() => app.requests.find(r => r.method === 'agent.steer'))
+    .toMatchObject({ params: { text: 'An immediate correction', run_id: 'run-e2e' } });
+  expect(app.requests.filter(r => r.method === 'settings.set')).toEqual([]);
+  expect(app.pageErrors).toEqual([]);
+});

--- a/desktop/e2e/tests/rabbita_dom.spec.js
+++ b/desktop/e2e/tests/rabbita_dom.spec.js
@@ -1834,3 +1834,43 @@ test('composer selects queue for one message and preserves queued controls', asy
   expect(app.requests.filter(r => r.method === 'settings.set')).toEqual([]);
   expect(app.pageErrors).toEqual([]);
 });
+
+test('composer follow-up menu supports keyboard choice and a queue default', async ({ page }, testInfo) => {
+  const app = new DesktopBrowserHarness(page);
+  app.hostSettings.followup_behavior = 'queue';
+  await app.install();
+  await app.goto();
+  await app.openSession();
+  const composer = page.locator('#task');
+  await composer.fill('Start a turn');
+  await page.getByTitle('Send', { exact: true }).click();
+  const choice = page.getByRole('button', { name: 'Follow-up action', exact: true });
+  await expect(choice).toContainText('Queue next');
+  await composer.fill('Correct the current turn');
+  await choice.focus();
+  await choice.press('ArrowDown');
+  await expect(page.getByRole('option', { name: /Queue next/ })).toBeFocused();
+  await expect(page.getByRole('listbox', { name: 'Follow-up action' })).toBeVisible();
+  await page.keyboard.press('Home');
+  await expect(page.getByRole('option', { name: 'Steer now', exact: true })).toBeFocused();
+  await page.keyboard.press('Enter');
+  await expect(choice).toContainText('Steer now');
+  await composer.press('Enter');
+  await expect.poll(() => app.requests.find(r => r.method === 'agent.steer'))
+    .toMatchObject({ params: { text: 'Correct the current turn' } });
+  await expect(choice).toContainText('Queue next');
+  await page.setViewportSize({ width: 800, height: 800 });
+  await composer.fill('A queued follow-up');
+  await choice.click();
+  const menu = page.getByRole('listbox', { name: 'Follow-up action' });
+  await expect(menu).toBeVisible();
+  const box = await menu.boundingBox();
+  expect(box.x).toBeGreaterThanOrEqual(0);
+  expect(box.x + box.width).toBeLessThanOrEqual(800);
+  await page.screenshot({ path: testInfo.outputPath('followup-menu.png') });
+  await page.keyboard.press('Escape');
+  await expect(menu).toBeHidden();
+  await expect(choice).toBeFocused();
+  expect(app.requests.filter(r => r.method === 'settings.set')).toEqual([]);
+  expect(app.pageErrors).toEqual([]);
+});

--- a/desktop/e2e/tests/support/desktop_browser_harness.js
+++ b/desktop/e2e/tests/support/desktop_browser_harness.js
@@ -585,6 +585,10 @@ export class DesktopBrowserHarness {
         return { removed: true };
       case 'agent.start':
         return { run_id: 'run-e2e', status: 'accepted', exit_code: 0 };
+      case 'agent.queue':
+        return { accepted: true };
+      case 'agent.steer':
+        return { steered: true, run_id: request.params?.run_id };
       case 'agent.cancel':
         return { run_id: request.params?.run_id || 'run-e2e' };
       case 'session.archive': {

--- a/desktop/frontend/codex/completion.mbt
+++ b/desktop/frontend/codex/completion.mbt
@@ -328,6 +328,7 @@ pub fn State::composer_input(
     !missing_worktree
   let primary_action = if active_turn is Some(_) {
     @composer.Running(
+      queue_available=false,
       steer_available=can_edit,
       can_stop=true,
       submit=@composer.Steer,
@@ -504,6 +505,7 @@ fn State::apply_composer_action(
     | @composer.SelectMenuDismissed(..)
     | @composer.ApprovalAnswered(..)
     | @composer.ApiSetupRequested(..)
+    | @composer.FollowupSubmitted(..)
     | @composer.QueuedInputEditRequested(..)
     | @composer.QueuedInputSteerRequested(..)
     | @composer.QueuedInputDeleteRequested(..)

--- a/desktop/frontend/codex/completion.mbt
+++ b/desktop/frontend/codex/completion.mbt
@@ -365,6 +365,7 @@ pub fn State::composer_input(
     .bind(placement => placement.checkout_root()),
     installed_skills: self.installed_codex_skills(),
     context_generation: 0,
+    turn_id: active_turn,
     submission_sequence: self.submission_sequence,
     retirements: [],
     file_candidates: context.file_candidates,

--- a/desktop/frontend/composer/component.mbt
+++ b/desktop/frontend/composer/component.mbt
@@ -79,6 +79,8 @@ priv struct Entry {
   root : @common.Uri?
   installed_skills : Array[@skills.InstalledItem]
   context_generation : Int
+  followup_choice : FollowupChoice?
+  followup_menu_open : Bool
   pending_submission : PendingSubmission?
 } derive(Eq)
 
@@ -98,6 +100,8 @@ fn Entry::Entry(input : Input) -> Entry {
     root: input.root,
     installed_skills: input.installed_skills,
     context_generation: input.context_generation,
+    followup_choice: None,
+    followup_menu_open: false,
     pending_submission: None,
   }
 }
@@ -137,6 +141,12 @@ fn Entry::file_completion_for(
 /// Reconcile root-authored recovery with local edits. Submission acknowledgement
 /// clears only the submitted editor: prompt and goal drafts are independent.
 fn Entry::reconciled(self : Entry, input : Input) -> Entry {
+  let self = if input.presentation.primary_action
+    is Running(queue_available=true, submit=Steer | Queue, ..) {
+    self
+  } else {
+    { ..self, followup_choice: None, followup_menu_open: false, }
+  }
   let incoming = input.draft
   let incoming_goal = input.goal.draft
   let root_changed = input.root != self.root
@@ -167,6 +177,8 @@ fn Entry::reconciled(self : Entry, input : Input) -> Entry {
       root: input.root,
       installed_skills: input.installed_skills,
       context_generation: input.context_generation,
+      followup_choice: None,
+      followup_menu_open: false,
       pending_submission: None,
     }
   }
@@ -320,6 +332,9 @@ priv enum Msg {
   MentionJumped(Int)
   GoalCancelled
   SubmitRequested
+  FollowupMenuToggled
+  FollowupMenuDismissed
+  FollowupSelected(String)
   SymbolsLoaded(
     owner~ : @interop.ConversationKey,
     root~ : @common.Uri,
@@ -541,6 +556,54 @@ fn Model::update(
   let entry = self.active(input)
   let self = self.with_entry(entry)
   match msg {
+    FollowupMenuToggled => {
+      guard input.presentation.primary_action
+        is Running(
+          queue_available=true,
+          steer_available=true,
+          submit=Steer
+          | Queue,
+          ..
+        ) &&
+        input.goal.draft is None else {
+        return (self, @cmd.none)
+      }
+      (
+        self.with_entry({
+          ..entry,
+          followup_menu_open: !entry.followup_menu_open,
+        }),
+        @cmd.none,
+      )
+    }
+    FollowupMenuDismissed =>
+      (self.with_entry({ ..entry, followup_menu_open: false, }), @cmd.none)
+    FollowupSelected(value) => {
+      guard input.presentation.primary_action
+        is Running(
+          queue_available=true,
+          steer_available=true,
+          submit=Steer
+          | Queue,
+          ..
+        ) &&
+        input.goal.draft is None else {
+        return (self, @cmd.none)
+      }
+      let choice = match value {
+        "steer" => SteerNow
+        "queue" => QueueNext
+        _ => return (self, @cmd.none)
+      }
+      (
+        self.with_entry({
+          ..entry,
+          followup_choice: Some(choice),
+          followup_menu_open: false,
+        }),
+        @cmd.none,
+      )
+    }
     TextChanged(value) => {
       let (next, command) = entry.edited(input, value, action_emit)
       self.commit_entry_change(entry, next, command, action_emit)
@@ -649,7 +712,16 @@ fn Model::update(
             ),
           }),
           action_emit(
-            DraftSubmitted(identity=entry.identity(), draft=entry.draft),
+            match entry.submission_choice(input) {
+              Some(choice) =>
+                FollowupSubmitted(
+                  identity=entry.identity(),
+                  draft=entry.draft,
+                  choice~,
+                )
+              None =>
+                DraftSubmitted(identity=entry.identity(), draft=entry.draft)
+            },
           ),
         )
       }

--- a/desktop/frontend/composer/component.mbt
+++ b/desktop/frontend/composer/component.mbt
@@ -177,7 +177,10 @@ fn Entry::reconciled(self : Entry, input : Input) -> Entry {
       root: input.root,
       installed_skills: input.installed_skills,
       context_generation: input.context_generation,
-      followup_choice: None,
+      followup_choice: match self.pending_submission {
+        Some(PromptSubmission(_, ..)) => None
+        _ => self.followup_choice
+      },
       followup_menu_open: false,
       pending_submission: None,
     }

--- a/desktop/frontend/composer/component.mbt
+++ b/desktop/frontend/composer/component.mbt
@@ -79,6 +79,7 @@ priv struct Entry {
   root : @common.Uri?
   installed_skills : Array[@skills.InstalledItem]
   context_generation : Int
+  turn_id : String?
   followup_choice : FollowupChoice?
   followup_menu_open : Bool
   pending_submission : PendingSubmission?
@@ -100,6 +101,7 @@ fn Entry::Entry(input : Input) -> Entry {
     root: input.root,
     installed_skills: input.installed_skills,
     context_generation: input.context_generation,
+    turn_id: input.turn_id,
     followup_choice: None,
     followup_menu_open: false,
     pending_submission: None,
@@ -141,11 +143,17 @@ fn Entry::file_completion_for(
 /// Reconcile root-authored recovery with local edits. Submission acknowledgement
 /// clears only the submitted editor: prompt and goal drafts are independent.
 fn Entry::reconciled(self : Entry, input : Input) -> Entry {
-  let self = if input.presentation.primary_action
+  let self = if self.turn_id == input.turn_id &&
+    input.presentation.primary_action
     is Running(queue_available=true, submit=Steer | Queue, ..) {
     self
   } else {
-    { ..self, followup_choice: None, followup_menu_open: false, }
+    {
+      ..self,
+      turn_id: input.turn_id,
+      followup_choice: None,
+      followup_menu_open: false,
+    }
   }
   let incoming = input.draft
   let incoming_goal = input.goal.draft

--- a/desktop/frontend/composer/component_view.mbt
+++ b/desktop/frontend/composer/component_view.mbt
@@ -186,7 +186,8 @@ fn Entry::action_buttons(
           content: @icons.icon(@icons.icon_arrow_up),
         },
       ]
-    Running(steer_available~, can_stop~, submit~) => {
+    Running(steer_available~, can_stop~, submit~, ..) => {
+      let submit = self.running_submit(submit)
       let actions : Array[ActionButton] = [
         {
           id: "stop",
@@ -245,7 +246,14 @@ fn Entry::view(
     } else {
       self.draft.task
     },
-    placeholder: input.presentation.placeholder,
+    placeholder: if !goal_mode && self.submission_choice(input) is Some(choice) {
+      match choice {
+        SteerNow => "Steer the running task."
+        QueueNext => "Queue a follow-up for the next turn."
+      }
+    } else {
+      input.presentation.placeholder
+    },
     disabled: input.presentation.disabled,
     input: emit.map(value => TextChanged(value)),
     keyboard: {
@@ -264,10 +272,78 @@ fn Entry::view(
       component.render(self.identity(), action_emit)
     }),
     actions,
+    followup_menu: self.followup_menu(input, emit),
     overlay: if goal_mode {
       None
     } else {
       self.completion.map(completion => completion.view(emit))
     },
   }.render()
+}
+
+///|
+fn Entry::running_submit(
+  self : Entry,
+  default : RunningSubmit,
+) -> RunningSubmit {
+  if default is SaveQueue {
+    return SaveQueue
+  }
+  match self.followup_choice {
+    Some(SteerNow) => Steer
+    Some(QueueNext) => Queue
+    None => default
+  }
+}
+
+///|
+fn Entry::submission_choice(self : Entry, input : Input) -> FollowupChoice? {
+  guard input.presentation.primary_action
+    is Running(queue_available=true, submit~, ..) else {
+    return None
+  }
+  match self.running_submit(submit) {
+    Steer => Some(SteerNow)
+    Queue => Some(QueueNext)
+    SaveQueue => None
+  }
+}
+
+///|
+fn Entry::followup_menu(
+  self : Entry,
+  input : Input,
+  emit : @cmd.Emit[Msg],
+) -> @html.Html? {
+  guard input.goal.draft is None &&
+    input.presentation.primary_action is Running(steer_available~, ..) &&
+    self.submission_choice(input) is Some(choice) else {
+    return None
+  }
+  Some(
+    @select_control.Control::{
+      id: "composer-followup-select",
+      groups: [
+        {
+          label: "This message",
+          options: [
+            { value: "steer", label: "Steer now", },
+            { value: "queue", label: "Queue next", },
+          ],
+        },
+      ],
+      selected: match choice {
+        SteerNow => "steer"
+        QueueNext => "queue"
+      },
+      disabled: !steer_available,
+      open: self.followup_menu_open,
+      toggle: emit(FollowupMenuToggled),
+      dismiss: emit(FollowupMenuDismissed),
+      change: emit.map(value => FollowupSelected(value)),
+      title: "Send this message now or after the current turn",
+      aria_label: "Follow-up action",
+      presentation: Composer("↳", true),
+    }.render(),
+  )
 }

--- a/desktop/frontend/composer/component_xxtest.mbt
+++ b/desktop/frontend/composer/component_xxtest.mbt
@@ -46,7 +46,12 @@ test "a running draft keeps Stop beside Steer" {
     ..base,
     presentation: {
       ..base.presentation,
-      primary_action: Running(steer_available=true, can_stop=true, submit=Steer),
+      primary_action: Running(
+        steer_available=true,
+        can_stop=true,
+        submit=Steer,
+        queue_available=true,
+      ),
     },
   }
   let actions = Model(input)
@@ -454,4 +459,122 @@ test "an elapsed span never shows finer units than its own scale" {
   // Past an hour the seconds column is noise to anyone reading it.
   assert_eq(elapsed_label(3_600_000.0), "1h 0m")
   assert_eq(elapsed_label(87_240_000.0), "24h 14m")
+}
+
+///|
+test "follow-up choice is per draft and resets after submission or turn completion" {
+  let base = Input::fixture("follow-up")
+  let input = {
+    ..base,
+    presentation: {
+      ..base.presentation,
+      primary_action: Running(
+        steer_available=true,
+        can_stop=true,
+        submit=Steer,
+        queue_available=true,
+      ),
+    },
+  }
+  let initial = Model(input)
+  assert_eq(initial.active(input).submission_choice(input), Some(SteerNow))
+  let (queued, _) = initial.update(
+    input,
+    FollowupSelected("queue"),
+    Msg::test_emit(),
+    Action::test_emit(),
+  )
+  assert_eq(queued.active(input).submission_choice(input), Some(QueueNext))
+  let actions = queued
+    .active(input)
+    .action_buttons(Msg::test_emit(), Action::test_emit(), input)
+  assert_eq(actions[1].title, "Queue for the next turn")
+  // An unrelated render or a rejected local submission keeps the choice.
+  let (sending, _) = queued.update(
+    input,
+    SubmitRequested,
+    Msg::test_emit(),
+    Action::test_emit(),
+  )
+  assert_eq(sending.active(input).submission_choice(input), Some(QueueNext))
+  let accepted = {
+    ..input,
+    draft: { task: "", mentions: [], },
+    submission_sequence: 1,
+  }
+  assert_eq(
+    sending.active(accepted).submission_choice(accepted),
+    Some(SteerNow),
+  )
+  assert_eq(queued.active(base).followup_choice, None)
+  let other = {
+    ..input,
+    identity: {
+      ..input.identity,
+      owner: { ..input.identity.owner, session: "another", },
+    },
+  }
+  assert_eq(queued.active(other).submission_choice(other), Some(SteerNow))
+}
+
+///|
+test "queue default can be overridden but queue editing and steer-only hosts cannot" {
+  let base = Input::fixture("follow-up")
+  let input = {
+    ..base,
+    presentation: {
+      ..base.presentation,
+      primary_action: Running(
+        steer_available=true,
+        can_stop=true,
+        submit=Queue,
+        queue_available=true,
+      ),
+    },
+  }
+  let (steering, _) = Model(input).update(
+    input,
+    FollowupSelected("steer"),
+    Msg::test_emit(),
+    Action::test_emit(),
+  )
+  assert_eq(steering.active(input).submission_choice(input), Some(SteerNow))
+  let editing = {
+    ..input,
+    presentation: {
+      ..input.presentation,
+      primary_action: Running(
+        steer_available=true,
+        can_stop=true,
+        submit=SaveQueue,
+        queue_available=true,
+      ),
+    },
+  }
+  let entry = steering.active(editing)
+  assert_eq(entry.submission_choice(editing), None)
+  assert_eq(
+    entry.action_buttons(Msg::test_emit(), Action::test_emit(), editing)[1].title,
+    "Save queued message",
+  )
+  let codex = {
+    ..input,
+    presentation: {
+      ..input.presentation,
+      primary_action: Running(
+        steer_available=true,
+        can_stop=true,
+        submit=Steer,
+        queue_available=false,
+      ),
+    },
+  }
+  let (unchanged, _) = Model(codex).update(
+    codex,
+    FollowupSelected("queue"),
+    Msg::test_emit(),
+    Action::test_emit(),
+  )
+  assert_eq(unchanged.active(codex).followup_choice, None)
+  assert_eq(unchanged.active(codex).submission_choice(codex), None)
 }

--- a/desktop/frontend/composer/component_xxtest.mbt
+++ b/desktop/frontend/composer/component_xxtest.mbt
@@ -578,3 +578,39 @@ test "queue default can be overridden but queue editing and steer-only hosts can
   assert_eq(unchanged.active(codex).followup_choice, None)
   assert_eq(unchanged.active(codex).submission_choice(codex), None)
 }
+
+///|
+test "setting a goal preserves the pending message follow-up choice" {
+  let base = Input::fixture("waiting prompt")
+  let input = {
+    ..base,
+    presentation: {
+      ..base.presentation,
+      primary_action: Running(
+        steer_available=true,
+        can_stop=true,
+        submit=Steer,
+        queue_available=true,
+      ),
+    },
+  }
+  let (queued, _) = Model(input).update(
+    input,
+    FollowupSelected("queue"),
+    Msg::test_emit(),
+    Action::test_emit(),
+  )
+  let goal = { ..input, goal: { ..input.goal, draft: Some("new goal"), }, }
+  let (submitted, _) = queued.update(
+    goal,
+    SubmitRequested,
+    Msg::test_emit(),
+    Action::test_emit(),
+  )
+  let accepted = { ..input, submission_sequence: 1, }
+  assert_eq(submitted.active(accepted).draft.task, "waiting prompt")
+  assert_eq(
+    submitted.active(accepted).submission_choice(accepted),
+    Some(QueueNext),
+  )
+}

--- a/desktop/frontend/composer/component_xxtest.mbt
+++ b/desktop/frontend/composer/component_xxtest.mbt
@@ -8,6 +8,7 @@ fn Input::fixture(task : String) -> Input {
     identity: { owner, archive_generation: 0, },
     draft: { task, mentions: [], },
     run: None,
+    turn_id: None,
     goal: { draft: None, standing: None, pending: None, },
     slash_commands: [],
     root: Some(@common.Uri::file("/workspace")),
@@ -613,4 +614,55 @@ test "setting a goal preserves the pending message follow-up choice" {
     submitted.active(accepted).submission_choice(accepted),
     Some(QueueNext),
   )
+}
+
+///|
+test "a background successor turn resets the unsent follow-up override" {
+  let base = Input::fixture("unsent draft")
+  let first = {
+    ..base,
+    turn_id: Some("turn-1"),
+    presentation: {
+      ..base.presentation,
+      primary_action: Running(
+        steer_available=true,
+        can_stop=true,
+        submit=Steer,
+        queue_available=true,
+      ),
+    },
+  }
+  let (queued, _) = Model(first).update(
+    first,
+    FollowupSelected("queue"),
+    Msg::test_emit(),
+    Action::test_emit(),
+  )
+  let (opened, _) = queued.update(
+    first,
+    FollowupMenuToggled,
+    Msg::test_emit(),
+    Action::test_emit(),
+  )
+  let other = {
+    ..base,
+    identity: {
+      ..base.identity,
+      owner: { ..base.identity.owner, session: "other", },
+    },
+  }
+  let (away, _) = opened.update(
+    other,
+    TextChanged("another conversation"),
+    Msg::test_emit(),
+    Action::test_emit(),
+  )
+  // Visiting another conversation alone must not discard the selection.
+  assert_eq(away.active(first).submission_choice(first), Some(QueueNext))
+  // No idle presentation for turn-1 was ever delivered to this entry.
+  let successor = { ..first, turn_id: Some("turn-2"), }
+  let returned = away.active(successor)
+  assert_eq(returned.draft.task, "unsent draft")
+  assert_eq(returned.submission_choice(successor), Some(SteerNow))
+  assert_false(returned.followup_menu_open)
 }

--- a/desktop/frontend/composer/contract.mbt
+++ b/desktop/frontend/composer/contract.mbt
@@ -71,9 +71,20 @@ pub(all) enum RunningSubmit {
 } derive(Eq, @debug.Debug)
 
 ///|
+pub(all) enum FollowupChoice {
+  SteerNow
+  QueueNext
+} derive(Eq, @debug.Debug)
+
+///|
 pub(all) enum PrimaryAction {
   Send(available~ : Bool)
-  Running(steer_available~ : Bool, can_stop~ : Bool, submit~ : RunningSubmit)
+  Running(
+    steer_available~ : Bool,
+    can_stop~ : Bool,
+    submit~ : RunningSubmit,
+    queue_available~ : Bool
+  )
 } derive(Eq, @debug.Debug)
 
 ///|
@@ -226,6 +237,11 @@ pub(all) struct Input {
 /// navigation, debounce ticks, and async replies remain private to the package.
 pub(all) enum Action {
   DraftSubmitted(identity~ : Identity, draft~ : Draft)
+  FollowupSubmitted(
+    identity~ : Identity,
+    draft~ : Draft,
+    choice~ : FollowupChoice
+  )
   DraftPresenceChanged(
     identity~ : Identity,
     present~ : Bool,
@@ -280,6 +296,7 @@ pub(all) enum Action {
 pub fn Action::identity(self : Action) -> Identity {
   match self {
     DraftSubmitted(identity~, ..)
+    | FollowupSubmitted(identity~, ..)
     | DraftPresenceChanged(identity~, ..)
     | RootMentionRemoved(identity~, ..)
     | SlashCommand(identity~, ..)
@@ -417,3 +434,9 @@ pub extend SlashCommand with Eq::{equal, not_equal}
 #deprecated("Use `==` or the `Eq` trait directly", skip_current_package=true)
 #doc(hidden)
 pub extend StatusComponent with Eq::{equal, not_equal}
+
+///|
+pub extend FollowupChoice with Eq::{equal, not_equal}
+
+///|
+pub extend FollowupChoice with @debug.Debug::{to_repr}

--- a/desktop/frontend/composer/contract.mbt
+++ b/desktop/frontend/composer/contract.mbt
@@ -219,6 +219,8 @@ pub(all) struct Input {
   goal : GoalInput
   // The turn in flight, `None` between runs.
   run : RunHeartbeat?
+  // Canonical turn identity, including transitions while this entry is hidden.
+  turn_id : String?
   slash_commands : Array[SlashCommand]
   root : @common.Uri?
   installed_skills : Array[@skills.InstalledItem]

--- a/desktop/frontend/composer/view.mbt
+++ b/desktop/frontend/composer/view.mbt
@@ -719,11 +719,34 @@ priv struct View {
   keyboard : KeyboardActions
   status : Array[@html.Html]
   actions : Array[ActionButton]
+  followup_menu : @html.Html?
   overlay : @html.Html?
 }
 
 ///|
 fn View::render(self : View) -> @html.Html {
+  let actions : Array[@html.Html] = []
+  for action in self.actions {
+    if action.id != "stop" {
+      continue
+    }
+    actions.push(action.render())
+  }
+  actions.push(
+    @html.div(
+      class="composer-followup",
+      match self.followup_menu {
+        Some(menu) => [menu]
+        None => []
+      },
+    ),
+  )
+  for action in self.actions {
+    if action.id == "stop" {
+      continue
+    }
+    actions.push(action.render())
+  }
   let inner : Array[@html.Html] = [
     // Keep the input wrapper and its two children permanently mounted. Rabbita
     // diffs array children by position, so chips appearing must not replace
@@ -746,10 +769,7 @@ fn View::render(self : View) -> @html.Html {
     @html.div(class="composer-toolbar", [
       @html.div(class="composer-controls", [
         @html.div(class="composer-status", self.status),
-        @html.div(
-          class="composer-actions",
-          self.actions.map(action => action.render()),
-        ),
+        @html.div(class="composer-actions", actions),
       ]),
     ]),
   ]

--- a/desktop/frontend/composer_contract_wbtest.mbt
+++ b/desktop/frontend/composer_contract_wbtest.mbt
@@ -26,8 +26,16 @@ test "the composer is handed the turn's facts, not a rendered row" {
     is Some({ stage: Thinking, started_ms: None, tokens: 0, }) else {
     fail("expected the open turn's heartbeat facts")
   }
+  assert_eq(
+    running.composer_input().turn_id,
+    match conv.run {
+      Open(run_id~, ..) => Some(run_id)
+      _ => None
+    },
+  )
   let idle = running.replace_conversation({ ..conv, run: NoRun(ended=None), })
   assert_eq(idle.composer_input().run, None)
+  assert_eq(idle.composer_input().turn_id, None)
 }
 
 ///|

--- a/desktop/frontend/composer_contract_wbtest.mbt
+++ b/desktop/frontend/composer_contract_wbtest.mbt
@@ -144,3 +144,40 @@ test "a background retirement expires old actions without poisoning a reopened i
     is Some(_),
   )
 }
+
+///|
+test "composer follow-up overrides route the message without changing the default" {
+  for
+    pair in [
+      (@composer.QueueNext, FollowupSteer),
+      (@composer.SteerNow, FollowupQueue),
+    ] {
+    let (choice, default) = pair
+    let model = { ..running_model(), followup_behavior: default, }
+    let identity = model.composer_input().identity
+    let (_, submitted) = update(
+      test_dispatch(),
+      ComposerAction(
+        @composer.FollowupSubmitted(
+          identity~,
+          draft={ task: "one message", mentions: [], },
+          choice~,
+        ),
+      ),
+      model,
+    )
+    assert_true(submitted.followup_behavior == default)
+    let conv = submitted.active()
+    assert_eq(conv.pending_steers.length(), 1)
+    match choice {
+      @composer.QueueNext => {
+        assert_true(conv.pending_steers[0].behavior is FollowupQueue)
+        assert_eq(conv.queued_inputs.length(), 1)
+      }
+      @composer.SteerNow => {
+        assert_true(conv.pending_steers[0].behavior is FollowupSteer)
+        assert_true(conv.queued_inputs.is_empty())
+      }
+    }
+  }
+}

--- a/desktop/frontend/composer_input.mbt
+++ b/desktop/frontend/composer_input.mbt
@@ -191,6 +191,10 @@ fn Model::composer_input(self : Model) -> @composer.Input {
     root: self.conversation_root(conv),
     installed_skills: self.installed_skills,
     context_generation: self.composer_context_generation,
+    turn_id: match conv.run {
+      Open(run_id~, ..) => Some(run_id)
+      _ => None
+    },
     submission_sequence: self.submission_sequence,
     retirements: self.composer_entry_retirements,
     file_candidates: self.file_search().candidates,
@@ -296,6 +300,7 @@ fn Model::dormant_composer_input(self : Model) -> @composer.Input {
     root: None,
     installed_skills: self.installed_skills,
     context_generation: self.composer_context_generation,
+    turn_id: None,
     submission_sequence: self.submission_sequence,
     retirements: self.composer_entry_retirements,
     file_candidates: [],

--- a/desktop/frontend/composer_input.mbt
+++ b/desktop/frontend/composer_input.mbt
@@ -28,6 +28,7 @@ fn Model::composer_input(self : Model) -> @composer.Input {
     checkout_ready
   let primary_action : @composer.PrimaryAction = if conv.is_running() {
     @composer.Running(
+      queue_available=true,
       steer_available=root_ready &&
         conv.run is Open(stage~, ..) &&
         !(stage is Cancelling),

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -1870,6 +1870,7 @@ priv enum Msg {
   // Everything the Skills page does with itself once it is open.
   Skills(@skills.Msg)
   Send
+  SendFollowup(@composer.FollowupChoice)
   Stop
   // The user answered the active conversation's permission question. `allow`
   // grants the one action it asked about; the card stays until the engine's

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -2293,7 +2293,8 @@ fn update_msg(
             _ => (@cmd.none, model)
           }
         }
-        @composer.DraftSubmitted(identity~, draft~) => {
+        @composer.DraftSubmitted(identity~, draft~)
+        | @composer.FollowupSubmitted(identity~, draft~, ..) => {
           guard model.conversation_for_composer_action(identity) is Some(conv) else {
             return (@cmd.none, model)
           }
@@ -2312,7 +2313,11 @@ fn update_msg(
             focused: conv.device,
             active_session: conv.session_id,
           }
-          let (command, submitted) = update_msg(dispatch, Send, target)
+          let submit = match action {
+            @composer.FollowupSubmitted(choice~, ..) => SendFollowup(choice)
+            _ => Send
+          }
+          let (command, submitted) = update_msg(dispatch, submit, target)
           (
             command,
             {
@@ -3579,7 +3584,12 @@ fn update_msg(
       }
       (@cmd.batch([page_cmd, fetch_installed_skills(dispatch, channel)]), model)
     }
-    Send => {
+    Send | SendFollowup(_) => {
+      let followup_behavior = match msg {
+        SendFollowup(@composer.SteerNow) => FollowupSteer
+        SendFollowup(@composer.QueueNext) => FollowupQueue
+        _ => model.followup_behavior
+      }
       guard model.active_conversation() is Some(conv) else {
         return (@cmd.none, model)
       }
@@ -3629,9 +3639,9 @@ fn update_msg(
             task,
             conv.task,
             conv.mentions,
-            model.followup_behavior,
+            followup_behavior,
           )
-          let command = if model.followup_behavior is FollowupQueue {
+          let command = if followup_behavior is FollowupQueue {
             queue_openseek(
               dispatch,
               model.focused,

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -1151,7 +1151,7 @@ fn settings_page(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
             disabled=!settings_loaded,
           ),
         ],
-        desc="Steer is the default. Queue keeps follow-ups editable until their turn starts.",
+        desc="Default for messages sent while a task is running. Change it for one message beside the send button.",
       ),
       @settings.row(
         "Theme",

--- a/desktop/styles/composer.css
+++ b/desktop/styles/composer.css
@@ -633,6 +633,10 @@
   flex: none;
 }
 
+.composer-followup:empty {
+  display: none;
+}
+
 /* The git chip. It deliberately does *not* establish a containing block: the
    popover anchors to `.composer-inner` instead, so its width is the
    composer's business rather than the chip's position along the row. See


### PR DESCRIPTION
Messages sent during an OpenSeek turn can now choose **Steer now** or **Queue next** beside the send button, without visiting Settings. The choice applies to one message, uses the same path for Enter and clicking Send, and resets to the configured default after submission. Queue editing retains Save, and setting a standing goal preserves the pending message's choice. Canonical turn identity also resets the selection when a background conversation moves to a successor turn.

Reuses the existing queue/steer protocol and queue edit/delete controls. Codex mode keeps its existing steer-only behavior. The selector uses the existing accessible menu component, including keyboard navigation and narrow-window positioning.

Validation:
- `just check`, `just test`, `just build`, `moon info && moon fmt` passed; the final goal-preservation change also passed the scoped composer tests and `just check`.
- Added component, root-routing, and browser coverage for per-message overrides, both defaults, Enter/click submission, reset, queue edit/delete, keyboard navigation, and narrow layouts.
- Browser suite: 42/44 passed initially; both failing existing tests passed on isolated rerun. The Codex first-send timeout also reproduced with the unmodified upstream JavaScript bundle. The full desktop browser suite subsequently passed in GitHub CI.
- `openseek review --base upstream/main` completed with zero findings. A fresh Codex CLI review using `gpt-6-astra` with medium reasoning found one P2 background-turn reset bug. Fixed in `7315792b2` with a regression test; a second fresh Astra/medium review of `7315792b2` found no actionable introduced defects and explicitly recommended merging.
