### PR TITLE
fix(editor): keep documentation contrast consistent when folded

### DIFF
--- a/editor/internal/viewer/contrib/markdown_comments/browser/README.mbt.md
+++ b/editor/internal/viewer/contrib/markdown_comments/browser/README.mbt.md
@@ -16,8 +16,9 @@ accessible name `Original source`, reports the selected presentation through
 always reserves its trailing hit area, while a one-line separator constrains
 the control to the existing ViewZone height. Source controls appear on block
 hover or keyboard focus and remain visible while inspecting source. Documentation uses a subtle
-tinted surface, with smaller preview text. Leading item separators use whitespace instead of
-a horizontal stroke; interior Markdown rules remain visible. Separator-only
+tinted surface and the same prose foreground in preview and full modes.
+Leading item separators use whitespace instead of a horizontal stroke;
+interior Markdown rules remain visible. Separator-only
 blocks retain the editor background.
 Item-delimited multi-line API documents whose provider registration opted
 into folding start on the preview. Two affordances drive one fold state: a

--- a/editor/tests/browser/smoke/viewer.spec.js
+++ b/editor/tests/browser/smoke/viewer.spec.js
@@ -265,6 +265,52 @@ test('renders MoonBit documentation comments through the real workbench', async 
   );
 });
 
+test('keeps documentation colors consistent across folding states', async ({ page }, testInfo) => {
+  await page.goto('/');
+  await openWorkspaceFile(page, 'src/documentation.mbt');
+  const comments = page.locator('.moonbit-viewer-markdown-comment');
+  await expect(comments).toHaveCount(3);
+  const multiline = comments.nth(0);
+  const single = comments.nth(1);
+  const separator = comments.nth(2);
+  const preview = multiline.locator('.moonbit-viewer-markdown-comment-preview > p');
+  const full = multiline.locator('.moonbit-viewer-markdown-comment-full > p').first();
+  const singleText = single.locator('.moonbit-viewer-markdown-comment-full > p');
+  await expect(preview).toBeVisible();
+  await expect(singleText).toBeVisible();
+  for (const theme of ['dark', 'light']) {
+    if (theme === 'light') {
+      await page.getByRole('button', { name: 'Toggle color theme' }).click();
+    }
+    await expect(page.locator('.editor-shell')).toHaveAttribute('data-theme', theme);
+    const background = await single.evaluate(
+      (node) => getComputedStyle(node).backgroundColor,
+    );
+    const foreground = await singleText.evaluate(
+      (node) => getComputedStyle(node).color,
+    );
+    const screenshot = testInfo.outputPath(`documentation-${theme}.png`);
+    await page.screenshot({ path: screenshot });
+    await testInfo.attach(`documentation-${theme}`, {
+      path: screenshot,
+      contentType: 'image/png',
+    });
+    await expect(multiline).toHaveCSS('background-color', background);
+    await expect(preview).toHaveCSS('color', foreground);
+    await multiline.getByRole('button', { name: 'Expand API documentation' }).click();
+    await expect(full).toBeVisible();
+    await expect(full).toHaveCSS('color', foreground);
+    await expect(multiline).toHaveCSS('background-color', background);
+    await multiline.getByRole('button', { name: 'Collapse API documentation' }).click();
+    await expect(preview).toHaveCSS('color', foreground);
+    await expect(multiline).toHaveCSS('background-color', background);
+    const editorBackground = await page.locator('.overflow-guard').evaluate(
+      (node) => getComputedStyle(node).backgroundColor,
+    );
+    await expect(separator).toHaveCSS('background-color', editorBackground);
+  }
+});
+
 test('renders undocumented MoonBit item anchors as quiet spacing', async ({
   page,
 }) => {

--- a/editor/tests/fixtures/workspace/src/documentation.mbt
+++ b/editor/tests/fixtures/workspace/src/documentation.mbt
@@ -1,0 +1,12 @@
+///|
+/// Multi-line documentation summary.
+///
+/// Additional documentation shown on expansion.
+pub let documented_value : Int = 100
+
+///|
+/// Single-line documentation summary.
+pub let another_documented_value : Int = 10
+
+///|
+pub let undocumented_value : Int = 1

--- a/editor/viewer/contrib/markdown_comments/browser/markdown_comments.css
+++ b/editor/viewer/contrib/markdown_comments/browser/markdown_comments.css
@@ -72,9 +72,8 @@
   display: block;
 }
 
-.moonbit-viewer-markdown-comment-preview {
-  color: var(--vscode-descriptionForeground, var(--vscode-editor-foreground));
-}
+/* Folding changes content and geometry, not prose contrast. Inherit the same
+ * foreground as full and single-line documentation on the shared surface. */
 
 .moonbit-viewer-markdown-comment-preview > :not(hr) {
   overflow: hidden;


### PR DESCRIPTION
Collapsed multi-line MoonBit documentation looked dimmer than adjacent single-line documentation. Browser reproduction confirms that both panels already share the same background: the preview alone overrides the prose foreground with `descriptionForeground` (rgb(157, 157, 157) instead of rgb(204, 204, 204) in the shell's dark theme).

Remove that override so collapsed, expanded, and single-line prose share the same contrast. Preserve separator-only spacing. Desktop imports the same stylesheet, so no host API or adapter changes are needed.

Add a real-workbench fixture and browser regression covering background and foreground equality, expand/collapse round trips, separator backgrounds, and dark/light themes, with screenshots. The regression failed on the original preview foreground and passes after the fix.

Validation:

- `just check`, `just test`, `just build`
- `just editor-test` (Wasm 1083, JS 1867, Native 1217 passed)
- `just editor-test-browser` (104 passed), followed by the focused regression with added light-theme coverage
- Editor all-target warning-denying check; root/editor `moon info` and `moon fmt`; no generated interface changes

Native commands used `MOON_CC=/opt/homebrew/opt/llvm/bin/clang` because the system Apple Clang rejects an atomic switch in the existing async dependency.
