### PR TITLE
Make job_output an immediate read without wait_ms

### DIFF
--- a/agent/tool_definition.mbt
+++ b/agent/tool_definition.mbt
@@ -336,25 +336,16 @@ async test "a handed-off job cleans builds but keeps result files until teardown
     guard action is Respond(output) else { fail("expected Respond") }
     assert_true(output.content.contains("moved to the background"))
     guard bg_runtime.list() is [job, ..] else { fail("no job registered") }
+    @async.with_timeout(120_000, () => bg_runtime.wait_any([job.id]))
     let read = run_async_tool(@job_output.definition(bg_runtime), {
       "job_id": job.id,
-      "wait_ms": 120_000,
     })
     guard read is Respond(result) else { fail("expected Respond") }
     assert_false(result.is_error)
     assert_eq(@fs.read_file(result_path).text(), "kept")
     let build_dir = "\{spill_dir}/snippet-0/build"
-    let mut build_reclaimed = !@fs.exists(build_dir)
-    // job_output may observe the terminal state just before its cleanup callback
-    // finishes, so wait for that callback rather than racing it.
-    for _ in 0..<400 {
-      if !@fs.exists(build_dir) {
-        build_reclaimed = true
-        break
-      }
-      @async.sleep(25)
-    }
-    assert_true(build_reclaimed)
+    // wait_any includes launcher cleanup and completion publication.
+    assert_false(@fs.exists(build_dir))
     assert_true(@fs.exists("\{spill_dir}/snippet-0/tmp"))
     @fs.rmdir(spill_dir, recursive=true) catch {
       _ => ()
@@ -385,9 +376,9 @@ async test "an escalated handed-off job does not invent a policy refusal" {
     guard action is Respond(output) else { fail("expected Respond") }
     assert_true(output.content.contains("moved to the background"))
     guard bg_runtime.list() is [job, ..] else { fail("no job registered") }
+    @async.with_timeout(30_000, () => bg_runtime.wait_any([job.id]))
     let read = run_async_tool(@job_output.definition(bg_runtime), {
       "job_id": job.id,
-      "wait_ms": 30_000,
     })
     guard read is Respond(result) else { fail("expected Respond") }
     assert_false(result.is_error)
@@ -418,9 +409,9 @@ async test "a non-wasm handed-off job does not invent a policy refusal" {
     guard action is Respond(output) else { fail("expected Respond") }
     assert_true(output.content.contains("moved to the background"))
     guard bg_runtime.list() is [job, ..] else { fail("no job registered") }
+    @async.with_timeout(30_000, () => bg_runtime.wait_any([job.id]))
     let read = run_async_tool(@job_output.definition(bg_runtime), {
       "job_id": job.id,
-      "wait_ms": 30_000,
     })
     guard read is Respond(result) else { fail("expected Respond") }
     assert_false(result.is_error)

--- a/agent_tool/bgjobs/bgjobs.mbt
+++ b/agent_tool/bgjobs/bgjobs.mbt
@@ -490,9 +490,9 @@ pub async fn BgJobRuntime::read_output_tail(
 
 ///|
 /// Await the job reaching a terminal status, up to `timeout_ms`. Returns `true`
-/// once terminal, `false` on deadline or an unknown id. This is the await
-/// primitive behind `shell_output`'s `wait_ms`: a caller that needs the result
-/// *now* blocks here once instead of burning model round trips on polling.
+/// once terminal, `false` on deadline or an unknown id. Retained for bounded
+/// runtime callers; agent turns use `wait_any`, which also waits for completion
+/// publication, while `job_output` only reads available output.
 pub async fn BgJobRuntime::wait_exit(
   self : BgJobRuntime,
   id : String,

--- a/agent_tool/job_output/README.mbt.md
+++ b/agent_tool/job_output/README.mbt.md
@@ -4,11 +4,13 @@
 `job_id` — the id `mbtx` returns when a run is still active after its
 five-second foreground grace period and moves to the background automatically.
 
-The primary consumption path for job results is the **pushed completion
-notice** (a job announces itself when it finishes); `job_output` is for
-checking progress on a still-running job, and for reading the output once the
-notice arrives. The tool description and system prompts steer the model away
-from calling it in a polling loop.
+Reads return the currently available output and status without waiting for the
+job to finish. If the result is needed and there is no other work, call
+`job_wait({"job_ids":["bg-3"]})` alone first, then read with `job_output`.
+Completion notices still use the runtime's existing publication path.
+
+`wait_ms` has been removed. Calls that still supply it receive an actionable
+error directing the caller to `job_wait`; no wait duration is guessed or polled.
 
 ## Result Shape
 

--- a/agent_tool/job_output/internal/decode/README.mbt.md
+++ b/agent_tool/job_output/internal/decode/README.mbt.md
@@ -1,110 +1,30 @@
-# agent_tool/job_output/internal/decode
+# Job output arguments
 
-Argument decoding for the `job_output` tool, which reads a background job's
-output and status by id. This package is internal to `agent_tool/job_output`
-and owns only argument-shape decoding: validating `job_id` and turning the
-`wait_ms`/`offset` selectors into typed optionals. Waiting on the job, reading
-its retained output, and rendering the `<system>` footer stay in the parent
-package.
+The decoder validates `job_output` arguments independently of the model-facing
+schema. It returns the required `job_id` and an optional character `offset`.
 
-## Arguments
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `job_id` | string, required | Background job to read. |
+| `offset` | number, optional | Zero or positive character offset from the start. Absent/null selects the recent tail. |
 
-| Name | Type | Required | Decoder behavior |
-| --- | --- | --- | --- |
-| `job_id` | string | yes | Missing or non-string raises `job_output requires a string job_id`. |
-| `wait_ms` | number | no | Absent/`null` means no waiting (`None`). Must be positive; an oversized value is capped to `max_wait_ms` (`120000`) rather than rejected. Non-number raises `job_output wait_ms must be a number`. |
-| `offset` | number | no | Absent/`null` means the recent tail (`None`). Must be zero or positive. Non-number raises `job_output offset must be a number`. |
-
-Extra fields are ignored.
-
-## Defaults and Explicit Selectors
+`job_output` no longer accepts `wait_ms`, including null or zero. Older callers
+receive an error directing them to `job_wait` with `job_ids`. Reading and waiting
+are separate operations; this decoder never selects a wait duration.
 
 ```mbt check
 ///|
-test "decode defaults wait_ms and offset when only job_id is given" {
-  debug_inspect(
-    @decode.decode({ "job_id": "bg-3" }),
-    content="{ job_id: \"bg-3\", wait_ms: None, offset: None }",
-  )
+test "decode an immediate tail read" {
+  let input = @decode.decode({ "job_id": "bg-3" })
+  assert_eq(input.job_id, "bg-3")
+  assert_eq(input.offset, None)
 }
 
 ///|
-test "decode reads explicit wait_ms and offset selectors" {
-  debug_inspect(
-    @decode.decode({ "job_id": "bg-3", "wait_ms": 30000, "offset": 12000 }),
-    content="{ job_id: \"bg-3\", wait_ms: Some(30000), offset: Some(12000) }",
-  )
-}
-```
-
-## `wait_ms` is capped, not trusted
-
-`wait_ms` bounds how long one call blocks awaiting the job's exit. A caller may
-ask for any positive wait, but not more than `max_wait_ms`: the ceiling exists
-so one `job_output` call cannot hold the turn indefinitely — a deadline expiry
-is not an error, and the model can always call again.
-
-```mbt check
-///|
-test "an oversized wait_ms clamps silently to max_wait_ms" {
-  inspect(@decode.max_wait_ms, content="120000")
-  debug_inspect(
-    @decode.decode({ "job_id": "bg-3", "wait_ms": 999999 }).wait_ms,
-    content="Some(120000)",
-  )
-}
-```
-
-Zero and negative values are rejected rather than clamped, because they express
-an intent the tool cannot satisfy — no waiting is already spelled by omitting
-the argument.
-
-```mbt check
-///|
-/// True when decoding `arguments` fails with a message containing `expected`.
-fn decode_error_says(arguments : Json, expected : String) -> Bool {
-  try {
-    ignore(@decode.decode(arguments))
-    false
-  } catch {
-    err => "\{err}".contains(expected)
-  }
-}
-
-///|
-test "malformed selectors are errors that name the argument to fix" {
-  inspect(
-    decode_error_says(
-      { "job_id": "bg-3", "wait_ms": 0 },
-      "wait_ms must be a positive number",
-    ),
-    content="true",
-  )
-  inspect(
-    decode_error_says(
-      { "job_id": "bg-3", "wait_ms": "30000" },
-      "wait_ms must be a number",
-    ),
-    content="true",
-  )
-  inspect(
-    decode_error_says(
-      { "job_id": "bg-3", "offset": -1 },
-      "offset must be zero or a positive number",
-    ),
-    content="true",
-  )
-  inspect(
-    decode_error_says(
-      { "job_id": "bg-3", "offset": "0" },
-      "offset must be a number",
-    ),
-    content="true",
-  )
-  // A missing or wrong-typed job_id is caught before the selectors.
-  inspect(
-    decode_error_says({ "wait_ms": 500 }, "requires a string job_id"),
-    content="true",
+test "decode an earlier output window" {
+  assert_eq(
+    @decode.decode({ "job_id": "bg-3", "offset": 12000 }).offset,
+    Some(12000),
   )
 }
 ```

--- a/agent_tool/job_output/internal/decode/decode.mbt
+++ b/agent_tool/job_output/internal/decode/decode.mbt
@@ -1,60 +1,22 @@
 ///|
-/// Decoded arguments of the `job_output` tool: the `job_id` of the background
-/// job to read, plus the optional `wait_ms` and `offset` selectors. Either
-/// selector is `None` when the caller omits it (or passes `null`): `None`
-/// `wait_ms` means no waiting, `None` `offset` means the recent tail.
+/// Arguments of the immediate job_output read. An absent/null offset means
+/// the recent tail; a supplied offset selects a window from the start.
 pub struct JobOutputInput {
   job_id : String
-  wait_ms : Int?
   offset : Int?
 } derive(Debug)
 
 ///|
-/// Longest a single `job_output` call may block awaiting a job, so one tool
-/// call cannot hold the turn indefinitely; the model can always call again. A
-/// caller that asks for longer is capped to this, not rejected — the cap is a
-/// bounded wait, and the response still reports the job running if the wait
-/// expires.
-pub let max_wait_ms : Int = 120_000
-
-///|
-/// Decode `job_output` tool-call arguments.
-///
-/// `job_id` is a required string naming the background job to read. `wait_ms`,
-/// when present, must be a positive number and is capped at `max_wait_ms`;
-/// absent or null means no waiting. `offset`, when present, must be zero or a
-/// positive number; absent or null means the recent tail. The local dispatcher
-/// does not enforce the JSON schema, so the decoder must: failures name the
-/// argument to fix.
+/// Decode arguments locally because the dispatcher does not enforce schemas.
+/// Reject the removed waiting parameter with guidance for older callers.
 pub fn decode(arguments : Json) -> JobOutputInput raise {
-  match arguments {
-    { "job_id": String(job_id), .. } =>
-      { job_id, wait_ms: wait_ms(arguments), offset: offset(arguments), }
-    _ => fail("job_output requires a string job_id")
+  guard arguments is { "job_id": String(job_id), .. } else {
+    fail("job_output requires a string job_id")
   }
-}
-
-///|
-/// Decode the optional `wait_ms` argument: a positive number, capped at
-/// `max_wait_ms`. Absent/null means no waiting.
-fn wait_ms(arguments : Json) -> Int? raise {
-  match arguments {
-    { "wait_ms": Number(value, ..), .. } => {
-      let wait = value.to_int()
-      if wait <= 0 {
-        fail("job_output wait_ms must be a positive number")
-      } else if wait > max_wait_ms {
-        Some(max_wait_ms)
-      } else {
-        Some(wait)
-      }
-    }
-    { "wait_ms": Null, .. } => None
-    // Present but not a number (e.g. a stringified "30000"): reject rather
-    // than silently skip the wait.
-    { "wait_ms": _, .. } => fail("job_output wait_ms must be a number")
-    _ => None
+  if arguments is { "wait_ms": _, .. } {
+    fail("job_output no longer accepts wait_ms; use job_wait with job_ids")
   }
+  { job_id, offset: offset(arguments), }
 }
 
 ///|

--- a/agent_tool/job_output/internal/decode/decode_test.mbt
+++ b/agent_tool/job_output/internal/decode/decode_test.mbt
@@ -1,71 +1,60 @@
 ///|
-test "decode defaults wait_ms and offset when only job_id is given" {
-  debug_inspect(
-    @decode.decode({ "job_id": "bg-3" }),
-    content="{ job_id: \"bg-3\", wait_ms: None, offset: None }",
+test "decode defaults offset when only job_id is given" {
+  let input = @decode.decode({ "job_id": "bg-3" })
+  assert_eq(input.job_id, "bg-3")
+  assert_eq(input.offset, None)
+}
+
+///|
+test "decode reads an explicit offset and treats null as absent" {
+  assert_eq(
+    @decode.decode({ "job_id": "bg-3", "offset": 12000 }).offset,
+    Some(12000),
+  )
+  assert_eq(
+    @decode.decode({ "job_id": "bg-3", "offset": Json::null() }).offset,
+    None,
   )
 }
 
 ///|
-test "decode reads explicit wait_ms and offset selectors" {
-  debug_inspect(
-    @decode.decode({ "job_id": "bg-3", "wait_ms": 30000, "offset": 12000 }),
-    content="{ job_id: \"bg-3\", wait_ms: Some(30000), offset: Some(12000) }",
-  )
-}
-
-///|
-test "decode treats explicitly-null selectors as absent" {
-  debug_inspect(
-    @decode.decode({
-      "job_id": "bg-3",
-      "wait_ms": Json::null(),
-      "offset": Json::null(),
-    }),
-    content="{ job_id: \"bg-3\", wait_ms: None, offset: None }",
-  )
-}
-
-///|
-test "decode caps an oversized wait_ms at max_wait_ms instead of rejecting it" {
-  inspect(@decode.max_wait_ms, content="120000")
-  debug_inspect(
-    @decode.decode({ "job_id": "bg-3", "wait_ms": 999999 }),
-    content="{ job_id: \"bg-3\", wait_ms: Some(120000), offset: None }",
-  )
+test "decode rejects all forms of the removed wait_ms" {
+  for
+    value in [
+      Json::number(30000),
+      Json::number(0),
+      Json::string("30000"),
+      Json::null(),
+    ] {
+    assert_eq(
+      decode_error({ "job_id": "bg-3", "wait_ms": value }),
+      Some("job_output no longer accepts wait_ms; use job_wait with job_ids"),
+    )
+  }
 }
 
 ///|
 test "decode names the argument to repair in malformed arguments" {
-  debug_inspect(
-    [
-      decode_error({ "wait_ms": 500 }),
-      decode_error({ "job_id": 7 }),
-      decode_error({ "job_id": "bg-3", "wait_ms": -5 }),
-      decode_error({ "job_id": "bg-3", "wait_ms": "30000" }),
-      decode_error({ "job_id": "bg-3", "offset": -1 }),
-      decode_error({ "job_id": "bg-3", "offset": "0" }),
-    ],
-    content=(
-      #|[
-      #|  "job_output requires a string job_id",
-      #|  "job_output requires a string job_id",
-      #|  "job_output wait_ms must be a positive number",
-      #|  "job_output wait_ms must be a number",
-      #|  "job_output offset must be zero or a positive number",
-      #|  "job_output offset must be a number",
-      #|]
-    ),
+  assert_eq(decode_error({}), Some("job_output requires a string job_id"))
+  assert_eq(
+    decode_error({ "job_id": 7 }),
+    Some("job_output requires a string job_id"),
+  )
+  assert_eq(
+    decode_error({ "job_id": "bg-3", "offset": -1 }),
+    Some("job_output offset must be zero or a positive number"),
+  )
+  assert_eq(
+    decode_error({ "job_id": "bg-3", "offset": "0" }),
+    Some("job_output offset must be a number"),
   )
 }
 
 ///|
-/// The decoder's failure message with the source-location wrapper stripped, or
-/// "unexpected success" when decoding somehow succeeds.
-fn decode_error(arguments : Json) -> String {
+fn decode_error(arguments : Json) -> String? {
   try @decode.decode(arguments) catch {
-    error => @tool_error.failure_message("\{error}")
+    error => Some(@tool_error.failure_message("\{error}"))
   } noraise {
-    _ => "unexpected success"
+    _ => None
   }
 }

--- a/agent_tool/job_output/internal/decode/pkg.generated.mbti
+++ b/agent_tool/job_output/internal/decode/pkg.generated.mbti
@@ -8,14 +8,11 @@ import {
 // Values
 pub fn decode(Json) -> JobOutputInput raise
 
-pub let max_wait_ms : Int
-
 // Errors
 
 // Types and methods
 pub struct JobOutputInput {
   job_id : String
-  wait_ms : Int?
   offset : Int?
 } derive(@debug.Debug)
 pub fn JobOutputInput::to_repr(Self) -> @debug.Repr

--- a/agent_tool/job_output/job_output.mbt
+++ b/agent_tool/job_output/job_output.mbt
@@ -15,21 +15,13 @@ pub fn definition(
       #|running. Output beyond the window is retained: pass offset (a character offset
       #|from the START) to read an earlier window instead — offsets 0, 12000, 24000, …
       #|page through all of total_chars. If you need the job's result before you can
-      #|continue and have no other work to do, pass wait_ms to block until it finishes
-      #|instead of checking repeatedly.
+      #|continue and have no other work to do, call job_wait with job_ids first.
+      #|This tool reads immediately without waiting for completion; it has no wait_ms.
     ),
     schema=JsonSchema({
       "type": "object",
       "properties": {
         "job_id": { "type": "string" },
-        "wait_ms": {
-          "type": "number",
-          "description": (
-            #|Wait up to this many milliseconds (capped at 120000) for the job to finish
-            #|before reading. Use when you need the result now and have nothing else to
-            #|do; never poll in a loop.
-          ),
-        },
         "offset": {
           "type": "number",
           "description": (
@@ -63,17 +55,6 @@ async fn execute(
       "error: no background job with id \{job_id}",
       is_error=true,
     )
-  }
-  // Await-before-read: with wait_ms the caller blocks (bounded) until the job
-  // exits — one efficient await instead of a model round trip per poll. A
-  // deadline expiry is not an error; the response simply reports the job still
-  // running. The cap keeps a single tool call from holding the turn for long —
-  // the model can always call again.
-  match input.wait_ms {
-    Some(wait) => {
-      let _ = bg_runtime.wait_exit(job_id, wait)
-    }
-    None => ()
   }
   // Recent output, bounded to a window so a poll cannot flood the conversation
   // with a large job's full log. For output over the window, show the *tail*

--- a/agent_tool/job_output/job_output_test.mbt
+++ b/agent_tool/job_output/job_output_test.mbt
@@ -11,12 +11,6 @@ const CLI_SEQ : String = "cli/seq@0.1.0"
 const CLI_PRINTF : String = "cli/printf@0.1.0"
 
 ///|
-const CLI_SLEEP : String = "cli/sleep@0.1.0"
-
-///|
-const CLI_TRUE : String = "cli/true@0.1.0"
-
-///|
 /// Execute the job_output tool and unwrap its Respond output.
 async fn run_job_output(
   bg : @bgjobs.BgJobRuntime,
@@ -166,16 +160,16 @@ async test "job_output errors on an unknown job id" {
 }
 
 ///|
-async test "wait_ms blocks until the job finishes and returns its output" {
+async test "job_output reads the result after explicit completion waiting" {
   @async.with_task_group(group => {
     let bg = @bgjobs.BgJobRuntime(AgentTaskScope(group))
     let id = bg.start(
       program="moonx",
-      args=[CLI_SH, "-c", "sleep 1; echo WAITED-OK"],
+      args=[CLI_PRINTF, "WAITED-OK"],
       command="waited",
     )
-    // No polling loop: a single call awaits the exit and returns the result.
-    let output = run_job_output(bg, { "job_id": id, "wait_ms": 30000 })
+    @async.with_timeout(30000, () => bg.wait_any([id]))
+    let output = run_job_output(bg, { "job_id": id })
     assert_false(output.is_error)
     assert_true(output.content.contains("WAITED-OK"))
     assert_true(output.content.contains("exit=0"))
@@ -183,37 +177,46 @@ async test "wait_ms blocks until the job finishes and returns its output" {
 }
 
 ///|
-async test "a wait_ms deadline on a still-running job is not an error" {
-  @async.with_task_group(group => {
-    let bg = @bgjobs.BgJobRuntime(AgentTaskScope(group))
-    let id = bg.start(program="moonx", args=[CLI_SLEEP, "30"], command="slow")
-    let output = run_job_output(bg, { "job_id": id, "wait_ms": 200 })
-    // Deadline expiry just reports the live status; the model can call again.
-    assert_false(output.is_error)
-    assert_true(output.content.contains("running"))
-    let _ = bg.stop(id)
+#cfg(not(platform="windows"))
+async test "job_output returns before a gated job can complete" {
+  @async.with_timeout(5000, () => {
+    @async.with_task_group(group => {
+      let bg = @bgjobs.BgJobRuntime(AgentTaskScope(group))
+      let (input, release) = @process.write_to_process()
+      defer release.close()
+      let id = bg.start(
+        program="/bin/cat",
+        args=[],
+        command="gate",
+        stdin=input,
+      )
+      // Completion is impossible until after the read returns. No elapsed-time
+      // assertion or sleep-based race is needed to prove it does not wait.
+      let output = run_job_output(bg, { "job_id": id })
+      assert_false(output.is_error)
+      assert_true(output.content.contains("running"))
+      release.close()
+      bg.wait_any([id])
+    })
   })
 }
 
 ///|
-async test "a non-positive wait_ms is a tool error" {
+async test "removed wait_ms returns actionable tool error" {
   @async.with_task_group(group => {
     let bg = @bgjobs.BgJobRuntime(AgentTaskScope(group))
-    let id = bg.start(program="moonx", args=[CLI_TRUE], command="noop")
-    let output = run_job_output(bg, { "job_id": id, "wait_ms": -5 })
-    assert_true(output.is_error)
-    assert_true(output.content.contains("wait_ms"))
-  })
-}
-
-///|
-async test "a non-numeric wait_ms is a tool error, not silently ignored" {
-  @async.with_task_group(group => {
-    let bg = @bgjobs.BgJobRuntime(AgentTaskScope(group))
-    let id = bg.start(program="moonx", args=[CLI_TRUE], command="noop")
-    let output = run_job_output(bg, { "job_id": id, "wait_ms": "30000" })
-    assert_true(output.is_error)
-    assert_true(output.content.contains("wait_ms must be a number"))
+    for
+      value in [
+        Json::number(30000),
+        Json::number(-5),
+        Json::string("30000"),
+        Json::null(),
+      ] {
+      let output = run_job_output(bg, { "job_id": "bg-1", "wait_ms": value })
+      assert_true(output.is_error)
+      assert_true(output.content.contains("no longer accepts wait_ms"))
+      assert_true(output.content.contains("job_wait"))
+    }
   })
 }
 

--- a/agent_tool/job_output/moon.pkg
+++ b/agent_tool/job_output/moon.pkg
@@ -11,6 +11,7 @@ import {
   "bobzhang/openseek/agent_runtime",
   "moonbitlang/async",
   "moonbitlang/async/fs",
+  "moonbitlang/async/process",
 } for "test"
 
 supported_targets = "+wasm+native"

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -571,7 +571,9 @@ stderr warning while exit stays 0 — treat skipped blocks as a blind spot.
     workflow ever attached. Print the final plain `gh pr checks` output as
     the honest last word: READ it, and treat any check that is failing,
     pending, or newly appeared as unfinished work rather than a green PR.
-    Then keep working or finish the turn; a completion notice arrives.
+    While the monitor runs, keep working or call `job_wait` with its job ID
+    if you have no other work. The completion notice resumes that wait; an
+    already-finished turn is not restarted. Read the result with `job_output`.
     Never call a PR done while a check is pending or unreported.
     This bounded monitor discovers the current branch's PR, watches registered
     checks, then gives late workflows one settle interval to appear:

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -576,7 +576,9 @@ fn default_prompt() -> String {
     #|    workflow ever attached. Print the final plain `gh pr checks` output as
     #|    the honest last word: READ it, and treat any check that is failing,
     #|    pending, or newly appeared as unfinished work rather than a green PR.
-    #|    Then keep working or finish the turn; a completion notice arrives.
+    #|    While the monitor runs, keep working or call `job_wait` with its job ID
+    #|    if you have no other work. The completion notice resumes that wait; an
+    #|    already-finished turn is not restarted. Read the result with `job_output`.
     #|    Never call a PR done while a check is pending or unreported.
     #|    This bounded monitor discovers the current branch's PR, watches registered
     #|    checks, then gives late workflows one settle interval to appear:


### PR DESCRIPTION
#1369 is merged. This PR is rebased onto `main` and contains only the immediate `job_output` follow-up.

Remove `job_output.wait_ms` from the tool schema, argument decoder, and execution path. `job_output` reads available logs and status immediately; callers that need completion use `job_wait(job_ids)` first. Existing calls that still supply `wait_ms` get an actionable tool error rather than silently assuming a wait occurred. Tail windows, offset pagination, retained logs, and error classification are preserved.

Update examples and tests to wait explicitly before reading. The shipping prompt also directs the model to wait for its CI monitor instead of finishing a turn that still needs the monitor's result.

Validation:
- `just check`, offline `just test` (3230 native, 3196 JS, 24 cram cases), and `just build` for native and JS.
- A gated-process regression proves output reading returns before the job can complete; legacy-parameter cases verify migration feedback.
- Existing output paging, truncation, binary-output, policy-refusal, and nonzero-exit tests retained.
- Real CLI/local scripted-provider lifecycle test repeated on the final implementation.
- `moon info --target native`, `moon fmt`, generated API inspection, and self-review of the stacked diff.

No live-model smoke test or manual desktop GUI test was performed.


Before retargeting to main, the combined implementation passed `just check`, 134 focused agent/runtime/job-output tests, `just build`, and both real CLI scenarios (completion/read/finish and live serve goal-clear wake). Interface and format generation left the worktree clean. The base follow-up also passed the full workspace suite (3237 native, 3196 JS, 24 cram cases plus both CLI scenarios).

