### PR TITLE
refactor: make all-private-field pub structs abstract types

### DIFF
--- a/agent_review/pkg.generated.mbti
+++ b/agent_review/pkg.generated.mbti
@@ -20,9 +20,7 @@ pub async fn run_review(String, @deepseek.Model, String, workspace_root? : Strin
 // Types and methods
 type Finding derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
-pub struct ReviewReport {
-  // private fields
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+type ReviewReport derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn ReviewReport::digest(Self) -> String
 pub fn ReviewReport::finding_count(Self) -> Int
 pub fn ReviewReport::has_blockers(Self) -> Bool

--- a/agent_review/types.mbt
+++ b/agent_review/types.mbt
@@ -35,13 +35,14 @@ struct ReviewStats {
 } derive(Debug, Eq, ToJson, FromJson)
 
 ///|
-/// The full review report.
-pub struct ReviewReport {
-  priv schema_version : Int
-  priv scope : ReviewScope
-  priv findings : Array[Finding]
-  priv summary : String
-  priv stats : ReviewStats
+/// The full review report. Abstract: the representation stays inside this
+/// package; callers reach it through the accessors and JSON contract below.
+struct ReviewReport {
+  schema_version : Int
+  scope : ReviewScope
+  findings : Array[Finding]
+  summary : String
+  stats : ReviewStats
 } derive(Debug, Eq, ToJson, FromJson)
 
 ///|

--- a/agent_runtime/pkg.generated.mbti
+++ b/agent_runtime/pkg.generated.mbti
@@ -15,9 +15,7 @@ pub let default_agent_event_capacity : Int
 pub(all) extenum AgentEvent {
 }
 
-pub struct AgentRuntime {
-  // private fields
-}
+type AgentRuntime
 pub fn AgentRuntime::AgentRuntime(workspace_root? : String, approval? : ApprovalChannel) -> Self
 pub fn AgentRuntime::approval_channel(Self) -> ApprovalChannel?
 pub fn AgentRuntime::drain_events(Self) -> Array[AgentEvent]
@@ -27,9 +25,7 @@ pub fn AgentRuntime::queue_steer(Self, SteerInput, wake? : Bool) -> Unit
 pub async fn AgentRuntime::wait_for_user_input(Self) -> Unit
 pub fn AgentRuntime::workspace_root(Self) -> String
 
-pub struct AgentTaskScope[X] {
-  // private fields
-}
+type AgentTaskScope[X]
 pub fn[X] AgentTaskScope::AgentTaskScope(@async.TaskGroup[X]) -> Self[X]
 pub fn[X] AgentTaskScope::group(Self[X]) -> @async.TaskGroup[X]
 

--- a/agent_runtime/runtime.mbt
+++ b/agent_runtime/runtime.mbt
@@ -37,20 +37,20 @@ pub(all) extenum AgentEvent {}
 ///
 /// It does not own background task lifetime. Tools that need to spawn bounded
 /// background work receive an `AgentTaskScope` alongside the runtime.
-pub struct AgentRuntime {
+struct AgentRuntime {
   /// Workspace root used by local tools when resolving relative paths.
   /// Defaults to "." so direct package users keep current-directory behavior.
-  priv workspace_root : String
+  workspace_root : String
   /// Bounded event bus (see `default_agent_event_capacity`) that background
   /// tools can post updates to; consumers choose when and how to drain and
   /// render retained tool output.
-  priv events : @aqueue.Queue[AgentEvent]
+  events : @aqueue.Queue[AgentEvent]
   /// Unbounded queue of typed mid-turn input. Deliberately separate from the
   /// lossy event bus: a noisy watcher may fill `events` and cause later runtime
   /// updates to be ignored, but user-visible input must never be the casualty.
-  priv steers : @aqueue.Queue[SteerInput]
-  priv user_input_changed : @async.CondVar
-  priv mut user_input_pending : Bool
+  steers : @aqueue.Queue[SteerInput]
+  user_input_changed : @async.CondVar
+  mut user_input_pending : Bool
   /// Where a tool's permission question goes, when anything can answer one
   /// (see `approval_channel`). `None` is the fail-closed default, and it is
   /// also what tells a tool registry not to advertise the arguments that ask.
@@ -58,7 +58,7 @@ pub struct AgentRuntime {
   /// A bare function rather than a service type, so a tool package asking for
   /// approval does not acquire a dependency on the protocol, the engine, or
   /// whichever controller happens to be attached.
-  priv approval : ApprovalChannel?
+  approval : ApprovalChannel?
 }
 
 ///|
@@ -108,8 +108,8 @@ pub fn AgentRuntime::workspace_root(self : AgentRuntime) -> String {
 /// the loop's task group exits. The type parameter `X` is the return type of
 /// that enclosing task group; it is carried through so MoonBit's task-group type
 /// remains precise.
-pub struct AgentTaskScope[X] {
-  priv group : @async.TaskGroup[X]
+struct AgentTaskScope[X] {
+  group : @async.TaskGroup[X]
 }
 
 ///|

--- a/agent_session/goal.mbt
+++ b/agent_session/goal.mbt
@@ -51,11 +51,11 @@ pub const GoalContinuePrompt : String =
 
 ///|
 /// A standing goal derived from the durable event log.
-pub struct StandingGoal {
-  priv text : String
-  priv answered_since_set : Bool
-  priv set_sequence : Int
-  priv blocked : Bool
+struct StandingGoal {
+  text : String
+  answered_since_set : Bool
+  set_sequence : Int
+  blocked : Bool
 } derive(Debug)
 
 ///|

--- a/agent_session/pkg.generated.mbti
+++ b/agent_session/pkg.generated.mbti
@@ -36,9 +36,7 @@ pub fn parse_goal_baseline(String) -> GoalBaseline?
 // Errors
 
 // Types and methods
-pub struct AssistantMessage {
-  // private fields
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+type AssistantMessage derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn AssistantMessage::AssistantMessage(String, tool_calls? : Array[@deepseek.ToolCall], reasoning_content? : String, is_replay? : Bool) -> Self
 pub fn AssistantMessage::content(Self) -> String
 pub fn AssistantMessage::is_replay(Self) -> Bool
@@ -61,15 +59,11 @@ pub enum GoalMarker {
 } derive(@debug.Debug)
 pub fn GoalMarker::to_repr(Self) -> @debug.Repr
 
-pub struct RuntimeNotice {
-  // private fields
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+type RuntimeNotice derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn RuntimeNotice::RuntimeNotice(String) -> Self
 pub fn RuntimeNotice::content(Self) -> String
 
-pub struct Session {
-  // private fields
-} derive(Eq, @debug.Debug)
+type Session derive(Eq, @debug.Debug)
 pub fn Session::Session(SessionId, system_prompt~ : String, events? : @vector.Vector[SessionEvent]) -> Self
 pub fn Session::append(Self, SessionItem, unix_ms? : Int64) -> Self
 pub fn Session::append_event(Self, SessionItem, unix_ms? : Int64) -> (Self, SessionEvent)
@@ -87,17 +81,13 @@ pub fn Session::to_json(Self) -> Json
 pub impl ToJson for Session
 pub impl @json.FromJson for Session
 
-pub struct SessionEvent {
-  // private fields
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+type SessionEvent derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn SessionEvent::is_agent_step(Self) -> Bool
 pub fn SessionEvent::item(Self) -> SessionItem
 pub fn SessionEvent::sequence(Self) -> Int
 pub fn SessionEvent::unix_ms(Self) -> Int64
 
-pub struct SessionId {
-  // private fields
-} derive(Eq, @debug.Debug)
+type SessionId derive(Eq, @debug.Debug)
 pub fn SessionId::SessionId(String) -> Self
 pub fn SessionId::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SessionId::generated(prefix~ : String, now_ms~ : Int64, salt? : String) -> Self
@@ -115,26 +105,20 @@ pub(all) enum SessionItem {
 pub fn SessionItem::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub impl @json.FromJson for SessionItem
 
-pub struct SessionSummary {
-  // private fields
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+type SessionSummary derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn SessionSummary::SessionSummary(content~ : String, from_sequence~ : Int, to_sequence~ : Int) -> Self
 pub fn SessionSummary::content(Self) -> String
 pub fn SessionSummary::from_sequence(Self) -> Int
 pub fn SessionSummary::to_sequence(Self) -> Int
 
-pub struct StandingGoal {
-  // private fields
-} derive(@debug.Debug)
+type StandingGoal derive(@debug.Debug)
 pub fn StandingGoal::answered_since_set(Self) -> Bool
 pub fn StandingGoal::blocked(Self) -> Bool
 pub fn StandingGoal::set_sequence(Self) -> Int
 pub fn StandingGoal::text(Self) -> String
 pub fn StandingGoal::to_repr(Self) -> @debug.Repr
 
-pub struct ToolResult {
-  // private fields
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+type ToolResult derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn ToolResult::ToolResult(tool_call_id~ : String, tool_name~ : String, content~ : String, is_error? : Bool, brief? : String) -> Self
 pub fn ToolResult::brief(Self) -> String?
 pub fn ToolResult::content(Self) -> String
@@ -151,9 +135,7 @@ pub(all) enum TurnTerminal {
 pub fn TurnTerminal::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub impl @json.FromJson for TurnTerminal
 
-pub struct UserMessage {
-  // private fields
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+type UserMessage derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn UserMessage::UserMessage(String, submission_id? : String) -> Self
 pub fn UserMessage::content(Self) -> String
 pub fn UserMessage::submission_id(Self) -> String?

--- a/agent_session/store/pkg.generated.mbti
+++ b/agent_session/store/pkg.generated.mbti
@@ -11,18 +11,14 @@ import {
 // Errors
 
 // Types and methods
-pub struct SessionListing {
-  // private fields
-} derive(@debug.Debug)
+type SessionListing derive(@debug.Debug)
 pub fn SessionListing::first_prompt(Self) -> String
 pub fn SessionListing::id(Self) -> @agent_session.SessionId
 pub fn SessionListing::last_active_unix_seconds(Self) -> Int64?
 pub fn SessionListing::title(Self) -> String?
 pub fn SessionListing::to_repr(Self) -> @debug.Repr
 
-pub struct SessionStore {
-  // private fields
-} derive(@debug.Debug)
+type SessionStore derive(@debug.Debug)
 pub fn SessionStore::SessionStore(String) -> Self
 pub async fn SessionStore::append(Self, @agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session
 pub async fn SessionStore::compact(Self, @agent_session.Session, content~ : String, from_sequence~ : Int, to_sequence~ : Int) -> @agent_session.Session

--- a/agent_session/store/store.mbt
+++ b/agent_session/store/store.mbt
@@ -30,14 +30,14 @@ let title_file_name : String = "session-title"
 /// lines) and `session.lock`. The store is not a handle to one current
 /// session; APIs that operate on a session either take a `SessionId` or a
 /// `Session` carrying its id.
-pub struct SessionStore {
-  priv root : String
+struct SessionStore {
+  root : String
   // The last session value this store instance loaded from or persisted to
   // disk, per id, with the file fingerprint at that moment. Purely an
   // optimization: it lets the stale-snapshot check skip re-reading the whole
   // file on the common append path. Never required for correctness — a
   // missing or mismatching mark falls back to the full comparison.
-  priv marks : Map[String, DurableMark]
+  marks : Map[String, DurableMark]
 } derive(Debug)
 
 ///|
@@ -514,11 +514,11 @@ pub fn SessionStore::session_file(
 /// built without replaying the full event log, so it is suitable for pickers
 /// and `--session-list`. A row can also represent a damaged directory: in that
 /// case timestamp may be `None` and first prompt may be empty.
-pub struct SessionListing {
-  priv id : @agent_session.SessionId
-  priv last_active_unix_seconds : Int64?
-  priv first_prompt : String
-  priv title : String?
+struct SessionListing {
+  id : @agent_session.SessionId
+  last_active_unix_seconds : Int64?
+  first_prompt : String
+  title : String?
 } derive(Debug)
 
 ///|

--- a/agent_session/types.mbt
+++ b/agent_session/types.mbt
@@ -23,8 +23,8 @@ pub const ContextYieldAnswerPrefix : String = "[context ceiling]"
 /// This type deliberately stores the raw string without normalizing or
 /// validating it; store APIs validate filesystem safety before constructing
 /// paths. Use `generated` for ids created by OpenSeek itself.
-pub struct SessionId {
-  priv value : String
+struct SessionId {
+  value : String
 } derive(Eq, Debug)
 
 ///|
@@ -105,9 +105,9 @@ pub fn SessionId::generated(
 /// prompts, and every record written before the field existed. Encoding
 /// omits it when absent, so untagged lines are byte for byte what this store
 /// has always written.
-pub struct UserMessage {
-  priv content : String
-  priv submission_id : String?
+struct UserMessage {
+  content : String
+  submission_id : String?
 } derive(Eq, Debug, ToJson, FromJson)
 
 ///|
@@ -158,13 +158,13 @@ pub fn UserMessage::submission_id(self : UserMessage) -> String? {
 /// This stores visible assistant text, requested tool calls, and optional
 /// reasoning content. Tool calls are durable because later `ToolResult` events
 /// must match their call ids during `Session::chat_messages` projection.
-pub struct AssistantMessage {
-  priv content : String
-  priv tool_calls : Array[SessionToolCall]
-  priv reasoning_content : String?
+struct AssistantMessage {
+  content : String
+  tool_calls : Array[SessionToolCall]
+  reasoning_content : String?
   // True only when a checkpoint re-appends an answer that an earlier durable
   // provider step already owns. Absent on ordinary messages.
-  priv is_replay : Bool?
+  is_replay : Bool?
 } derive(Eq, Debug, ToJson, FromJson)
 
 ///|
@@ -241,12 +241,12 @@ pub fn AssistantMessage::is_replay(self : AssistantMessage) -> Bool {
 /// During model projection, a `ToolResult` is emitted only when its
 /// `tool_call_id` matches a pending assistant tool call. Unmatched results are
 /// ignored to keep replay protocol-valid.
-pub struct ToolResult {
-  priv tool_call_id : String
-  priv tool_name : String
-  priv content : String
-  priv is_error : Bool
-  priv brief : String?
+struct ToolResult {
+  tool_call_id : String
+  tool_name : String
+  content : String
+  is_error : Bool
+  brief : String?
 } derive(Eq, Debug, ToJson, FromJson)
 
 ///|
@@ -302,8 +302,8 @@ pub fn ToolResult::is_error(self : ToolResult) -> Bool {
 /// Runtime notices are projected as user-role messages. They are intended for
 /// loop-injected context such as plan reminders or other text that did not
 /// originate from the user's prompt.
-pub struct RuntimeNotice {
-  priv content : String
+struct RuntimeNotice {
+  content : String
 } derive(Eq, Debug, ToJson, FromJson)
 
 ///|
@@ -331,10 +331,10 @@ pub fn RuntimeNotice::content(self : RuntimeNotice) -> String {
 /// A summary does not delete the covered raw events. It records that
 /// `from_sequence..to_sequence` can be replaced by `content` when projecting
 /// model context. The durable event log remains append-only.
-pub struct SessionSummary {
-  priv content : String
-  priv from_sequence : Int
-  priv to_sequence : Int
+struct SessionSummary {
+  content : String
+  from_sequence : Int
+  to_sequence : Int
 } derive(Eq, Debug, ToJson, FromJson)
 
 ///|
@@ -422,15 +422,15 @@ pub(all) enum SessionItem {
 /// when loading from disk. The timestamp is unix milliseconds; in-memory
 /// appends default to `0`, while `SessionStore::append` stamps with the current
 /// wall clock.
-pub struct SessionEvent {
-  priv sequence : Int
+struct SessionEvent {
+  sequence : Int
   // Wall-clock stamp (unix milliseconds) of when the event was appended; 0
   // for purely in-memory sessions appended without a clock (the durable
   // store always stamps). The field is named for its wire key, and typed
   // Double so it serializes as a JSON number (core encodes Int64 as a
   // string); milliseconds are exactly representable until year ~2255.
-  priv ts : Double
-  priv item : SessionItem
+  ts : Double
+  item : SessionItem
 } derive(Eq, Debug, ToJson, FromJson)
 
 ///|
@@ -479,11 +479,11 @@ pub fn SessionEvent::is_agent_step(self : SessionEvent) -> Bool {
 /// `append`/`append_event` preserve it by construction; the `Session::Session`
 /// constructor trusts callers to supply a log that already satisfies it — see
 /// that constructor for the full contract.
-pub struct Session {
-  priv id : SessionId
-  priv system_prompt : String
-  priv events : @vector.Vector[SessionEvent]
-  priv last_sequence : Int
+struct Session {
+  id : SessionId
+  system_prompt : String
+  events : @vector.Vector[SessionEvent]
+  last_sequence : Int
 } derive(Eq, Debug)
 
 ///|

--- a/agent_subrun/pkg.generated.mbti
+++ b/agent_subrun/pkg.generated.mbti
@@ -15,9 +15,7 @@ pub async fn[T] run_subrun(command~ : String, args~ : Array[String], input~ : Js
 // Errors
 
 // Types and methods
-pub struct ChildSession {
-  // private fields
-}
+type ChildSession
 pub fn ChildSession::ChildSession(root~ : String, parent~ : String, first_free? : Int) -> Self
 pub fn ChildSession::injection(Self, exe~ : String, workspace_root~ : String, model? : String, api_url? : String) -> @host.SubrunInjection
 

--- a/agent_subrun/runner.mbt
+++ b/agent_subrun/runner.mbt
@@ -201,10 +201,10 @@ pub async fn[T] run_subrun(
 /// sub-run counter is per-process, so without this floor a RESUMED durable
 /// session would reuse `sr-1` — and the fresh child session would die on
 /// its first append against the old child's file (stale-snapshot check).
-pub struct ChildSession {
-  priv root : String
-  priv parent : String
-  priv first_free : Int
+struct ChildSession {
+  root : String
+  parent : String
+  first_free : Int
 }
 
 ///|

--- a/agent_tool/agent_tool.mbt
+++ b/agent_tool/agent_tool.mbt
@@ -231,10 +231,10 @@ fn ToolAction::abort(reason : String) -> ToolAction {
 ///|
 /// A name-indexed collection of `AgentToolDefinition` values. Construct via
 /// `Tools(definitions)`, which raises if any two definitions share a name.
-pub struct Tools {
-  priv by_name : Map[String, AgentToolDefinition]
+struct Tools {
+  by_name : Map[String, AgentToolDefinition]
   /// Shared execution registry, also used by the loop for wait/finish decisions.
-  priv background_jobs : @bgjobs.BgJobRuntime?
+  background_jobs : @bgjobs.BgJobRuntime?
 }
 
 ///|

--- a/agent_tool/file_state.mbt
+++ b/agent_tool/file_state.mbt
@@ -56,8 +56,8 @@ priv struct Entry {
 /// restored from a durable log. A file created in an earlier process (before a
 /// resume) is absent, so consumers must read "absent" as "unknown provenance",
 /// never as "not created".
-pub struct FileStateMap {
-  priv entries : Map[String, Entry]
+struct FileStateMap {
+  entries : Map[String, Entry]
 }
 
 ///|

--- a/agent_tool/pkg.generated.mbti
+++ b/agent_tool/pkg.generated.mbti
@@ -55,9 +55,7 @@ pub fn FileState::equal(Self, Self) -> Bool
 pub fn FileState::not_equal(Self, Self) -> Bool
 pub fn FileState::to_repr(Self) -> @debug.Repr
 
-pub struct FileStateMap {
-  // private fields
-}
+type FileStateMap
 pub fn FileStateMap::FileStateMap() -> Self
 pub fn FileStateMap::created_and_unchanged(Self, String, String) -> Bool
 pub fn FileStateMap::forget(Self, String) -> Unit
@@ -89,9 +87,7 @@ pub struct ToolOutput {
 } derive(@debug.Debug)
 pub fn ToolOutput::to_repr(Self) -> @debug.Repr
 
-pub struct Tools {
-  // private fields
-}
+type Tools
 pub fn Tools::Tools(Array[AgentToolDefinition], background_jobs? : @bgjobs.BgJobRuntime) -> Self raise
 pub fn Tools::background_job_runtime(Self) -> @bgjobs.BgJobRuntime?
 pub fn Tools::find(Self, String) -> AgentToolDefinition?

--- a/agent_tool/shell_exec/execution.mbt
+++ b/agent_tool/shell_exec/execution.mbt
@@ -42,33 +42,33 @@ fn ExecStatus::is_terminal(self : ExecStatus) -> Bool {
 /// `shell` tool and `moon_check`): the process library exposes no process-group
 /// kill, so a command that daemonizes its own children can leave descendants
 /// running after the execution is terminal.
-pub struct ShellExecution {
-  priv sink : ShellOutputSink
-  priv process : @process.Process
-  priv mut status : ExecStatus
+struct ShellExecution {
+  sink : ShellOutputSink
+  process : @process.Process
+  mut status : ExecStatus
   // Set before the child is cancelled (by `stop`, or by the output-limit kill)
   // so the monitor reports `Killed` rather than the kill signal's exit code.
-  priv mut cancel_requested : Bool
+  mut cancel_requested : Bool
   // Foreground semantics: kill the child once the sink fills (output prefix hit
   // the hard cap or the kill threshold), so an un-timed runaway cannot hang the
   // tool call. Cleared by `background()` — a detached job keeps running.
-  priv mut kill_when_full : Bool
+  mut kill_when_full : Bool
   // Background watchdog: kill the child once full output hits the *hard* cap —
   // past it every further byte is dropped, so the job is a runaway producing
   // nothing anyone can read. Unlike `kill_when_full` this survives
   // `background()`: a detached job keeps running but not unboundedly.
-  priv kill_at_hard_cap : Bool
+  kill_at_hard_cap : Bool
   // Set when the child was cancelled by an output-limit watchdog (either flag
   // above), so a consumer can tell a watchdog kill from a requested stop and
   // surface it rather than letting the job die silently.
-  priv mut killed_by_output_limit : Bool
+  mut killed_by_output_limit : Bool
   // Monotonic start stamp, so a wall-clock reaper measures a job's lifetime
   // from process start — a detached (adopted) job keeps its original
   // deadline, not one restarted at adoption.
-  priv started_at_ms : Int64
+  started_at_ms : Int64
   // Set when the child was cancelled by the wall-clock reaper, so consumers
   // can tell a lifetime kill from a requested stop.
-  priv mut killed_by_time_limit : Bool
+  mut killed_by_time_limit : Bool
 }
 
 ///|

--- a/agent_tool/shell_exec/pkg.generated.mbti
+++ b/agent_tool/shell_exec/pkg.generated.mbti
@@ -23,9 +23,7 @@ pub fn ExecStatus::equal(Self, Self) -> Bool
 pub fn ExecStatus::not_equal(Self, Self) -> Bool
 pub fn ExecStatus::to_repr(Self) -> @debug.Repr
 
-pub struct ShellExecution {
-  // private fields
-}
+type ShellExecution
 pub fn ShellExecution::background(Self) -> Bool
 pub async fn ShellExecution::discard(Self) -> Unit
 pub fn ShellExecution::exit_code(Self) -> Int?
@@ -48,10 +46,6 @@ pub fn ShellExecution::status(Self) -> ExecStatus
 pub async fn ShellExecution::stop(Self) -> Bool
 pub async fn ShellExecution::wait(Self) -> Unit
 pub async fn ShellExecution::wait_or_invalid(Self) -> Unit
-
-pub struct ShellOutputSink {
-  // private fields
-}
 
 // Type aliases
 

--- a/agent_tool/shell_exec/sink.mbt
+++ b/agent_tool/shell_exec/sink.mbt
@@ -24,31 +24,31 @@ pub let default_hard_cap : Int = 20_000_000
 /// With no `spill_path` the sink is memory-only: it keeps the head and drops the
 /// rest (bounded, never touches disk) — used by contexts that never need full
 /// large output (tests, the scope-less `collect_shell_output`).
-pub struct ShellOutputSink {
+priv struct ShellOutputSink {
   // The first `inline_cap` characters, for inline rendering without a file read.
-  priv head : StringBuilder
-  priv mut head_chars : Int
+  head : StringBuilder
+  mut head_chars : Int
   // Total decoded characters of full output (across memory + file), ≤ hard_cap.
-  priv mut total_chars : Int
+  mut total_chars : Int
   // Trailing bytes of an incomplete UTF-8 sequence carried to the next chunk.
-  priv mut pending : Bytes
+  mut pending : Bytes
   // Bumps whenever retained output grows, for poll change detection.
-  priv mut seq : Int
+  mut seq : Int
   // Set once output was dropped at the hard cap.
-  priv mut truncated : Bool
+  mut truncated : Bool
   // Set once any invalid (non-UTF-8 / binary) bytes were decoded lossily, so a
   // consumer can preserve the strict-decode "binary output" error rather than
   // silently showing replacement characters.
-  priv mut had_invalid : Bool
+  mut had_invalid : Bool
   // Full-output spill file, opened lazily once output exceeds `inline_cap` and a
   // spill path is configured. None → memory-only (small output, or no path).
-  priv mut file : @fs.File?
+  mut file : @fs.File?
   // Bytes written to the file so far (== full output byte length once spilled).
-  priv mut file_bytes : Int64
+  mut file_bytes : Int64
   // Where to spill; None → never spill (memory-only, head kept, rest dropped).
-  priv spill_path : String?
-  priv inline_cap : Int
-  priv hard_cap : Int
+  spill_path : String?
+  inline_cap : Int
+  hard_cap : Int
 }
 
 ///|

--- a/deepseek/client/client.mbt
+++ b/deepseek/client/client.mbt
@@ -103,10 +103,10 @@ pub fn Client::Client(
 /// `reason` describes the failure. Pre-stream retries (429, 5xx, connect
 /// errors) report through it too, so a consumer can show that the request is
 /// being retried rather than silently waiting.
-pub struct StreamHandler {
-  priv on_content_delta : async (String) -> Unit
-  priv on_reasoning_delta : async (String) -> Unit
-  priv on_retry : ((Int, Int, String) -> Unit)?
+struct StreamHandler {
+  on_content_delta : async (String) -> Unit
+  on_reasoning_delta : async (String) -> Unit
+  on_retry : ((Int, Int, String) -> Unit)?
 }
 
 ///|

--- a/deepseek/client/pkg.generated.mbti
+++ b/deepseek/client/pkg.generated.mbti
@@ -24,9 +24,7 @@ pub fn Client::Client(api_key~ : String, model? : @deepseek.Model, api_url? : St
 pub async fn Client::chat(Self, Array[@deepseek.ChatMessage], tools? : Array[@deepseek.ToolDefinition], response_format? : @deepseek.ResponseFormat, stream? : StreamHandler) -> @deepseek.ChatResponse
 pub fn Client::to_repr(Self) -> @debug.Repr
 
-pub struct StreamHandler {
-  // private fields
-}
+type StreamHandler
 pub fn StreamHandler::StreamHandler(on_content_delta~ : async (String) -> Unit, on_reasoning_delta? : async (String) -> Unit, on_retry? : (Int, Int, String) -> Unit) -> Self
 
 // Type aliases

--- a/desktop/frontend/grep_search/types.mbt
+++ b/desktop/frontend/grep_search/types.mbt
@@ -100,9 +100,9 @@ pub fn EditorHighlights::ranges(
 }
 
 ///|
-pub struct State {
-  priv page : Page
-  priv generation : Int
+struct State {
+  page : Page
+  generation : Int
 } derive(Eq)
 
 ///|

--- a/desktop/frontend/quick_open/types.mbt
+++ b/desktop/frontend/quick_open/types.mbt
@@ -70,12 +70,12 @@ priv struct FileQueryCache {
 ///|
 /// The palette's whole state. The shell holds this value but cannot read into
 /// it; every transition goes through `open`, `handle`, or `reconcile`.
-pub struct State {
-  priv open : Open?
+struct State {
+  open : Open?
   /// Page-level counter, kept across close so an old reply cannot become
   /// current again by reopening the palette.
-  priv generation : Int
-  priv cache : FileQueryCache
+  generation : Int
+  cache : FileQueryCache
 } derive(Eq)
 
 ///|

--- a/desktop/frontend/terminal/state.mbt
+++ b/desktop/frontend/terminal/state.mbt
@@ -53,30 +53,30 @@ priv struct Tab {
 } derive(Eq)
 
 ///|
-pub struct State {
-  priv open : Bool
-  priv tabs : Array[Tab]
+struct State {
+  open : Bool
+  tabs : Array[Tab]
   /// The remembered active tab per workspace group, as an association list
   /// (small; a workspace rarely has more than a handful of tabs).
-  priv active : Array[(WorkspaceKey, String)]
+  active : Array[(WorkspaceKey, String)]
   /// The tab whose emulator element is currently displayed (`None` while
   /// the panel is closed). Mirrors imperative DOM state so `sync` can tell
   /// when a conversation switch must re-aim the display — the switch itself
   /// produces no terminal message.
-  priv shown : String?
+  shown : String?
   /// Session UUIDs whose exit event beat their `terminal_open` reply, paired
   /// with the channel used to discard that channel's pending output on loss.
   /// The reply is the first event that identifies the opening tab, so it
   /// consumes the pair and retires that tab instead of reviving an
   /// already-dead session.
-  priv exited_before_open : Array[(@interop.ChannelId, String)]
+  exited_before_open : Array[(@interop.ChannelId, String)]
   /// The color scheme last applied to every mounted emulator. Keeping this in
   /// model state lets `sync` refresh existing xterm instances exactly once
   /// when the application switches between light and dark mode.
-  priv synced_dark_mode : Bool?
+  synced_dark_mode : Bool?
   /// Root-owned input snapshot used to retire dead channels. Keeping it
   /// beside the tabs makes input reconciliation a normal state transition.
-  priv live_channels : Array[@interop.ChannelId]
+  live_channels : Array[@interop.ChannelId]
 } derive(Eq)
 
 ///|

--- a/editor/internal/viewer/code_editor_widget/contribution_descriptors.mbt
+++ b/editor/internal/viewer/code_editor_widget/contribution_descriptors.mbt
@@ -19,8 +19,8 @@ priv enum CodeEditorContributionKind {
 /// Explicit contribution set for one code-editor kernel. The fields stay
 /// opaque outside this package so hosts choose a reviewed factory rather than
 /// rebuilding a second contribution policy from booleans or editor roles.
-pub struct CodeEditorContributionDescriptors {
-  priv enabled : Array[CodeEditorContributionKind]
+struct CodeEditorContributionDescriptors {
+  enabled : Array[CodeEditorContributionKind]
 }
 
 ///|

--- a/editor/internal/viewer/code_editor_widget/pkg.generated.mbti
+++ b/editor/internal/viewer/code_editor_widget/pkg.generated.mbti
@@ -28,9 +28,7 @@ pub fn view_zone(Int, @dom.Element, after_column? : Int, after_column_affinity? 
 // Errors
 
 // Types and methods
-pub struct CodeEditorContributionDescriptors {
-  // private fields
-}
+type CodeEditorContributionDescriptors
 pub fn CodeEditorContributionDescriptors::diff_pane() -> Self
 pub fn CodeEditorContributionDescriptors::peek_preview() -> Self
 pub fn CodeEditorContributionDescriptors::standalone() -> Self

--- a/editor/internal/viewer/contrib/goto_symbol/pkg.generated.mbti
+++ b/editor/internal/viewer/contrib/goto_symbol/pkg.generated.mbti
@@ -17,34 +17,26 @@ pub fn symbol_navigation_context_commands(@languages.LanguageHandle, @model.Text
 // Errors
 
 // Types and methods
-pub struct DefinitionAction {
-  // private fields
-}
+type DefinitionAction
 pub fn DefinitionAction::DefinitionAction(SymbolNavigationAction) -> Self
 pub fn DefinitionAction::begin(Self, SymbolNavigationAnchor) -> Int?
 pub async fn DefinitionAction::run(Self, SymbolNavigationAnchor, SymbolNavigationActionConfig) -> Unit noraise
 pub async fn DefinitionAction::run_reserved(Self, SymbolNavigationAnchor, SymbolNavigationActionConfig, Int) -> Unit noraise
 
-pub struct DefinitionLinkResolver {
-  // private fields
-}
+type DefinitionLinkResolver
 pub fn DefinitionLinkResolver::DefinitionLinkResolver(@languages.LanguageHandle, is_anchor_current~ : (SymbolNavigationAnchor) -> Bool, async (Array[async () -> Unit]) -> Unit) -> Self
 pub fn DefinitionLinkResolver::begin(Self, SymbolNavigationAnchor) -> Int?
 pub fn DefinitionLinkResolver::cancel(Self) -> Unit
 pub fn DefinitionLinkResolver::dispose(Self) -> Unit
 pub async fn DefinitionLinkResolver::resolve_reserved(Self, SymbolNavigationAnchor, Int) -> Array[@language.Location] noraise
 
-pub struct ReferencesAction {
-  // private fields
-}
+type ReferencesAction
 pub fn ReferencesAction::ReferencesAction(SymbolNavigationAction) -> Self
 pub fn ReferencesAction::begin(Self, SymbolNavigationAnchor) -> Int?
 pub async fn ReferencesAction::run(Self, SymbolNavigationAnchor, SymbolNavigationActionConfig) -> Unit noraise
 pub async fn ReferencesAction::run_reserved(Self, SymbolNavigationAnchor, SymbolNavigationActionConfig, Int) -> Unit noraise
 
-pub struct SymbolNavigationAction {
-  // private fields
-}
+type SymbolNavigationAction
 pub fn SymbolNavigationAction::SymbolNavigationAction(@languages.LanguageHandle, SymbolNavigationActionHost, async (Array[async () -> Unit]) -> Unit) -> Self
 pub fn SymbolNavigationAction::cancel(Self) -> Unit
 pub fn SymbolNavigationAction::dispose(Self) -> Unit
@@ -66,9 +58,7 @@ pub(all) struct SymbolNavigationActionHost {
   show_message : (SymbolNavigationAnchor, String) -> Unit
 }
 
-pub struct SymbolNavigationAnchor {
-  // private fields
-}
+type SymbolNavigationAnchor
 pub fn SymbolNavigationAnchor::from_model(@model.TextModel, @common.Position, @common.Range, Int) -> Self
 pub fn SymbolNavigationAnchor::model(Self) -> @model.TextModel
 pub fn SymbolNavigationAnchor::model_is_current(Self) -> Bool

--- a/editor/internal/viewer/contrib/goto_symbol/symbol_navigation.mbt
+++ b/editor/internal/viewer/contrib/goto_symbol/symbol_navigation.mbt
@@ -2,13 +2,13 @@
 /// Immutable semantic origin for one symbol-navigation request. Surface
 /// adapters reduce DOM/cursor input to this value before shared actions see
 /// it; the original TextModel remains the only provider input.
-pub struct SymbolNavigationAnchor {
-  priv model : @model.TextModel
-  priv position : @base_common.Position
-  priv range : @base_common.Range
-  priv model_identity : Int
-  priv model_version_id : Int
-  priv surface_generation : Int
+struct SymbolNavigationAnchor {
+  model : @model.TextModel
+  position : @base_common.Position
+  range : @base_common.Range
+  model_identity : Int
+  model_version_id : Int
+  surface_generation : Int
 }
 
 ///|
@@ -217,13 +217,13 @@ priv enum SymbolNavigationQueryKind {
 /// Shared cancellation, provider-query, normalization, and result-policy
 /// owner. DefinitionAction and ReferencesAction are typed views over this one
 /// mutually-cancelling request stream.
-pub struct SymbolNavigationAction {
-  priv languages : @languages.LanguageHandle
-  priv host : SymbolNavigationActionHost
-  priv run_provider_tasks : async (Array[async () -> Unit]) -> Unit
-  priv mut generation : Int
-  priv mut source : @language.CancellationTokenSource?
-  priv mut disposed : Bool
+struct SymbolNavigationAction {
+  languages : @languages.LanguageHandle
+  host : SymbolNavigationActionHost
+  run_provider_tasks : async (Array[async () -> Unit]) -> Unit
+  mut generation : Int
+  mut source : @language.CancellationTokenSource?
+  mut disposed : Bool
 }
 
 ///|
@@ -351,13 +351,13 @@ fn normalize_symbol_locations(
 ///|
 /// Shared provider-query owner for modifier-hover Definition links. Surfaces
 /// retain only hit testing and projected-decoration work.
-pub struct DefinitionLinkResolver {
-  priv languages : @languages.LanguageHandle
-  priv is_anchor_current : (SymbolNavigationAnchor) -> Bool
-  priv run_provider_tasks : async (Array[async () -> Unit]) -> Unit
-  priv mut generation : Int
-  priv mut source : @language.CancellationTokenSource?
-  priv mut disposed : Bool
+struct DefinitionLinkResolver {
+  languages : @languages.LanguageHandle
+  is_anchor_current : (SymbolNavigationAnchor) -> Bool
+  run_provider_tasks : async (Array[async () -> Unit]) -> Unit
+  mut generation : Int
+  mut source : @language.CancellationTokenSource?
+  mut disposed : Bool
 }
 
 ///|
@@ -581,8 +581,8 @@ async fn SymbolNavigationAction::run_reserved(
 }
 
 ///|
-pub struct DefinitionAction {
-  priv action : SymbolNavigationAction
+struct DefinitionAction {
+  action : SymbolNavigationAction
 }
 
 ///|
@@ -621,8 +621,8 @@ pub async fn DefinitionAction::run(
 }
 
 ///|
-pub struct ReferencesAction {
-  priv action : SymbolNavigationAction
+struct ReferencesAction {
+  action : SymbolNavigationAction
 }
 
 ///|

--- a/editor/internal/viewer/contrib/references/browser/pkg.generated.mbti
+++ b/editor/internal/viewer/contrib/references/browser/pkg.generated.mbti
@@ -17,9 +17,7 @@ pub let references_peek_height_in_lines : Int
 // Errors
 
 // Types and methods
-pub struct ReferencesController {
-  // private fields
-}
+type ReferencesController
 pub fn ReferencesController::ReferencesController(ReferencesPeekHost, ReferencesPeekPreviewFactory, resolver? : @navigation_api.TextModelResolverHandle, (async () -> Unit noraise) -> Unit) -> Self
 pub fn ReferencesController::close(Self, restore_focus~ : Bool) -> Unit
 pub fn ReferencesController::contains_focus(Self) -> Bool
@@ -37,16 +35,12 @@ pub(all) struct ReferencesPeekHost {
   show_message : (@goto_symbol.SymbolNavigationAnchor, String) -> Unit
 }
 
-pub struct ReferencesPeekMount {
-  // private fields
-}
+type ReferencesPeekMount
 pub fn ReferencesPeekMount::ReferencesPeekMount(is_current~ : () -> Bool, dispose~ : () -> Unit) -> Self
 pub fn ReferencesPeekMount::dispose(Self) -> Unit
 pub fn ReferencesPeekMount::is_current(Self) -> Bool
 
-pub struct ReferencesPeekPreview {
-  // private fields
-}
+type ReferencesPeekPreview
 pub fn ReferencesPeekPreview::ReferencesPeekPreview(contains_focus~ : () -> Bool, focus~ : () -> Unit, dispose~ : () -> Unit) -> Self
 pub fn ReferencesPeekPreview::contains_focus(Self) -> Bool
 pub fn ReferencesPeekPreview::dispose(Self) -> Unit
@@ -56,9 +50,7 @@ pub(all) struct ReferencesPeekPreviewFactory {
   create : (@dom.Element, @model.TextModel, @common.Range, Array[@common.Range], @references.ReferencesPeekMode) -> ReferencesPeekPreview?
 }
 
-pub struct ReferencesPeekWidget {
-  // private fields
-}
+type ReferencesPeekWidget
 #alias(new, deprecated)
 pub fn ReferencesPeekWidget::ReferencesPeekWidget(@references.ReferencesPeekMode, ReferencesPeekWidgetCallbacks) -> Self
 pub fn ReferencesPeekWidget::dispose(Self) -> Unit

--- a/editor/internal/viewer/contrib/references/browser/references_controller.mbt
+++ b/editor/internal/viewer/contrib/references/browser/references_controller.mbt
@@ -2,10 +2,10 @@
 /// Exact surface mount owned by one Peek session. The adapter captures its
 /// concrete ViewZone/overlay or Markdown overlay node; the shared controller
 /// only asks whether that mount is still current and disposes it once.
-pub struct ReferencesPeekMount {
-  priv is_current_callback : () -> Bool
-  priv dispose_callback : () -> Unit
-  priv mut disposed : Bool
+struct ReferencesPeekMount {
+  is_current_callback : () -> Bool
+  dispose_callback : () -> Unit
+  mut disposed : Bool
 }
 
 ///|
@@ -37,11 +37,11 @@ pub fn ReferencesPeekMount::dispose(self : ReferencesPeekMount) -> Unit {
 ///|
 /// Surface-independent lifetime of the embedded CodeEditor preview. The
 /// injected factory owns concrete editor construction and decorations.
-pub struct ReferencesPeekPreview {
-  priv contains_focus_callback : () -> Bool
-  priv focus_callback : () -> Unit
-  priv dispose_callback : () -> Unit
-  priv mut disposed : Bool
+struct ReferencesPeekPreview {
+  contains_focus_callback : () -> Bool
+  focus_callback : () -> Unit
+  dispose_callback : () -> Unit
+  mut disposed : Bool
 }
 
 ///|
@@ -131,27 +131,27 @@ priv struct DetachedReferencesGroupResources {
 ///|
 /// One mutable Peek state machine per source surface. Controller instances are
 /// never shared between Code and Markdown surfaces.
-pub struct ReferencesController {
-  priv host : ReferencesPeekHost
-  priv preview_factory : ReferencesPeekPreviewFactory
-  priv resolver : @navigation_api.TextModelResolverHandle?
-  priv mut launch_async_task : (async () -> Unit noraise) -> Unit
-  priv mut generation : Int
-  priv mut preview_generation : Int
-  priv mut mode : @references.ReferencesPeekMode?
-  priv mut phase : @references.ReferencesPeekPhase
-  priv mut anchor : @goto_symbol.SymbolNavigationAnchor?
-  priv mut session_key : @references.ReferencesSessionKey?
-  priv mut model : @references.ReferencesModel?
-  priv mut selected_index : Int
-  priv mut widget : ReferencesPeekWidget?
-  priv mut mount : ReferencesPeekMount?
-  priv mut preview_source : @language.CancellationTokenSource?
-  priv mut preview_reference : @navigation_api.TextModelReference?
-  priv mut preview : ReferencesPeekPreview?
-  priv mut group_preview_owners : Array[ReferencesGroupPreviewOwner]
-  priv mut focus_frame : @base_common.Disposable?
-  priv mut disposed : Bool
+struct ReferencesController {
+  host : ReferencesPeekHost
+  preview_factory : ReferencesPeekPreviewFactory
+  resolver : @navigation_api.TextModelResolverHandle?
+  mut launch_async_task : (async () -> Unit noraise) -> Unit
+  mut generation : Int
+  mut preview_generation : Int
+  mut mode : @references.ReferencesPeekMode?
+  mut phase : @references.ReferencesPeekPhase
+  mut anchor : @goto_symbol.SymbolNavigationAnchor?
+  mut session_key : @references.ReferencesSessionKey?
+  mut model : @references.ReferencesModel?
+  mut selected_index : Int
+  mut widget : ReferencesPeekWidget?
+  mut mount : ReferencesPeekMount?
+  mut preview_source : @language.CancellationTokenSource?
+  mut preview_reference : @navigation_api.TextModelReference?
+  mut preview : ReferencesPeekPreview?
+  mut group_preview_owners : Array[ReferencesGroupPreviewOwner]
+  mut focus_frame : @base_common.Disposable?
+  mut disposed : Bool
 }
 
 ///|

--- a/editor/internal/viewer/contrib/references/browser/references_peek_widget.mbt
+++ b/editor/internal/viewer/contrib/references/browser/references_peek_widget.mbt
@@ -21,18 +21,18 @@ pub let references_peek_height_in_lines : Int = 18
 /// Detached browser shell shared by Definition and References Peek sessions.
 /// The root owns the presentation mount and nested readonly Viewer; this type
 /// owns only its DOM, result-tree state, and event-listener lifetime.
-pub struct ReferencesPeekWidget {
-  priv mode : @references.ReferencesPeekMode
-  priv root : @rdom.Element
-  priv title_meta : @rdom.Element
-  priv preview_host : @rdom.Element
-  priv status : @rdom.Element
-  priv results_scrollable : @scrollbar.ScrollableElementDom
-  priv results_scrollbar_input : @scrollbar.NativeScrollableElementInput
-  priv tree : ReferenceResultsTree
-  priv callbacks : ReferencesPeekWidgetCallbacks
-  priv listeners : Array[@base_common.Disposable]
-  priv mut disposed : Bool
+struct ReferencesPeekWidget {
+  mode : @references.ReferencesPeekMode
+  root : @rdom.Element
+  title_meta : @rdom.Element
+  preview_host : @rdom.Element
+  status : @rdom.Element
+  results_scrollable : @scrollbar.ScrollableElementDom
+  results_scrollbar_input : @scrollbar.NativeScrollableElementInput
+  tree : ReferenceResultsTree
+  callbacks : ReferencesPeekWidgetCallbacks
+  listeners : Array[@base_common.Disposable]
+  mut disposed : Bool
 }
 
 ///|

--- a/editor/syntax/pkg.generated.mbti
+++ b/editor/syntax/pkg.generated.mbti
@@ -69,9 +69,7 @@ pub fn TokenizationRegistry::on_did_change(Self, (TokenizationChangedEvent) -> U
 pub fn TokenizationRegistry::register(Self, String, &LineTokenizer) -> @common.Disposable
 pub fn TokenizationRegistry::set_color_map(Self, Array[String]) -> Unit
 
-pub struct TokenizerState {
-  // private fields
-} derive(Eq)
+type TokenizerState derive(Eq)
 pub fn TokenizerState::TokenizerState() -> Self
 pub fn TokenizerState::equal(Self, Self) -> Bool
 pub fn TokenizerState::last_mode(Self) -> Byte?

--- a/editor/syntax/tokenizer.mbt
+++ b/editor/syntax/tokenizer.mbt
@@ -4,8 +4,8 @@
 /// contains only open lexer modes. Stack edits share unchanged tails
 /// while cached states remain isolated from later edits. Derived equality is
 /// what callers use to detect re-tokenization convergence.
-pub struct TokenizerState {
-  priv modes : @list.List[Byte]
+struct TokenizerState {
+  modes : @list.List[Byte]
 } derive(Eq)
 
 ///|


### PR DESCRIPTION
## Summary

Follow-up to #1386 (`moon ide analyze agent_review` → shrink the public API). Review feedback
pointed out that for a struct whose **every** field is private, the better MoonBit practice is
to declare it as an abstract type — no `pub`, no per-field `priv` — because abstract is the
default type visibility: only the name is visible outside the package and the representation is
hidden. A `pub struct` with all-`priv` fields was a readonly type exposing nothing readable,
with every `priv` marker redundant.

What changed:

- `ReviewReport` in `agent_review` is now a plain abstract `struct` (`type ReviewReport` in the
  generated interface). External consumers (`cmd/openseek`) are unchanged: `parse`, `validate`,
  `digest`, `to_json_string`, `has_blockers`, `finding_count` and the JSON round-trip all still
  compile and behave identically.
- The same conversion applied to 26 more all-private-field `pub struct`s across the repo:
  `agent_session` (`Session`, `SessionId`, `UserMessage`, `AssistantMessage`, `ToolResult`,
  `RuntimeNotice`, `SessionSummary`, `SessionEvent`, `StandingGoal`, `SessionStore`,
  `SessionListing`), `agent_subrun` (`ChildSession`), `agent_runtime` (`AgentRuntime`,
  `AgentTaskScope[X]`), `agent_tool` (`Tools`, `FileStateMap`, `ShellExecution`),
  `deepseek/client` (`StreamHandler`), desktop frontends (grep/quick-open/terminal `State`), and
  editor internals (`TokenizerState`, symbol-navigation and references types).
- `ShellOutputSink` no longer occurs in any public signature, so it became fully `priv` (the
  compiler's `missing_priv` suggestion).
- `pkg.generated.mbti` regenerated: affected types now export as `type X` instead of
  `pub struct X { // private fields }`. Net diff −63 lines.

Behavior is unchanged everywhere: all of these structs already had no externally constructible or
readable surface, so dropping `pub`/`priv` markers is a pure API-documentation cleanup.

## What I verified

- `moon fmt` and `moon check`: clean, 0 errors / 0 warnings.
- `moon test` on the touched agent packages (`agent_review`, `agent_session(+store)`,
  `agent_runtime`, `agent_subrun`, `agent_tool(+shell_exec)`, `deepseek/client`): 205/205 pass.
- `moon test` on the touched editor/desktop packages: 339/339 pass.

Generated with SeekMoon