### PR TITLE
Add mbtx descriptions to transcripts and background jobs

### DIFF
--- a/agent/job_wait.mbt
+++ b/agent/job_wait.mbt
@@ -8,7 +8,9 @@ fn AgentLoop::background_finish_notice(self : AgentLoop) -> String? {
     .filter(job => !self.jobs_before_turn.contains(job.id))
   guard !pending.is_empty() else { return None }
   let labels = pending
-    .map(job => "\{job.id}: \{@agent_tool.brief_line(job.command, limit=100)}")
+    .map(job => {
+      "\{job.id}: \{@agent_tool.brief_line(job.description.unwrap_or(job.command), limit=100)}"
+    })
     .join("\n")
   Some(
     "Background jobs still need a decision:\n\{labels}\nIf your work is complete, call finish. If you need their results and have no other work, call job_wait with job_ids. Otherwise keep working, or stop unneeded jobs with job_stop.",

--- a/agent/tool_definition.mbt
+++ b/agent/tool_definition.mbt
@@ -15,7 +15,11 @@ fn background_notice_text(snapshot : @bgjobs.BgJobSnapshot) -> String {
       }
     Running => "running"
   }
-  "background job \{snapshot.id} finished (\{status}): `\{snapshot.command}` — read its output with job_output (job_id=\"\{snapshot.id}\")."
+  let label = match snapshot.description {
+    Some(description) => "\{description} · \{snapshot.command}"
+    None => snapshot.command
+  }
+  "background job \{snapshot.id} finished (\{status}): `\{label}` — read its output with job_output (job_id=\"\{snapshot.id}\")."
 }
 
 ///|
@@ -212,8 +216,8 @@ async test "the registry has no shell tool family" {
       fail("expected an object schema")
     }
     let names = properties.keys().collect()
-    assert_eq(names.length(), 4)
-    for name in ["source", "target", "cwd", "warning"] {
+    assert_eq(names.length(), 5)
+    for name in ["source", "description", "target", "cwd", "warning"] {
       assert_true(names.contains(name))
     }
     assert_false(mbtx.description.contains("run_in_background"))
@@ -265,7 +269,11 @@ async test "a handoff carries build warnings and the build-ok label" {
       #|  let unused = 1
       #|  @async.sleep(60_000)
       #|}
-    let action = run_async_tool(mbtx, { "source": source, "warning": "on" })
+    let action = run_async_tool(mbtx, {
+      "source": source,
+      "warning": "on",
+      "description": "Check compiler warnings",
+    })
     guard action is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
     assert_true(output.content.contains("moved to the background"))
@@ -274,6 +282,8 @@ async test "a handoff carries build warnings and the build-ok label" {
     assert_true(output.content.contains("source:"))
     guard bg_runtime.list() is [job, ..] else { fail("no job was registered") }
     assert_true(job.command.contains("build ok"))
+    assert_eq(job.description, Some("Check compiler warnings"))
+    assert_true(background_notice_text(job).contains("Check compiler warnings"))
     let _ = bg_runtime.stop(job.id)
     @fs.rmdir(spill_dir, recursive=true) catch {
       _ => ()

--- a/agent_tool/bgjobs/bgjobs.mbt
+++ b/agent_tool/bgjobs/bgjobs.mbt
@@ -93,6 +93,7 @@ struct BgJobRuntime {
 priv struct BgJob {
   id : String
   command : String
+  description : String?
   exec : @shell_exec.ShellExecution
   // The opaque prepared command is carried from launch so a reader can apply
   // the same source-write-denial detection the foreground path does.
@@ -125,6 +126,7 @@ priv struct BgJob {
 pub struct BgJobSnapshot {
   id : String
   command : String
+  description : String?
   status : BgJobStatus
   priv output : String
   output_truncated : Bool
@@ -255,6 +257,7 @@ pub async fn BgJobRuntime::start(
   program~ : String,
   args~ : Array[String],
   command~ : String,
+  description? : String,
   cwd? : String,
   max_output_chars? : Int = default_max_output_chars,
   sandboxed_command? : @sandbox.SandboxedCommand,
@@ -274,6 +277,7 @@ pub async fn BgJobRuntime::start(
     id,
     exec,
     command~,
+    description?,
     sandboxed_command?,
     read_only_review~,
     output_rewrites~,
@@ -292,6 +296,7 @@ pub fn BgJobRuntime::adopt(
   self : BgJobRuntime,
   exec : @shell_exec.ShellExecution,
   command~ : String,
+  description? : String,
   sandboxed_command? : @sandbox.SandboxedCommand,
   read_only_review? : Bool = false,
   output_rewrites? : Array[(String, String)] = [],
@@ -303,6 +308,7 @@ pub fn BgJobRuntime::adopt(
     id,
     exec,
     command~,
+    description?,
     sandboxed_command?,
     read_only_review~,
     output_rewrites~,
@@ -319,6 +325,7 @@ fn BgJobRuntime::register(
   id : String,
   exec : @shell_exec.ShellExecution,
   command~ : String,
+  description? : String,
   sandboxed_command? : @sandbox.SandboxedCommand,
   read_only_review~ : Bool,
   output_rewrites~ : Array[(String, String)],
@@ -328,6 +335,7 @@ fn BgJobRuntime::register(
   self.jobs[id] = {
     id,
     command,
+    description,
     exec,
     sandboxed_command,
     read_only_review,
@@ -398,6 +406,7 @@ fn BgJob::to_snapshot(self : BgJob) -> BgJobSnapshot {
   {
     id: self.id,
     command: self.command,
+    description: self.description,
     status: bg_status(self.exec.status()),
     output: self.exec.head(),
     output_truncated: self.exec.output_truncated(),

--- a/agent_tool/bgjobs/pkg.generated.mbti
+++ b/agent_tool/bgjobs/pkg.generated.mbti
@@ -15,14 +15,14 @@ import {
 // Types and methods
 type BgJobRuntime
 pub fn[X] BgJobRuntime::BgJobRuntime(@agent_runtime.AgentTaskScope[X], spill_dir? : String, hard_output_cap? : Int, hard_timeout_ms? : Int, on_job_exit? : (BgJobSnapshot) -> Unit) -> Self
-pub fn BgJobRuntime::adopt(Self, @shell_exec.ShellExecution, command~ : String, sandboxed_command? : @sandbox.SandboxedCommand, read_only_review? : Bool, output_rewrites? : Array[(String, String)], moonrun_policy_active? : Bool, on_terminal? : async () -> Unit) -> String
+pub fn BgJobRuntime::adopt(Self, @shell_exec.ShellExecution, command~ : String, description? : String, sandboxed_command? : @sandbox.SandboxedCommand, read_only_review? : Bool, output_rewrites? : Array[(String, String)], moonrun_policy_active? : Bool, on_terminal? : async () -> Unit) -> String
 pub fn BgJobRuntime::list(Self) -> Array[BgJobSnapshot]
 pub fn BgJobRuntime::pending(Self) -> Array[BgJobSnapshot]
 pub async fn BgJobRuntime::read_output(Self, String) -> String?
 pub async fn BgJobRuntime::read_output_tail(Self, String, Int) -> String?
 pub fn BgJobRuntime::snapshot(Self, String) -> BgJobSnapshot?
 pub async fn BgJobRuntime::spawn_foreground_retained(Self, String, Array[String], String?, Int, stdin? : &@process.ProcessInput) -> @shell_exec.ShellExecution
-pub async fn BgJobRuntime::start(Self, program~ : String, args~ : Array[String], command~ : String, cwd? : String, max_output_chars? : Int, sandboxed_command? : @sandbox.SandboxedCommand, read_only_review? : Bool, output_rewrites? : Array[(String, String)], moonrun_policy_active? : Bool, stdin? : &@process.ProcessInput) -> String
+pub async fn BgJobRuntime::start(Self, program~ : String, args~ : Array[String], command~ : String, description? : String, cwd? : String, max_output_chars? : Int, sandboxed_command? : @sandbox.SandboxedCommand, read_only_review? : Bool, output_rewrites? : Array[(String, String)], moonrun_policy_active? : Bool, stdin? : &@process.ProcessInput) -> String
 pub async fn BgJobRuntime::stop(Self, String) -> Bool
 pub async fn BgJobRuntime::terminal_denial_feedback(Self, String) -> String?
 pub async fn BgJobRuntime::wait_any(Self, Array[String]) -> Unit
@@ -31,6 +31,7 @@ pub async fn BgJobRuntime::wait_exit(Self, String, Int) -> Bool
 pub struct BgJobSnapshot {
   id : String
   command : String
+  description : String?
   status : BgJobStatus
   output_truncated : Bool
   size : Int

--- a/agent_tool/job_output/job_output.mbt
+++ b/agent_tool/job_output/job_output.mbt
@@ -175,7 +175,10 @@ async fn execute(
   }
   content.write_string(footer)
   let content = content.to_string()
-  @agent_tool.respond(content, is_error~)
+  let brief = snapshot.description.map(description => {
+    "job \{job_id} (\{status_label}): \{description}"
+  })
+  @agent_tool.respond(content, is_error~, brief?)
 }
 
 ///|

--- a/agent_tool/job_output/job_output_test.mbt
+++ b/agent_tool/job_output/job_output_test.mbt
@@ -68,12 +68,14 @@ async test "job_output returns a running job's output and status" {
       program="moonx",
       args=[CLI_SH, "-c", "printf hi; sleep 30"],
       command="job",
+      description="Collect progress",
     )
     poll_bg_output(bg, id, "hi")
     let output = run_job_output(bg, { "job_id": id })
     assert_false(output.is_error)
     assert_true(output.content.contains("hi"))
     assert_true(output.content.contains("running"))
+    assert_eq(output.brief, Some("job \{id} (running): Collect progress"))
     let _ = bg.stop(id)
   })
 }

--- a/agent_tool/mbtx/README.mbt.md
+++ b/agent_tool/mbtx/README.mbt.md
@@ -45,6 +45,10 @@ cancelled at that deadline.
 
 ## Arguments
 
+- `description` (string, optional): a short human-readable label shown in the
+  transcript and inherited by any background job. Presentation only; it does
+  not affect compilation, execution, sandboxing, or background handoff.
+
 - `source` (string, required): a full `.mbtx` program. It may open with an
   inline `import { "pkg", "pkg", … }` block (comma-separated module paths),
   then the program including its own `main`. Use `async fn main` for

--- a/agent_tool/mbtx/internal/decode/decode.mbt
+++ b/agent_tool/mbtx/internal/decode/decode.mbt
@@ -5,6 +5,8 @@
 /// program runs in; `None` means the workspace root).
 pub struct MbtxInput {
   source : String
+  /// Presentation metadata, inherited by a background job.
+  description : String?
   target : String
   cwd : String?
   /// Whether compiler warnings appear in the run output — decoded from the
@@ -58,6 +60,12 @@ pub fn decode(arguments : Json) -> MbtxInput raise {
   }
   match arguments {
     { "source": String(source), .. } => {
+      let description = match arguments {
+        { "description": String(text), .. } => Some(text)
+        { "description": Null, .. } => None
+        { "description": _, .. } => fail("arguments.description to be a string")
+        _ => None
+      }
       let target = match arguments {
         { "target": String(t), .. } => t
         { "target": Null, .. } => "wasm"
@@ -93,7 +101,7 @@ pub fn decode(arguments : Json) -> MbtxInput raise {
         { "subrun": _, .. } => fail("arguments.subrun to be a boolean")
         _ => false
       }
-      { source, target, cwd, warning, escalated, subrun, }
+      { source, description, target, cwd, warning, escalated, subrun, }
     }
     Object(_) => fail("arguments.source")
     _ => fail("object arguments")
@@ -164,6 +172,7 @@ test "decode rejects malformed arguments" {
     // missing source, and arguments that are not an object at all.
     { "source": "x", "warning": "loud" },
     { "source": "x", "cwd": 3 },
+    { "source": "x", "description": 3 },
     { "source": "x", "target": "banana" },
     { "code": "x" },
     Json("x"),
@@ -186,3 +195,14 @@ test "decode rejects malformed arguments" {
 #deprecated("the derived Debug impl is the API; use @debug.repr or the trait directly")
 #doc(hidden)
 pub extend MbtxInput with Debug::{to_repr}
+
+///|
+test "description is optional presentation metadata" {
+  assert_eq(decode({ "source": "x" }).description, None)
+  assert_eq(decode({ "source": "x", "description": null }).description, None)
+  assert_eq(
+    decode({ "source": "x", "description": "Run tests" }).description,
+    Some("Run tests"),
+  )
+  assert_eq(decode({ "source": "x", "description": "" }).description, Some(""))
+}

--- a/agent_tool/mbtx/internal/decode/pkg.generated.mbti
+++ b/agent_tool/mbtx/internal/decode/pkg.generated.mbti
@@ -13,6 +13,7 @@ pub fn decode(Json) -> MbtxInput raise
 // Types and methods
 pub struct MbtxInput {
   source : String
+  description : String?
   target : String
   cwd : String?
   warning : Bool

--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -726,6 +726,7 @@ async fn execute(
       // program output and its `exit=N` is the program's own by construction.
       let id = runtime.adopt(
         exec,
+        description?=input.description,
         command=if staged {
           "mbtx run (build ok): \{@agent_tool.brief_line(input.source, limit=64)}"
         } else {
@@ -1326,6 +1327,13 @@ fn schema(escalation~ : Bool, hosting~ : Bool) -> Json {
       Map(
         [
           ("source", Json({ "type": "string" })),
+          (
+            "description",
+            {
+              "type": "string",
+              "description": "Short human-readable description of this call for the transcript. Inherited by any background job; does not affect execution.",
+            },
+          ),
           (
             "target",
             {

--- a/agent_tool/mbtx/mbtx_test.mbt
+++ b/agent_tool/mbtx/mbtx_test.mbt
@@ -695,8 +695,8 @@ test "the schema advertises every decoded argument" {
   // MoonBit's String ordering is by length first, so a sorted expectation would
   // encode neither what this test means nor what a reader expects.
   let names = properties.keys().collect()
-  assert_eq(names.length(), 4)
-  for name in ["source", "target", "cwd", "warning"] {
+  assert_eq(names.length(), 5)
+  for name in ["source", "description", "target", "cwd", "warning"] {
     assert_true(names.contains(name))
   }
   assert_eq(required, (["source"] : Json))

--- a/cmd/viz_app/e2e/tests/support/viz_browser_harness.js
+++ b/cmd/viz_app/e2e/tests/support/viz_browser_harness.js
@@ -64,7 +64,7 @@ export class VizBrowserHarness {
               {
                 id: 'mbtx-build',
                 name: 'mbtx',
-                arguments: JSON.stringify({ source: 'fn main { compile_error }' }),
+                arguments: JSON.stringify({ source: 'fn main { compile_error }', description: 'Check <compiler> diagnostics' }),
               },
               {
                 id: 'mbtx-run',

--- a/cmd/viz_app/e2e/tests/viz_dom.spec.js
+++ b/cmd/viz_app/e2e/tests/viz_dom.spec.js
@@ -47,6 +47,9 @@ test('build-error filter separates build diagnostics from other failures', async
   await page.getByRole('button', { name: 'Raw log' }).click();
 
   const buildFailure = page.locator('details.card').filter({ hasText: 'type mismatch' });
+  const buildCall = page.locator('summary.tool-call-name').filter({ hasText: 'Check <compiler> diagnostics' });
+  await expect(buildCall).toBeVisible();
+  await expect(buildCall).toContainText('mbtx (build failed, exit=1)');
   const runtimeFailure = page.locator('details.card').filter({ hasText: 'runtime trap' });
   const shellFailure = page.locator('details.card').filter({ hasText: 'fixture failure' });
   await page.getByRole('button', { name: 'Build errors only', exact: true }).click();

--- a/desktop/e2e/tests/rabbita_dom.spec.js
+++ b/desktop/e2e/tests/rabbita_dom.spec.js
@@ -645,6 +645,7 @@ test('tool-call tabs keep focus-driven scrolling inside the transcript', async (
             name: 'mbtx',
             arguments: JSON.stringify({
               source: 'fn main { println("browser fixture") }',
+              description: 'Print <browser> fixture',
             }),
           },
         ],
@@ -661,6 +662,7 @@ test('tool-call tabs keep focus-driven scrolling inside the transcript', async (
   await app.openSession();
 
   const transcript = page.locator('#transcript');
+  await expect(transcript.locator('.tool-call-summary')).toContainText('Print <browser> fixture');
   const tabs = transcript.locator('.tool-call-tabs');
   const originalJson = tabs.getByText('Original JSON', { exact: true });
   await transcript.locator('.tool-call-summary').click();

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -295,6 +295,14 @@ fn tool_request_view(
   } else {
     name
   }
+  let label = if name == "mbtx" &&
+    card_fields(arguments) is Some(fields) &&
+    fields.get("description") is Some(String(description)) &&
+    !description.is_blank() {
+    "\{label} · \{description}"
+  } else {
+    label
+  }
   let error_class = (if is_error { " error" } else { "" }) +
     failure_stage_class(name, brief, is_error, Some(arguments))
   // The row's always-visible line: the brief, a literal marker when the

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -1046,6 +1046,13 @@ fn tool_call_view(
   if briefs.get(call.id) is Some(brief) && !brief.is_blank() {
     name_row.push(@html.span(class="tool-call-brief") <| " · \{brief}")
   }
+  if call.name == "mbtx" {
+    let arguments = Some(@json.parse(call.arguments)) catch { _ => None }
+    if arguments is Some({ "description": String(description), .. }) &&
+      !description.is_blank() {
+      name_row.push(@html.span(class="tool-call-brief", " · \{description}"))
+    }
+  }
   let plan_steps = plan_call_steps(call)
   if plan_steps is Some(steps) {
     name_row.push(plan_ribbon(steps))


### PR DESCRIPTION
An mbtx call can now include an optional description so readers can identify its purpose without expanding the source. The desktop transcript and session viewer show it alongside the existing execution status.

Background jobs inherit the description for completion notices, pending-job reminders, and job_output captions. Compilation, sandboxing, handoff timing, process lifecycle, and output content are unchanged; calls without a description retain their existing presentation.

Validation:
- `moon info && moon fmt`, `just check`, `just test`, and `just build` pass.
- 3,238 native tests and 3,197 JavaScript tests pass, plus offline cram and CLI lifecycle tests.
- Focused Playwright checks pass in both desktop and the session viewer, including literal angle-bracket text and preserved failure status.
