### PR TITLE
refactor(desktop): decide the chat column once for the view and the transcript slot

### DIFF
--- a/desktop/frontend/component_transcript.mbt
+++ b/desktop/frontend/component_transcript.mbt
@@ -2,9 +2,9 @@
 /// The conversation whose transcript the root view places on screen. It keys
 /// the transcript component's lifetime (`Val::switch_by` in `boot`): a new
 /// slot builds a fresh component whose `init` places the scroller and clears
-/// overview state, and `None` disposes the current one. The view's own fork
-/// — the console gate, Chat onboarding, loading, and load failure — is
-/// mirrored here so the component exists exactly while its DOM does.
+/// overview state, and `None` disposes the current one. It derives from the
+/// same `console_gate` and `chat_column` the view places the column from, so
+/// the component exists exactly while its DOM does.
 priv struct TranscriptSlot {
   source : @transcript_component.Source
   channel : @interop.ChannelId
@@ -22,15 +22,61 @@ fn TranscriptSlot::key(self : TranscriptSlot) -> String {
 }
 
 ///|
-fn Model::transcript_slot(self : Model) -> TranscriptSlot? {
-  if self.console is Some(console) &&
+/// A browser page is gated on both its relay session and its required
+/// query-selected device. Until both exist the view shows the gate instead of
+/// the console frame, so no transcript is on screen either.
+fn Model::console_gate(self : Model) -> ConsoleState? {
+  guard self.console is Some(console) &&
     (
       console.page_device is None ||
       !(console.auth is AuthSignedIn(..)) ||
       self.focused_device() is None
-    ) {
+    ) else {
     return None
   }
+  Some(console)
+}
+
+///|
+/// What the Chat screen's conversation column shows. A chat needs a
+/// conversation, and a conversation needs a project to work in, so with none
+/// on screen — the registry has not arrived, or no project is attached — the
+/// column is onboarding instead. The view places the column from this value
+/// and the transcript component's lifetime follows it, so the fork is decided
+/// once.
+priv enum ChatColumn {
+  LoadFailed(message~ : String)
+  Loading
+  Onboarding
+  Transcript(slot~ : TranscriptSlot, conversation~ : Conversation)
+}
+
+///|
+fn Model::chat_column(self : Model) -> ChatColumn {
+  if self.conversation_load_failure is Some(failure) &&
+    self.selected_conversation == Some(failure.target) {
+    return LoadFailed(message=failure.message)
+  }
+  if !self.selected_conversation_loaded() {
+    return Loading
+  }
+  match self.active_conversation() {
+    None => Onboarding
+    Some(conversation) =>
+      Transcript(
+        slot={
+          source: OpenSeek,
+          channel: self.focused,
+          session: Some(self.active_session),
+        },
+        conversation~,
+      )
+  }
+}
+
+///|
+fn Model::transcript_slot(self : Model) -> TranscriptSlot? {
+  guard self.console_gate() is None else { return None }
   match self.screen {
     Codex =>
       Some({
@@ -38,21 +84,11 @@ fn Model::transcript_slot(self : Model) -> TranscriptSlot? {
         channel: self.focused,
         session: self.codex.active_id(),
       })
-    Chat => {
-      if self.conversation_load_failure is Some(failure) &&
-        self.selected_conversation == Some(failure.target) {
-        return None
+    Chat =>
+      match self.chat_column() {
+        Transcript(slot~, ..) => Some(slot)
+        LoadFailed(..) | Loading | Onboarding => None
       }
-      guard self.selected_conversation_loaded() &&
-        self.active_conversation() is Some(_) else {
-        return None
-      }
-      Some({
-        source: OpenSeek,
-        channel: self.focused,
-        session: Some(self.active_session),
-      })
-    }
     Skills | Settings | WorkspaceSettings(..) => None
   }
 }

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -1675,15 +1675,10 @@ fn view(
 ) -> @html.Html {
   let (quick_open_html, context_menu_html) = quick_open_and_context_menu
   let (skills_html, workspace_settings_html) = skills_and_workspace_settings
-  // A browser page is gated on both its relay session and its required
-  // query-selected device. Until both exist, the console frame — sidebar,
-  // composer, overlays — stays unbuilt and inert Local cannot receive UI work.
-  if model.console is Some(console) &&
-    (
-      console.page_device is None ||
-      !(console.auth is AuthSignedIn(..)) ||
-      model.focused_device() is None
-    ) {
+  // Until the relay session and its device exist, the console frame —
+  // sidebar, composer, overlays — stays unbuilt and inert Local cannot
+  // receive UI work.
+  if model.console_gate() is Some(console) {
     return console_gate_view(dispatch, console)
   }
   let file_panel_visible = model.file_panel_visible()
@@ -1701,33 +1696,26 @@ fn view(
     model.is_desktop,
   )
   let content = match model.screen {
-    // The one fork that decides what the conversation column is. A chat needs
-    // a conversation, and a conversation needs a project to work in, so with
-    // none on screen — the registry has not arrived, or no project is
-    // attached — the column is onboarding instead. Everything below this
-    // point in the Chat branch has both.
+    // `Model::chat_column` is the one fork that decides what the conversation
+    // column is; the transcript component's lifetime follows the same value.
     Chat =>
-      if model.conversation_load_failure is Some(failure) &&
-        model.selected_conversation == Some(failure.target) {
-        [conversation_load_failed_view(dispatch, failure.message)]
-      } else if !model.selected_conversation_loaded() {
-        [conversation_loading_view()]
-      } else {
-        match model.active_conversation() {
-          None => [onboarding_view(dispatch, model)]
-          Some(conv) =>
-            [
-              topbar_view(
-                dispatch, toggle_terminal, toggle_right_panel, model, conv,
-              ),
-              transcript_html,
-              if conv.is_archived_read_only() {
-                conv.archived_read_only_view(dispatch)
-              } else {
-                composer_html
-              },
-            ]
-        }
+      match model.chat_column() {
+        LoadFailed(message~) =>
+          [conversation_load_failed_view(dispatch, message)]
+        Loading => [conversation_loading_view()]
+        Onboarding => [onboarding_view(dispatch, model)]
+        Transcript(conversation=conv, ..) =>
+          [
+            topbar_view(
+              dispatch, toggle_terminal, toggle_right_panel, model, conv,
+            ),
+            transcript_html,
+            if conv.is_archived_read_only() {
+              conv.archived_read_only_view(dispatch)
+            } else {
+              composer_html
+            },
+          ]
       }
     Codex =>
       model.codex.page(


### PR DESCRIPTION
## Why

After #1383, `Model::transcript_slot` re-encoded the root view's console gate and its Chat fork (load failure, loading, onboarding) to decide whether a transcript component should exist. Nothing kept the two copies in step: an edit to one fork without the other would leave a component alive with no DOM, or the view placing a transcript whose branch renders nothing.

## What

- `Model::console_gate` returns the console state while the gate is shown; the view returns the gate page from it.
- `Model::chat_column` is the single Chat fork (`LoadFailed` / `Loading` / `Onboarding` / `Transcript(slot, conversation)`); the view places the conversation column by matching it.
- `Model::transcript_slot` derives the component's lifetime from those two values instead of repeating their conditions.

Pure consolidation, no behavior change: `component_transcript.mbt` +36, `view.mbt` -12.

## Verification

- `moon check --target js`
- `moon test --target js` in `desktop/`: 3209 passed
- `just test-browser`: 50 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dp6jf4fKxaVzVq2heQR6dX
