### PR TITLE
fix(editor): preserve ignored source alignment in semantic review

### DIFF
--- a/editor/internal/viewer/contrib/quick_diff/browser/quick_diff_model.mbt
+++ b/editor/internal/viewer/contrib/quick_diff/browser/quick_diff_model.mbt
@@ -30,5 +30,5 @@ pub fn compute_changes(
     TextSnapshot(original_lines.join("\n")),
     TextSnapshot(modified_lines.join("\n")),
     { ignore_trim_whitespace, },
-  ).changes
+  ).changes.map(change => change.mapping)
 }

--- a/editor/internal/viewer/contrib/quick_diff/common/quick_diff_wbtest.mbt
+++ b/editor/internal/viewer/contrib/quick_diff/common/quick_diff_wbtest.mbt
@@ -4,10 +4,10 @@ fn test_change(
   modified : Array[String],
 ) -> @diff.DetailedLineRangeMapping raise {
   let changes = @diff.LineDocumentDiffProvider().compute_diff(
-      TextSnapshot(original.join("\n")),
-      TextSnapshot(modified.join("\n")),
-      { ignore_trim_whitespace: false, },
-    ).changes
+    TextSnapshot(original.join("\n")),
+    TextSnapshot(modified.join("\n")),
+    { ignore_trim_whitespace: false, },
+  ).changes.map(change => change.mapping)
   assert_eq(changes.length(), 1)
   changes[0]
 }

--- a/editor/internal/viewer/diff_editor/alignment_geometry.mbt
+++ b/editor/internal/viewer/diff_editor/alignment_geometry.mbt
@@ -289,14 +289,14 @@ priv struct LineRangeAlignment {
   original_height_in_px : Double
   modified_height_in_px : Double
   /// The canonical diff that produced this alignment. Geometry-only
-  /// alignments (wrapping, foreign ViewZones, and additional alignments) keep
+  /// alignments (wrapping, foreign ViewZones, and ignored changes) keep
   /// this empty so Inline projection never mistakes them for deleted code.
   diff : @diff.DetailedLineRangeMapping?
 }
 
 ///|
 // Direct port of VS Code's computeRangeAlignment. The only addition is that
-// DiffState::alignments also yields geometry-only `additional_alignments` with
+// DiffState::alignments also yields Ignored changes with
 // `diff=None`; the algorithm itself is otherwise shared.
 fn compute_range_alignments(
   diff_state : DiffState,

--- a/editor/internal/viewer/diff_editor/alignment_geometry_wbtest.mbt
+++ b/editor/internal/viewer/diff_editor/alignment_geometry_wbtest.mbt
@@ -1,13 +1,32 @@
 ///|
 fn alignment_test_state(
   changes : Array[@diff.DetailedLineRangeMapping],
-  additional_alignments : Array[@diff.LineRangeMapping],
+  ignored_mappings : Array[@diff.LineRangeMapping],
   original_line_count : Int,
   modified_line_count : Int,
 ) -> DiffState {
   ignore(original_line_count)
   ignore(modified_line_count)
-  DiffState::from_diff_result({ changes, additional_alignments, })
+  let entries = changes.map(mapping => @diff.DocumentDiffChange(mapping))
+  entries.append(
+    ignored_mappings.map(mapping => {
+      DocumentDiffChange(
+        DetailedLineRangeMapping(mapping.original, mapping.modified, None),
+        kind=Ignored,
+      )
+    }),
+  )
+  entries.sort_by((left, right) => {
+    let old_order = left.mapping.original.start_line_number -
+      right.mapping.original.start_line_number
+    if old_order != 0 {
+      old_order
+    } else {
+      left.mapping.modified.start_line_number -
+      right.mapping.modified.start_line_number
+    }
+  })
+  DiffState::from_diff_result({ changes: entries, })
 }
 
 ///|
@@ -160,10 +179,10 @@ test "SideBySide replacement aligns rich comment zones instead of hidden source 
 }
 
 ///|
-test "additional alignment can align omitted geometry without a real change" {
+test "ignored changes align omitted geometry without visible differences" {
   let additional = @diff.LineRangeMapping(LineRange(2, 2), LineRange(2, 3))
   let diff_state = alignment_test_state([], [additional], 3, 4)
-  assert_eq(diff_state.mappings.length(), 0)
+  assert_eq(diff_state.visible_mappings().length(), 0)
   let spacers = compute_managed_alignment_spacers(
     diff_state,
     PaneGeometrySnapshot(3, 20.0),

--- a/editor/internal/viewer/diff_editor/diff_state.mbt
+++ b/editor/internal/viewer/diff_editor/diff_state.mbt
@@ -1,97 +1,47 @@
-// The renderer-facing state mirrors VS Code's DiffState/DiffMapping boundary.
-// A real change has exactly one canonical DetailedLineRangeMapping. The only
-// local extension is `additional_alignments`; those mappings are injected into
-// alignment computation and are deliberately absent from every visual feature.
+// All source changes share one ordered stream. Visible changes drive diff
+// features; ignored changes retain geometry without decorations or navigation.
 
 ///|
 pub struct DiffMapping {
+  kind : @diff.DocumentDiffChangeKind
   line_range_mapping : @diff.DetailedLineRangeMapping
 }
 
 ///|
 pub struct DiffState {
   mappings : Array[DiffMapping]
-  additional_alignments : Array[@diff.LineRangeMapping]
 }
 
 ///|
 fn DiffState::from_diff_result(result : @diff.DocumentDiff) -> DiffState {
   {
-    mappings: result.changes.map(change => { line_range_mapping: change, }),
-    additional_alignments: result.additional_alignments.copy(),
+    mappings: result.changes.map(change => {
+      kind: change.kind,
+      line_range_mapping: change.mapping,
+    }),
   }
 }
 
 ///|
-priv struct IndexedDiffAlignment {
-  source_index : Int
-  line_range_mapping : @diff.LineRangeMapping
-  diff : @diff.DetailedLineRangeMapping?
-}
-
-///|
-fn compare_line_range(
-  left : @base_common.LineRange,
-  right : @base_common.LineRange,
-) -> Int {
-  if left.start_line_number != right.start_line_number {
-    left.start_line_number - right.start_line_number
-  } else {
-    left.end_line_number_exclusive - right.end_line_number_exclusive
-  }
-}
-
-///|
-fn compare_indexed_diff_alignment(
-  left : IndexedDiffAlignment,
-  right : IndexedDiffAlignment,
-) -> Int {
-  let original = compare_line_range(
-    left.line_range_mapping.original,
-    right.line_range_mapping.original,
-  )
-  if original != 0 {
-    return original
-  }
-  let modified = compare_line_range(
-    left.line_range_mapping.modified,
-    right.line_range_mapping.modified,
-  )
-  if modified != 0 {
-    return modified
-  }
-  left.source_index - right.source_index
+fn DiffState::visible_mappings(self : DiffState) -> Array[DiffMapping] {
+  self.mappings.filter(mapping => mapping.kind is Visible)
 }
 
 ///|
 priv struct DiffAlignment {
   line_range_mapping : @diff.LineRangeMapping
-  /// `None` is the sole extension point: a geometry-only alignment must never
-  /// be mistaken for a visible diff mapping.
+  /// Ignored changes participate in geometry without visible diff features.
   diff : @diff.DetailedLineRangeMapping?
 }
 
 ///|
 fn DiffState::alignments(self : DiffState) -> Array[DiffAlignment] {
-  let indexed : Array[IndexedDiffAlignment] = []
-  for mapping in self.mappings {
-    indexed.push({
-      source_index: indexed.length(),
-      line_range_mapping: mapping.line_range_mapping.line_mapping(),
-      diff: Some(mapping.line_range_mapping),
-    })
-  }
-  for alignment in self.additional_alignments {
-    indexed.push({
-      source_index: indexed.length(),
-      line_range_mapping: alignment,
-      diff: None,
-    })
-  }
-  indexed.sort_by(compare_indexed_diff_alignment)
-  indexed.map(item => {
-    line_range_mapping: item.line_range_mapping,
-    diff: item.diff,
+  self.mappings.map(mapping => {
+    line_range_mapping: mapping.line_range_mapping.line_mapping(),
+    diff: match mapping.kind {
+      Visible => Some(mapping.line_range_mapping)
+      Ignored => None
+    },
   })
 }
 
@@ -114,7 +64,7 @@ fn DiffState::navigation_changes(
   self : DiffState,
 ) -> Array[@diff.DetailedLineRangeMapping] {
   let result : Array[@diff.DetailedLineRangeMapping] = []
-  for mapping in self.mappings {
+  for mapping in self.visible_mappings() {
     let change = mapping.line_range_mapping
     if result.is_empty() {
       result.push(change)

--- a/editor/internal/viewer/diff_editor/diff_state_wbtest.mbt
+++ b/editor/internal/viewer/diff_editor/diff_state_wbtest.mbt
@@ -17,8 +17,7 @@ test "DiffState preserves canonical provider order" {
   let first = diff_state_test_change(1, 1, 1, 2)
   let second = diff_state_test_change(3, 4, 4, 5)
   let state = DiffState::from_diff_result({
-    changes: [first, second],
-    additional_alignments: [],
+    changes: [DocumentDiffChange(first), DocumentDiffChange(second)],
   })
   assert_eq(state.mappings[0].line_range_mapping, first)
   assert_eq(state.mappings[1].line_range_mapping, second)
@@ -28,10 +27,9 @@ test "DiffState preserves canonical provider order" {
 test "Accessible F7 groups mappings whose three-line contexts overlap" {
   let state = DiffState::from_diff_result({
     changes: [
-      diff_state_test_change(2, 3, 2, 3),
-      diff_state_test_change(7, 8, 7, 8),
+      DocumentDiffChange(diff_state_test_change(2, 3, 2, 3)),
+      DocumentDiffChange(diff_state_test_change(7, 8, 7, 8)),
     ],
-    additional_alignments: [],
   })
   let groups = state.navigation_changes()
   assert_eq(state.mappings.length(), 2)
@@ -49,10 +47,9 @@ test "Accessible F7 groups mappings whose three-line contexts overlap" {
 test "Accessible F7 keeps mappings separate at an exact six-line gap" {
   let state = DiffState::from_diff_result({
     changes: [
-      diff_state_test_change(2, 3, 2, 3),
-      diff_state_test_change(9, 10, 9, 10),
+      DocumentDiffChange(diff_state_test_change(2, 3, 2, 3)),
+      DocumentDiffChange(diff_state_test_change(9, 10, 9, 10)),
     ],
-    additional_alignments: [],
   })
   assert_eq(state.navigation_changes().length(), 2)
   assert_eq(
@@ -65,12 +62,11 @@ test "Accessible F7 keeps mappings separate at an exact six-line gap" {
 test "grouped F7 navigation starts at the modified cursor and wraps" {
   let state = DiffState::from_diff_result({
     changes: [
-      diff_state_test_change(2, 3, 2, 3),
-      diff_state_test_change(6, 7, 6, 6),
-      diff_state_test_change(12, 13, 12, 13),
-      diff_state_test_change(19, 20, 19, 20),
+      DocumentDiffChange(diff_state_test_change(2, 3, 2, 3)),
+      DocumentDiffChange(diff_state_test_change(6, 7, 6, 6)),
+      DocumentDiffChange(diff_state_test_change(12, 13, 12, 13)),
+      DocumentDiffChange(diff_state_test_change(19, 20, 19, 20)),
     ],
-    additional_alignments: [],
   })
   // The first two mappings form one group; the later exact-six-line gaps do
   // not. Selection remains relative to each group's modified start line.
@@ -103,10 +99,9 @@ test "grouped F7 navigation starts at the modified cursor and wraps" {
 test "multi-diff navigation detects an item boundary without wrapping" {
   let state = DiffState::from_diff_result({
     changes: [
-      diff_state_test_change(2, 3, 2, 3),
-      diff_state_test_change(9, 10, 9, 10),
+      DocumentDiffChange(diff_state_test_change(2, 3, 2, 3)),
+      DocumentDiffChange(diff_state_test_change(9, 10, 9, 10)),
     ],
-    additional_alignments: [],
   })
   assert_eq(
     state.next_change_from_modified_line_without_wrap(2).unwrap().change_index,
@@ -123,8 +118,7 @@ test "multi-diff navigation detects an item boundary without wrapping" {
 ///|
 test "multi-diff next includes an EOF deletion anchor" {
   let state = DiffState::from_diff_result({
-    changes: [diff_state_test_change(11, 12, 11, 11)],
-    additional_alignments: [],
+    changes: [DocumentDiffChange(diff_state_test_change(11, 12, 11, 11))],
   })
   assert_eq(
     state.next_change_from_modified_line_without_wrap(10).unwrap().change_index,
@@ -136,10 +130,9 @@ test "multi-diff next includes an EOF deletion anchor" {
 test "next F7 at the last modified line wraps before an EOF deletion anchor" {
   let state = DiffState::from_diff_result({
     changes: [
-      diff_state_test_change(2, 3, 2, 3),
-      diff_state_test_change(11, 12, 11, 11),
+      DocumentDiffChange(diff_state_test_change(2, 3, 2, 3)),
+      DocumentDiffChange(diff_state_test_change(11, 12, 11, 11)),
     ],
-    additional_alignments: [],
   })
   assert_eq(
     state.next_change_from_modified_line(10, 10).unwrap().change_index,
@@ -151,10 +144,9 @@ test "next F7 at the last modified line wraps before an EOF deletion anchor" {
 test "standalone deletion navigation retains an empty modified anchor" {
   let state = DiffState::from_diff_result({
     changes: [
-      diff_state_test_change(2, 3, 2, 3),
-      diff_state_test_change(9, 10, 9, 9),
+      DocumentDiffChange(diff_state_test_change(2, 3, 2, 3)),
+      DocumentDiffChange(diff_state_test_change(9, 10, 9, 9)),
     ],
-    additional_alignments: [],
   })
   let deletion = state.next_change_from_modified_line(2, 10).unwrap()
   assert_eq(deletion.change_index, 1)
@@ -179,8 +171,7 @@ test "real-widget-sized navigation projection groups fifty-seven mappings into t
     }
   }
   let state = DiffState::from_diff_result({
-    changes,
-    additional_alignments: [],
+    changes: changes.map(mapping => DocumentDiffChange(mapping)),
   })
   assert_eq(state.mappings.length(), 57)
   assert_eq(state.navigation_changes().length(), 31)
@@ -192,25 +183,55 @@ test "real-widget-sized navigation projection groups fifty-seven mappings into t
 
 ///|
 test "cursor-relative navigation has no target for an empty diff" {
-  let state = DiffState::from_diff_result({
-    changes: [],
-    additional_alignments: [],
-  })
+  let state = DiffState::from_diff_result({ changes: [], })
   assert_true(state.next_change_from_modified_line(1, 1) is None)
   assert_true(state.previous_change_from_modified_line(1) is None)
 }
 
 ///|
-test "additional alignments enter geometry only" {
+test "ignored changes enter geometry only" {
   let change = diff_state_test_change(1, 2, 1, 2)
   let additional = @diff.LineRangeMapping(LineRange(3, 3), LineRange(3, 4))
   let state = DiffState::from_diff_result({
-    changes: [change],
-    additional_alignments: [additional],
+    changes: [
+      DocumentDiffChange(change),
+      DocumentDiffChange(
+        DetailedLineRangeMapping(additional.original, additional.modified, None),
+        kind=Ignored,
+      ),
+    ],
   })
-  assert_eq(state.mappings.length(), 1)
+  assert_eq(state.visible_mappings().length(), 1)
   assert_eq(state.alignments().length(), 2)
   assert_eq(state.alignments()[0].diff, Some(change))
   assert_eq(state.alignments()[1].line_range_mapping, additional)
   assert_true(state.alignments()[1].diff is None)
+}
+
+///|
+test "navigation counts and targets exclude ignored changes at both ends and between hunks" {
+  let first = diff_state_test_change(10, 11, 10, 11)
+  let last = diff_state_test_change(30, 31, 30, 31)
+  let state = DiffState::from_diff_result({
+    changes: [
+      DocumentDiffChange(diff_state_test_change(1, 2, 1, 2), kind=Ignored),
+      DocumentDiffChange(first),
+      DocumentDiffChange(diff_state_test_change(20, 21, 20, 21), kind=Ignored),
+      DocumentDiffChange(last),
+      DocumentDiffChange(diff_state_test_change(40, 41, 40, 41), kind=Ignored),
+    ],
+  })
+  assert_eq(state.navigation_changes(), [first, last])
+  let next = state.next_change_from_modified_line(10, 50).unwrap()
+  assert_eq(next.change_index, 1)
+  assert_eq(next.change_count, 2)
+  assert_eq(next.change, last)
+  assert_eq(state.previous_change_from_modified_line(30).unwrap().change, first)
+  assert_true(state.next_change_from_modified_line_without_wrap(30) is None)
+  assert_true(state.previous_change_from_modified_line_without_wrap(10) is None)
+  let ignored = DiffState::from_diff_result({
+    changes: [DocumentDiffChange(first, kind=Ignored)],
+  })
+  assert_true(ignored.next_change_from_modified_line(1, 50) is None)
+  assert_true(ignored.previous_change_from_modified_line(50) is None)
 }

--- a/editor/internal/viewer/diff_editor/inline_deleted_lines.mbt
+++ b/editor/internal/viewer/diff_editor/inline_deleted_lines.mbt
@@ -63,6 +63,7 @@ fn inline_alignment_spacer_spec(
   after_line_number : Int,
   height_in_px : Double,
   pane_class : String,
+  ordinal~ : Int,
 ) -> @code_widget.ManagedCodeEditorViewZoneSpec {
   let document = @rdom.document()
   let node = document.create_element("div")
@@ -71,7 +72,9 @@ fn inline_alignment_spacer_spec(
     "moonbit-diff-editor-alignment-spacer \{pane_class}",
   )
   node.set_attribute("aria-hidden", "true")
-  ManagedCodeEditorViewZoneSpec(after_line_number, height_in_px, node)
+  // Spacers and deleted code can share an anchor. Use their common alignment
+  // order so ignored source rows stay before the following deleted code.
+  ManagedCodeEditorViewZoneSpec(after_line_number, height_in_px, node, ordinal~)
 }
 
 ///|
@@ -146,6 +149,7 @@ fn inline_deleted_view_zone_specs(
             alignment.original_range.end_line_number_exclusive - 1,
             delta,
             "moonbit-diff-editor-inline-original-alignment-spacer",
+            ordinal=alignment_index,
           ),
         )
       } else if delta < -0.01 {
@@ -154,6 +158,7 @@ fn inline_deleted_view_zone_specs(
             alignment.modified_range.end_line_number_exclusive - 1,
             -delta,
             "moonbit-diff-editor-inline-modified-alignment-spacer",
+            ordinal=alignment_index,
           ),
         )
       }
@@ -191,6 +196,7 @@ fn inline_deleted_view_zone_specs(
                   alignment.original_range.start_line_number + model_line_index,
                   (view_line_count - 1).to_double() * line_height,
                   "moonbit-diff-editor-inline-original-continuation-spacer",
+                  ordinal=alignment_index,
                 ),
               )
             }
@@ -227,6 +233,7 @@ fn inline_deleted_view_zone_specs(
           alignment.original_range.end_line_number_exclusive - 1,
           original_companion_height,
           "moonbit-diff-editor-inline-original-companion-spacer",
+          ordinal=alignment_index,
         ),
       )
     }
@@ -236,6 +243,7 @@ fn inline_deleted_view_zone_specs(
           alignment.modified_range.end_line_number_exclusive - 1,
           modified_compensation_height,
           "moonbit-diff-editor-inline-modified-companion-spacer",
+          ordinal=alignment_index,
         ),
       )
     }

--- a/editor/internal/viewer/diff_editor/overview_projection.mbt
+++ b/editor/internal/viewer/diff_editor/overview_projection.mbt
@@ -36,7 +36,7 @@ fn original_diff_overview_ruler_entries(
   diff_state : DiffState,
 ) -> Array[@code_widget.CodeEditorOverviewRulerEntry] {
   let entries : Array[@code_widget.CodeEditorOverviewRulerEntry] = []
-  for change_index, mapping in diff_state.mappings {
+  for change_index, mapping in diff_state.visible_mappings() {
     let range = mapping.line_range_mapping.original
     if !range.is_empty() {
       entries.push({
@@ -55,7 +55,7 @@ fn modified_diff_overview_ruler_entries(
   diff_state : DiffState,
 ) -> Array[@code_widget.CodeEditorOverviewRulerEntry] {
   let entries : Array[@code_widget.CodeEditorOverviewRulerEntry] = []
-  for change_index, mapping in diff_state.mappings {
+  for change_index, mapping in diff_state.visible_mappings() {
     let range = mapping.line_range_mapping.modified
     if !range.is_empty() {
       entries.push({

--- a/editor/internal/viewer/diff_editor/overview_projection_wbtest.mbt
+++ b/editor/internal/viewer/diff_editor/overview_projection_wbtest.mbt
@@ -16,8 +16,15 @@ test "overview rulers keep original and modified model coordinates separate" {
     None,
   )
   let diff_state = DiffState::from_diff_result({
-    changes: [insert, modify, delete],
-    additional_alignments: [LineRangeMapping(LineRange(6, 6), LineRange(6, 7))],
+    changes: [
+      DocumentDiffChange(insert),
+      DocumentDiffChange(
+        DetailedLineRangeMapping(LineRange(1, 2), LineRange(2, 2), None),
+        kind=Ignored,
+      ),
+      DocumentDiffChange(modify),
+      DocumentDiffChange(delete),
+    ],
   })
 
   assert_eq(original_diff_overview_ruler_entries(diff_state), [

--- a/editor/internal/viewer/diff_editor/pkg.generated.mbti
+++ b/editor/internal/viewer/diff_editor/pkg.generated.mbti
@@ -182,12 +182,12 @@ pub fn DiffEditorWidget::set_scroll_left(Self, Double) -> Unit
 pub fn DiffEditorWidget::update_options(Self, @code_editor_widget.CodeEditorOptions, DiffEditorOptions) -> Unit
 
 pub struct DiffMapping {
+  kind : @diff.DocumentDiffChangeKind
   line_range_mapping : @diff.DetailedLineRangeMapping
 }
 
 pub struct DiffState {
   mappings : Array[DiffMapping]
-  additional_alignments : Array[@diff.LineRangeMapping]
 }
 
 pub(all) enum DiffWordWrap {

--- a/editor/internal/viewer/diff_editor/view_model_wbtest.mbt
+++ b/editor/internal/viewer/diff_editor/view_model_wbtest.mbt
@@ -122,59 +122,64 @@ impl @diff.DocumentDiffProvider for FakeDocumentDiffProvider with fn compute_dif
     None => ()
   }
   match self.result.val {
-    Empty => { changes: [], additional_alignments: [], }
+    Empty => { changes: [], }
     OneChange => {
       let original_range = @base_common.LineRange(1, 2)
       let modified_range = @base_common.LineRange(1, 2)
       {
         changes: [
-          DetailedLineRangeMapping(original_range, modified_range, None),
+          DocumentDiffChange(
+            DetailedLineRangeMapping(original_range, modified_range, None),
+          ),
         ],
-        additional_alignments: [],
       }
     }
     InvalidLineMapping =>
       {
         changes: [
-          DetailedLineRangeMapping(LineRange(0, 2), LineRange(1, 2), None),
+          DocumentDiffChange(
+            DetailedLineRangeMapping(LineRange(0, 2), LineRange(1, 2), None),
+          ),
         ],
-        additional_alignments: [],
       }
     InvalidInnerMapping =>
       {
         changes: [
-          DetailedLineRangeMapping(
-            LineRange(1, 2),
-            LineRange(1, 2),
-            Some([RangeMapping(Range(1, 1, 1, 99), Range(1, 1, 1, 2))]),
+          DocumentDiffChange(
+            DetailedLineRangeMapping(
+              LineRange(1, 2),
+              LineRange(1, 2),
+              Some([RangeMapping(Range(1, 1, 1, 99), Range(1, 1, 1, 2))]),
+            ),
           ),
         ],
-        additional_alignments: [],
       }
     InnerOutsideParent =>
       {
         changes: [
-          DetailedLineRangeMapping(
-            LineRange(1, 2),
-            LineRange(1, 2),
-            Some([RangeMapping(Range(2, 1, 2, 2), Range(1, 1, 1, 2))]),
+          DocumentDiffChange(
+            DetailedLineRangeMapping(
+              LineRange(1, 2),
+              LineRange(1, 2),
+              Some([RangeMapping(Range(2, 1, 2, 2), Range(1, 1, 1, 2))]),
+            ),
           ),
         ],
-        additional_alignments: [],
       }
     OverlappingInnerMappings =>
       {
         changes: [
-          DetailedLineRangeMapping(
-            LineRange(1, 2),
-            LineRange(1, 2),
-            Some([
-              RangeMapping(Range(1, 1, 1, 3), Range(1, 1, 1, 3)),
-              RangeMapping(Range(1, 2, 1, 3), Range(1, 2, 1, 3)),
-            ]),
+          DocumentDiffChange(
+            DetailedLineRangeMapping(
+              LineRange(1, 2),
+              LineRange(1, 2),
+              Some([
+                RangeMapping(Range(1, 1, 1, 3), Range(1, 1, 1, 3)),
+                RangeMapping(Range(1, 2, 1, 3), Range(1, 2, 1, 3)),
+              ]),
+            ),
           ),
         ],
-        additional_alignments: [],
       }
     Failure => raise FakeDocumentDiffProviderError::ComputeFailed
   }
@@ -406,8 +411,8 @@ test "validator accepts Line inner anchors on empty hunk sides" {
     ignore_trim_whitespace: true,
   })
   assert_eq(result.changes.length(), 2)
-  assert_true(result.changes[0].modified.is_empty())
-  assert_true(result.changes[1].original.is_empty())
+  assert_true(result.changes[0].mapping.modified.is_empty())
+  assert_true(result.changes[1].mapping.original.is_empty())
   assert_true(
     @diff.normalize_and_validate_document_diff(result, original, modified)
     is Some(_),
@@ -458,7 +463,7 @@ test "ViewModel accepts pinned newline mapping for a pure deletion" {
 
   assert_true(view_model.get_state() == Ready)
   assert_true(view_model.get_failure_diagnostic() is None)
-  guard view_model.get_diff() is Some({ changes: [change], .. }) &&
+  guard view_model.get_diff() is Some({ changes: [{ mapping: change, .. }], }) &&
     change.inner_changes is Some([inner]) else {
     fail("expected one normalized pure-deletion mapping")
   }
@@ -489,7 +494,7 @@ test "ViewModel accepts pinned newline mapping for a pure insertion" {
 
   assert_true(view_model.get_state() == Ready)
   assert_true(view_model.get_failure_diagnostic() is None)
-  guard view_model.get_diff() is Some({ changes: [change], .. }) &&
+  guard view_model.get_diff() is Some({ changes: [{ mapping: change, .. }], }) &&
     change.inner_changes is Some([inner]) else {
     fail("expected one normalized pure-insertion mapping")
   }
@@ -509,13 +514,14 @@ test "validator rejects newline anchor over non-empty empty-hunk line" {
   let modified = @model.TextSnapshot("not empty\nkeep")
   let invalid : @diff.DocumentDiff = {
     changes: [
-      DetailedLineRangeMapping(
-        LineRange(1, 2),
-        LineRange(1, 1),
-        Some([RangeMapping(Range(1, 1, 2, 1), Range(1, 1, 2, 1))]),
+      DocumentDiffChange(
+        DetailedLineRangeMapping(
+          LineRange(1, 2),
+          LineRange(1, 1),
+          Some([RangeMapping(Range(1, 1, 2, 1), Range(1, 1, 2, 1))]),
+        ),
       ),
     ],
-    additional_alignments: [],
   }
 
   assert_true(
@@ -530,19 +536,20 @@ test "ViewModel normalizes full-line inner mappings like VS Code" {
   let modified = @model.TextSnapshot("new\nkeep")
   let result : @diff.DocumentDiff = {
     changes: [
-      DetailedLineRangeMapping(
-        LineRange(1, 2),
-        LineRange(1, 2),
-        Some([RangeMapping(Range(1, 1, 1, 4), Range(1, 1, 1, 4))]),
+      DocumentDiffChange(
+        DetailedLineRangeMapping(
+          LineRange(1, 2),
+          LineRange(1, 2),
+          Some([RangeMapping(Range(1, 1, 1, 4), Range(1, 1, 1, 4))]),
+        ),
       ),
     ],
-    additional_alignments: [],
   }
   guard @diff.normalize_and_validate_document_diff(result, original, modified)
     is Some(normalized) else {
     fail("expected a valid normalized document diff")
   }
-  guard normalized.changes[0].inner_changes is Some([inner]) else {
+  guard normalized.changes[0].mapping.inner_changes is Some([inner]) else {
     fail("expected normalized inner mapping")
   }
   assert_eq(inner.original, Range(1, 1, 2, 1))
@@ -559,19 +566,20 @@ test "normalization extends an empty-line anchor only with its full-line peer" {
   let modified = @model.TextSnapshot("\nkeep")
   let raw : @diff.DocumentDiff = {
     changes: [
-      DetailedLineRangeMapping(
-        LineRange(1, 2),
-        LineRange(1, 1),
-        Some([RangeMapping(Range(1, 1, 1, 8), Range(1, 1, 1, 1))]),
+      DocumentDiffChange(
+        DetailedLineRangeMapping(
+          LineRange(1, 2),
+          LineRange(1, 1),
+          Some([RangeMapping(Range(1, 1, 1, 8), Range(1, 1, 1, 1))]),
+        ),
       ),
     ],
-    additional_alignments: [],
   }
   guard @diff.normalize_and_validate_document_diff(raw, original, modified)
     is Some(normalized) else {
     fail("expected a valid normalized deletion mapping")
   }
-  guard normalized.changes[0].inner_changes is Some([inner]) else {
+  guard normalized.changes[0].mapping.inner_changes is Some([inner]) else {
     fail("expected normalized deletion mapping")
   }
   assert_eq(inner.original, Range(1, 1, 2, 1))
@@ -588,18 +596,24 @@ test "ViewModel rejects touching provider rows that were not grouped" {
   let modified = @model.TextSnapshot("new one\nnew two\nkeep")
   let fragmented : @diff.DocumentDiff = {
     changes: [
-      DetailedLineRangeMapping(LineRange(1, 2), LineRange(1, 2), None),
-      DetailedLineRangeMapping(LineRange(2, 3), LineRange(2, 3), None),
+      DocumentDiffChange(
+        DetailedLineRangeMapping(LineRange(1, 2), LineRange(1, 2), None),
+      ),
+      DocumentDiffChange(
+        DetailedLineRangeMapping(LineRange(2, 3), LineRange(2, 3), None),
+      ),
     ],
-    additional_alignments: [],
   }
   assert_true(
     @diff.normalize_and_validate_document_diff(fragmented, original, modified)
     is None,
   )
   let grouped : @diff.DocumentDiff = {
-    changes: [DetailedLineRangeMapping(LineRange(1, 3), LineRange(1, 3), None)],
-    additional_alignments: [],
+    changes: [
+      DocumentDiffChange(
+        DetailedLineRangeMapping(LineRange(1, 3), LineRange(1, 3), None),
+      ),
+    ],
   }
   assert_true(
     @diff.normalize_and_validate_document_diff(grouped, original, modified)
@@ -613,13 +627,14 @@ test "normalization leaves invalid provider coordinates for validation" {
   let modified = @model.TextSnapshot("new\nkeep")
   let invalid : @diff.DocumentDiff = {
     changes: [
-      DetailedLineRangeMapping(
-        LineRange(1, 2),
-        LineRange(1, 2),
-        Some([RangeMapping(Range(1, 1, 99, 1), Range(1, 1, 99, 1))]),
+      DocumentDiffChange(
+        DetailedLineRangeMapping(
+          LineRange(1, 2),
+          LineRange(1, 2),
+          Some([RangeMapping(Range(1, 1, 99, 1), Range(1, 1, 99, 1))]),
+        ),
       ),
     ],
-    additional_alignments: [],
   }
   assert_true(
     @diff.normalize_and_validate_document_diff(invalid, original, modified)

--- a/editor/internal/viewer/diff_editor/widget.mbt
+++ b/editor/internal/viewer/diff_editor/widget.mbt
@@ -813,7 +813,7 @@ fn DiffEditorWidget::apply_diff_state_decorations(
   let modified_snapshot = model.modified.snapshot()
   let original_decorations : Array[@model.ModelDeltaDecoration] = []
   let modified_decorations : Array[@model.ModelDeltaDecoration] = []
-  for mapping in diff_state.mappings {
+  for mapping in diff_state.visible_mappings() {
     let change = mapping.line_range_mapping
     let original_range = changed_line_range(change.original, original_snapshot)
     let modified_range = changed_line_range(change.modified, modified_snapshot)
@@ -1673,9 +1673,10 @@ fn DiffEditorWidget::try_reveal_first_diff(self : DiffEditorWidget) -> Unit {
   }
   guard self.diff_state is Some(diff_state) else { return }
   self.pending_reveal_first_diff_generation = None
-  if !diff_state.mappings.is_empty() {
+  let visible = diff_state.visible_mappings()
+  if !visible.is_empty() {
     self.reveal_change(
-      diff_state.mappings[0].line_range_mapping,
+      visible[0].line_range_mapping,
       source="diffEditor.revealFirstDiff",
     )
     |> ignore
@@ -1725,9 +1726,10 @@ fn DiffEditorWidget::try_reveal_last_diff(self : DiffEditorWidget) -> Unit {
   }
   guard self.diff_state is Some(diff_state) else { return }
   self.pending_reveal_last_diff_generation = None
-  guard !diff_state.mappings.is_empty() else { return }
+  let visible = diff_state.visible_mappings()
+  guard !visible.is_empty() else { return }
   self.reveal_change(
-    diff_state.mappings[diff_state.mappings.length() - 1].line_range_mapping,
+    visible[visible.length() - 1].line_range_mapping,
     source="diffEditor.revealLastDiff",
   )
   |> ignore

--- a/editor/tests/browser/component/diff_editor_lifecycle.spec.js
+++ b/editor/tests/browser/component/diff_editor_lifecycle.spec.js
@@ -547,3 +547,53 @@ test('renderIndicators removes only split and inline glyphs while retaining diff
 
   await disposeDiffLifecycle(page);
 });
+
+
+for (const layout of ['split', 'inline']) {
+  test(`ignored changes retain ${layout} geometry without visible markers`, async ({ page }) => {
+    const root = await openDiffLifecycle(page);
+    await setDiffLifecycleFixture(page, 'ignored');
+    await setDiffLifecycleOptions(page, { layout, renderIndicators: true });
+    const original = root.locator('.moonbit-diff-editor-original');
+    const modified = root.locator('.moonbit-diff-editor-modified');
+    const bands = root.locator('[data-diff-overview-side="modified"]');
+    const deleted = root.locator('.diff-editor-inline-deleted-block');
+
+    for (const provider of ['ignored', 'core', 'ignored']) {
+      await page.evaluate((kind) =>
+        globalThis.__diffEditorLifecycleControls.set_provider(kind), provider);
+      await expect(root).not.toHaveAttribute('data-diff-failure');
+      if (provider === 'core') {
+        await expect.poll(async () => Number(await bands.getAttribute(
+          'data-overview-ruler-band-count'))).toBeGreaterThan(1);
+        if (layout === 'inline') {
+          await expect(deleted.filter({ hasText: '// removed' })).toHaveCount(1);
+        }
+        continue;
+      }
+      await expect(bands).toHaveAttribute('data-overview-ruler-band-count', '1');
+      await expect(modified.locator('.diff-editor-line-insert')).toHaveCount(1);
+      if (layout === 'split') {
+        await expect(original.locator('.diff-editor-line-delete')).toHaveCount(1);
+        // Inserted/deleted ignored rows still contribute spacers, so retained
+        // source anchors after both edits must line up in the actual DOM.
+        for (const text of ['keep', 'last', 'end']) {
+          const oldLine = original.locator('.view-line').filter({ hasText: new RegExp(`^${text}$`) });
+          const newLine = modified.locator('.view-line').filter({ hasText: new RegExp(`^${text}$`) });
+          await expect.poll(async () => {
+            const a = await oldLine.boundingBox();
+            const b = await newLine.boundingBox();
+            return a && b ? Math.abs(a.y - b.y) : Number.POSITIVE_INFINITY;
+          }).toBeLessThanOrEqual(1);
+        }
+      } else {
+        await expect(deleted).toHaveCount(1);
+        await expect(deleted).toContainText('old value');
+        await expect(deleted).not.toContainText('// removed');
+        await expect(deleted).not.toContainText('// tail old');
+        await expect(modified.locator('.view-line').filter({ hasText: '// inserted' })).toBeVisible();
+      }
+    }
+    await disposeDiffLifecycle(page);
+  });
+}

--- a/editor/tests/browser/component/diff_editor_lifecycle.spec.js
+++ b/editor/tests/browser/component/diff_editor_lifecycle.spec.js
@@ -592,6 +592,15 @@ for (const layout of ['split', 'inline']) {
         await expect(deleted).not.toContainText('// removed');
         await expect(deleted).not.toContainText('// tail old');
         await expect(modified.locator('.view-line').filter({ hasText: '// inserted' })).toBeVisible();
+        // The ignored deletion and visible old code share a modified-side
+        // anchor. Their ViewZones must keep source order so old code stays
+        // beside its own line number, including after provider toggles.
+        const oldNumber = original.locator('.line-numbers').filter({ hasText: /^5$/ });
+        await expect.poll(async () => {
+          const code = await deleted.boundingBox();
+          const gutter = await oldNumber.boundingBox();
+          return code && gutter ? Math.abs(code.y - gutter.y) : Number.POSITIVE_INFINITY;
+        }).toBeLessThanOrEqual(1);
       }
     }
     await disposeDiffLifecycle(page);

--- a/editor/tests/browser/moonbit/component/diff_editor_lifecycle_scenario.mbt
+++ b/editor/tests/browser/moonbit/component/diff_editor_lifecycle_scenario.mbt
@@ -111,14 +111,18 @@ impl @diff.DocumentDiffProvider for IgnoredDiffLifecycleProvider with fn compute
         kind=Ignored,
       ),
       DocumentDiffChange(
-        DetailedLineRangeMapping(LineRange(3, 4), LineRange(2, 3), None),
-      ),
-      DocumentDiffChange(
-        DetailedLineRangeMapping(LineRange(4, 4), LineRange(3, 4), None),
+        DetailedLineRangeMapping(LineRange(3, 5), LineRange(2, 2), None),
         kind=Ignored,
       ),
       DocumentDiffChange(
-        DetailedLineRangeMapping(LineRange(5, 6), LineRange(5, 6), None),
+        DetailedLineRangeMapping(LineRange(5, 6), LineRange(2, 3), None),
+      ),
+      DocumentDiffChange(
+        DetailedLineRangeMapping(LineRange(6, 6), LineRange(3, 4), None),
+        kind=Ignored,
+      ),
+      DocumentDiffChange(
+        DetailedLineRangeMapping(LineRange(7, 8), LineRange(5, 6), None),
         kind=Ignored,
       ),
     ],
@@ -184,7 +188,7 @@ pub fn run_diff_editor_lifecycle_test() -> Unit {
     "indicator-modified", "shared head\nnew value\nshared tail",
   )
   let ignored_original = diff_editor_lifecycle_model(
-    "ignored-original", "// removed\nkeep\nold value\nlast\n// tail old\nend",
+    "ignored-original", "// removed\nkeep\n// before value one\n// before value two\nold value\nlast\n// tail old\nend",
   )
   let ignored_modified = diff_editor_lifecycle_model(
     "ignored-modified", "keep\nnew value\n// inserted\nlast\n// tail new\nend",

--- a/editor/tests/browser/moonbit/component/diff_editor_lifecycle_scenario.mbt
+++ b/editor/tests/browser/moonbit/component/diff_editor_lifecycle_scenario.mbt
@@ -75,13 +75,58 @@ impl @diff.DocumentDiffProvider for InvalidDiffLifecycleProvider with fn compute
 ) {
   self.marker |> ignore
   {
-    changes: [DetailedLineRangeMapping(LineRange(0, 2), LineRange(1, 2), None)],
-    additional_alignments: [],
+    changes: [
+      DocumentDiffChange(
+        DetailedLineRangeMapping(LineRange(0, 2), LineRange(1, 2), None),
+      ),
+    ],
   }
 }
 
 ///|
 impl @diff.DocumentDiffProvider for InvalidDiffLifecycleProvider with fn on_did_change(
+  _self,
+  _listener,
+) {
+  @base_common.Disposable::from(() => ())
+}
+
+///|
+priv struct IgnoredDiffLifecycleProvider {
+  marker : Unit
+}
+
+///|
+impl @diff.DocumentDiffProvider for IgnoredDiffLifecycleProvider with fn compute_diff(
+  self,
+  _original,
+  _modified,
+  _options,
+) {
+  ignore(self.marker)
+  {
+    changes: [
+      DocumentDiffChange(
+        DetailedLineRangeMapping(LineRange(1, 2), LineRange(1, 1), None),
+        kind=Ignored,
+      ),
+      DocumentDiffChange(
+        DetailedLineRangeMapping(LineRange(3, 4), LineRange(2, 3), None),
+      ),
+      DocumentDiffChange(
+        DetailedLineRangeMapping(LineRange(4, 4), LineRange(3, 4), None),
+        kind=Ignored,
+      ),
+      DocumentDiffChange(
+        DetailedLineRangeMapping(LineRange(5, 6), LineRange(5, 6), None),
+        kind=Ignored,
+      ),
+    ],
+  }
+}
+
+///|
+impl @diff.DocumentDiffProvider for IgnoredDiffLifecycleProvider with fn on_did_change(
   _self,
   _listener,
 ) {
@@ -104,6 +149,8 @@ pub fn run_diff_editor_lifecycle_test() -> Unit {
   let failing_provider_object : &@diff.DocumentDiffProvider = failing_provider
   let invalid_provider = InvalidDiffLifecycleProvider::InvalidDiffLifecycleProvider()
   let invalid_provider_object : &@diff.DocumentDiffProvider = invalid_provider
+  let ignored_provider = IgnoredDiffLifecycleProvider::{ marker: (), }
+  let ignored_provider_object : &@diff.DocumentDiffProvider = ignored_provider
   let widget = @diff_editor.DiffEditorWidget::create(
     host,
     provider_object,
@@ -135,6 +182,12 @@ pub fn run_diff_editor_lifecycle_test() -> Unit {
   )
   let indicator_modified = diff_editor_lifecycle_model(
     "indicator-modified", "shared head\nnew value\nshared tail",
+  )
+  let ignored_original = diff_editor_lifecycle_model(
+    "ignored-original", "// removed\nkeep\nold value\nlast\n// tail old\nend",
+  )
+  let ignored_modified = diff_editor_lifecycle_model(
+    "ignored-modified", "keep\nnew value\n// inserted\nlast\n// tail new\nend",
   )
   let late_prefix = diff_editor_lifecycle_numbered_lines(1, 121) + "\n"
   let late_middle = "\n" + diff_editor_lifecycle_numbered_lines(122, 190) + "\n"
@@ -177,6 +230,7 @@ pub fn run_diff_editor_lifecycle_test() -> Unit {
   install_diff_editor_lifecycle_controls(
     fixture => {
       let pair : @diff_editor.DiffEditorModelData = match fixture {
+        "ignored" => { original: ignored_original, modified: ignored_modified, }
         "digits" => { original: digit_original, modified: digit_modified, }
         "indicators" =>
           { original: indicator_original, modified: indicator_modified, }
@@ -209,6 +263,7 @@ pub fn run_diff_editor_lifecycle_test() -> Unit {
     },
     provider_kind => {
       match provider_kind {
+        "ignored" => widget.set_diff_provider(ignored_provider_object)
         "provider" => widget.set_diff_provider(failing_provider_object)
         "validator" => widget.set_diff_provider(invalid_provider_object)
         _ => widget.set_diff_provider(provider_object)
@@ -228,6 +283,8 @@ pub fn run_diff_editor_lifecycle_test() -> Unit {
     () => widget.reveal_last_diff(),
     () => widget.dispose(),
     () => {
+      ignored_original.dispose()
+      ignored_modified.dispose()
       original.dispose()
       modified.dispose()
       digit_original.dispose()

--- a/editor/viewer/README.mbt.md
+++ b/editor/viewer/README.mbt.md
@@ -115,11 +115,10 @@ Hosts own every `TextModel`, DOM host, and explicitly supplied
 ## Diff editor contract
 
 `DiffEditor` accepts a synchronous `DocumentDiffProvider`. The default line-diff
-provider lives in `viewer/common/diff`. A diff result has
-two distinct inputs:
-
-- `changes` drive decorations, overview markers, and change navigation; and
-- `additional_alignments` affect geometry only.
+provider lives in `viewer/common/diff`. Its result contains one ordered
+`changes` list. Each change carries `kind: Visible | Ignored` and a detailed
+line mapping. All changes drive alignment; only Visible changes drive
+decorations, overview markers, Inline deleted blocks, and navigation.
 
 The shared `DiffEditorViewModel` publishes `NoModel`, `Pending`, `Ready`, or
 `Failed`. Model, provider, and option changes rotate a generation. Computation
@@ -141,9 +140,10 @@ DocumentDiff
        -> navigation
 ```
 
-`additional_alignments` is the only renderer-state extension. It is injected
-only into alignment computation and cannot create decorations, overview
-markers, Inline deleted blocks, or navigation targets.
+`DiffState` retains each mapping's kind and projects visible mappings for diff
+features. Ignored mappings enter alignment only. The host recomputes the
+provider result when ignore settings change, restoring complete visible
+changes from the new result.
 
 The kernel exposes stable geometry, managed-zone, viewport-state, render, and
 scroll adapters for this work. Diff features do not access raw `View`,

--- a/editor/viewer/common/diff/README.mbt.md
+++ b/editor/viewer/common/diff/README.mbt.md
@@ -7,8 +7,9 @@ provider. The package has no DOM or editor-widget dependency.
 flowchart LR
   O["original TextSnapshot"] --> P["DocumentDiffProvider"]
   M["modified TextSnapshot"] --> P
-  P --> C["DocumentDiff.changes<br/>render and navigate"]
-  P --> A["additional_alignments<br/>geometry only"]
+  P --> C["DocumentDiff.changes"]
+  C --> V["Visible: render, navigate, align"]
+  C --> I["Ignored: align only"]
 ```
 
 ## Computing a diff
@@ -30,9 +31,9 @@ test "an edited line maps original and modified ranges" {
     strict_options,
   )
   assert_eq(result.changes.length(), 1)
-  assert_eq(result.changes[0].original, LineRange(2, 3))
-  assert_eq(result.changes[0].modified, LineRange(2, 3))
-  assert_true(result.additional_alignments.is_empty())
+  assert_eq(result.changes[0].mapping.original, LineRange(2, 3))
+  assert_eq(result.changes[0].mapping.modified, LineRange(2, 3))
+  assert_true(result.changes[0].kind is Visible)
 }
 ```
 
@@ -48,8 +49,8 @@ test "insertions keep half-open line-range semantics" {
     strict_options,
   )
   assert_eq(inserted.changes.length(), 1)
-  assert_true(inserted.changes[0].original.is_empty())
-  assert_eq(inserted.changes[0].modified, LineRange(2, 3))
+  assert_true(inserted.changes[0].mapping.original.is_empty())
+  assert_eq(inserted.changes[0].mapping.modified, LineRange(2, 3))
 }
 ```
 
@@ -100,13 +101,19 @@ test "trim whitespace can ignore re-indentation" {
 }
 ```
 
-External providers implement `DocumentDiffProvider` and may fill
-`additional_alignments` for ignored source rows. `LineRangeMapping`,
-`DetailedLineRangeMapping`, and `RangeMapping` are public constructible values,
-so no viewer-layer adapter is required. As in VS Code's
-`lineRangeMappingFromRangeMappings`, touching changed rows must be grouped into
-one hunk. Consecutive hunks are strictly separated, ordered on both sides, and
-have equal unchanged gaps. `normalize_and_validate_document_diff` is the shared
+External providers implement `DocumentDiffProvider` and return a single ordered
+`changes` list. Each `DocumentDiffChange` contains a `kind` (`Visible` or
+`Ignored`) and a `DetailedLineRangeMapping`. All entries drive alignment;
+only `Visible` entries drive decorations, overview markers, Inline deleted
+blocks, and navigation. Visibility describes the current computation, not the
+source's semantic category. Changing an ignore policy requires recomputing the
+provider result; ignored entries need not retain renderable character diffs.
+
+`DocumentDiffChange`, `LineRangeMapping`, `DetailedLineRangeMapping`, and
+`RangeMapping` are public constructible values, so no viewer-layer adapter is
+required. Touching changes of the same kind must be grouped. Different kinds
+may touch; all mappings remain ordered and non-overlapping on both sides, with
+equal unchanged gaps. `normalize_and_validate_document_diff` is the shared
 contract boundary: optional providers can reject a specialized candidate and
 fall back before publishing their effective mode, while the ViewModel invokes
 the same helper again before rendering any provider result. Invalid generic

--- a/editor/viewer/common/diff/advanced_diff_reference_wbtest.mbt
+++ b/editor/viewer/common/diff/advanced_diff_reference_wbtest.mbt
@@ -25,7 +25,8 @@ test "reference: one natural parameter insertion is not fragmented" {
   let result = advanced_compute(
     "function x(alignments: RangeMapping[]): x[] { }", "function x(alignments: RangeMapping[], originalLines: string[], modifiedLines: string[]): x[] { }",
   )
-  guard result.changes is [change] && change.inner_changes is Some([inner]) else {
+  guard result.changes is [{ mapping: change, .. }] &&
+    change.inner_changes is Some([inner]) else {
     fail("expected one line hunk with one inner insertion")
   }
   assert_eq(inner.original, Range(1, 38, 1, 38))
@@ -39,7 +40,8 @@ test "reference: Array to FixedArray highlights only the inserted subword" {
   let result = advanced_compute(
     "let values : Array[Int] = []", "let values : FixedArray[Int] = []",
   )
-  guard result.changes is [change] && change.inner_changes is Some([inner]) else {
+  guard result.changes is [{ mapping: change, .. }] &&
+    change.inner_changes is Some([inner]) else {
     fail("expected one inserted subword")
   }
   assert_eq(inner.original, Range(1, 14, 1, 14))
@@ -54,7 +56,8 @@ test "reference: shared letters do not split ordinary identifier replacements" {
   let result = advanced_compute(
     "\tconst private = 1;", "\tconst protected = 1;",
   )
-  guard result.changes is [change] && change.inner_changes is Some([inner]) else {
+  guard result.changes is [{ mapping: change, .. }] &&
+    change.inner_changes is Some([inner]) else {
     fail("expected one whole-identifier replacement")
   }
   assert_eq(inner.original, Range(1, 8, 1, 15))
@@ -68,7 +71,8 @@ test "reference: repeated identifier letters shift insertion to punctuation" {
   let result = advanced_compute(
     "import { IFooBar, IFoo } from 'foo';", "import { IFooBar, IBar, IFoo } from 'foo';",
   )
-  guard result.changes is [change] && change.inner_changes is Some([inner]) else {
+  guard result.changes is [{ mapping: change, .. }] &&
+    change.inner_changes is Some([inner]) else {
     fail("expected one punctuation-aligned insertion")
   }
   assert_eq(inner.original, Range(1, 18, 1, 18))
@@ -88,7 +92,7 @@ test "reference: tiny unchanged structural line joins substantial refactor hunks
     "  new_gamma()", "  new_delta()",
   ]
   let result = advanced_compute(original.join("\n"), modified.join("\n"))
-  guard result.changes is [change] else {
+  guard result.changes is [{ mapping: change, .. }] else {
     fail("expected the refactor to form one readable hunk")
   }
   assert_eq(change.original, LineRange(1, 8))
@@ -112,7 +116,8 @@ test "reference: substantial edits absorb at most twenty UTF-16 units of matchin
   for entry in cases {
     let (original, modified, expected) = entry
     let result = advanced_compute(original, modified)
-    guard result.changes is [{ inner_changes: Some([inner]), .. }] else {
+    guard result.changes
+      is [{ mapping: { inner_changes: Some([inner]), .. }, .. }] else {
       fail("expected one long-diff refinement")
     }
     assert_eq(inner.original, expected)
@@ -123,7 +128,8 @@ test "reference: substantial edits absorb at most twenty UTF-16 units of matchin
     "a".repeat(80) + " 123456789012345678901 " + "c".repeat(80),
     "b".repeat(80) + " 123456789012345678901 " + "d".repeat(80),
   )
-  guard separated.changes is [{ inner_changes: Some(inner), .. }] else {
+  guard separated.changes
+    is [{ mapping: { inner_changes: Some(inner), .. }, .. }] else {
     fail("expected refined long diff")
   }
   assert_eq(inner.length(), 2)
@@ -139,7 +145,8 @@ test "reference: only changes over one hundred UTF-16 units absorb short line tr
     "  " + "a".repeat(60) + " ; ",
     "  " + "b".repeat(60) + " ; ",
   )
-  guard expanded.changes is [{ inner_changes: Some([inner]), .. }] else {
+  guard expanded.changes
+    is [{ mapping: { inner_changes: Some([inner]), .. }, .. }] else {
     fail("expected one expanded long diff")
   }
   assert_eq(inner.original, Range(1, 1, 1, 66))
@@ -149,7 +156,8 @@ test "reference: only changes over one hundred UTF-16 units absorb short line tr
     "  " + "a".repeat(50),
     "  " + "b".repeat(50),
   )
-  guard exact_guard.changes is [{ inner_changes: Some([inner]), .. }] else {
+  guard exact_guard.changes
+    is [{ mapping: { inner_changes: Some([inner]), .. }, .. }] else {
     fail("expected one unexpanded threshold diff")
   }
   assert_eq(inner.original, Range(1, 3, 1, 53))
@@ -159,7 +167,7 @@ test "reference: only changes over one hundred UTF-16 units absorb short line tr
 ///|
 test "reference: two emoji are a four-unit match and stay between small diffs" {
   let result = advanced_compute("aa😀😀cc", "bb😀😀dd")
-  guard result.changes is [{ inner_changes: Some(inner), .. }] else {
+  guard result.changes is [{ mapping: { inner_changes: Some(inner), .. }, .. }] else {
     fail("expected refined emoji-gap changes")
   }
   assert_eq(inner.length(), 2)

--- a/editor/viewer/common/diff/default_lines_diff_computer.mbt
+++ b/editor/viewer/common/diff/default_lines_diff_computer.mbt
@@ -60,7 +60,7 @@ fn LineDocumentDiffProvider::compute_lines_diff(
     modified_lines
   }
   if old_input == new_input {
-    return { changes: [], additional_alignments: [], }
+    return { changes: [], }
   }
 
   // Preserve Monaco's useful empty-document shape: its one logical empty line
@@ -69,19 +69,20 @@ fn LineDocumentDiffProvider::compute_lines_diff(
     (new_input.length() == 1 && new_input[0].length() == 0) {
     return {
       changes: [
-        DetailedLineRangeMapping(
-          LineRange(1, original_lines.length() + 1),
-          LineRange(1, modified_lines.length() + 1),
-          compute_inner_changes(
-            original_lines,
-            modified_lines,
+        DocumentDiffChange(
+          DetailedLineRangeMapping(
             LineRange(1, original_lines.length() + 1),
             LineRange(1, modified_lines.length() + 1),
-            options.ignore_trim_whitespace,
+            compute_inner_changes(
+              original_lines,
+              modified_lines,
+              LineRange(1, original_lines.length() + 1),
+              LineRange(1, modified_lines.length() + 1),
+              options.ignore_trim_whitespace,
+            ),
           ),
         ),
       ],
-      additional_alignments: [],
     }
   }
 
@@ -123,7 +124,7 @@ fn LineDocumentDiffProvider::compute_lines_diff(
       ),
     )
   }
-  { changes, additional_alignments: [], }
+  { changes: changes.map(mapping => DocumentDiffChange(mapping)), }
 }
 
 ///|

--- a/editor/viewer/common/diff/default_lines_diff_computer_wbtest.mbt
+++ b/editor/viewer/common/diff/default_lines_diff_computer_wbtest.mbt
@@ -46,7 +46,7 @@ test "Line provider satisfies the public provider contract" {
     default_options,
   )
   assert_eq(result.changes.length(), 1)
-  assert_true(result.additional_alignments.is_empty())
+
   let notifications = Ref(0)
   let subscription = provider.on_did_change(() => notifications.val += 1)
   subscription.dispose()
@@ -57,7 +57,7 @@ test "Line provider satisfies the public provider contract" {
 test "character refinement keeps unchanged text outside the inner ranges" {
   let result = compute(["return 1"], ["return 20"])
   assert_eq(result.changes.length(), 1)
-  guard result.changes[0].get_inner_changes() is Some(changes) else {
+  guard result.changes[0].mapping.get_inner_changes() is Some(changes) else {
     fail("expected character-level changes")
   }
   assert_eq(changes.length(), 1)
@@ -69,7 +69,7 @@ test "character refinement keeps unchanged text outside the inner ranges" {
 ///|
 test "character refinement anchors pure insertions and deletions" {
   let insertion = compute(["abc"], ["abXYc"])
-  guard insertion.changes[0].get_inner_changes() is Some(insertions) else {
+  guard insertion.changes[0].mapping.get_inner_changes() is Some(insertions) else {
     fail("expected insertion refinement")
   }
   assert_eq(insertions.length(), 1)
@@ -78,7 +78,7 @@ test "character refinement anchors pure insertions and deletions" {
   assert_eq(inserted, Range(1, 3, 1, 5))
 
   let deletion = compute(["abXYc"], ["abc"])
-  guard deletion.changes[0].get_inner_changes() is Some(deletions) else {
+  guard deletion.changes[0].mapping.get_inner_changes() is Some(deletions) else {
     fail("expected deletion refinement")
   }
   assert_eq(deletions.length(), 1)
@@ -90,7 +90,8 @@ test "character refinement anchors pure insertions and deletions" {
 ///|
 test "blank-line insertion refines the canonical newline boundary" {
   let result = compute(["a", "b"], ["a", "", "b"])
-  guard result.changes is [change] && change.inner_changes is Some(inner) else {
+  guard result.changes is [{ mapping: change, .. }] &&
+    change.inner_changes is Some(inner) else {
     fail("expected one refined blank-line insertion")
   }
   assert_eq(change.original, LineRange(2, 2))
@@ -103,28 +104,32 @@ test "blank-line insertion refines the canonical newline boundary" {
 ///|
 test "whole-line insertion and deletion keep pinned newline anchors" {
   let leading_insert = compute(["b", "c"], ["x", "b", "c"])
-  guard leading_insert.changes is [{ inner_changes: Some([leading]), .. }] else {
+  guard leading_insert.changes
+    is [{ mapping: { inner_changes: Some([leading]), .. }, .. }] else {
     fail("expected leading insertion refinement")
   }
   assert_eq(leading.original, Range(1, 1, 1, 1))
   assert_eq(leading.modified, Range(1, 1, 2, 1))
 
   let leading_delete = compute(["x", "b", "c"], ["b", "c"])
-  guard leading_delete.changes is [{ inner_changes: Some([leading]), .. }] else {
+  guard leading_delete.changes
+    is [{ mapping: { inner_changes: Some([leading]), .. }, .. }] else {
     fail("expected leading deletion refinement")
   }
   assert_eq(leading.original, Range(1, 1, 2, 1))
   assert_eq(leading.modified, Range(1, 1, 1, 1))
 
   let trailing_insert = compute(["a"], ["a", "x"])
-  guard trailing_insert.changes is [{ inner_changes: Some([trailing]), .. }] else {
+  guard trailing_insert.changes
+    is [{ mapping: { inner_changes: Some([trailing]), .. }, .. }] else {
     fail("expected trailing insertion refinement")
   }
   assert_eq(trailing.original, Range(1, 2, 1, 2))
   assert_eq(trailing.modified, Range(1, 2, 2, 2))
 
   let trailing_delete = compute(["a", "x"], ["a"])
-  guard trailing_delete.changes is [{ inner_changes: Some([trailing]), .. }] else {
+  guard trailing_delete.changes
+    is [{ mapping: { inner_changes: Some([trailing]), .. }, .. }] else {
     fail("expected trailing deletion refinement")
   }
   assert_eq(trailing.original, Range(1, 2, 2, 2))
@@ -134,7 +139,8 @@ test "whole-line insertion and deletion keep pinned newline anchors" {
 ///|
 test "final newline and trimmed successor keep column-one boundaries" {
   let final_newline = compute(["a"], ["a", ""])
-  guard final_newline.changes is [{ inner_changes: Some([mapping]), .. }] else {
+  guard final_newline.changes
+    is [{ mapping: { inner_changes: Some([mapping]), .. }, .. }] else {
     fail("expected final-newline refinement")
   }
   assert_eq(mapping.original, Range(1, 2, 1, 2))
@@ -143,7 +149,8 @@ test "final newline and trimmed successor keep column-one boundaries" {
   let trimmed = compute(["a", "  b"], ["a", "x", "  b"], options={
     ignore_trim_whitespace: true,
   })
-  guard trimmed.changes is [{ inner_changes: Some([mapping]), .. }] else {
+  guard trimmed.changes
+    is [{ mapping: { inner_changes: Some([mapping]), .. }, .. }] else {
     fail("expected trimmed-successor refinement")
   }
   assert_eq(mapping.original, Range(2, 1, 2, 1))
@@ -154,7 +161,7 @@ test "final newline and trimmed successor keep column-one boundaries" {
 test "character refinement keeps supplementary characters atomic" {
   let result = compute(["x😀y"], ["x😃y"])
   assert_eq(result.changes.length(), 1)
-  guard result.changes[0].get_inner_changes() is Some(changes) else {
+  guard result.changes[0].mapping.get_inner_changes() is Some(changes) else {
     fail("expected character-level changes")
   }
   assert_eq(changes.length(), 1)
@@ -169,7 +176,7 @@ test "oversized character refinement falls back to line changes" {
   let modified = "b".repeat(MaxInnerDiffCodeUnits + 1)
   let result = compute([original], [modified])
   assert_eq(result.changes.length(), 1)
-  assert_true(result.changes[0].get_inner_changes() is None)
+  assert_true(result.changes[0].mapping.get_inner_changes() is None)
 }
 
 ///|
@@ -209,8 +216,8 @@ fn assert_valid(
   result : DocumentDiff,
 ) -> Unit raise {
   for i in 1..<result.changes.length() {
-    let m1 = result.changes[i - 1]
-    let m2 = result.changes[i]
+    let m1 = result.changes[i - 1].mapping
+    let m2 = result.changes[i].mapping
     assert_true(
       m1.original.end_line_number_exclusive < m2.original.start_line_number,
     )
@@ -223,7 +230,11 @@ fn assert_valid(
     )
   }
   assert_eq(
-    apply_changes(original, modified, result.changes).join("\n"),
+    apply_changes(
+      original,
+      modified,
+      result.changes.map(change => change.mapping),
+    ).join("\n"),
     modified.join("\n"),
   )
 }
@@ -271,7 +282,8 @@ test "scalar sequence at the 500 threshold keeps a precise Myers refinement" {
   let original = "ab".repeat(130) + " OLD " + "cd".repeat(130)
   let modified = "ab".repeat(130) + " NEW " + "cd".repeat(130)
   let result = compute([original], [modified])
-  guard result.changes is [{ inner_changes: Some([inner]), .. }] else {
+  guard result.changes
+    is [{ mapping: { inner_changes: Some([inner]), .. }, .. }] else {
     fail("expected one precise scalar fallback refinement")
   }
   assert_eq(inner.original, Range(1, 262, 1, 265))
@@ -293,7 +305,8 @@ test "trim whitespace is excluded from mixed character refinements" {
   let result = compute(["  x=1"], ["x=2  "], options={
     ignore_trim_whitespace: true,
   })
-  guard result.changes is [change] && change.inner_changes is Some([inner]) else {
+  guard result.changes is [{ mapping: change, .. }] &&
+    change.inner_changes is Some([inner]) else {
     fail("expected one content-only inner change")
   }
   assert_eq(inner.original, Range(1, 5, 1, 6))
@@ -324,14 +337,14 @@ test "snapshot normalization makes CRLF and LF equal" {
 ///|
 test "combining marks and ZWJ sequences keep UTF-16 range coordinates" {
   let combining = compute(["cafe\u{301}"], ["cafe"])
-  guard combining.changes[0].inner_changes is Some(combining_changes) else {
+  guard combining.changes[0].mapping.inner_changes is Some(combining_changes) else {
     fail("expected combining-mark refinement")
   }
   assert_eq(combining_changes[0].original, Range(1, 5, 1, 6))
   assert_eq(combining_changes[0].modified, Range(1, 5, 1, 5))
 
   let zwj = compute(["x👩‍💻y"], ["x👨‍💻y"])
-  guard zwj.changes[0].inner_changes is Some(zwj_changes) else {
+  guard zwj.changes[0].mapping.inner_changes is Some(zwj_changes) else {
     fail("expected ZWJ refinement")
   }
   assert_eq(zwj_changes[0].original, Range(1, 2, 1, 4))
@@ -341,14 +354,14 @@ test "combining marks and ZWJ sequences keep UTF-16 range coordinates" {
 ///|
 test "tabs CJK and RTL text keep logical UTF-16 columns" {
   let cjk = compute(["\t中文x"], ["\t中語x"])
-  guard cjk.changes[0].inner_changes is Some(cjk_changes) else {
+  guard cjk.changes[0].mapping.inner_changes is Some(cjk_changes) else {
     fail("expected CJK refinement")
   }
   assert_eq(cjk_changes[0].original, Range(1, 3, 1, 4))
   assert_eq(cjk_changes[0].modified, Range(1, 3, 1, 4))
 
   let rtl = compute(["אבג"], ["אדג"])
-  guard rtl.changes[0].inner_changes is Some(rtl_changes) else {
+  guard rtl.changes[0].mapping.inner_changes is Some(rtl_changes) else {
     fail("expected RTL refinement")
   }
   assert_eq(rtl_changes[0].original, Range(1, 2, 1, 3))

--- a/editor/viewer/common/diff/document_diff_provider_test.mbt
+++ b/editor/viewer/common/diff/document_diff_provider_test.mbt
@@ -12,8 +12,11 @@ impl @diff.DocumentDiffProvider for ExternalDocumentDiffProvider with fn compute
   let modified = @base_common.LineRange(1, 2)
   let inner = @diff.RangeMapping(Range(1, 1, 1, 2), Range(1, 1, 1, 3))
   {
-    changes: [DetailedLineRangeMapping(original, modified, Some([inner]))],
-    additional_alignments: [LineRangeMapping(original, modified)],
+    changes: [
+      DocumentDiffChange(
+        DetailedLineRangeMapping(original, modified, Some([inner])),
+      ),
+    ],
   }
 }
 
@@ -34,8 +37,11 @@ test "an external package can implement the provider and construct mappings" {
     { ignore_trim_whitespace: false, },
   )
   assert_eq(result.changes.length(), 1)
-  assert_eq(result.additional_alignments.length(), 1)
-  assert_eq(result.changes[0].inner_changes.unwrap()[0].modified.end_column, 3)
+  assert_true(result.changes[0].kind is Visible)
+  assert_eq(
+    result.changes[0].mapping.inner_changes.unwrap()[0].modified.end_column,
+    3,
+  )
 }
 
 ///|
@@ -78,7 +84,8 @@ test "line provider keeps EOF inner changes inside their line hunks" {
       TextSnapshot(modified),
       { ignore_trim_whitespace: false, },
     )
-    guard result.changes is [change] && change.inner_changes is Some([inner]) else {
+    guard result.changes is [{ mapping: change, .. }] &&
+      change.inner_changes is Some([inner]) else {
       fail("expected one refined EOF change")
     }
     assert_eq(change.original, original_lines)

--- a/editor/viewer/common/diff/document_diff_validation.mbt
+++ b/editor/viewer/common/diff/document_diff_validation.mbt
@@ -80,17 +80,17 @@ fn normalize_document_diff(
 ) -> DocumentDiff {
   {
     changes: result.changes.map(change => {
-      DetailedLineRangeMapping(
-        change.original,
-        change.modified,
-        change.inner_changes.map(inner_changes => {
+      ..change,
+      mapping: DetailedLineRangeMapping(
+        change.mapping.original,
+        change.mapping.modified,
+        change.mapping.inner_changes.map(inner_changes => {
           inner_changes.map(inner => {
             normalize_document_range_mapping(inner, original, modified)
           })
         }),
-      )
+      ),
     }),
-    additional_alignments: result.additional_alignments.copy(),
   }
 }
 
@@ -185,62 +185,21 @@ fn valid_document_inner_changes(
 }
 
 ///|
-priv struct IndexedDocumentValidationAlignment {
-  source_index : Int
-  mapping : LineRangeMapping
-  is_change : Bool
-}
-
-///|
-fn compare_document_validation_alignment(
-  left : IndexedDocumentValidationAlignment,
-  right : IndexedDocumentValidationAlignment,
-) -> Int {
-  if left.mapping.original.start_line_number !=
-    right.mapping.original.start_line_number {
-    return left.mapping.original.start_line_number -
-      right.mapping.original.start_line_number
-  }
-  if left.mapping.modified.start_line_number !=
-    right.mapping.modified.start_line_number {
-    return left.mapping.modified.start_line_number -
-      right.mapping.modified.start_line_number
-  }
-  left.source_index - right.source_index
-}
-
-///|
-fn valid_combined_document_alignment_sequence(
+fn valid_document_alignment_sequence(
   result : DocumentDiff,
   original_line_count : Int,
   modified_line_count : Int,
 ) -> Bool {
-  let indexed : Array[IndexedDocumentValidationAlignment] = []
-  for change in result.changes {
-    indexed.push({
-      source_index: indexed.length(),
-      mapping: change.line_mapping(),
-      is_change: true,
-    })
-  }
-  for alignment in result.additional_alignments {
-    indexed.push({
-      source_index: indexed.length(),
-      mapping: alignment,
-      is_change: false,
-    })
-  }
-  indexed.sort_by(compare_document_validation_alignment)
-  if indexed.is_empty() {
+  if result.changes.is_empty() {
     return original_line_count == modified_line_count
   }
-  let first = indexed[0].mapping
+  let first = result.changes[0].mapping
   if first.original.start_line_number != first.modified.start_line_number {
     return false
   }
-  for index in 1..<indexed.length() {
-    let previous = indexed[index - 1]
-    let current = indexed[index]
+  for index in 1..<result.changes.length() {
+    let previous = result.changes[index - 1]
+    let current = result.changes[index]
     let original_gap = current.mapping.original.start_line_number -
       previous.mapping.original.end_line_number_exclusive
     let modified_gap = current.mapping.modified.start_line_number -
@@ -248,11 +207,11 @@ fn valid_combined_document_alignment_sequence(
     if original_gap < 0 ||
       modified_gap < 0 ||
       original_gap != modified_gap ||
-      (previous.is_change && current.is_change && original_gap == 0) {
+      (previous.kind == current.kind && original_gap == 0) {
       return false
     }
   }
-  let last = indexed[indexed.length() - 1].mapping
+  let last = result.changes[result.changes.length() - 1].mapping
   original_line_count - last.original.end_line_number_exclusive ==
   modified_line_count - last.modified.end_line_number_exclusive
 }
@@ -265,7 +224,8 @@ fn valid_document_diff(
 ) -> Bool {
   let mut original_end = 1
   let mut modified_end = 1
-  for change in result.changes {
+  for entry in result.changes {
+    let change = entry.mapping
     if !valid_document_line_range(change.original, original.line_count()) ||
       !valid_document_line_range(change.modified, modified.line_count()) ||
       change.original.start_line_number < original_end ||
@@ -288,19 +248,7 @@ fn valid_document_diff(
       None => ()
     }
   }
-  original_end = 1
-  modified_end = 1
-  for alignment in result.additional_alignments {
-    if !valid_document_line_range(alignment.original, original.line_count()) ||
-      !valid_document_line_range(alignment.modified, modified.line_count()) ||
-      alignment.original.start_line_number < original_end ||
-      alignment.modified.start_line_number < modified_end {
-      return false
-    }
-    original_end = alignment.original.end_line_number_exclusive
-    modified_end = alignment.modified.end_line_number_exclusive
-  }
-  valid_combined_document_alignment_sequence(
+  valid_document_alignment_sequence(
     result,
     original.line_count(),
     modified.line_count(),

--- a/editor/viewer/common/diff/document_diff_validation_wbtest.mbt
+++ b/editor/viewer/common/diff/document_diff_validation_wbtest.mbt
@@ -4,19 +4,20 @@ test "document diff validation canonicalizes newline anchors idempotently" {
   let modified = @model.TextSnapshot("\nkeep")
   let raw : DocumentDiff = {
     changes: [
-      DetailedLineRangeMapping(
-        LineRange(1, 2),
-        LineRange(1, 1),
-        Some([RangeMapping(Range(1, 1, 1, 8), Range(1, 1, 1, 1))]),
+      DocumentDiffChange(
+        DetailedLineRangeMapping(
+          LineRange(1, 2),
+          LineRange(1, 1),
+          Some([RangeMapping(Range(1, 1, 1, 8), Range(1, 1, 1, 1))]),
+        ),
       ),
     ],
-    additional_alignments: [],
   }
   guard normalize_and_validate_document_diff(raw, original, modified)
     is Some(canonical) else {
     fail("expected canonical pure-deletion mapping")
   }
-  guard canonical.changes[0].inner_changes is Some([inner]) else {
+  guard canonical.changes[0].mapping.inner_changes is Some([inner]) else {
     fail("expected one canonical inner mapping")
   }
   assert_eq(inner.original, Range(1, 1, 2, 1))
@@ -28,14 +29,21 @@ test "document diff validation canonicalizes newline anchors idempotently" {
 }
 
 ///|
-test "document diff validation rejects overlapping changes and alignments" {
+test "document diff validation rejects overlapping visible and ignored changes" {
   let original = @model.TextSnapshot("fn stable() {}")
   let modified = @model.TextSnapshot(
     "/// ignored before\nfn inserted() {}\n/// ignored after\nfn stable() {}",
   )
   let invalid : DocumentDiff = {
-    changes: [DetailedLineRangeMapping(LineRange(1, 1), LineRange(2, 3), None)],
-    additional_alignments: [LineRangeMapping(LineRange(1, 1), LineRange(1, 4))],
+    changes: [
+      DocumentDiffChange(
+        DetailedLineRangeMapping(LineRange(1, 1), LineRange(1, 4), None),
+        kind=Ignored,
+      ),
+      DocumentDiffChange(
+        DetailedLineRangeMapping(LineRange(1, 1), LineRange(2, 3), None),
+      ),
+    ],
   }
   assert_true(
     normalize_and_validate_document_diff(invalid, original, modified) is None,
@@ -43,16 +51,24 @@ test "document diff validation rejects overlapping changes and alignments" {
 }
 
 ///|
-test "document diff validation accepts separated ignored-row alignments" {
+test "document diff validation accepts interleaved visible and ignored changes" {
   let original = @model.TextSnapshot("fn stable() {}")
   let modified = @model.TextSnapshot(
     "/// ignored before\nfn inserted() {}\n/// ignored after\nfn stable() {}",
   )
   let valid : DocumentDiff = {
-    changes: [DetailedLineRangeMapping(LineRange(1, 1), LineRange(2, 3), None)],
-    additional_alignments: [
-      LineRangeMapping(LineRange(1, 1), LineRange(1, 2)),
-      LineRangeMapping(LineRange(1, 1), LineRange(3, 4)),
+    changes: [
+      DocumentDiffChange(
+        DetailedLineRangeMapping(LineRange(1, 1), LineRange(1, 2), None),
+        kind=Ignored,
+      ),
+      DocumentDiffChange(
+        DetailedLineRangeMapping(LineRange(1, 1), LineRange(2, 3), None),
+      ),
+      DocumentDiffChange(
+        DetailedLineRangeMapping(LineRange(1, 1), LineRange(3, 4), None),
+        kind=Ignored,
+      ),
     ],
   }
   assert_eq(
@@ -67,15 +83,81 @@ test "document diff validation rejects invalid provider coordinates" {
   let modified = @model.TextSnapshot("new\nkeep")
   let invalid : DocumentDiff = {
     changes: [
-      DetailedLineRangeMapping(
-        LineRange(1, 2),
-        LineRange(1, 2),
-        Some([RangeMapping(Range(1, 1, 99, 1), Range(1, 1, 99, 1))]),
+      DocumentDiffChange(
+        DetailedLineRangeMapping(
+          LineRange(1, 2),
+          LineRange(1, 2),
+          Some([RangeMapping(Range(1, 1, 99, 1), Range(1, 1, 99, 1))]),
+        ),
       ),
     ],
-    additional_alignments: [],
   }
   assert_true(
     normalize_and_validate_document_diff(invalid, original, modified) is None,
+  )
+}
+
+///|
+test "visibility never bypasses document mapping validation" {
+  let source = @model.TextSnapshot("a\nb\nc")
+  for kind in [Visible, Ignored] {
+    let adjacent : DocumentDiff = {
+      changes: [
+        DocumentDiffChange(
+          DetailedLineRangeMapping(LineRange(1, 2), LineRange(1, 2), None),
+          kind~,
+        ),
+        DocumentDiffChange(
+          DetailedLineRangeMapping(LineRange(2, 3), LineRange(2, 3), None),
+          kind~,
+        ),
+      ],
+    }
+    assert_true(
+      normalize_and_validate_document_diff(adjacent, source, source) is None,
+    )
+    let invalid : DocumentDiff = {
+      changes: [
+        DocumentDiffChange(
+          DetailedLineRangeMapping(
+            LineRange(1, 2),
+            LineRange(1, 2),
+            Some([RangeMapping(Range(1, 1, 1, 99), Range(1, 1, 1, 2))]),
+          ),
+          kind~,
+        ),
+      ],
+    }
+    assert_true(
+      normalize_and_validate_document_diff(invalid, source, source) is None,
+    )
+  }
+  let unordered : DocumentDiff = {
+    changes: [
+      DocumentDiffChange(
+        DetailedLineRangeMapping(LineRange(2, 3), LineRange(2, 3), None),
+        kind=Ignored,
+      ),
+      DocumentDiffChange(
+        DetailedLineRangeMapping(LineRange(1, 2), LineRange(1, 2), None),
+      ),
+    ],
+  }
+  assert_true(
+    normalize_and_validate_document_diff(unordered, source, source) is None,
+  )
+  let unequal_gap : DocumentDiff = {
+    changes: [
+      DocumentDiffChange(
+        DetailedLineRangeMapping(LineRange(1, 2), LineRange(1, 2), None),
+        kind=Ignored,
+      ),
+      DocumentDiffChange(
+        DetailedLineRangeMapping(LineRange(3, 4), LineRange(2, 3), None),
+      ),
+    ],
+  }
+  assert_true(
+    normalize_and_validate_document_diff(unequal_gap, source, source) is None,
   )
 }

--- a/editor/viewer/common/diff/lines_diff_computer.mbt
+++ b/editor/viewer/common/diff/lines_diff_computer.mbt
@@ -1,7 +1,7 @@
 // Renderer-neutral document diff contract. Unlike the old partial Monaco
 // `ILinesDiffComputer` facade, this API describes only behavior implemented by
-// this repository: synchronous calculation, trim-whitespace policy, rendered
-// changes, and geometry-only alignments.
+// this repository: synchronous calculation, trim-whitespace policy, changes
+// classified by visibility.
 
 ///|
 /// Options shared by all synchronous document diff providers.
@@ -10,15 +10,35 @@ pub(all) struct DocumentDiffOptions {
 } derive(Eq, Debug)
 
 ///|
-/// A complete document diff. `changes` drive decorations, overview markers,
-/// navigation, and alignment. `additional_alignments` affect geometry only;
-/// providers use them for source rows deliberately omitted from the visible
-/// diff, such as ignored comments. `changes` follow VS Code's canonical hunk
-/// invariants: touching rows are grouped, mappings are ordered on both sides,
-/// and consecutive hunks have equal unchanged gaps.
+/// Whether a change participates in visible diff features. Ignored changes
+/// still participate in line alignment; providers recompute when filters change.
+pub(all) enum DocumentDiffChangeKind {
+  Visible
+  Ignored
+} derive(Eq, Debug)
+
+///|
+/// One source change and its visibility in this computation.
+pub(all) struct DocumentDiffChange {
+  kind : DocumentDiffChangeKind
+  mapping : DetailedLineRangeMapping
+} derive(Eq, Debug)
+
+///|
+pub fn DocumentDiffChange::DocumentDiffChange(
+  mapping : DetailedLineRangeMapping,
+  kind? : DocumentDiffChangeKind = Visible,
+) -> DocumentDiffChange {
+  { kind, mapping, }
+}
+
+///|
+/// A complete document diff. All changes drive alignment; only Visible changes
+/// drive decorations, overview markers, and navigation. Mappings are ordered
+/// on both sides, with equal unchanged gaps. Touching changes of the same kind
+/// are grouped; different kinds may touch but never overlap.
 pub(all) struct DocumentDiff {
-  changes : Array[DetailedLineRangeMapping]
-  additional_alignments : Array[LineRangeMapping]
+  changes : Array[DocumentDiffChange]
 } derive(Eq, Debug)
 
 ///|
@@ -50,3 +70,15 @@ pub extend DocumentDiffOptions with Debug::{to_repr}
 
 ///|
 pub extend DocumentDiffOptions with Eq::{equal, not_equal}
+
+///|
+pub extend DocumentDiffChangeKind with Debug::{to_repr}
+
+///|
+pub extend DocumentDiffChangeKind with Eq::{equal, not_equal}
+
+///|
+pub extend DocumentDiffChange with Debug::{to_repr}
+
+///|
+pub extend DocumentDiffChange with Eq::{equal, not_equal}

--- a/editor/viewer/common/diff/pkg.generated.mbti
+++ b/editor/viewer/common/diff/pkg.generated.mbti
@@ -28,12 +28,28 @@ pub fn DetailedLineRangeMapping::not_equal(Self, Self) -> Bool
 pub fn DetailedLineRangeMapping::to_repr(Self) -> @debug.Repr
 
 pub(all) struct DocumentDiff {
-  changes : Array[DetailedLineRangeMapping]
-  additional_alignments : Array[LineRangeMapping]
+  changes : Array[DocumentDiffChange]
 } derive(Eq, @debug.Debug)
 pub fn DocumentDiff::equal(Self, Self) -> Bool
 pub fn DocumentDiff::not_equal(Self, Self) -> Bool
 pub fn DocumentDiff::to_repr(Self) -> @debug.Repr
+
+pub(all) struct DocumentDiffChange {
+  kind : DocumentDiffChangeKind
+  mapping : DetailedLineRangeMapping
+} derive(Eq, @debug.Debug)
+pub fn DocumentDiffChange::DocumentDiffChange(DetailedLineRangeMapping, kind? : DocumentDiffChangeKind) -> Self
+pub fn DocumentDiffChange::equal(Self, Self) -> Bool
+pub fn DocumentDiffChange::not_equal(Self, Self) -> Bool
+pub fn DocumentDiffChange::to_repr(Self) -> @debug.Repr
+
+pub(all) enum DocumentDiffChangeKind {
+  Visible
+  Ignored
+} derive(Eq, @debug.Debug)
+pub fn DocumentDiffChangeKind::equal(Self, Self) -> Bool
+pub fn DocumentDiffChangeKind::not_equal(Self, Self) -> Bool
+pub fn DocumentDiffChangeKind::to_repr(Self) -> @debug.Repr
 
 pub(all) struct DocumentDiffOptions {
   ignore_trim_whitespace : Bool

--- a/editor/viewer/diff_provider/moondiff/moon.pkg
+++ b/editor/viewer/diff_provider/moondiff/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "moonbitlang/core/diff" @core_diff,
   "moonbitlang/editor/base/common" @base_common,
   "moonbitlang/editor/viewer/common/diff",
   "moonbitlang/editor/viewer/common/model",

--- a/editor/viewer/diff_provider/moondiff/provider.mbt
+++ b/editor/viewer/diff_provider/moondiff/provider.mbt
@@ -268,15 +268,68 @@ fn append_fragment_rows(
 }
 
 ///|
+// MoonDiff hunks are sparse, but section models contain the complete source.
+// Text outside the returned hunks is not a visible semantic change. Preserve
+// its physical alignment as Ignored, matching unchanged lines within each gap
+// instead of assigning the entire line-count difference to a hunk boundary.
+fn append_ignored_gap(
+  original : ArrayView[String],
+  modified : ArrayView[String],
+  original_offset : Int,
+  modified_offset : Int,
+  changes : Array[@diff.DocumentDiffChange],
+) -> Unit {
+  for edit in @core_diff.Diff(old=original, new=modified).edits() {
+    let (old_start, old_len, new_start, new_len) = match edit {
+      Equal(..) => continue
+      Delete(old_index~, old_len~, new_index~) =>
+        (old_index, old_len, new_index, 0)
+      Insert(old_index~, new_index~, new_len~) =>
+        (old_index, 0, new_index, new_len)
+    }
+    append_change(
+      changes,
+      DetailedLineRangeMapping(
+        LineRange(
+          original_offset + old_start + 1,
+          original_offset + old_start + old_len + 1,
+        ),
+        LineRange(
+          modified_offset + new_start + 1,
+          modified_offset + new_start + new_len + 1,
+        ),
+        None,
+      ),
+      Ignored,
+    )
+  }
+}
+
+///|
 fn adapt_fragment_document(
   document : @mbtdiff.HunkDocument,
   original_lines : Array[String],
   modified_lines : Array[String],
 ) -> @diff.DocumentDiff? {
   let changes : Array[@diff.DocumentDiffChange] = []
+  let mut old_end = 0
+  let mut new_end = 0
   for hunk in document.hunks {
     if !valid_hunk_range(hunk.old_start, hunk.old_len, original_lines.length()) ||
       !valid_hunk_range(hunk.new_start, hunk.new_len, modified_lines.length()) {
+      return None
+    }
+    // Adjacent MoonDiff hunks may share context. Validate their rows as usual,
+    // but only diff source gaps outside the union of their covered ranges.
+    if hunk.old_start >= old_end && hunk.new_start >= new_end {
+      append_ignored_gap(
+        original_lines[old_end:hunk.old_start],
+        modified_lines[new_end:hunk.new_start],
+        old_end,
+        new_end,
+        changes,
+      )
+    } else if hunk.old_start > old_end || hunk.new_start > new_end {
       return None
     }
     let mut old_cursor = hunk.old_start
@@ -322,7 +375,16 @@ fn adapt_fragment_document(
       new_cursor != hunk.new_start + hunk.new_len {
       return None
     }
+    old_end = old_end.max(old_cursor)
+    new_end = new_end.max(new_cursor)
   }
+  append_ignored_gap(
+    original_lines[old_end:],
+    modified_lines[new_end:],
+    old_end,
+    new_end,
+    changes,
+  )
   Some({ changes, })
 }
 

--- a/editor/viewer/diff_provider/moondiff/provider.mbt
+++ b/editor/viewer/diff_provider/moondiff/provider.mbt
@@ -182,28 +182,25 @@ fn new_only_change(
 }
 
 ///|
-fn ranges_touch(
-  left : @base_common.LineRange,
-  right : @base_common.LineRange,
-) -> Bool {
-  left.end_line_number_exclusive >= right.start_line_number &&
-  right.end_line_number_exclusive >= left.start_line_number
-}
-
-///|
 fn append_change(
-  changes : Array[@diff.DetailedLineRangeMapping],
+  changes : Array[@diff.DocumentDiffChange],
   change : @diff.DetailedLineRangeMapping,
+  kind : @diff.DocumentDiffChangeKind,
 ) -> Unit {
   guard !changes.is_empty() else {
-    changes.push(change)
+    changes.push(DocumentDiffChange(change, kind~))
     return
   }
   let index = changes.length() - 1
-  let previous = changes[index]
-  if !ranges_touch(previous.original, change.original) &&
-    !ranges_touch(previous.modified, change.modified) {
-    changes.push(change)
+  let previous = changes[index].mapping
+  // Only merge consecutive rows on both sides. Overlapping or out-of-order
+  // hunks must reach validation unchanged rather than being hidden by a join.
+  if changes[index].kind != kind ||
+    previous.original.end_line_number_exclusive !=
+    change.original.start_line_number ||
+    previous.modified.end_line_number_exclusive !=
+    change.modified.start_line_number {
+    changes.push(DocumentDiffChange(change, kind~))
     return
   }
   let inner_changes = match (previous.inner_changes, change.inner_changes) {
@@ -214,50 +211,28 @@ fn append_change(
     }
     _ => None
   }
-  changes[index] = DetailedLineRangeMapping(
-    previous.original.join(change.original),
-    previous.modified.join(change.modified),
-    inner_changes,
-  )
-}
-
-///|
-fn append_alignment(
-  alignments : Array[@diff.LineRangeMapping],
-  alignment : @diff.LineRangeMapping,
-) -> Unit {
-  guard !alignments.is_empty() else {
-    alignments.push(alignment)
-    return
-  }
-  let index = alignments.length() - 1
-  let previous = alignments[index]
-  if !ranges_touch(previous.original, alignment.original) &&
-    !ranges_touch(previous.modified, alignment.modified) {
-    alignments.push(alignment)
-    return
-  }
-  alignments[index] = LineRangeMapping(
-    previous.original.join(alignment.original),
-    previous.modified.join(alignment.modified),
+  changes[index] = DocumentDiffChange(
+    DetailedLineRangeMapping(
+      previous.original.join(change.original),
+      previous.modified.join(change.modified),
+      inner_changes,
+    ),
+    kind~,
   )
 }
 
 ///|
 fn append_fragment_rows(
   rows : ArrayView[@mbtdiff.DiffRow],
-  visible : Bool,
+  kind : @diff.DocumentDiffChangeKind,
   original_lines : Array[String],
   modified_lines : Array[String],
   original_cursor : Int,
   modified_cursor : Int,
-  changes : Array[@diff.DetailedLineRangeMapping],
-  alignments : Array[@diff.LineRangeMapping],
+  changes : Array[@diff.DocumentDiffChange],
 ) -> (Int, Int)? {
   let mut old_cursor = original_cursor
   let mut new_cursor = modified_cursor
-  let block_changes : Array[@diff.DetailedLineRangeMapping] = []
-  let block_alignments : Array[@diff.LineRangeMapping] = []
   for row in rows {
     match row {
       Paired(original, modified) => {
@@ -265,8 +240,8 @@ fn append_fragment_rows(
           !valid_fragment_line(modified, new_cursor, modified_lines) {
           return None
         }
-        if visible {
-          append_change(block_changes, paired_change(original, modified))
+        if kind is Visible || original.text() != modified.text() {
+          append_change(changes, paired_change(original, modified), kind)
         }
         old_cursor += 1
         new_cursor += 1
@@ -276,11 +251,7 @@ fn append_fragment_rows(
           return None
         }
         let change = old_only_change(original, new_cursor, modified_lines)
-        if visible {
-          append_change(block_changes, change)
-        } else {
-          append_alignment(block_alignments, change.line_mapping())
-        }
+        append_change(changes, change, kind)
         old_cursor += 1
       }
       NewOnly(modified) => {
@@ -288,17 +259,11 @@ fn append_fragment_rows(
           return None
         }
         let change = new_only_change(modified, old_cursor, original_lines)
-        if visible {
-          append_change(block_changes, change)
-        } else {
-          append_alignment(block_alignments, change.line_mapping())
-        }
+        append_change(changes, change, kind)
         new_cursor += 1
       }
     }
   }
-  changes.append(block_changes)
-  alignments.append(block_alignments)
   Some((old_cursor, new_cursor))
 }
 
@@ -308,8 +273,7 @@ fn adapt_fragment_document(
   original_lines : Array[String],
   modified_lines : Array[String],
 ) -> @diff.DocumentDiff? {
-  let changes : Array[@diff.DetailedLineRangeMapping] = []
-  let alignments : Array[@diff.LineRangeMapping] = []
+  let changes : Array[@diff.DocumentDiffChange] = []
   for hunk in document.hunks {
     if !valid_hunk_range(hunk.old_start, hunk.old_len, original_lines.length()) ||
       !valid_hunk_range(hunk.new_start, hunk.new_len, modified_lines.length()) {
@@ -335,13 +299,16 @@ fn adapt_fragment_document(
         ChangeBlock(rows) | IgnoredBlock(rows) => {
           guard append_fragment_rows(
               rows,
-              block is ChangeBlock(_),
+              if block is ChangeBlock(_) {
+                Visible
+              } else {
+                Ignored
+              },
               original_lines,
               modified_lines,
               old_cursor,
               new_cursor,
               changes,
-              alignments,
             )
             is Some((next_old, next_new)) else {
             return None
@@ -356,7 +323,7 @@ fn adapt_fragment_document(
       return None
     }
   }
-  Some({ changes, additional_alignments: alignments, })
+  Some({ changes, })
 }
 
 ///|

--- a/editor/viewer/diff_provider/moondiff/provider_wbtest.mbt
+++ b/editor/viewer/diff_provider/moondiff/provider_wbtest.mbt
@@ -183,3 +183,106 @@ test "fragment adapter does not merge away overlapping ignored hunks" {
     fragment_document_diff({ hunks: [hunk, hunk], }, "// old", "// new") is None,
   )
 }
+
+///|
+test "sparse fragments align ignored prefix middle and suffix at unchanged anchors" {
+  let hunks : Array[@mbtdiff.DiffHunk] = [
+    for
+      (old_index, new_index, old_text, new_text) in [
+        (1, 2, "old-a", "new-a"),
+        (5, 5, "old-b", "new-b"),
+      ] => {
+      {
+        old_start: old_index,
+        old_len: 1,
+        new_start: new_index,
+        new_len: 1,
+        blocks: [
+          ChangeBlock([
+            Paired(
+              changed_line(old_index, "", old_text, ""),
+              changed_line(new_index, "", new_text, ""),
+            ),
+          ]),
+        ],
+      }
+    }
+  ]
+  guard fragment_document_diff(
+      { hunks: hunks[:], },
+      "head\nold-a\nkeep-1\n// removed\nkeep-2\nold-b\ntail",
+      "// added\nhead\nnew-a\nkeep-1\nkeep-2\nnew-b\ntail\n// end",
+    )
+    is Some(result) else {
+    fail("expected a complete mapping for the sparse fragment")
+  }
+  assert_eq(
+    result.changes.map(change => {
+      (change.kind, change.mapping.original, change.mapping.modified)
+    }),
+    [
+      (Ignored, LineRange(1, 1), LineRange(1, 2)),
+      (Visible, LineRange(2, 3), LineRange(3, 4)),
+      (Ignored, LineRange(4, 5), LineRange(5, 5)),
+      (Visible, LineRange(6, 7), LineRange(6, 7)),
+      (Ignored, LineRange(8, 8), LineRange(8, 9)),
+    ],
+  )
+}
+
+///|
+test "sparse fragment hunks can share unchanged context" {
+  let shared : @mbtdiff.DiffBlock = ContextBlock([
+    { old_index: 2, new_index: 3, text: "shared", },
+  ])
+  let document : @mbtdiff.HunkDocument = {
+    hunks: [
+      {
+        old_start: 1,
+        old_len: 2,
+        new_start: 2,
+        new_len: 2,
+        blocks: [
+          ChangeBlock([
+            Paired(
+              changed_line(1, "", "old-a", ""),
+              changed_line(2, "", "new-a", ""),
+            ),
+          ]),
+          shared,
+        ],
+      },
+      {
+        old_start: 2,
+        old_len: 2,
+        new_start: 3,
+        new_len: 2,
+        blocks: [
+          shared,
+          ChangeBlock([
+            Paired(
+              changed_line(3, "", "old-b", ""),
+              changed_line(4, "", "new-b", ""),
+            ),
+          ]),
+        ],
+      },
+    ],
+  }
+  guard fragment_document_diff(
+      document, "// pre\nold-a\nshared\nold-b\ntail", "// pre\n// added\nnew-a\nshared\nnew-b\ntail",
+    )
+    is Some(result) else {
+    fail("expected overlapping context to remain valid")
+  }
+  assert_eq(
+    result.changes.map(change => {
+      (change.kind, change.mapping.original, change.mapping.modified)
+    }),
+    [
+      (Ignored, LineRange(2, 2), LineRange(2, 3)),
+      (Visible, LineRange(2, 3), LineRange(3, 4)),
+      (Visible, LineRange(4, 5), LineRange(5, 6)),
+    ],
+  )
+}

--- a/editor/viewer/diff_provider/moondiff/provider_wbtest.mbt
+++ b/editor/viewer/diff_provider/moondiff/provider_wbtest.mbt
@@ -36,7 +36,7 @@ test "fragment adapter keeps MoonDiff coordinates local to one section" {
     ],
   }
   guard fragment_document_diff(document, "fn value() { 1 }", "fn value() { 2 }")
-    is Some({ changes: [change], additional_alignments: [], }) else {
+    is Some({ changes: [{ mapping: change, .. }], }) else {
     fail("expected one valid fragment-local change")
   }
   assert_eq(change.original, LineRange(1, 2))
@@ -62,7 +62,7 @@ test "fragment adapter preserves one-sided intraline mappings" {
     ],
   }
   guard fragment_document_diff(document, "anchor", "new()\nanchor")
-    is Some({ changes: [change], additional_alignments: [], }) else {
+    is Some({ changes: [{ mapping: change, .. }], }) else {
     fail("expected one insertion")
   }
   assert_eq(change.original, LineRange(1, 1))
@@ -98,16 +98,16 @@ test "ignored fragment rows do not become visible changes" {
   guard fragment_document_diff(document, "// old", "// new") is Some(result) else {
     fail("expected a valid ignored fragment")
   }
-  assert_true(result.changes.is_empty())
-  assert_true(result.additional_alignments.is_empty())
+  guard result.changes is [{ kind: Ignored, mapping, }] else {
+    fail("expected an ignored paired change")
+  }
+  assert_eq(mapping.original, LineRange(1, 2))
+  assert_eq(mapping.modified, LineRange(1, 2))
 }
 
 ///|
 test "fragment provider returns its prevalidated document unchanged" {
-  let document : @diff.DocumentDiff = {
-    changes: [],
-    additional_alignments: [],
-  }
+  let document : @diff.DocumentDiff = { changes: [], }
   let provider = MoonFragmentDiffProvider(document)
   let object = provider.as_document_diff_provider()
   assert_eq(
@@ -115,5 +115,71 @@ test "fragment provider returns its prevalidated document unchanged" {
       ignore_trim_whitespace: true,
     }),
     document,
+  )
+}
+
+///|
+test "fragment adapter groups same-kind rows while retaining visibility boundaries" {
+  let line = fn(index, text) {
+    @mbtdiff.DiffLine::{ index, segments: [{ kind: Ignored, text, }], }
+  }
+  let document : @mbtdiff.HunkDocument = {
+    hunks: [
+      {
+        old_start: 0,
+        old_len: 2,
+        new_start: 0,
+        new_len: 5,
+        blocks: [
+          IgnoredBlock([Paired(line(0, "// same"), line(0, "// same"))]),
+          IgnoredBlock([NewOnly(line(1, "// first"))]),
+          IgnoredBlock([NewOnly(line(2, "// second"))]),
+          ChangeBlock([
+            Paired(
+              changed_line(1, "", "old", ""),
+              changed_line(3, "", "new", ""),
+            ),
+          ]),
+          IgnoredBlock([NewOnly(line(4, "// last"))]),
+        ],
+      },
+    ],
+  }
+  guard fragment_document_diff(
+      document, "// same\nold", "// same\n// first\n// second\nnew\n// last",
+    )
+    is Some(result) else {
+    fail("expected valid interleaved changes")
+  }
+  assert_eq(result.changes.map(change => change.kind), [
+    Ignored,
+    Visible,
+    Ignored,
+  ])
+  assert_eq(result.changes[0].mapping.original, LineRange(2, 2))
+  assert_eq(result.changes[0].mapping.modified, LineRange(2, 4))
+  assert_eq(result.changes[1].mapping.modified, LineRange(4, 5))
+  assert_eq(result.changes[2].mapping.modified, LineRange(5, 6))
+}
+
+///|
+test "fragment adapter does not merge away overlapping ignored hunks" {
+  let old : @mbtdiff.DiffLine = {
+    index: 0,
+    segments: [{ kind: Ignored, text: "// old", }],
+  }
+  let new : @mbtdiff.DiffLine = {
+    index: 0,
+    segments: [{ kind: Ignored, text: "// new", }],
+  }
+  let hunk : @mbtdiff.DiffHunk = {
+    old_start: 0,
+    old_len: 1,
+    new_start: 0,
+    new_len: 1,
+    blocks: [IgnoredBlock([Paired(old, new)])],
+  }
+  assert_true(
+    fragment_document_diff({ hunks: [hunk, hunk], }, "// old", "// new") is None,
   )
 }

--- a/editor/viewer/diff_provider/moondiff/semantic_review_plan_test.mbt
+++ b/editor/viewer/diff_provider/moondiff/semantic_review_plan_test.mbt
@@ -1,0 +1,56 @@
+///|
+test "Tree retains ignored documentation alignment outside the visible hunk" {
+  let original =
+    #|/// original docs
+    #|fn f() -> Int {
+    #|  let x0 = 0
+    #|  let x1 = 1
+    #|  let x2 = 2
+    #|  let x3 = 3
+    #|  let x4 = 4
+    #|  let x5 = 5
+    #|  let x6 = 6
+    #|  let x7 = 7
+    #|  1
+    #|}
+  let modified = original
+    .replace(
+      old="/// original docs",
+      new="/// original docs\n/// added docs 1\n/// added docs 2",
+    )
+    .replace(old="  1\n}", new="  2\n}")
+  for
+    (old, new, old_line, new_line) in [
+      (original, modified, 11, 13),
+      (modified, original, 13, 11),
+    ] {
+    guard @moondiff.compute_sectioned_semantic_review_plan(old, new, Tree)
+      is Some({ main_sections: [section], .. }) else {
+      fail(
+        "expected Tree to accept a changed function with distant ignored docs",
+      )
+    }
+    assert_eq(section.original_source, old)
+    assert_eq(section.modified_source, new)
+    guard section.diff is Fragment(document) else {
+      fail("expected a semantic fragment")
+    }
+    guard document.changes
+      is [{ kind: Ignored, mapping: docs, }, { kind: Visible, mapping: code, }] else {
+      fail("expected ignored docs followed by the code change")
+    }
+    assert_eq(docs.original.start_line_number, 2)
+    assert_eq(docs.modified.start_line_number, 2)
+    assert_eq(docs.original.length(), old_line - 11)
+    assert_eq(docs.modified.length(), new_line - 11)
+    assert_eq(code.original.start_line_number, old_line)
+    assert_eq(code.modified.start_line_number, new_line)
+    guard code.inner_changes is Some([inner]) else {
+      fail("expected only the changed return value to be highlighted")
+    }
+    assert_eq(inner.original.start_column, 3)
+    assert_eq(inner.original.end_column, 4)
+    assert_eq(inner.modified.start_column, 3)
+    assert_eq(inner.modified.end_column, 4)
+  }
+}

--- a/editor/viewer/diff_provider/moondiff/semantic_review_plan_wbtest.mbt
+++ b/editor/viewer/diff_provider/moondiff/semantic_review_plan_wbtest.mbt
@@ -88,7 +88,7 @@ test "changed matched declarations carry only fragment-local DiffEditor data" {
   guard target.diff is Fragment(diff) else {
     fail("expected a MoonDiff fragment provider")
   }
-  guard diff.changes is [change] else {
+  guard diff.changes is [{ mapping: change, .. }] else {
     fail("expected one local changed range")
   }
   assert_eq(change.original, LineRange(2, 3))
@@ -183,4 +183,45 @@ test "default semantic filters return explicit empty plans for ignored-only chan
   assert_eq(test_only.status, IgnoredOnly)
   assert_true(test_only.main_sections.is_empty())
   assert_true(test_only.deleted_sections.is_empty())
+}
+
+///|
+test "comment filtering recomputes mixed-line highlights in both semantic modes" {
+  let original = "fn value() -> Int {\n  1 // old comment\n}"
+  let modified = "fn value() -> Int {\n  2 // new comment\n}"
+  for mode in [Token, Tree] {
+    for ignore_comments in [false, true, false] {
+      let plan = semantic_plan_or_fail(
+        original,
+        modified,
+        mode,
+        ignore_comments~,
+      )
+      guard plan.main_sections is [{ diff: Fragment(document), .. }] else {
+        fail("expected one changed function")
+      }
+      let mut saw_code = false
+      let mut saw_comment = false
+      for change in document.changes {
+        if change.kind is Ignored {
+          continue
+        }
+        guard change.mapping.inner_changes is Some(inner) else {
+          fail("expected character mappings")
+        }
+        for span in inner {
+          if span.original.start_line_number == 2 {
+            if span.original.start_column <= 3 && span.original.end_column > 3 {
+              saw_code = true
+            }
+            if span.original.end_column > 5 {
+              saw_comment = true
+            }
+          }
+        }
+      }
+      assert_true(saw_code)
+      assert_eq(saw_comment, !ignore_comments)
+    }
+  }
 }


### PR DESCRIPTION
Tree review could reject a changed function when added or removed documentation fell outside MoonDiff's returned hunks. Preserve the complete source alignment by filling those gaps with ignored changes while retaining MoonDiff's visible changes and intraline highlights.

This branch also unifies `DocumentDiff` into one ordered list of `Visible` and `Ignored` changes. Layout consumes both kinds; decorations, navigation, and review features consume only visible changes. Inline review preserves the order of neutral alignment spacers, and sparse hunk adaptation accepts shared context while continuing to reject overlapping changes.

Validation:

- The supplied before/after files pass in both directions, in Token and Tree modes, with comments included and ignored (8 combinations).
- `just check`, `just test`, and `just build`.
- `just editor-test` and the editor's strict all-target check.
- `just editor-test-browser`.
- `git range-diff` confirms all three commits are patch-equivalent after rebasing onto `origin/main`.
