### PR TITLE
refactor(agent_review): shrink the public API by encapsulating findings

### DIFF
--- a/agent_review/pkg.generated.mbti
+++ b/agent_review/pkg.generated.mbti
@@ -18,16 +18,14 @@ pub async fn run_review(String, @deepseek.Model, String, workspace_root? : Strin
 // Errors
 
 // Types and methods
-pub struct Finding {
-  severity : String
-  // private fields
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+type Finding derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
 pub struct ReviewReport {
-  findings : Array[Finding]
   // private fields
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn ReviewReport::digest(Self) -> String
+pub fn ReviewReport::finding_count(Self) -> Int
+pub fn ReviewReport::has_blockers(Self) -> Bool
 pub fn ReviewReport::parse(Json) -> Result[Self, String]
 pub fn ReviewReport::to_json(Self) -> Json
 pub fn ReviewReport::to_json_string(Self) -> String

--- a/agent_review/types.mbt
+++ b/agent_review/types.mbt
@@ -6,14 +6,14 @@
 
 ///|
 /// A single review finding at an optional source location.
-pub struct Finding {
-  priv file : String
-  priv line : Int?
+struct Finding {
+  file : String
+  line : Int?
   severity : String
-  priv category : String
-  priv title : String
-  priv detail : String
-  priv suggestion : String?
+  category : String
+  title : String
+  detail : String
+  suggestion : String?
 } derive(Debug, Eq, ToJson, FromJson)
 
 ///|
@@ -39,7 +39,7 @@ struct ReviewStats {
 pub struct ReviewReport {
   priv schema_version : Int
   priv scope : ReviewScope
-  findings : Array[Finding]
+  priv findings : Array[Finding]
   priv summary : String
   priv stats : ReviewStats
 } derive(Debug, Eq, ToJson, FromJson)
@@ -48,6 +48,20 @@ pub struct ReviewReport {
 /// Encode the report as a single-line JSON string (the CLI stdout contract).
 pub fn ReviewReport::to_json_string(self : ReviewReport) -> String {
   ToJson::to_json(self).stringify()
+}
+
+///|
+/// True when the report carries at least one blocker finding: the audit's
+/// verdict is that the reviewed claim does NOT hold. Callers use this for
+/// exit codes and error flags without reaching into the findings shape.
+pub fn ReviewReport::has_blockers(self : ReviewReport) -> Bool {
+  self.findings.any(f => f.severity == "blocker")
+}
+
+///|
+/// Number of findings carried by the report, for summaries and briefs.
+pub fn ReviewReport::finding_count(self : ReviewReport) -> Int {
+  self.findings.length()
 }
 
 ///|

--- a/cmd/openseek/review.mbt
+++ b/cmd/openseek/review.mbt
@@ -72,7 +72,7 @@ async fn run_review_cli(
     }
   }
   @stdio.stdout.write(report.to_json_string() + "\n")
-  if report.findings.any(f => f.severity == "blocker") {
+  if report.has_blockers() {
     remove_scratch_lab(scratch_dir)
     @sys.exit(2)
   }

--- a/cmd/openseek/review_tool.mbt
+++ b/cmd/openseek/review_tool.mbt
@@ -110,8 +110,8 @@ async fn execute_review(
     Some(report) =>
       @agent_tool.respond(
         report.digest(),
-        is_error=report.findings.any(f => f.severity == "blocker"),
-        brief="review \{result.subrun_id()} (\{report.findings.length()} finding(s), \{result.steps_used()} step(s))",
+        is_error=report.has_blockers(),
+        brief="review \{result.subrun_id()} (\{report.finding_count()} finding(s), \{result.steps_used()} step(s))",
       )
     None =>
       @agent_tool.respond(


### PR DESCRIPTION
## Summary

`moon ide analyze agent_review` showed the package's public surface is used entirely by one
consumer, `cmd/openseek` — but it was leakier than the consumer needs. Nobody outside the
package ever names `Finding`, and the only reads of `ReviewReport.findings` / `Finding.severity`
were to ask two questions: *does the report have blockers?* and *how many findings are there?*

This PR encapsulates the findings shape behind behavior:

- `Finding` becomes a private type and `ReviewReport.findings` becomes a private field
  (the nested contract type disappears from the public interface).
- Callers get `ReviewReport::has_blockers()` and `ReviewReport::finding_count()` — the only
  two behaviors the three read sites demonstrated.
- Call sites in `cmd/openseek` (`review.mbt` exit-2 branch, `review_tool.mbt` is_error/brief)
  move to the new methods.

The JSON contract is untouched: serialization still happens inside the package via the existing
derives, so `openseek review` stdout and the subrun/gate report lines are byte-identical.
Remaining public surface: `run_review`, `run_goal_audit`, `default_audit_max_steps`, and an
opaque `ReviewReport` with `parse`/`validate`/`digest`/`to_json_string`/`has_blockers`/`finding_count`.

## What I verified

- `moon fmt agent_review cmd/openseek` and full `moon check` clean (0 errors, 0 warnings).
- `moon test agent_review`: 12/12 pass.
- `moon test cmd/openseek --filter *review*`: 6/6 pass.

Generated with SeekMoon