### PR TITLE
refactor(agent_tool): abstract BgJobRuntime; split job_output decode

### DIFF
--- a/agent_tool/bgjobs/bgjobs.mbt
+++ b/agent_tool/bgjobs/bgjobs.mbt
@@ -38,11 +38,11 @@ let default_hard_timeout_ms : Int = 1_800_000
 /// (`run_in_background`), `shell_output`, and `shell_stop` tools. the constructor captures
 /// the session group in a spawn closure, so the runtime is not generic and can be
 /// an optional tool argument.
-pub struct BgJobRuntime {
+struct BgJobRuntime {
   // Spawn a `ShellExecution` on the captured session group: (program, args, cwd,
   // inline-preview budget, spill path) -> execution. Captured so the runtime type
   // is not generic.
-  priv spawn_exec : async (
+  spawn_exec : async (
     String,
     Array[String],
     String?,
@@ -55,7 +55,7 @@ pub struct BgJobRuntime {
   // cap so a timed command that floods output is an immediate output-limit error;
   // `background()` clears that kill so a detached-under-the-limit job keeps
   // growing. The `String?` is the spill path.
-  priv spawn_foreground_retained_exec : async (
+  spawn_foreground_retained_exec : async (
     String,
     Array[String],
     String?,
@@ -64,25 +64,25 @@ pub struct BgJobRuntime {
     &@process.ProcessInput?,
   ) -> @shell_exec.ShellExecution
   // Spawn a per-job watcher task on that same group.
-  priv spawn_watcher : (async () -> Unit) -> Unit
+  spawn_watcher : (async () -> Unit) -> Unit
   // Directory for per-job spill files (full output beyond the inline preview).
   // None → memory-only jobs (no full-output file).
-  priv spill_dir : String?
+  spill_dir : String?
   // Wall-clock lifetime cap for any registered job, measured from process
   // start (an adopted job keeps its original deadline). Bounded lifetime,
   // not machine protection: the kill reaches the direct child only, so a
   // spinning grandchild can be orphaned — true process-group kill is
   // upstream work in moonbitlang/async. Tests shrink it to fire cheaply.
-  priv hard_timeout_ms : Int
+  hard_timeout_ms : Int
   // Called once, with the terminal snapshot, when a job exits on its own (not on
   // `stop`/teardown) — e.g. to push a completion notice into the agent loop.
-  priv on_job_exit : ((BgJobSnapshot) -> Unit)?
-  priv jobs : Map[String, BgJob]
-  priv mut next_index : Int
+  on_job_exit : ((BgJobSnapshot) -> Unit)?
+  jobs : Map[String, BgJob]
+  mut next_index : Int
   // Separate counter for the spill files of detachable foreground executions
   // (which are not registered until adopted), so their `fg-<n>.out` files never
   // collide with a job's `bg-<n>.out`.
-  priv mut fg_index : Int
+  mut fg_index : Int
 }
 
 ///|

--- a/agent_tool/bgjobs/pkg.generated.mbti
+++ b/agent_tool/bgjobs/pkg.generated.mbti
@@ -13,9 +13,7 @@ import {
 // Errors
 
 // Types and methods
-pub struct BgJobRuntime {
-  // private fields
-}
+type BgJobRuntime
 pub fn[X] BgJobRuntime::BgJobRuntime(@agent_runtime.AgentTaskScope[X], spill_dir? : String, hard_output_cap? : Int, hard_timeout_ms? : Int, on_job_exit? : (BgJobSnapshot) -> Unit) -> Self
 pub fn BgJobRuntime::adopt(Self, @shell_exec.ShellExecution, command~ : String, sandboxed_command? : @sandbox.SandboxedCommand, read_only_review? : Bool, output_rewrites? : Array[(String, String)], moonrun_policy_active? : Bool, on_terminal? : async () -> Unit) -> String
 pub fn BgJobRuntime::list(Self) -> Array[BgJobSnapshot]

--- a/agent_tool/job_output/internal/decode/README.mbt.md
+++ b/agent_tool/job_output/internal/decode/README.mbt.md
@@ -1,0 +1,110 @@
+# agent_tool/job_output/internal/decode
+
+Argument decoding for the `job_output` tool, which reads a background job's
+output and status by id. This package is internal to `agent_tool/job_output`
+and owns only argument-shape decoding: validating `job_id` and turning the
+`wait_ms`/`offset` selectors into typed optionals. Waiting on the job, reading
+its retained output, and rendering the `<system>` footer stay in the parent
+package.
+
+## Arguments
+
+| Name | Type | Required | Decoder behavior |
+| --- | --- | --- | --- |
+| `job_id` | string | yes | Missing or non-string raises `job_output requires a string job_id`. |
+| `wait_ms` | number | no | Absent/`null` means no waiting (`None`). Must be positive; an oversized value is capped to `max_wait_ms` (`120000`) rather than rejected. Non-number raises `job_output wait_ms must be a number`. |
+| `offset` | number | no | Absent/`null` means the recent tail (`None`). Must be zero or positive. Non-number raises `job_output offset must be a number`. |
+
+Extra fields are ignored.
+
+## Defaults and Explicit Selectors
+
+```mbt check
+///|
+test "decode defaults wait_ms and offset when only job_id is given" {
+  debug_inspect(
+    @decode.decode({ "job_id": "bg-3" }),
+    content="{ job_id: \"bg-3\", wait_ms: None, offset: None }",
+  )
+}
+
+///|
+test "decode reads explicit wait_ms and offset selectors" {
+  debug_inspect(
+    @decode.decode({ "job_id": "bg-3", "wait_ms": 30000, "offset": 12000 }),
+    content="{ job_id: \"bg-3\", wait_ms: Some(30000), offset: Some(12000) }",
+  )
+}
+```
+
+## `wait_ms` is capped, not trusted
+
+`wait_ms` bounds how long one call blocks awaiting the job's exit. A caller may
+ask for any positive wait, but not more than `max_wait_ms`: the ceiling exists
+so one `job_output` call cannot hold the turn indefinitely — a deadline expiry
+is not an error, and the model can always call again.
+
+```mbt check
+///|
+test "an oversized wait_ms clamps silently to max_wait_ms" {
+  inspect(@decode.max_wait_ms, content="120000")
+  debug_inspect(
+    @decode.decode({ "job_id": "bg-3", "wait_ms": 999999 }).wait_ms,
+    content="Some(120000)",
+  )
+}
+```
+
+Zero and negative values are rejected rather than clamped, because they express
+an intent the tool cannot satisfy — no waiting is already spelled by omitting
+the argument.
+
+```mbt check
+///|
+/// True when decoding `arguments` fails with a message containing `expected`.
+fn decode_error_says(arguments : Json, expected : String) -> Bool {
+  try {
+    ignore(@decode.decode(arguments))
+    false
+  } catch {
+    err => "\{err}".contains(expected)
+  }
+}
+
+///|
+test "malformed selectors are errors that name the argument to fix" {
+  inspect(
+    decode_error_says(
+      { "job_id": "bg-3", "wait_ms": 0 },
+      "wait_ms must be a positive number",
+    ),
+    content="true",
+  )
+  inspect(
+    decode_error_says(
+      { "job_id": "bg-3", "wait_ms": "30000" },
+      "wait_ms must be a number",
+    ),
+    content="true",
+  )
+  inspect(
+    decode_error_says(
+      { "job_id": "bg-3", "offset": -1 },
+      "offset must be zero or a positive number",
+    ),
+    content="true",
+  )
+  inspect(
+    decode_error_says(
+      { "job_id": "bg-3", "offset": "0" },
+      "offset must be a number",
+    ),
+    content="true",
+  )
+  // A missing or wrong-typed job_id is caught before the selectors.
+  inspect(
+    decode_error_says({ "wait_ms": 500 }, "requires a string job_id"),
+    content="true",
+  )
+}
+```

--- a/agent_tool/job_output/internal/decode/decode.mbt
+++ b/agent_tool/job_output/internal/decode/decode.mbt
@@ -1,0 +1,80 @@
+///|
+/// Decoded arguments of the `job_output` tool: the `job_id` of the background
+/// job to read, plus the optional `wait_ms` and `offset` selectors. Either
+/// selector is `None` when the caller omits it (or passes `null`): `None`
+/// `wait_ms` means no waiting, `None` `offset` means the recent tail.
+pub struct JobOutputInput {
+  job_id : String
+  wait_ms : Int?
+  offset : Int?
+} derive(Debug)
+
+///|
+/// Longest a single `job_output` call may block awaiting a job, so one tool
+/// call cannot hold the turn indefinitely; the model can always call again. A
+/// caller that asks for longer is capped to this, not rejected — the cap is a
+/// bounded wait, and the response still reports the job running if the wait
+/// expires.
+pub let max_wait_ms : Int = 120_000
+
+///|
+/// Decode `job_output` tool-call arguments.
+///
+/// `job_id` is a required string naming the background job to read. `wait_ms`,
+/// when present, must be a positive number and is capped at `max_wait_ms`;
+/// absent or null means no waiting. `offset`, when present, must be zero or a
+/// positive number; absent or null means the recent tail. The local dispatcher
+/// does not enforce the JSON schema, so the decoder must: failures name the
+/// argument to fix.
+pub fn decode(arguments : Json) -> JobOutputInput raise {
+  match arguments {
+    { "job_id": String(job_id), .. } =>
+      { job_id, wait_ms: wait_ms(arguments), offset: offset(arguments), }
+    _ => fail("job_output requires a string job_id")
+  }
+}
+
+///|
+/// Decode the optional `wait_ms` argument: a positive number, capped at
+/// `max_wait_ms`. Absent/null means no waiting.
+fn wait_ms(arguments : Json) -> Int? raise {
+  match arguments {
+    { "wait_ms": Number(value, ..), .. } => {
+      let wait = value.to_int()
+      if wait <= 0 {
+        fail("job_output wait_ms must be a positive number")
+      } else if wait > max_wait_ms {
+        Some(max_wait_ms)
+      } else {
+        Some(wait)
+      }
+    }
+    { "wait_ms": Null, .. } => None
+    // Present but not a number (e.g. a stringified "30000"): reject rather
+    // than silently skip the wait.
+    { "wait_ms": _, .. } => fail("job_output wait_ms must be a number")
+    _ => None
+  }
+}
+
+///|
+/// Decode the optional `offset` argument: a character offset from the start of
+/// the captured output, zero or more. Absent/null means the recent tail.
+fn offset(arguments : Json) -> Int? raise {
+  match arguments {
+    { "offset": Number(value, ..), .. } => {
+      let offset = value.to_int()
+      if offset < 0 {
+        fail("job_output offset must be zero or a positive number")
+      } else {
+        Some(offset)
+      }
+    }
+    { "offset": Null, .. } => None
+    { "offset": _, .. } => fail("job_output offset must be a number")
+    _ => None
+  }
+}
+
+///|
+pub extend JobOutputInput with Debug::{to_repr}

--- a/agent_tool/job_output/internal/decode/decode_test.mbt
+++ b/agent_tool/job_output/internal/decode/decode_test.mbt
@@ -1,0 +1,71 @@
+///|
+test "decode defaults wait_ms and offset when only job_id is given" {
+  debug_inspect(
+    @decode.decode({ "job_id": "bg-3" }),
+    content="{ job_id: \"bg-3\", wait_ms: None, offset: None }",
+  )
+}
+
+///|
+test "decode reads explicit wait_ms and offset selectors" {
+  debug_inspect(
+    @decode.decode({ "job_id": "bg-3", "wait_ms": 30000, "offset": 12000 }),
+    content="{ job_id: \"bg-3\", wait_ms: Some(30000), offset: Some(12000) }",
+  )
+}
+
+///|
+test "decode treats explicitly-null selectors as absent" {
+  debug_inspect(
+    @decode.decode({
+      "job_id": "bg-3",
+      "wait_ms": Json::null(),
+      "offset": Json::null(),
+    }),
+    content="{ job_id: \"bg-3\", wait_ms: None, offset: None }",
+  )
+}
+
+///|
+test "decode caps an oversized wait_ms at max_wait_ms instead of rejecting it" {
+  inspect(@decode.max_wait_ms, content="120000")
+  debug_inspect(
+    @decode.decode({ "job_id": "bg-3", "wait_ms": 999999 }),
+    content="{ job_id: \"bg-3\", wait_ms: Some(120000), offset: None }",
+  )
+}
+
+///|
+test "decode names the argument to repair in malformed arguments" {
+  debug_inspect(
+    [
+      decode_error({ "wait_ms": 500 }),
+      decode_error({ "job_id": 7 }),
+      decode_error({ "job_id": "bg-3", "wait_ms": -5 }),
+      decode_error({ "job_id": "bg-3", "wait_ms": "30000" }),
+      decode_error({ "job_id": "bg-3", "offset": -1 }),
+      decode_error({ "job_id": "bg-3", "offset": "0" }),
+    ],
+    content=(
+      #|[
+      #|  "job_output requires a string job_id",
+      #|  "job_output requires a string job_id",
+      #|  "job_output wait_ms must be a positive number",
+      #|  "job_output wait_ms must be a number",
+      #|  "job_output offset must be zero or a positive number",
+      #|  "job_output offset must be a number",
+      #|]
+    ),
+  )
+}
+
+///|
+/// The decoder's failure message with the source-location wrapper stripped, or
+/// "unexpected success" when decoding somehow succeeds.
+fn decode_error(arguments : Json) -> String {
+  try @decode.decode(arguments) catch {
+    error => @tool_error.failure_message("\{error}")
+  } noraise {
+    _ => "unexpected success"
+  }
+}

--- a/agent_tool/job_output/internal/decode/moon.pkg
+++ b/agent_tool/job_output/internal/decode/moon.pkg
@@ -1,0 +1,11 @@
+import {
+  "moonbitlang/core/json",
+}
+
+import {
+  "bobzhang/openseek/agent_tool/internal/error" @tool_error,
+} for "test"
+
+warnings = "+unnecessary_annotation"
+
+supported_targets = "+wasm+native"

--- a/agent_tool/job_output/internal/decode/pkg.generated.mbti
+++ b/agent_tool/job_output/internal/decode/pkg.generated.mbti
@@ -1,0 +1,25 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_tool/job_output/internal/decode"
+
+import {
+  "moonbitlang/core/debug",
+}
+
+// Values
+pub fn decode(Json) -> JobOutputInput raise
+
+pub let max_wait_ms : Int
+
+// Errors
+
+// Types and methods
+pub struct JobOutputInput {
+  job_id : String
+  wait_ms : Int?
+  offset : Int?
+} derive(@debug.Debug)
+pub fn JobOutputInput::to_repr(Self) -> @debug.Repr
+
+// Type aliases
+
+// Traits

--- a/agent_tool/job_output/job_output.mbt
+++ b/agent_tool/job_output/job_output.mbt
@@ -51,12 +51,13 @@ async fn execute(
   bg_runtime : @bgjobs.BgJobRuntime,
   arguments : Json,
 ) -> @agent_tool.ToolAction {
-  guard arguments is { "job_id": String(job_id), .. } else {
-    return @agent_tool.respond(
-      "error: job_output requires a string job_id",
-      is_error=true,
-    )
+  let input = @decode.decode(arguments) catch {
+    error => {
+      let message = @tool_error.failure_message("\{error}")
+      return @agent_tool.respond("error: \{message}", is_error=true)
+    }
   }
+  let job_id = input.job_id
   guard bg_runtime.snapshot(job_id) is Some(_) else {
     return @agent_tool.respond(
       "error: no background job with id \{job_id}",
@@ -68,20 +69,16 @@ async fn execute(
   // deadline expiry is not an error; the response simply reports the job still
   // running. The cap keeps a single tool call from holding the turn for long —
   // the model can always call again.
-  match wait_ms(arguments) {
-    Ok(Some(wait)) => {
+  match input.wait_ms {
+    Some(wait) => {
       let _ = bg_runtime.wait_exit(job_id, wait)
     }
-    Ok(None) => ()
-    Err(message) => return @agent_tool.respond(message, is_error=true)
+    None => ()
   }
   // Recent output, bounded to a window so a poll cannot flood the conversation
   // with a large job's full log. For output over the window, show the *tail*
   // (recent progress).
-  let page = match window_offset(arguments) {
-    Ok(page) => page
-    Err(message) => return @agent_tool.respond(message, is_error=true)
-  }
+  let page = input.offset
   let window = 12000
   // A page reads the retained log from the start — the spill file for a large
   // job — so a result bigger than one window (a workflow's several reports)
@@ -190,54 +187,6 @@ fn apply_output_rewrites(
     let (old, replacement) = rewrite
     output.replace_all(old~, new=replacement)
   })
-}
-
-///|
-/// Longest a single job_output call may block awaiting a job, so one tool
-/// call cannot hold the turn indefinitely; the model can always call again.
-let max_wait_ms : Int = 120_000
-
-///|
-/// Decode the optional `wait_ms` argument: a positive number, capped at
-/// `max_wait_ms`. Absent/null means no waiting.
-fn wait_ms(arguments : Json) -> Result[Int?, String] {
-  match arguments {
-    { "wait_ms": Number(value, ..), .. } => {
-      let wait = value.to_int()
-      if wait <= 0 {
-        Err("error: job_output wait_ms must be a positive number")
-      } else if wait > max_wait_ms {
-        Ok(Some(max_wait_ms))
-      } else {
-        Ok(Some(wait))
-      }
-    }
-    { "wait_ms": Null, .. } => Ok(None)
-    // Present but not a number (e.g. a stringified "30000"): reject rather than
-    // silently skip the wait — the local dispatcher does not enforce the JSON
-    // schema, so the decoder must.
-    { "wait_ms": _, .. } => Err("error: job_output wait_ms must be a number")
-    _ => Ok(None)
-  }
-}
-
-///|
-/// Decode the optional `offset` argument: a character offset from the start of
-/// the captured output, zero or more. Absent/null means the recent tail.
-fn window_offset(arguments : Json) -> Result[Int?, String] {
-  match arguments {
-    { "offset": Number(value, ..), .. } => {
-      let offset = value.to_int()
-      if offset < 0 {
-        Err("error: job_output offset must be zero or a positive number")
-      } else {
-        Ok(Some(offset))
-      }
-    }
-    { "offset": Null, .. } => Ok(None)
-    { "offset": _, .. } => Err("error: job_output offset must be a number")
-    _ => Ok(None)
-  }
 }
 
 ///|

--- a/agent_tool/job_output/moon.pkg
+++ b/agent_tool/job_output/moon.pkg
@@ -1,7 +1,9 @@
 import {
   "bobzhang/openseek/agent_tool",
   "bobzhang/openseek/agent_tool/bgjobs",
+  "bobzhang/openseek/agent_tool/internal/error" @tool_error,
   "bobzhang/openseek/agent_tool/internal/sandbox",
+  "bobzhang/openseek/agent_tool/job_output/internal/decode",
   "moonbitlang/core/json",
 }
 


### PR DESCRIPTION
## BgJobRuntime is now an abstract struct

[`agent_tool/bgjobs`](agent_tool/bgjobs/bgjobs.mbt) declared `BgJobRuntime`
as a `pub struct` whose every field was marked `priv`. In MoonBit's
visibility model a bare `struct` (no `pub`) is an *abstract type*: its name
stays visible outside the package while its representation is hidden —
exactly what the nine per-field `priv` markers achieved, stated once on the
type instead. The pub constructor, methods, and all external consumers are
unchanged.

## job_output argument decoding moves to internal/decode

[`agent_tool/job_output`](agent_tool/job_output/job_output.mbt) now follows
the repo's `internal/decode` convention (read, goal, edit, write, shell, ...):

- New `agent_tool/job_output/internal/decode` owns argument decoding —
  `JobOutputInput { job_id, wait_ms, offset }`, a raising `decode`, and the
  `max_wait_ms` cap — with focused tests and a README whose doctests run
  under `moon test`.
- The tool package keeps orchestration: waiting on the job, reading its
  retained output, applying rewrites, and rendering the `<system>` footer.

Decoded error text fed back to callers is unchanged (the parent prefixes
`error: ` where the decoder used to embed it). One ordering nuance: decode
now runs once up front, so with arguments that are both malformed *and*
name an unknown job the decode error reports first.

## Verification

- `moon check` clean on both packages, the new decode package, and all
  consumers (`agent`, `mbtx`, `job_stop`, `shell`).
- `moon test agent_tool/bgjobs agent_tool/job_output agent_tool/job_stop`:
  45/45 passed.
- `moon test agent_tool/job_output/internal/decode` (incl. README
  doctests): 9/9 passed.
- `moon test agent --filter "*job*"`: 6/6 passed.
- `moon fmt --check agent_tool/bgjobs agent_tool/job_output`: clean.

Generated with SeekMoon