### PR TITLE
Polish folded code and documentation presentation

### DIFF
--- a/editor/internal/viewer/code_editor_widget/folding_host_wbtest.mbt
+++ b/editor/internal/viewer/code_editor_widget/folding_host_wbtest.mbt
@@ -127,7 +127,10 @@ test "folding: MoonBit outline keeps the complete signature and opening brace" {
     if decoration.options.description ==
       "folding-collapsed-outline-body-highlighted-visual-decoration" {
       saw_outline_body = true
-      assert_eq(decoration.options.after_content_class_name, None)
+      assert_eq(
+        decoration.options.after_content_class_name,
+        Some("inline-folded-body"),
+      )
       assert_eq(decoration.range.start_line_number, 3)
     }
   }
@@ -669,7 +672,10 @@ test "folding: MoonBit outline survives folding decoration option updates" {
     if decoration.options.description ==
       "folding-no-controls-outline-body-range-decoration" {
       saw_outline_body = true
-      assert_eq(decoration.options.after_content_class_name, None)
+      assert_eq(
+        decoration.options.after_content_class_name,
+        Some("inline-folded-body"),
+      )
     }
   }
   assert_true(saw_outline_body)

--- a/editor/internal/viewer/code_editor_widget/markdown_comments_contribution.mbt
+++ b/editor/internal/viewer/code_editor_widget/markdown_comments_contribution.mbt
@@ -334,7 +334,7 @@ fn render_markdown_comment_body(
 ///|
 /// Selects the first non-empty Markdown source line as the collapsed preview
 /// only for an item-delimited API document with meaningful content after it.
-/// The leading exact thematic break remains visible in both presentations;
+/// The leading exact thematic break is retained in both presentations;
 /// ordinary whole-line Markdown keeps its historical always-expanded surface.
 fn markdown_comment_folded_preview(
   markdown : String,

--- a/editor/internal/viewer/contrib/folding/browser/README.mbt.md
+++ b/editor/internal/viewer/contrib/folding/browser/README.mbt.md
@@ -38,8 +38,9 @@ The root may compose a host-computed range with
 `OUTLINE_BODY_FOLDING_RANGE_TYPE` before an explicit outline action. The range
 uses its complete declaration header's final line as the ordinary fold header,
 so the standard hidden-range model needs no partial-line projection. Its
-collapsed decoration keeps the chevron/highlight but omits `inline-folded`'s
-trailing ellipsis. Provider and user folds retain the Monaco presentation.
+collapsed decoration keeps the chevron and completes the hidden body with an
+inline `… }` suffix. Ordinary folds retain their trailing ellipsis. Collapsed
+rows have no background tint, so they cannot be mistaken for selected lines.
 
 Exact callable types are in `pkg.generated.mbti`. Run focused tests with:
 

--- a/editor/internal/viewer/contrib/folding/browser/folding_decorations.mbt
+++ b/editor/internal/viewer/contrib/folding/browser/folding_decorations.mbt
@@ -53,12 +53,12 @@ let collapsed_highlighted_visual_decoration : @model.ModelDecorationOptions = Mo
 
 ///|
 /// A collapsed host outline whose visible line already ends at the body
-/// delimiter. The chevron communicates collapse without appending `⋯` to the
-/// complete declaration header.
+/// delimiter. A quiet inline suffix completes the hidden body as `{ … }`.
 let collapsed_outline_body_visual_decoration : @model.ModelDecorationOptions = ModelDecorationOptions(
   "",
   description="folding-collapsed-outline-body-visual-decoration",
   stickiness=AlwaysGrowsWhenTypingAtEdges,
+  after_content_class_name="inline-folded-body",
   is_whole_line=true,
   first_line_decoration_class_name=FOLDING_COLLAPSED_ICON_CLASS,
 )
@@ -68,6 +68,7 @@ let collapsed_outline_body_highlighted_visual_decoration : @model.ModelDecoratio
   "folded-background",
   description="folding-collapsed-outline-body-highlighted-visual-decoration",
   stickiness=AlwaysGrowsWhenTypingAtEdges,
+  after_content_class_name="inline-folded-body",
   is_whole_line=true,
   first_line_decoration_class_name=FOLDING_COLLAPSED_ICON_CLASS,
 )
@@ -119,6 +120,7 @@ let no_controls_collapsed_outline_body_range_decoration : @model.ModelDecoration
   "",
   description="folding-no-controls-outline-body-range-decoration",
   stickiness=AlwaysGrowsWhenTypingAtEdges,
+  after_content_class_name="inline-folded-body",
   is_whole_line=true,
 )
 
@@ -127,6 +129,7 @@ let no_controls_collapsed_outline_body_highlighted_range_decoration : @model.Mod
   "folded-background",
   description="folding-no-controls-outline-body-range-decoration",
   stickiness=AlwaysGrowsWhenTypingAtEdges,
+  after_content_class_name="inline-folded-body",
   is_whole_line=true,
 )
 

--- a/editor/internal/viewer/contrib/folding/browser/folding_decorations_wbtest.mbt
+++ b/editor/internal/viewer/contrib/folding/browser/folding_decorations_wbtest.mbt
@@ -43,14 +43,14 @@ test "folding decoration controls preserve mouseover always and never policies" 
 }
 
 ///|
-test "outline body decorations omit the trailing folded ellipsis" {
+test "outline body decorations complete the hidden body inline" {
   let provider = FoldingDecorationProvider(folding_test_model(["line"]))
   let collapsed = provider.get_decoration_option(true, false, false, true)
   assert_eq(
     collapsed.description,
     "folding-collapsed-outline-body-highlighted-visual-decoration",
   )
-  assert_eq(collapsed.after_content_class_name, None)
+  assert_eq(collapsed.after_content_class_name, Some("inline-folded-body"))
   assert_eq(
     collapsed.first_line_decoration_class_name,
     Some(FOLDING_COLLAPSED_ICON_CLASS),

--- a/editor/internal/viewer/contrib/markdown_comments/browser/README.mbt.md
+++ b/editor/internal/viewer/contrib/markdown_comments/browser/README.mbt.md
@@ -16,7 +16,8 @@ accessible name `Original source`, reports the selected presentation through
 always reserves its trailing hit area, while a one-line separator constrains
 the control to the existing ViewZone height. Source controls appear on block
 hover or keyboard focus and remain visible while inspecting source. Documentation uses a subtle
-tinted surface, with smaller preview text and quiet separators. Separator-only
+tinted surface, with smaller preview text. Leading item separators use whitespace instead of
+a horizontal stroke; interior Markdown rules remain visible. Separator-only
 blocks retain the editor background.
 Item-delimited multi-line API documents whose provider registration opted
 into folding start on the preview. Two affordances drive one fold state: a

--- a/editor/internal/viewer/contrib/markdown_comments/browser/README.mbt.md
+++ b/editor/internal/viewer/contrib/markdown_comments/browser/README.mbt.md
@@ -14,7 +14,9 @@ Returning to Markdown restores the prior documentation-fold state. The toggle ke
 accessible name `Original source`, reports the selected presentation through
 `aria-pressed`, and uses its tooltip for the next action. Rendered content
 always reserves its trailing hit area, while a one-line separator constrains
-the control to the existing ViewZone height.
+the control to the existing ViewZone height. Source controls appear on block
+hover or keyboard focus and remain visible while inspecting source. Comments
+share the editor background, with smaller preview text and quiet separators.
 Item-delimited multi-line API documents whose provider registration opted
 into folding start on the preview. Two affordances drive one fold state: a
 mouse-only gutter chevron that reuses the code-folding `.cldr` codicons and

--- a/editor/internal/viewer/contrib/markdown_comments/browser/README.mbt.md
+++ b/editor/internal/viewer/contrib/markdown_comments/browser/README.mbt.md
@@ -15,8 +15,9 @@ accessible name `Original source`, reports the selected presentation through
 `aria-pressed`, and uses its tooltip for the next action. Rendered content
 always reserves its trailing hit area, while a one-line separator constrains
 the control to the existing ViewZone height. Source controls appear on block
-hover or keyboard focus and remain visible while inspecting source. Comments
-share the editor background, with smaller preview text and quiet separators.
+hover or keyboard focus and remain visible while inspecting source. Documentation uses a subtle
+tinted surface, with smaller preview text and quiet separators. Separator-only
+blocks retain the editor background.
 Item-delimited multi-line API documents whose provider registration opted
 into folding start on the preview. Two affordances drive one fold state: a
 mouse-only gutter chevron that reuses the code-folding `.cldr` codicons and

--- a/editor/tests/browser/smoke/viewer.spec.js
+++ b/editor/tests/browser/smoke/viewer.spec.js
@@ -128,6 +128,7 @@ test('opens MoonBit models as a top-level outline without enforcing later folds'
     hasText: 'pub fn startup_event',
   });
   await expect(functionLine.locator('.inline-folded')).toHaveCount(0);
+  await expect(functionLine.locator('.inline-folded-body')).toHaveCount(1);
   expect((await functionLine.innerText()).replaceAll('\u00a0', ' ').trim()).toBe(
     'pub fn startup_event() -> StartupEvent {',
   );

--- a/editor/tests/browser/smoke/viewer.spec.js
+++ b/editor/tests/browser/smoke/viewer.spec.js
@@ -265,7 +265,7 @@ test('renders MoonBit documentation comments through the real workbench', async 
   );
 });
 
-test('renders undocumented MoonBit item anchors as horizontal separators', async ({
+test('renders undocumented MoonBit item anchors as quiet spacing', async ({
   page,
 }) => {
   await page.goto('/');
@@ -279,6 +279,8 @@ test('renders undocumented MoonBit item anchors as horizontal separators', async
   );
   await expect(first.locator('hr')).toBeVisible();
   await expect(second.locator('hr')).toBeVisible();
+  await expect(first.locator('hr')).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)');
+  await expect(second.locator('hr')).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)');
   await expect(first).toHaveAttribute('data-documentation-foldable', 'false');
   await expect(second).toHaveAttribute('data-documentation-foldable', 'false');
   await expect(first.locator('.moonbit-viewer-markdown-comment-toggle')).toBeHidden();

--- a/editor/viewer/contrib/folding/browser/folding.css
+++ b/editor/viewer/contrib/folding/browser/folding.css
@@ -28,7 +28,8 @@
   opacity: 1;
 }
 
-.inline-folded:after {
+.inline-folded:after,
+.inline-folded-body:after {
   color: var(--vscode-editor-foldPlaceholderForeground);
   margin: 0.1em 0.2em 0 0.2em;
   content: "\22EF"; /* ellipses unicode character */
@@ -37,8 +38,14 @@
   cursor: pointer;
 }
 
+.inline-folded-body:after {
+  content: "\2026  }";
+}
+
+/* A folded row is not a selection. The gutter and inline placeholder carry
+ * its state without painting a second selection-like band across the code. */
 .folded-background {
-  background-color: var(--vscode-editor-foldBackground);
+  background-color: transparent;
 }
 
 .cldr.codicon.codicon-folding-expanded,

--- a/editor/viewer/contrib/markdown_comments/browser/markdown_comments.css
+++ b/editor/viewer/contrib/markdown_comments/browser/markdown_comments.css
@@ -10,16 +10,9 @@
    * Markdown input above it, but below editor cursors (4) and widgets (50+). */
   z-index: 2;
   color: var(--vscode-editor-foreground);
-  /* Give documentation its own quiet surface while leaving the stronger
-   * textCodeBlock background available for nested inline and fenced code. */
   background: var(--vscode-editor-background);
-  background: color-mix(
-    in srgb,
-    var(--vscode-editor-foreground) 4%,
-    var(--vscode-editor-background)
-  );
   font-family: var(--ui-font-family, var(--editor-font-family));
-  font-size: var(--editor-font-size);
+  font-size: calc(var(--editor-font-size) * 0.92);
   line-height: 1.5;
 }
 
@@ -31,7 +24,7 @@
   box-sizing: border-box;
   /* The pinned outer already ends at the vertical scrollbar rail. */
   width: 100%;
-  padding: 6px 40px 8px 0;
+  padding: 4px 40px 5px 0;
   overflow-wrap: anywhere;
   user-select: text;
   -webkit-user-select: text;
@@ -65,6 +58,10 @@
 .moonbit-viewer-markdown-comment[data-documentation-foldable="true"][data-documentation-expanded="false"]
   .moonbit-viewer-markdown-comment-preview {
   display: block;
+}
+
+.moonbit-viewer-markdown-comment-preview {
+  color: var(--vscode-descriptionForeground, var(--vscode-editor-foreground));
 }
 
 .moonbit-viewer-markdown-comment-preview > :not(hr) {
@@ -122,7 +119,12 @@
   font-family: var(--monaco-monospace-font, var(--editor-font-family));
   font-size: 11px;
   cursor: pointer;
-  opacity: 0.55;
+  opacity: 0;
+}
+
+.moonbit-viewer-markdown-comment:hover .moonbit-viewer-markdown-comment-source-toggle,
+.moonbit-viewer-markdown-comment:focus-within .moonbit-viewer-markdown-comment-source-toggle {
+  opacity: 1;
 }
 
 .moonbit-viewer-markdown-comment-source-toggle:hover,
@@ -312,13 +314,13 @@
   height: 1px;
   margin: 10px 0;
   border: 0;
-  background: var(--vscode-editorWidget-border, var(--vscode-widget-border));
+  background: color-mix(in srgb, var(--vscode-editor-foreground) 10%, transparent);
 }
 
 /* An item separator replaces one source line. Its content box is otherwise
- * 15px tall (6px + 1px + 8px), so retain the configured line geometry. */
+ * 10px tall (4px + 1px + 5px), so retain the configured line geometry. */
 .moonbit-viewer-markdown-comment-body > hr:only-child {
-  margin-bottom: calc(var(--editor-line-height, 18px) - 15px);
+  margin-bottom: calc(var(--editor-line-height, 18px) - 10px);
 }
 
 .moonbit-viewer-markdown-comment-content a {

--- a/editor/viewer/contrib/markdown_comments/browser/markdown_comments.css
+++ b/editor/viewer/contrib/markdown_comments/browser/markdown_comments.css
@@ -10,10 +10,22 @@
    * Markdown input above it, but below editor cursors (4) and widgets (50+). */
   z-index: 2;
   color: var(--vscode-editor-foreground);
-  background: var(--vscode-editor-background);
+  background: color-mix(
+    in srgb,
+    var(--vscode-editor-foreground) 3%,
+    var(--vscode-editor-background)
+  );
   font-family: var(--ui-font-family, var(--editor-font-family));
   font-size: calc(var(--editor-font-size) * 0.92);
   line-height: 1.5;
+}
+
+/* Bare item separators are spacing, not documentation panels. Keep source
+ * inspection on the tinted surface even for a separator-only source block. */
+.moonbit-viewer-markdown-comment[data-source-visible="false"]:has(
+  .moonbit-viewer-markdown-comment-full > hr:only-child
+) {
+  background: var(--vscode-editor-background);
 }
 
 /* Vertical and trailing padding belong to the measured inner target, so

--- a/editor/viewer/contrib/markdown_comments/browser/markdown_comments.css
+++ b/editor/viewer/contrib/markdown_comments/browser/markdown_comments.css
@@ -329,6 +329,12 @@
   background: color-mix(in srgb, var(--vscode-editor-foreground) 10%, transparent);
 }
 
+/* Leading item anchors separate blocks through whitespace. Interior Markdown
+ * rules keep their stroke; preserve the anchor's measured source geometry. */
+.moonbit-viewer-markdown-comment-body > hr:first-child {
+  background: transparent;
+}
+
 /* An item separator replaces one source line. Its content box is otherwise
  * 10px tall (4px + 1px + 5px), so retain the configured line geometry. */
 .moonbit-viewer-markdown-comment-body > hr:only-child {


### PR DESCRIPTION
Folded code currently shows selection-like blue bands and heavy documentation panels. This change removes the blue bands, gives documentation a subtle tinted background while using whitespace instead of strokes for leading item separators, reduces documentation text and padding, and reveals original-source buttons on hover or keyboard focus. Collapsed MoonBit function bodies end with a quiet `{ … }` marker.

The change is limited to presentation and decoration rendering; business logic, folding ranges, and public APIs are unchanged. OpenSeek's desktop editor imports the shared styles directly.

Validation:
- Root `just check`, `just test`, and `just build` passed for the implementation.
- Editor all-target check and `just editor-test` passed.
- `just editor-test-browser`: all 103 scenarios passed after the final stylesheet adjustment.
- `moon info` and `moon fmt` completed with no public interface changes.
- Inspected the real `agent_tool/job_output/job_output.mbt` preview in light and dark themes. Dark-mode checks cover documentation contrast (5.72:1), keyboard source toggling, documentation and code folding, theme switching and persistence, and absence of browser errors.
