### PR TITLE
Show job descriptions in waiting rows

### DIFF
--- a/desktop/e2e/tests/rabbita_dom.spec.js
+++ b/desktop/e2e/tests/rabbita_dom.spec.js
@@ -1876,3 +1876,32 @@ test('composer follow-up menu supports keyboard choice and a queue default', asy
   expect(app.requests.filter(r => r.method === 'settings.set')).toEqual([]);
   expect(app.pageErrors).toEqual([]);
 });
+
+test('pending job waits show descriptions from earlier tool rows', async ({ page }) => {
+  const app = new DesktopBrowserHarness(page);
+  app.sessionEvents = [
+    { sequence: 1, item: { kind: 'user', payload: { content: 'Show the browser fixture waiting for CI' } } },
+    { sequence: 2, item: { kind: 'assistant', payload: {
+      content: '', tool_calls: [{ id: 'start', name: 'mbtx',
+        arguments: JSON.stringify({ description: 'Watch CI on rebased PR 27' }) }],
+    } } },
+    { sequence: 3, item: { kind: 'tool_result', payload: {
+      tool_call_id: 'start', tool_name: 'mbtx', content: '',
+      is_error: false, brief: 'mbtx → bg bg-10',
+    } } },
+    { sequence: 4, item: { kind: 'assistant', payload: {
+      content: '', tool_calls: [{ id: 'wait', name: 'job_wait',
+        arguments: JSON.stringify({ job_ids: ['bg-10', 'bg-11'] }) }],
+    } } },
+  ];
+  await app.install();
+  await app.goto();
+  await app.openSession();
+  const wait = page.locator('details.tool-call').filter({ hasText: 'Waiting for' });
+  await expect(wait.locator('.tool-call-text')).toHaveText(
+    'Waiting for bg-10: Watch CI on rebased PR 27, bg-11');
+  await expect(wait).not.toHaveAttribute('open', '');
+  await wait.locator('summary').click();
+  await expect(wait).toContainText('"job_ids"');
+  expect(app.pageErrors).toEqual([]);
+});

--- a/desktop/e2e/tests/rabbita_dom.spec.js
+++ b/desktop/e2e/tests/rabbita_dom.spec.js
@@ -1891,7 +1891,8 @@ test('pending job waits show descriptions from earlier tool rows', async ({ page
     } } },
     { sequence: 4, item: { kind: 'assistant', payload: {
       content: '', tool_calls: [{ id: 'wait', name: 'job_wait',
-        arguments: JSON.stringify({ job_ids: ['bg-10', 'bg-11'] }) }],
+        arguments: JSON.stringify({ job_ids: ['bg-10', 'bg-11'] }) },
+        { id: 'wait', name: 'job_wait', arguments: JSON.stringify({ job_ids: ['bg-11'] }) }],
     } } },
   ];
   await app.install();
@@ -1899,9 +1900,9 @@ test('pending job waits show descriptions from earlier tool rows', async ({ page
   await app.openSession();
   const wait = page.locator('details.tool-call').filter({ hasText: 'Waiting for' });
   await expect(wait.locator('.tool-call-text')).toHaveText(
-    'Waiting for bg-10: Watch CI on rebased PR 27, bg-11');
-  await expect(wait).not.toHaveAttribute('open', '');
-  await wait.locator('summary').click();
-  await expect(wait).toContainText('"job_ids"');
+    ['Waiting for bg-10: Watch CI on rebased PR 27, bg-11', 'Waiting for bg-11']);
+  await expect(wait.first()).not.toHaveAttribute('open', '');
+  await wait.first().locator('summary').click();
+  await expect(wait.first()).toContainText('"job_ids"');
   expect(app.pageErrors).toEqual([]);
 });

--- a/desktop/frontend/transcript/component/job_wait.mbt
+++ b/desktop/frontend/transcript/component/job_wait.mbt
@@ -42,16 +42,18 @@ fn collect_job_description(
     call.arguments is Some(arguments) else {
     return
   }
-  let args = @json.parse(arguments) catch { _ => return }
   if call.name == "mbtx" {
-    guard brief.strip_prefix("mbtx → bg ") is Some(id) &&
-      !id.is_blank() &&
-      args is { "description": String(description), .. } &&
+    guard brief.strip_prefix("mbtx → bg ") is Some(id) && !id.is_blank() else {
+      return
+    }
+    let args = @json.parse(arguments) catch { _ => return }
+    guard args is { "description": String(description), .. } &&
       !description.is_blank() else {
       return
     }
     descriptions[id.to_owned()] = description
   } else if call.name == "job_output" {
+    let args = @json.parse(arguments) catch { _ => return }
     guard args is { "job_id": String(id), .. } &&
       brief.strip_prefix("job \{id} (") is Some(rest) &&
       rest.to_owned().split_once("): ") is Some((_, description)) &&
@@ -66,15 +68,15 @@ fn collect_job_description(
 fn job_wait_labels(
   item : @transcript.TranscriptItem,
   descriptions : Map[String, String],
-) -> Map[String, String] {
-  let labels : Map[String, String] = Map([])
+) -> Map[Int, String] {
+  let labels : Map[Int, String] = Map([])
   if item.kind is Assistant(calls~, ..) {
     for call in calls {
       collect_job_description(call, descriptions)
     }
-    for call in calls {
+    for index, call in calls {
       if pending_job_wait_label(call, descriptions~) is Some(label) {
-        labels[call.call_id] = label
+        labels[index] = label
       }
     }
   }

--- a/desktop/frontend/transcript/component/job_wait.mbt
+++ b/desktop/frontend/transcript/component/job_wait.mbt
@@ -1,7 +1,10 @@
 ///|
 /// Keep the selected jobs visible even when the arguments disclosure is shut.
 /// Pending is already part of the normal tool lifecycle; no new run state.
-fn pending_job_wait_label(call : @transcript.ToolCall) -> String? {
+fn pending_job_wait_label(
+  call : @transcript.ToolCall,
+  descriptions? : Map[String, String] = Map([]),
+) -> String? {
   guard call.name == "job_wait" &&
     call.outcome is Pending(..) &&
     call.arguments is Some(arguments) else {
@@ -18,5 +21,62 @@ fn pending_job_wait_label(call : @transcript.ToolCall) -> String? {
       ids.push(id)
     }
   }
-  Some("Waiting for \{ids.join(", ")}")
+  let targets = ids.map(id => {
+    match descriptions.get(id) {
+      Some(description) => "\{id}: \{description}"
+      None => id
+    }
+  })
+  Some("Waiting for \{targets.join(", ")}")
+}
+
+///|
+/// Read only tool metadata, never command output. The map belongs to one
+/// transcript render, so identical job IDs in other sessions cannot leak in.
+fn collect_job_description(
+  call : @transcript.ToolCall,
+  descriptions : Map[String, String],
+) -> Unit {
+  guard (call.name == "mbtx" || call.name == "job_output") &&
+    call.outcome is Done(is_error=false, brief=Some(brief), ..) &&
+    call.arguments is Some(arguments) else {
+    return
+  }
+  let args = @json.parse(arguments) catch { _ => return }
+  if call.name == "mbtx" {
+    guard brief.strip_prefix("mbtx → bg ") is Some(id) &&
+      !id.is_blank() &&
+      args is { "description": String(description), .. } &&
+      !description.is_blank() else {
+      return
+    }
+    descriptions[id.to_owned()] = description
+  } else if call.name == "job_output" {
+    guard args is { "job_id": String(id), .. } &&
+      brief.strip_prefix("job \{id} (") is Some(rest) &&
+      rest.to_owned().split_once("): ") is Some((_, description)) &&
+      !description.is_blank() else {
+      return
+    }
+    descriptions[id] = description.to_owned()
+  }
+}
+
+///|
+fn job_wait_labels(
+  item : @transcript.TranscriptItem,
+  descriptions : Map[String, String],
+) -> Map[String, String] {
+  let labels : Map[String, String] = Map([])
+  if item.kind is Assistant(calls~, ..) {
+    for call in calls {
+      collect_job_description(call, descriptions)
+    }
+    for call in calls {
+      if pending_job_wait_label(call, descriptions~) is Some(label) {
+        labels[call.call_id] = label
+      }
+    }
+  }
+  labels
 }

--- a/desktop/frontend/transcript/component/job_wait_wbtest.mbt
+++ b/desktop/frontend/transcript/component/job_wait_wbtest.mbt
@@ -17,3 +17,88 @@ test "pending job wait labels expose targets and clear on result" {
   assert_eq(pending_job_wait_label({ ..call, arguments: Some("{}"), }), None)
   assert_eq(pending_job_wait_label({ ..call, name: "job_output", }), None)
 }
+
+///|
+test "waiting labels reuse recorded job descriptions and keep unknown IDs" {
+  let start : @transcript.ToolCall = {
+    call_id: "start",
+    name: "mbtx",
+    arguments: Some("{\"description\":\"Watch CI on rebased PR 27\"}"),
+    outcome: Done(
+      content="untrusted output",
+      is_error=false,
+      brief=Some("mbtx → bg bg-10"),
+    ),
+  }
+  let wait : @transcript.ToolCall = {
+    call_id: "wait",
+    name: "job_wait",
+    arguments: Some("{\"job_ids\":[\"bg-10\",\"bg-11\",\"bg-10\"]}"),
+    outcome: Pending(output=None),
+  }
+  let item : @transcript.TranscriptItem = {
+    kind: Assistant(
+      reasoning=None,
+      prose=None,
+      calls=[start, wait],
+      replay=false,
+      finished=false,
+    ),
+    ts: None,
+    sequence: None,
+  }
+  let descriptions : Map[String, String] = Map([])
+  assert_eq(
+    job_wait_labels(item, descriptions).get("wait"),
+    Some("Waiting for bg-10: Watch CI on rebased PR 27, bg-11"),
+  )
+  assert_eq(pending_job_wait_label(wait), Some("Waiting for bg-10, bg-11"))
+  let output : @transcript.ToolCall = {
+    call_id: "output",
+    name: "job_output",
+    arguments: Some("{\"job_id\":\"bg-11\"}"),
+    outcome: Done(
+      content="",
+      is_error=false,
+      brief=Some("job bg-11 (running): Run tests: native"),
+    ),
+  }
+  collect_job_description(output, descriptions)
+  assert_eq(
+    pending_job_wait_label(wait, descriptions~),
+    Some(
+      "Waiting for bg-10: Watch CI on rebased PR 27, bg-11: Run tests: native",
+    ),
+  )
+  // A matching-looking log is not metadata; malformed and failed calls do
+  // not create a description either.
+  let ignored : Map[String, String] = Map([])
+  collect_job_description(
+    {
+      ..output,
+      outcome: Done(
+        content="job bg-11 (running): fake",
+        is_error=false,
+        brief=None,
+      ),
+    },
+    ignored,
+  )
+  collect_job_description({ ..start, arguments: Some("{"), }, ignored)
+  collect_job_description(
+    { ..start, arguments: Some("{\"description\":\"  \"}"), },
+    ignored,
+  )
+  collect_job_description(
+    {
+      ..output,
+      outcome: Done(
+        content="",
+        is_error=true,
+        brief=Some("job bg-11 (running): fake"),
+      ),
+    },
+    ignored,
+  )
+  assert_true(ignored.is_empty())
+}

--- a/desktop/frontend/transcript/component/job_wait_wbtest.mbt
+++ b/desktop/frontend/transcript/component/job_wait_wbtest.mbt
@@ -49,7 +49,7 @@ test "waiting labels reuse recorded job descriptions and keep unknown IDs" {
   }
   let descriptions : Map[String, String] = Map([])
   assert_eq(
-    job_wait_labels(item, descriptions).get("wait"),
+    job_wait_labels(item, descriptions).get(1),
     Some("Waiting for bg-10: Watch CI on rebased PR 27, bg-11"),
   )
   assert_eq(pending_job_wait_label(wait), Some("Waiting for bg-10, bg-11"))
@@ -101,4 +101,31 @@ test "waiting labels reuse recorded job descriptions and keep unknown IDs" {
     ignored,
   )
   assert_true(ignored.is_empty())
+}
+
+///|
+test "waiting labels distinguish duplicate call IDs by position" {
+  let first : @transcript.ToolCall = {
+    call_id: "duplicate",
+    name: "job_wait",
+    arguments: Some("{\"job_ids\":[\"bg-1\"]}"),
+    outcome: Pending(output=None),
+  }
+  let item : @transcript.TranscriptItem = {
+    kind: Assistant(
+      reasoning=None,
+      prose=None,
+      calls=[first, { ..first, arguments: Some("{\"job_ids\":[\"bg-2\"]}"), }],
+      replay=false,
+      finished=false,
+    ),
+    ts: None,
+    sequence: None,
+  }
+  let labels = job_wait_labels(item, {
+    "bg-1": "First job",
+    "bg-2": "Second job",
+  })
+  assert_eq(labels.get(0), Some("Waiting for bg-1: First job"))
+  assert_eq(labels.get(1), Some("Waiting for bg-2: Second job"))
 }

--- a/desktop/frontend/transcript/component/rendering.mbt
+++ b/desktop/frontend/transcript/component/rendering.mbt
@@ -433,7 +433,8 @@ priv enum BlockContent {
     anchor~ : String?,
     step_label~ : String?,
     assistant_name~ : String,
-    subrun_parent~ : String?
+    subrun_parent~ : String?,
+    wait_labels~ : Map[String, String]
   )
   /// The rule closing a user turn.
   TurnRule(ts~ : Double?)
@@ -475,6 +476,7 @@ fn stream_blocks(input : Input) -> @vector.Vector[Block] {
   let blocks : Array[Block] = []
   // OpenSeek numbers its model steps: every provider response that is not a
   // checkpoint replay is one. Codex and legacy items carry no ordinal.
+  let descriptions : Map[String, String] = Map([])
   let mut steps = 0
   for index, row in input.items {
     let item = row.item
@@ -499,6 +501,7 @@ fn stream_blocks(input : Input) -> @vector.Vector[Block] {
         step_label~,
         assistant_name~,
         subrun_parent~,
+        wait_labels=job_wait_labels(item, descriptions),
       ),
     })
     if item.kind is User(_) {
@@ -542,10 +545,18 @@ fn Block::render(self : Block, actions : Actions) -> @html.Html {
   let on_open = path => (actions.open)(path)
   match self.content {
     Empty(empty) => empty.render(actions)
-    Item(item~, anchor~, step_label~, assistant_name~, subrun_parent~) =>
+    Item(
+      item~,
+      anchor~,
+      step_label~,
+      assistant_name~,
+      subrun_parent~,
+      wait_labels~
+    ) =>
       transcript_item_view(
         item,
         on_open,
+        wait_labels~,
         anchor?,
         on_jump=target => (actions.jump)(target),
         assistant_name~,

--- a/desktop/frontend/transcript/component/rendering.mbt
+++ b/desktop/frontend/transcript/component/rendering.mbt
@@ -434,7 +434,7 @@ priv enum BlockContent {
     step_label~ : String?,
     assistant_name~ : String,
     subrun_parent~ : String?,
-    wait_labels~ : Map[String, String]
+    wait_labels~ : Map[Int, String]
   )
   /// The rule closing a user turn.
   TurnRule(ts~ : Double?)

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -21,6 +21,7 @@
 /// and output stay folded by default, like every other call.
 fn assistant_view(
   on_open : (String) -> @cmd.Cmd,
+  wait_labels? : Map[String, String] = Map([]),
   prose? : String,
   reasoning? : String,
   calls? : Array[@transcript.ToolCall] = [],
@@ -100,7 +101,7 @@ fn assistant_view(
     Some(
       @html.div(
         class="activity-work",
-        tool_run_views(calls, sequence?, subrun?),
+        tool_run_views(calls, sequence?, subrun?, wait_labels~),
       ),
     )
   }
@@ -176,6 +177,7 @@ fn tool_run_views(
   calls : Array[@transcript.ToolCall],
   sequence? : Int,
   subrun? : SubrunLink,
+  wait_labels? : Map[String, String] = Map([]),
 ) -> Map[String, @html.Html] {
   let rows : Map[String, @html.Html] = Map([])
   let burst = calls.length() > 1 && calls.all(call => call.arguments is Some(_))
@@ -184,6 +186,7 @@ fn tool_run_views(
       rows[tool_run_row_key(call, index, "request")] = tool_request_view(
         call,
         sequence?,
+        wait_labels~,
       )
     }
     for index, call in calls {
@@ -201,6 +204,7 @@ fn tool_run_views(
         rows[tool_run_row_key(call, index, "request")] = tool_request_view(
           call,
           sequence?,
+          wait_labels~,
         )
       }
       if tool_result_row_is_visible(call) {
@@ -280,6 +284,7 @@ fn tool_result_row_is_visible(call : @transcript.ToolCall) -> Bool {
 fn tool_request_view(
   call : @transcript.ToolCall,
   sequence? : Int,
+  wait_labels? : Map[String, String] = Map([]),
 ) -> @html.Html {
   guard call.arguments is Some(arguments) else { return @html.nothing }
   let name = call.name
@@ -290,6 +295,8 @@ fn tool_request_view(
   }
   let label = if brief is Some(brief) && !brief.is_blank() {
     brief
+  } else if wait_labels.get(call.call_id) is Some(label) {
+    label
   } else if pending_job_wait_label(call) is Some(label) {
     label
   } else {
@@ -819,6 +826,7 @@ fn turn_rule_view(ts? : Double) -> @html.Html {
 fn transcript_item_view(
   item : @transcript.TranscriptItem,
   on_open : (String) -> @cmd.Cmd,
+  wait_labels? : Map[String, String] = Map([]),
   anchor? : String,
   on_jump? : (@mention_context.Target) -> @cmd.Cmd,
   assistant_name? : String = "OpenSeek",
@@ -833,6 +841,7 @@ fn transcript_item_view(
         prose?,
         reasoning?,
         calls~,
+        wait_labels~,
         sequence?=item.sequence,
         ts?=item.ts,
         step_label?,

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -21,7 +21,7 @@
 /// and output stay folded by default, like every other call.
 fn assistant_view(
   on_open : (String) -> @cmd.Cmd,
-  wait_labels? : Map[String, String] = Map([]),
+  wait_labels? : Map[Int, String] = Map([]),
   prose? : String,
   reasoning? : String,
   calls? : Array[@transcript.ToolCall] = [],
@@ -177,7 +177,7 @@ fn tool_run_views(
   calls : Array[@transcript.ToolCall],
   sequence? : Int,
   subrun? : SubrunLink,
-  wait_labels? : Map[String, String] = Map([]),
+  wait_labels? : Map[Int, String] = Map([]),
 ) -> Map[String, @html.Html] {
   let rows : Map[String, @html.Html] = Map([])
   let burst = calls.length() > 1 && calls.all(call => call.arguments is Some(_))
@@ -186,7 +186,7 @@ fn tool_run_views(
       rows[tool_run_row_key(call, index, "request")] = tool_request_view(
         call,
         sequence?,
-        wait_labels~,
+        wait_label?=wait_labels.get(index),
       )
     }
     for index, call in calls {
@@ -204,7 +204,7 @@ fn tool_run_views(
         rows[tool_run_row_key(call, index, "request")] = tool_request_view(
           call,
           sequence?,
-          wait_labels~,
+          wait_label?=wait_labels.get(index),
         )
       }
       if tool_result_row_is_visible(call) {
@@ -284,7 +284,7 @@ fn tool_result_row_is_visible(call : @transcript.ToolCall) -> Bool {
 fn tool_request_view(
   call : @transcript.ToolCall,
   sequence? : Int,
-  wait_labels? : Map[String, String] = Map([]),
+  wait_label? : String,
 ) -> @html.Html {
   guard call.arguments is Some(arguments) else { return @html.nothing }
   let name = call.name
@@ -295,7 +295,7 @@ fn tool_request_view(
   }
   let label = if brief is Some(brief) && !brief.is_blank() {
     brief
-  } else if wait_labels.get(call.call_id) is Some(label) {
+  } else if wait_label is Some(label) {
     label
   } else if pending_job_wait_label(call) is Some(label) {
     label
@@ -826,7 +826,7 @@ fn turn_rule_view(ts? : Double) -> @html.Html {
 fn transcript_item_view(
   item : @transcript.TranscriptItem,
   on_open : (String) -> @cmd.Cmd,
-  wait_labels? : Map[String, String] = Map([]),
+  wait_labels? : Map[Int, String] = Map([]),
   anchor? : String,
   on_jump? : (@mention_context.Target) -> @cmd.Cmd,
   assistant_name? : String = "OpenSeek",


### PR DESCRIPTION
Pending `job_wait` rows showed only IDs even when earlier tool rows already carried the job description. They now display labels such as `Waiting for bg-10: Watch CI on rebased PR 27`, with an ID-only fallback for jobs without a recorded description.

Resolve descriptions from prior `mbtx` launch metadata and `job_output` briefs within the current transcript, and include the resulting labels in memoized render blocks. Tool arguments and the wire protocol stay unchanged.

Validation: `just check`, the full native/JS tests and offline CLI checks, and `just build` passed for the initial implementation. After review fixes, `just check`, all 22 transcript component tests, and the focused Playwright regression passed. `moon info` and `moon fmt` completed with no generated interface changes. All GitHub CI checks passed on the updated commit, and OpenSeek’s follow-up ran checks and tests across all targets successfully.

Regression coverage includes multiple jobs, duplicate IDs, missing descriptions, malformed metadata, duplicate tool call IDs, and collapsed-row rendering. Description parsing is limited to actual background `mbtx` launches, and waiting labels are keyed by call position.
