### PR TITLE
fix(agent): retry interrupted provider streams

### DIFF
--- a/agent/steer_test.mbt
+++ b/agent/steer_test.mbt
@@ -365,6 +365,17 @@ async test "streaming reasoning deltas survive a stream retry and stay transient
       entries.any(entry => {
         entry
         is {
+          "event": String("stream_retry"),
+          "attempt": Number(2, ..),
+          "max_attempts": Number(5, ..),
+          ..
+        }
+      }),
+    )
+    assert_true(
+      entries.any(entry => {
+        entry
+        is {
           "event": String("assistant_delta"),
           "content": String("discarded"),
           ..

--- a/agent/steer_test.mbt
+++ b/agent/steer_test.mbt
@@ -285,43 +285,40 @@ async fn reasoning_log_test_server(
   group : @async.TaskGroup[Unit],
 ) -> (String, Ref[Int])? {
   let hits : Ref[Int] = { val: 0, }
-  guard serve_chat_completions(
-      group,
-      "local TCP bind unavailable; skipping reasoning log test",
-      max_connections=2,
-      (_request, _body, conn) => {
-        hits.val += 1
-        conn.send_response(200, "OK", extra_headers={
-          "Content-Type": "text/event-stream",
-        })
-        if hits.val == 1 {
-          // The first attempt deliberately dies after visible output. Agent's
-          // retry boundary must keep that fragment transient.
-          conn.write(
-            "data: {\"choices\":[{\"delta\":{\"content\":\"discarded\"}}]}\n\n",
-          )
-          return
-        }
+  let url = serve_chat_completions(
+    group,
+    "local TCP bind unavailable; skipping reasoning log test",
+    max_connections=2,
+    (_request, _body, conn) => {
+      hits.val += 1
+      conn.send_response(200, "OK", extra_headers={
+        "Content-Type": "text/event-stream",
+      })
+      if hits.val == 1 {
+        // The first attempt dies after visible output; the agent's retry
+        // boundary must keep that fragment transient.
         conn.write(
-          "data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"stream-retry:\"}}]}\n\n",
+          "data: {\"choices\":[{\"delta\":{\"content\":\"discarded\"}}]}\n\n",
         )
-        conn.write(
-          "data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"reasoning-proof\"}}]}\n\n",
-        )
-        conn.write(
-          "data: {\"choices\":[{\"delta\":{\"content\":\"done\"}}],\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":5,\"total_tokens\":8,\"prompt_cache_hit_tokens\":1,\"prompt_cache_miss_tokens\":2}}\n\n",
-        )
-        conn.write("data: [DONE]\n\n")
-      },
-    )
-    is Some(url) else {
-    return None
-  }
-  Some((url, hits))
+        return
+      }
+      conn.write(
+        "data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"stream-retry:\"}}]}\n\n",
+      )
+      conn.write(
+        "data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"reasoning-proof\"}}]}\n\n",
+      )
+      conn.write(
+        "data: {\"choices\":[{\"delta\":{\"content\":\"done\"}}],\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":5,\"total_tokens\":8,\"prompt_cache_hit_tokens\":1,\"prompt_cache_miss_tokens\":2}}\n\n",
+      )
+      conn.write("data: [DONE]\n\n")
+    },
+  )
+  url.map(url => (url, hits))
 }
 
 ///|
-async test "stream retries and reasoning deltas stay transient" {
+async test "streaming reasoning deltas survive a stream retry and stay transient" {
   @async.with_task_group() <| group => {
     guard reasoning_log_test_server(group) is Some((url, hits)) else { return }
     // The sink is process-global and drops events until opened: open it for
@@ -358,11 +355,22 @@ async test "stream retries and reasoning deltas stay transient" {
     // The events this turn reported, read back off the protocol sink.
     let entries = drain_emitted()
     let event_names = entries.map(log_event)
-    // The first connection cannot finish, so two hits prove Agent opted into
-    // the retry. The three durable events above prove that its boundary and
-    // discarded delta never became SessionItems/session.jsonl lines.
+    // The first connection cannot finish, so two hits prove the agent opted
+    // into the retry. Its "discarded" delta went out live, yet the three
+    // durable events above show it never became a session item. The sink is
+    // shared with concurrently running tests, so assertions below pick this
+    // turn's events out by their unique content.
     assert_eq(hits.val, 2)
-    assert_true(event_names.contains("stream_retry"))
+    assert_true(
+      entries.any(entry => {
+        entry
+        is {
+          "event": String("assistant_delta"),
+          "content": String("discarded"),
+          ..
+        }
+      }),
+    )
     assert_true(event_names.contains("reasoning_message"))
     assert_true(event_names.contains("assistant_delta"))
     assert_true(event_names.contains("assistant_message"))

--- a/agent/steer_test.mbt
+++ b/agent/steer_test.mbt
@@ -281,33 +281,49 @@ fn log_event(entry : Json) -> String {
 }
 
 ///|
-async fn reasoning_log_test_server(group : @async.TaskGroup[Unit]) -> String? {
-  serve_chat_completions(
-    group,
-    "local TCP bind unavailable; skipping reasoning log test",
-    max_connections=1,
-    (_request, _body, conn) => {
-      conn.send_response(200, "OK", extra_headers={
-        "Content-Type": "text/event-stream",
-      })
-      conn.write(
-        "data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"I\"}}]}\n\n",
-      )
-      conn.write(
-        "data: {\"choices\":[{\"delta\":{\"reasoning_content\":\" think\"}}]}\n\n",
-      )
-      conn.write(
-        "data: {\"choices\":[{\"delta\":{\"content\":\"done\"}}],\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":5,\"total_tokens\":8,\"prompt_cache_hit_tokens\":1,\"prompt_cache_miss_tokens\":2}}\n\n",
-      )
-      conn.write("data: [DONE]\n\n")
-    },
-  )
+async fn reasoning_log_test_server(
+  group : @async.TaskGroup[Unit],
+) -> (String, Ref[Int])? {
+  let hits : Ref[Int] = { val: 0, }
+  guard serve_chat_completions(
+      group,
+      "local TCP bind unavailable; skipping reasoning log test",
+      max_connections=2,
+      (_request, _body, conn) => {
+        hits.val += 1
+        conn.send_response(200, "OK", extra_headers={
+          "Content-Type": "text/event-stream",
+        })
+        if hits.val == 1 {
+          // The first attempt deliberately dies after visible output. Agent's
+          // retry boundary must keep that fragment transient.
+          conn.write(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"discarded\"}}]}\n\n",
+          )
+          return
+        }
+        conn.write(
+          "data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"stream-retry:\"}}]}\n\n",
+        )
+        conn.write(
+          "data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"reasoning-proof\"}}]}\n\n",
+        )
+        conn.write(
+          "data: {\"choices\":[{\"delta\":{\"content\":\"done\"}}],\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":5,\"total_tokens\":8,\"prompt_cache_hit_tokens\":1,\"prompt_cache_miss_tokens\":2}}\n\n",
+        )
+        conn.write("data: [DONE]\n\n")
+      },
+    )
+    is Some(url) else {
+    return None
+  }
+  Some((url, hits))
 }
 
 ///|
-async test "streaming reasoning deltas are always emitted and stay transient" {
+async test "stream retries and reasoning deltas stay transient" {
   @async.with_task_group() <| group => {
-    guard reasoning_log_test_server(group) is Some(url) else { return }
+    guard reasoning_log_test_server(group) is Some((url, hits)) else { return }
     // The sink is process-global and drops events until opened: open it for
     // this turn and close it after, so the other tests in this binary never
     // accumulate lines. Drop whatever an earlier open left, so the capture
@@ -335,13 +351,18 @@ async test "streaming reasoning deltas are always emitted and stay transient" {
       fail("expected a durable reasoning-bearing assistant response")
     }
     assert_eq(message.content(), "done")
-    assert_eq(message.reasoning_content(), Some("I think"))
+    assert_eq(message.reasoning_content(), Some("stream-retry:reasoning-proof"))
     guard events[2].item() is Terminal(Finished("done")) else {
       fail("expected a completed one-step turn")
     }
     // The events this turn reported, read back off the protocol sink.
     let entries = drain_emitted()
     let event_names = entries.map(log_event)
+    // The first connection cannot finish, so two hits prove Agent opted into
+    // the retry. The three durable events above prove that its boundary and
+    // discarded delta never became SessionItems/session.jsonl lines.
+    assert_eq(hits.val, 2)
+    assert_true(event_names.contains("stream_retry"))
     assert_true(event_names.contains("reasoning_message"))
     assert_true(event_names.contains("assistant_delta"))
     assert_true(event_names.contains("assistant_message"))
@@ -352,11 +373,12 @@ async test "streaming reasoning deltas are always emitted and stay transient" {
           "event": String("reasoning_delta"),
           "content": String(content),
           ..
-        } {
+        } &&
+        (content == "stream-retry:" || content == "reasoning-proof") {
         reasoning_deltas.push(content)
       }
     }
-    assert_eq(reasoning_deltas.join(""), "I think")
+    assert_eq(reasoning_deltas.join(""), "stream-retry:reasoning-proof")
   }
 }
 

--- a/agent/turn_loop.mbt
+++ b/agent/turn_loop.mbt
@@ -464,14 +464,10 @@ async fn AgentLoop::chat(self : Self, step : Int) -> @deepseek.ChatResponse {
           @emit.emit(ReasoningDelta(content=delta))
         }
       },
-      on_retry=(attempt, max_attempts, reason) => {
-        // Repeat the existing step boundary first so an older controller that
-        // does not know `stream_retry` still drops the failed attempt's live
-        // preview. This does not append a session item or rerun any tool: the
-        // chat client is only reopening this step's provider request.
-        @emit.emit(AgentStep(step=step + 1))
-        @emit.emit(StreamRetry(attempt~, max_attempts~, reason~))
-      },
+      // The provider request for this step is being reopened. Re-announcing
+      // the same step makes every controller drop the failed attempt's live
+      // preview; it appends no session item and reruns no tool.
+      on_retry=() => @emit.emit(AgentStep(step=step + 1)),
     ),
   )
   response.log_and_reasoning_content()

--- a/agent/turn_loop.mbt
+++ b/agent/turn_loop.mbt
@@ -464,6 +464,14 @@ async fn AgentLoop::chat(self : Self, step : Int) -> @deepseek.ChatResponse {
           @emit.emit(ReasoningDelta(content=delta))
         }
       },
+      on_retry=(attempt, max_attempts, reason) => {
+        // Repeat the existing step boundary first so an older controller that
+        // does not know `stream_retry` still drops the failed attempt's live
+        // preview. This does not append a session item or rerun any tool: the
+        // chat client is only reopening this step's provider request.
+        @emit.emit(AgentStep(step=step + 1))
+        @emit.emit(StreamRetry(attempt~, max_attempts~, reason~))
+      },
     ),
   )
   response.log_and_reasoning_content()

--- a/agent/turn_loop.mbt
+++ b/agent/turn_loop.mbt
@@ -464,10 +464,12 @@ async fn AgentLoop::chat(self : Self, step : Int) -> @deepseek.ChatResponse {
           @emit.emit(ReasoningDelta(content=delta))
         }
       },
-      // The provider request for this step is being reopened. Re-announcing
-      // the same step makes every controller drop the failed attempt's live
-      // preview; it appends no session item and reruns no tool.
-      on_retry=() => @emit.emit(AgentStep(step=step + 1)),
+      // The provider request for this step is being retried. Controllers drop
+      // the failed attempt's live preview and show the retry; nothing is
+      // appended to the session and no tool reruns.
+      on_retry=(attempt, max_attempts, reason) => {
+        @emit.emit(StreamRetry(attempt~, max_attempts~, reason~))
+      },
     ),
   )
   response.log_and_reasoning_content()

--- a/deepseek/client/README.mbt.md
+++ b/deepseek/client/README.mbt.md
@@ -22,8 +22,8 @@ The package depends on `moonbitlang/async/http` and is native-only.
   still returns the accumulated response.
 - `StreamHandler(on_content_delta~, on_reasoning_delta?, on_retry?)`: receive
   non-empty content and reasoning deltas while a streaming chat request is in
-  progress. `on_retry`, when present, is the boundary where the consumer must
-  discard deltas from the failed attempt before the replacement stream starts.
+  progress. `on_retry` opts into retrying an interrupted stream; the
+  `StreamHandler` docstring states the contract.
 
 `Client` implements `Debug` with the API key redacted.
 
@@ -158,18 +158,12 @@ The stream reader:
 - accumulates content, reasoning, tool-call fragments, and final usage
 - returns the accumulated value as a normal `@deepseek.ChatResponse`
 
-By default, streaming calls retry only until the first SSE event is produced.
-After any event - text, reasoning, tool-call, or usage - retrying could
-duplicate or change the completion, so later failures surface directly.
-
-A consumer that can replace its transient preview may opt in with `on_retry`.
-Then a socket read error, EOF before `[DONE]`, or idle timeout may reopen the
-same chat request even after output began. The callback runs immediately before
-the next attempt after a failed attempt emitted an SSE event, and receives
-`(attempt, max_attempts, reason)`; it must clear the failed attempt rather than
-concatenate both streams. A retry before the first event remains silent because
-there is no preview to discard. Malformed SSE and errors raised by delta
-callbacks remain final and are not retried.
+Streaming calls retry only until the first SSE event is produced. After any
+event - text, reasoning, tool-call, or usage - retrying could duplicate or
+change the completion, so later failures surface directly. A handler that
+supplies `on_retry` opts out of that rule for socket, EOF, and idle-timeout
+failures: the callback runs before the replacement attempt so the consumer can
+discard the failed attempt's output.
 
 At runtime:
 

--- a/deepseek/client/README.mbt.md
+++ b/deepseek/client/README.mbt.md
@@ -22,7 +22,8 @@ The package depends on `moonbitlang/async/http` and is native-only.
   still returns the accumulated response.
 - `StreamHandler(on_content_delta~, on_reasoning_delta?, on_retry?)`: receive
   non-empty content and reasoning deltas while a streaming chat request is in
-  progress. `on_retry` opts into retrying an interrupted stream; the
+  progress. `on_retry(attempt, max_attempts, reason)` opts into retrying an
+  interrupted stream and is told about every retry before its backoff; the
   `StreamHandler` docstring states the contract.
 
 `Client` implements `Debug` with the API key redacted.
@@ -162,8 +163,9 @@ Streaming calls retry only until the first SSE event is produced. After any
 event - text, reasoning, tool-call, or usage - retrying could duplicate or
 change the completion, so later failures surface directly. A handler that
 supplies `on_retry` opts out of that rule for socket, EOF, and idle-timeout
-failures: the callback runs before the replacement attempt so the consumer can
-discard the failed attempt's output.
+failures: the callback runs when the retry is decided, before the backoff
+sleep, so the consumer can discard the failed attempt's output and show that
+a retry is pending.
 
 At runtime:
 

--- a/deepseek/client/README.mbt.md
+++ b/deepseek/client/README.mbt.md
@@ -20,8 +20,10 @@ The package depends on `moonbitlang/async/http` and is native-only.
   and decode the response as `@deepseek.ChatResponse`. Without `stream`, this
   is a normal JSON response. With `stream=StreamHandler(...)`, it uses SSE and
   still returns the accumulated response.
-- `StreamHandler(on_content_delta~, on_reasoning_delta?)`: receive non-empty
-  content and reasoning deltas while a streaming chat request is in progress.
+- `StreamHandler(on_content_delta~, on_reasoning_delta?, on_retry?)`: receive
+  non-empty content and reasoning deltas while a streaming chat request is in
+  progress. `on_retry`, when present, is the boundary where the consumer must
+  discard deltas from the failed attempt before the replacement stream starts.
 
 `Client` implements `Debug` with the API key redacted.
 
@@ -156,9 +158,18 @@ The stream reader:
 - accumulates content, reasoning, tool-call fragments, and final usage
 - returns the accumulated value as a normal `@deepseek.ChatResponse`
 
-Streaming calls retry only until the first SSE event is produced. After any
-event - text, reasoning, tool-call, or usage - retrying could duplicate or
-change the completion, so later failures surface directly.
+By default, streaming calls retry only until the first SSE event is produced.
+After any event - text, reasoning, tool-call, or usage - retrying could
+duplicate or change the completion, so later failures surface directly.
+
+A consumer that can replace its transient preview may opt in with `on_retry`.
+Then a socket read error, EOF before `[DONE]`, or idle timeout may reopen the
+same chat request even after output began. The callback runs immediately before
+the next attempt after a failed attempt emitted an SSE event, and receives
+`(attempt, max_attempts, reason)`; it must clear the failed attempt rather than
+concatenate both streams. A retry before the first event remains silent because
+there is no preview to discard. Malformed SSE and errors raised by delta
+callbacks remain final and are not retried.
 
 At runtime:
 

--- a/deepseek/client/client.mbt
+++ b/deepseek/client/client.mbt
@@ -92,16 +92,21 @@ pub fn Client::Client(
 /// By default a failure after the first SSE event is final: the completion is
 /// already running and billed, and replaying it could duplicate content or
 /// regenerate a tool call. Supplying `on_retry` says the consumer can discard
-/// every fragment it received from a failed attempt. A socket error, EOF
-/// before `[DONE]`, or idle timeout then reopens the same request, and
-/// `on_retry` runs immediately before that next attempt so the consumer can
-/// clear the failed attempt's output. It is not called for a retry before the
-/// first event, since there is nothing to discard. Malformed SSE and errors
-/// raised by the delta callbacks stay final either way.
+/// every fragment it received from a failed attempt, which lets a socket
+/// error, EOF before `[DONE]`, or idle timeout reopen the same request.
+/// Malformed SSE and errors raised by the delta callbacks stay final either
+/// way.
+///
+/// `on_retry(attempt, max_attempts, reason)` runs for every retry the client
+/// is about to make, before its backoff sleep: `attempt` is the 1-based number
+/// of the attempt that will follow, `max_attempts` the total budget, and
+/// `reason` describes the failure. Pre-stream retries (429, 5xx, connect
+/// errors) report through it too, so a consumer can show that the request is
+/// being retried rather than silently waiting.
 pub struct StreamHandler {
   priv on_content_delta : async (String) -> Unit
   priv on_reasoning_delta : async (String) -> Unit
-  priv on_retry : (() -> Unit)?
+  priv on_retry : ((Int, Int, String) -> Unit)?
 }
 
 ///|
@@ -109,7 +114,7 @@ pub struct StreamHandler {
 pub fn StreamHandler::StreamHandler(
   on_content_delta~ : async (String) -> Unit,
   on_reasoning_delta? : async (String) -> Unit = _ => (),
-  on_retry? : () -> Unit,
+  on_retry? : (Int, Int, String) -> Unit,
 ) -> StreamHandler {
   { on_content_delta, on_reasoning_delta, on_retry, }
 }
@@ -129,7 +134,7 @@ priv suberror RetryableApiError {
   HttpStatusError(Int, String)
   IdleTimeout(String, Int)
   StreamEnded
-  StreamTransport(String)
+  StreamTransport(Error)
 }
 
 ///|
@@ -158,7 +163,9 @@ let max_backoff_ms : Int = 60_000
 /// anything else is transport-shaped (connect refused, reset, DNS) and
 /// retries within budget. `bail` lets an attempt declare later retries
 /// pointless for the error it raised; streaming chat uses it to refuse
-/// replaying a half-consumed completion (see `StreamHandler`).
+/// replaying a half-consumed completion (see `StreamHandler`). `on_retry`
+/// runs with the number of the attempt about to start and the error that
+/// prompted it, at the decision point and therefore before the backoff sleep.
 ///
 /// Errors propagate with their types intact. The chat boundary observes the
 /// final cause before adding request context for the caller.
@@ -167,7 +174,9 @@ async fn[T] Client::with_retries(
   attempt : async () -> T,
   bail : (Error) -> Bool,
   progress? : RequestProgress,
+  on_retry? : (Int, Error) -> Unit = (_, _) => (),
 ) -> T {
+  let mut attempts = 0
   @async.retry(
     ExponentialDelay(
       initial=self.retry_backoff_ms,
@@ -191,9 +200,17 @@ async fn[T] Client::with_retries(
           AttemptsExhausted
         }
       }
+      // `fatal_error` also runs for the last attempt of the budget, when no
+      // retry follows; only announce a retry that will actually happen.
+      if !fatal && attempts < self.retry_attempts {
+        on_retry(attempts + 1, error)
+      }
       fatal
     },
-    attempt,
+    () => {
+      attempts += 1
+      attempt()
+    },
   )
 }
 
@@ -229,11 +246,6 @@ pub async fn Client::chat(
         let progress = RequestProgress()
         self.with_retries(
           () => {
-            // `progress` still describes the previous attempt here, so this is
-            // the boundary where an opted-in handler discards its output.
-            if progress.streamed() && stream.on_retry is Some(on_retry) {
-              on_retry()
-            }
             progress.begin_attempt()
             self.chat_stream_attempt(body, progress, stream)
           },
@@ -242,6 +254,11 @@ pub async fn Client::chat(
             !(stream.on_retry is Some(_) && is_stream_interruption(error))
           },
           progress~,
+          on_retry=(attempt, error) => {
+            if stream.on_retry is Some(on_retry) {
+              on_retry(attempt, self.retry_attempts, error_detail(error))
+            }
+          },
         ) catch {
           error if @async.is_being_cancelled() ||
             @async.is_cancellation_error(error) => raise error

--- a/deepseek/client/client.mbt
+++ b/deepseek/client/client.mbt
@@ -86,20 +86,22 @@ pub fn Client::Client(
 ///
 /// `on_content_delta` is called for each assistant content fragment as it
 /// arrives; `on_reasoning_delta` likewise for each thinking-mode reasoning
-/// fragment (it is simply not called when thinking is off).
+/// fragment (it is simply not called when thinking is off). `Client::chat`
+/// returns the fully accumulated response after the stream reaches `[DONE]`.
 ///
-/// Supplying `on_retry` explicitly says that the consumer can discard every
-/// fragment from a failed attempt. When such an attempt emitted an SSE event,
-/// the callback runs immediately before the next request starts, with the
-/// 1-based attempt number, the total attempt budget, and the previous failure.
-/// A pre-event retry needs no discard boundary and remains silent. Without the
-/// callback, a failure after any SSE event keeps the conservative no-replay
-/// behavior. `Client::chat` returns the fully accumulated response only after
-/// one attempt reaches `[DONE]`.
+/// By default a failure after the first SSE event is final: the completion is
+/// already running and billed, and replaying it could duplicate content or
+/// regenerate a tool call. Supplying `on_retry` says the consumer can discard
+/// every fragment it received from a failed attempt. A socket error, EOF
+/// before `[DONE]`, or idle timeout then reopens the same request, and
+/// `on_retry` runs immediately before that next attempt so the consumer can
+/// clear the failed attempt's output. It is not called for a retry before the
+/// first event, since there is nothing to discard. Malformed SSE and errors
+/// raised by the delta callbacks stay final either way.
 pub struct StreamHandler {
   priv on_content_delta : async (String) -> Unit
   priv on_reasoning_delta : async (String) -> Unit
-  priv on_retry : ((Int, Int, String) -> Unit)?
+  priv on_retry : (() -> Unit)?
 }
 
 ///|
@@ -107,7 +109,7 @@ pub struct StreamHandler {
 pub fn StreamHandler::StreamHandler(
   on_content_delta~ : async (String) -> Unit,
   on_reasoning_delta? : async (String) -> Unit = _ => (),
-  on_retry? : (Int, Int, String) -> Unit,
+  on_retry? : () -> Unit,
 ) -> StreamHandler {
   { on_content_delta, on_reasoning_delta, on_retry, }
 }
@@ -131,6 +133,14 @@ priv suberror RetryableApiError {
 }
 
 ///|
+/// Failures where the connection died mid-stream. These are the only errors an
+/// opted-in stream handler may retry after output has started; malformed SSE
+/// and delta-callback errors are plain `Failure` values and stay final.
+fn is_stream_interruption(error : Error) -> Bool {
+  error is (IdleTimeout(_, _) | StreamEnded | StreamTransport(_))
+}
+
+///|
 /// Ceiling on a single backoff sleep. The doubling sequence from
 /// `retry_backoff_ms` stops growing here — but this bounds each sleep, not
 /// their sum, which stays a geometric series: raising `retry_attempts` buys
@@ -147,9 +157,8 @@ let max_backoff_ms : Int = 60_000
 /// failures, and malformed-api_url parse errors propagate immediately;
 /// anything else is transport-shaped (connect refused, reset, DNS) and
 /// retries within budget. `bail` lets an attempt declare later retries
-/// pointless based on the error it raised. Streaming chat uses that to keep
-/// post-event replay disabled unless its handler explicitly opted in, and even
-/// then permits only transport, EOF, and idle-timeout failures.
+/// pointless for the error it raised; streaming chat uses it to refuse
+/// replaying a half-consumed completion (see `StreamHandler`).
 ///
 /// Errors propagate with their types intact. The chat boundary observes the
 /// final cause before adding request context for the caller.
@@ -217,52 +226,20 @@ pub async fn Client::chat(
     match stream {
       None => self.with_retries(() => self.chat_attempt(body), _ => false)
       Some(stream) => {
-        // The handler, not this client, owns already-rendered deltas. An absent
-        // retry callback preserves the conservative no-replay rule after the
-        // first event. An opted-in consumer gets a boundary before the next
-        // attempt and must clear that transient output there.
         let progress = RequestProgress()
-        let mut previous_streamed = false
-        let mut retry_reason = ""
         self.with_retries(
           () => {
-            let attempt = progress.attempts + 1
-            if attempt > 1 && previous_streamed {
-              match stream.on_retry {
-                Some(on_retry) =>
-                  on_retry(attempt, self.retry_attempts, retry_reason)
-                None => ()
-              }
+            // `progress` still describes the previous attempt here, so this is
+            // the boundary where an opted-in handler discards its output.
+            if progress.streamed() && stream.on_retry is Some(on_retry) {
+              on_retry()
             }
-            previous_streamed = false
             progress.begin_attempt()
             self.chat_stream_attempt(body, progress, stream)
           },
           error => {
-            previous_streamed = match progress.phase {
-              Sse(sse) => sse.event_count > 0 || sse.buffered_data
-              Decode(event_count~, ..) => event_count > 0
-              Connect | WriteRequest | ResponseHeaders | ResponseBody => false
-            }
-            retry_reason = match error {
-              IdleTimeout(context, timeout_ms) =>
-                "\{context} idle for \{timeout_ms}ms"
-              StreamEnded => "DeepSeek stream ended before [DONE]"
-              StreamTransport(detail) =>
-                "DeepSeek stream transport error: \{detail}"
-              HttpStatusError(code, body) =>
-                "DeepSeek API error \{code}: \{body}"
-              error => "\{error}"
-            }
-            // Malformed SSE and callback failures are plain Failure values and
-            // remain final. Only transport, EOF, and idle-timeout failures may
-            // cross a boundary after output has started.
-            let retryable_stream_error = match error {
-              IdleTimeout(_, _) | StreamEnded | StreamTransport(_) => true
-              _ => false
-            }
-            previous_streamed &&
-            (stream.on_retry is None || !retryable_stream_error)
+            progress.streamed() &&
+            !(stream.on_retry is Some(_) && is_stream_interruption(error))
           },
           progress~,
         ) catch {

--- a/deepseek/client/client.mbt
+++ b/deepseek/client/client.mbt
@@ -86,11 +86,20 @@ pub fn Client::Client(
 ///
 /// `on_content_delta` is called for each assistant content fragment as it
 /// arrives; `on_reasoning_delta` likewise for each thinking-mode reasoning
-/// fragment (it is simply not called when thinking is off). `Client::chat`
-/// returns the fully accumulated response after the stream reaches `[DONE]`.
+/// fragment (it is simply not called when thinking is off).
+///
+/// Supplying `on_retry` explicitly says that the consumer can discard every
+/// fragment from a failed attempt. When such an attempt emitted an SSE event,
+/// the callback runs immediately before the next request starts, with the
+/// 1-based attempt number, the total attempt budget, and the previous failure.
+/// A pre-event retry needs no discard boundary and remains silent. Without the
+/// callback, a failure after any SSE event keeps the conservative no-replay
+/// behavior. `Client::chat` returns the fully accumulated response only after
+/// one attempt reaches `[DONE]`.
 pub struct StreamHandler {
   priv on_content_delta : async (String) -> Unit
   priv on_reasoning_delta : async (String) -> Unit
+  priv on_retry : ((Int, Int, String) -> Unit)?
 }
 
 ///|
@@ -98,8 +107,9 @@ pub struct StreamHandler {
 pub fn StreamHandler::StreamHandler(
   on_content_delta~ : async (String) -> Unit,
   on_reasoning_delta? : async (String) -> Unit = _ => (),
+  on_retry? : (Int, Int, String) -> Unit,
 ) -> StreamHandler {
-  { on_content_delta, on_reasoning_delta, }
+  { on_content_delta, on_reasoning_delta, on_retry, }
 }
 
 ///|
@@ -117,6 +127,7 @@ priv suberror RetryableApiError {
   HttpStatusError(Int, String)
   IdleTimeout(String, Int)
   StreamEnded
+  StreamTransport(String)
 }
 
 ///|
@@ -136,16 +147,16 @@ let max_backoff_ms : Int = 60_000
 /// failures, and malformed-api_url parse errors propagate immediately;
 /// anything else is transport-shaped (connect refused, reset, DNS) and
 /// retries within budget. `bail` lets an attempt declare later retries
-/// pointless — streaming chat sets it once the stream has produced any event,
-/// since replaying a half-consumed completion would duplicate content (or
-/// regenerate tool calls) downstream.
+/// pointless based on the error it raised. Streaming chat uses that to keep
+/// post-event replay disabled unless its handler explicitly opted in, and even
+/// then permits only transport, EOF, and idle-timeout failures.
 ///
 /// Errors propagate with their types intact. The chat boundary observes the
 /// final cause before adding request context for the caller.
 async fn[T] Client::with_retries(
   self : Client,
   attempt : async () -> T,
-  bail : () -> Bool,
+  bail : (Error) -> Bool,
   progress? : RequestProgress,
 ) -> T {
   @async.retry(
@@ -156,14 +167,14 @@ async fn[T] Client::with_retries(
     ),
     max_retry=self.retry_attempts - 1,
     fatal_error=error => {
-      let streamed = bail()
-      let fatal = streamed ||
+      let stopped = bail(error)
+      let fatal = stopped ||
         @async.is_cancellation_error(error) ||
         error is Failure::Failure(_) ||
         error is @http.URIParseError::InvalidFormat ||
         error is @http.URIParseError::UnsupportedProtocol(_)
       if progress is Some(progress) {
-        progress.stop_reason = if streamed {
+        progress.stop_reason = if stopped {
           StreamStarted
         } else if fatal {
           NotRetryable
@@ -204,26 +215,54 @@ pub async fn Client::chat(
   ) <| messages
   try {
     match stream {
-      None => self.with_retries(() => self.chat_attempt(body), () => false)
+      None => self.with_retries(() => self.chat_attempt(body), _ => false)
       Some(stream) => {
-        // Once the server has produced any complete SSE event the completion is
-        // running and billed — text deltas, tool-call deltas, and usage alike,
-        // even though only text reaches the callbacks. A retry past that point
-        // could duplicate content or generate a different tool call, so the
-        // first event (not just the first text delta) bails the retry loop and
-        // failures surface instead (Codex review).
+        // The handler, not this client, owns already-rendered deltas. An absent
+        // retry callback preserves the conservative no-replay rule after the
+        // first event. An opted-in consumer gets a boundary before the next
+        // attempt and must clear that transient output there.
         let progress = RequestProgress()
+        let mut previous_streamed = false
+        let mut retry_reason = ""
         self.with_retries(
           () => {
+            let attempt = progress.attempts + 1
+            if attempt > 1 && previous_streamed {
+              match stream.on_retry {
+                Some(on_retry) =>
+                  on_retry(attempt, self.retry_attempts, retry_reason)
+                None => ()
+              }
+            }
+            previous_streamed = false
             progress.begin_attempt()
             self.chat_stream_attempt(body, progress, stream)
           },
-          () => {
-            match progress.phase {
+          error => {
+            previous_streamed = match progress.phase {
               Sse(sse) => sse.event_count > 0 || sse.buffered_data
               Decode(event_count~, ..) => event_count > 0
               Connect | WriteRequest | ResponseHeaders | ResponseBody => false
             }
+            retry_reason = match error {
+              IdleTimeout(context, timeout_ms) =>
+                "\{context} idle for \{timeout_ms}ms"
+              StreamEnded => "DeepSeek stream ended before [DONE]"
+              StreamTransport(detail) =>
+                "DeepSeek stream transport error: \{detail}"
+              HttpStatusError(code, body) =>
+                "DeepSeek API error \{code}: \{body}"
+              error => "\{error}"
+            }
+            // Malformed SSE and callback failures are plain Failure values and
+            // remain final. Only transport, EOF, and idle-timeout failures may
+            // cross a boundary after output has started.
+            let retryable_stream_error = match error {
+              IdleTimeout(_, _) | StreamEnded | StreamTransport(_) => true
+              _ => false
+            }
+            previous_streamed &&
+            (stream.on_retry is None || !retryable_stream_error)
           },
           progress~,
         ) catch {

--- a/deepseek/client/client_retry_test.mbt
+++ b/deepseek/client/client_retry_test.mbt
@@ -279,18 +279,22 @@ async test "streaming chat retries after a delta when the consumer opts in" {
       retry_backoff_ms=1,
     )
     let deltas : Array[String] = []
-    let mut retries = 0
+    let retries : Array[String] = []
     let response = client.chat(
       [ChatMessage(User, content="hello")],
-      stream=StreamHandler(on_content_delta=delta => deltas.push(delta), on_retry=() => {
+      stream=StreamHandler(on_content_delta=delta => deltas.push(delta), on_retry=(
+        attempt,
+        max_attempts,
+        reason,
+      ) => {
         deltas.clear()
-        retries += 1
+        retries.push("\{attempt}/\{max_attempts}: \{reason}")
       }),
     )
     assert_eq(response.content, "replacement")
     assert_eq(deltas.join("|"), "replacement")
     assert_eq(hits.val, 2)
-    assert_eq(retries, 1)
+    assert_eq(retries, ["2/3: Stream ended before [DONE]"])
   }
 }
 

--- a/deepseek/client/client_retry_test.mbt
+++ b/deepseek/client/client_retry_test.mbt
@@ -279,24 +279,18 @@ async test "streaming chat retries after a delta when the consumer opts in" {
       retry_backoff_ms=1,
     )
     let deltas : Array[String] = []
-    let retries : Array[String] = []
+    let mut retries = 0
     let response = client.chat(
       [ChatMessage(User, content="hello")],
-      stream=StreamHandler(on_content_delta=delta => deltas.push(delta), on_retry=(
-        attempt,
-        max_attempts,
-        reason,
-      ) => {
+      stream=StreamHandler(on_content_delta=delta => deltas.push(delta), on_retry=() => {
         deltas.clear()
-        retries.push("\{attempt}/\{max_attempts}: \{reason}")
+        retries += 1
       }),
     )
     assert_eq(response.content, "replacement")
     assert_eq(deltas.join("|"), "replacement")
     assert_eq(hits.val, 2)
-    assert_eq(retries.length(), 1)
-    assert_true(retries[0].has_prefix("2/3: "))
-    assert_true(retries[0].contains("ended before [DONE]"))
+    assert_eq(retries, 1)
   }
 }
 

--- a/deepseek/client/client_retry_test.mbt
+++ b/deepseek/client/client_retry_test.mbt
@@ -239,6 +239,68 @@ async test "streaming chat never retries after the first delta" {
 }
 
 ///|
+/// A consumer that supplies `on_retry` promises to discard every delta from
+/// the failed attempt. That makes a transport/EOF interruption replayable: the
+/// callback clears "partial" before the second request delivers "replacement".
+async test "streaming chat retries after a delta when the consumer opts in" {
+  @async.with_task_group() <| group => {
+    guard bind_test_server("local TCP bind unavailable; skipping retry test")
+      is Some(server) else {
+      return
+    }
+    let hits : Ref[Int] = { val: 0, }
+    group.spawn_bg(no_wait=true) <| () => {
+      server.run_forever(
+        (_request, body, conn) => {
+          let _ = body.read_all()
+          hits.val += 1
+          conn.send_response(200, "OK", extra_headers={
+            "Content-Type": "text/event-stream",
+          })
+          if hits.val == 1 {
+            conn.write(
+              "data: {\"choices\":[{\"delta\":{\"content\":\"partial\"}}]}\n\n",
+            )
+          } else {
+            conn.write(
+              "data: {\"choices\":[{\"delta\":{\"content\":\"replacement\"}}]}\n\n",
+            )
+            conn.write("data: [DONE]\n\n")
+          }
+        },
+        max_connections=8,
+      )
+    }
+    let url = "http://127.0.0.1:\{server.addr.port()}/chat/completions"
+    let client = @client.Client(
+      api_key="test-key",
+      api_url=url,
+      retry_attempts=3,
+      retry_backoff_ms=1,
+    )
+    let deltas : Array[String] = []
+    let retries : Array[String] = []
+    let response = client.chat(
+      [ChatMessage(User, content="hello")],
+      stream=StreamHandler(on_content_delta=delta => deltas.push(delta), on_retry=(
+        attempt,
+        max_attempts,
+        reason,
+      ) => {
+        deltas.clear()
+        retries.push("\{attempt}/\{max_attempts}: \{reason}")
+      }),
+    )
+    assert_eq(response.content, "replacement")
+    assert_eq(deltas.join("|"), "replacement")
+    assert_eq(hits.val, 2)
+    assert_eq(retries.length(), 1)
+    assert_true(retries[0].has_prefix("2/3: "))
+    assert_true(retries[0].contains("ended before [DONE]"))
+  }
+}
+
+///|
 /// Tool-call deltas carry no text, so the content callbacks never fire —
 /// but they are model output all the same. A stream that emits only a
 /// tool-call delta and then drops must surface the failure rather than

--- a/deepseek/client/diagnostics.mbt
+++ b/deepseek/client/diagnostics.mbt
@@ -53,6 +53,18 @@ fn RequestProgress::begin_attempt(self : Self) -> Unit {
 }
 
 ///|
+/// Whether the current attempt received any SSE event (or part of one). The
+/// completion is then running and billed, so replaying it is unsafe unless the
+/// consumer promised to discard what it already received.
+fn RequestProgress::streamed(self : Self) -> Bool {
+  match self.phase {
+    Sse(sse) => sse.event_count > 0 || sse.buffered_data
+    Decode(event_count~, ..) => event_count > 0
+    Connect | WriteRequest | ResponseHeaders | ResponseBody => false
+  }
+}
+
+///|
 fn RequestProgress::failure_message(
   self : Self,
   client : Client,

--- a/deepseek/client/diagnostics.mbt
+++ b/deepseek/client/diagnostics.mbt
@@ -64,6 +64,7 @@ fn RequestProgress::failure_message(
       "Request idle for \{timeout_ms} ms: \{context}"
     HttpStatusError(code, body) => "HTTP \{code}: \{body}"
     StreamEnded => "Stream ended before [DONE]"
+    StreamTransport(detail) => "Stream transport error: \{detail}"
     @http.IncorrectBodyLength => "HTTP response body length mismatch"
     error => "\{@debug.Repr(error)}"
   }

--- a/deepseek/client/diagnostics.mbt
+++ b/deepseek/client/diagnostics.mbt
@@ -65,21 +65,28 @@ fn RequestProgress::streamed(self : Self) -> Bool {
 }
 
 ///|
+/// One line naming what went wrong, for both the final failure message and
+/// the retry notice. Preserves the original payload, including errors not
+/// classified here.
+fn error_detail(error : Error) -> String {
+  match error {
+    IdleTimeout(context, timeout_ms) =>
+      "Request idle for \{timeout_ms} ms: \{context}"
+    HttpStatusError(code, body) => "HTTP \{code}: \{body}"
+    StreamEnded => "Stream ended before [DONE]"
+    StreamTransport(cause) => "Stream transport error: \{@debug.Repr(cause)}"
+    @http.IncorrectBodyLength => "HTTP response body length mismatch"
+    error => "\{@debug.Repr(error)}"
+  }
+}
+
+///|
 fn RequestProgress::failure_message(
   self : Self,
   client : Client,
   error : Error,
 ) -> String {
-  // Preserve the original payload, including errors not classified here.
-  let detail = match error {
-    IdleTimeout(context, timeout_ms) =>
-      "Request idle for \{timeout_ms} ms: \{context}"
-    HttpStatusError(code, body) => "HTTP \{code}: \{body}"
-    StreamEnded => "Stream ended before [DONE]"
-    StreamTransport(detail) => "Stream transport error: \{detail}"
-    @http.IncorrectBodyLength => "HTTP response body length mismatch"
-    error => "\{@debug.Repr(error)}"
-  }
+  let detail = error_detail(error)
   let reason = match self.stop_reason {
     StreamStarted => "Not retried because response data was already received."
     NotRetryable => "This error cannot be retried automatically."

--- a/deepseek/client/moon.pkg
+++ b/deepseek/client/moon.pkg
@@ -3,6 +3,7 @@ import {
   "moonbitlang/async",
   "moonbitlang/async/http",
   "moonbitlang/async/io",
+  "moonbitlang/async/os_error",
   "moonbitlang/core/json",
   "moonbitlang/core/debug",
 }

--- a/deepseek/client/pkg.generated.mbti
+++ b/deepseek/client/pkg.generated.mbti
@@ -27,7 +27,7 @@ pub fn Client::to_repr(Self) -> @debug.Repr
 pub struct StreamHandler {
   // private fields
 }
-pub fn StreamHandler::StreamHandler(on_content_delta~ : async (String) -> Unit, on_reasoning_delta? : async (String) -> Unit) -> Self
+pub fn StreamHandler::StreamHandler(on_content_delta~ : async (String) -> Unit, on_reasoning_delta? : async (String) -> Unit, on_retry? : (Int, Int, String) -> Unit) -> Self
 
 // Type aliases
 

--- a/deepseek/client/pkg.generated.mbti
+++ b/deepseek/client/pkg.generated.mbti
@@ -27,7 +27,7 @@ pub fn Client::to_repr(Self) -> @debug.Repr
 pub struct StreamHandler {
   // private fields
 }
-pub fn StreamHandler::StreamHandler(on_content_delta~ : async (String) -> Unit, on_reasoning_delta? : async (String) -> Unit, on_retry? : () -> Unit) -> Self
+pub fn StreamHandler::StreamHandler(on_content_delta~ : async (String) -> Unit, on_reasoning_delta? : async (String) -> Unit, on_retry? : (Int, Int, String) -> Unit) -> Self
 
 // Type aliases
 

--- a/deepseek/client/pkg.generated.mbti
+++ b/deepseek/client/pkg.generated.mbti
@@ -27,7 +27,7 @@ pub fn Client::to_repr(Self) -> @debug.Repr
 pub struct StreamHandler {
   // private fields
 }
-pub fn StreamHandler::StreamHandler(on_content_delta~ : async (String) -> Unit, on_reasoning_delta? : async (String) -> Unit, on_retry? : (Int, Int, String) -> Unit) -> Self
+pub fn StreamHandler::StreamHandler(on_content_delta~ : async (String) -> Unit, on_reasoning_delta? : async (String) -> Unit, on_retry? : () -> Unit) -> Self
 
 // Type aliases
 

--- a/deepseek/client/stream.mbt
+++ b/deepseek/client/stream.mbt
@@ -236,12 +236,13 @@ async fn read_stream_line(
       @async.with_timeout_opt(idle_timeout_ms, () => reader.read_until("\n"))
     }
   } catch {
-    error if @async.is_being_cancelled() || @async.is_cancellation_error(error) =>
-      raise error
+    error if @async.is_being_cancelled() => raise error
     // A socket reset/close while reading is the same retry class as EOF and an
-    // idle timeout; keeping it out of `Failure` lets `Client::chat` tell it
-    // apart from callback and malformed-SSE failures.
-    error => raise StreamTransport("\{error}")
+    // idle timeout. Only those are re-tagged: HTTP framing errors and anything
+    // else the reader raises are deterministic and stay non-replayable.
+    @io.ReaderClosed | @os_error.OSError(_) as cause =>
+      raise StreamTransport(cause)
+    error => raise error
   }
 }
 

--- a/deepseek/client/stream.mbt
+++ b/deepseek/client/stream.mbt
@@ -229,10 +229,20 @@ async fn read_stream_line(
   reader : @http.Client,
   idle_timeout_ms : Int,
 ) -> String?? {
-  if idle_timeout_ms <= 0 {
-    Some(reader.read_until("\n"))
-  } else {
-    @async.with_timeout_opt(idle_timeout_ms, () => reader.read_until("\n"))
+  try {
+    if idle_timeout_ms <= 0 {
+      Some(reader.read_until("\n"))
+    } else {
+      @async.with_timeout_opt(idle_timeout_ms, () => reader.read_until("\n"))
+    }
+  } catch {
+    error if @async.is_being_cancelled() || @async.is_cancellation_error(error) =>
+      raise error
+    // A socket reset/close while reading is the same retry class as EOF and an
+    // idle timeout. Keeping it out of `Failure` lets an opted-in stream owner
+    // discard the failed attempt, while callback and malformed-SSE failures
+    // remain final even after output has started.
+    error => raise StreamTransport("\{error}")
   }
 }
 

--- a/deepseek/client/stream.mbt
+++ b/deepseek/client/stream.mbt
@@ -239,9 +239,8 @@ async fn read_stream_line(
     error if @async.is_being_cancelled() || @async.is_cancellation_error(error) =>
       raise error
     // A socket reset/close while reading is the same retry class as EOF and an
-    // idle timeout. Keeping it out of `Failure` lets an opted-in stream owner
-    // discard the failed attempt, while callback and malformed-SSE failures
-    // remain final even after output has started.
+    // idle timeout; keeping it out of `Failure` lets `Client::chat` tell it
+    // apart from callback and malformed-SSE failures.
     error => raise StreamTransport("\{error}")
   }
 }

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -87,6 +87,11 @@ terminal boundary, so an older commit cannot be mistaken for the next step and
 a finish cannot outrun the canonical row. The UI likewise renders
 `assistant_delta` as a live answer bubble, while durable `session.event`
 commits remain the only permanent transcript source.
+If the provider request fails and the engine decides to retry, `stream_retry`
+clears both live previews and the heartbeat reads "Retrying · attempt 2/5 ·
+reason" until the replacement attempt streams its first delta. It leaves the
+current model step and all durable rows untouched; the retry notice is live
+state and is not written to `session.jsonl`.
 
 While a turn runs, the composer exposes a **Steer now / Queue next** selector
 beside Send. It starts from Settings → Interface → Follow-up messages, applies

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -89,7 +89,8 @@ a finish cannot outrun the canonical row. The UI likewise renders
 commits remain the only permanent transcript source.
 If the provider request fails and the engine decides to retry, `stream_retry`
 clears both live previews and the heartbeat reads "Retrying · attempt 2/5 ·
-reason" until the replacement attempt streams its first delta. It leaves the
+reason" until the engine next reports progress on that request (a delta, the
+response's usage, a tool result, or the next step). It leaves the
 current model step and all durable rows untouched; the retry notice is live
 state and is not written to `session.jsonl`.
 

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -87,6 +87,10 @@ terminal boundary, so an older commit cannot be mistaken for the next step and
 a finish cannot outrun the canonical row. The UI likewise renders
 `assistant_delta` as a live answer bubble, while durable `session.event`
 commits remain the only permanent transcript source.
+If the provider stream is interrupted, `stream_retry` clears both live previews
+before the replacement attempt starts. It leaves the current model step and all
+durable rows untouched; the retry boundary is live state and is not written to
+`session.jsonl`.
 
 While a turn runs, the composer exposes a **Steer now / Queue next** selector
 beside Send. It starts from Settings → Interface → Follow-up messages, applies

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -87,10 +87,6 @@ terminal boundary, so an older commit cannot be mistaken for the next step and
 a finish cannot outrun the canonical row. The UI likewise renders
 `assistant_delta` as a live answer bubble, while durable `session.event`
 commits remain the only permanent transcript source.
-If the provider stream is interrupted, `stream_retry` clears both live previews
-before the replacement attempt starts. It leaves the current model step and all
-durable rows untouched; the retry boundary is live state and is not written to
-`session.jsonl`.
 
 While a turn runs, the composer exposes a **Steer now / Queue next** selector
 beside Send. It starts from Settings → Interface → Follow-up messages, applies

--- a/desktop/frontend/composer/component_wbtest.mbt
+++ b/desktop/frontend/composer/component_wbtest.mbt
@@ -419,6 +419,12 @@ test "the heartbeat reports only the detail it actually has" {
   }
   assert_eq(bare(Starting), "Starting…")
   assert_eq(bare(AtStep(3)), "Working · step 3")
+  assert_eq(
+    bare(
+      Retrying(attempt=2, max_attempts=5, reason="Stream ended before [DONE]"),
+    ),
+    "Retrying · attempt 2/5 · Stream ended before [DONE]",
+  )
   assert_eq(bare(Working), "Working…")
   assert_eq(bare(Stopping), "Stopping…")
 }

--- a/desktop/frontend/composer/contract.mbt
+++ b/desktop/frontend/composer/contract.mbt
@@ -189,6 +189,9 @@ pub(all) enum RunStage {
   Thinking
   // The engine's latest 1-based step counter.
   AtStep(Int)
+  // The step's provider request failed and the engine is waiting out its
+  // backoff before attempt `attempt` of `max_attempts`.
+  Retrying(attempt~ : Int, max_attempts~ : Int, reason~ : String)
   // Open and stepping, from an engine that does not number its steps.
   Working
   // A Stop was sent and the engine has not honored it yet.

--- a/desktop/frontend/composer/pkg.generated.mbti
+++ b/desktop/frontend/composer/pkg.generated.mbti
@@ -274,6 +274,7 @@ pub(all) enum RunStage {
   Starting
   Thinking
   AtStep(Int)
+  Retrying(attempt~ : Int, max_attempts~ : Int, reason~ : String)
   Working
   Stopping
 } derive(Eq, @debug.Debug)

--- a/desktop/frontend/composer/view.mbt
+++ b/desktop/frontend/composer/view.mbt
@@ -825,6 +825,8 @@ fn RunHeartbeat::label(self : RunHeartbeat, clock_ms~ : Double) -> String {
     Starting => "Starting…"
     Thinking => "Thinking…"
     AtStep(step) => "Working · step \{step}"
+    Retrying(attempt~, max_attempts~, reason~) =>
+      "Retrying · attempt \{attempt}/\{max_attempts} · \{reason}"
     Working => "Working…"
     Stopping => "Stopping…"
   }

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -705,6 +705,15 @@ priv struct LiveReasoning {
 } derive(Eq, Debug)
 
 ///|
+/// A provider retry the engine announced for the open step: the attempt about
+/// to be made, out of the client's budget, and why the last one failed.
+priv struct RetryNotice {
+  attempt : Int
+  max_attempts : Int
+  reason : String
+} derive(Eq)
+
+///|
 /// Everything that belongs to one turn and to nothing outside it.
 ///
 /// It is replaced wholesale when a run opens, so a fragment or token count
@@ -727,6 +736,10 @@ priv struct RunState {
   // sole history; rendering de-duplicates an equal completed preview without
   // letting the untagged commit mutate this run-scoped state.
   live_reasoning : LiveReasoning?
+  // The retry the engine is waiting out, from `stream_retry` until the
+  // replacement attempt produces a delta or the step moves on. Shown in place
+  // of the step heartbeat so a backoff does not read as a hang.
+  retrying : RetryNotice?
   // Highest durable event already known when this run opened. Only reasoning
   // committed after this frontier can visually de-duplicate this run's sealed
   // preview; identical text from an earlier turn is unrelated.
@@ -745,6 +758,7 @@ fn RunState::empty() -> RunState {
   {
     streaming_response: None,
     live_reasoning: None,
+    retrying: None,
     reasoning_frontier: 0,
     subruns: [],
     usage_tokens: 0,
@@ -3737,6 +3751,17 @@ fn Conversation::run_heartbeat(self : Conversation) -> @composer.RunHeartbeat? {
     Open(stage=AtStep(None), ..) => Working
     Open(stage=Cancelling, ..) => Stopping
   }
+  // A pending retry replaces the step wording; a Stop already sent still wins.
+  let stage : @composer.RunStage = if self.turn.retrying is Some(retrying) &&
+    !(stage is Stopping) {
+    Retrying(
+      attempt=retrying.attempt,
+      max_attempts=retrying.max_attempts,
+      reason=retrying.reason,
+    )
+  } else {
+    stage
+  }
   Some({
     stage,
     started_ms: self.run_started_ms,
@@ -3748,7 +3773,12 @@ fn Conversation::run_heartbeat(self : Conversation) -> @composer.RunHeartbeat? {
 fn Conversation::clear_streams(self : Conversation) -> Conversation {
   {
     ..self,
-    turn: { ..self.turn, streaming_response: None, live_reasoning: None, },
+    turn: {
+      ..self.turn,
+      streaming_response: None,
+      live_reasoning: None,
+      retrying: None,
+    },
   }
 }
 

--- a/desktop/frontend/transcript/engine_event.mbt
+++ b/desktop/frontend/transcript/engine_event.mbt
@@ -8,6 +8,10 @@ pub(all) enum EngineEvent {
   // carries it (`AtStep`) is: every engine that emits `agent_step` has
   // numbered it (1f761102, the commit that introduced both).
   AgentStep(Int?)
+  // The provider request for the current step failed and is being retried.
+  // The view discards the failed attempt's transient streams and shows the
+  // retry while the engine waits out its backoff.
+  StreamRetry(attempt~ : Int, max_attempts~ : Int, reason~ : String)
   AssistantDelta(String)
   ReasoningDelta(String)
   ReasoningMessage(String)
@@ -98,6 +102,8 @@ pub fn decode_engine_event(
 ) -> EngineEvent? {
   match stream.event {
     AgentStep(step~) => Some(AgentStep(Some(step)))
+    StreamRetry(attempt~, max_attempts~, reason~) =>
+      Some(StreamRetry(attempt~, max_attempts~, reason~))
     AssistantDelta(content~) => Some(AssistantDelta(content))
     ReasoningDelta(content~) => Some(ReasoningDelta(content))
     ReasoningMessage(content~) => Some(ReasoningMessage(content))
@@ -216,6 +222,23 @@ fn event_fields(json : Json) -> @desktop_protocol.AgentStreamEvent raise {
 
 ///|
 test "decode recognizes the streaming events" {
+  assert_true(
+    decode_engine_event(
+      event_fields({
+        "event": "stream_retry",
+        "attempt": 2,
+        "max_attempts": 5,
+        "reason": "Stream ended before [DONE]",
+      }),
+    )
+    is Some(
+      StreamRetry(
+        attempt=2,
+        max_attempts=5,
+        reason="Stream ended before [DONE]"
+      )
+    ),
+  )
   guard decode_engine_event(
       event_fields({ "event": "assistant_delta", "content": "abc" }),
     )

--- a/desktop/frontend/transcript/engine_event.mbt
+++ b/desktop/frontend/transcript/engine_event.mbt
@@ -8,6 +8,9 @@ pub(all) enum EngineEvent {
   // carries it (`AtStep`) is: every engine that emits `agent_step` has
   // numbered it (1f761102, the commit that introduced both).
   AgentStep(Int?)
+  // A retry boundary within the same step. Attempt metadata stays on the wire;
+  // the view only needs to discard the failed attempt's transient streams.
+  StreamRetry
   AssistantDelta(String)
   ReasoningDelta(String)
   ReasoningMessage(String)
@@ -98,6 +101,7 @@ pub fn decode_engine_event(
 ) -> EngineEvent? {
   match stream.event {
     AgentStep(step~) => Some(AgentStep(Some(step)))
+    StreamRetry(..) => Some(StreamRetry)
     AssistantDelta(content~) => Some(AssistantDelta(content))
     ReasoningDelta(content~) => Some(ReasoningDelta(content))
     ReasoningMessage(content~) => Some(ReasoningMessage(content))
@@ -216,6 +220,17 @@ fn event_fields(json : Json) -> @desktop_protocol.AgentStreamEvent raise {
 
 ///|
 test "decode recognizes the streaming events" {
+  guard decode_engine_event(
+      event_fields({
+        "event": "stream_retry",
+        "attempt": 2,
+        "max_attempts": 3,
+        "reason": "ConnectionClosed",
+      }),
+    )
+    is Some(StreamRetry) else {
+    fail("stream_retry not decoded")
+  }
   guard decode_engine_event(
       event_fields({ "event": "assistant_delta", "content": "abc" }),
     )

--- a/desktop/frontend/transcript/engine_event.mbt
+++ b/desktop/frontend/transcript/engine_event.mbt
@@ -8,9 +8,6 @@ pub(all) enum EngineEvent {
   // carries it (`AtStep`) is: every engine that emits `agent_step` has
   // numbered it (1f761102, the commit that introduced both).
   AgentStep(Int?)
-  // A retry boundary within the same step. Attempt metadata stays on the wire;
-  // the view only needs to discard the failed attempt's transient streams.
-  StreamRetry
   AssistantDelta(String)
   ReasoningDelta(String)
   ReasoningMessage(String)
@@ -101,7 +98,6 @@ pub fn decode_engine_event(
 ) -> EngineEvent? {
   match stream.event {
     AgentStep(step~) => Some(AgentStep(Some(step)))
-    StreamRetry(..) => Some(StreamRetry)
     AssistantDelta(content~) => Some(AssistantDelta(content))
     ReasoningDelta(content~) => Some(ReasoningDelta(content))
     ReasoningMessage(content~) => Some(ReasoningMessage(content))
@@ -220,17 +216,6 @@ fn event_fields(json : Json) -> @desktop_protocol.AgentStreamEvent raise {
 
 ///|
 test "decode recognizes the streaming events" {
-  guard decode_engine_event(
-      event_fields({
-        "event": "stream_retry",
-        "attempt": 2,
-        "max_attempts": 3,
-        "reason": "ConnectionClosed",
-      }),
-    )
-    is Some(StreamRetry) else {
-    fail("stream_retry not decoded")
-  }
   guard decode_engine_event(
       event_fields({ "event": "assistant_delta", "content": "abc" }),
     )

--- a/desktop/frontend/transcript/pkg.generated.mbti
+++ b/desktop/frontend/transcript/pkg.generated.mbti
@@ -33,6 +33,7 @@ pub fn subrun_parent(String) -> String?
 // Types and methods
 pub(all) enum EngineEvent {
   AgentStep(Int?)
+  StreamRetry(attempt~ : Int, max_attempts~ : Int, reason~ : String)
   AssistantDelta(String)
   ReasoningDelta(String)
   ReasoningMessage(String)

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1099,6 +1099,23 @@ fn apply_engine_event(
         },
       )
     }
+    // The engine is waiting out a backoff before reopening this step's
+    // provider request. Drop every delta of the failed attempt so the
+    // replacement stream cannot be concatenated with it, and show the retry
+    // in the heartbeat; the step and every durable row stay as they are.
+    StreamRetry(attempt~, max_attempts~, reason~) => {
+      let cleared = conv.clear_streams()
+      (
+        None,
+        {
+          ..cleared,
+          turn: {
+            ..cleared.turn,
+            retrying: Some({ attempt, max_attempts, reason, }),
+          },
+        },
+      )
+    }
     AssistantDelta(content) =>
       if content.is_empty() {
         (None, conv)
@@ -1109,7 +1126,11 @@ fn apply_engine_event(
           None,
           {
             ..conv,
-            turn: { ..conv.turn, streaming_response: Some(carried + content), },
+            turn: {
+              ..conv.turn,
+              streaming_response: Some(carried + content),
+              retrying: None,
+            },
           },
         )
       }
@@ -1134,6 +1155,7 @@ fn apply_engine_event(
                 content: carried + content,
                 complete: false,
               }),
+              retrying: None,
             },
           },
         )
@@ -9086,6 +9108,60 @@ test "a new agent step clears the live stream" {
 }
 
 ///|
+test "a stream retry clears previews and shows the retry until a delta lands" {
+  let dispatch = test_dispatch()
+  let model = running_model().replace_conversation({
+    ..running_conversation(),
+    run: Open(run_id="r7", stage=AtStep(Some(2))),
+    turn: {
+      ..running_conversation().turn,
+      streaming_response: Some("left"),
+      live_reasoning: Some({ content: "old thought", complete: false, }),
+    },
+  })
+  let (_, retrying) = update_dev(
+    dispatch,
+    Engine(
+      Some("r7"),
+      StreamRetry(
+        attempt=2,
+        max_attempts=5,
+        reason="Stream ended before [DONE]",
+      ),
+      session=None,
+    ),
+    model,
+  )
+  let conv = retrying.active()
+  assert_eq(conv.turn.streaming_response, None)
+  assert_eq(conv.turn.live_reasoning, None)
+  assert_true(conv.run is Open(run_id="r7", stage=AtStep(Some(2))))
+  assert_true(
+    conv.run_heartbeat()
+    is Some(
+      {
+        stage: Retrying(
+          attempt=2,
+          max_attempts=5,
+          reason="Stream ended before [DONE]"
+        ),
+        ..
+      }
+    ),
+  )
+  // The replacement attempt's first delta ends the notice.
+  let (_, streaming) = update_dev(
+    dispatch,
+    Engine(Some("r7"), AssistantDelta("again"), session=None),
+    retrying,
+  )
+  assert_eq(streaming.active().turn.streaming_response, Some("again"))
+  assert_true(
+    streaming.active().run_heartbeat() is Some({ stage: AtStep(2), .. }),
+  )
+}
+
+///|
 test "finished run clears any leftover stream" {
   let dispatch = test_dispatch()
   let model = running_model().replace_conversation({
@@ -11335,6 +11411,7 @@ test "a run boundary discards the previous turn's live state whole" {
     turn: {
       streaming_response: Some("old answer fragment"),
       live_reasoning: None,
+      retrying: None,
       reasoning_frontier: 0,
       subruns: [lane],
       usage_tokens: 4200,

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1099,11 +1099,6 @@ fn apply_engine_event(
         },
       )
     }
-    StreamRetry =>
-      // The provider is reopening only this chat request. Keep the run and its
-      // step/frontier intact, but remove every delta from the failed attempt so
-      // the replacement stream cannot be concatenated with it.
-      (None, conv.clear_streams())
     AssistantDelta(content) =>
       if content.is_empty() {
         (None, conv)
@@ -9088,28 +9083,6 @@ test "a new agent step clears the live stream" {
     model,
   )
   assert_eq(next.active().turn.streaming_response, None)
-}
-
-///|
-test "a stream retry clears previews without changing the step" {
-  let dispatch = test_dispatch()
-  let model = running_model().replace_conversation({
-    ..running_conversation(),
-    run: Open(run_id="r7", stage=AtStep(Some(2))),
-    turn: {
-      ..running_conversation().turn,
-      streaming_response: Some("left"),
-      live_reasoning: Some({ content: "old thought", complete: false, }),
-    },
-  })
-  let (_, next) = update_dev(
-    dispatch,
-    Engine(Some("r7"), StreamRetry, session=None),
-    model,
-  )
-  assert_eq(next.active().turn.streaming_response, None)
-  assert_eq(next.active().turn.live_reasoning, None)
-  assert_true(next.active().run is Open(run_id="r7", stage=AtStep(Some(2))))
 }
 
 ///|

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1069,6 +1069,45 @@ fn send_goal(
 }
 
 ///|
+/// Whether an engine event reports progress on the open step's model request,
+/// which ends a pending retry notice: the replacement attempt produced output
+/// or completed (a tool-only response has no deltas, so its usage report or
+/// tool result is the first sign), or the step moved on or the run ended.
+/// Events about other work in the same run say nothing about that request.
+fn ends_retry(event : @transcript.EngineEvent) -> Bool {
+  match event {
+    AssistantDelta(_)
+    | ReasoningDelta(_)
+    | ReasoningMessage(_)
+    | AssistantMessage(_)
+    | Usage(..)
+    | ToolResult(..)
+    | ToolCallDecodeError(..)
+    | AgentStep(_)
+    | AgentFinished(_)
+    | ContextYield(_)
+    | AgentAborted(_)
+    | MaxStepsExhausted
+    | AgentSetupFailed(_) => true
+    StreamRetry(..)
+    | BackgroundNotice(_)
+    | SubrunOpened(..)
+    | SubrunClosed(..)
+    | WorkflowOpened(..)
+    | WorkflowClosed(..)
+    | SteerApplied(..)
+    | SteerDropped(..)
+    | AutoCompactionFinished(_)
+    | CompactionStarted
+    | CompactionFinished(_)
+    | CompactionFailed(_)
+    | ApprovalRequested(..)
+    | ApprovalResolved(..)
+    | SessionAppendFailed(_) => false
+  }
+}
+
+///|
 /// Fold one engine event into its conversation. Returns the new conversation
 /// and, when the event reported a failure the durable record will never carry,
 /// the text to raise as a toast — the caller owns the dispatch a toast needs.
@@ -1077,6 +1116,13 @@ fn apply_engine_event(
   event : @transcript.EngineEvent,
   event_run_id : String?,
 ) -> (String?, Conversation) {
+  // A retry notice lasts until the engine reports progress on the request it
+  // is retrying; events about other work in the run leave it in place.
+  let conv = if ends_retry(event) {
+    { ..conv, turn: { ..conv.turn, retrying: None, }, }
+  } else {
+    conv
+  }
   match event {
     AgentStep(step) => {
       // The next model request starts after every durable commit this page
@@ -1102,7 +1148,8 @@ fn apply_engine_event(
     // The engine is waiting out a backoff before reopening this step's
     // provider request. Drop every delta of the failed attempt so the
     // replacement stream cannot be concatenated with it, and show the retry
-    // in the heartbeat; the step and every durable row stay as they are.
+    // in the heartbeat until `ends_retry`; the step and every durable row
+    // stay as they are.
     StreamRetry(attempt~, max_attempts~, reason~) => {
       let cleared = conv.clear_streams()
       (
@@ -1126,11 +1173,7 @@ fn apply_engine_event(
           None,
           {
             ..conv,
-            turn: {
-              ..conv.turn,
-              streaming_response: Some(carried + content),
-              retrying: None,
-            },
+            turn: { ..conv.turn, streaming_response: Some(carried + content), },
           },
         )
       }
@@ -1155,7 +1198,6 @@ fn apply_engine_event(
                 content: carried + content,
                 complete: false,
               }),
-              retrying: None,
             },
           },
         )
@@ -9158,6 +9200,49 @@ test "a stream retry clears previews and shows the retry until a delta lands" {
   assert_eq(streaming.active().turn.streaming_response, Some("again"))
   assert_true(
     streaming.active().run_heartbeat() is Some({ stage: AtStep(2), .. }),
+  )
+}
+
+///|
+test "a retry notice ends at the model's next progress, not at unrelated events" {
+  let dispatch = test_dispatch()
+  let model = running_model().replace_conversation({
+    ..running_conversation(),
+    run: Open(run_id="r7", stage=AtStep(Some(2))),
+  })
+  let (_, retrying) = update_dev(
+    dispatch,
+    Engine(
+      Some("r7"),
+      StreamRetry(attempt=2, max_attempts=5, reason="connection reset"),
+      session=None,
+    ),
+    model,
+  )
+  // A background job finishing while the engine waits says nothing about
+  // the request being retried.
+  let (_, still) = update_dev(
+    dispatch,
+    Engine(Some("r7"), BackgroundNotice("job done"), session=None),
+    retrying,
+  )
+  assert_true(
+    still.active().run_heartbeat()
+    is Some({ stage: Retrying(attempt=2, ..), .. }),
+  )
+  // A tool-only response streams no deltas; its usage report is the first
+  // sign the replacement attempt completed.
+  let (_, resumed) = update_dev(
+    dispatch,
+    Engine(
+      Some("r7"),
+      Usage(prompt_tokens=10, completion_tokens=5),
+      session=None,
+    ),
+    still,
+  )
+  assert_true(
+    resumed.active().run_heartbeat() is Some({ stage: AtStep(2), .. }),
   )
 }
 

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1099,6 +1099,11 @@ fn apply_engine_event(
         },
       )
     }
+    StreamRetry =>
+      // The provider is reopening only this chat request. Keep the run and its
+      // step/frontier intact, but remove every delta from the failed attempt so
+      // the replacement stream cannot be concatenated with it.
+      (None, conv.clear_streams())
     AssistantDelta(content) =>
       if content.is_empty() {
         (None, conv)
@@ -9083,6 +9088,28 @@ test "a new agent step clears the live stream" {
     model,
   )
   assert_eq(next.active().turn.streaming_response, None)
+}
+
+///|
+test "a stream retry clears previews without changing the step" {
+  let dispatch = test_dispatch()
+  let model = running_model().replace_conversation({
+    ..running_conversation(),
+    run: Open(run_id="r7", stage=AtStep(Some(2))),
+    turn: {
+      ..running_conversation().turn,
+      streaming_response: Some("left"),
+      live_reasoning: Some({ content: "old thought", complete: false, }),
+    },
+  })
+  let (_, next) = update_dev(
+    dispatch,
+    Engine(Some("r7"), StreamRetry, session=None),
+    model,
+  )
+  assert_eq(next.active().turn.streaming_response, None)
+  assert_eq(next.active().turn.live_reasoning, None)
+  assert_true(next.active().run is Open(run_id="r7", stage=AtStep(Some(2))))
 }
 
 ///|

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -83,8 +83,16 @@ and `context_yield` are omitted. The separate `agent.finished` lifecycle
 notification remains, including its optional `answer`;
 `compaction_finished` remains with an empty `summary` so it still closes the
 lifecycle state. Deltas — including the `reasoning_delta` progress stream —
-usage, step progress, tool-decode errors, runtime status, steer
-receipts, and all other run/compaction lifecycle and error events are unchanged.
+usage, step progress, `stream_retry` boundaries, tool-decode errors, runtime
+status, steer receipts, and all other run/compaction lifecycle and error events
+are unchanged.
+`stream_retry` means the provider request for the current model step failed
+and the engine is waiting out its backoff before attempt `attempt` of
+`max_attempts`: clients must discard that attempt's live reasoning and answer
+deltas and should show the retry (Desktop replaces the step heartbeat with
+"Retrying · attempt 2/5 · reason"), but must not remove durable transcript rows
+or advance the step. It is never a `session.event` and never appears in
+`session.jsonl`.
 Before publishing a new `agent_step` or a successful terminal lifecycle event,
 the Desktop host drains that session's serialized follower. Consequently every
 durable commit preceding the boundary reaches both local and remote clients
@@ -283,7 +291,7 @@ Notifications:
 | method | params |
 |---|---|
 | `agent.started` | `{run_id, submission_id?, session, engine, model, max_steps, session_root?}` — `session_root` is a host-derived durable-store fact, never a client-selected path; the prompt bubble comes from its own `session.event` commit |
-| `agent.event` | `{run_id?, session, event: {…}}` — the engine's event object (`assistant_delta`, `tool_result`, `agent_finished`, …); for a correlated steer receipt the host adds its optional `submission_id`. `run_id` is absent for events emitted before any run of the engine process's lifetime (a compaction on a freshly spawned engine), which route by `session` |
+| `agent.event` | `{run_id?, session, event: {…}}` — the engine's event object (`assistant_delta`, `stream_retry`, `tool_result`, `agent_finished`, …); for a correlated steer receipt the host adds its optional `submission_id`. `stream_retry` carries `{attempt, max_attempts, reason}`: it clears only the failed attempt's transient deltas and announces the retry the engine is waiting to make. `run_id` is absent for events emitted before any run of the engine process's lifetime (a compaction on a freshly spawned engine), which route by `session` |
 | `agent.error` | `{message, run_id?, exit_code?, diagnostics?}` |
 | `agent.finished` | `{run_id, status, answer?, exit_code?}` — the run's outcome, published when the engine's stdout event that ends the turn arrives, or at the engine's death for a turn whose event never came (`failed`). The durable record renders the conversation and never settles a run: the two travel independently, so a client may see this before, after, or without the matching `session.event` commit |
 

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -83,13 +83,8 @@ and `context_yield` are omitted. The separate `agent.finished` lifecycle
 notification remains, including its optional `answer`;
 `compaction_finished` remains with an empty `summary` so it still closes the
 lifecycle state. Deltas — including the `reasoning_delta` progress stream —
-usage, step progress, `stream_retry` boundaries, tool-decode errors, runtime
-status, steer receipts, and all other run/compaction lifecycle and error events
-are unchanged.
-`stream_retry` means the provider request for the current model step is being
-reopened: clients must discard that attempt's live reasoning and answer deltas,
-but must not remove durable transcript rows or advance the step. It is never a
-`session.event` and never appears in `session.jsonl`.
+usage, step progress, tool-decode errors, runtime status, steer
+receipts, and all other run/compaction lifecycle and error events are unchanged.
 Before publishing a new `agent_step` or a successful terminal lifecycle event,
 the Desktop host drains that session's serialized follower. Consequently every
 durable commit preceding the boundary reaches both local and remote clients
@@ -288,7 +283,7 @@ Notifications:
 | method | params |
 |---|---|
 | `agent.started` | `{run_id, submission_id?, session, engine, model, max_steps, session_root?}` — `session_root` is a host-derived durable-store fact, never a client-selected path; the prompt bubble comes from its own `session.event` commit |
-| `agent.event` | `{run_id?, session, event: {…}}` — the engine's event object (`assistant_delta`, `stream_retry`, `tool_result`, `agent_finished`, …); for a correlated steer receipt the host adds its optional `submission_id`. `stream_retry` carries `{attempt, max_attempts, reason}` and clears only the failed attempt's transient deltas. `run_id` is absent for events emitted before any run of the engine process's lifetime (a compaction on a freshly spawned engine), which route by `session` |
+| `agent.event` | `{run_id?, session, event: {…}}` — the engine's event object (`assistant_delta`, `tool_result`, `agent_finished`, …); for a correlated steer receipt the host adds its optional `submission_id`. `run_id` is absent for events emitted before any run of the engine process's lifetime (a compaction on a freshly spawned engine), which route by `session` |
 | `agent.error` | `{message, run_id?, exit_code?, diagnostics?}` |
 | `agent.finished` | `{run_id, status, answer?, exit_code?}` — the run's outcome, published when the engine's stdout event that ends the turn arrives, or at the engine's death for a turn whose event never came (`failed`). The durable record renders the conversation and never settles a run: the two travel independently, so a client may see this before, after, or without the matching `session.event` commit |
 

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -83,8 +83,13 @@ and `context_yield` are omitted. The separate `agent.finished` lifecycle
 notification remains, including its optional `answer`;
 `compaction_finished` remains with an empty `summary` so it still closes the
 lifecycle state. Deltas — including the `reasoning_delta` progress stream —
-usage, step progress, tool-decode errors, runtime status, steer
-receipts, and all other run/compaction lifecycle and error events are unchanged.
+usage, step progress, `stream_retry` boundaries, tool-decode errors, runtime
+status, steer receipts, and all other run/compaction lifecycle and error events
+are unchanged.
+`stream_retry` means the provider request for the current model step is being
+reopened: clients must discard that attempt's live reasoning and answer deltas,
+but must not remove durable transcript rows or advance the step. It is never a
+`session.event` and never appears in `session.jsonl`.
 Before publishing a new `agent_step` or a successful terminal lifecycle event,
 the Desktop host drains that session's serialized follower. Consequently every
 durable commit preceding the boundary reaches both local and remote clients
@@ -283,7 +288,7 @@ Notifications:
 | method | params |
 |---|---|
 | `agent.started` | `{run_id, submission_id?, session, engine, model, max_steps, session_root?}` — `session_root` is a host-derived durable-store fact, never a client-selected path; the prompt bubble comes from its own `session.event` commit |
-| `agent.event` | `{run_id?, session, event: {…}}` — the engine's event object (`assistant_delta`, `tool_result`, `agent_finished`, …); for a correlated steer receipt the host adds its optional `submission_id`. `run_id` is absent for events emitted before any run of the engine process's lifetime (a compaction on a freshly spawned engine), which route by `session` |
+| `agent.event` | `{run_id?, session, event: {…}}` — the engine's event object (`assistant_delta`, `stream_retry`, `tool_result`, `agent_finished`, …); for a correlated steer receipt the host adds its optional `submission_id`. `stream_retry` carries `{attempt, max_attempts, reason}` and clears only the failed attempt's transient deltas. `run_id` is absent for events emitted before any run of the engine process's lifetime (a compaction on a freshly spawned engine), which route by `session` |
 | `agent.error` | `{message, run_id?, exit_code?, diagnostics?}` |
 | `agent.finished` | `{run_id, status, answer?, exit_code?}` — the run's outcome, published when the engine's stdout event that ends the turn arrives, or at the engine's death for a turn whose event never came (`failed`). The durable record renders the conversation and never settles a run: the two travel independently, so a client may see this before, after, or without the matching `session.event` commit |
 

--- a/eval/file_edit/harness/harness.mbt
+++ b/eval/file_edit/harness/harness.mbt
@@ -252,10 +252,9 @@ fn summarize_agent_log(log_text : String) -> AgentLogSummary {
   for line in log_text.split("\n") {
     let json = @json.parse(line.trim()) catch { _ => continue }
     match json {
-      { "event": String("agent_step"), "step": Number(step, ..), .. } => {
+      { "event": String("agent_step"), .. } => {
         has_json_events = true
-        // A retried provider stream re-announces the same step number.
-        steps = steps.max(step.to_int())
+        steps += 1
       }
       {
         "event": String("tool_result"),

--- a/eval/file_edit/harness/harness.mbt
+++ b/eval/file_edit/harness/harness.mbt
@@ -252,9 +252,10 @@ fn summarize_agent_log(log_text : String) -> AgentLogSummary {
   for line in log_text.split("\n") {
     let json = @json.parse(line.trim()) catch { _ => continue }
     match json {
-      { "event": String("agent_step"), .. } => {
+      { "event": String("agent_step"), "step": Number(step, ..), .. } => {
         has_json_events = true
-        steps += 1
+        // A retried provider stream re-announces the same step number.
+        steps = steps.max(step.to_int())
       }
       {
         "event": String("tool_result"),

--- a/protocol/emit/emit_test.mbt
+++ b/protocol/emit/emit_test.mbt
@@ -63,6 +63,11 @@ fn all_events() -> Array[@protocol.Event] {
   [
     AgentSetupFailed(error="boom"),
     AgentStep(step=3),
+    StreamRetry(
+      attempt=2,
+      max_attempts=3,
+      reason="DeepSeek stream transport error: ConnectionClosed",
+    ),
     AgentAborted(reason="interrupted"),
     AgentFinished(answer="done"),
     MaxStepsExhausted,

--- a/protocol/emit/emit_test.mbt
+++ b/protocol/emit/emit_test.mbt
@@ -63,11 +63,6 @@ fn all_events() -> Array[@protocol.Event] {
   [
     AgentSetupFailed(error="boom"),
     AgentStep(step=3),
-    StreamRetry(
-      attempt=2,
-      max_attempts=3,
-      reason="DeepSeek stream transport error: ConnectionClosed",
-    ),
     AgentAborted(reason="interrupted"),
     AgentFinished(answer="done"),
     MaxStepsExhausted,

--- a/protocol/event.mbt
+++ b/protocol/event.mbt
@@ -14,6 +14,14 @@ pub(all) enum Event {
   // ── agent loop ─────────────────────────────────────────────────────────
   AgentSetupFailed(error~ : String)
   AgentStep(step~ : Int)
+  /// The current step's provider request failed and attempt `attempt` (of
+  /// `max_attempts`) is about to be made, after the client's backoff. It is
+  /// emitted when the retry is decided, so a controller can discard the failed
+  /// attempt's live output and show the retry while the client waits. This is
+  /// transient controller state: it is emitted on the live JSONL stream, never
+  /// represented by `agent_session.SessionItem`, and therefore never appended
+  /// to `session.jsonl`.
+  StreamRetry(attempt~ : Int, max_attempts~ : Int, reason~ : String)
   AgentAborted(reason~ : String)
   AgentFinished(answer~ : String)
   MaxStepsExhausted

--- a/protocol/event.mbt
+++ b/protocol/event.mbt
@@ -14,11 +14,6 @@ pub(all) enum Event {
   // ── agent loop ─────────────────────────────────────────────────────────
   AgentSetupFailed(error~ : String)
   AgentStep(step~ : Int)
-  /// The current step is reopening its provider stream after a retryable
-  /// interruption. This is transient controller state: it is emitted on the
-  /// live JSONL stream, never represented by `agent_session.SessionItem`, and
-  /// therefore never appended to `session.jsonl`.
-  StreamRetry(attempt~ : Int, max_attempts~ : Int, reason~ : String)
   AgentAborted(reason~ : String)
   AgentFinished(answer~ : String)
   MaxStepsExhausted

--- a/protocol/event.mbt
+++ b/protocol/event.mbt
@@ -14,6 +14,11 @@ pub(all) enum Event {
   // ── agent loop ─────────────────────────────────────────────────────────
   AgentSetupFailed(error~ : String)
   AgentStep(step~ : Int)
+  /// The current step is reopening its provider stream after a retryable
+  /// interruption. This is transient controller state: it is emitted on the
+  /// live JSONL stream, never represented by `agent_session.SessionItem`, and
+  /// therefore never appended to `session.jsonl`.
+  StreamRetry(attempt~ : Int, max_attempts~ : Int, reason~ : String)
   AgentAborted(reason~ : String)
   AgentFinished(answer~ : String)
   MaxStepsExhausted

--- a/protocol/parse.mbt
+++ b/protocol/parse.mbt
@@ -50,6 +50,14 @@ pub fn parse(line : Json) -> Event? {
     "agent_setup_failed" =>
       text(fields, "error").map(error => AgentSetupFailed(error~))
     "agent_step" => int(fields, "step").map(step => AgentStep(step~))
+    "stream_retry" => {
+      guard int(fields, "attempt") is Some(attempt) &&
+        int(fields, "max_attempts") is Some(max_attempts) &&
+        text(fields, "reason") is Some(reason) else {
+        return None
+      }
+      Some(StreamRetry(attempt~, max_attempts~, reason~))
+    }
     "agent_aborted" =>
       text(fields, "reason").map(reason => AgentAborted(reason~))
     "agent_finished" =>

--- a/protocol/parse.mbt
+++ b/protocol/parse.mbt
@@ -50,14 +50,6 @@ pub fn parse(line : Json) -> Event? {
     "agent_setup_failed" =>
       text(fields, "error").map(error => AgentSetupFailed(error~))
     "agent_step" => int(fields, "step").map(step => AgentStep(step~))
-    "stream_retry" => {
-      guard int(fields, "attempt") is Some(attempt) &&
-        int(fields, "max_attempts") is Some(max_attempts) &&
-        text(fields, "reason") is Some(reason) else {
-        return None
-      }
-      Some(StreamRetry(attempt~, max_attempts~, reason~))
-    }
     "agent_aborted" =>
       text(fields, "reason").map(reason => AgentAborted(reason~))
     "agent_finished" =>

--- a/protocol/parse_test.mbt
+++ b/protocol/parse_test.mbt
@@ -38,6 +38,20 @@ test "decodes a reasoning delta" {
 }
 
 ///|
+test "decodes a transient stream retry boundary" {
+  debug_inspect(
+    decode(
+      (
+        #|{"event":"stream_retry","attempt":2,"max_attempts":3,"reason":"ConnectionClosed"}
+      ),
+    ),
+    content=(
+      #|Some(StreamRetry(attempt=2, max_attempts=3, reason="ConnectionClosed"))
+    ),
+  )
+}
+
+///|
 /// The envelope is ignored: a reader cares about the event, not about which
 /// line of the engine reported it.
 test "decodes with the envelope absent" {
@@ -222,6 +236,15 @@ test "unknown and malformed lines are ignored" {
   assert_eq(@openseek_protocol.parse({ "event": "from_a_newer_engine" }), None)
   // `agent_step` without its required payload.
   assert_eq(@openseek_protocol.parse({ "event": "agent_step" }), None)
+  // Retry fields describe one concrete attempt; none is optional.
+  assert_eq(
+    @openseek_protocol.parse({
+      "event": "stream_retry",
+      "attempt": 2,
+      "max_attempts": 3,
+    }),
+    None,
+  )
   // A fractional `step` is not an Int.
   assert_eq(
     @openseek_protocol.parse({ "event": "agent_step", "step": 1.5 }),

--- a/protocol/parse_test.mbt
+++ b/protocol/parse_test.mbt
@@ -38,20 +38,6 @@ test "decodes a reasoning delta" {
 }
 
 ///|
-test "decodes a transient stream retry boundary" {
-  debug_inspect(
-    decode(
-      (
-        #|{"event":"stream_retry","attempt":2,"max_attempts":3,"reason":"ConnectionClosed"}
-      ),
-    ),
-    content=(
-      #|Some(StreamRetry(attempt=2, max_attempts=3, reason="ConnectionClosed"))
-    ),
-  )
-}
-
-///|
 /// The envelope is ignored: a reader cares about the event, not about which
 /// line of the engine reported it.
 test "decodes with the envelope absent" {
@@ -236,15 +222,6 @@ test "unknown and malformed lines are ignored" {
   assert_eq(@openseek_protocol.parse({ "event": "from_a_newer_engine" }), None)
   // `agent_step` without its required payload.
   assert_eq(@openseek_protocol.parse({ "event": "agent_step" }), None)
-  // Retry fields describe one concrete attempt; none is optional.
-  assert_eq(
-    @openseek_protocol.parse({
-      "event": "stream_retry",
-      "attempt": 2,
-      "max_attempts": 3,
-    }),
-    None,
-  )
   // A fractional `step` is not an Int.
   assert_eq(
     @openseek_protocol.parse({ "event": "agent_step", "step": 1.5 }),

--- a/protocol/pkg.generated.mbti
+++ b/protocol/pkg.generated.mbti
@@ -32,6 +32,7 @@ pub fn Command::to_repr(Self) -> @debug.Repr
 pub(all) enum Event {
   AgentSetupFailed(error~ : String)
   AgentStep(step~ : Int)
+  StreamRetry(attempt~ : Int, max_attempts~ : Int, reason~ : String)
   AgentAborted(reason~ : String)
   AgentFinished(answer~ : String)
   MaxStepsExhausted

--- a/protocol/pkg.generated.mbti
+++ b/protocol/pkg.generated.mbti
@@ -32,7 +32,6 @@ pub fn Command::to_repr(Self) -> @debug.Repr
 pub(all) enum Event {
   AgentSetupFailed(error~ : String)
   AgentStep(step~ : Int)
-  StreamRetry(attempt~ : Int, max_attempts~ : Int, reason~ : String)
   AgentAborted(reason~ : String)
   AgentFinished(answer~ : String)
   MaxStepsExhausted

--- a/protocol/to_json.mbt
+++ b/protocol/to_json.mbt
@@ -29,6 +29,13 @@ pub fn Event::to_json(self : Event) -> Json {
     AgentSetupFailed(error~) =>
       { "event": "agent_setup_failed", "error": error }
     AgentStep(step~) => { "event": "agent_step", "step": step }
+    StreamRetry(attempt~, max_attempts~, reason~) =>
+      {
+        "event": "stream_retry",
+        "attempt": attempt,
+        "max_attempts": max_attempts,
+        "reason": reason,
+      }
     AgentAborted(reason~) => { "event": "agent_aborted", "reason": reason }
     AgentFinished(answer~) => { "event": "agent_finished", "answer": answer }
     MaxStepsExhausted => { "event": "max_steps_exhausted" }

--- a/protocol/to_json.mbt
+++ b/protocol/to_json.mbt
@@ -29,13 +29,6 @@ pub fn Event::to_json(self : Event) -> Json {
     AgentSetupFailed(error~) =>
       { "event": "agent_setup_failed", "error": error }
     AgentStep(step~) => { "event": "agent_step", "step": step }
-    StreamRetry(attempt~, max_attempts~, reason~) =>
-      {
-        "event": "stream_retry",
-        "attempt": attempt,
-        "max_attempts": max_attempts,
-        "reason": reason,
-      }
     AgentAborted(reason~) => { "event": "agent_aborted", "reason": reason }
     AgentFinished(answer~) => { "event": "agent_finished", "answer": answer }
     MaxStepsExhausted => { "event": "max_steps_exhausted" }


### PR DESCRIPTION
## Summary

- let streaming consumers opt into retrying socket, EOF, and idle-timeout failures after partial SSE output via `StreamHandler(on_retry?)`
- `on_retry(attempt, max_attempts, reason)` fires when the retry is decided, before the client's backoff sleep, and only when a retry will follow; pre-stream retries (429, 5xx, connect errors) report through it too
- the agent emits `stream_retry {attempt, max_attempts, reason}`; Desktop discards the failed attempt's transient answer and reasoning and shows "Retrying · attempt 2/5 · reason" in the heartbeat until the replacement attempt streams; nothing is written to session.jsonl and no tool reruns
- only `ReaderClosed` and OS socket errors are re-tagged as replayable transport failures; HTTP framing errors, malformed SSE, and callback failures stay final

## Testing

- moon info (native and js; js-only mbti hunks applied by hand)
- moon fmt
- moon check --target native; moon check --target js desktop/frontend{,/composer,/transcript}
- moon test --target native deepseek/client agent protocol protocol/emit eval/file_edit/harness (168/168)
- moon test --target js desktop/frontend desktop/frontend/composer desktop/frontend/transcript (527/527)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JrTMMHNrPwbUsxCXiPZazN
