### PR TITLE
chore(desktop): drop the space from the development bundle name

### DIFF
--- a/desktop/package/build.mjs
+++ b/desktop/package/build.mjs
@@ -46,7 +46,7 @@ const EsbuildVersion = "0.28.1";
 // `desktop/main.mbt` too.
 const DevelopmentSuffix = ".dev";
 const DevelopmentConfig = "proton.project.dev.json";
-const DevelopmentProduct = "SeekMoon Dev";
+const DevelopmentProduct = "SeekMoonDev";
 
 // These archives already contain browser-ready distributions. Fetching the
 // exact tarballs avoids installing a package manager or recreating its


### PR DESCRIPTION
## Summary

- The development package was written to `dist/SeekMoon Dev.app`; it is now `dist/SeekMoonDev.app`.
- Only `DevelopmentProduct` in `desktop/package/build.mjs` changes. It feeds both `package.product_name` in the generated `proton.project.dev.json` and the path packaging opens afterwards, so the bundle and its CEF helpers are named consistently.
- The `.dev` identifier suffix is untouched: a development build still has its own identity, permission grants, and data directory.

## Test plan

- [x] `node --check desktop/package/build.mjs`
- [ ] `node desktop/package/build.mjs macos` produces `desktop/dist/SeekMoonDev.app` and it launches (a stale `SeekMoon Dev.app` in `dist/` is not removed automatically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TooZjN8RDD5meZ3ybCKzb5
