### PR TITLE
Exclude .claude and _build directories from desktop text search

### DIFF
--- a/desktop/internal/host/text_search.mbt
+++ b/desktop/internal/host/text_search.mbt
@@ -25,12 +25,13 @@ const MaxTextSearchPreviewUnits : Int = 400
 const TextSearchContextBeforeUnits : Int = 120
 
 ///|
-/// VS Code's default `files.exclude` plus `search.exclude`, and Claude metadata.
+/// VS Code's default `files.exclude` plus `search.exclude`, Claude metadata,
+/// and MoonBit build output.
 /// `getRgArgs` emits folder exclusions after every include, so an exclusion
 /// always wins.
 let default_text_search_excludes : Array[String] = [
   "**/.git", "**/.svn", "**/.hg", "**/.DS_Store", "**/Thumbs.db", "**/node_modules",
-  "**/bower_components", "**/*.code-search", "**/.claude",
+  "**/bower_components", "**/*.code-search", "**/.claude", "**/_build",
 ]
 
 ///|
@@ -1172,10 +1173,10 @@ test "text search arguments mirror VS Code regex, ignore, and glob defaults" {
     "-g", "**/src/**", "-g", "**/tests/*.{mbt,md}/**", "-g", "**/tests/*.{mbt,md}",
     "-g", "!**/.git", "-g", "!**/.svn", "-g", "!**/.hg", "-g", "!**/.DS_Store", "-g",
     "!**/Thumbs.db", "-g", "!**/node_modules", "-g", "!**/bower_components", "-g",
-    "!**/*.code-search", "-g", "!**/.claude", "-g", "!**/*.snap/**", "-g", "!**/*.snap",
-    "-g", "!**/generated/**", "--max-filesize", "17179869184", "--no-ignore-parent",
-    "--follow", "--crlf", "--engine", "auto", "--regexp", "\\bmoon.*bit\\b", "--no-config",
-    "--no-ignore-global", "--json", "--", ".",
+    "!**/*.code-search", "-g", "!**/.claude", "-g", "!**/_build", "-g", "!**/*.snap/**",
+    "-g", "!**/*.snap", "-g", "!**/generated/**", "--max-filesize", "17179869184",
+    "--no-ignore-parent", "--follow", "--crlf", "--engine", "auto", "--regexp", "\\bmoon.*bit\\b",
+    "--no-config", "--no-ignore-global", "--json", "--", ".",
   ])
   assert_eq(args, expected)
 }

--- a/desktop/internal/host/text_search.mbt
+++ b/desktop/internal/host/text_search.mbt
@@ -25,11 +25,12 @@ const MaxTextSearchPreviewUnits : Int = 400
 const TextSearchContextBeforeUnits : Int = 120
 
 ///|
-/// VS Code's default `files.exclude` plus `search.exclude`. `getRgArgs` emits
-/// folder exclusions after every include, so an exclusion always wins.
+/// VS Code's default `files.exclude` plus `search.exclude`, and Claude metadata.
+/// `getRgArgs` emits folder exclusions after every include, so an exclusion
+/// always wins.
 let default_text_search_excludes : Array[String] = [
   "**/.git", "**/.svn", "**/.hg", "**/.DS_Store", "**/Thumbs.db", "**/node_modules",
-  "**/bower_components", "**/*.code-search",
+  "**/bower_components", "**/*.code-search", "**/.claude",
 ]
 
 ///|
@@ -1171,10 +1172,10 @@ test "text search arguments mirror VS Code regex, ignore, and glob defaults" {
     "-g", "**/src/**", "-g", "**/tests/*.{mbt,md}/**", "-g", "**/tests/*.{mbt,md}",
     "-g", "!**/.git", "-g", "!**/.svn", "-g", "!**/.hg", "-g", "!**/.DS_Store", "-g",
     "!**/Thumbs.db", "-g", "!**/node_modules", "-g", "!**/bower_components", "-g",
-    "!**/*.code-search", "-g", "!**/*.snap/**", "-g", "!**/*.snap", "-g", "!**/generated/**",
-    "--max-filesize", "17179869184", "--no-ignore-parent", "--follow", "--crlf",
-    "--engine", "auto", "--regexp", "\\bmoon.*bit\\b", "--no-config", "--no-ignore-global",
-    "--json", "--", ".",
+    "!**/*.code-search", "-g", "!**/.claude", "-g", "!**/*.snap/**", "-g", "!**/*.snap",
+    "-g", "!**/generated/**", "--max-filesize", "17179869184", "--no-ignore-parent",
+    "--follow", "--crlf", "--engine", "auto", "--regexp", "\\bmoon.*bit\\b", "--no-config",
+    "--no-ignore-global", "--json", "--", ".",
   ])
   assert_eq(args, expected)
 }


### PR DESCRIPTION
Desktop text search currently includes files under `.claude` and `_build`, so Claude worktree copies and MoonBit build output can appear as duplicate or generated search results. Add `**/.claude` and `**/_build` to the default ripgrep exclusions to skip these directories at any depth, and update the existing search argument test.

Validation: `just check`, the JavaScript suite (3,197 tests), offline cram tests, CLI lifecycle checks, `just build`, and `moon info && moon fmt` passed. The native suite passed 3,233 of 3,234 tests; the unrelated live DeepSeek API smoke test failed because its response contained trailing spaces after the expected JSON. Generated interfaces are unchanged. A temporary ripgrep fixture also verified that root and nested `.claude` and `_build` directories are excluded even with an explicit `**/*` include, while ordinary source and other hidden files remain searchable.
