### PR TITLE
feat(mbtx): save scripts and run bundled workflows

### DIFF
--- a/agent/tool_definition.mbt
+++ b/agent/tool_definition.mbt
@@ -216,8 +216,9 @@ async test "the registry has no shell tool family" {
       fail("expected an object schema")
     }
     let names = properties.keys().collect()
-    assert_eq(names.length(), 5)
-    for name in ["source", "description", "target", "cwd", "warning"] {
+    assert_eq(names.length(), 6)
+    for
+      name in ["source", "filename", "description", "target", "cwd", "warning"] {
       assert_true(names.contains(name))
     }
     assert_false(mbtx.description.contains("run_in_background"))

--- a/agent/tool_definition.mbt
+++ b/agent/tool_definition.mbt
@@ -119,6 +119,7 @@ pub async fn[X] build_tools(
       // would have nowhere to leave a transcript.
       @mbtx.definition(
         workspace_root~,
+        file_state~,
         bg_runtime~,
         job_dir?=spill_dir,
         approval?=runtime.approval_channel(),

--- a/agent_tool/mbtx/README.mbt.md
+++ b/agent_tool/mbtx/README.mbt.md
@@ -10,7 +10,8 @@ sandboxed automation surface.
 ## How it works
 
 The `source` is a `.mbtx` **single-file script** — MoonBit's own one-file
-program format. The tool writes it into a throwaway directory and, for the
+program format. Alternatively, `filename` loads a saved script. The tool
+writes the program into a throwaway directory and, for the
 default wasm target, runs it in **two phases**. The BUILD runs first,
 synchronously: `moon run <file>.mbtx --build-only --target wasm --target-dir
 <temp>`, bounded by its own wall clock (10s by default) so a hung dependency
@@ -26,7 +27,7 @@ exec'd — with the workspace (or explicit `cwd`) as the program's working
 directory, so relative reads reach workspace files while build artifacts stay
 out of your `_build`. A failure there is labeled `at RUNTIME — … from the
 run, not the build`. Compiler diagnostics are rewritten to stable
-`source:LINE:COL` locations, and build output (warnings under
+`source:LINE:COL` locations (or the supplied filename), and build output (warnings under
 `warning: "on"`) is kept apart from program output by construction. The
 non-wasm targets keep the single-shot `moon run` and their reports claim no
 stage.
@@ -49,10 +50,22 @@ cancelled at that deadline.
   transcript and inherited by any background job. Presentation only; it does
   not affect compilation, execution, sandboxing, or background handoff.
 
-- `source` (string, required): a full `.mbtx` program. It may open with an
+- `source` (string, mutually exclusive with `filename`): a full `.mbtx` program. It may open with an
   inline `import { "pkg", "pkg", … }` block (comma-separated module paths),
   then the program including its own `main`. Use `async fn main` for
   filesystem/stdio work.
+- `filename` (string, mutually exclusive with `source`): a saved `.mbtx`
+  script name or path. A bare name (no `/` or `\`, and not `.` or `..`)
+  resolves under `OPENSEEK_REFERENCES/workflow/`. Use `./check.mbtx` for a
+  workspace file; other relative paths resolve from the workspace root and
+  absolute paths remain absolute. There is no fallback between locations.
+  Supply exactly one of these two fields. `cwd` does not change resolution. Each call
+  reads the current file once and compiles that snapshot through the same
+  isolated execution path as inline source; diagnostics cite the filename.
+  For repeated calls, save a script with the file tools and reuse it with
+  `{"filename":"scripts/check.mbtx"}`, omitting `source` entirely. `filename`
+  reads an existing file; it does not save or name an inline `source` program.
+  Use `source` alone for one-off snippets.
 - `target` (string, optional, default `wasm`): one of `wasm`, `wasm-gc`, `js`,
   or `llvm`. The default wasm backend is the policy-bound command/IO surface;
   the other targets are intended for pure compute, reject explicit native FFI,

--- a/agent_tool/mbtx/README.mbt.md
+++ b/agent_tool/mbtx/README.mbt.md
@@ -50,21 +50,26 @@ cancelled at that deadline.
   transcript and inherited by any background job. Presentation only; it does
   not affect compilation, execution, sandboxing, or background handoff.
 
-- `source` (string, mutually exclusive with `filename`): a full `.mbtx` program. It may open with an
+- `source` (string): a full `.mbtx` program. It may open with an
   inline `import { "pkg", "pkg", … }` block (comma-separated module paths),
   then the program including its own `main`. Use `async fn main` for
   filesystem/stdio work.
-- `filename` (string, mutually exclusive with `source`): a saved `.mbtx`
-  script name or path. A bare name (no `/` or `\`, and not `.` or `..`)
-  resolves under `OPENSEEK_REFERENCES/workflow/`. Use `./check.mbtx` for a
-  workspace file; other relative paths resolve from the workspace root and
+- `filename` (string): a `.mbtx` script name or path. Ordinary names, including
+  `check.mbtx`, resolve from the workspace root. `@builtin/check.mbtx` resolves
+  under `OPENSEEK_REFERENCES/workflow/`. Other namespaces are reserved for future
+  use and currently rejected. Paths cannot escape the namespace root, including
+  through symlinks. Use `./@builtin/check.mbtx` for a literal workspace path;
   absolute paths remain absolute. There is no fallback between locations.
-  Supply exactly one of these two fields. `cwd` does not change resolution. Each call
+  Supply at least one of these two fields. `cwd` does not change resolution. A filename-only call
   reads the current file once and compiles that snapshot through the same
   isolated execution path as inline source; diagnostics cite the filename.
-  For repeated calls, save a script with the file tools and reuse it with
-  `{"filename":"scripts/check.mbtx"}`, omitting `source` entirely. `filename`
-  reads an existing file; it does not save or name an inline `source` program.
+  With both source and filename, the tool saves the script inside the writable
+  workspace and runs the submitted snapshot. Missing parents are created;
+  identical existing content is reused, while different content is rejected
+  without overwriting or running. Use edit to change a saved file. Subsequent
+  calls can use `{"filename":"scripts/check.mbtx"}` without source. Saving is
+  unavailable in read-only mode and obeys worker write scopes. Namespaced
+  filenames cannot accompany source: bundled scripts are read-only.
   Use `source` alone for one-off snippets.
 - `target` (string, optional, default `wasm`): one of `wasm`, `wasm-gc`, `js`,
   or `llvm`. The default wasm backend is the policy-bound command/IO surface;

--- a/agent_tool/mbtx/filename.mbt
+++ b/agent_tool/mbtx/filename.mbt
@@ -1,0 +1,56 @@
+///|
+fn is_bundled_filename(filename : String) -> Bool {
+  filename != "." &&
+  filename != ".." &&
+  !filename.contains("/") &&
+  !filename.contains("\\")
+}
+
+///|
+fn resolve_filename(
+  workspace_root : String,
+  filename : String,
+  references : String?,
+) -> String raise {
+  if is_bundled_filename(filename) {
+    guard references is Some(root) && !root.trim().is_empty() else {
+      fail(
+        "bundled filename \{filename} needs OPENSEEK_REFERENCES. For a workspace script, use ./\{filename}; bundled workflows are unavailable in this environment",
+      )
+    }
+    @workspace_path.resolve(root, "workflow/\{filename}")
+  } else {
+    @workspace_path.resolve(workspace_root, filename)
+  }
+}
+
+///|
+test "bare filenames select bundled workflows without workspace fallback" {
+  assert_eq(
+    resolve_filename("/project", "check.mbtx", Some("/share")),
+    "/share/workflow/check.mbtx",
+  )
+  assert_eq(
+    resolve_filename("/project", "./check.mbtx", Some("/share")),
+    "/project/check.mbtx",
+  )
+  assert_eq(
+    resolve_filename("/project", "scripts/check.mbtx", None),
+    "/project/scripts/check.mbtx",
+  )
+  assert_eq(
+    resolve_filename("/project", "/other/check.mbtx", Some("/share")),
+    "/other/check.mbtx",
+  )
+  assert_false(is_bundled_filename("."))
+  assert_false(is_bundled_filename(".."))
+  assert_false(is_bundled_filename(".\\check.mbtx"))
+  assert_false(is_bundled_filename("C:\\scripts\\check.mbtx"))
+  for references in [None, Some("  ")] {
+    try resolve_filename("/project", "check.mbtx", references) catch {
+      error => assert_true(error.to_string().contains("./check.mbtx"))
+    } noraise {
+      _ => fail("missing resources must not select a workspace file")
+    }
+  }
+}

--- a/agent_tool/mbtx/filename.mbt
+++ b/agent_tool/mbtx/filename.mbt
@@ -1,9 +1,6 @@
 ///|
 fn is_bundled_filename(filename : String) -> Bool {
-  filename != "." &&
-  filename != ".." &&
-  !filename.contains("/") &&
-  !filename.contains("\\")
+  filename.has_prefix("@builtin/")
 }
 
 ///|
@@ -12,23 +9,42 @@ fn resolve_filename(
   filename : String,
   references : String?,
 ) -> String raise {
-  if is_bundled_filename(filename) {
-    guard references is Some(root) && !root.trim().is_empty() else {
+  if filename.has_prefix("@") {
+    guard is_bundled_filename(filename) else {
       fail(
-        "bundled filename \{filename} needs OPENSEEK_REFERENCES. For a workspace script, use ./\{filename}; bundled workflows are unavailable in this environment",
+        "unknown script namespace in \{filename}. Only @builtin/ is supported. Use ./\{filename} for a literal workspace path",
       )
     }
-    @workspace_path.resolve(root, "workflow/\{filename}")
+    let name = filename[9:].to_owned()
+    guard !name.is_empty() &&
+      !name.contains("\\") &&
+      name
+      .split("/")
+      .all(part => !part.is_empty() && part != "." && part != "..") else {
+      fail(
+        "invalid bundled script path \{filename}; use @builtin/check.mbtx or a relative path within that namespace, without . or .. components",
+      )
+    }
+    guard references is Some(root) && !root.trim().is_empty() else {
+      fail(
+        "bundled filename \{filename} needs OPENSEEK_REFERENCES; bundled workflows are unavailable in this environment. Use a workspace filename or inline source instead",
+      )
+    }
+    @workspace_path.resolve(root, "workflow/\{name}")
   } else {
     @workspace_path.resolve(workspace_root, filename)
   }
 }
 
 ///|
-test "bare filenames select bundled workflows without workspace fallback" {
+test "only the builtin namespace selects bundled workflows" {
+  assert_eq(
+    resolve_filename("/project", "@builtin/check.mbtx", Some("/share")),
+    "/share/workflow/check.mbtx",
+  )
   assert_eq(
     resolve_filename("/project", "check.mbtx", Some("/share")),
-    "/share/workflow/check.mbtx",
+    "/project/check.mbtx",
   )
   assert_eq(
     resolve_filename("/project", "./check.mbtx", Some("/share")),
@@ -47,10 +63,25 @@ test "bare filenames select bundled workflows without workspace fallback" {
   assert_false(is_bundled_filename(".\\check.mbtx"))
   assert_false(is_bundled_filename("C:\\scripts\\check.mbtx"))
   for references in [None, Some("  ")] {
-    try resolve_filename("/project", "check.mbtx", references) catch {
-      error => assert_true(error.to_string().contains("./check.mbtx"))
+    try resolve_filename("/project", "@builtin/check.mbtx", references) catch {
+      error => assert_true(error.to_string().contains("OPENSEEK_REFERENCES"))
     } noraise {
       _ => fail("missing resources must not select a workspace file")
     }
   }
+  for
+    name in [
+      "@skill/check.mbtx", "@builtin/", "@builtin/../check.mbtx", "@builtin//check.mbtx",
+      "@builtin/a\\check.mbtx",
+    ] {
+    try resolve_filename("/project", name, Some("/share")) catch {
+      _ => ()
+    } noraise {
+      _ => fail("invalid namespace path accepted: \{name}")
+    }
+  }
+  assert_eq(
+    resolve_filename("/project", "./@builtin/check.mbtx", None),
+    "/project/@builtin/check.mbtx",
+  )
 }

--- a/agent_tool/mbtx/internal/decode/README.mbt.md
+++ b/agent_tool/mbtx/internal/decode/README.mbt.md
@@ -1,7 +1,8 @@
 # mbtx/internal/decode
 
 Argument decoding for the `mbtx` tool. `decode(Json) -> MbtxInput`
-reads the required `source` string (a `.mbtx` program) and the optional
+reads exactly one of `source` (a `.mbtx` program) and `filename` (a saved
+script path), represented by the `Program` enum, and the optional
 `target` backend (default `wasm`, validated against
 `wasm`/`wasm-gc`/`js`/`llvm`), `cwd`, `warning`, and `escalated` fields. It names
 the offending field on failure so the error fed back to the model says exactly

--- a/agent_tool/mbtx/internal/decode/README.mbt.md
+++ b/agent_tool/mbtx/internal/decode/README.mbt.md
@@ -1,8 +1,9 @@
 # mbtx/internal/decode
 
 Argument decoding for the `mbtx` tool. `decode(Json) -> MbtxInput`
-reads exactly one of `source` (a `.mbtx` program) and `filename` (a saved
-script path), represented by the `Program` enum, and the optional
+reads `source` (a `.mbtx` program), `filename` (an existing script), or both
+(save and run a workspace script), represented by the `Program` enum. Namespaced
+filenames cannot accompany source. It also reads the optional
 `target` backend (default `wasm`, validated against
 `wasm`/`wasm-gc`/`js`/`llvm`), `cwd`, `warning`, and `escalated` fields. It names
 the offending field on failure so the error fed back to the model says exactly

--- a/agent_tool/mbtx/internal/decode/decode.mbt
+++ b/agent_tool/mbtx/internal/decode/decode.mbt
@@ -1,10 +1,14 @@
 ///|
-/// Decoded arguments of the `mbtx` tool: a self-contained MoonBit
-/// program (`.mbtx` single-file script) to compile and run, the backend
-/// `target` to run it on, and an optional `cwd` (the working directory the
-/// program runs in; `None` means the workspace root).
+/// Exactly one inline program or saved script path.
+pub enum Program {
+  Source(String)
+  File(String)
+} derive(Debug)
+
+///|
+/// Decoded program and execution options. `None` cwd means workspace root.
 pub struct MbtxInput {
-  source : String
+  program : Program
   /// Presentation metadata, inherited by a background job.
   description : String?
   target : String
@@ -30,6 +34,11 @@ pub struct MbtxInput {
 } derive(Debug)
 
 ///|
+#deprecated("the derived Debug impl is the API")
+#doc(hidden)
+pub extend Program with Debug::{to_repr}
+
+///|
 /// The moon backends `--target` accepts.
 fn valid_target(target : String) -> Bool {
   // `native` is deliberately absent: moonrun's policy — the only confinement
@@ -41,7 +50,8 @@ fn valid_target(target : String) -> Bool {
 }
 
 ///|
-/// Decode `mbtx` tool-call arguments. `source` is a required string
+/// Decode `mbtx` tool-call arguments. Exactly one of `source` and `filename`
+/// is required. `filename` names a saved script; `source` is a string
 /// holding a full `.mbtx` program (an optional leading `import { … }` block,
 /// then the program including its own `main`). `target` is an optional backend
 /// name defaulting to `wasm`, which is the backend moonrun's policy sandbox
@@ -59,7 +69,34 @@ pub fn decode(arguments : Json) -> MbtxInput raise {
     )
   }
   match arguments {
-    { "source": String(source), .. } => {
+    Object(fields) => {
+      let program = match (fields.get("source"), fields.get("filename")) {
+        (Some(_), Some(_)) =>
+          fail(
+            "exactly one of arguments.source and arguments.filename, not both. filename reads an existing script; it does not save or name source. For repeated runs, first save the program with the file tools, then call mbtx with {\"filename\":\"scripts/check.mbtx\"} and omit source. For a one-off run, omit filename and pass only source",
+          )
+        (Some(String(source)), None) => Source(source)
+        (None, Some(String(filename))) => {
+          guard !filename.is_blank() else {
+            fail(
+              "arguments.filename to be a nonblank path to an existing script, for example {\"filename\":\"./check.mbtx\"}. Omit source entirely",
+            )
+          }
+          File(filename)
+        }
+        (None, None) =>
+          fail(
+            "exactly one of arguments.source and arguments.filename. Use {\"source\":\"fn main { println(42) }\"} for inline code, or {\"filename\":\"./check.mbtx\"} for an existing workspace script. Omit the unused field entirely; do not send null",
+          )
+        (Some(_), None) =>
+          fail(
+            "arguments.source to be a string containing a complete .mbtx program. To run a saved script, omit source entirely and use {\"filename\":\"./check.mbtx\"}; do not send source: null",
+          )
+        (None, Some(_)) =>
+          fail(
+            "arguments.filename to be a string naming an existing script, for example {\"filename\":\"./check.mbtx\"}. For inline code, omit filename entirely and pass source; do not send filename: null",
+          )
+      }
       let description = match arguments {
         { "description": String(text), .. } => Some(text)
         { "description": Null, .. } => None
@@ -101,9 +138,8 @@ pub fn decode(arguments : Json) -> MbtxInput raise {
         { "subrun": _, .. } => fail("arguments.subrun to be a boolean")
         _ => false
       }
-      { source, description, target, cwd, warning, escalated, subrun, }
+      { program, description, target, cwd, warning, escalated, subrun, }
     }
-    Object(_) => fail("arguments.source")
     _ => fail("object arguments")
   }
 }
@@ -111,7 +147,7 @@ pub fn decode(arguments : Json) -> MbtxInput raise {
 ///|
 test "decode reads source with the default wasm target" {
   let input = decode({ "source": "fn main { println(1) }" })
-  assert_eq(input.source, "fn main { println(1) }")
+  assert_true(input.program is Source("fn main { println(1) }"))
   assert_eq(input.target, "wasm")
 }
 
@@ -168,6 +204,15 @@ test "decode defaults warning to off and reads on/off" {
 /// the model is supposed to read.
 test "decode rejects malformed arguments" {
   let malformed : Array[Json] = [
+    {},
+    { "filename": "" },
+    { "filename": "  " },
+    { "filename": 3 },
+    { "filename": null },
+    { "source": null },
+    { "source": "x", "filename": "run.mbtx" },
+    { "source": "x", "filename": null },
+    { "source": null, "filename": "run.mbtx" },
     // An unknown warning value, a non-string cwd, an unknown target, a
     // missing source, and arguments that are not an object at all.
     { "source": "x", "warning": "loud" },
@@ -185,6 +230,61 @@ test "decode rejects malformed arguments" {
       _ => true
     }
     assert_true(failed, msg="accepted \{arguments.stringify()}")
+  }
+}
+
+///|
+test "decode explains how to recover from source and filename together" {
+  try
+    decode({ "source": "fn main {}", "filename": "scripts/check.mbtx" })
+  catch {
+    error => {
+      let message = error.to_string()
+      assert_true(message.contains("filename reads an existing script"))
+      assert_true(
+        message.contains("first save the program with the file tools"),
+      )
+      assert_true(message.contains("{\"filename\":\"scripts/check.mbtx\"}"))
+      assert_true(message.contains("omit filename and pass only source"))
+    }
+  } noraise {
+    _ => fail("expected mutually exclusive inputs to be rejected")
+  }
+}
+
+///|
+test "decode accepts filename with unchanged execution options" {
+  let input = decode({
+    "filename": "scripts/check.mbtx",
+    "cwd": "sub",
+    "warning": "on",
+  })
+  assert_true(input.program is File("scripts/check.mbtx"))
+  assert_eq(input.cwd, Some("sub"))
+  assert_eq(input.target, "wasm")
+  assert_true(input.warning)
+}
+
+///|
+test "missing or invalid program fields give an actionable retry" {
+  for
+    arguments in [
+      ({} : Json),
+      Json({ "source": null }),
+      Json({ "source": 42 }),
+      Json({ "filename": null }),
+      Json({ "filename": 42 }),
+      Json({ "filename": " " }),
+    ] {
+    try decode(arguments) catch {
+      error => {
+        let message = error.to_string()
+        assert_true(message.contains("{\"filename\":\"./check.mbtx\"}"))
+        assert_true(message.contains("omit") || message.contains("Omit"))
+      }
+    } noraise {
+      _ => fail("malformed input must fail before execution")
+    }
   }
 }
 

--- a/agent_tool/mbtx/internal/decode/decode.mbt
+++ b/agent_tool/mbtx/internal/decode/decode.mbt
@@ -1,8 +1,9 @@
 ///|
-/// Exactly one inline program or saved script path.
+/// Inline code, an existing script, or code to save before running.
 pub enum Program {
   Source(String)
   File(String)
+  Save(String, String)
 } derive(Debug)
 
 ///|
@@ -50,8 +51,8 @@ fn valid_target(target : String) -> Bool {
 }
 
 ///|
-/// Decode `mbtx` tool-call arguments. Exactly one of `source` and `filename`
-/// is required. `filename` names a saved script; `source` is a string
+/// Decode `mbtx` tool-call arguments. At least one of `source` and `filename`
+/// is required; both means save and run a workspace script. `source` is a string
 /// holding a full `.mbtx` program (an optional leading `import { … }` block,
 /// then the program including its own `main`). `target` is an optional backend
 /// name defaulting to `wasm`, which is the backend moonrun's policy sandbox
@@ -71,9 +72,22 @@ pub fn decode(arguments : Json) -> MbtxInput raise {
   match arguments {
     Object(fields) => {
       let program = match (fields.get("source"), fields.get("filename")) {
+        (Some(String(source)), Some(String(filename))) => {
+          guard !filename.is_blank() else {
+            fail(
+              "arguments.filename to be a nonblank workspace path when saving source",
+            )
+          }
+          guard !filename.has_prefix("@") else {
+            fail(
+              "a workspace filename when source is supplied. Namespaced scripts are read-only: call {\"filename\":\"@builtin/check.mbtx\"} without source, or save your custom source as {\"source\":\"...\",\"filename\":\"check.mbtx\"}",
+            )
+          }
+          Save(source, filename)
+        }
         (Some(_), Some(_)) =>
           fail(
-            "exactly one of arguments.source and arguments.filename, not both. filename reads an existing script; it does not save or name source. For repeated runs, first save the program with the file tools, then call mbtx with {\"filename\":\"scripts/check.mbtx\"} and omit source. For a one-off run, omit filename and pass only source",
+            "source and filename to both be strings for save-and-run. Omit unused fields entirely instead of sending null",
           )
         (Some(String(source)), None) => Source(source)
         (None, Some(String(filename))) => {
@@ -86,7 +100,7 @@ pub fn decode(arguments : Json) -> MbtxInput raise {
         }
         (None, None) =>
           fail(
-            "exactly one of arguments.source and arguments.filename. Use {\"source\":\"fn main { println(42) }\"} for inline code, or {\"filename\":\"./check.mbtx\"} for an existing workspace script. Omit the unused field entirely; do not send null",
+            "source or filename. Use {\"source\":\"fn main { println(42) }\"} for inline code, {\"filename\":\"./check.mbtx\"} for an existing script, or both strings to save and run. Omit unused fields entirely; do not send null",
           )
         (Some(_), None) =>
           fail(
@@ -210,7 +224,7 @@ test "decode rejects malformed arguments" {
     { "filename": 3 },
     { "filename": null },
     { "source": null },
-    { "source": "x", "filename": "run.mbtx" },
+    { "source": "x", "filename": "@builtin/check.mbtx" },
     { "source": "x", "filename": null },
     { "source": null, "filename": "run.mbtx" },
     // An unknown warning value, a non-string cwd, an unknown target, a
@@ -234,26 +248,27 @@ test "decode rejects malformed arguments" {
 }
 
 ///|
-test "decode explains how to recover from source and filename together" {
+test "decode rejects saving to a namespace with retry guidance" {
   try
-    decode({ "source": "fn main {}", "filename": "scripts/check.mbtx" })
+    decode({ "source": "fn main {}", "filename": "@builtin/check.mbtx" })
   catch {
     error => {
       let message = error.to_string()
-      assert_true(message.contains("filename reads an existing script"))
-      assert_true(
-        message.contains("first save the program with the file tools"),
-      )
-      assert_true(message.contains("{\"filename\":\"scripts/check.mbtx\"}"))
-      assert_true(message.contains("omit filename and pass only source"))
+      assert_true(message.contains("Namespaced scripts are read-only"))
+      assert_true(message.contains("without source"))
+      assert_true(message.contains("@builtin/check.mbtx"))
     }
   } noraise {
-    _ => fail("expected mutually exclusive inputs to be rejected")
+    _ => fail("expected namespace write to be rejected")
   }
 }
 
 ///|
 test "decode accepts filename with unchanged execution options" {
+  assert_true(
+    decode({ "source": "fn main {}", "filename": "check.mbtx" }).program
+    is Save("fn main {}", "check.mbtx"),
+  )
   let input = decode({
     "filename": "scripts/check.mbtx",
     "cwd": "sub",

--- a/agent_tool/mbtx/internal/decode/pkg.generated.mbti
+++ b/agent_tool/mbtx/internal/decode/pkg.generated.mbti
@@ -24,6 +24,7 @@ pub struct MbtxInput {
 pub enum Program {
   Source(String)
   File(String)
+  Save(String, String)
 } derive(@debug.Debug)
 
 // Type aliases

--- a/agent_tool/mbtx/internal/decode/pkg.generated.mbti
+++ b/agent_tool/mbtx/internal/decode/pkg.generated.mbti
@@ -12,13 +12,18 @@ pub fn decode(Json) -> MbtxInput raise
 
 // Types and methods
 pub struct MbtxInput {
-  source : String
+  program : Program
   description : String?
   target : String
   cwd : String?
   warning : Bool
   escalated : Bool
   subrun : Bool
+} derive(@debug.Debug)
+
+pub enum Program {
+  Source(String)
+  File(String)
 } derive(@debug.Debug)
 
 // Type aliases

--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -222,6 +222,39 @@ async fn execute(
         is_error=true,
       )
   }
+  // Read once, before validation/approval, then compile this same snapshot.
+  // A saved script has the same isolation and execution path as inline code.
+  let (source, source_name) = match input.program {
+    Source(source) => (source, "source")
+    File(filename) => {
+      let path = resolve_filename(
+        workspace_root,
+        filename,
+        @env.get_env_var("OPENSEEK_REFERENCES"),
+      ) catch {
+        error =>
+          return @agent_tool.respond(
+            "error: mbtx \{@tool_error.failure_message("\{error}")}",
+            is_error=true,
+          )
+      }
+      let source = @fs.read_file(path).text() catch {
+        error if @async.is_being_cancelled() => raise error
+        error => {
+          let hint = if is_bundled_filename(filename) {
+            " Bundled workflows: check.mbtx, test.mbtx, check-test.mbtx, info-fmt.mbtx, check-json.mbtx. For a workspace file, use ./\{filename}."
+          } else {
+            " filename must name an existing readable script. Save it with the file tools first, then retry with filename only; or run inline code with source only. Paths resolve from the workspace, independently of cwd."
+          }
+          return @agent_tool.respond(
+            "error: mbtx could not read filename \{filename}: \{error}\{hint}",
+            is_error=true,
+          )
+        }
+      }
+      (source, filename)
+    }
+  }
   // Refuse FFI (`extern`), the one construct no mbtx target runs sandboxed.
   // The wasm family needs no scan — the compiler refuses `extern "c"` and
   // `extern "js"` on those backends outright — but the js target's host is
@@ -231,7 +264,7 @@ async fn execute(
   // literals (a snippet quoting a commit message was refused once), the quote
   // that follows it does not. A substring scan is NOT a real boundary; it is
   // what keeps the non-wasm targets' "compute-only" promise true.
-  if input.source.contains("extern \"") {
+  if source.contains("extern \"") {
     return @agent_tool.respond(
       "mbtx refuses this program: it uses native FFI (extern), which no mbtx target can run sandboxed — the wasm family refuses to compile it, and the js/llvm targets have no policy to contain it.",
       is_error=true,
@@ -307,12 +340,12 @@ async fn execute(
       Some(channel) =>
         // The program goes with the question. It is what the user is actually
         // deciding about, and `detail` — which is a constant — describes only
-        // the permission. Passed as the exact string this call was made with,
-        // so what is approved and what runs cannot differ.
+        // the permission. This is the resolved snapshot, so what is approved
+        // and what runs cannot differ even if the saved file changes.
         channel.ask({
           tool_name: "mbtx",
           detail: "run this snippet with no sandbox policy: no spawn allowlist, and writes anywhere",
-          body: Some(input.source),
+          body: Some(source),
         })
       // The argument was not advertised in this build's schema, so reaching
       // here means the model asked for a field it was never offered.
@@ -417,7 +450,7 @@ async fn execute(
   }
   @fs.write_file(
     "\{build_dir}/snippet.mbtx",
-    input.source,
+    source,
     create_mode=CreateOrTruncate,
   )
   let log = "\{build_dir}/output.log"
@@ -621,6 +654,7 @@ async fn execute(
         build_timeout_ms~,
         empty_stdin~,
         rewrite_bases=[real, build_dir],
+        source_name~,
         confine~,
       ) {
       NotBuilt(action) => return action
@@ -728,12 +762,12 @@ async fn execute(
         exec,
         description?=input.description,
         command=if staged {
-          "mbtx run (build ok): \{@agent_tool.brief_line(input.source, limit=64)}"
+          "mbtx run (build ok): \{@agent_tool.brief_line(source, limit=64)}"
         } else {
-          "mbtx: \{@agent_tool.brief_line(input.source, limit=64)}"
+          "mbtx: \{@agent_tool.brief_line(source, limit=64)}"
         },
         sandboxed_command?,
-        output_rewrites=temp_path_rewrites([real, build_dir]),
+        output_rewrites=temp_path_rewrites([real, build_dir], source_name~),
         moonrun_policy_active=policy_active,
         on_terminal=terminal_cleanup,
       )
@@ -769,7 +803,7 @@ async fn execute(
       policy_active~,
     )
     exec.discard()
-    let text = rewrite_temp_paths(raw, [real, build_dir])
+    let text = rewrite_temp_paths(raw, [real, build_dir], source_name~)
     let body = with_build_notes(
       build_notes,
       finished_body(text, exit_code, staged~),
@@ -820,9 +854,8 @@ async fn execute(
   )
   let action = match result {
     Some((exit_code, raw)) => {
-      // Rewrite the throwaway temp path to `source` so the model reads
-      // `source:LINE:COL` about its own input, not a random temp path.
-      let text = rewrite_temp_paths(raw, [real, build_dir])
+      // Rewrite the throwaway temp path to the inline label or saved filename.
+      let text = rewrite_temp_paths(raw, [real, build_dir], source_name~)
       // PREPEND the exit status so it survives the agent loop's outer 60k
       // result clamp (which cuts the tail); the output cap is below 60k so
       // both the status line and the body are retained.
@@ -842,7 +875,11 @@ async fn execute(
       // still on disk (cleanup runs below), so surface the captured prefix
       // instead of discarding it behind a generic timeout message. The status
       // line stays first so it survives the outer result clamp.
-      let partial = rewrite_temp_paths(read_capped(log), [real, build_dir])
+      let partial = rewrite_temp_paths(
+        read_capped(log),
+        [real, build_dir],
+        source_name~,
+      )
       let head = timeout_head(foreground_timeout_ms, staged~)
       let body = if partial.is_blank() {
         head
@@ -892,6 +929,7 @@ async fn build_snippet(
   build_timeout_ms~ : Int,
   empty_stdin~ : String,
   rewrite_bases~ : Array[String],
+  source_name~ : String,
   confine~ : async (String, Array[String]) -> @sandbox.SandboxedCommand?,
 ) -> BuildOutcome {
   let build_argv = [
@@ -938,7 +976,7 @@ async fn build_snippet(
       ),
     )
   }
-  let text = rewrite_temp_paths(raw, rewrite_bases)
+  let text = rewrite_temp_paths(raw, rewrite_bases, source_name~)
   if exit_code != 0 {
     // The exit code is moon's and it is kept: build-stage faults are not all
     // exit 1 (a dependency-resolution fault exits 255), and distinct codes
@@ -1156,31 +1194,38 @@ async fn refusal_guidance(
 }
 
 ///|
-/// Rewrite moon's throwaway temp paths back to `source` in its diagnostics, for
+/// Rewrite moon's throwaway temp paths to the input label in its diagnostics, for
 /// both `/` and `\` separators — moon reports the canonical native path (with
-/// backslashes on Windows), so `source:LINE:COL` shows on every host rather than
+/// backslashes on Windows), so the original label shows on every host rather than
 /// a random `_build` path leaking through.
-fn temp_path_rewrites(bases : Array[String]) -> Array[(String, String)] {
+fn temp_path_rewrites(
+  bases : Array[String],
+  source_name~ : String,
+) -> Array[(String, String)] {
   let rewrites : Array[(String, String)] = []
   for base in bases {
     for sep in ["/", "\\"] {
       // `.mbtx` first: replacing `snippet.mbt` before it would leave a stray
       // `x` (`sourcex`). Older moon versions copy the source to `snippet.mbt`
       // under the target directory, sometimes with another `_build` layer.
-      rewrites.push(("\{base}\{sep}snippet.mbtx", "source"))
+      rewrites.push(("\{base}\{sep}snippet.mbtx", source_name))
       rewrites.push(
-        ("\{base}\{sep}_build\{sep}_build\{sep}snippet.mbt", "source"),
+        ("\{base}\{sep}_build\{sep}_build\{sep}snippet.mbt", source_name),
       )
-      rewrites.push(("\{base}\{sep}_build\{sep}snippet.mbt", "source"))
-      rewrites.push(("\{base}\{sep}snippet.mbt", "source"))
+      rewrites.push(("\{base}\{sep}_build\{sep}snippet.mbt", source_name))
+      rewrites.push(("\{base}\{sep}snippet.mbt", source_name))
     }
   }
   rewrites
 }
 
 ///|
-fn rewrite_temp_paths(text : String, bases : Array[String]) -> String {
-  temp_path_rewrites(bases).fold(init=text, (out, rewrite) => {
+fn rewrite_temp_paths(
+  text : String,
+  bases : Array[String],
+  source_name~ : String,
+) -> String {
+  temp_path_rewrites(bases, source_name~).fold(init=text, (out, rewrite) => {
     let (old, replacement) = rewrite
     out.replace_all(old~, new=replacement)
   })
@@ -1326,7 +1371,21 @@ fn schema(escalation~ : Bool, hosting~ : Bool) -> Json {
     "properties": Json(
       Map(
         [
-          ("source", Json({ "type": "string" })),
+          (
+            "source",
+            Json({
+              "type": "string",
+              "description": "Inline program to execute once. Omit filename when using source. To reuse a program, save it with the file tools first, then call with filename only.",
+            }),
+          ),
+          (
+            "filename",
+            {
+              "type": "string",
+              "minLength": 1,
+              "description": "Read and execute an existing .mbtx file; this does not save source. A bare name such as check.mbtx resolves under OPENSEEK_REFERENCES/workflow/. Use ./check.mbtx for a workspace file; other relative paths resolve from the workspace, and absolute paths stay absolute. Save new custom scripts with file tools first. Omit source. cwd controls execution only.",
+            },
+          ),
           (
             "description",
             {
@@ -1401,7 +1460,7 @@ fn schema(escalation~ : Bool, hosting~ : Bool) -> Json {
         ],
       ),
     ),
-    "required": ["source"],
+    "oneOf": [{ "required": ["source"] }, { "required": ["filename"] }],
   }
 }
 
@@ -1469,8 +1528,28 @@ fn description(
     #|scripting surface: there is no shell tool, so commands, IO, and computation
     #|happen inside the submitted MoonBit program.
     #|
-    #|`source` is the whole program. Diagnostics are rewritten to `source:LINE:COL`
-    #|about your input; `target` defaults to wasm, the sandboxed backend.
+    #|Choose exactly one input. For a one-off probe, pass `source` and omit
+    #|`filename`. When OPENSEEK_REFERENCES is available, bundled workflows
+    #|already exist and need no file creation: check.mbtx (moon check),
+    #|test.mbtx (moon test), check-test.mbtx (check then test), info-fmt.mbtx
+    #|(moon info then moon fmt), and check-json.mbtx (moon check --output-json).
+    #|For custom repeated validation or automation (for example, running
+    #|`moon check` and `moon test` after edits), follow these two steps:
+    #|1. Use the file tools to save the program as `scripts/check.mbtx`.
+    #|2. Execute it with `{"filename":"scripts/check.mbtx"}`. Omit `source`
+    #|   entirely. Use this same filename-only call for subsequent runs.
+    #|`filename` READS an existing file. It does not create a file, save `source`,
+    #|or assign a name to an inline program. Passing both inputs is an error.
+    #|If the program needs to change, edit the saved file and run it again.
+    #|A filename with no `/` or `\` and unequal to `.` or `..` selects
+    #|OPENSEEK_REFERENCES/workflow/ (for example, `{"filename":"check.mbtx"}`).
+    #|Use `./check.mbtx` for a workspace file. Other relative paths resolve
+    #|from the workspace root; absolute paths stay absolute. No lookup fallback
+    #|occurs. `cwd` controls execution only, not filename resolution.
+    #|Each call reads the current file once
+    #|and runs that snapshot with the same sandbox and isolated imports as source.
+    #|Diagnostics cite `source:LINE:COL` or the supplied filename and line/column.
+    #|`target` defaults to wasm, the sandboxed backend.
     #|
     #|## Which programs a snippet may start
     #|

--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -112,6 +112,8 @@ fn duration_label(milliseconds : Int) -> String {
 pub fn definition(
   workspace_root~ : String,
   read_only? : Bool = false,
+  file_state? : @agent_tool.FileStateMap = FileStateMap(),
+  write_scope? : @write_scope.WriteScope,
   bg_runtime? : @bgjobs.BgJobRuntime,
   job_dir? : String,
   scratch_dir? : String,
@@ -141,10 +143,14 @@ pub fn definition(
       schema(escalation=approval is Some(_), hosting=subrun is Some(_)),
     ),
     execute=Async(arguments => {
-      execute(
+      let saved : Ref[String?] = Ref(None)
+      let action = execute(
         workspace_root,
         arguments,
         read_only~,
+        file_state~,
+        write_scope?,
+        saved~,
         bg_runtime?,
         job_dir?,
         scratch_dir?,
@@ -156,6 +162,17 @@ pub fn definition(
         approval?,
         subrun?,
       )
+      match (saved.val, action) {
+        (Some(filename), Respond(output)) => {
+          let retry : Json = { "filename": filename }
+          @agent_tool.respond(
+            "Script saved at \{filename}. For subsequent runs, call mbtx with \{retry.stringify()} and omit source.\n\n\{output.content}",
+            is_error=output.is_error,
+            brief?=output.brief,
+          )
+        }
+        _ => action
+      }
     }),
   )
 }
@@ -201,6 +218,9 @@ async fn execute(
   workspace_root : String,
   arguments : Json,
   read_only~ : Bool,
+  file_state~ : @agent_tool.FileStateMap,
+  write_scope? : @write_scope.WriteScope,
+  saved~ : Ref[String?],
   bg_runtime? : @bgjobs.BgJobRuntime,
   job_dir? : String,
   scratch_dir? : String,
@@ -226,6 +246,31 @@ async fn execute(
   // A saved script has the same isolation and execution path as inline code.
   let (source, source_name) = match input.program {
     Source(source) => (source, "source")
+    Save(source, filename) => {
+      if worker_sandbox is Some(_) && write_scope is None {
+        return @agent_tool.respond(
+          "error: mbtx cannot save without the worker write scope; use the write tool first",
+          is_error=true,
+        )
+      }
+      save_script(
+        workspace_root,
+        filename,
+        source,
+        read_only~,
+        file_state~,
+        write_scope?,
+      ) catch {
+        error if @async.is_being_cancelled() => raise error
+        error =>
+          return @agent_tool.respond(
+            "error: mbtx could not save \{filename}: \{@tool_error.failure_message("\{error}")}",
+            is_error=true,
+          )
+      }
+      saved.val = Some(filename)
+      (source, filename)
+    }
     File(filename) => {
       let path = resolve_filename(
         workspace_root,
@@ -238,13 +283,24 @@ async fn execute(
             is_error=true,
           )
       }
+      if is_bundled_filename(filename) &&
+        @env.get_env_var("OPENSEEK_REFERENCES") is Some(root) {
+        check_builtin_containment(path, root) catch {
+          error if @async.is_being_cancelled() => raise error
+          error =>
+            return @agent_tool.respond(
+              "error: mbtx \{@tool_error.failure_message("\{error}")}",
+              is_error=true,
+            )
+        }
+      }
       let source = @fs.read_file(path).text() catch {
         error if @async.is_being_cancelled() => raise error
         error => {
           let hint = if is_bundled_filename(filename) {
-            " Bundled workflows: check.mbtx, test.mbtx, check-test.mbtx, info-fmt.mbtx, check-json.mbtx. For a workspace file, use ./\{filename}."
+            " Bundled workflows: @builtin/check.mbtx, @builtin/test.mbtx, @builtin/check-test.mbtx, @builtin/info-fmt.mbtx, @builtin/check-json.mbtx. Ordinary filenames select workspace files."
           } else {
-            " filename must name an existing readable script. Save it with the file tools first, then retry with filename only; or run inline code with source only. Paths resolve from the workspace, independently of cwd."
+            " filename alone must name an existing readable script. To save a new workspace script, pass source and filename together; or run inline with source only. Paths resolve from the workspace, independently of cwd."
           }
           return @agent_tool.respond(
             "error: mbtx could not read filename \{filename}: \{error}\{hint}",
@@ -1375,7 +1431,7 @@ fn schema(escalation~ : Bool, hosting~ : Bool) -> Json {
             "source",
             Json({
               "type": "string",
-              "description": "Inline program to execute once. Omit filename when using source. To reuse a program, save it with the file tools first, then call with filename only.",
+              "description": "Complete .mbtx program. Alone: run inline. With a workspace filename: save and run, then reuse filename-only calls. Cannot accompany a namespaced filename. Different existing content is never overwritten.",
             }),
           ),
           (
@@ -1383,7 +1439,7 @@ fn schema(escalation~ : Bool, hosting~ : Bool) -> Json {
             {
               "type": "string",
               "minLength": 1,
-              "description": "Read and execute an existing .mbtx file; this does not save source. A bare name such as check.mbtx resolves under OPENSEEK_REFERENCES/workflow/. Use ./check.mbtx for a workspace file; other relative paths resolve from the workspace, and absolute paths stay absolute. Save new custom scripts with file tools first. Omit source. cwd controls execution only.",
+              "description": "Script path. Ordinary paths resolve from the workspace root; @builtin/check.mbtx resolves under OPENSEEK_REFERENCES/workflow/. Alone: read and run. With source: save and run inside the workspace, refusing to overwrite different content. Namespaced scripts are read-only; omit source for them. cwd controls execution only.",
             },
           ),
           (
@@ -1460,7 +1516,11 @@ fn schema(escalation~ : Bool, hosting~ : Bool) -> Json {
         ],
       ),
     ),
-    "oneOf": [{ "required": ["source"] }, { "required": ["filename"] }],
+    "anyOf": [{ "required": ["source"] }, { "required": ["filename"] }],
+    "not": {
+      "required": ["source", "filename"],
+      "properties": { "filename": { "pattern": "^@" } },
+    },
   }
 }
 
@@ -1528,26 +1588,26 @@ fn description(
     #|scripting surface: there is no shell tool, so commands, IO, and computation
     #|happen inside the submitted MoonBit program.
     #|
-    #|Choose exactly one input. For a one-off probe, pass `source` and omit
-    #|`filename`. When OPENSEEK_REFERENCES is available, bundled workflows
-    #|already exist and need no file creation: check.mbtx (moon check),
-    #|test.mbtx (moon test), check-test.mbtx (check then test), info-fmt.mbtx
-    #|(moon info then moon fmt), and check-json.mbtx (moon check --output-json).
-    #|For custom repeated validation or automation (for example, running
-    #|`moon check` and `moon test` after edits), follow these two steps:
-    #|1. Use the file tools to save the program as `scripts/check.mbtx`.
-    #|2. Execute it with `{"filename":"scripts/check.mbtx"}`. Omit `source`
-    #|   entirely. Use this same filename-only call for subsequent runs.
-    #|`filename` READS an existing file. It does not create a file, save `source`,
-    #|or assign a name to an inline program. Passing both inputs is an error.
-    #|If the program needs to change, edit the saved file and run it again.
-    #|A filename with no `/` or `\` and unequal to `.` or `..` selects
-    #|OPENSEEK_REFERENCES/workflow/ (for example, `{"filename":"check.mbtx"}`).
-    #|Use `./check.mbtx` for a workspace file. Other relative paths resolve
+    #|Pass source to run inline, filename to run an existing script, or both to
+    #|save and run a workspace script. For repeated automation, use
+    #|`{"source":"...","filename":"scripts/check.mbtx"}` once, then
+    #|`{"filename":"scripts/check.mbtx"}` for later runs. Missing parents are
+    #|created. Identical existing content is reused; different content is never
+    #|overwritten. Use the edit tool to change a saved script. Saving is limited
+    #|to the writable workspace and is unavailable in read-only mode.
+    #|When OPENSEEK_REFERENCES is available, these scripts are already bundled:
+    #|@builtin/check.mbtx (moon check), @builtin/test.mbtx (moon test),
+    #|@builtin/check-test.mbtx (check then test), @builtin/info-fmt.mbtx (info
+    #|then fmt), and @builtin/check-json.mbtx (moon check --output-json).
+    #|Call `{"filename":"@builtin/check.mbtx"}` without source. Namespaced
+    #|scripts are read-only. Only @builtin/ is supported; skill namespaces are
+    #|not implemented. Paths within the namespace cannot escape its root.
+    #|Ordinary names such as check.mbtx select workspace files. Use
+    #|./@builtin/check.mbtx for a literal workspace path. Relative paths resolve
     #|from the workspace root; absolute paths stay absolute. No lookup fallback
     #|occurs. `cwd` controls execution only, not filename resolution.
-    #|Each call reads the current file once
-    #|and runs that snapshot with the same sandbox and isolated imports as source.
+    #|Existing scripts are read once; each run executes its selected snapshot
+    #|with the same sandbox and isolated imports as inline source.
     #|Diagnostics cite `source:LINE:COL` or the supplied filename and line/column.
     #|`target` defaults to wasm, the sandboxed backend.
     #|

--- a/agent_tool/mbtx/mbtx_test.mbt
+++ b/agent_tool/mbtx/mbtx_test.mbt
@@ -39,6 +39,141 @@ async test "runs a pure-core program and returns its output" {
 }
 
 ///|
+async test "bundled workflows use cwd and propagate check and test failures" {
+  // Run this test with OPENSEEK_REFERENCES set to this checkout's share/ to
+  // exercise bare-name dispatch too. Ordinary suite runs use absolute paths.
+  let references = @fs.realpath("share")
+  async fn workflow_filename(name : String) -> String {
+    if @env.get_env_var("OPENSEEK_REFERENCES") == Some(references) {
+      name
+    } else {
+      @fs.realpath("share/workflow/\{name}")
+    }
+  }
+  let check_path = workflow_filename("check.mbtx")
+  let test_path = workflow_filename("test.mbtx")
+  let combined_path = workflow_filename("check-test.mbtx")
+  let json_path = workflow_filename("check-json.mbtx")
+  let format_path = workflow_filename("info-fmt.mbtx")
+  @vfs.with_tmpdir(ws => {
+    let project = "\{ws}/nested"
+    @fs.mkdir(project)
+    @fs.write_file(
+      "\{project}/moon.mod",
+      "name = \"test/workflow\"\n",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file("\{project}/moon.pkg", "", create_mode=CreateOrTruncate)
+    @fs.write_file(
+      "\{project}/main_test.mbt",
+      "test { assert_eq(1, 1) }\n",
+      create_mode=CreateOrTruncate,
+    )
+    for
+      filename in [check_path, test_path, combined_path, json_path, format_path] {
+      let out = run_in(ws, { "filename": filename, "cwd": "nested" })
+      assert_false(out.is_error, msg=out.content)
+    }
+    @fs.write_file(
+      "\{project}/main_test.mbt",
+      "test { assert_eq(1, 2) }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let out = run_in(ws, { "filename": test_path, "cwd": "nested" })
+    assert_true(out.is_error, msg=out.content)
+    assert_true(out.content.contains("moon test failed"), msg=out.content)
+    let out = run_in(ws, { "filename": combined_path, "cwd": "nested" })
+    assert_true(out.is_error, msg=out.content)
+    assert_true(out.content.contains("moon test failed"), msg=out.content)
+    @fs.write_file(
+      "\{project}/main.mbt",
+      "fn broken() -> Int { true }\n",
+      create_mode=CreateOrTruncate,
+    )
+    let out = run_in(ws, { "filename": check_path, "cwd": "nested" })
+    assert_true(out.is_error, msg=out.content)
+    assert_true(out.content.contains("moon check failed"), msg=out.content)
+    let out = run_in(ws, { "filename": combined_path, "cwd": "nested" })
+    assert_true(out.is_error, msg=out.content)
+    assert_true(out.content.contains("moon check failed"), msg=out.content)
+    assert_false(out.content.contains("moon test failed"), msg=out.content)
+    let out = run_in(ws, { "filename": json_path, "cwd": "nested" })
+    assert_true(out.is_error, msg=out.content)
+    assert_true(out.content.contains("main.mbt"), msg=out.content)
+  })
+}
+
+///|
+async test "filename resolves from workspace independently of cwd and is reread" {
+  @vfs.with_tmpdir(ws => {
+    @fs.mkdir("\{ws}/sub")
+    @fs.write_file(
+      "\{ws}/sub/marker",
+      "saved-script-ok",
+      create_mode=CreateOrTruncate,
+    )
+    let path = "\{ws}/saved script.mbtx"
+    @fs.write_file(
+      path,
+      (
+        #|import { "moonbitlang/async", "moonbitlang/async/fs" }
+        #|async fn main { println(@fs.read_file("marker").text()) }
+      ),
+      create_mode=CreateOrTruncate,
+    )
+    let out = run_in(ws, { "filename": "./saved script.mbtx", "cwd": "sub" })
+    assert_false(out.is_error, msg=out.content)
+    assert_true(out.content.contains("saved-script-ok"))
+    @fs.write_file(
+      path,
+      "fn main { println(43) }",
+      create_mode=CreateOrTruncate,
+    )
+    let out = run_in(ws, { "filename": path })
+    assert_false(out.is_error, msg=out.content)
+    assert_true(out.content.contains("43"))
+  })
+}
+
+///|
+async test "filename reports read failures and refuses ambiguous calls" {
+  @vfs.with_tmpdir(ws => {
+    for
+      arguments in [
+        Json({ "filename": "missing.mbtx" }),
+        Json({ "filename": ws }),
+        Json({ "source": "fn main { println(42) }", "filename": "missing.mbtx" }),
+      ] {
+      let out = run_in(ws, arguments)
+      assert_true(out.is_error)
+      assert_true(out.content.contains("filename"))
+    }
+  })
+}
+
+///|
+async test "saved scripts retain compiler filename and FFI checks" {
+  @vfs.with_tmpdir(ws => {
+    @fs.write_file(
+      "\{ws}/broken.mbtx",
+      "fn main { let _x : Int = \"nope\" }",
+      create_mode=CreateOrTruncate,
+    )
+    let out = run_in(ws, { "filename": "./broken.mbtx" })
+    assert_true(out.is_error)
+    assert_true(out.content.contains("broken.mbtx:1:"), msg=out.content)
+    @fs.write_file(
+      "\{ws}/ffi.mbtx",
+      "extern \"js\" fn escape() -> Unit = \"() => {}\"\nfn main { escape() }",
+      create_mode=CreateOrTruncate,
+    )
+    let out = run_in(ws, { "filename": "./ffi.mbtx", "target": "js" })
+    assert_true(out.is_error)
+    assert_true(out.content.contains("native FFI"))
+  })
+}
+
+///|
 async test "surfaces a compile error via moon's own diagnostics" {
   let out = run("fn main { let _x : Int = \"nope\" }")
   assert_true(out.is_error)
@@ -685,21 +820,53 @@ test "the description advertises the Proton CLI command surface" {
 
 ///|
 /// The schema is the model-facing argument contract, so pin its shape: the
-/// arguments the tool decodes are all present, and only `source` is required.
+/// arguments the tool decodes are all present, with exactly one program input.
 test "the schema advertises every decoded argument" {
   let JsonSchema(schema) = @mbtx.definition(workspace_root=".").schema
-  guard schema is { "properties": Object(properties), "required": required, .. } else {
-    fail("expected an object schema with properties and required")
+  guard schema is { "properties": Object(properties), "oneOf": choices, .. } else {
+    fail("expected an object schema with properties and oneOf")
   }
   // Order-independent: `Map` iteration order is not the declaration order, and
   // MoonBit's String ordering is by length first, so a sorted expectation would
   // encode neither what this test means nor what a reader expects.
   let names = properties.keys().collect()
-  assert_eq(names.length(), 5)
-  for name in ["source", "description", "target", "cwd", "warning"] {
+  assert_eq(names.length(), 6)
+  for name in ["source", "filename", "description", "target", "cwd", "warning"] {
     assert_true(names.contains(name))
   }
-  assert_eq(required, (["source"] : Json))
+  assert_eq(
+    choices,
+    ([{ "required": ["source"] }, { "required": ["filename"] }] : Json),
+  )
+  assert_false(schema is { "required": _, .. })
+}
+
+///|
+async test "filename approval executes the reviewed snapshot even if the file changes" {
+  @vfs.with_tmpdir(ws => {
+    let path = "\{ws}/approved.mbtx"
+    let original = "fn main { println(\"approved snapshot\") }"
+    @fs.write_file(path, original, create_mode=CreateOrTruncate)
+    let definition = @mbtx.definition(
+      workspace_root=ws,
+      approval=ApprovalChannel(ask => {
+        assert_eq(ask.body, Some(original))
+        @fs.write_file(
+          path,
+          "fn main { println(\"replacement program\") }",
+          create_mode=CreateOrTruncate,
+        )
+        AllowedOnce
+      }),
+    )
+    let out = dispatch(definition, {
+      "filename": "./approved.mbtx",
+      "escalated": true,
+    })
+    assert_false(out.is_error, msg=out.content)
+    assert_true(out.content.contains("approved snapshot"))
+    assert_false(out.content.contains("replacement program"))
+  })
 }
 
 ///|

--- a/agent_tool/mbtx/mbtx_test.mbt
+++ b/agent_tool/mbtx/mbtx_test.mbt
@@ -39,13 +39,98 @@ async test "runs a pure-core program and returns its output" {
 }
 
 ///|
+async test "save and run creates parents, suggests reuse, and preserves existing content" {
+  @vfs.with_tmpdir(ws => {
+    let state = @agent_tool.FileStateMap()
+    let tool = @mbtx.definition(workspace_root=ws, file_state=state)
+    let source = "fn main { println(42) }"
+    let args : Json = { "source": source, "filename": "scripts/check.mbtx" }
+    let out = dispatch(tool, args)
+    assert_false(out.is_error, msg=out.content)
+    assert_true(out.content.contains("42"))
+    assert_true(out.content.contains("{\"filename\":\"scripts/check.mbtx\"}"))
+    assert_true(out.content.contains("omit source"))
+    let path = "\{ws}/scripts/check.mbtx"
+    assert_eq(@fs.read_file(path).text(), source)
+    assert_true(
+      state.created_and_unchanged(path, @agent_tool.content_digest(source)),
+    )
+    assert_false(dispatch(tool, args).is_error)
+    assert_false(dispatch(tool, { "filename": "scripts/check.mbtx" }).is_error)
+    let out = dispatch(tool, {
+      "source": "fn main { println(99) }",
+      "filename": "scripts/check.mbtx",
+    })
+    assert_true(out.is_error)
+    assert_true(out.content.contains("different content"))
+    assert_eq(@fs.read_file(path).text(), source)
+    assert_false(
+      dispatch(tool, { "source": source, "filename": "check.mbtx" }).is_error,
+    )
+    assert_false(dispatch(tool, { "filename": "check.mbtx" }).is_error)
+  })
+}
+
+///|
+async test "saving rejects read-only, outside-workspace, namespace, and worker scope violations" {
+  @vfs.with_tmpdir(ws => {
+    @vfs.with_tmpdir(outside => {
+      let source = "fn main {}"
+      let read_only_tool = @mbtx.definition(workspace_root=ws, read_only=true)
+      assert_true(
+        dispatch(read_only_tool, { "source": source, "filename": "check.mbtx" }).is_error,
+      )
+      assert_false(@fs.exists("\{ws}/check.mbtx"))
+      let out = run_in(ws, {
+        "source": source,
+        "filename": "\{outside}/check.mbtx",
+      })
+      assert_true(out.is_error)
+      assert_false(@fs.exists("\{outside}/check.mbtx"))
+      assert_true(
+        run_in(ws, { "source": source, "filename": "@builtin/check.mbtx" }).is_error,
+      )
+      let scope = match
+        @write_scope.WriteScope::create(root=ws, allowed_paths=["allowed"]) {
+        Ok(scope) => scope
+        Err(reason) => fail(reason)
+      }
+      let worker = @mbtx.definition(workspace_root=ws, write_scope=scope)
+      assert_true(
+        dispatch(worker, { "source": source, "filename": "denied/check.mbtx" }).is_error,
+      )
+      assert_false(@fs.exists("\{ws}/denied"))
+      assert_false(
+        dispatch(worker, { "source": source, "filename": "allowed/check.mbtx" }).is_error,
+      )
+    })
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "saving refuses symlinks escaping the workspace" {
+  @vfs.with_tmpdir(ws => {
+    @vfs.with_tmpdir(outside => {
+      @fs.symlink(target=outside, "\{ws}/link")
+      let out = run_in(ws, {
+        "source": "fn main {}",
+        "filename": "link/check.mbtx",
+      })
+      assert_true(out.is_error)
+      assert_false(@fs.exists("\{outside}/check.mbtx"))
+    })
+  })
+}
+
+///|
 async test "bundled workflows use cwd and propagate check and test failures" {
   // Run this test with OPENSEEK_REFERENCES set to this checkout's share/ to
-  // exercise bare-name dispatch too. Ordinary suite runs use absolute paths.
+  // exercise @builtin/ dispatch too. Ordinary suite runs use absolute paths.
   let references = @fs.realpath("share")
   async fn workflow_filename(name : String) -> String {
     if @env.get_env_var("OPENSEEK_REFERENCES") == Some(references) {
-      name
+      "@builtin/\{name}"
     } else {
       @fs.realpath("share/workflow/\{name}")
     }
@@ -142,7 +227,10 @@ async test "filename reports read failures and refuses ambiguous calls" {
       arguments in [
         Json({ "filename": "missing.mbtx" }),
         Json({ "filename": ws }),
-        Json({ "source": "fn main { println(42) }", "filename": "missing.mbtx" }),
+        Json({
+          "source": "fn main { println(42) }",
+          "filename": "@builtin/check.mbtx",
+        }),
       ] {
       let out = run_in(ws, arguments)
       assert_true(out.is_error)
@@ -820,11 +908,19 @@ test "the description advertises the Proton CLI command surface" {
 
 ///|
 /// The schema is the model-facing argument contract, so pin its shape: the
-/// arguments the tool decodes are all present, with exactly one program input.
+/// arguments the tool decodes are all present, including save-and-run inputs.
 test "the schema advertises every decoded argument" {
   let JsonSchema(schema) = @mbtx.definition(workspace_root=".").schema
-  guard schema is { "properties": Object(properties), "oneOf": choices, .. } else {
-    fail("expected an object schema with properties and oneOf")
+  guard schema
+    is {
+      "properties": Object(properties),
+      "anyOf": choices,
+      "not": namespace_write,
+      ..
+    } else {
+    fail(
+      "expected an object schema with input choices and namespace write exclusion",
+    )
   }
   // Order-independent: `Map` iteration order is not the declaration order, and
   // MoonBit's String ordering is by length first, so a sorted expectation would
@@ -839,6 +935,14 @@ test "the schema advertises every decoded argument" {
     ([{ "required": ["source"] }, { "required": ["filename"] }] : Json),
   )
   assert_false(schema is { "required": _, .. })
+  assert_eq(
+    namespace_write,
+    (
+      {
+        "required": ["source", "filename"],
+        "properties": { "filename": { "pattern": "^@" } },
+      } : Json),
+  )
 }
 
 ///|

--- a/agent_tool/mbtx/moon.pkg
+++ b/agent_tool/mbtx/moon.pkg
@@ -11,6 +11,7 @@ import {
   "moonbitlang/async/fs",
   "moonbitlang/async/process",
   "moonbitlang/core/json",
+  "moonbitlang/core/env",
   "moonbitlang/core/encoding/utf8",
   "bobzhang/openseek_protocol",
   "bobzhang/openseek_protocol/emit",

--- a/agent_tool/mbtx/moon.pkg
+++ b/agent_tool/mbtx/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/agent_tool/write_scope",
   "bobzhang/openseek/agent_subrun/host",
   "bobzhang/openseek/agent_tool/bgjobs",
   "bobzhang/openseek/agent_runtime",

--- a/agent_tool/mbtx/pkg.generated.mbti
+++ b/agent_tool/mbtx/pkg.generated.mbti
@@ -6,10 +6,11 @@ import {
   "bobzhang/openseek/agent_subrun/host",
   "bobzhang/openseek/agent_tool",
   "bobzhang/openseek/agent_tool/bgjobs",
+  "bobzhang/openseek/agent_tool/write_scope",
 }
 
 // Values
-pub fn definition(workspace_root~ : String, read_only? : Bool, bg_runtime? : @bgjobs.BgJobRuntime, job_dir? : String, scratch_dir? : String, worker_sandbox? : WorkerSandbox, auto_background_after_ms? : Int, foreground_timeout_ms? : Int, build_timeout_ms? : Int, approval? : @agent_runtime.ApprovalChannel, subrun? : @host.SubrunInjection) -> @agent_tool.AgentToolDefinition
+pub fn definition(workspace_root~ : String, read_only? : Bool, file_state? : @agent_tool.FileStateMap, write_scope? : @write_scope.WriteScope, bg_runtime? : @bgjobs.BgJobRuntime, job_dir? : String, scratch_dir? : String, worker_sandbox? : WorkerSandbox, auto_background_after_ms? : Int, foreground_timeout_ms? : Int, build_timeout_ms? : Int, approval? : @agent_runtime.ApprovalChannel, subrun? : @host.SubrunInjection) -> @agent_tool.AgentToolDefinition
 
 // Errors
 

--- a/agent_tool/mbtx/save.mbt
+++ b/agent_tool/mbtx/save.mbt
@@ -1,0 +1,60 @@
+///|
+/// Save without clobbering user edits, using the same canonical containment
+/// checks as file tools and exclusive creation to reject a racing file.
+async fn save_script(
+  workspace_root : String,
+  filename : String,
+  source : String,
+  read_only~ : Bool,
+  file_state~ : @agent_tool.FileStateMap,
+  write_scope? : @write_scope.WriteScope,
+) -> Unit {
+  guard !read_only else {
+    fail(
+      "this read-only tool cannot save scripts. Run an existing filename without source, or use source alone",
+    )
+  }
+  let path = resolve_filename(workspace_root, filename, None)
+  let scope = match @write_scope.WriteScope::create(root=workspace_root) {
+    Ok(scope) => scope
+    Err(reason) => fail(reason)
+  }
+  async fn check_scope() {
+    if scope.deny_reason(path) is Some(reason) {
+      fail("save blocked: \{reason}")
+    }
+    if write_scope is Some(worker) && worker.deny_reason(path) is Some(reason) {
+      fail("save blocked: \{reason}")
+    }
+  }
+  check_scope()
+  if @fs.exists(path) {
+    let existing = @fs.read_file(path).text()
+    guard existing == source else {
+      fail(
+        "\{filename} already exists with different content; nothing was overwritten or run. Use the edit tool to change it, choose a new filename, or omit source to run the existing file",
+      )
+    }
+    return
+  }
+  if @workspace_path.parent_dir(path) is Some(parent) && !@fs.exists(parent) {
+    @fs.mkdir(parent, recursive=true)
+  }
+  check_scope()
+  @fs.write_file(path, source, create_mode=CreateNew)
+  file_state.record_created(path, @agent_tool.content_digest(source))
+}
+
+///|
+async fn check_builtin_containment(path : String, references : String) -> Unit {
+  let scope = match
+    @write_scope.WriteScope::create(
+      root=@workspace_path.resolve(references, "workflow"),
+    ) {
+    Ok(scope) => scope
+    Err(reason) => fail("bundled workflows unavailable: \{reason}")
+  }
+  if scope.deny_reason(path) is Some(reason) {
+    fail("bundled script must remain inside @builtin/: \{reason}")
+  }
+}

--- a/agent_tool/mbtx/save_wbtest.mbt
+++ b/agent_tool/mbtx/save_wbtest.mbt
@@ -1,0 +1,14 @@
+///|
+#cfg(not(platform="windows"))
+async test "builtin namespace refuses symlinks outside its root" {
+  @vfs.with_tmpdir(root => {
+    @fs.mkdir("\{root}/workflow")
+    @fs.write_file("\{root}/outside.mbtx", "fn main {}")
+    @fs.symlink(target="\{root}/outside.mbtx", "\{root}/workflow/escape.mbtx")
+    try check_builtin_containment("\{root}/workflow/escape.mbtx", root) catch {
+      error => assert_true(error.to_string().contains("inside @builtin/"))
+    } noraise {
+      _ => fail("namespace escape accepted")
+    }
+  })
+}

--- a/agent_worker/tool.mbt
+++ b/agent_worker/tool.mbt
@@ -157,7 +157,12 @@ pub async fn run_child(
     tools=captured => {
       Tools([
         @read.definition(workspace_root=input.worker_root),
-        @mbtx.definition(workspace_root=input.worker_root, worker_sandbox~),
+        @mbtx.definition(
+          workspace_root=input.worker_root,
+          worker_sandbox~,
+          file_state~,
+          write_scope~,
+        ),
         @edit.definition(
           workspace_root=input.worker_root,
           file_state~,

--- a/desktop/frontend/transcript/component/mbtx.mbt
+++ b/desktop/frontend/transcript/component/mbtx.mbt
@@ -4,7 +4,8 @@
 // shows the recorded JSON: the program arrives as one long line with every
 // newline spelled `\n`, so the one field a reader came for is the one field
 // they cannot read. The card below lifts `source` out as verbatim program text
-// and states the call's remaining arguments as chips above it.
+// and states the call's remaining arguments as chips above it. Saved-script
+// calls display the filename as plain text in their own Filename view.
 //
 // Nothing is hidden by that: the payload as the model actually sent it stays a
 // click away in the neighboring Original JSON tab. So the card is free to show
@@ -16,10 +17,15 @@
 // tool `is_error` means the run failed, not that the arguments were refused.
 
 ///|
+priv enum MbtxProgram {
+  Source(String)
+  Filename(String)
+}
+
+///|
 /// A recorded `mbtx` call, decoded for display.
 priv struct MbtxCall {
-  /// The `.mbtx` program, exactly as the model sent it.
-  source : String
+  program : MbtxProgram
   /// The call's other scalar arguments, as `key: value` chip text.
   chips : Array[String]
 }
@@ -27,7 +33,7 @@ priv struct MbtxCall {
 ///|
 /// Decode recorded `mbtx` arguments, or `None` when they are not a call
 /// this card can show: past the shared payload bound, not JSON, not an object,
-/// or carrying no program to display.
+/// or carrying no unambiguous program to display.
 ///
 /// Deliberately more permissive than the tool's own decoder — it does not
 /// re-check the target name, or that `warning` is `on`/`off`. Whether the call
@@ -36,10 +42,11 @@ priv struct MbtxCall {
 /// An argument with an unexpected value therefore still shows, as its own
 /// chip, which is what a reader looking at a rejected call needs to see.
 fn decode_mbtx_call(arguments : String) -> MbtxCall? {
-  guard card_fields(arguments) is Some(fields) &&
-    fields.get("source") is Some(String(source)) &&
-    !source.is_blank() else {
-    return None
+  guard card_fields(arguments) is Some(fields) else { return None }
+  let program = match (fields.get("source"), fields.get("filename")) {
+    (Some(String(source)), None) if !source.is_blank() => Source(source)
+    (None, Some(String(filename))) if !filename.is_blank() => Filename(filename)
+    _ => return None
   }
   let chips = scalar_chips(
     fields,
@@ -47,9 +54,9 @@ fn decode_mbtx_call(arguments : String) -> MbtxCall? {
     // removed `run_in_background` last so transcripts recorded by older
     // versions remain readable; new calls never emit it.
     known=["target", "cwd", "escalated", "warning", "run_in_background"],
-    dramatized=["source"],
+    dramatized=["source", "filename"],
   )
-  Some({ source, chips, })
+  Some({ program, chips, })
 }
 
 ///|
@@ -64,16 +71,20 @@ fn decode_mbtx_call(arguments : String) -> MbtxCall? {
 /// after its skip marker. Cost stays bounded without it — `card_fields`
 /// refuses payloads past the shared card ceiling, and the numbered renderer
 /// clamps a degenerate line count itself, keeping true numbers on the tail.
-fn mbtx_card(arguments : String) -> @html.Html? {
+fn mbtx_card(arguments : String) -> (String, @html.Html)? {
   guard decode_mbtx_call(arguments) is Some(call) else { return None }
-  Some(
-    @html.div(class="mbtx-args", [
-      chip_row(call.chips),
-      @html.pre(class="moonbit-source", [
-        @syntax_html.moonbit_numbered_source(call.source),
-      ]),
-    ]),
-  )
+  let (label, content) = match call.program {
+    Source(source) =>
+      (
+        "Source",
+        @html.pre(class="moonbit-source", [
+          @syntax_html.moonbit_numbered_source(source),
+        ]),
+      )
+    Filename(filename) =>
+      ("Filename", @html.pre(class="tool-card-original-json", filename))
+  }
+  Some((label, @html.div(class="mbtx-args", [chip_row(call.chips), content])))
 }
 
 ///|

--- a/desktop/frontend/transcript/component/mbtx.mbt
+++ b/desktop/frontend/transcript/component/mbtx.mbt
@@ -20,6 +20,7 @@
 priv enum MbtxProgram {
   Source(String)
   Filename(String)
+  Save(String, String)
 }
 
 ///|
@@ -46,6 +47,8 @@ fn decode_mbtx_call(arguments : String) -> MbtxCall? {
   let program = match (fields.get("source"), fields.get("filename")) {
     (Some(String(source)), None) if !source.is_blank() => Source(source)
     (None, Some(String(filename))) if !filename.is_blank() => Filename(filename)
+    (Some(String(source)), Some(String(filename))) if !source.is_blank() &&
+      !filename.is_blank() => Save(source, filename)
     _ => return None
   }
   let chips = scalar_chips(
@@ -74,6 +77,16 @@ fn decode_mbtx_call(arguments : String) -> MbtxCall? {
 fn mbtx_card(arguments : String) -> (String, @html.Html)? {
   guard decode_mbtx_call(arguments) is Some(call) else { return None }
   let (label, content) = match call.program {
+    Save(source, filename) =>
+      (
+        "Save & run",
+        @html.div([
+          @html.pre(class="tool-card-original-json", filename),
+          @html.pre(class="moonbit-source", [
+            @syntax_html.moonbit_numbered_source(source),
+          ]),
+        ]),
+      )
     Source(source) =>
       (
         "Source",

--- a/desktop/frontend/transcript/component/mbtx_wbtest.mbt
+++ b/desktop/frontend/transcript/component/mbtx_wbtest.mbt
@@ -5,8 +5,9 @@ test "an mbtx call decodes to its program and its arguments" {
   guard decode_mbtx_call(arguments) is Some(call) else {
     fail("expected a readable mbtx call")
   }
+  guard call.program is Source(source) else { fail("expected inline source") }
   assert_eq(
-    call.source,
+    source,
     (
       #|fn main {
       #|  println("hi")
@@ -14,6 +15,39 @@ test "an mbtx call decodes to its program and its arguments" {
     ),
   )
   assert_eq(call.chips, ["target: js", "cwd: sub/dir"])
+}
+
+///|
+test "a saved mbtx call displays a Filename variant" {
+  guard decode_mbtx_call(
+      (
+        #|{"filename":"scripts/check.mbtx","cwd":"subdir"}
+      ),
+    )
+    is Some(call) else {
+    fail("expected a saved script call")
+  }
+  assert_true(call.program is Filename("scripts/check.mbtx"))
+  assert_eq(call.chips, ["cwd: subdir"])
+  assert_true(decode_mbtx_call("{\"filename\":\"  \"}") is None)
+}
+
+///|
+test "mbtx tabs identify Source and Filename and leave ambiguous inputs as JSON" {
+  guard custom_card("mbtx", "{\"source\":\"fn main {}\"}")
+    is Some((source_label, _)) else {
+    fail("expected Source card")
+  }
+  assert_eq(source_label, "Source")
+  guard custom_card("mbtx", "{\"filename\":\"scripts/check.mbtx\"}")
+    is Some((file_label, _)) else {
+    fail("expected Filename card")
+  }
+  assert_eq(file_label, "Filename")
+  assert_true(
+    decode_mbtx_call("{\"source\":\"fn main {}\",\"filename\":\"check.mbtx\"}")
+    is None,
+  )
 }
 
 ///|

--- a/desktop/frontend/transcript/component/mbtx_wbtest.mbt
+++ b/desktop/frontend/transcript/component/mbtx_wbtest.mbt
@@ -33,7 +33,7 @@ test "a saved mbtx call displays a Filename variant" {
 }
 
 ///|
-test "mbtx tabs identify Source and Filename and leave ambiguous inputs as JSON" {
+test "mbtx tabs identify Source, Filename, and Save and run" {
   guard custom_card("mbtx", "{\"source\":\"fn main {}\"}")
     is Some((source_label, _)) else {
     fail("expected Source card")
@@ -46,8 +46,15 @@ test "mbtx tabs identify Source and Filename and leave ambiguous inputs as JSON"
   assert_eq(file_label, "Filename")
   assert_true(
     decode_mbtx_call("{\"source\":\"fn main {}\",\"filename\":\"check.mbtx\"}")
-    is None,
+    is Some({ program: Save("fn main {}", "check.mbtx"), .. }),
   )
+  guard custom_card(
+      "mbtx", "{\"source\":\"fn main {}\",\"filename\":\"check.mbtx\"}",
+    )
+    is Some((save_label, _)) else {
+    fail("expected Save & run card")
+  }
+  assert_eq(save_label, "Save & run")
 }
 
 ///|

--- a/desktop/frontend/transcript/component/tool_card.mbt
+++ b/desktop/frontend/transcript/component/tool_card.mbt
@@ -5,7 +5,7 @@
 // Every card needs the same two things around that shape: a row of chips for
 // the arguments it did not dramatize, and the recorded payload itself, so the
 // card is a reading of the call and never the only account of it.
-// `mbtx` uses the same pieces for its Program view.
+// `mbtx` uses the same pieces for its Source and Filename views.
 
 ///|
 /// The custom card for a tool whose arguments have a shape the recorded JSON
@@ -14,7 +14,7 @@
 /// so a card never has to invent a reading of a call it does not understand.
 fn custom_card(name : String, arguments : String) -> (String, @html.Html)? {
   match name {
-    "mbtx" => mbtx_card(arguments).map(card => ("Program", card))
+    "mbtx" => mbtx_card(arguments)
     "edit" => edit_card(arguments).map(card => ("Change", card))
     "multi_edit" => multi_edit_card(arguments).map(card => ("Changes", card))
     _ => None

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -51,6 +51,21 @@ bundled documentation is available.
 
 ## Running Commands
 
+The `mbtx` tool accepts these script forms:
+
+| Arguments | Behavior |
+| --- | --- |
+| `source="..."` | Run inline. |
+| `filename="check.mbtx"` | Run an existing workspace script. |
+| `source="...", filename="check.mbtx"` | Save in the workspace and run; reuse filename-only calls afterward. |
+| `filename="@builtin/check.mbtx"` | Run the bundled workflow under `OPENSEEK_REFERENCES/workflow/`. |
+
+Ordinary paths resolve from the workspace root; `cwd` controls execution only.
+Saving refuses to overwrite different existing content: use the edit tool to
+change a saved script. Namespaced scripts are read-only; never supply `source`
+with `@builtin/`. Only `@builtin/` is supported today; other namespaces are
+reserved. Use `./@builtin/check.mbtx` for a literal workspace path.
+
 There is no shell tool. Every command — `moon`, `git`, anything else — is
 spawned from a `mbtx` snippet through the shell-free
 `moonbitlang/async/shell` API. The `source` argument is a whole `.mbtx`

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -75,6 +75,21 @@ fn default_prompt() -> String {
     #|
     #|## Running Commands
     #|
+    #|The `mbtx` tool accepts these script forms:
+    #|
+    #|| Arguments | Behavior |
+    #|| --- | --- |
+    #|| `source="..."` | Run inline. |
+    #|| `filename="check.mbtx"` | Run an existing workspace script. |
+    #|| `source="...", filename="check.mbtx"` | Save in the workspace and run; reuse filename-only calls afterward. |
+    #|| `filename="@builtin/check.mbtx"` | Run the bundled workflow under `OPENSEEK_REFERENCES/workflow/`. |
+    #|
+    #|Ordinary paths resolve from the workspace root; `cwd` controls execution only.
+    #|Saving refuses to overwrite different existing content: use the edit tool to
+    #|change a saved script. Namespaced scripts are read-only; never supply `source`
+    #|with `@builtin/`. Only `@builtin/` is supported today; other namespaces are
+    #|reserved. Use `./@builtin/check.mbtx` for a literal workspace path.
+    #|
     #|There is no shell tool. Every command — `moon`, `git`, anything else — is
     #|spawned from a `mbtx` snippet through the shell-free
     #|`moonbitlang/async/shell` API. The `source` argument is a whole `.mbtx`

--- a/share/workflow/README.md
+++ b/share/workflow/README.md
@@ -11,7 +11,7 @@ this resource root's absolute path.
 - `info-fmt.mbtx` runs info then fmt, modifying generated interfaces and formatting.
 - `check-json.mbtx` relays `moon check --output-json` diagnostics without filtering.
 
-Call `mbtx(filename="check.mbtx")` (or another bundled name) and omit `source`. No file
+Call `mbtx(filename="@builtin/check.mbtx")` (or another bundled name) and omit `source`. No file
 creation is needed. `cwd` selects the module to check or test, defaulting to
 the workspace. The commands use project/toolchain target defaults, stream
 output, and fail when the underlying command fails. Follow repository-specific
@@ -20,7 +20,9 @@ validation commands when they differ from these defaults.
 Scripts use the ordinary mbtx sandbox and approval path. Read them with the
 file tools to inspect their behavior; save a customized copy in the workspace
 when needed. The bundled copies are installation resources and should not be
-edited. Bare names resolve under `OPENSEEK_REFERENCES/workflow/`; use
-`./check.mbtx` for a workspace file. Paths with separators and absolute paths
-retain their ordinary resolution. Missing bundled names do not fall back to
-workspace files. There is no special `@` filename syntax.
+edited. `@builtin/` resolves under `OPENSEEK_REFERENCES/workflow/` and refuses
+escaping paths. Ordinary names such as `check.mbtx` resolve from the workspace.
+Missing bundled names do not fall back to workspace files. Other `@namespace/`
+prefixes are reserved and currently rejected. To customize a script, save the
+modified source with an ordinary workspace filename; never send source with
+`@builtin/`.

--- a/share/workflow/README.md
+++ b/share/workflow/README.md
@@ -2,10 +2,8 @@
 
 These OpenSeek scripts ship in the toolchain payload's `share/workflow/`,
 alongside the official documentation in `share/doc/moonbit/`.
-`OPENSEEK_REFERENCES` points to `share/`.
-
-The scripts are packaged for future integration. The agent does not yet
-advertise or automatically select them, and no filename tool API is added here.
+`OPENSEEK_REFERENCES` points to `share/`; the engine's environment prompt gives
+this resource root's absolute path.
 
 - `check.mbtx` runs `moon check`.
 - `test.mbtx` runs `moon test` without updating snapshots.
@@ -13,8 +11,16 @@ advertise or automatically select them, and no filename tool API is added here.
 - `info-fmt.mbtx` runs info then fmt, modifying generated interfaces and formatting.
 - `check-json.mbtx` relays `moon check --output-json` diagnostics without filtering.
 
-The commands use project/toolchain target defaults, stream
+Call `mbtx(filename="check.mbtx")` (or another bundled name) and omit `source`. No file
+creation is needed. `cwd` selects the module to check or test, defaulting to
+the workspace. The commands use project/toolchain target defaults, stream
 output, and fail when the underlying command fails. Follow repository-specific
 validation commands when they differ from these defaults.
 
-The bundled copies are read-only installation resources.
+Scripts use the ordinary mbtx sandbox and approval path. Read them with the
+file tools to inspect their behavior; save a customized copy in the workspace
+when needed. The bundled copies are installation resources and should not be
+edited. Bare names resolve under `OPENSEEK_REFERENCES/workflow/`; use
+`./check.mbtx` for a workspace file. Paths with separators and absolute paths
+retain their ordinary resolution. Missing bundled names do not fall back to
+workspace files. There is no special `@` filename syntax.


### PR DESCRIPTION
The `mbtx` tool can now run an existing script with `filename`, or save a reusable workspace script by accepting `source` and `filename` together. Existing `mbtx(source=...)` calls keep their behavior. A successful save returns the filename-only call to use next; saving refuses to overwrite different existing content and respects workspace, read-only, and worker write restrictions.

Bundled workflows use explicit names such as `mbtx(filename="@builtin/check.mbtx")`, resolved under `OPENSEEK_REFERENCES/workflow/`. Ordinary filenames resolve from the workspace root, independently of execution `cwd`. Namespaced scripts are read-only, cannot escape their root, and cannot accompany `source`. Only `@builtin/` is implemented; other namespaces are reserved for future extensions.

The schema, recovery messages, tool description, static system prompt, generated prompt, documentation, and transcript cards describe these call forms consistently. Saved scripts use the same isolated execution and sandbox path as inline source. The bundled resources themselves come from merged #1401.

Validation:
- Self-reviewed path resolution, overwrite protection, worker restrictions, diagnostics, schema, and prompt consistency.
- All five workflows passed through actual `@builtin/...` calls, including execution-directory and failure propagation checks.
- `just test` passed with live API credentials and `OPENSEEK_REFERENCES` unset: 3,265 native tests, 3,229 JS tests, 24 cram cases, and both CLI integration checks.
- `just build`, `moon info`, `moon fmt`, `just check-prompt`, and `git diff --check` passed.
- `just check` remains blocked by 10 pre-existing unused-import errors on the installed Moon nightly; these were also present before this change.

No new A/B evaluation was run.
