### PR TITLE
perf(desktop): suspend editor mouse events during panel resizing

### DIFF
--- a/desktop/e2e/tests/editor_resize.spec.js
+++ b/desktop/e2e/tests/editor_resize.spec.js
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test';
+import { DesktopBrowserHarness } from './support/desktop_browser_harness.js';
+
+for (const handleSelector of ['.editor-resize-handle', '.tree-resize-handle']) {
+  test(`${handleSelector} suspends editor mouse events until the drag ends`, async ({ page }) => {
+    const app = new DesktopBrowserHarness(page);
+    await app.install();
+    await app.goto();
+    await app.openSession();
+    await app.openQuickOpen();
+    await page.getByRole('option', { name: /src\/main\.mbt/ }).click();
+
+    const viewer = page.locator('#viewer-host');
+    await expect(viewer).toBeVisible();
+    const content = viewer.locator('.view-lines');
+    await expect(content).toBeVisible();
+    // Observe actual browser hit testing, rather than dispatching synthetic
+    // events, which would bypass pointer-events and still reach the editor.
+    await viewer.evaluate(element => {
+      element.dataset.testMouseMoves = '0';
+      element.addEventListener('mousemove', () => {
+        element.dataset.testMouseMoves = String(Number(element.dataset.testMouseMoves) + 1);
+      }, true);
+    });
+    await content.hover();
+    await expect.poll(() => viewer.getAttribute('data-test-mouse-moves'))
+      .not.toBe('0');
+
+    const handle = page.locator(handleSelector);
+    await expect(handle).toBeVisible();
+    await handle.hover();
+    const start = await handle.boundingBox();
+    const editorBefore = await viewer.boundingBox();
+    await page.mouse.move(start.x + start.width / 2, start.y + start.height / 2);
+    await page.mouse.down();
+    try {
+      await expect(content).toHaveCSS('pointer-events', 'none');
+      await expect(handle).not.toHaveCSS('pointer-events', 'none');
+      await viewer.evaluate(element => { element.dataset.testMouseMoves = '0'; });
+      await page.mouse.move(
+        editorBefore.x + editorBefore.width * 0.7,
+        editorBefore.y + 30,
+        { steps: 6 },
+      );
+      await expect(viewer).toHaveAttribute('data-test-mouse-moves', '0');
+      // The document drag listener still receives movement over the disabled
+      // viewer, so the divider actually moves while the editor stays quiet.
+      await expect.poll(async () => (await handle.boundingBox()).x)
+        .not.toBe(start.x);
+    } finally {
+      await page.mouse.up();
+    }
+
+    await expect(content).not.toHaveCSS('pointer-events', 'none');
+    await page.mouse.move(2, 2);
+    await viewer.evaluate(element => { element.dataset.testMouseMoves = '0'; });
+    await content.hover();
+    await expect.poll(() => viewer.getAttribute('data-test-mouse-moves'))
+      .not.toBe('0');
+    expect(app.pageErrors).toEqual([]);
+  });
+}

--- a/desktop/styles/file_panel.css
+++ b/desktop/styles/file_panel.css
@@ -340,6 +340,21 @@ html.is-resizing * {
   user-select: none !important;
 }
 
+/* Like VS Code's SplitView, keep divider drags out of the editor's mouse
+   hit testing: a mousemove there reads geometry after the drag writes sizes.
+   Restrict this to viewer content so Desktop's divider handles remain usable.
+   Include descendants because viewer widgets can explicitly enable pointers.
+   Removing the existing drag class restores each widget's normal behavior. */
+html:is(
+  .is-resizing,
+  .is-resizing-row,
+  .is-resizing-col,
+  .is-resizing-terminal,
+  .is-resizing-review
+) :is(.viewer-stack, .viewer-stack *) {
+  pointer-events: none !important;
+}
+
 /* ---------- dock: browser tabs, launcher, file picker ---------- */
 /* The active tab's kind is a class on .editor (mode-file / mode-browser /
    mode-picker / mode-launcher); every body part below the strip is always


### PR DESCRIPTION
Dragging a Desktop panel divider can send mousemove events into the file editor, whose hit testing reads geometry after the divider changes layout. Disable pointer events on viewer content and its descendants while the existing resize classes are active; removing the class restores normal interaction. Desktop divider handles remain outside the disabled content.

This is limited to Desktop CSS and two Playwright tests. It does not change editor internals or address the separate transcript ResizeObserver / document VDOM comparison bottleneck.

Validation: built and ran the complete Desktop browser suite on this branch independently of the reasoning changes. The added tests exercise real mouse dragging on the editor and file-tree dividers, verify that editor mousemove events stop while the divider still moves, and verify restoration after mouseup. JavaScript syntax, MoonBit interface generation, formatting, and diff checks also pass.
