### PR TITLE
refactor(desktop): create the transcript component per conversation on screen

### DIFF
--- a/desktop/e2e/tests/transcript_scroll.spec.js
+++ b/desktop/e2e/tests/transcript_scroll.spec.js
@@ -1,0 +1,126 @@
+import { test, expect } from '@playwright/test';
+import { DesktopBrowserHarness } from './support/desktop_browser_harness.js';
+
+// Enough turns to make the transcript scroll in the default viewport.
+function longSessionEvents(prefix) {
+  const events = [];
+  let sequence = 1;
+  for (let turn = 1; turn <= 60; turn += 1) {
+    events.push({
+      sequence,
+      ts: 1_781_144_350_123 + sequence * 1_000,
+      item: {
+        kind: 'user',
+        payload: { content: `${prefix} question ${turn}` },
+      },
+    });
+    sequence += 1;
+    events.push({
+      sequence,
+      ts: 1_781_144_350_123 + sequence * 1_000,
+      item: {
+        kind: 'assistant',
+        payload: { content: `${prefix} answer ${turn}` },
+      },
+    });
+    sequence += 1;
+  }
+  return events;
+}
+
+async function openConversation(page, title, firstQuestion) {
+  await page.getByText(title, { exact: true }).first().click();
+  await page.locator('.transcript .msg-content', { hasText: firstQuestion }).first().waitFor();
+}
+
+function distanceFromBottom(transcript) {
+  return transcript.evaluate(node =>
+    node.scrollHeight - node.scrollTop - node.clientHeight);
+}
+
+async function waitUntilScrollable(transcript) {
+  await expect.poll(() => transcript.evaluate(node =>
+    node.scrollHeight - node.clientHeight)).toBeGreaterThan(1000);
+}
+
+test('sending re-pins a transcript the reader had scrolled up', async ({ page }) => {
+  const app = new DesktopBrowserHarness(page);
+  app.sessionEvents = longSessionEvents('First fixture:');
+  await app.install();
+  await app.goto();
+  await openConversation(page, 'Rabbita browser fixture', /^First fixture: question 1$/);
+
+  const transcript = page.locator('#transcript');
+  await waitUntilScrollable(transcript);
+  await transcript.evaluate(node => { node.scrollTop = 0; });
+  await expect.poll(() => transcript.evaluate(node => node.scrollTop)).toBe(0);
+
+  await page.locator('#task').fill('Run the browser E2E turn');
+  await page.getByTitle('Send', { exact: true }).click();
+  await expect.poll(() => app.requests.some(request =>
+    request.method === 'agent.start')).toBe(true);
+  await expect.poll(() => distanceFromBottom(transcript)).toBeLessThanOrEqual(4);
+
+  // The pin must survive the jump: streamed content keeps the tail in view.
+  const heightBeforeStream = await transcript.evaluate(node => node.scrollHeight);
+  app.notify('agent.started', {
+    run_id: 'run-e2e',
+    session: 'session-1',
+    session_root: '/workspace/.openseek',
+    model: 'deepseek-v4-pro',
+    max_steps: 1000,
+  });
+  app.notify('agent.event', {
+    run_id: 'run-e2e',
+    session: 'session-1',
+    event: {
+      event: 'assistant_delta',
+      content: Array.from({ length: 40 }, (_, line) => `Streamed line ${line}`).join('\n\n'),
+    },
+  });
+  await expect.poll(() => transcript.evaluate(node => node.scrollHeight))
+    .toBeGreaterThan(heightBeforeStream);
+  await expect.poll(() => distanceFromBottom(transcript)).toBeLessThanOrEqual(4);
+  expect(app.pageErrors).toEqual([]);
+});
+
+test('returning to a conversation restores where the reader left it', async ({ page }) => {
+  const app = new DesktopBrowserHarness(page);
+  const first = longSessionEvents('First fixture:');
+  const second = longSessionEvents('Second fixture:');
+  app.liveSessions.push({
+    id: 'session-2',
+    title: 'Second browser fixture',
+    updated_at_ms: 2,
+  });
+  const replyFor = app.replyFor.bind(app);
+  app.replyFor = (request) => {
+    if (request.method === 'session.load') {
+      const id = request.params?.session;
+      const events = id === 'session-2' ? second : first;
+      return {
+        session: { version: 1, id, events },
+        watermark: events.at(-1).sequence,
+      };
+    }
+    return replyFor(request);
+  };
+  await app.install();
+  await app.goto();
+  await openConversation(page, 'Rabbita browser fixture', /^First fixture: question 1$/);
+
+  const transcript = page.locator('#transcript');
+  await waitUntilScrollable(transcript);
+  await transcript.evaluate(node => { node.scrollTop = 600; });
+  await expect.poll(() => transcript.evaluate(node => node.scrollTop)).toBe(600);
+
+  await page.locator('.conversation-row[title="session-2"]').click();
+  await page.locator('.transcript .msg-content', { hasText: /^Second fixture: question 1$/ }).waitFor();
+  // A conversation opened for the first time starts at its tail.
+  await expect.poll(() => distanceFromBottom(transcript)).toBeLessThanOrEqual(4);
+
+  await page.locator('.conversation-row[title="session-1"]').click();
+  await page.locator('.transcript .msg-content', { hasText: /^First fixture: question 1$/ }).waitFor();
+  await expect.poll(() => transcript.evaluate(node => node.scrollTop)).toBe(600);
+  expect(app.pageErrors).toEqual([]);
+});

--- a/desktop/frontend/boot.mbt
+++ b/desktop/frontend/boot.mbt
@@ -543,8 +543,7 @@ pub fn boot() -> Unit {
     let terminal_html = @terminal.component(
       terminal_input, terminal_state, terminal_emit,
     )
-    let transcript_input = state.map(model => model.transcript_input())
-    let transcript_html = @transcript_component.component(transcript_input, {
+    let transcript_actions : @transcript_component.Actions = {
       open: emit.map(path => OpenFile(path)),
       jump: emit.map(target => {
         JumpToLocation(
@@ -559,7 +558,31 @@ pub fn boot() -> Unit {
       toggle_project_menu: emit(ToggleSelectMenu(ProjectMenu)),
       dismiss_project_menu: emit(CloseSelectMenu),
       project_query_changed: emit.map(query => ProjectMenuQueryChanged(query)),
-    })
+    }
+    // One transcript component per conversation on screen. Switching
+    // conversations or leaving the Chat/Codex page disposes the component
+    // with its scroll and overview state; returning creates a fresh one, so
+    // the component never has to detect a switch from its own DOM.
+    let transcript_html = state
+      .map(model => model.transcript_slot())
+      .switch_by(
+        slot => {
+          match slot {
+            None => @rabbita.Val::constant(@html.nothing)
+            Some(_) =>
+              @transcript_component.component(
+                state.map(model => model.transcript_input()),
+                transcript_actions,
+              )
+          }
+        },
+        by=slot => {
+          match slot {
+            None => ""
+            Some(slot) => slot.wire()
+          }
+        },
+      )
     let composer_input = state.map(model => model.composer_input())
     let composer_html = @composer.component(
       composer_input,

--- a/desktop/frontend/boot.mbt
+++ b/desktop/frontend/boot.mbt
@@ -543,21 +543,29 @@ pub fn boot() -> Unit {
     let terminal_html = @terminal.component(
       terminal_input, terminal_state, terminal_emit,
     )
-    let transcript_actions : @transcript_component.Actions = {
-      open: emit.map(path => OpenFile(path)),
-      jump: emit.map(target => {
-        JumpToLocation(
-          path=target.file,
-          range=target.range,
-          annotation=target.annotation,
-        )
-      }),
-      open_session: emit.map(session => OpenSessionHere(session)),
-      choose_project: emit.map(project => ProjectMenuProjectChosen(project)),
-      new_project: emit(AddProjectRequested),
-      toggle_project_menu: emit(ToggleSelectMenu(ProjectMenu)),
-      dismiss_project_menu: emit(CloseSelectMenu),
-      project_query_changed: emit.map(query => ProjectMenuQueryChanged(query)),
+    let transcript_actions = (slot : String) => {
+      (
+        {
+          open: emit.map(path => OpenFile(path)),
+          jump: emit.map(target => {
+            JumpToLocation(
+              path=target.file,
+              range=target.range,
+              annotation=target.annotation,
+            )
+          }),
+          open_session: emit.map(session => OpenSessionHere(session)),
+          choose_project: emit.map(project => ProjectMenuProjectChosen(project)),
+          new_project: emit(AddProjectRequested),
+          toggle_project_menu: emit(ToggleSelectMenu(ProjectMenu)),
+          dismiss_project_menu: emit(CloseSelectMenu),
+          project_query_changed: emit.map(query => {
+            ProjectMenuQueryChanged(query)
+          }),
+          // Bound to the slot at construction: by the time the report
+          // arrives the model already shows the next conversation.
+          departed: emit.map(scroll => TranscriptLeft(slot~, scroll~)),
+        } : @transcript_component.Actions)
     }
     // One transcript component per conversation on screen. Switching
     // conversations or leaving the Chat/Codex page disposes the component
@@ -569,17 +577,17 @@ pub fn boot() -> Unit {
         slot => {
           match slot {
             None => @rabbita.Val::constant(@html.nothing)
-            Some(_) =>
+            Some(slot) =>
               @transcript_component.component(
                 state.map(model => model.transcript_input()),
-                transcript_actions,
+                transcript_actions(slot.key()),
               )
           }
         },
         by=slot => {
           match slot {
             None => ""
-            Some(slot) => slot.wire()
+            Some(slot) => slot.key()
           }
         },
       )

--- a/desktop/frontend/component_transcript.mbt
+++ b/desktop/frontend/component_transcript.mbt
@@ -1,23 +1,24 @@
 ///|
 /// The conversation whose transcript the root view places on screen. It keys
 /// the transcript component's lifetime (`Val::switch_by` in `boot`): a new
-/// slot builds a fresh component whose `init` pins the scroller and clears
+/// slot builds a fresh component whose `init` places the scroller and clears
 /// overview state, and `None` disposes the current one. The view's own fork
 /// — the console gate, Chat onboarding, loading, and load failure — is
 /// mirrored here so the component exists exactly while its DOM does.
 priv struct TranscriptSlot {
   source : @transcript_component.Source
   channel : @interop.ChannelId
-  session : String
+  // The Codex page shows a transcript even before a task is selected.
+  session : String?
 } derive(Eq)
 
 ///|
-fn TranscriptSlot::wire(self : TranscriptSlot) -> String {
-  let source = match self.source {
-    OpenSeek => "openseek"
-    Codex => "codex"
+fn TranscriptSlot::key(self : TranscriptSlot) -> String {
+  let key = self.source.wire() + "\u{0}" + self.channel.uri_authority()
+  match self.session {
+    Some(session) => key + "\u{0}" + session
+    None => key
   }
-  source + "\u{0}" + self.channel.uri_authority() + "\u{0}" + self.session
 }
 
 ///|
@@ -35,7 +36,7 @@ fn Model::transcript_slot(self : Model) -> TranscriptSlot? {
       Some({
         source: Codex,
         channel: self.focused,
-        session: self.codex.active_id().unwrap_or("none"),
+        session: self.codex.active_id(),
       })
     Chat => {
       if self.conversation_load_failure is Some(failure) &&
@@ -49,11 +50,22 @@ fn Model::transcript_slot(self : Model) -> TranscriptSlot? {
       Some({
         source: OpenSeek,
         channel: self.focused,
-        session: self.active_session,
+        session: Some(self.active_session),
       })
     }
     Skills | Settings | WorkspaceSettings(..) => None
   }
+}
+
+///|
+/// Where the reader left the conversation on screen, if it has been on screen
+/// before. A conversation never visited, or one that was pinned when left,
+/// opens at its tail.
+fn Model::remembered_scroll(
+  self : Model,
+) -> @transcript_component.ScrollPosition {
+  guard self.transcript_slot() is Some(slot) else { return Pinned }
+  self.transcript_scroll.get(slot.key()).unwrap_or(Pinned)
 }
 
 ///|
@@ -85,6 +97,7 @@ fn Model::transcript_input(self : Model) -> @transcript_component.Input {
         source=@transcript_component.Codex,
         focused=self.focused,
         active_session=self.codex.active_id().unwrap_or("none"),
+        scroll=self.remembered_scroll(),
         project_label?,
         current_project=placement.bind(value => value.project_root()),
         projects~,
@@ -123,6 +136,7 @@ fn Model::transcript_input(self : Model) -> @transcript_component.Input {
             source=@transcript_component.OpenSeek,
             focused=self.focused,
             active_session=self.active_session,
+            scroll=self.remembered_scroll(),
             project_label=@resource.label(conversation.project()),
             current_project=Some(conversation.project()),
             projects~,

--- a/desktop/frontend/component_transcript.mbt
+++ b/desktop/frontend/component_transcript.mbt
@@ -1,10 +1,68 @@
 ///|
+/// The conversation whose transcript the root view places on screen. It keys
+/// the transcript component's lifetime (`Val::switch_by` in `boot`): a new
+/// slot builds a fresh component whose `init` pins the scroller and clears
+/// overview state, and `None` disposes the current one. The view's own fork
+/// — the console gate, Chat onboarding, loading, and load failure — is
+/// mirrored here so the component exists exactly while its DOM does.
+priv struct TranscriptSlot {
+  source : @transcript_component.Source
+  channel : @interop.ChannelId
+  session : String
+} derive(Eq)
+
+///|
+fn TranscriptSlot::wire(self : TranscriptSlot) -> String {
+  let source = match self.source {
+    OpenSeek => "openseek"
+    Codex => "codex"
+  }
+  source + "\u{0}" + self.channel.uri_authority() + "\u{0}" + self.session
+}
+
+///|
+fn Model::transcript_slot(self : Model) -> TranscriptSlot? {
+  if self.console is Some(console) &&
+    (
+      console.page_device is None ||
+      !(console.auth is AuthSignedIn(..)) ||
+      self.focused_device() is None
+    ) {
+    return None
+  }
+  match self.screen {
+    Codex =>
+      Some({
+        source: Codex,
+        channel: self.focused,
+        session: self.codex.active_id().unwrap_or("none"),
+      })
+    Chat => {
+      if self.conversation_load_failure is Some(failure) &&
+        self.selected_conversation == Some(failure.target) {
+        return None
+      }
+      guard self.selected_conversation_loaded() &&
+        self.active_conversation() is Some(_) else {
+        return None
+      }
+      Some({
+        source: OpenSeek,
+        channel: self.focused,
+        session: self.active_session,
+      })
+    }
+    Skills | Settings | WorkspaceSettings(..) => None
+  }
+}
+
+///|
 /// Project the application data that the transcript package renders. The
 /// component owns scroll position; the root owns durable conversation data.
 ///
-/// The component stays mounted while onboarding is on screen — the root view
-/// simply does not place it — so a model with no conversation projects an
-/// empty transcript rather than inventing one to read.
+/// The input is read only while a slot is on screen, but the switch may
+/// recompute it while disposing a branch, so a model with no conversation
+/// projects an empty transcript rather than inventing one to read.
 fn Model::transcript_projects(
   self : Model,
 ) -> Array[@transcript_component.ProjectChoice] {
@@ -34,7 +92,6 @@ fn Model::transcript_input(self : Model) -> @transcript_component.Input {
         project_menu_open=false,
         project_query="",
         root=placement.bind(value => value.checkout_root()),
-        submission_generation=0,
         items=@transcript_component.VisibleRow::history(
           self.codex.transcript_items(),
         ),
@@ -55,7 +112,6 @@ fn Model::transcript_input(self : Model) -> @transcript_component.Input {
             project_menu_open=false,
             project_query="",
             root=None,
-            submission_generation=self.submission_sequence,
             items=[],
             streaming_response=None,
             streaming_identity="",
@@ -77,7 +133,6 @@ fn Model::transcript_input(self : Model) -> @transcript_component.Input {
             root=self
               .conversation_placement(conversation)
               .bind(value => value.checkout_root()),
-            submission_generation=self.submission_sequence,
             items=conversation.visible_transcript_rows(),
             streaming_response=conversation.turn.streaming_response,
             streaming_reasoning?,

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -1514,6 +1514,13 @@ priv struct Model {
   // the same model remains deterministic.
   page_namespace : String
   submission_sequence : Int
+  // Where the reader left each transcript that has been on screen, keyed by
+  // its `TranscriptSlot` key. The transcript component reports it when its
+  // conversation leaves the screen and reads it back on return.
+  transcript_scroll : @sorted_map.SortedMap[
+    String,
+    @transcript_component.ScrollPosition,
+  ]
   // Every conversation with live client state this app run: the active one,
   // those still running in the background, and those visited and kept for an
   // instant switch back. Copy-on-write, like the transcript arrays.
@@ -2025,6 +2032,9 @@ priv enum Msg {
   // Clicks away from a transient menu, one per menu. Each is separate from
   // its toggle on purpose: a dismissal must never reopen what it closed.
   CloseGitDetails
+  // The transcript component reports where its reader was as it leaves the
+  // screen; the root remembers it for the conversation's next visit.
+  TranscriptLeft(slot~ : String, scroll~ : @transcript_component.ScrollPosition)
   // The right panel renders these root-owned values and reports only user
   // actions. Keeping the transitions here avoids a component mirror and a
   // second message that writes the same visibility back into the root.
@@ -2634,6 +2644,7 @@ fn initial_model() -> Model {
     transcript_request_generation: 0,
     page_namespace: generated_session_id(),
     submission_sequence: 0,
+    transcript_scroll: @sorted_map.new(),
     conversations: [],
     project_picker: None,
     pending_project_adoption: None,

--- a/desktop/frontend/moon.pkg
+++ b/desktop/frontend/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "moonbitlang/core/cmp",
   "moonbitlang/core/debug",
+  "moonbitlang/core/immut/sorted_map",
   "moonbitlang/core/json",
   "moonbitlang/core/string",
   "moonbit-community/rabbita",

--- a/desktop/frontend/transcript/component/component.mbt
+++ b/desktop/frontend/transcript/component/component.mbt
@@ -7,7 +7,7 @@ pub(all) enum Source {
 } derive(Eq)
 
 ///|
-fn Source::wire(self : Source) -> String {
+pub fn Source::wire(self : Source) -> String {
   match self {
     OpenSeek => "openseek"
     Codex => "codex"
@@ -53,6 +53,16 @@ pub(all) struct ProjectChoice {
 pub extend ProjectChoice with Eq::{equal, not_equal}
 
 ///|
+/// Where the reader is in a transcript. `Pinned` follows the tail as content
+/// grows; `Unpinned` is a fixed offset the reader scrolled to. The component
+/// reports it when its conversation leaves the screen and receives it back
+/// through `Input::scroll` when the conversation returns.
+pub(all) enum ScrollPosition {
+  Pinned
+  Unpinned(top~ : Double)
+} derive(Eq)
+
+///|
 /// The conversation data rendered by the component. The application computes
 /// durable chronology and active-run ownership; this package owns only the
 /// transcript subtree and its scroll behavior.
@@ -60,6 +70,8 @@ struct Input {
   source : Source
   focused : @interop.ChannelId
   active_session : String
+  // Where the reader left this conversation last time, read once by `init`.
+  scroll : ScrollPosition
   // The registered project that owns this conversation, kept separate from
   // `root`: a managed worktree resolves files from its checkout while the
   // empty-state question should still name the project the user selected.
@@ -94,6 +106,7 @@ pub fn Input::Input(
   source~ : Source,
   focused~ : @interop.ChannelId,
   active_session~ : String,
+  scroll? : ScrollPosition = Pinned,
   project_label? : String,
   current_project~ : @common.Uri?,
   projects~ : Array[ProjectChoice],
@@ -111,6 +124,7 @@ pub fn Input::Input(
     source,
     focused,
     active_session,
+    scroll,
     project_label,
     current_project,
     projects,
@@ -142,13 +156,16 @@ pub(all) struct Actions {
   toggle_project_menu : @cmd.Cmd
   dismiss_project_menu : @cmd.Cmd
   project_query_changed : @cmd.Emit[String]
+  /// Where the reader was when this conversation left the screen. The root
+  /// keeps it per conversation and hands it back through `Input::scroll`.
+  departed : @cmd.Emit[ScrollPosition]
 }
 
 ///|
 /// Scroll ownership and overview state for one mounted conversation. The
 /// component lives exactly as long as its conversation is on screen (the
-/// root keys it by conversation), so a fresh conversation or a return from
-/// another page always starts pinned with an empty overview through `init`.
+/// root keys it by conversation), so `init` alone decides where a fresh
+/// component starts: at the tail, or where the reader left this conversation.
 priv struct Model {
   pinned : Bool
   overview : @transcript_overview.State
@@ -189,7 +206,7 @@ fn Model::update(
         { ..self, pinned: true, },
         @cmd.batch([
           scroll_after_render(),
-          report_visible_turn_after_render(emit, skip_unchanged=true),
+          report_visible_turn_after_render(emit, current=self.overview.active),
         ]),
       )
     ContentRendered => {
@@ -199,7 +216,9 @@ fn Model::update(
       if self.pinned {
         commands.push(scroll_after_render())
       }
-      commands.push(report_visible_turn_after_render(emit, skip_unchanged=true))
+      commands.push(
+        report_visible_turn_after_render(emit, current=self.overview.active),
+      )
       commands.push(self.images.apply_after_render())
       (self, @cmd.batch(commands))
     }
@@ -244,8 +263,9 @@ fn Model::update(
 /// Create one component per conversation on screen and dispose it when that
 /// conversation leaves the screen (`Val::switch_by` keyed by conversation at
 /// the root). Conversation identity therefore never changes inside a
-/// component: `init` pins the fresh scroller to its tail and reports the
-/// first visible turn once its DOM exists.
+/// component: `init` places the fresh scroller where the reader left this
+/// conversation (or at its tail) and reports the first visible turn once its
+/// DOM exists.
 pub fn component(
   input : @rabbita.Val[Input],
   actions : Actions,
@@ -255,19 +275,24 @@ pub fn component(
     init=(emit, input) => {
       (
         {
-          pinned: true,
+          pinned: input.scroll is Pinned,
           overview: @transcript_overview.State::empty(),
           image_owner: input.image_owner(),
           images: ImageCache::empty(),
         },
         @cmd.batch([
-          scroll_after_render(),
-          report_visible_turn_after_render(emit),
+          match input.scroll {
+            Pinned => scroll_after_render()
+            Unpinned(top~) => restore_scroll_after_render(top)
+          },
+          report_visible_turn_after_render(emit, current=None),
         ]),
       )
     },
     update=(state, input, msg, emit) => state.update(input, msg, emit),
-    subscriptions=(_, _, emit) => transcript_subscription(emit),
+    subscriptions=(model, _, emit) => {
+      transcript_subscription(model, emit, actions.departed)
+    },
   )
   // Every stream child renders in its own branch, keyed by the block within
   // its stream. A streaming delta then recomputes only the live block's Html;
@@ -331,10 +356,10 @@ fn focus_empty_project_trigger_after_render() -> @cmd.Cmd {
 }
 
 ///|
-/// Re-pin the transcript to its tail after the next render. The root issues
+/// Scroll the transcript to its tail after the next render. The root issues
 /// this when Send accepts a prompt or a steer, before the durable User item
 /// arrives, so early streamed work is immediately visible. The scroll it
-/// causes reaches the component's own listener as `Pinned(true)`.
+/// causes reaches the component's own listener, which records the pin.
 pub fn scroll_to_latest() -> @cmd.Cmd {
   scroll_after_render()
 }
@@ -343,10 +368,6 @@ pub fn scroll_to_latest() -> @cmd.Cmd {
 fn scroll_after_render() -> @cmd.Cmd {
   @cmd.custom_cmd(
     _ => {
-      // A forced tail jump must also reset the subscription's DOM cache. A
-      // freshly mounted short transcript may clamp without emitting a scroll
-      // event.
-      transcript_pinned_watch.val = true
       if @dom.document().get_element_by_id("transcript").to_option()
         is Some(transcript) {
         transcript.set_scroll_top(transcript.get_scroll_height())
@@ -354,6 +375,35 @@ fn scroll_after_render() -> @cmd.Cmd {
     },
     kind=@cmd.after_render,
   )
+}
+
+///|
+/// Put a returning conversation back where its reader left it. Lazily loaded
+/// images may still shift the content afterwards; the offset is the best
+/// available approximation of the same reading position.
+fn restore_scroll_after_render(top : Double) -> @cmd.Cmd {
+  @cmd.custom_cmd(
+    _ => {
+      if @dom.document().get_element_by_id("transcript").to_option()
+        is Some(transcript) {
+        transcript.set_scroll_top(top)
+      }
+    },
+    kind=@cmd.after_render,
+  )
+}
+
+///|
+/// The reader is pinned while the scroller sits within a few pixels of its
+/// bottom edge; anything else is a fixed offset worth restoring later.
+fn scroll_position(transcript : @dom.Element) -> ScrollPosition {
+  let top = transcript.get_scroll_top()
+  if transcript.get_scroll_height() - top - transcript.get_client_height() <=
+    4.0 {
+    Pinned
+  } else {
+    Unpinned(top~)
+  }
 }
 
 ///|
@@ -385,12 +435,12 @@ fn reveal_active_overview_tick() -> @cmd.Cmd {
 }
 
 ///|
-/// The last DOM state reported by the scroll subscription. The overview jump
-/// commands update the same cache because a clamped scroll emits no event.
-let transcript_pinned_watch : Ref[Bool] = Ref(true)
-
-///|
-let transcript_turn_anchor : Ref[String?] = Ref(None)
+/// The user turn under the reading line, as the overview names it.
+fn visible_turn(transcript : @dom.Element) -> @transcript_overview.TurnKey? {
+  visible_turn_anchor(transcript).bind(
+    @transcript_overview.TurnKey::from_anchor,
+  )
+}
 
 ///|
 /// The user turn under the reading line, expressed through the same anchor
@@ -436,28 +486,19 @@ fn scroll_turn_into_view(
       let offset = bubble.get_bounding_client_rect().get_top() -
         transcript.get_bounding_client_rect().get_top()
       transcript.set_scroll_top(transcript.get_scroll_top() + offset - 10.0)
-      let client_height = transcript.get_client_height()
-      let pinned = transcript.get_scroll_height() -
-        transcript.get_scroll_top() -
-        client_height <=
-        4.0
-      transcript_pinned_watch.val = pinned
-      scheduler.add(emit(Pinned(pinned)))
-      let anchor = visible_turn_anchor(transcript)
-      transcript_turn_anchor.val = anchor
-      let active = anchor.bind(@transcript_overview.TurnKey::from_anchor)
-      scheduler.add(emit(Overview(ActiveChanged(active))))
+      scheduler.add(emit(Pinned(scroll_position(transcript) is Pinned)))
+      scheduler.add(emit(Overview(ActiveChanged(visible_turn(transcript)))))
     },
     kind=@cmd.after_render,
   )
 }
 
 ///|
-/// Re-read the overview highlight after content or geometry changed. Session
-/// switches force a report even when two sessions happen to reuse an anchor.
+/// Re-read the overview highlight after content or geometry changed. `current`
+/// is the Model's active turn; an unchanged reading is not re-reported.
 fn report_visible_turn_after_render(
   emit : @cmd.Emit[Msg],
-  skip_unchanged? : Bool = false,
+  current~ : @transcript_overview.TurnKey?,
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(
     scheduler => {
@@ -465,13 +506,10 @@ fn report_visible_turn_after_render(
         is Some(transcript) else {
         return
       }
-      let anchor = visible_turn_anchor(transcript)
-      if skip_unchanged && anchor == transcript_turn_anchor.val {
-        return
+      let active = visible_turn(transcript)
+      if active != current {
+        scheduler.add(emit(Overview(ActiveChanged(active))))
       }
-      transcript_turn_anchor.val = anchor
-      let active = anchor.bind(@transcript_overview.TurnKey::from_anchor)
-      scheduler.add(emit(Overview(ActiveChanged(active))))
     },
     kind=@cmd.after_render,
   )
@@ -479,18 +517,35 @@ fn report_visible_turn_after_render(
 
 ///|
 priv suberror TranscriptSubscription {
-  TranscriptSubscription(@cmd.Emit[Msg])
+  TranscriptSubscription(
+    emit~ : @cmd.Emit[Msg],
+    departed~ : @cmd.Emit[ScrollPosition],
+    // The Model's current reading, refreshed after every message. The scroll
+    // listener reports only readings that differ from it, so the Model is the
+    // single source of truth and no cache can drift from it.
+    pinned~ : Bool,
+    active~ : @transcript_overview.TurnKey?
+  )
 }
 
 ///|
 /// Scroll position and rendered-content growth are DOM signals owned by the
 /// transcript. Keeping both in this component means the application no longer
 /// forwards a synthetic "content changed" message into child state.
-fn transcript_subscription(emit : @cmd.Emit[Msg]) -> @sub.Sub {
+fn transcript_subscription(
+  model : Model,
+  emit : @cmd.Emit[Msg],
+  departed : @cmd.Emit[ScrollPosition],
+) -> @sub.Sub {
   @sub.custom_sub(
     "transcript-dom",
     @sub.Local,
-    TranscriptSubscription(emit),
+    TranscriptSubscription(
+      emit~,
+      departed~,
+      pinned=model.pinned,
+      active=model.overview.active,
+    ),
     transcript_sub_loader,
   )
 }
@@ -501,28 +556,29 @@ fn transcript_sub_loader(
   scheduler : &@cmd.Scheduler,
 ) -> @sub.RunningSub? {
   match payload {
-    TranscriptSubscription(emit) => {
+    TranscriptSubscription(emit~, departed~, pinned~, active~) => {
       let mut emit = emit
+      let mut departed = departed
+      let mut pinned = pinned
+      let mut active = active
       let target = @dom.document().as_event_target()
       let listener : @dom.Listener = event => {
         guard event.target().to_element() is Some(element) &&
           element.get_property("id").to_option() == Some("transcript") else {
           return
         }
-        let client_height = element.get_client_height()
-        let pinned = element.get_scroll_height() -
-          element.get_scroll_top() -
-          client_height <=
-          4.0
-        if pinned != transcript_pinned_watch.val {
-          transcript_pinned_watch.val = pinned
-          scheduler.add(emit(Pinned(pinned)))
+        // Report only what differs from the Model. Its next message brings
+        // the same value back through `update_tagger`; assigning here just
+        // keeps a burst of scroll events from repeating the report meanwhile.
+        let position_pinned = scroll_position(element) is Pinned
+        if position_pinned != pinned {
+          pinned = position_pinned
+          scheduler.add(emit(Pinned(position_pinned)))
         }
-        let anchor = visible_turn_anchor(element)
-        if anchor != transcript_turn_anchor.val {
-          transcript_turn_anchor.val = anchor
-          let active = anchor.bind(@transcript_overview.TurnKey::from_anchor)
-          scheduler.add(emit(Overview(ActiveChanged(active))))
+        let visible = visible_turn(element)
+        if visible != active {
+          active = visible
+          scheduler.add(emit(Overview(ActiveChanged(visible))))
         }
       }
       target.add_event_listener_with_options("scroll", listener, capture=true)
@@ -531,17 +587,36 @@ fn transcript_sub_loader(
         path => scheduler.add(emit(ImageRequested(path))),
       )
       Some({
-        unload: _ => {
+        unload: scheduler => {
           target.remove_event_listener_with_options(
             "scroll",
             listener,
             capture=true,
           )
           observers.disconnect()
+          // The branch is disposed while the incremental graph is read, one
+          // step before Rabbita replaces the DOM, so the scroller still shows
+          // this conversation. Report where the reader was so a return can
+          // put them back there.
+          if @dom.document().get_element_by_id("transcript").to_option()
+            is Some(transcript) {
+            scheduler.add(departed(scroll_position(transcript)))
+          }
         },
         update_tagger: payload => {
-          guard payload is TranscriptSubscription(next) else { return }
+          guard payload
+            is TranscriptSubscription(
+              emit=next,
+              departed=left,
+              pinned=next_pinned,
+              active=next_active
+            ) else {
+            return
+          }
           emit = next
+          departed = left
+          pinned = next_pinned
+          active = next_active
         },
       })
     }
@@ -780,6 +855,9 @@ test "an overview click unpins and highlights inside the component" {
 
 ///|
 pub extend Input with Eq::{equal, not_equal}
+
+///|
+pub extend ScrollPosition with Eq::{equal, not_equal}
 
 ///|
 pub extend Source with Eq::{equal, not_equal}

--- a/desktop/frontend/transcript/component/component.mbt
+++ b/desktop/frontend/transcript/component/component.mbt
@@ -77,7 +77,6 @@ struct Input {
   // The concrete project or worktree root sent alongside relative Markdown
   // image paths so the owning host, rather than the frontend, resolves them.
   root : @common.Uri?
-  submission_generation : Int
   items : Array[VisibleRow]
   // The in-flight assistant text to show below the committed rows, or `None`
   // when nothing is streaming. It is deliberately not a `VisibleRow`: the
@@ -102,7 +101,6 @@ pub fn Input::Input(
   project_menu_open~ : Bool,
   project_query~ : String,
   root~ : @common.Uri?,
-  submission_generation~ : Int,
   items~ : Array[VisibleRow],
   streaming_response~ : String?,
   streaming_reasoning? : String,
@@ -120,7 +118,6 @@ pub fn Input::Input(
     project_menu_open,
     project_query,
     root,
-    submission_generation,
     items,
     streaming_response,
     streaming_reasoning,
@@ -148,23 +145,22 @@ pub(all) struct Actions {
 }
 
 ///|
+/// Scroll ownership and overview state for one mounted conversation. The
+/// component lives exactly as long as its conversation is on screen (the
+/// root keys it by conversation), so a fresh conversation or a return from
+/// another page always starts pinned with an empty overview through `init`.
 priv struct Model {
   pinned : Bool
   overview : @transcript_overview.State
-  source : Source
-  focused : @interop.ChannelId
-  active_session : String
   image_owner : ImageOwner
   images : ImageCache
-  submission_generation : Int
-  mounted : Bool
 } derive(Eq)
 
 ///|
 priv enum Msg {
   Pinned(Bool)
   JumpToLatest
-  ContentRendered(mounted~ : Bool)
+  ContentRendered
   ImageRequested(String)
   ImageResolved(ImageOwner, String, ImageReadResult)
   Overview(@transcript_overview.Msg)
@@ -177,9 +173,9 @@ fn Model::update(
   msg : Msg,
   emit : @cmd.Emit[Msg],
 ) -> (Model, @cmd.Cmd) {
-  // A conversation switch can reach the component through input before its
-  // DOM mutation notification. Never project the previous owner's data URLs
-  // into that intermediate render.
+  // The conversation is fixed for this component's lifetime, but its image
+  // root can move (a worktree gets bound after the first send). Never project
+  // the previous root's data URLs into a render for the new one.
   let image_owner = input.image_owner()
   let self = if self.image_owner == image_owner {
     self
@@ -196,47 +192,16 @@ fn Model::update(
           report_visible_turn_after_render(emit, skip_unchanged=true),
         ]),
       )
-    ContentRendered(mounted~) => {
-      // The component outlives the Chat DOM while Skills, Settings, or the
-      // signed-out console gate is shown. A newly mounted scroller therefore
-      // resets scroll and overview state even when the conversation identity
-      // itself did not change.
-      let remounted = mounted && !self.mounted
-      let navigated = remounted ||
-        self.source != input.source ||
-        self.focused != input.focused ||
-        self.active_session != input.active_session
-      // Submission generation changes synchronously when Send accepts either
-      // a prompt or a steer, before its durable User item arrives. Re-pin on
-      // that explicit signal so early streamed work is immediately visible;
-      // another client's later User item must not impersonate a local send.
-      let submitted = !navigated &&
-        input.submission_generation != self.submission_generation
-      let pinned = navigated || submitted || self.pinned
-      let next = {
-        pinned,
-        overview: if navigated {
-          @transcript_overview.State::empty()
-        } else {
-          self.overview
-        },
-        source: input.source,
-        focused: input.focused,
-        active_session: input.active_session,
-        image_owner,
-        images: self.images,
-        submission_generation: input.submission_generation,
-        mounted,
-      }
+    ContentRendered => {
+      // Rendered content grew or changed size. A pinned reader follows the
+      // tail; the overview re-reads which turn sits under the reading line.
       let commands : Array[@cmd.Cmd] = []
-      if pinned {
+      if self.pinned {
         commands.push(scroll_after_render())
       }
-      commands.push(
-        report_visible_turn_after_render(emit, skip_unchanged=!navigated),
-      )
+      commands.push(report_visible_turn_after_render(emit, skip_unchanged=true))
       commands.push(self.images.apply_after_render())
-      (next, @cmd.batch(commands))
+      (self, @cmd.batch(commands))
     }
     ImageRequested(path) => {
       let (images, command) = self.images.begin_read(image_owner, path, emit)
@@ -275,26 +240,30 @@ fn Model::update(
 
 ///|
 /// Build the transcript state and return its independently updating Html.
+///
+/// Create one component per conversation on screen and dispose it when that
+/// conversation leaves the screen (`Val::switch_by` keyed by conversation at
+/// the root). Conversation identity therefore never changes inside a
+/// component: `init` pins the fresh scroller to its tail and reports the
+/// first visible turn once its DOM exists.
 pub fn component(
   input : @rabbita.Val[Input],
   actions : Actions,
 ) -> @rabbita.Val[@html.Html] {
   let (state, emit) = @rabbita.create_state_with_input(
     input~,
-    init=(_, input) => {
+    init=(emit, input) => {
       (
         {
           pinned: true,
           overview: @transcript_overview.State::empty(),
-          source: input.source,
-          focused: input.focused,
-          active_session: input.active_session,
           image_owner: input.image_owner(),
           images: ImageCache::empty(),
-          submission_generation: input.submission_generation,
-          mounted: false,
         },
-        @cmd.none,
+        @cmd.batch([
+          scroll_after_render(),
+          report_visible_turn_after_render(emit),
+        ]),
       )
     },
     update=(state, input, msg, emit) => state.update(input, msg, emit),
@@ -362,11 +331,21 @@ fn focus_empty_project_trigger_after_render() -> @cmd.Cmd {
 }
 
 ///|
+/// Re-pin the transcript to its tail after the next render. The root issues
+/// this when Send accepts a prompt or a steer, before the durable User item
+/// arrives, so early streamed work is immediately visible. The scroll it
+/// causes reaches the component's own listener as `Pinned(true)`.
+pub fn scroll_to_latest() -> @cmd.Cmd {
+  scroll_after_render()
+}
+
+///|
 fn scroll_after_render() -> @cmd.Cmd {
   @cmd.custom_cmd(
     _ => {
       // A forced tail jump must also reset the subscription's DOM cache. A
-      // remounted short transcript may clamp without emitting a scroll event.
+      // freshly mounted short transcript may clamp without emitting a scroll
+      // event.
       transcript_pinned_watch.val = true
       if @dom.document().get_element_by_id("transcript").to_option()
         is Some(transcript) {
@@ -548,7 +527,7 @@ fn transcript_sub_loader(
       }
       target.add_event_listener_with_options("scroll", listener, capture=true)
       let observers = TranscriptObservers::install(
-        mounted => scheduler.add(emit(ContentRendered(mounted~))),
+        () => scheduler.add(emit(ContentRendered)),
         path => scheduler.add(emit(ImageRequested(path))),
       )
       Some({
@@ -572,9 +551,11 @@ fn transcript_sub_loader(
 
 ///|
 /// Observe the transcript through Rabbita's typed DOM bindings. The document
-/// observer only follows mount/replacement; content and identity changes are
-/// observed directly on the current transcript, so unrelated page mutations
-/// cannot feed back into component updates.
+/// observer only finds the scroller element once Rabbita has inserted it (the
+/// subscription starts before the first paint); content growth and geometry
+/// are then observed directly on that element, so unrelated page mutations
+/// cannot feed back into component updates. Conversation identity is never
+/// read back from the DOM: it is fixed for the component's lifetime.
 priv struct TranscriptObservers {
   document : @dom.MutationObserver
   content : @dom.MutationObserver
@@ -656,14 +637,9 @@ fn TranscriptDomMount::observe_content(
   if self.element is Some(element) {
     observer.observe(
       element.as_node(),
-      attributes=true,
       child_list=true,
       character_data=true,
       subtree=true,
-      attribute_filter=[
-        "data-transcript-source", "data-transcript-channel", "data-transcript-session",
-        "data-transcript-root", "data-transcript-submission",
-      ],
     )
   }
 }
@@ -685,11 +661,11 @@ fn TranscriptDomMount::dispose(self : Self) -> Unit {
 
 ///|
 fn TranscriptObservers::install(
-  on_change : (Bool) -> Unit,
+  on_change : () -> Unit,
   on_image : (String) -> Unit,
 ) -> Self {
-  let mount = TranscriptDomMount(() => on_change(true), on_image)
-  let resize = @dom.ResizeObserver::new((_, _) => on_change(true))
+  let mount = TranscriptDomMount(on_change, on_image)
+  let resize = @dom.ResizeObserver::new((_, _) => on_change())
   let content = @dom.MutationObserver::new((_, observer) => {
     // Reconciliation itself moves the SVG and installs toolbar nodes. Pause
     // this same observer while doing that so those owned mutations cannot
@@ -697,7 +673,7 @@ fn TranscriptObservers::install(
     observer.disconnect()
     mount.refresh_content()
     mount.observe_content(observer)
-    on_change(true)
+    on_change()
   })
   let attach = () => {
     let next = @dom.document().get_element_by_id("transcript").to_option()
@@ -707,7 +683,9 @@ fn TranscriptObservers::install(
     mount.replace(next)
     mount.observe_content(content)
     mount.observe_resize(resize)
-    on_change(next is Some(_))
+    if next is Some(_) {
+      on_change()
+    }
   }
   let document = @dom.MutationObserver::new((_, _) => attach())
   if @dom.document().get_document_element() is Some(root) {
@@ -740,7 +718,6 @@ fn base_input() -> Input {
     project_menu_open=false,
     project_query="",
     root=None,
-    submission_generation=0,
     items=[],
     streaming_response=None,
     streaming_identity="idle",
@@ -748,18 +725,13 @@ fn base_input() -> Input {
 }
 
 ///|
-/// The mounted, pinned model matching `base_input()`.
+/// The pinned model matching `base_input()`.
 fn pinned_model(input : Input) -> Model {
   {
     pinned: true,
     overview: @transcript_overview.State::empty(),
-    source: OpenSeek,
-    focused: Local,
-    active_session: "desktop-test",
     image_owner: input.image_owner(),
     images: ImageCache::empty(),
-    submission_generation: 0,
-    mounted: true,
   }
 }
 
@@ -772,7 +744,10 @@ test "local pinned transitions are pure" {
   let (second, _) = state.update(input, Pinned(false), emit)
   assert_false(first.pinned)
   assert_false(second.pinned)
-  let (grown, _) = first.update(input, ContentRendered(mounted=true), emit)
+  // Content growth never re-pins by itself: only the reader's scroll or an
+  // explicit jump does. Another client's User item must not impersonate a
+  // local send.
+  let (grown, _) = first.update(input, ContentRendered, emit)
   assert_false(grown.pinned)
   let (received, _) = first.update(
     {
@@ -784,24 +759,12 @@ test "local pinned transitions are pure" {
         },
       ],
     },
-    ContentRendered(mounted=true),
+    ContentRendered,
     emit,
   )
   assert_false(received.pinned)
-  let (submitted, _) = first.update(
-    { ..input, submission_generation: 1, },
-    ContentRendered(mounted=true),
-    emit,
-  )
-  assert_true(submitted.pinned)
   let (jumped, _) = grown.update(input, JumpToLatest, emit)
   assert_true(jumped.pinned)
-  let (navigated, _) = grown.update(
-    { ..input, active_session: "another-session", },
-    ContentRendered(mounted=true),
-    emit,
-  )
-  assert_true(navigated.pinned)
 }
 
 ///|
@@ -813,43 +776,6 @@ test "an overview click unpins and highlights inside the component" {
   let (next, _) = state.update(input, Overview(Clicked(key)), emit)
   assert_false(next.pinned)
   @debug.assert_eq(next.overview.active, Some(key))
-}
-
-///|
-test "a conversation switch clears component-owned overview state" {
-  let input = base_input()
-  let state = {
-    ..pinned_model(input),
-    pinned: false,
-    overview: {
-      hover: Some({
-        key: @transcript_overview.Durable(2),
-        flip: false,
-        anchor: 0,
-      }),
-      active: Some(@transcript_overview.Durable(3)),
-    },
-  }
-  let emit : @cmd.Emit[Msg] = @cmd.Emit(_ => @cmd.none)
-  let (next, _) = state.update(
-    { ..input, active_session: "desktop-other", },
-    ContentRendered(mounted=true),
-    emit,
-  )
-  assert_true(next.pinned)
-  @debug.assert_eq(next.overview.hover, None)
-  @debug.assert_eq(next.overview.active, None)
-  let (removed, _) = state.update(input, ContentRendered(mounted=false), emit)
-  let (remounted, _) = removed.update(
-    input,
-    ContentRendered(mounted=true),
-    emit,
-  )
-  assert_false(removed.mounted)
-  assert_true(remounted.mounted)
-  assert_true(remounted.pinned)
-  @debug.assert_eq(remounted.overview.hover, None)
-  @debug.assert_eq(remounted.overview.active, None)
 }
 
 ///|

--- a/desktop/frontend/transcript/component/pkg.generated.mbti
+++ b/desktop/frontend/transcript/component/pkg.generated.mbti
@@ -14,6 +14,8 @@ import {
 // Values
 pub fn component(@rabbita.Val[Input], Actions) -> @rabbita.Val[@html.Html]
 
+pub fn scroll_to_latest() -> @cmd.Cmd
+
 // Errors
 
 // Types and methods
@@ -29,7 +31,7 @@ pub(all) struct Actions {
 }
 
 type Input derive(Eq)
-pub fn Input::Input(source~ : Source, focused~ : @interop.ChannelId, active_session~ : String, project_label? : String, current_project~ : @common.Uri?, projects~ : Array[ProjectChoice], can_choose_project~ : Bool, project_menu_open~ : Bool, project_query~ : String, root~ : @common.Uri?, submission_generation~ : Int, items~ : Array[VisibleRow], streaming_response~ : String?, streaming_reasoning? : String, reasoning_complete? : Bool, streaming_identity~ : String) -> Self
+pub fn Input::Input(source~ : Source, focused~ : @interop.ChannelId, active_session~ : String, project_label? : String, current_project~ : @common.Uri?, projects~ : Array[ProjectChoice], can_choose_project~ : Bool, project_menu_open~ : Bool, project_query~ : String, root~ : @common.Uri?, items~ : Array[VisibleRow], streaming_response~ : String?, streaming_reasoning? : String, reasoning_complete? : Bool, streaming_identity~ : String) -> Self
 pub fn Input::equal(Self, Self) -> Bool
 pub fn Input::not_equal(Self, Self) -> Bool
 

--- a/desktop/frontend/transcript/component/pkg.generated.mbti
+++ b/desktop/frontend/transcript/component/pkg.generated.mbti
@@ -28,10 +28,11 @@ pub(all) struct Actions {
   toggle_project_menu : @cmd.Cmd
   dismiss_project_menu : @cmd.Cmd
   project_query_changed : @cmd.Emit[String]
+  departed : @cmd.Emit[ScrollPosition]
 }
 
 type Input derive(Eq)
-pub fn Input::Input(source~ : Source, focused~ : @interop.ChannelId, active_session~ : String, project_label? : String, current_project~ : @common.Uri?, projects~ : Array[ProjectChoice], can_choose_project~ : Bool, project_menu_open~ : Bool, project_query~ : String, root~ : @common.Uri?, items~ : Array[VisibleRow], streaming_response~ : String?, streaming_reasoning? : String, reasoning_complete? : Bool, streaming_identity~ : String) -> Self
+pub fn Input::Input(source~ : Source, focused~ : @interop.ChannelId, active_session~ : String, scroll? : ScrollPosition, project_label? : String, current_project~ : @common.Uri?, projects~ : Array[ProjectChoice], can_choose_project~ : Bool, project_menu_open~ : Bool, project_query~ : String, root~ : @common.Uri?, items~ : Array[VisibleRow], streaming_response~ : String?, streaming_reasoning? : String, reasoning_complete? : Bool, streaming_identity~ : String) -> Self
 pub fn Input::equal(Self, Self) -> Bool
 pub fn Input::not_equal(Self, Self) -> Bool
 
@@ -42,12 +43,20 @@ pub(all) struct ProjectChoice {
 pub fn ProjectChoice::equal(Self, Self) -> Bool
 pub fn ProjectChoice::not_equal(Self, Self) -> Bool
 
+pub(all) enum ScrollPosition {
+  Pinned
+  Unpinned(top~ : Double)
+} derive(Eq)
+pub fn ScrollPosition::equal(Self, Self) -> Bool
+pub fn ScrollPosition::not_equal(Self, Self) -> Bool
+
 pub(all) enum Source {
   OpenSeek
   Codex
 } derive(Eq)
 pub fn Source::equal(Self, Self) -> Bool
 pub fn Source::not_equal(Self, Self) -> Bool
+pub fn Source::wire(Self) -> String
 
 pub(all) struct VisibleRow {
   item : @transcript.TranscriptItem

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -993,25 +993,16 @@ fn transcript_view(
     overview_emit~,
     on_jump_latest~,
   )
-  // These identity attributes make conversation and root changes observable
-  // even when the rendered children stay identical. The component subscription
-  // reconciles local state on their mutation instead of relying on incidental
-  // transcript DOM changes.
+  // The identity attributes name the conversation this scroller shows, for
+  // tests and tooling. Nothing observes them: the component is created per
+  // conversation, so its state never has to detect a switch from the DOM.
   @html.section(
     attrs=@html.Attrs::build()
       .id("transcript")
       .class("transcript")
       .data_set("transcript-source", input.source.wire())
       .data_set("transcript-channel", input.focused.uri_authority())
-      .data_set("transcript-session", input.active_session)
-      .data_set(
-        "transcript-root",
-        input.root.map(uri => uri.to_string()).unwrap_or(""),
-      )
-      .data_set(
-        "transcript-submission",
-        input.submission_generation.to_string(),
-      ),
+      .data_set("transcript-session", input.active_session),
     children,
   )
 }

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -993,15 +993,14 @@ fn transcript_view(
     overview_emit~,
     on_jump_latest~,
   )
-  // The identity attributes name the conversation this scroller shows, for
-  // tests and tooling. Nothing observes them: the component is created per
-  // conversation, so its state never has to detect a switch from the DOM.
+  // Nothing in the app reads the session back from the DOM: the component is
+  // created per conversation. The attribute is a test hook only: a draft
+  // rotation has no other visible signal (`rabbita_dom.spec.js`, "new-chat
+  // project title filters and switches registered projects").
   @html.section(
     attrs=@html.Attrs::build()
       .id("transcript")
       .class("transcript")
-      .data_set("transcript-source", input.source.wire())
-      .data_set("transcript-channel", input.focused.uri_authority())
       .data_set("transcript-session", input.active_session),
     children,
   )

--- a/desktop/frontend/transcript/component/view_wbtest.mbt
+++ b/desktop/frontend/transcript/component/view_wbtest.mbt
@@ -38,7 +38,6 @@ test "transcript stream children use stable typed keys in display order" {
     project_menu_open=false,
     project_query="",
     root=None,
-    submission_generation=1,
     items=[
       {
         item: { kind: User("question"), ts: None, sequence: Some(41), },
@@ -97,7 +96,6 @@ test "the live response is one node, replaced by the durable one" {
     project_menu_open=false,
     project_query="",
     root=None,
-    submission_generation=1,
     items=[user],
     streaming_response=None,
     streaming_reasoning="next thought",
@@ -145,7 +143,6 @@ test "a streaming delta changes only the live block" {
     project_menu_open=false,
     project_query="",
     root=None,
-    submission_generation=1,
     items=[
       {
         item: { kind: User("question"), ts: Some(1.0e12), sequence: Some(1), },
@@ -196,7 +193,6 @@ test "transcript stream section key scopes equal session ids by channel" {
     project_menu_open=false,
     project_query="",
     root=None,
-    submission_generation=0,
     items=[],
     streaming_response=None,
     streaming_identity="idle",

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -4593,6 +4593,14 @@ fn update_msg(
       )
     }
     CloseGitDetails => (@cmd.none, { ..model, git_details_open: false, })
+    TranscriptLeft(slot~, scroll~) =>
+      (
+        @cmd.none,
+        {
+          ..model,
+          transcript_scroll: model.transcript_scroll.add(slot, scroll),
+        },
+      )
     ToggleRightPanel => {
       let opening = !model.right_panel_open
       // A direct visibility toggle has no later semantic action to fence old
@@ -4696,10 +4704,7 @@ fn update_msg(
       // then nothing would carry the user's writing.
       let (model, command) = model.allocate_submission_id()
       (
-        @cmd.batch([
-          send_goal(dispatch, model, conv, command, Some(text)),
-          @transcript_component.scroll_to_latest(),
-        ]),
+        send_goal(dispatch, model, conv, command, Some(text)),
         model.replace_conversation({
           ..conv,
           goal_edit: None,
@@ -4727,10 +4732,7 @@ fn update_msg(
       }
       let (model, command) = model.allocate_submission_id()
       (
-        @cmd.batch([
-          send_goal(dispatch, model, conv, command, None),
-          @transcript_component.scroll_to_latest(),
-        ]),
+        send_goal(dispatch, model, conv, command, None),
         model.replace_conversation({
           ..conv,
           goal_edit: None,

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -3660,7 +3660,7 @@ fn update_msg(
             )
           }
           (
-            command,
+            @cmd.batch([command, @transcript_component.scroll_to_latest()]),
             {
               ..model.replace_conversation({
                 ..conv,
@@ -3743,7 +3743,12 @@ fn update_msg(
             workspace=conv.project(),
           )
         }
-        (start_cmd, model.replace_conversation(next))
+        // Re-pin now, before the durable User item arrives, so the early
+        // streamed work is visible even if the reader had scrolled up.
+        (
+          @cmd.batch([start_cmd, @transcript_component.scroll_to_latest()]),
+          model.replace_conversation(next),
+        )
       }
     }
     Stop => {
@@ -4691,7 +4696,10 @@ fn update_msg(
       // then nothing would carry the user's writing.
       let (model, command) = model.allocate_submission_id()
       (
-        send_goal(dispatch, model, conv, command, Some(text)),
+        @cmd.batch([
+          send_goal(dispatch, model, conv, command, Some(text)),
+          @transcript_component.scroll_to_latest(),
+        ]),
         model.replace_conversation({
           ..conv,
           goal_edit: None,
@@ -4719,7 +4727,10 @@ fn update_msg(
       }
       let (model, command) = model.allocate_submission_id()
       (
-        send_goal(dispatch, model, conv, command, None),
+        @cmd.batch([
+          send_goal(dispatch, model, conv, command, None),
+          @transcript_component.scroll_to_latest(),
+        ]),
         model.replace_conversation({
           ..conv,
           goal_edit: None,


### PR DESCRIPTION
## Why

The transcript component was built once in `boot` and outlived its DOM while onboarding, Settings, Skills, or the console gate were shown. To notice a conversation switch, a remount, or a new submission, it wrote the identity into `data-transcript-*` attributes and watched them with a `MutationObserver`, then fed that back into its own `update` as `ContentRendered(mounted~)`. That uses the DOM as a signal bus for input changes, which Rabbita never does: input alone triggers nothing, and the sanctioned way to react to an input transition is branch lifecycle (`switch_by` / `assoc_by`).

## What

- `Model::transcript_slot` mirrors the root view's fork (console gate, Chat onboarding/loading/load failure, Codex) and keys a `Val::switch_by` in `boot`. A new slot builds a fresh component; `None` disposes the current one. The component exists exactly while its DOM does.
- The component's `init` places the scroller and reports the first visible turn. `Model` drops `source`, `focused`, `active_session`, `submission_generation`, and `mounted`; `ContentRendered` only follows content growth and geometry.
- The `MutationObserver` no longer watches attributes. Only `data-transcript-session` remains, as a test hook (`rabbita_dom.spec.js` uses it to detect a draft rotation, which has no other visible signal).
- Re-pinning on Send is an explicit after-render command the root issues with the prompt and steer commands (`@transcript_component.scroll_to_latest`). Goal set/clear no longer re-pin.
- The two module-level `Ref`s in the component (`transcript_pinned_watch`, `transcript_turn_anchor`) are gone. The subscription payload carries the Model's `pinned` and `overview.active`, refreshed by `update_tagger` after every message, and the scroll listener reports only readings that differ from the Model.
- Where a reader left a conversation is remembered across visits: the subscription's `unload` runs while the old DOM is still on screen and reports the position through `Actions::departed`; the root keeps it per slot key in `Model.transcript_scroll`; `Input::scroll` hands it back so the next component's `init` restores the offset (or pins to the tail).

## Verification

- `moon check --target js`, `moon info --target js` (component mbti synced by the js-only recipe)
- `moon test --target js` in `desktop/`: 3207 passed
- `just test-browser`: 45 existing tests pass; new `transcript_scroll.spec.js` covers Send re-pinning after the reader scrolled up (including following a streamed delta afterwards) and A → B → A restoring A's offset while B opens at its tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dp6jf4fKxaVzVq2heQR6dX
