### PR TITLE
Add OpenRouter as a DeepSeek backend preset

### DIFF
--- a/deepseek/chatresponse_decode_test.mbt
+++ b/deepseek/chatresponse_decode_test.mbt
@@ -202,6 +202,19 @@ test "chat response decode rejects malformed reasoning_content" {
 }
 
 ///|
+test "chat response accepts OpenRouter reasoning alias" {
+  let response : @deepseek.ChatResponse = @json.from_json(
+    @json.parse(
+      (
+        #|{"choices":[{"message":{"role":"assistant","content":"done","reasoning":"checked the workspace"}}]}
+      ),
+    ),
+  )
+  assert_eq(response.content, "done")
+  assert_eq(response.reasoning_content, "checked the workspace")
+}
+
+///|
 test "chat response decode rejects malformed tool_calls" {
   try
     decode_chat_response(

--- a/deepseek/client/README.mbt.md
+++ b/deepseek/client/README.mbt.md
@@ -77,6 +77,13 @@ Without `stream`, `Client::chat` builds the same JSON body as
 configuration, then posts it to `api_url` with `Content-Type:
 application/json` and bearer authorization.
 
+When `api_url` is OpenRouter's canonical
+`https://openrouter.ai/api/v1/chat/completions` endpoint, the client maps
+DeepSeek V4 models to OpenRouter's namespaced ids and translates the configured
+thinking effort to OpenRouter's portable `reasoning` object. Both
+`reasoning_content` and OpenRouter's `reasoning` response field are normalized
+into `ChatResponse::reasoning_content`.
+
 Use `tools=[...]` when the model may request native function calls.
 Use `response_format=JsonObject` only when the assistant content itself must be
 a JSON object.

--- a/deepseek/client/README.mbt.md
+++ b/deepseek/client/README.mbt.md
@@ -84,6 +84,11 @@ thinking effort to OpenRouter's portable `reasoning` object. Both
 `reasoning_content` and OpenRouter's `reasoning` response field are normalized
 into `ChatResponse::reasoning_content`.
 
+| DeepSeek model      | OpenRouter ids                    |
+|---------------------|-----------------------------------|
+| `deepseek-v4-flash` | `deepseek/deepseek-v4-flash-0731` |
+| `deepseek-v4-pro`   | `deepseek/deepseek-v4-pro`        |
+
 Use `tools=[...]` when the model may request native function calls.
 Use `response_format=JsonObject` only when the assistant content itself must be
 a JSON object.

--- a/deepseek/client/client.mbt
+++ b/deepseek/client/client.mbt
@@ -275,8 +275,7 @@ pub async fn Client::chat(
     thinking=self.thinking,
     stream=is_streaming,
     response_format?,
-    messages,
-  )
+  ) <| messages
   try {
     match stream {
       None => self.with_retries(() => self.chat_attempt(body), _ => false)

--- a/deepseek/client/client.mbt
+++ b/deepseek/client/client.mbt
@@ -8,6 +8,9 @@ const KimiDefaultApiUrl : String = "https://api.moonshot.cn/v1/chat/completions"
 const GlmDefaultApiUrl : String = "https://api.z.ai/api/paas/v4/chat/completions"
 
 ///|
+const OpenRouterChatCompletionsUrl : String = "https://openrouter.ai/api/v1/chat/completions"
+
+///|
 let default_model : @deepseek.Model = Deepseek(V4Pro)
 
 ///|
@@ -17,6 +20,34 @@ fn default_api_url_for_model(model : @deepseek.Model) -> String {
     Glm(_) => GlmDefaultApiUrl
     Deepseek(_) => DeepSeekDefaultApiUrl
   }
+}
+
+///|
+/// OpenRouter is OpenAI-compatible, but its DeepSeek catalog uses namespaced
+/// model ids and its portable reasoning control instead of DeepSeek's native
+/// `thinking` object. Keep that endpoint-specific translation at the transport
+/// boundary so the rest of OpenSeek can continue to reason about the same
+/// typed DeepSeek model.
+fn adapt_chat_request_for_endpoint(
+  api_url : String,
+  model : @deepseek.Model,
+  thinking : @deepseek.ThinkingMode,
+  body : Json,
+) -> Json {
+  guard api_url == OpenRouterChatCompletionsUrl && model is Deepseek(_) else {
+    return body
+  }
+  guard body is Object(fields) else { return body }
+  fields["model"] = "deepseek/\{model}"
+  fields.remove("thinking")
+  fields.remove("reasoning_effort")
+  let effort = match thinking {
+    No => "none"
+    High => "high"
+    Max => "max"
+  }
+  fields["reasoning"] = { "effort": effort }
+  Json(fields)
 }
 
 ///|
@@ -232,13 +263,18 @@ pub async fn Client::chat(
   stream? : StreamHandler,
 ) -> @deepseek.ChatResponse {
   let is_streaming = stream is Some(_)
-  let body = @deepseek.encode_chat_request(
-    model=self.model,
-    tools~,
-    thinking=self.thinking,
-    stream=is_streaming,
-    response_format?,
-  ) <| messages
+  let body = adapt_chat_request_for_endpoint(
+    self.api_url,
+    self.model,
+    self.thinking,
+    @deepseek.encode_chat_request(
+      model=self.model,
+      tools~,
+      thinking=self.thinking,
+      stream=is_streaming,
+      response_format?,
+    ) <| messages,
+  )
   try {
     match stream {
       None => self.with_retries(() => self.chat_attempt(body), _ => false)

--- a/deepseek/client/client.mbt
+++ b/deepseek/client/client.mbt
@@ -34,7 +34,7 @@ fn encode_chat_request_for_endpoint(
   response_format? : @deepseek.ResponseFormat,
   messages : Array[@deepseek.ChatMessage],
 ) -> Json {
-  if api_url == OpenRouterChatCompletionsUrl && model is Deepseek(variant) {
+  if api_url is OpenRouterChatCompletionsUrl && model is Deepseek(variant) {
     @deepseek.openrouter_encode_chat_request(
       model=variant,
       tools~,

--- a/deepseek/client/client.mbt
+++ b/deepseek/client/client.mbt
@@ -23,31 +23,36 @@ fn default_api_url_for_model(model : @deepseek.Model) -> String {
 }
 
 ///|
-/// OpenRouter is OpenAI-compatible, but its DeepSeek catalog uses namespaced
-/// model ids and its portable reasoning control instead of DeepSeek's native
-/// `thinking` object. Keep that endpoint-specific translation at the transport
-/// boundary so the rest of OpenSeek can continue to reason about the same
-/// typed DeepSeek model.
-fn adapt_chat_request_for_endpoint(
-  api_url : String,
-  model : @deepseek.Model,
-  thinking : @deepseek.ThinkingMode,
-  body : Json,
+/// Route OpenRouter DeepSeek requests to their dedicated encoder for model ids
+/// and reasoning fields. Other endpoints and model families use native encoding.
+fn encode_chat_request_for_endpoint(
+  api_url~ : String,
+  model~ : @deepseek.Model,
+  tools~ : Array[@deepseek.ToolDefinition],
+  thinking~ : @deepseek.ThinkingMode,
+  stream~ : Bool,
+  response_format? : @deepseek.ResponseFormat,
+  messages : Array[@deepseek.ChatMessage],
 ) -> Json {
-  guard api_url == OpenRouterChatCompletionsUrl && model is Deepseek(_) else {
-    return body
+  if api_url == OpenRouterChatCompletionsUrl && model is Deepseek(variant) {
+    @deepseek.openrouter_encode_chat_request(
+      model=variant,
+      tools~,
+      thinking~,
+      stream~,
+      response_format?,
+      messages,
+    )
+  } else {
+    @deepseek.encode_chat_request(
+      model~,
+      tools~,
+      thinking~,
+      stream~,
+      response_format?,
+      messages,
+    )
   }
-  guard body is Object(fields) else { return body }
-  fields["model"] = "deepseek/\{model}"
-  fields.remove("thinking")
-  fields.remove("reasoning_effort")
-  let effort = match thinking {
-    No => "none"
-    High => "high"
-    Max => "max"
-  }
-  fields["reasoning"] = { "effort": effort }
-  Json(fields)
 }
 
 ///|
@@ -263,17 +268,14 @@ pub async fn Client::chat(
   stream? : StreamHandler,
 ) -> @deepseek.ChatResponse {
   let is_streaming = stream is Some(_)
-  let body = adapt_chat_request_for_endpoint(
-    self.api_url,
-    self.model,
-    self.thinking,
-    @deepseek.encode_chat_request(
-      model=self.model,
-      tools~,
-      thinking=self.thinking,
-      stream=is_streaming,
-      response_format?,
-    ) <| messages,
+  let body = encode_chat_request_for_endpoint(
+    api_url=self.api_url,
+    model=self.model,
+    tools~,
+    thinking=self.thinking,
+    stream=is_streaming,
+    response_format?,
+    messages,
   )
   try {
     match stream {

--- a/deepseek/client/client_stream_test.mbt
+++ b/deepseek/client/client_stream_test.mbt
@@ -36,6 +36,9 @@ async fn stream_test_server(
           "data: {\"choices\":[{\"delta\":{\"content\":\" world\",\"reasoning_content\":\"hidden\",\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"read\",\"arguments\":\"{\\\"path\\\"\"}}]}}]}\n\n",
         )
         conn.write(
+          "data: {\"choices\":[{\"delta\":{\"reasoning\":\" via OpenRouter\"}}]}\n\n",
+        )
+        conn.write(
           if kimi_usage {
             "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\":\\\"moon.mod\\\"}\"}}]},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":5,\"total_tokens\":8}}\n\n"
           } else {
@@ -74,13 +77,13 @@ async test "chat stream handler accumulates SSE content, tool calls, and usage" 
       ),
     )
     assert_eq(deltas.join("|"), "Hello| world")
-    assert_eq(reasoning_deltas.join("|"), "hidden")
+    assert_eq(reasoning_deltas.join("|"), "hidden| via OpenRouter")
     assert_eq(
       callbacks.join("|"),
-      "content:Hello|reasoning:hidden|content: world",
+      "content:Hello|reasoning:hidden|content: world|reasoning: via OpenRouter",
     )
     assert_eq(response.content, "Hello world")
-    assert_eq(response.reasoning_content, "hidden")
+    assert_eq(response.reasoning_content, "hidden via OpenRouter")
     assert_eq(response.tool_calls.length(), 1)
     assert_eq(response.tool_calls[0].id, "call_1")
     assert_eq(response.tool_calls[0].name, "read")

--- a/deepseek/client/openrouter_wbtest.mbt
+++ b/deepseek/client/openrouter_wbtest.mbt
@@ -1,45 +1,33 @@
 ///|
-test "OpenRouter adapts DeepSeek model and reasoning fields" {
-  let body = @deepseek.encode_chat_request(model=Deepseek(V4Pro), thinking=High) <| [
-    ChatMessage(User, content="hello"),
-  ]
-  json_inspect(
-    adapt_chat_request_for_endpoint(
-      "https://openrouter.ai/api/v1/chat/completions",
-      Deepseek(V4Pro),
-      High,
-      body,
-    ),
-    content={
-      "model": "deepseek/deepseek-v4-pro",
-      "messages": [{ "role": "user", "content": "hello" }],
-      "stream": false,
-      "reasoning": { "effort": "high" },
-    },
-  )
-}
-
-///|
-test "non-OpenRouter custom endpoints keep DeepSeek wire format" {
-  let body = @deepseek.encode_chat_request(
-    model=Deepseek(V4Flash),
-    thinking=Max,
-  ) <| [
-    ChatMessage(User, content="hello"),
-  ]
-  json_inspect(
-    adapt_chat_request_for_endpoint(
-      "https://proxy.example/v1/chat/completions",
-      Deepseek(V4Flash),
-      Max,
-      body,
-    ),
-    content={
-      "model": "deepseek-v4-flash",
-      "messages": [{ "role": "user", "content": "hello" }],
-      "stream": false,
-      "thinking": { "type": "enabled" },
-      "reasoning_effort": "max",
-    },
-  )
+test "OpenRouter encodes DeepSeek models and reasoning fields" {
+  for
+    (model, model_id) in [
+      (@deepseek.Deepseek(V4Pro), "deepseek/deepseek-v4-pro"),
+      (Deepseek(V4Flash), "deepseek/deepseek-v4-flash-0731"),
+    ] {
+    for
+      (thinking, effort) in [
+        (@deepseek.No, "none"),
+        (High, "high"),
+        (Max, "max"),
+      ] {
+      let expected : Json = {
+        "model": model_id,
+        "messages": [{ "role": "user", "content": "hello" }],
+        "stream": false,
+        "reasoning": { "effort": effort },
+      }
+      assert_eq(
+        encode_chat_request_for_endpoint(
+          api_url="https://openrouter.ai/api/v1/chat/completions",
+          model~,
+          thinking~,
+          tools=[],
+          stream=false,
+          [ChatMessage(User, content="hello")],
+        ),
+        expected,
+      )
+    }
+  }
 }

--- a/deepseek/client/openrouter_wbtest.mbt
+++ b/deepseek/client/openrouter_wbtest.mbt
@@ -1,0 +1,45 @@
+///|
+test "OpenRouter adapts DeepSeek model and reasoning fields" {
+  let body = @deepseek.encode_chat_request(model=Deepseek(V4Pro), thinking=High) <| [
+    ChatMessage(User, content="hello"),
+  ]
+  json_inspect(
+    adapt_chat_request_for_endpoint(
+      "https://openrouter.ai/api/v1/chat/completions",
+      Deepseek(V4Pro),
+      High,
+      body,
+    ),
+    content={
+      "model": "deepseek/deepseek-v4-pro",
+      "messages": [{ "role": "user", "content": "hello" }],
+      "stream": false,
+      "reasoning": { "effort": "high" },
+    },
+  )
+}
+
+///|
+test "non-OpenRouter custom endpoints keep DeepSeek wire format" {
+  let body = @deepseek.encode_chat_request(
+    model=Deepseek(V4Flash),
+    thinking=Max,
+  ) <| [
+    ChatMessage(User, content="hello"),
+  ]
+  json_inspect(
+    adapt_chat_request_for_endpoint(
+      "https://proxy.example/v1/chat/completions",
+      Deepseek(V4Flash),
+      Max,
+      body,
+    ),
+    content={
+      "model": "deepseek-v4-flash",
+      "messages": [{ "role": "user", "content": "hello" }],
+      "stream": false,
+      "thinking": { "type": "enabled" },
+      "reasoning_effort": "max",
+    },
+  )
+}

--- a/deepseek/client/stream.mbt
+++ b/deepseek/client/stream.mbt
@@ -118,12 +118,10 @@ async fn apply_stream_delta(
 ) -> Unit {
   // Compatible providers may put both fields in one SSE object. Reasoning
   // logically precedes the answer, so preserve that order for live clients.
-  let reasoning = match delta {
-    { "reasoning_content": String(reasoning), .. } => Some(reasoning)
-    { "reasoning": String(reasoning), .. } => Some(reasoning)
-    _ => None
-  }
-  if reasoning is Some(reasoning) && reasoning != "" {
+  if delta
+    is ({ "reasoning_content": String(reasoning), .. }
+    | { "reasoning": String(reasoning), .. }) &&
+    !reasoning.is_empty() {
     acc.reasoning_content <+ "\{reasoning}"
     on_reasoning_delta(reasoning)
   }

--- a/deepseek/client/stream.mbt
+++ b/deepseek/client/stream.mbt
@@ -118,7 +118,12 @@ async fn apply_stream_delta(
 ) -> Unit {
   // Compatible providers may put both fields in one SSE object. Reasoning
   // logically precedes the answer, so preserve that order for live clients.
-  if delta is { "reasoning_content": String(reasoning), .. } && reasoning != "" {
+  let reasoning = match delta {
+    { "reasoning_content": String(reasoning), .. } => Some(reasoning)
+    { "reasoning": String(reasoning), .. } => Some(reasoning)
+    _ => None
+  }
+  if reasoning is Some(reasoning) && reasoning != "" {
     acc.reasoning_content <+ "\{reasoning}"
     on_reasoning_delta(reasoning)
   }

--- a/deepseek/json_decode.mbt
+++ b/deepseek/json_decode.mbt
@@ -147,16 +147,21 @@ pub impl FromJson for ChatResponse with fn from_json(
       )
   }
   let reasoning_content = match message_fields {
-    {
-      "reasoning_content"? : Some(String(reasoning_content))
-      | (Some(Null) | None with reasoning_content = ""),
-      ..
-    } => reasoning_content
-    _ =>
+    { "reasoning_content": String(reasoning_content), .. } => reasoning_content
+    { "reasoning_content": Null, .. } => ""
+    { "reasoning_content": _, .. } =>
       json_decode_error(
         message_path.add_key("reasoning_content"),
         "ChatResponse::from_json: expected reasoning_content string",
       )
+    { "reasoning": String(reasoning), .. } => reasoning
+    { "reasoning": Null, .. } => ""
+    { "reasoning": _, .. } =>
+      json_decode_error(
+        message_path.add_key("reasoning"),
+        "ChatResponse::from_json: expected reasoning string",
+      )
+    _ => ""
   }
   let usage = match usage_json {
     Some(usage) => FromJson::from_json(usage, path.add_key("usage"))

--- a/deepseek/json_decode.mbt
+++ b/deepseek/json_decode.mbt
@@ -80,6 +80,42 @@ impl FromJson for ToolCall with fn from_json(json : Json, path : @json.JsonPath)
 }
 
 ///|
+fn decode_nullable_string(
+  fields : Map[String, Json],
+  key~ : String,
+  path~ : @json.JsonPath,
+) -> String? raise @json.JsonDecodeError {
+  if fields.get(key) is Some(value) {
+    if value is (String(value) | (Null with value = "")) {
+      Some(value)
+    } else {
+      raise json_decode_error(
+        path.add_key(key),
+        "ChatResponse::from_json: expected \{key} string",
+      )
+    }
+  } else {
+    None
+  }
+}
+
+///|
+fn decode_reasoning_content(
+  fields : Map[String, Json],
+  path~ : @json.JsonPath,
+) -> String raise @json.JsonDecodeError {
+  if decode_nullable_string(fields, key="reasoning_content", path~)
+    is Some(reasoning_content) {
+    return reasoning_content
+  } else if decode_nullable_string(fields, key="reasoning", path~)
+    is Some(reasoning_content) {
+    return reasoning_content
+  } else {
+    return ""
+  }
+}
+
+///|
 /// Decodes a DeepSeek chat completions JSON response envelope.
 ///
 /// Missing usage information is represented as zero token counts.
@@ -146,23 +182,10 @@ pub impl FromJson for ChatResponse with fn from_json(
         "ChatResponse::from_json: expected message content",
       )
   }
-  let reasoning_content = match message_fields {
-    { "reasoning_content": String(reasoning_content), .. } => reasoning_content
-    { "reasoning_content": Null, .. } => ""
-    { "reasoning_content": _, .. } =>
-      json_decode_error(
-        message_path.add_key("reasoning_content"),
-        "ChatResponse::from_json: expected reasoning_content string",
-      )
-    { "reasoning": String(reasoning), .. } => reasoning
-    { "reasoning": Null, .. } => ""
-    { "reasoning": _, .. } =>
-      json_decode_error(
-        message_path.add_key("reasoning"),
-        "ChatResponse::from_json: expected reasoning string",
-      )
-    _ => ""
-  }
+  let reasoning_content = decode_reasoning_content(
+    message_fields,
+    path=message_path,
+  )
   let usage = match usage_json {
     Some(usage) => FromJson::from_json(usage, path.add_key("usage"))
     None => Usage::empty()

--- a/deepseek/openrouter_encode.mbt
+++ b/deepseek/openrouter_encode.mbt
@@ -1,0 +1,39 @@
+///|
+/// Encodes a DeepSeek V4 request for OpenRouter directly.
+pub fn openrouter_encode_chat_request(
+  model~ : DsVariant,
+  thinking~ : ThinkingMode,
+  tools? : Array[ToolDefinition] = [],
+  stream? : Bool = false,
+  response_format? : ResponseFormat,
+  messages : Array[ChatMessage],
+) -> Json {
+  let model = match model {
+    V4Flash => "deepseek/deepseek-v4-flash-0731"
+    V4Pro => "deepseek/deepseek-v4-pro"
+  }
+  let effort = match thinking {
+    No => "none"
+    High => "high"
+    Max => "max"
+  }
+  Json(
+    Map(
+      [
+        ("model", Json(model)),
+        ("messages", ([ for message in messages => message ] : Json)),
+        ("stream", Json(stream)),
+        ("reasoning", { "effort": effort }),
+        ..if response_format is Some(format) {
+          [("response_format", ({ "type": "\{format}" } : Json))]
+        },
+        ..if stream {
+          [("stream_options", ({ "include_usage": true } : Json))]
+        },
+        ..if tools.length() > 0 {
+          [("tools", ([ for tool in tools => tool ] : Json))]
+        },
+      ],
+    ),
+  )
+}

--- a/deepseek/pkg.generated.mbti
+++ b/deepseek/pkg.generated.mbti
@@ -9,6 +9,8 @@ import {
 // Values
 pub fn encode_chat_request(tools? : Array[ToolDefinition], thinking? : ThinkingMode, stream? : Bool, response_format? : ResponseFormat, model? : Model, Array[ChatMessage]) -> Json
 
+pub fn openrouter_encode_chat_request(model~ : DsVariant, thinking~ : ThinkingMode, tools? : Array[ToolDefinition], stream? : Bool, response_format? : ResponseFormat, Array[ChatMessage]) -> Json
+
 // Errors
 
 // Types and methods

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -141,8 +141,11 @@ billed to that account. The default, **DeepSeek official**, sends requests
 to `api.deepseek.com` with your own key; the engine also falls back to the
 `DEEPSEEK` environment variable when no key is stored. **Z.AI GLM** sends
 requests to `api.z.ai` with its own key (env fallback `GLM`) and offers the
-GLM 5.3 models on the composer's model chip. **Custom URL**
-accepts any OpenAI-compatible chat-completions endpoint, with the key
+GLM 5.3 models on the composer's model chip. **OpenRouter** configures its
+canonical chat-completions endpoint through the existing custom backend; its
+setup form accepts the supported namespaced DeepSeek model id and maps reasoning
+fields to OpenRouter's wire format. **Custom URL**
+accepts any other OpenAI-compatible chat-completions endpoint, with the key
 optional — whether one is needed is the endpoint's business. The provider
 choice, the custom URL, and the keys live in the host's settings store
 (`engine-settings.json` in the runtime dir), shared by the desktop window

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -143,8 +143,10 @@ to `api.deepseek.com` with your own key; the engine also falls back to the
 requests to `api.z.ai` with its own key (env fallback `GLM`) and offers the
 GLM 5.3 models on the composer's model chip. **OpenRouter** configures its
 canonical chat-completions endpoint through the existing custom backend; its
-setup form accepts the supported namespaced DeepSeek model id and maps reasoning
-fields to OpenRouter's wire format. **Custom URL**
+setup form only asks for an API key. Choose Flash or Pro in the composer, just
+as with DeepSeek official. The shared request encoder maps Flash to
+`deepseek/deepseek-v4-flash-0731` and translates the reasoning fields; Desktop
+keeps the same model preference for both endpoints. **Custom URL**
 accepts any other OpenAI-compatible chat-completions endpoint, with the key
 optional — whether one is needed is the endpoint's business. The provider
 choice, the custom URL, and the keys live in the host's settings store

--- a/desktop/e2e/tests/rabbita_dom.spec.js
+++ b/desktop/e2e/tests/rabbita_dom.spec.js
@@ -1752,7 +1752,7 @@ test('settings persist host API changes through settings.set', async ({ page }) 
   expect(app.pageErrors).toEqual([]);
 });
 
-test('initial API setup accepts an OpenRouter key and DeepSeek model', async ({ page }) => {
+test('initial OpenRouter setup only needs an API key', async ({ page }) => {
   const app = new DesktopBrowserHarness(page);
   app.hostSettings.has_deepseek_key = false;
   await app.install();
@@ -1761,9 +1761,7 @@ test('initial API setup accepts an OpenRouter key and DeepSeek model', async ({ 
   await expect(page.getByText('Set up your DeepSeek API key')).toBeVisible();
   await page.getByRole('button', { name: 'API endpoint' }).click();
   await page.getByRole('option', { name: 'OpenRouter' }).click();
-  const model = page.getByRole('textbox', { name: 'OpenRouter model' });
-  await expect(model).toHaveValue('deepseek/deepseek-v4-flash');
-  await model.fill('deepseek/deepseek-v4-pro');
+  await expect(page.getByLabel('OpenRouter model')).toHaveCount(0);
   await page.getByLabel('API key').fill('sk-openrouter-test');
   await page.getByRole('button', { name: 'Save API key' }).click();
 
@@ -1778,6 +1776,19 @@ test('initial API setup accepts an OpenRouter key and DeepSeek model', async ({ 
   await expect(page.getByText('Set up OpenRouter')).toBeHidden();
   expect(app.hostSettings.has_deepseek_key).toBe(false);
   expect(app.hostSettings.has_custom_key).toBe(true);
+
+  // OpenRouter uses the ordinary chat model selector and persisted preference.
+  await app.openSession();
+  await page.getByRole('button', { name: 'Model', exact: true }).click();
+  await page.getByRole('option', { name: 'DS Pro', exact: true }).click();
+  await expect.poll(() => page.evaluate(() => localStorage.getItem('openseek.model')))
+    .toBe('deepseek-v4-pro');
+  await page.getByRole('button', { name: 'Model', exact: true }).click();
+  await page.getByRole('option', { name: 'DS Flash', exact: true }).click();
+  await expect.poll(() => page.evaluate(() => localStorage.getItem('openseek.model')))
+    .toBe('deepseek-v4-flash');
+  await page.getByRole('button', { name: 'Settings', exact: true }).click();
+  await expect(page.getByLabel('OpenRouter model')).toHaveCount(0);
   expect(app.pageErrors).toEqual([]);
 });
 

--- a/desktop/e2e/tests/rabbita_dom.spec.js
+++ b/desktop/e2e/tests/rabbita_dom.spec.js
@@ -1752,6 +1752,35 @@ test('settings persist host API changes through settings.set', async ({ page }) 
   expect(app.pageErrors).toEqual([]);
 });
 
+test('initial API setup accepts an OpenRouter key and DeepSeek model', async ({ page }) => {
+  const app = new DesktopBrowserHarness(page);
+  app.hostSettings.has_deepseek_key = false;
+  await app.install();
+  await app.goto();
+
+  await expect(page.getByText('Set up your DeepSeek API key')).toBeVisible();
+  await page.getByRole('button', { name: 'API endpoint' }).click();
+  await page.getByRole('option', { name: 'OpenRouter' }).click();
+  const model = page.getByRole('textbox', { name: 'OpenRouter model' });
+  await expect(model).toHaveValue('deepseek/deepseek-v4-flash');
+  await model.fill('deepseek/deepseek-v4-pro');
+  await page.getByLabel('API key').fill('sk-openrouter-test');
+  await page.getByRole('button', { name: 'Save API key' }).click();
+
+  await expect.poll(() => app.requests.some(request =>
+    request.method === 'settings.set' &&
+    request.params?.provider === 'custom' &&
+    request.params?.custom_api_url === 'https://openrouter.ai/api/v1/chat/completions')).toBe(true);
+  await expect.poll(() => app.requests.some(request =>
+    request.method === 'settings.set' &&
+    request.params?.provider === 'custom' &&
+    request.params?.custom_api_key === 'sk-openrouter-test')).toBe(true);
+  await expect(page.getByText('Set up OpenRouter')).toBeHidden();
+  expect(app.hostSettings.has_deepseek_key).toBe(false);
+  expect(app.hostSettings.has_custom_key).toBe(true);
+  expect(app.pageErrors).toEqual([]);
+});
+
 test('skills installs a catalog entry and refreshes the installed library', async ({ page }) => {
   const app = new DesktopBrowserHarness(page);
   await app.install();

--- a/desktop/frontend/agent_model.mbt
+++ b/desktop/frontend/agent_model.mbt
@@ -134,6 +134,7 @@ fn openseek_model_group(
   let listed : Array[EngineModel] = match provider {
     Deepseek => [DsPro, DsFlash]
     Glm => [Glm53, Glm53Flash]
+    OpenRouter => [DsPro, DsFlash]
     Custom => [DsPro, DsFlash, Glm53, Glm53Flash]
   }
   let options = listed.map(model => @composer.ModelOption::{
@@ -156,6 +157,10 @@ test "the model group follows the configured provider" {
   let glm = openseek_model_group(Glm, Glm53)
   assert_eq(glm.options.map(option => option.value), [
     "openseek:glm-5.3", "openseek:glm-5.3-flash",
+  ])
+  let openrouter = openseek_model_group(OpenRouter, DsFlash)
+  assert_eq(openrouter.options.map(option => option.label), [
+    "DS Pro", "DS Flash",
   ])
   // A conversation carried across a provider switch keeps its model visible,
   // same as an unknown wire name always did.

--- a/desktop/frontend/composer_input.mbt
+++ b/desktop/frontend/composer_input.mbt
@@ -85,6 +85,8 @@ fn Model::composer_input(self : Model) -> @composer.Input {
       "No endpoint URL configured — Send is disabled."
     } else if self.api_provider is Glm {
       "No GLM API key configured — Send is disabled."
+    } else if self.api_provider is OpenRouter {
+      "OpenRouter needs an API key and supported DeepSeek model — Send is disabled."
     } else {
       "No DeepSeek API key configured — Send is disabled."
     }

--- a/desktop/frontend/composer_input.mbt
+++ b/desktop/frontend/composer_input.mbt
@@ -86,7 +86,7 @@ fn Model::composer_input(self : Model) -> @composer.Input {
     } else if self.api_provider is Glm {
       "No GLM API key configured — Send is disabled."
     } else if self.api_provider is OpenRouter {
-      "OpenRouter needs an API key and supported DeepSeek model — Send is disabled."
+      "No OpenRouter API key configured — Send is disabled."
     } else {
       "No DeepSeek API key configured — Send is disabled."
     }

--- a/desktop/frontend/host_settings.mbt
+++ b/desktop/frontend/host_settings.mbt
@@ -95,10 +95,21 @@ fn push_host_settings(
 ///|
 fn provider_settings_patch(
   provider : ApiProvider,
+  custom_api_url : String,
 ) -> @protocol.SettingsSetPayload {
   {
-    provider: Some(provider.wire()),
-    custom_api_url: None,
+    provider: Some(
+      if provider is OpenRouter {
+        "custom"
+      } else {
+        provider.wire()
+      },
+    ),
+    custom_api_url: match provider {
+      OpenRouter => Some(OpenRouterChatCompletionsUrl)
+      Custom if custom_api_url == OpenRouterChatCompletionsUrl => Some("")
+      _ => None
+    },
     deepseek_api_key: None,
     glm_api_key: None,
     custom_api_key: None,
@@ -126,8 +137,18 @@ fn api_key_settings_patch(
   key : String,
 ) -> @protocol.SettingsSetPayload {
   {
-    provider: None,
-    custom_api_url: None,
+    provider: Some(
+      if provider is OpenRouter {
+        "custom"
+      } else {
+        provider.wire()
+      },
+    ),
+    custom_api_url: if provider is OpenRouter {
+      Some(OpenRouterChatCompletionsUrl)
+    } else {
+      None
+    },
     deepseek_api_key: if provider is Deepseek {
       Some(key)
     } else {
@@ -138,13 +159,30 @@ fn api_key_settings_patch(
     } else {
       None
     },
-    custom_api_key: if provider is Custom {
+    custom_api_key: if provider is (OpenRouter | Custom) {
       Some(key)
     } else {
       None
     },
     followup_behavior: None,
   }
+}
+
+///|
+test "OpenRouter is an atomic custom-backend preset" {
+  json_inspect(provider_settings_patch(OpenRouter, "").to_json(), content={
+    "provider": "custom",
+    "custom_api_url": "https://openrouter.ai/api/v1/chat/completions",
+  })
+  json_inspect(api_key_settings_patch(OpenRouter, "sk-openrouter").to_json(), content={
+    "provider": "custom",
+    "custom_api_url": "https://openrouter.ai/api/v1/chat/completions",
+    "custom_api_key": "sk-openrouter",
+  })
+  json_inspect(
+    provider_settings_patch(Custom, OpenRouterChatCompletionsUrl).to_json(),
+    content={ "provider": "custom", "custom_api_url": "" },
+  )
 }
 
 ///|

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -404,9 +404,13 @@ fn AppFontSize::pixels(self : AppFontSize) -> Double {
 }
 
 ///|
+const OpenRouterChatCompletionsUrl : String = "https://openrouter.ai/api/v1/chat/completions"
+
+///|
 /// Which chat-completions endpoint the engine talks to. SeekMoon runs are
 /// bring-your-own-key only: the hosted proxy is retired. `Deepseek` is the
-/// official endpoint and needs the user's own key; `Custom` is any other
+/// official endpoint and needs the user's own key; `OpenRouter` is a preset
+/// over the existing custom endpoint; `Custom` accepts any other
 /// OpenAI-compatible endpoint, whose key is optional. The retired hosted
 /// names (`openseek` / `openseek-staging`) parse as `Deepseek` so old
 /// stores and old clients land on the BYOK default instead of wedging.
@@ -416,6 +420,7 @@ fn AppFontSize::pixels(self : AppFontSize) -> Double {
 priv enum ApiProvider {
   Deepseek
   Glm
+  OpenRouter
   Custom
 } derive(Eq)
 
@@ -447,6 +452,7 @@ fn ApiProvider::wire(self : ApiProvider) -> String {
   match self {
     Deepseek => "deepseek"
     Glm => "glm"
+    OpenRouter => "openrouter"
     Custom => "custom"
   }
 }
@@ -459,6 +465,7 @@ fn ApiProvider::parse(value : String) -> ApiProvider {
   match value.trim().to_owned() {
     "openseek" | "openseek-staging" | "deepseek" => Deepseek
     "glm" => Glm
+    "openrouter" => OpenRouter
     "custom" => Custom
     _ => Deepseek
   }
@@ -469,13 +476,13 @@ fn ApiProvider::parse(value : String) -> ApiProvider {
 /// the page's last model choice belong to different known model families.
 fn ApiProvider::default_model(self : ApiProvider) -> EngineModel {
   match self {
-    Deepseek | Custom => DsFlash
+    Deepseek | OpenRouter | Custom => DsFlash
     Glm => Glm53
   }
 }
 
 ///|
-/// Whether a known model belongs to the official provider. Custom endpoints
+/// Whether a known model belongs to the selected provider. Custom endpoints
 /// deliberately accept every model, and an unknown wire name stays pinned so
 /// a newer engine's model is never silently replaced by an older frontend.
 fn EngineModel::matches_provider(
@@ -484,8 +491,31 @@ fn EngineModel::matches_provider(
 ) -> Bool {
   match (provider, self) {
     (Custom, _) | (_, Other(_)) => true
-    (Deepseek, DsPro | DsFlash) | (Glm, Glm53 | Glm53Flash) => true
+    (Deepseek | OpenRouter, DsPro | DsFlash) | (Glm, Glm53 | Glm53Flash) => true
     _ => false
+  }
+}
+
+///|
+/// OpenRouter currently carries the DeepSeek models understood by the engine.
+/// Accept direct-API names as conveniences while showing canonical,
+/// namespaced OpenRouter ids in the setup field.
+fn parse_openrouter_model(value : String) -> EngineModel? {
+  match value.trim().to_owned() {
+    "deepseek-v4-pro" | "deepseek/deepseek-v4-pro" => Some(DsPro)
+    "deepseek-v4-flash" | "deepseek/deepseek-v4-flash" => Some(DsFlash)
+    _ => None
+  }
+}
+
+///|
+fn EngineModel::openrouter_wire(self : EngineModel) -> String? {
+  match self {
+    DsPro => Some("deepseek/deepseek-v4-pro")
+    DsFlash => Some("deepseek/deepseek-v4-flash")
+    Other(name) =>
+      parse_openrouter_model(name).bind(model => model.openrouter_wire())
+    Glm53 | Glm53Flash => None
   }
 }
 
@@ -1399,6 +1429,9 @@ priv struct Model {
   api_provider : ApiProvider
   custom_api_url : String
   followup_behavior : FollowupBehavior
+  // Editable only in the initial OpenRouter setup. A valid value also feeds
+  // `default_model`, which remains the conversation-level source of truth.
+  openrouter_model : String?
   // Host-settings writes still in flight. While any are, incoming
   // `settings.changed` broadcasts and `settings.get` replies may predate an
   // optimistic edit, so the newest revision is deferred until the last write
@@ -1762,6 +1795,7 @@ priv enum Msg {
   ProviderChanged(String)
   FollowupBehaviorChanged(String)
   CustomApiUrlChanged(String)
+  OpenRouterModelChanged(String)
   // The Settings choice of which window corner error toasts pop up in.
   NotificationCornerChanged(String)
   // The Settings choice of where the editor's file tree docks.
@@ -2578,6 +2612,7 @@ fn initial_model() -> Model {
     api_provider: Deepseek,
     custom_api_url: "",
     followup_behavior: FollowupSteer,
+    openrouter_model: Some("deepseek/deepseek-v4-flash"),
     settings_saves: 0,
     host_settings_revision: -1,
     deferred_host_settings: None,
@@ -2783,16 +2818,35 @@ fn Model::clear_host_settings(self : Model) -> Model {
 /// mirrors the store, so a payload applied from a deferred flush can never
 /// yank the screen around on its own.
 fn Model::apply_host_settings(self : Model, settings : HostSettings) -> Model {
+  let provider = if settings.provider == "custom" &&
+    settings.custom_api_url == OpenRouterChatCompletionsUrl {
+    OpenRouter
+  } else {
+    ApiProvider::parse(settings.provider)
+  }
+  let openrouter_model = if provider is OpenRouter {
+    if self.api_provider is OpenRouter {
+      self.openrouter_model
+    } else {
+      match self.default_model.openrouter_wire() {
+        Some(model) => Some(model)
+        None => self.openrouter_model
+      }
+    }
+  } else {
+    self.openrouter_model
+  }
   let next = {
     ..self,
     host_settings_revision: settings.revision,
     deferred_host_settings: None,
-    api_provider: ApiProvider::parse(settings.provider),
+    api_provider: provider,
     custom_api_url: settings.custom_api_url,
     followup_behavior: FollowupBehavior::parse(settings.followup_behavior),
     deepseek_key_saved: settings.has_deepseek_key,
     glm_key_saved: settings.has_glm_key,
     custom_key_saved: settings.has_custom_key,
+    openrouter_model,
   }
   next.align_fresh_conversation_with_provider()
 }
@@ -2901,14 +2955,17 @@ fn Model::settle_api_setup(self : Model) -> Model {
 }
 
 ///|
-/// Whether the configured endpoint is usable as it stands: the official
-/// endpoint needs a key stored on the host, and a custom endpoint needs a
-/// plausible URL. The credentials themselves live on the host; a start
-/// carries none.
+/// Whether the configured endpoint is usable as it stands: keyed providers
+/// need their own credential, OpenRouter also needs a supported DeepSeek model,
+/// and a custom endpoint needs a plausible URL. The credentials themselves
+/// live on the host; a start carries none.
 fn Model::api_ready(self : Model) -> Bool {
   match self.api_provider {
     Deepseek => self.deepseek_key_saved
     Glm => self.glm_key_saved
+    OpenRouter =>
+      self.custom_key_saved &&
+      self.openrouter_model.bind(parse_openrouter_model) is Some(_)
     Custom => plausible_endpoint_url(self.custom_api_url)
   }
 }
@@ -2929,7 +2986,7 @@ fn plausible_endpoint_url(url : String) -> Bool {
 fn Model::settings_status(self : Model) -> Status {
   if self.api_ready() {
     Ready
-  } else if self.api_provider is (Deepseek | Glm) {
+  } else if self.api_provider is (Deepseek | Glm | OpenRouter) {
     ApiKeyRequired
   } else {
     SetupRequired

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -497,29 +497,6 @@ fn EngineModel::matches_provider(
 }
 
 ///|
-/// OpenRouter currently carries the DeepSeek models understood by the engine.
-/// Accept direct-API names as conveniences while showing canonical,
-/// namespaced OpenRouter ids in the setup field.
-fn parse_openrouter_model(value : String) -> EngineModel? {
-  match value.trim().to_owned() {
-    "deepseek-v4-pro" | "deepseek/deepseek-v4-pro" => Some(DsPro)
-    "deepseek-v4-flash" | "deepseek/deepseek-v4-flash" => Some(DsFlash)
-    _ => None
-  }
-}
-
-///|
-fn EngineModel::openrouter_wire(self : EngineModel) -> String? {
-  match self {
-    DsPro => Some("deepseek/deepseek-v4-pro")
-    DsFlash => Some("deepseek/deepseek-v4-flash")
-    Other(name) =>
-      parse_openrouter_model(name).bind(model => model.openrouter_wire())
-    Glm53 | Glm53Flash => None
-  }
-}
-
-///|
 /// The compaction lifecycle of one conversation, mirroring the host's
 /// `EnginePhase` design: one value instead of loose booleans, so a compact
 /// request that is in flight but not yet acknowledged still has a
@@ -1429,9 +1406,6 @@ priv struct Model {
   api_provider : ApiProvider
   custom_api_url : String
   followup_behavior : FollowupBehavior
-  // Editable only in the initial OpenRouter setup. A valid value also feeds
-  // `default_model`, which remains the conversation-level source of truth.
-  openrouter_model : String?
   // Host-settings writes still in flight. While any are, incoming
   // `settings.changed` broadcasts and `settings.get` replies may predate an
   // optimistic edit, so the newest revision is deferred until the last write
@@ -1795,7 +1769,6 @@ priv enum Msg {
   ProviderChanged(String)
   FollowupBehaviorChanged(String)
   CustomApiUrlChanged(String)
-  OpenRouterModelChanged(String)
   // The Settings choice of which window corner error toasts pop up in.
   NotificationCornerChanged(String)
   // The Settings choice of where the editor's file tree docks.
@@ -2612,7 +2585,6 @@ fn initial_model() -> Model {
     api_provider: Deepseek,
     custom_api_url: "",
     followup_behavior: FollowupSteer,
-    openrouter_model: Some("deepseek/deepseek-v4-flash"),
     settings_saves: 0,
     host_settings_revision: -1,
     deferred_host_settings: None,
@@ -2824,18 +2796,6 @@ fn Model::apply_host_settings(self : Model, settings : HostSettings) -> Model {
   } else {
     ApiProvider::parse(settings.provider)
   }
-  let openrouter_model = if provider is OpenRouter {
-    if self.api_provider is OpenRouter {
-      self.openrouter_model
-    } else {
-      match self.default_model.openrouter_wire() {
-        Some(model) => Some(model)
-        None => self.openrouter_model
-      }
-    }
-  } else {
-    self.openrouter_model
-  }
   let next = {
     ..self,
     host_settings_revision: settings.revision,
@@ -2846,7 +2806,6 @@ fn Model::apply_host_settings(self : Model, settings : HostSettings) -> Model {
     deepseek_key_saved: settings.has_deepseek_key,
     glm_key_saved: settings.has_glm_key,
     custom_key_saved: settings.has_custom_key,
-    openrouter_model,
   }
   next.align_fresh_conversation_with_provider()
 }
@@ -2956,16 +2915,14 @@ fn Model::settle_api_setup(self : Model) -> Model {
 
 ///|
 /// Whether the configured endpoint is usable as it stands: keyed providers
-/// need their own credential, OpenRouter also needs a supported DeepSeek model,
-/// and a custom endpoint needs a plausible URL. The credentials themselves
-/// live on the host; a start carries none.
+/// need their own credential, and a custom endpoint needs a plausible URL.
+/// OpenRouter uses the same model selector as the official DeepSeek endpoint.
+/// The credentials themselves live on the host; a start carries none.
 fn Model::api_ready(self : Model) -> Bool {
   match self.api_provider {
     Deepseek => self.deepseek_key_saved
     Glm => self.glm_key_saved
-    OpenRouter =>
-      self.custom_key_saved &&
-      self.openrouter_model.bind(parse_openrouter_model) is Some(_)
+    OpenRouter => self.custom_key_saved
     Custom => plausible_endpoint_url(self.custom_api_url)
   }
 }

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -2077,6 +2077,11 @@ fn update_msg(
         app_font_size,
         fps_overlay_enabled,
         default_model,
+        openrouter_model: if model.api_provider is OpenRouter {
+          default_model.openrouter_wire()
+        } else {
+          model.openrouter_model
+        },
         default_agent,
         conversation_models: parse_conversation_models(remembered),
         openseek_reasoning,
@@ -3116,12 +3121,27 @@ fn update_msg(
       let push = push_host_settings(
         dispatch,
         model.focused,
-        provider_settings_patch(provider),
+        provider_settings_patch(provider, model.custom_api_url),
         model.focused_connection_generation(),
       )
       let next = {
         ..model,
         api_provider: provider,
+        custom_api_url: if provider is Custom &&
+          model.custom_api_url == OpenRouterChatCompletionsUrl {
+          ""
+        } else {
+          model.custom_api_url
+        },
+        openrouter_model: if provider is OpenRouter {
+          Some(
+            model.default_model
+            .openrouter_wire()
+            .unwrap_or("deepseek/deepseek-v4-flash"),
+          )
+        } else {
+          model.openrouter_model
+        },
         setup_api_key: "",
         settings_saves: model.settings_saves + 1,
         select_menu: None,
@@ -3165,6 +3185,24 @@ fn update_msg(
           settings_saves: model.settings_saves + 1,
         },
       )
+    }
+    OpenRouterModelChanged(value) => {
+      guard model.host_settings_loaded() && model.api_provider is OpenRouter else {
+        return (@cmd.none, model)
+      }
+      let staged = {
+        ..model,
+        openrouter_model: if value.is_blank() {
+          None
+        } else {
+          Some(value)
+        },
+      }
+      guard parse_openrouter_model(value) is Some(engine_model) else {
+        return (@cmd.none, staged.settle_api_setup())
+      }
+      let next = { ..staged, default_model: engine_model, }.align_fresh_conversation_with_provider()
+      (save_default_model(engine_model), next.settle_api_setup())
     }
     NotificationCornerChanged(value) => {
       let corner = NotificationCorner::parse(value)
@@ -3569,13 +3607,14 @@ fn update_msg(
           // modal optimistically; one that leaves it incomplete (Custom
           // with no URL yet) keeps the modal up mid-setup. A failed save
           // comes back as a toast.
-          Deepseek | Glm | Custom as provider => {
+          Deepseek | Glm | OpenRouter | Custom as provider => {
             let next = {
               ..model,
               deepseek_key_saved: model.deepseek_key_saved ||
               provider is Deepseek,
               glm_key_saved: model.glm_key_saved || provider is Glm,
-              custom_key_saved: model.custom_key_saved || provider is Custom,
+              custom_key_saved: model.custom_key_saved ||
+              provider is (OpenRouter | Custom),
               setup_api_key: "",
               settings_saves: model.settings_saves + 1,
             }
@@ -13018,6 +13057,61 @@ test "the official endpoint requires a key, a custom endpoint a URL" {
 }
 
 ///|
+test "OpenRouter requires a stored custom key and a supported DeepSeek model" {
+  let openrouter = {
+    ..test_model(),
+    api_provider: OpenRouter,
+    deepseek_key_saved: true,
+    custom_key_saved: false,
+    openrouter_model: Some("deepseek/deepseek-v4-flash"),
+  }
+  assert_false(openrouter.api_ready())
+  assert_true({ ..openrouter, custom_key_saved: true, }.api_ready())
+  assert_false(
+    {
+      ..openrouter,
+      custom_key_saved: true,
+      openrouter_model: Some("openai/gpt-5"),
+    }.api_ready(),
+  )
+  assert_false(
+    { ..openrouter, custom_key_saved: true, openrouter_model: None, }.api_ready(),
+  )
+}
+
+///|
+test "the OpenRouter setup model updates only after a valid model id" {
+  let dispatch = test_dispatch()
+  let model = {
+    ..test_model(),
+    api_provider: OpenRouter,
+    custom_key_saved: true,
+    openrouter_model: Some("deepseek/deepseek-v4-flash"),
+    api_setup_open: true,
+  }
+  let (_, invalid) = update(
+    dispatch,
+    OpenRouterModelChanged("openai/gpt-5"),
+    model,
+  )
+  assert_eq(invalid.openrouter_model, Some("openai/gpt-5"))
+  assert_true(invalid.default_model is DsFlash)
+  assert_true(invalid.api_setup_open)
+  let (_, valid) = update(
+    dispatch,
+    OpenRouterModelChanged("deepseek/deepseek-v4-pro"),
+    invalid,
+  )
+  assert_eq(valid.openrouter_model, Some("deepseek/deepseek-v4-pro"))
+  assert_true(valid.default_model is DsPro)
+  assert_true(valid.active().engine_model is DsPro)
+  assert_false(valid.api_setup_open)
+  let (_, blank) = update(dispatch, OpenRouterModelChanged("  "), valid)
+  assert_true(blank.openrouter_model is None)
+  assert_true(blank.api_setup_open)
+}
+
+///|
 test "loaded UI preferences parse their wire names" {
   let dispatch = test_dispatch()
   let (_, restored) = update(
@@ -13500,6 +13594,7 @@ fn host_settings(
   revision? : Int = 0,
   has_deepseek_key? : Bool = false,
   has_glm_key? : Bool = false,
+  has_custom_key? : Bool = false,
   custom_api_url? : String = "",
 ) -> HostSettings {
   {
@@ -13508,9 +13603,22 @@ fn host_settings(
     custom_api_url,
     has_deepseek_key,
     has_glm_key,
-    has_custom_key: false,
+    has_custom_key,
     followup_behavior: "steer",
   }
+}
+
+///|
+test "the OpenRouter custom preset restores as OpenRouter" {
+  let restored = test_model().apply_host_settings(
+    host_settings(
+      provider="custom",
+      custom_api_url=OpenRouterChatCompletionsUrl,
+      has_custom_key=true,
+    ),
+  )
+  assert_true(restored.api_provider is OpenRouter)
+  assert_true(restored.api_ready())
 }
 
 ///|
@@ -14192,6 +14300,17 @@ test "saving a key marks the active provider credential only" {
   assert_false(saved_glm.deepseek_key_saved)
   assert_false(saved_glm.custom_key_saved)
   assert_true(saved_glm.screen is Settings)
+  let openrouter = {
+    ..test_model(),
+    api_provider: OpenRouter,
+    deepseek_key_saved: false,
+    custom_key_saved: false,
+    setup_api_key: "  sk-openrouter-new  ",
+    screen: Settings,
+  }
+  let (_, saved_openrouter) = update(dispatch, SaveApiKey, openrouter)
+  assert_true(saved_openrouter.custom_key_saved)
+  assert_false(saved_openrouter.deepseek_key_saved)
 }
 
 ///|

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -2077,11 +2077,6 @@ fn update_msg(
         app_font_size,
         fps_overlay_enabled,
         default_model,
-        openrouter_model: if model.api_provider is OpenRouter {
-          default_model.openrouter_wire()
-        } else {
-          model.openrouter_model
-        },
         default_agent,
         conversation_models: parse_conversation_models(remembered),
         openseek_reasoning,
@@ -3133,15 +3128,6 @@ fn update_msg(
         } else {
           model.custom_api_url
         },
-        openrouter_model: if provider is OpenRouter {
-          Some(
-            model.default_model
-            .openrouter_wire()
-            .unwrap_or("deepseek/deepseek-v4-flash"),
-          )
-        } else {
-          model.openrouter_model
-        },
         setup_api_key: "",
         settings_saves: model.settings_saves + 1,
         select_menu: None,
@@ -3185,24 +3171,6 @@ fn update_msg(
           settings_saves: model.settings_saves + 1,
         },
       )
-    }
-    OpenRouterModelChanged(value) => {
-      guard model.host_settings_loaded() && model.api_provider is OpenRouter else {
-        return (@cmd.none, model)
-      }
-      let staged = {
-        ..model,
-        openrouter_model: if value.is_blank() {
-          None
-        } else {
-          Some(value)
-        },
-      }
-      guard parse_openrouter_model(value) is Some(engine_model) else {
-        return (@cmd.none, staged.settle_api_setup())
-      }
-      let next = { ..staged, default_model: engine_model, }.align_fresh_conversation_with_provider()
-      (save_default_model(engine_model), next.settle_api_setup())
     }
     NotificationCornerChanged(value) => {
       let corner = NotificationCorner::parse(value)
@@ -13057,58 +13025,19 @@ test "the official endpoint requires a key, a custom endpoint a URL" {
 }
 
 ///|
-test "OpenRouter requires a stored custom key and a supported DeepSeek model" {
+test "OpenRouter setup requires only its stored custom key" {
   let openrouter = {
     ..test_model(),
     api_provider: OpenRouter,
     deepseek_key_saved: true,
     custom_key_saved: false,
-    openrouter_model: Some("deepseek/deepseek-v4-flash"),
   }
   assert_false(openrouter.api_ready())
   assert_true({ ..openrouter, custom_key_saved: true, }.api_ready())
-  assert_false(
-    {
-      ..openrouter,
-      custom_key_saved: true,
-      openrouter_model: Some("openai/gpt-5"),
-    }.api_ready(),
+  // Model choice belongs to the chat, just as with the official endpoint.
+  assert_true(
+    { ..openrouter, custom_key_saved: true, default_model: DsPro, }.api_ready(),
   )
-  assert_false(
-    { ..openrouter, custom_key_saved: true, openrouter_model: None, }.api_ready(),
-  )
-}
-
-///|
-test "the OpenRouter setup model updates only after a valid model id" {
-  let dispatch = test_dispatch()
-  let model = {
-    ..test_model(),
-    api_provider: OpenRouter,
-    custom_key_saved: true,
-    openrouter_model: Some("deepseek/deepseek-v4-flash"),
-    api_setup_open: true,
-  }
-  let (_, invalid) = update(
-    dispatch,
-    OpenRouterModelChanged("openai/gpt-5"),
-    model,
-  )
-  assert_eq(invalid.openrouter_model, Some("openai/gpt-5"))
-  assert_true(invalid.default_model is DsFlash)
-  assert_true(invalid.api_setup_open)
-  let (_, valid) = update(
-    dispatch,
-    OpenRouterModelChanged("deepseek/deepseek-v4-pro"),
-    invalid,
-  )
-  assert_eq(valid.openrouter_model, Some("deepseek/deepseek-v4-pro"))
-  assert_true(valid.default_model is DsPro)
-  assert_true(valid.active().engine_model is DsPro)
-  assert_false(valid.api_setup_open)
-  let (_, blank) = update(dispatch, OpenRouterModelChanged("  "), valid)
-  assert_true(blank.openrouter_model is None)
-  assert_true(blank.api_setup_open)
 }
 
 ///|

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -954,8 +954,7 @@ fn byok_setup_guide(provider : ApiProvider) -> @html.Html {
     OpenRouter =>
       [
         step(1, "Open openrouter.ai and create an API key."),
-        step(2, "Enter a supported DeepSeek model id below."),
-        step(3, "Paste the OpenRouter API key and save."),
+        step(2, "Paste the OpenRouter API key and save."),
       ]
     Custom =>
       [
@@ -1060,27 +1059,6 @@ fn api_settings_rows(
       ),
     )
   }
-  if model.api_provider is OpenRouter {
-    rows.push(
-      @settings.row(
-        "Model",
-        [
-          @html.input(
-            input_type=@html.InputType::Text,
-            value=model.openrouter_model.unwrap_or(""),
-            placeholder="deepseek/deepseek-v4-flash",
-            on_input=dispatch.map(value => OpenRouterModelChanged(value)),
-            attrs=@html.Attrs::build()
-              .aria_label("OpenRouter model")
-              .data_set("focus-owner", "")
-              .disabled(!settings_loaded),
-          ),
-        ],
-        desc="Supported: deepseek/deepseek-v4-pro or deepseek/deepseek-v4-flash.",
-        stack=true,
-      ),
-    )
-  }
   // The key lives on the host and is never echoed back — the page only
   // knows one is saved; saving a new one overwrites it.
   {
@@ -1135,9 +1113,8 @@ fn api_settings_rows(
 fn settings_page(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
   let settings_loaded = model.host_settings_loaded()
   let ready = model.api_ready()
-  // Conversation models are normally picked on the composer's chip. The
-  // OpenRouter bootstrap id lives in the API group because setup must validate
-  // it before enabling Send.
+  // All providers use the composer's model selector; API setup only chooses
+  // the endpoint and credentials.
   let engine_rows : Array[@html.Html] = [
     @settings.row(
       "Max steps",
@@ -1344,7 +1321,7 @@ fn settings_page(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
             match model.api_provider {
               Deepseek => "Enter a DeepSeek API key to start."
               Glm => "Enter a GLM API key to start."
-              OpenRouter => "Enter an OpenRouter API key and model to start."
+              OpenRouter => "Enter an OpenRouter API key to start."
               Custom => "Enter a chat-completions endpoint URL to start."
             }
           },

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -920,6 +920,7 @@ fn provider_hint(provider : ApiProvider) -> String {
   match provider {
     Deepseek => "Requests go straight to api.deepseek.com with your key."
     Glm => "Requests go straight to api.z.ai with your key."
+    OpenRouter => "DeepSeek requests go through OpenRouter with your key."
     Custom => "Any OpenAI-compatible chat-completions URL; key optional."
   }
 }
@@ -949,6 +950,12 @@ fn byok_setup_guide(provider : ApiProvider) -> @html.Html {
         step(1, "Open z.ai and sign in."),
         step(2, "Create an API key under API Keys."),
         step(3, "Paste it into the GLM API key field below and save."),
+      ]
+    OpenRouter =>
+      [
+        step(1, "Open openrouter.ai and create an API key."),
+        step(2, "Enter a supported DeepSeek model id below."),
+        step(3, "Paste the OpenRouter API key and save."),
       ]
     Custom =>
       [
@@ -1021,6 +1028,7 @@ fn api_settings_rows(
           options=[
             { value: "deepseek", label: "DeepSeek official (your API key)", },
             { value: "glm", label: "Z.AI GLM (your API key)", },
+            { value: "openrouter", label: "OpenRouter", },
             { value: "custom", label: "Custom URL", },
           ],
           selected=model.api_provider.wire(),
@@ -1052,12 +1060,34 @@ fn api_settings_rows(
       ),
     )
   }
+  if model.api_provider is OpenRouter {
+    rows.push(
+      @settings.row(
+        "Model",
+        [
+          @html.input(
+            input_type=@html.InputType::Text,
+            value=model.openrouter_model.unwrap_or(""),
+            placeholder="deepseek/deepseek-v4-flash",
+            on_input=dispatch.map(value => OpenRouterModelChanged(value)),
+            attrs=@html.Attrs::build()
+              .aria_label("OpenRouter model")
+              .data_set("focus-owner", "")
+              .disabled(!settings_loaded),
+          ),
+        ],
+        desc="Supported: deepseek/deepseek-v4-pro or deepseek/deepseek-v4-flash.",
+        stack=true,
+      ),
+    )
+  }
   // The key lives on the host and is never echoed back — the page only
   // knows one is saved; saving a new one overwrites it.
   {
     let (key_label, key_saved) = match model.api_provider {
       Deepseek => ("DeepSeek API key", model.deepseek_key_saved)
       Glm => ("GLM API key", model.glm_key_saved)
+      OpenRouter => ("OpenRouter API key", model.custom_key_saved)
       Custom => ("Custom API key", model.custom_key_saved)
     }
     rows.push(
@@ -1105,8 +1135,9 @@ fn api_settings_rows(
 fn settings_page(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
   let settings_loaded = model.host_settings_loaded()
   let ready = model.api_ready()
-  // The model is not here: it belongs to a conversation, not to the app, and
-  // is picked on the composer's chip.
+  // Conversation models are normally picked on the composer's chip. The
+  // OpenRouter bootstrap id lives in the API group because setup must validate
+  // it before enabling Send.
   let engine_rows : Array[@html.Html] = [
     @settings.row(
       "Max steps",
@@ -1313,6 +1344,7 @@ fn settings_page(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
             match model.api_provider {
               Deepseek => "Enter a DeepSeek API key to start."
               Glm => "Enter a GLM API key to start."
+              OpenRouter => "Enter an OpenRouter API key and model to start."
               Custom => "Enter a chat-completions endpoint URL to start."
             }
           },
@@ -1906,6 +1938,7 @@ fn api_setup_modal(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
   let title = match model.api_provider {
     Deepseek => "Set up your DeepSeek API key"
     Glm => "Set up your GLM API key"
+    OpenRouter => "Set up OpenRouter"
     Custom => "Set your endpoint URL"
   }
   @html.div(class="modal-backdrop", on_click=dispatch(DismissApiSetup), [


### PR DESCRIPTION
## Summary

- add OpenRouter to the existing API endpoint selector without changing the host settings protocol
- persist OpenRouter through the existing custom backend fields with its canonical chat-completions URL
- accept an OpenRouter API key and supported DeepSeek model in initial setup
- translate DeepSeek model and reasoning fields at the HTTP transport boundary
- normalize OpenRouter reasoning fields in streaming and non-streaming responses

## Test plan

- `moon test deepseek/client` (36 passed)
- `moon test deepseek` (47 passed)
- `moon test --target js deepseek` (47 passed)
- `moon test --target js desktop/frontend` (471 passed)
- `npm test -- --grep "initial API setup accepts an OpenRouter"` (1 passed)

## Known repository issue

`just check`, `just build`, `just test`, and `moon info` currently stop in unchanged `eval/token_bench/bench.mbt`, which references removed DeepSeek provider/model APIs. The focused packages and OpenRouter browser flow pass as listed above.