### PR TITLE
chore: drop unused package imports

### DIFF
--- a/agent_tool/edit/internal/decode/moon.pkg
+++ b/agent_tool/edit/internal/decode/moon.pkg
@@ -1,5 +1,1 @@
-import {
-  "moonbitlang/core/json",
-}
-
 warnings = "+unnecessary_annotation"

--- a/agent_tool/finish/internal/decode/moon.pkg
+++ b/agent_tool/finish/internal/decode/moon.pkg
@@ -1,5 +1,1 @@
-import {
-  "moonbitlang/core/json",
-}
-
 warnings = "+unnecessary_annotation"

--- a/agent_tool/goal/internal/decode/moon.pkg
+++ b/agent_tool/goal/internal/decode/moon.pkg
@@ -1,8 +1,4 @@
 import {
-  "moonbitlang/core/json",
-}
-
-import {
   "bobzhang/openseek/agent_tool/internal/error" @tool_error,
 } for "test"
 

--- a/agent_tool/job_output/internal/decode/moon.pkg
+++ b/agent_tool/job_output/internal/decode/moon.pkg
@@ -1,8 +1,4 @@
 import {
-  "moonbitlang/core/json",
-}
-
-import {
   "bobzhang/openseek/agent_tool/internal/error" @tool_error,
 } for "test"
 

--- a/agent_tool/multi_edit/internal/decode/moon.pkg
+++ b/agent_tool/multi_edit/internal/decode/moon.pkg
@@ -1,7 +1,3 @@
-import {
-  "moonbitlang/core/json",
-}
-
 warnings = "+unnecessary_annotation"
 
 supported_targets = "+wasm+native"

--- a/agent_tool/read/internal/decode/moon.pkg
+++ b/agent_tool/read/internal/decode/moon.pkg
@@ -1,5 +1,1 @@
-import {
-  "moonbitlang/core/json",
-}
-
 warnings = "+unnecessary_annotation"

--- a/agent_tool/remove/internal/decode/moon.pkg
+++ b/agent_tool/remove/internal/decode/moon.pkg
@@ -1,5 +1,1 @@
-import {
-  "moonbitlang/core/json",
-}
-
 warnings = "+unnecessary_annotation"

--- a/agent_tool/shell/internal/decode/moon.pkg
+++ b/agent_tool/shell/internal/decode/moon.pkg
@@ -1,5 +1,1 @@
-import {
-  "moonbitlang/core/json",
-}
-
 warnings = "+unnecessary_annotation"

--- a/agent_tool/write/internal/decode/moon.pkg
+++ b/agent_tool/write/internal/decode/moon.pkg
@@ -1,5 +1,1 @@
-import {
-  "moonbitlang/core/json",
-}
-
 warnings = "+unnecessary_annotation"

--- a/cmd/openseek/moon.pkg
+++ b/cmd/openseek/moon.pkg
@@ -31,7 +31,6 @@ import {
   "moonbitlang/async/os_error",
   "moonbitlang/async/stdio",
   "moonbitlang/core/argparse",
-  "moonbitlang/core/encoding/utf8",
   "moonbitlang/core/env",
   "moonbitlang/x/path",
   "moonbitlang/x/sys",

--- a/desktop/frontend/grep_search/moon.pkg
+++ b/desktop/frontend/grep_search/moon.pkg
@@ -14,7 +14,3 @@ import {
 }
 
 supported_targets = "js"
-
-import {
-  "moonbitlang/core/debug",
-} for "test"

--- a/desktop/frontend/project_picker/moon.pkg
+++ b/desktop/frontend/project_picker/moon.pkg
@@ -11,7 +11,6 @@ import {
 
 import {
   "moonbit-community/rabbita/cmd",
-  "moonbitlang/core/debug",
   "openseek_desktop/frontend/interop",
 } for "test"
 

--- a/desktop/internal/terminal/launcher_test.mbt
+++ b/desktop/internal/terminal/launcher_test.mbt
@@ -6,13 +6,13 @@
 ///|
 async test "a default session launches a live platform shell" {
   @async.with_task_group(group => {
-    let state = new_terminal_state()
+    let state = @terminal.new_terminal_state()
     defer state.shutdown()
-    let pushes : @async.Queue[TerminalPush] = Queue(kind=Unbounded)
+    let pushes : @async.Queue[@terminal.TerminalPush] = Queue(kind=Unbounded)
     group.spawn_bg(allow_failure=true, () => {
-      run_terminal_pump(state, async fn(push) { pushes.put(push) })
+      @terminal.run_terminal_pump(state, async fn(push) { pushes.put(push) })
     })
-    let id = open_terminal(state, cwd=".", cols=80, rows=24)
+    let id = @terminal.open_terminal(state, cwd=".", cols=80, rows=24)
     // "Still running after its first output" is the property under test. The
     // timeout is generous because a real POSIX login shell runs the user's
     // profile (a slow one is not a failure); an early exit fails through the
@@ -34,7 +34,7 @@ async test "a default session launches a live platform shell" {
         }
       }
     })
-    close_terminal(state, id~)
+    @terminal.close_terminal(state, id~)
     // Windows keeps ConPTY's output pipe open after cmd.exe alone is killed.
     // Requiring `Exited` proves terminal close also cancels the pending pipe
     // read, allowing the session to reach its final PTY cleanup.
@@ -53,14 +53,14 @@ async test "a default session launches a live platform shell" {
 /// the session as open.
 async test "a session whose cwd does not exist fails while opening" {
   @async.with_task_group(group => {
-    let state = new_terminal_state()
+    let state = @terminal.new_terminal_state()
     defer state.shutdown()
-    let pushes : @async.Queue[TerminalPush] = Queue(kind=Unbounded)
+    let pushes : @async.Queue[@terminal.TerminalPush] = Queue(kind=Unbounded)
     group.spawn_bg(allow_failure=true, () => {
-      run_terminal_pump(state, async fn(push) { pushes.put(push) })
+      @terminal.run_terminal_pump(state, async fn(push) { pushes.put(push) })
     })
     let failed = try {
-      let _ = open_terminal(
+      let _ = @terminal.open_terminal(
         state,
         cwd="/nonexistent/openseek-terminal-test",
         cols=80,
@@ -68,7 +68,7 @@ async test "a session whose cwd does not exist fails while opening" {
       )
       false
     } catch {
-      TerminalError(_) => true
+      @terminal.TerminalError(_) => true
       _ => false
     }
     assert_true(failed)

--- a/desktop/internal/terminal/moon.pkg
+++ b/desktop/internal/terminal/moon.pkg
@@ -1,6 +1,5 @@
 import {
   "moonbit-community/pty",
-  "moonbitlang/core/encoding/utf8",
   "moonbitlang/core/deque",
   "moonbitlang/async",
   "moonbitlang/async/cond_var",

--- a/desktop/internal/uuid/moon.pkg
+++ b/desktop/internal/uuid/moon.pkg
@@ -1,5 +1,4 @@
 import {
-  "moonbitlang/core/encoding/utf8",
   "moonbitlang/core/env",
 }
 

--- a/editor/viewer/common/view_model/moon.pkg
+++ b/editor/viewer/common/view_model/moon.pkg
@@ -7,7 +7,6 @@ import {
   "moonbitlang/editor/viewer/common/model",
   "moonbitlang/editor/viewer/common/tokens",
   "moonbitlang/editor/viewer/common/view_layout",
-  "moonbitlang/core/json",
 }
 
 import {

--- a/prompt/moon.pkg
+++ b/prompt/moon.pkg
@@ -6,7 +6,6 @@ import {
   "moonbitlang/core/encoding/utf8",
   "moonbitlang/core/string",
   "moonbitlang/async",
-  "moonbitlang/core/argparse",
 } for "test"
 
 dev_build(

--- a/testkit/filesystem/moon.pkg
+++ b/testkit/filesystem/moon.pkg
@@ -4,10 +4,6 @@ import {
   "moonbitlang/core/json",
 }
 
-import {
-  "moonbitlang/core/test",
-} for "test"
-
 warnings = "+unnecessary_annotation"
 
 supported_targets = "+wasm+native"


### PR DESCRIPTION
Remove imports flagged by `unused_package` across the workspace.

### Changes
- Drop leftover `moonbitlang/core/json`, `moonbitlang/core/encoding/utf8`, `moonbitlang/core/argparse`, and `moonbitlang/core/test` imports.
- Convert `desktop/internal/terminal/launcher_wbtest.mbt` to a black-box test `launcher_test.mbt`: it only exercised public API, and `moon check` does not count wbtest references when flagging unused imports, so the `utf8` import it needed was a false positive.

### Validation
- `moon check --target native --deny-warn` ✅
- `moon check --target js --deny-warn` ✅
- `moon fmt --check` ✅
- `moon test --target native desktop/internal/terminal` ✅ (12/12)