### PR TITLE
fix(mbtx): separate snippet input from stable Moon build output

### DIFF
--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -402,6 +402,8 @@ async fn execute(
   defer cleanup()
   // Keep disposable compiler inputs and artifacts apart from `tmp`, whose
   // result files may need to remain readable after a background job exits.
+  // Moon places each single-file build under a directory named after its
+  // input, so its target directory must be separate from snippet.mbtx.
   let build_dir = "\{dir}/build"
   @fs.mkdir(build_dir) catch {
     error if @async.is_being_cancelled() => raise error
@@ -651,7 +653,7 @@ async fn execute(
         "--target",
         input.target,
         "--target-dir",
-        build_dir,
+        "\{build_dir}/_build",
         ..if !input.warning {
           ["--warn-list", WarnOffList]
         },
@@ -897,7 +899,7 @@ async fn build_snippet(
     "--target",
     "wasm",
     "--target-dir",
-    build_dir,
+    "\{build_dir}/_build",
     ..if !warning {
       ["--warn-list", WarnOffList]
     },
@@ -952,7 +954,7 @@ async fn build_snippet(
     )
   }
   let artifact = parse_artifacts_path(raw).unwrap_or(
-    "\{build_dir}/wasm/debug/build/single/single.wasm",
+    "\{build_dir}/_build/wasm/debug/build/single/single.wasm",
   )
   let artifact_present = @fs.exists(artifact) catch {
     error if @async.is_being_cancelled() => raise error

--- a/desktop/internal/terminal/moon.pkg
+++ b/desktop/internal/terminal/moon.pkg
@@ -14,6 +14,10 @@ import {
   "moonbitlang/core/encoding/utf8",
 } for "test"
 
+import {
+  "moonbitlang/core/encoding/utf8",
+} for "wbtest"
+
 warnings = "+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"
 
 supported_targets = "+native"

--- a/desktop/internal/terminal/moon.pkg
+++ b/desktop/internal/terminal/moon.pkg
@@ -14,10 +14,6 @@ import {
   "moonbitlang/core/encoding/utf8",
 } for "test"
 
-import {
-  "moonbitlang/core/encoding/utf8",
-} for "wbtest"
-
 warnings = "+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"
 
 supported_targets = "+native"


### PR DESCRIPTION
The September 7 MoonBit stable release places single-file build output under a directory named after the input file. `mbtx` currently passes the directory containing `snippet.mbtx` as `--target-dir`, so compilation fails because Moon tries to create a directory at that existing file path.

Use a separate `_build` target directory for both staged wasm builds and direct runs. Keep compiler inputs and outputs under the existing disposable build root so cleanup behavior is preserved.

Validation on Moon 0.1.20260907:

- Reproduced the collision with the upstream command; the updated command builds successfully.
- After rebasing: native check with warnings denied, all 72 `mbtx` tests, and all 12 terminal tests pass; generated interfaces are unchanged and formatting is clean.
- Before rebasing: `just check`, wasm check with warnings denied, `just test`, `just build`, and `just editor-test` all passed.

Upstream already contains the unused-import cleanup. The redundant terminal white-box-test import was removed after upstream converted that test to a black-box test.
