### PR TITLE
fix(desktop): show Markdown comments as source in diffs

### DIFF
--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -150,6 +150,7 @@ let viewer_state : ViewerHost = {
     layout=@viewer.SideBySide,
     automatic_inline=false,
     diff_word_wrap=@viewer.Off,
+    render_markdown_comments=false,
   ),
   point_range_highlight: None,
   search_match_highlights: None,

--- a/desktop/frontend/fileeditor/semantic_review_view.mbt
+++ b/desktop/frontend/fileeditor/semantic_review_view.mbt
@@ -627,12 +627,9 @@ fn semantic_diff_options(
     diff_word_wrap=@viewer.Off,
     overview_ruler=false,
     render_indicators=true,
-    render_markdown_comments=true,
+    render_markdown_comments=false,
     handle_mouse_wheel=false,
-    // Token/Tree use the same rich, initially folded Markdown-comment
-    // presentation as ordinary code reading and Line diff. MoonDiff has already
-    // decided which sections exist, so presentation must not fall back to raw
-    // `///` rows. The outer MultiDiff scroll plane owns wheel input, matching
+    // The outer MultiDiff scroll plane owns wheel input, matching
     // VS Code's per-item `handleMouseWheel: false` configuration.
   )
 }


### PR DESCRIPTION
Disable inline Markdown-comment rendering in SeekMoon’s Line, Token, and Tree diffs. Both Split and Unified layouts now show the original comment source and diff highlighting. Markdown files continue to use source diffs, while File view keeps its rendered presentation.

Validation:
- Rebased onto current `main`; the branch contains only the two Viewer host configuration changes.
- Fileeditor JS tests: 147/147 passed. Native/JS strict checks and formatting passed.
- Real packaged macOS UI validation of this unchanged rendering patch: all three diff modes in both layouts, Markdown file diffs, comment filtering, and File/Diff round trips. No page or console errors.
