### PR TITLE
prompt: teach abstract-by-default type visibility

### DIFF
--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -662,6 +662,13 @@ stderr warning while exit stays 0 — treat skipped blocks as a blind spot.
   `moonbitlang/core/argparse` for CLI parsing, or `moonbitlang/core/json` for
   `@json.parse`.
 - Use `pub fn` for APIs called from another package. Plain `fn` is private.
+- Types are abstract by default: a plain `struct X { ... }` (no `pub`) leaves
+  only the type *name* visible to other packages — they can call its `pub`
+  methods but cannot construct it or read its fields. Prefer that over
+  `pub struct X { priv ... }` when every field is internal: the per-field
+  `priv` markers are redundant and `pub` (readonly) exposes nothing when no
+  field is readable. Reserve `pub` for types with readable fields, and
+  `priv struct X` for a type whose name itself must not leave the package.
 - `_test.mbt` files are black-box tests. Use `_wbtest.mbt` only when tests must
   inspect private helpers.
 - Top-level MoonBit items are separated by `///|`.

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -667,6 +667,13 @@ fn default_prompt() -> String {
     #|  `moonbitlang/core/argparse` for CLI parsing, or `moonbitlang/core/json` for
     #|  `@json.parse`.
     #|- Use `pub fn` for APIs called from another package. Plain `fn` is private.
+    #|- Types are abstract by default: a plain `struct X { ... }` (no `pub`) leaves
+    #|  only the type *name* visible to other packages — they can call its `pub`
+    #|  methods but cannot construct it or read its fields. Prefer that over
+    #|  `pub struct X { priv ... }` when every field is internal: the per-field
+    #|  `priv` markers are redundant and `pub` (readonly) exposes nothing when no
+    #|  field is readable. Reserve `pub` for types with readable fields, and
+    #|  `priv struct X` for a type whose name itself must not leave the package.
     #|- `_test.mbt` files are black-box tests. Use `_wbtest.mbt` only when tests must
     #|  inspect private helpers.
     #|- Top-level MoonBit items are separated by `///|`.


### PR DESCRIPTION
## Summary

Follow-up to #1386/#1387 (the `pub struct` → abstract-type refactor). The MoonBit Project
Setup section of the default prompt tells agents that `pub fn` is the function-visibility
switch, but says nothing about *type* visibility — which is exactly the gap that produced the
anti-pattern the refactor fixed (a `pub struct` whose every field is `priv`).

Adds one bullet to `default_prompt.mbt.md`:

- Types are abstract by default in MoonBit: a plain `struct X { ... }` leaves only the type
  *name* visible to other packages (they can call its `pub` methods but cannot construct it or
  read its fields). Prefer that over `pub struct X { priv ... }` when every field is internal —
  the per-field `priv` markers are redundant and readonly `pub` exposes nothing when no field
  is readable. Reserve `pub` for types with readable fields, and `priv struct X` for a type
  whose name itself must not leave the package.

`generated_default_prompt.mbt` regenerated via the `md_to_mbt_string` dev-build rule (edit the
markdown, not the generated file).

## What I verified

- `moon check`: clean, 0 errors / 0 warnings.
- `moon test prompt`: 20/20 pass (selection contract unchanged).
- Generated string diff mirrors the markdown diff exactly (+7 lines each).

Generated with SeekMoon