### PR TITLE
refactor(desktop): drop the legacy localStorage settings migration

### DIFF
--- a/desktop/frontend/console.mbt
+++ b/desktop/frontend/console.mbt
@@ -522,7 +522,6 @@ test "a revoked page device is retired without connecting a survivor" {
       has_custom_key: false,
       followup_behavior: "steer",
     }),
-    legacy_cleanup_pending: true,
     installed_skills: [
       {
         id: "old-host",
@@ -552,7 +551,6 @@ test "a revoked page device is retired without connecting a survivor" {
   inspect(refreshed.settings_saves, content="0")
   inspect(refreshed.host_settings_revision, content="-1")
   assert_true(refreshed.deferred_host_settings is None)
-  assert_false(refreshed.legacy_cleanup_pending)
   inspect(
     refreshed.conversations
     .iter()

--- a/desktop/frontend/host_settings.mbt
+++ b/desktop/frontend/host_settings.mbt
@@ -61,7 +61,6 @@ fn push_host_settings(
   channel : @interop.ChannelId,
   patch : @protocol.SettingsSetPayload,
   connection_generation : Int,
-  cleans_legacy? : Bool = false,
 ) -> @cmd.Cmd {
   let dispatch = dispatch.map((msg : DeviceMsg) => FromDevice(channel, msg))
   @cmd.custom_cmd(scheduler => {
@@ -75,7 +74,6 @@ fn push_host_settings(
               HostSettingsSaveFailed(
                 @interop.bridge_error_text(error),
                 connection_generation~,
-                cleans_legacy~,
               ),
             ),
           )
@@ -87,7 +85,6 @@ fn push_host_settings(
           HostSettingsApplied(
             HostSettings::from_status(reply),
             connection_generation~,
-            cleans_legacy~,
           ),
         ),
       )
@@ -105,7 +102,6 @@ fn provider_settings_patch(
     deepseek_api_key: None,
     glm_api_key: None,
     custom_api_key: None,
-    legacy_migration: None,
     followup_behavior: None,
   }
 }
@@ -120,7 +116,6 @@ fn custom_url_settings_patch(url : String) -> @protocol.SettingsSetPayload {
     deepseek_api_key: None,
     glm_api_key: None,
     custom_api_key: None,
-    legacy_migration: None,
     followup_behavior: None,
   }
 }
@@ -148,41 +143,6 @@ fn api_key_settings_patch(
     } else {
       None
     },
-    legacy_migration: None,
-    followup_behavior: None,
-  }
-}
-
-///|
-/// The migration patch: every legacy value the page still held, in one
-/// write. Blank legacy fields are omitted (nothing stored) rather than
-/// sent as clears — the host may already hold newer values.
-fn legacy_settings_patch(
-  provider~ : String,
-  custom_url~ : String,
-  api_key~ : String,
-  custom_api_key~ : String,
-) -> @protocol.SettingsSetPayload {
-  // The host persists a one-shot fence with the first settings write.
-  // Retrying this import after a lost reply therefore acknowledges and
-  // clears localStorage without overwriting a newer host configuration.
-  fn carried(value : String) -> String? {
-    let value = value.trim().to_owned()
-    if value.is_empty() {
-      None
-    } else {
-      Some(value)
-    }
-  }
-
-  {
-    provider: carried(provider),
-    custom_api_url: carried(custom_url),
-    deepseek_api_key: carried(api_key),
-    // No legacy page ever stored a GLM key; the import has nothing to carry.
-    glm_api_key: None,
-    custom_api_key: carried(custom_api_key),
-    legacy_migration: Some(true),
     followup_behavior: None,
   }
 }
@@ -197,23 +157,6 @@ fn followup_behavior_patch(
     deepseek_api_key: None,
     glm_api_key: None,
     custom_api_key: None,
-    legacy_migration: None,
     followup_behavior: Some(behavior.wire()),
   }
-}
-
-///|
-test "legacy migration trims the values it preserves" {
-  let patch = legacy_settings_patch(
-    provider=" deepseek ",
-    custom_url=" https://example.invalid/chat ",
-    api_key=" sk-legacy ",
-    custom_api_key="",
-  ).to_json()
-  json_inspect(patch, content={
-    "legacy_migration": true,
-    "provider": "deepseek",
-    "custom_api_url": "https://example.invalid/chat",
-    "deepseek_api_key": "sk-legacy",
-  })
 }

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -207,22 +207,6 @@ const TranscriptRefreshFailedNotice : String = "Transcript refresh failed repeat
 const SteerDroppedNotice : String = "Input was not delivered (the task ended as you sent it) — it is back in the composer."
 
 ///|
-/// Legacy localStorage keys from when the page stored the engine endpoint
-/// settings itself. Those now live on the host (`settings.get`/`set`); the
-/// keys remain only so the desktop window can migrate stored values up once
-/// and every page can purge the leftover secrets.
-const LegacyApiKeyStorageKey : String = "openseek.deepseek_api_key"
-
-///|
-const LegacyCustomApiKeyStorageKey : String = "openseek.custom_api_key"
-
-///|
-const LegacyApiProviderStorageKey : String = "openseek.api_provider"
-
-///|
-const LegacyCustomApiUrlStorageKey : String = "openseek.custom_api_url"
-
-///|
 const NotificationCornerStorageKey : String = "openseek.notification_corner"
 
 ///|
@@ -293,17 +277,6 @@ const ConversationModelsStorageKey : String = "openseek.conversation_models"
 /// the least recently chosen conversation forgets and opens on the default,
 /// exactly like one the user never chose a tier for.
 const ConversationModelsLimit : Int = 200
-
-///|
-/// Obsolete: each workspace's launch-mode default lives in its own
-/// `.openseek/settings.json` now. The key is kept only so startup can
-/// delete whatever old builds stored.
-const WorkspaceDefaultModeStorageKey : String = "openseek.workspace_default_mode"
-
-///|
-/// Obsolete: the update channel is gone — there is one release stream. The
-/// key is kept only so startup can delete whatever old builds stored.
-const UpdateChannelStorageKey : String = "openseek.update_channel"
 
 ///|
 /// The app's appearance choice. System preference is tracked separately on
@@ -1436,9 +1409,6 @@ priv struct Model {
   // bridge generation has not accepted an authoritative status yet.
   host_settings_revision : Int
   deferred_host_settings : HostSettings?
-  // A legacy localStorage migration's push is in flight; its success is
-  // what deletes the migrated secrets from localStorage.
-  legacy_cleanup_pending : Bool
   // Whether the API-setup modal is up. Every settled settings snapshot
   // decides it through `settle_api_setup` — the one place that opens it —
   // and it closes the moment a usable endpoint arrives.
@@ -1738,16 +1708,6 @@ priv enum Msg {
     codex_effort~ : String,
     openseek_effort~ : String,
     glm_effort~ : String
-  )
-  // The legacy localStorage engine settings, read at bridge time. The
-  // desktop window migrates them up to the host once; a browser page only
-  // purges them (a stale secret in shared storage is the leak this design
-  // removes).
-  LegacySettingsRead(
-    provider~ : String,
-    custom_url~ : String,
-    api_key~ : String,
-    custom_api_key~ : String
   )
   // Deliberate actions emitted by the component-local input composer. Raw
   // keystrokes never enter this root message loop.
@@ -2145,17 +2105,9 @@ priv enum DeviceMsg {
   // is in flight — see `Model::settings_saves`.
   HostSettingsLoaded(HostSettings, connection_generation~ : Int?)
   // A `settings.set` this client sent came back with the post-write state.
-  HostSettingsApplied(
-    HostSettings,
-    connection_generation~ : Int,
-    cleans_legacy~ : Bool
-  )
+  HostSettingsApplied(HostSettings, connection_generation~ : Int)
   // A `settings.set` this client sent failed; the message pops as a toast.
-  HostSettingsSaveFailed(
-    String,
-    connection_generation~ : Int,
-    cleans_legacy~ : Bool
-  )
+  HostSettingsSaveFailed(String, connection_generation~ : Int)
   // A `skills.installed` reply is channel-scoped just like the invalidation
   // that prompted it. Only the currently focused host may replace the
   // page's library mirror.
@@ -2629,7 +2581,6 @@ fn initial_model() -> Model {
     settings_saves: 0,
     host_settings_revision: -1,
     deferred_host_settings: None,
-    legacy_cleanup_pending: false,
     is_desktop,
     window_focused: !is_desktop || @interop.page_has_focus(),
     app_version: "development",
@@ -2822,7 +2773,6 @@ fn Model::clear_host_settings(self : Model) -> Model {
     settings_saves: 0,
     host_settings_revision: -1,
     deferred_host_settings: None,
-    legacy_cleanup_pending: false,
   }
 }
 
@@ -2901,7 +2851,7 @@ fn Model::defer_host_settings(self : Model, settings : HostSettings) -> Model {
 /// the form. A lower revision is discarded; equal is deliberately accepted
 /// so a failed optimistic edit can be restored by an authoritative `get`.
 /// The settled mirror then decides the setup modal like any other snapshot —
-/// a deferred first snapshot (the legacy migration races it here) must be
+/// a deferred first snapshot (an optimistic write races it here) must be
 /// able to open the modal, not just retire it.
 fn Model::flush_host_settings(self : Model) -> Model {
   let next = match self.deferred_host_settings {

--- a/desktop/frontend/storage.mbt
+++ b/desktop/frontend/storage.mbt
@@ -5,18 +5,11 @@
 // The engine endpoint settings (provider, URLs, API keys) are NOT here: they
 // live on the host (`settings.get`/`set`), because relay pages
 // for different devices share one browser origin — a secret in
-// localStorage would leak across hosts. The legacy readers below exist
-// only for the one-time migration (desktop) and purge (browser).
+// localStorage would leak across hosts.
 
 ///|
 fn load_saved_settings(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
-    // The update channel stopped being its own setting (it derives from the
-    // server selection now), and each workspace's launch-mode default lives
-    // in its own `.openseek/settings.json`; drop both obsolete keys
-    // wherever they linger.
-    remove_setting(UpdateChannelStorageKey)
-    remove_setting(WorkspaceDefaultModeStorageKey)
     scheduler.add(
       dispatch(
         SettingsLoaded(
@@ -161,46 +154,6 @@ fn AppFontSize::save(self : AppFontSize) -> @cmd.Cmd {
 }
 
 ///|
-/// Read the legacy client-stored engine settings, dispatched only when any
-/// value is actually stored — a page that never held them (or already
-/// migrated) dispatches nothing.
-fn read_legacy_engine_settings(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
-  @cmd.custom_cmd(scheduler => {
-    let provider = load_setting(LegacyApiProviderStorageKey)
-    let custom_url = load_setting(LegacyCustomApiUrlStorageKey)
-    let api_key = load_setting(LegacyApiKeyStorageKey)
-    let custom_api_key = load_setting(LegacyCustomApiKeyStorageKey)
-    if [provider, custom_url, api_key, custom_api_key]
-      .iter()
-      .any(value => !value.is_blank()) {
-      scheduler.add(
-        dispatch(
-          LegacySettingsRead(provider~, custom_url~, api_key~, custom_api_key~),
-        ),
-      )
-    }
-  })
-}
-
-///|
-/// Delete the legacy client-stored engine settings — after the desktop
-/// migrated them up, or on any browser page (where the stored key is the
-/// cross-device leak this design removes).
-fn clear_legacy_engine_settings() -> @cmd.Cmd {
-  @cmd.custom_cmd(_ => {
-    for
-      key in [
-        LegacyApiProviderStorageKey,
-        LegacyCustomApiUrlStorageKey,
-        LegacyApiKeyStorageKey,
-        LegacyCustomApiKeyStorageKey,
-      ] {
-      remove_setting(key)
-    }
-  })
-}
-
-///|
 fn load_setting(storage_key : String) -> String {
   @js.Error_::wrap(
     fn() {
@@ -226,23 +179,6 @@ fn save_setting(storage_key : String, value : String) -> Unit {
       storage.apply_with_string("setItem", [
         @js.Value::cast_from(storage_key),
         @js.Value::cast_from(value),
-      ])
-    },
-    map_ok=_ => (),
-  ) catch {
-    _ => ()
-  }
-}
-
-///|
-fn remove_setting(storage_key : String) -> Unit {
-  @js.Error_::wrap(
-    fn() {
-      guard @interop.js_prop(@js.globalThis, "localStorage") is Some(storage) else {
-        return @js.Value::cast_from(())
-      }
-      storage.apply_with_string("removeItem", [
-        @js.Value::cast_from(storage_key),
       ])
     },
     map_ok=_ => (),

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1977,11 +1977,6 @@ fn update_msg(
             @cmd.batch([
               fetch_console_me(dispatch),
               load_saved_settings(dispatch),
-              // Browser localStorage is relay-origin state, not device
-              // state. Purge old client-held engine credentials even while
-              // signed out or when no device is online to reach
-              // `BridgeReady`.
-              clear_legacy_engine_settings(),
               watch_color_scheme(dispatch),
               request_sidebar_resize_mount(),
               measure_scrollbar_lane(),
@@ -2098,42 +2093,6 @@ fn update_msg(
     // edit broadcast. Revisions order concurrent clients and RPC replies;
     // while this page has optimistic writes, keep only the newest status and
     // apply it once the last write settles.
-    LegacySettingsRead(provider~, custom_url~, api_key~, custom_api_key~) =>
-      // Only the desktop window migrates: it is the one client whose stored
-      // values are unambiguously this host's. A browser page's copy may
-      // belong to a different device behind the same origin — pushing it is
-      // exactly the leak the host-side store removes — so it is purged.
-      if model.is_desktop {
-        let patch = legacy_settings_patch(
-          provider~,
-          custom_url~,
-          api_key~,
-          custom_api_key~,
-        )
-        // Mirror the pushed values optimistically so the Settings page and
-        // the ready gate reflect the migration immediately.
-        let next = {
-          ..model,
-          api_provider: ApiProvider::parse(provider),
-          custom_api_url: custom_url.trim().to_owned(),
-          deepseek_key_saved: model.deepseek_key_saved || !api_key.is_blank(),
-          custom_key_saved: model.custom_key_saved || !custom_api_key.is_blank(),
-          settings_saves: model.settings_saves + 1,
-          legacy_cleanup_pending: true,
-        }
-        (
-          push_host_settings(
-            dispatch,
-            model.focused,
-            patch,
-            model.focused_connection_generation(),
-            cleans_legacy=true,
-          ),
-          next,
-        )
-      } else {
-        (clear_legacy_engine_settings(), model)
-      }
     CodexComposerAction(action) =>
       match action {
         @composer.ModelMenuToggled(identity~) => {
@@ -5622,9 +5581,6 @@ fn update_device_msg(
         commands.push(
           fetch_host_settings(dispatch, channel, connection_generation),
         )
-        // Legacy client-stored engine settings: the desktop migrates them
-        // up to the host, a browser purges them (see `LegacySettingsRead`).
-        commands.push(read_legacy_engine_settings(dispatch))
         commands.push(fetch_installed_skills(dispatch, channel))
         // Codex conversations are always visible in the global sidebar, so
         // populate that focused-host catalog on bridge readiness rather than
@@ -5812,7 +5768,7 @@ fn update_device_msg(
         (@cmd.none, model.apply_host_settings(settings).settle_api_setup())
       }
     }
-    HostSettingsApplied(settings, connection_generation~, cleans_legacy~) => {
+    HostSettingsApplied(settings, connection_generation~) => {
       guard connection_generation == dev.connection_generation else {
         return (@cmd.none, model)
       }
@@ -5828,20 +5784,8 @@ fn update_device_msg(
           0
         },
       }.defer_host_settings(settings)
-      // The migration's secrets leave localStorage only once the host
-      // confirmed it holds them.
-      let cleanup = if cleans_legacy && next.legacy_cleanup_pending {
-        clear_legacy_engine_settings()
-      } else {
-        @cmd.none
-      }
-      let next = if cleans_legacy {
-        { ..next, legacy_cleanup_pending: false, }
-      } else {
-        next
-      }
       (
-        cleanup,
+        @cmd.none,
         if next.settings_saves > 0 {
           next
         } else {
@@ -5849,7 +5793,7 @@ fn update_device_msg(
         },
       )
     }
-    HostSettingsSaveFailed(message, connection_generation~, cleans_legacy~) => {
+    HostSettingsSaveFailed(message, connection_generation~) => {
       guard connection_generation == dev.connection_generation else {
         return (@cmd.none, model)
       }
@@ -5860,13 +5804,6 @@ fn update_device_msg(
           model.settings_saves - 1
         } else {
           0
-        },
-        // The push never landed; the legacy values stay in localStorage for
-        // the next launch's retry.
-        legacy_cleanup_pending: if cleans_legacy {
-          false
-        } else {
-          model.legacy_cleanup_pending
         },
       }
       let next = if next.settings_saves == 0 {
@@ -14053,7 +13990,6 @@ test "host settings are deferred while this client's writes are in flight" {
     HostSettingsApplied(
       host_settings(provider="deepseek", revision=2, has_deepseek_key=true),
       connection_generation=0,
-      cleans_legacy=false,
     ),
     model,
   )
@@ -14068,7 +14004,6 @@ test "host settings are deferred while this client's writes are in flight" {
     HostSettingsApplied(
       host_settings(provider="deepseek", revision=1),
       connection_generation=0,
-      cleans_legacy=false,
     ),
     stacked,
   )
@@ -14100,102 +14035,12 @@ test "a newer peer broadcast beats a delayed local settings reply" {
     HostSettingsApplied(
       host_settings(provider="openseek", revision=6),
       connection_generation=0,
-      cleans_legacy=false,
     ),
     broadcast,
   )
   assert_true(settled.api_provider is Deepseek)
   inspect(settled.host_settings_revision, content="7")
   inspect(settled.settings_saves, content="0")
-}
-
-///|
-test "legacy client settings migrate up only from the desktop window" {
-  let dispatch = test_dispatch()
-  let legacy = LegacySettingsRead(
-    provider="deepseek",
-    custom_url="",
-    api_key="sk-legacy",
-    custom_api_key="",
-  )
-  let (_, desktop) = update(dispatch, legacy, {
-    ..test_model(),
-    is_desktop: true,
-  })
-  assert_true(desktop.api_provider is Deepseek)
-  assert_true(desktop.deepseek_key_saved)
-  inspect(desktop.settings_saves, content="1")
-  assert_true(desktop.legacy_cleanup_pending)
-  // A browser page only purges — its copy may belong to another device.
-  // The keyless mirror is explicit: the fixture's saved key belongs to the
-  // desktop window's migration above, not to this page.
-  let (_, browser) = update(dispatch, legacy, {
-    ..test_model(),
-    is_desktop: false,
-    deepseek_key_saved: false,
-  })
-  assert_false(browser.deepseek_key_saved)
-  inspect(browser.settings_saves, content="0")
-  assert_false(browser.legacy_cleanup_pending)
-}
-
-///|
-test "only the migration settings response owns legacy cleanup" {
-  let dispatch = test_dispatch()
-  let pending = {
-    ..test_model(),
-    settings_saves: 2,
-    legacy_cleanup_pending: true,
-  }
-  // An unrelated save may finish first; it must not consume the migration's
-  // right to clear localStorage when that exact write is acknowledged.
-  let (_, unrelated) = update_dev(
-    dispatch,
-    HostSettingsApplied(
-      host_settings(provider="custom", revision=1),
-      connection_generation=0,
-      cleans_legacy=false,
-    ),
-    pending,
-  )
-  inspect(unrelated.settings_saves, content="1")
-  assert_true(unrelated.legacy_cleanup_pending)
-  let (_, migrated) = update_dev(
-    dispatch,
-    HostSettingsApplied(
-      host_settings(provider="deepseek", revision=2, has_deepseek_key=true),
-      connection_generation=0,
-      cleans_legacy=true,
-    ),
-    unrelated,
-  )
-  inspect(migrated.settings_saves, content="0")
-  assert_false(migrated.legacy_cleanup_pending)
-  assert_true(migrated.api_provider is Deepseek)
-  assert_true(migrated.deepseek_key_saved)
-}
-
-///|
-test "a failed migration keeps legacy storage for a later launch" {
-  let dispatch = test_dispatch()
-  let pending = {
-    ..test_model(),
-    settings_saves: 1,
-    legacy_cleanup_pending: true,
-  }
-  let (_, failed) = update_dev(
-    dispatch,
-    HostSettingsSaveFailed(
-      "host write failed",
-      connection_generation=0,
-      cleans_legacy=true,
-    ),
-    pending,
-  )
-  inspect(failed.settings_saves, content="0")
-  // False means this launch must not clear localStorage; LegacySettingsRead
-  // on the next launch will discover and retry the still-present values.
-  assert_false(failed.legacy_cleanup_pending)
 }
 
 ///|
@@ -14219,7 +14064,6 @@ test "background settings replies cannot alter the focused host mirror" {
       HostSettingsApplied(
         host_settings(provider="deepseek", revision=7),
         connection_generation=0,
-        cleans_legacy=false,
       ),
     ),
     focused,
@@ -14230,11 +14074,7 @@ test "background settings replies cannot alter the focused host mirror" {
     dispatch,
     FromDevice(
       Local,
-      HostSettingsSaveFailed(
-        "old host failed",
-        connection_generation=0,
-        cleans_legacy=false,
-      ),
+      HostSettingsSaveFailed("old host failed", connection_generation=0),
     ),
     applied,
   )

--- a/desktop/internal/api/api.mbt
+++ b/desktop/internal/api/api.mbt
@@ -524,7 +524,6 @@ pub fn endpoints(
           state.manager,
           payload.to_patch(),
           followup_behavior?=payload.followup_behavior,
-          legacy_migration=payload.legacy_migration == Some(true),
           on_committed=fn(status) {
             // Every client renders these settings; clients that did not ask
             // must learn about the committed revision too.

--- a/desktop/internal/engine/pkg.generated.mbti
+++ b/desktop/internal/engine/pkg.generated.mbti
@@ -59,7 +59,7 @@ pub fn steer_run(EngineManager, @protocol.SteerPayload) -> @protocol.SteerReply
 
 pub async fn unarchive_session(EngineManager, String, (String, String) -> Unit) -> @protocol.SessionsReply
 
-pub async fn update_settings(EngineManager, SettingsPatch, followup_behavior? : String, legacy_migration? : Bool, on_committed? : (@protocol.SettingsStatusPayload) -> Unit) -> @protocol.SettingsStatusPayload
+pub async fn update_settings(EngineManager, SettingsPatch, followup_behavior? : String, on_committed? : (@protocol.SettingsStatusPayload) -> Unit) -> @protocol.SettingsStatusPayload
 
 // Errors
 pub(all) suberror EngineError {

--- a/desktop/internal/engine/settings.mbt
+++ b/desktop/internal/engine/settings.mbt
@@ -25,12 +25,6 @@ const EngineSettingsVersion = 2
 const EngineSettingsFileName = "engine-settings.json"
 
 ///|
-/// Durable compatibility fence. The first settings write sets it; a retried
-/// localStorage import then returns the current settings without replacing a
-/// newer browser or desktop edit.
-const LegacyMigrationFence = "legacy_client_settings_migrated"
-
-///|
 /// The SeekMoon relay origin: remote access (browser sign-in) and the
 /// update manifest live here. The hosted chat proxy that used to live on
 /// this origin is retired — runs are bring-your-own-key only — so this
@@ -211,7 +205,6 @@ pub async fn update_settings(
   manager : EngineManager,
   patch : SettingsPatch,
   followup_behavior? : String,
-  legacy_migration? : Bool = false,
   on_committed? : (@protocol.SettingsStatusPayload) -> Unit,
 ) -> @protocol.SettingsStatusPayload {
   manager.settings_lock.acquire()
@@ -226,19 +219,6 @@ pub async fn update_settings(
     )
   }
   let raw = current.raw
-  // A migration may be retried after its commit reply was lost. It is also
-  // possible for a modern client to write first. In both cases the durable
-  // fence wins and the old localStorage snapshot is merely acknowledged so
-  // the desktop can delete it.
-  let store_claimed = raw.get(LegacyMigrationFence) is Some(True) ||
-    raw.get("provider") is Some(_) ||
-    raw.get("custom_api_url") is Some(_) ||
-    raw.get("deepseek_api_key") is Some(_) ||
-    raw.get("glm_api_key") is Some(_) ||
-    raw.get("custom_api_key") is Some(_)
-  if legacy_migration && store_claimed {
-    return settings_status_payload(current, manager.settings_revision)
-  }
   if patch.provider is Some(value) {
     guard ApiProvider::parse(value.trim().to_owned()) is Some(provider) else {
       raise EngineError("unknown API provider '\{value}'")
@@ -258,7 +238,6 @@ pub async fn update_settings(
   // Version 2 retired the WSL engine mode. A settings write also removes the
   // old group so the durable file no longer advertises an ignored capability.
   raw.remove("wsl")
-  raw[LegacyMigrationFence] = Json(true)
   raw["version"] = Json(EngineSettingsVersion.to_double())
   write_settings_file(dir, Json(raw).stringify(indent=2))
   // Disk is now committed. Advance the process-local order and publish while
@@ -512,8 +491,8 @@ async test "retired hosted providers converge on the DeepSeek default" {
     // Settings.
     @fsx.write_text(settings_file(dir), "{\"provider\": \"openseek\"}")
     assert_true(load_engine_settings(manager.runtime_dir).provider is Deepseek)
-    // A write carrying a retired name (e.g. a legacy client's migration)
-    // is accepted and persisted as the default it means now.
+    // A write carrying a retired name (e.g. from an older client) is
+    // accepted and persisted as the default it means now.
     let status = update_settings(manager, {
       provider: Some("openseek-staging"),
       custom_api_url: None,
@@ -590,51 +569,6 @@ async test "a save removes the retired WSL settings group" {
       fields.get("version") is Some(Number(version, ..)) &&
       version.to_int() == 2,
     )
-  })
-}
-
-///|
-async test "legacy migration cannot replay over a newer settings write" {
-  with_settings_dir(async fn(_dir, manager) {
-    let migrated = update_settings(
-      manager,
-      {
-        provider: Some("deepseek"),
-        custom_api_url: None,
-        deepseek_api_key: Some("sk-old"),
-        glm_api_key: None,
-        custom_api_key: None,
-      },
-      legacy_migration=true,
-    )
-    assert_eq(migrated.revision, 1)
-    let modern = update_settings(manager, {
-      provider: Some("custom"),
-      custom_api_url: Some("https://new.example/chat"),
-      deepseek_api_key: Some(""),
-      glm_api_key: None,
-      custom_api_key: Some("sk-new"),
-    })
-    assert_eq(modern.revision, 2)
-    // This is the desktop retry after the first migration's reply was lost.
-    // It gets the current status so the client can clear localStorage, but
-    // neither advances the revision nor restores the stale values.
-    let replay = update_settings(
-      manager,
-      {
-        provider: Some("deepseek"),
-        custom_api_url: None,
-        deepseek_api_key: Some("sk-old"),
-        glm_api_key: None,
-        custom_api_key: None,
-      },
-      legacy_migration=true,
-    )
-    assert_eq(replay.revision, 2)
-    let current = load_engine_settings(manager.runtime_dir)
-    assert_true(current.provider is Custom)
-    assert_true(current.deepseek_api_key is None)
-    assert_true(current.custom_api_key is Some("sk-new"))
   })
 }
 

--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -207,7 +207,6 @@ pub(all) struct ArchivedSessionPayload {
 
 ///|
 pub(all) struct SettingsSetPayload {
-  legacy_migration : Bool?
   provider : String?
   custom_api_url : String?
   deepseek_api_key : String?
@@ -220,7 +219,6 @@ pub(all) struct SettingsSetPayload {
 pub impl FromJson for SettingsSetPayload with fn from_json(json, path) {
   let object = JsonObject::decode(json, path, "settings patch payload")
   {
-    legacy_migration: object.optional_bool("legacy_migration"),
     provider: object.optional_string("provider"),
     custom_api_url: object.optional_string("custom_api_url"),
     deepseek_api_key: object.optional_string("deepseek_api_key"),
@@ -233,9 +231,6 @@ pub impl FromJson for SettingsSetPayload with fn from_json(json, path) {
 ///|
 pub impl ToJson for SettingsSetPayload with fn to_json(self) {
   let fields : Map[String, Json] = Map([])
-  if self.legacy_migration is Some(value) {
-    fields["legacy_migration"] = value.to_json()
-  }
   if self.provider is Some(value) {
     fields["provider"] = value.to_json()
   }

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -2146,7 +2146,6 @@ pub fn SessionsReply::to_json(Self) -> Json
 pub fn SessionsReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SettingsSetPayload {
-  legacy_migration : Bool?
   provider : String?
   custom_api_url : String?
   deepseek_api_key : String?

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -406,7 +406,7 @@ still signs out a session whose issuer no longer matches the origin.
 | method | params | result |
 |---|---|---|
 | `settings.get` | `{}` | the status shape below |
-| `settings.set` | `{provider?, custom_api_url?, deepseek_api_key?, glm_api_key?, custom_api_key?, legacy_migration?}` — absent fields stay unchanged; a present string field is trimmed and, when empty, **clears** the stored value; an unknown `provider` is refused. `legacy_migration:true` is reserved for the bundled desktop's one-time import: once any settings write has claimed the durable store, a replay is acknowledged without changing it. | the status shape below, post-write |
+| `settings.set` | `{provider?, custom_api_url?, deepseek_api_key?, glm_api_key?, custom_api_key?}` — absent fields stay unchanged; a present string field is trimmed and, when empty, **clears** the stored value; an unknown `provider` is refused. | the status shape below, post-write |
 
 The status shape, also the params of every `settings.changed` notification:
 


### PR DESCRIPTION
## Summary

Removes the one-time localStorage → host settings migration added in #608 and the leftover obsolete-key purges. Net −406 lines, no behavior change for any released build.

**Why it is safe to drop**

- #608 (2026-07-31) moved provider/URL/API-key settings to the host and added the import (desktop) / purge (browser) path for values older builds had stored in localStorage.
- The unified desktop release pipeline started with #646 (2026-08-05), so every published build already stored settings host-side. Only pre-#608 dev builds ever wrote a key into localStorage, and those machines have had six weeks of launches to migrate and clear.
- A relay browser page never stored a key at its origin, so the purge branch never had anything to purge.

**What goes**

- Frontend: the four `Legacy*StorageKey` constants, `read_legacy_engine_settings` / `clear_legacy_engine_settings`, the `LegacySettingsRead` message and handler, `legacy_cleanup_pending`, the `cleans_legacy` tag on `HostSettingsApplied` / `HostSettingsSaveFailed`, `legacy_settings_patch`, and the startup `removeItem` of the obsolete `update_channel` / `workspace_default_mode` keys.
- Protocol/API: `SettingsSetPayload.legacy_migration` and its passthrough.
- Engine: `LegacyMigrationFence`, the `store_claimed` replay guard and the `legacy_migration` parameter on `update_settings`. Existing `engine-settings.json` files keep the fence key as an ignored field.
- `docs/remote-protocol.md` `settings.set` row updated.

**Residual risk**: a machine still on a pre-2026-07-31 dev build that jumps straight to this version re-enters its API key once, and the old key file lingers unread in the CEF profile.

## Test plan

- `moon check --target js` / `--target native` clean
- `moon test --target js frontend internal/protocol` — 531 passed
- `moon test --target native internal/engine internal/api internal/protocol` — 200 passed
- `moon info`: only the two intended `pkg.generated.mbti` entries changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KrzreJHLi9VoJahTF6uRSf
