### PR TITLE
fix(desktop): keep the active dock tab visible

### DIFF
--- a/desktop/e2e/tests/dock_visibility.spec.js
+++ b/desktop/e2e/tests/dock_visibility.spec.js
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test';
+import { DesktopBrowserHarness } from './support/desktop_browser_harness.js';
+
+// Geometry assertions must not click the tab first: Playwright would scroll
+// the target into view and conceal the product bug.
+async function expectActiveVisible(page) {
+  await expect.poll(() => page.locator('.editor-tabs').evaluate(strip => {
+    const active = strip.querySelector('.editor-tab.active');
+    if (!active) return false;
+    const bounds = strip.getBoundingClientRect();
+    const tab = active.getBoundingClientRect();
+    const close = active.querySelector('.tab-close').getBoundingClientRect();
+    return tab.left >= bounds.left - 1 && tab.right <= bounds.right + 1 &&
+      close.left >= bounds.left - 1 && close.right <= bounds.right + 1;
+  })).toBe(true);
+}
+
+test('active dock tab stays visible when opening, switching, closing and resizing', async ({ page }) => {
+  const app = new DesktopBrowserHarness(page);
+  app.searchFiles = Array.from({ length: 8 }, (_, i) => `src/document_${i}_long_name.mbt`);
+  for (const path of app.searchFiles) app.workingFiles[path] = 'fn main {}\n';
+  await app.install();
+  await app.goto();
+  await app.openSession();
+  const openFile = async i => {
+    await app.openQuickOpen();
+    await page.locator('#quick-open-input').fill(`document_${i}`);
+    await page.getByRole('option', { name: new RegExp(`document_${i}`) }).click();
+    await expect(page.locator('.editor-tab.active')).toContainText(`document_${i}`);
+  };
+  for (let i = 0; i < 8; i++) await openFile(i);
+  await expect.poll(() => page.locator('.editor-tabs').evaluate(el => el.scrollWidth > el.clientWidth)).toBe(true);
+  await expectActiveVisible(page);
+  await openFile(0);
+  await expectActiveVisible(page);
+  await openFile(7);
+  await expectActiveVisible(page);
+  await page.getByRole('button', { name: 'Expand panel', exact: true }).click();
+  await expectActiveVisible(page);
+  await page.getByRole('button', { name: 'Restore panel', exact: true }).click();
+  await page.setViewportSize({ width: 1100, height: 900 });
+  await expectActiveVisible(page);
+  // A drag changes CSS geometry without a model message. Also exercise a
+  // strip narrower than the normal 200px chip cap.
+  const strip = page.locator('.editor-tabs');
+  await strip.evaluate(el => { el.style.flex = '0 1 120px'; });
+  await expect.poll(() => strip.evaluate(el => el.clientWidth)).toBeLessThan(200);
+  await expectActiveVisible(page);
+  await strip.evaluate(el => { el.style.removeProperty('flex'); });
+  await expectActiveVisible(page);
+  // Ordinary typing must not undo a user's deliberate horizontal scroll.
+  await strip.evaluate(el => { el.scrollLeft = 0; });
+  await page.locator('#task').fill('keep browsing the earlier tabs');
+  await expect.poll(() => strip.evaluate(el => el.scrollLeft)).toBe(0);
+  // Re-opening even the same active file is an explicit reveal request.
+  await openFile(7);
+  await expectActiveVisible(page);
+  await page.locator('.editor-tab.active .tab-close').click();
+  await expect(page.locator('.editor-tab')).toHaveCount(7);
+  await expectActiveVisible(page);
+  expect(app.pageErrors).toEqual([]);
+});

--- a/desktop/frontend/dock_visibility.mbt
+++ b/desktop/frontend/dock_visibility.mbt
@@ -1,0 +1,53 @@
+// DOM geometry belongs after rendering. Keep the observer with the current
+// strip, disconnecting it when the shell replaces/removes that element.
+
+///|
+extern "js" fn make_dock_visibility_sync() -> (Bool) -> Unit =
+  #| () => {
+  #|   let strip = null;
+  #|   let active = null;
+  #|   const reveal = () => {
+  #|     if (!strip || !active || strip.clientWidth === 0) return;
+  #|     const viewport = strip.getBoundingClientRect();
+  #|     const tab = active.getBoundingClientRect();
+  #|     // Scroll only this strip; scrollIntoView can also move the page or
+  #|     // other ancestors.
+  #|     if (tab.right > viewport.right) strip.scrollLeft += tab.right - viewport.right;
+  #|     else if (tab.left < viewport.left) strip.scrollLeft += tab.left - viewport.left;
+  #|   };
+  #|   const observer = new ResizeObserver(reveal);
+  #|   return force => {
+  #|     const nextStrip = document.querySelector('.editor-tabs');
+  #|     const nextActive = nextStrip?.querySelector('.editor-tab.active') ?? null;
+  #|     const changed = strip !== nextStrip || active !== nextActive;
+  #|     if (changed) {
+  #|       observer.disconnect();
+  #|       strip = nextStrip;
+  #|       active = nextActive;
+  #|       if (strip) observer.observe(strip);
+  #|       if (active) observer.observe(active);
+  #|     }
+  #|     if (changed || force) reveal();
+  #|   };
+  #| }
+
+///|
+let dock_visibility_sync : Ref[((Bool) -> Unit)?] = Ref(None)
+
+///|
+fn sync_dock_visibility(reveal : Bool) -> @cmd.Cmd {
+  @cmd.custom_cmd(
+    _ => {
+      let sync = match dock_visibility_sync.val {
+        Some(sync) => sync
+        None => {
+          let sync = make_dock_visibility_sync()
+          dock_visibility_sync.val = Some(sync)
+          sync
+        }
+      }
+      sync(reveal)
+    },
+    kind=@cmd.after_render,
+  )
+}

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1837,8 +1837,21 @@ fn update(
   let (model, browser_cmd) = sync_browser_view(dispatch, model)
   (
     @cmd.batch([
-      cmd, notification_badge_cmd, quick_open_cmd, panel_visibility_cmd, panel_cmd,
-      terminal_cmd, browser_cmd,
+      cmd,
+      notification_badge_cmd,
+      quick_open_cmd,
+      panel_visibility_cmd,
+      panel_cmd,
+      terminal_cmd,
+      browser_cmd,
+      sync_dock_visibility(
+        model.dock.active != previous.dock.active ||
+        model.dock.tabs != previous.dock.tabs ||
+        model.dock.owner != previous.dock.owner ||
+        panel_visibility_changed ||
+        msg.opens_file_before_panel_reconciliation() ||
+        msg is Dock(TabActivated(_)),
+      ),
     ]),
     model,
   )

--- a/desktop/styles/file_panel.css
+++ b/desktop/styles/file_panel.css
@@ -93,7 +93,7 @@ button.panel-toggle:not(:disabled):hover {
   align-items: center;
   gap: 2px;
   flex: 0 0 auto;
-  max-width: 200px;
+  max-width: min(200px, 100%);
   padding: 4px 4px 4px 10px;
   font-size: var(--font-size-sm);
   color: var(--color-text-faint);


### PR DESCRIPTION
Opening enough files to overflow the right-panel tab strip could leave the active tab and its close button offscreen. The strip retained its old horizontal position while hiding its scrollbar. Reproduced in Chromium with eight long file tabs: the active-tab geometry assertion fails on the original browser bundle.

Reveal the active tab after dock selection, membership, owner, or panel visibility changes, including explicitly reopening the same active file. Observe strip and active-tab size changes so panel resizing also keeps the close button reachable. Scroll only the strip, preserve deliberate scrolling during unrelated updates, and cap tab width to the available strip width. Disconnect old observations when rendered elements change.

Validation:
- Regression fails before the fix and passes afterward; covers opening, switching, closing, resizing, narrow strips, manual scrolling, and reopening the active file.
- Desktop browser suite: 45 tests passed.
- `just check`, `just test`, `just build`.
- `moon info` and `moon fmt`; no generated public interface changes.
