### PR TITLE
fix(editor): highlight the current line in dark and light themes

### DIFF
--- a/desktop/viewer_theme.css
+++ b/desktop/viewer_theme.css
@@ -82,9 +82,13 @@
   --vscode-editorGutter-foldingControlForeground: var(
     --vscode-icon-foreground
   );
-  /* editor.lineHighlightBackground stays unset like VS Code's defaults, so
-     the current line renders as the border box, not a fill. */
-  --vscode-editor-lineHighlightBorder: var(--color-border-subtle);
+  /* A neutral wash follows the app's light/dark palette automatically. */
+  --vscode-editor-lineHighlightBackground: color-mix(
+    in srgb,
+    var(--color-text-primary) 5%,
+    transparent
+  );
+  --vscode-editor-lineHighlightBorder: transparent;
   --vscode-editorWhitespace-foreground: color-mix(
     in srgb,
     var(--color-text-muted) 45%,

--- a/editor/internal/shell/workbench/theme.css
+++ b/editor/internal/shell/workbench/theme.css
@@ -49,12 +49,10 @@
   --vscode-editorGutter-foldingControlForeground: var(
     --vscode-icon-foreground
   );
-  /* editorCursor.foreground / editor.lineHighlightBorder registry defaults
-     (editorColorRegistry.ts:16,22); Dark Modern does not override them.
-     editor.lineHighlightBackground stays null like VS Code's defaults, so the
-     current line renders as the border box, not a fill. */
+  /* Neutral current-line wash stays distinct from selections and diff fills. */
   --vscode-editorCursor-foreground: #aeafad;
-  --vscode-editor-lineHighlightBorder: #282828;
+  --vscode-editor-lineHighlightBackground: #ffffff0d;
+  --vscode-editor-lineHighlightBorder: transparent;
   /* editorWhitespace.foreground registry default (editorColorRegistry.ts:28);
      the Modern themes do not override it. */
   --vscode-editorWhitespace-foreground: #e3e4e229;
@@ -206,10 +204,10 @@
   --vscode-editorGutter-foldingControlForeground: var(
     --vscode-icon-foreground
   );
-  /* See the Dark Modern block above (light defaults: black caret, #eeeeee
-     line-highlight border). */
+  /* Use a dark wash on the light code surface. */
   --vscode-editorCursor-foreground: #000000;
-  --vscode-editor-lineHighlightBorder: #eeeeee;
+  --vscode-editor-lineHighlightBackground: #0000000a;
+  --vscode-editor-lineHighlightBorder: transparent;
   /* See the Dark Modern block above (light registry default). */
   --vscode-editorWhitespace-foreground: #33333333;
   --vscode-editorLink-activeForeground: #0000ff;

--- a/editor/tests/browser/smoke/current_line.spec.js
+++ b/editor/tests/browser/smoke/current_line.spec.js
@@ -1,0 +1,32 @@
+import { expect, test } from '../support/test.js';
+import { openWorkspaceFile } from '../support/app.js';
+
+test('default current-line fill follows the caret and the theme, including blur', async ({ page }, testInfo) => {
+  await page.goto('/');
+  await openWorkspaceFile(page, 'notes.txt');
+  const editor = page.locator('.monaco-editor.readonly-editor');
+  const highlight = editor.locator('.view-overlays .current-line');
+
+  for (const [theme, color] of [
+    ['dark', 'rgba(255, 255, 255, 0.05)'],
+    ['light', 'rgba(0, 0, 0, 0.04)'],
+  ]) {
+    const line = editor.locator('.view-line').nth(theme === 'dark' ? 0 : 2);
+    if (theme === 'light') {
+      await page.locator('[data-action="toggle-theme"]').click();
+    }
+    await line.click({ position: { x: 8, y: 8 } });
+    await expect(highlight).toHaveCount(1);
+    await expect(highlight).toHaveCSS('background-color', color);
+    await expect.poll(async () => {
+      const a = await highlight.boundingBox();
+      const b = await line.boundingBox();
+      return a !== null && b !== null && Math.abs(a.y - b.y) < 1;
+    }).toBe(true);
+    await page.screenshot({ path: testInfo.outputPath(`current-line-${theme}.png`) });
+
+    await page.locator('[data-action="toggle-theme"]').focus();
+    await expect(editor).not.toHaveClass(/focused/);
+    await expect(highlight).toHaveCSS('background-color', color);
+  }
+});

--- a/editor/viewer/browser/view_parts/current_line_highlight/current_line_highlight.css
+++ b/editor/viewer/browser/view_parts/current_line_highlight/current_line_highlight.css
@@ -3,13 +3,10 @@
    plus the registerThemingParticipant rules (currentLineHighlight.ts:237-264),
    as static var() CSS (the viewer's theming design). Covers both the content
    overlay (this package) and the margin overlay (view_parts/margin), like the
-   Monaco source file. Deviations:
-   - editor.inactiveLineHighlightBackground defaults to
-     editor.lineHighlightBackground and both are null in the shipped themes,
-     so the unfocused background rule is omitted;
-   - Monaco emits the border rules only when no (opaque) background color is
-     defined (cLH:253-263) — statically true for the shipped themes, which
-     define only --vscode-editor-lineHighlightBorder. */
+   Monaco source file. Hosts supply a subtle fill and a transparent border;
+   border-only themes can still supply lineHighlightBorder. The inactive fill
+   falls back to the active fill, matching the default focus-independent
+   renderLineHighlight option. */
 
 .monaco-editor .view-overlays .current-line {
   display: block;
@@ -35,6 +32,14 @@
   .margin-view-overlays
   .current-line.current-line-margin.current-line-margin-both {
   border-right: 0;
+}
+
+.monaco-editor .view-overlays .current-line,
+.monaco-editor .margin-view-overlays .current-line-margin {
+  background-color: var(
+    --vscode-editor-inactiveLineHighlightBackground,
+    var(--vscode-editor-lineHighlightBackground, transparent)
+  );
 }
 
 .monaco-editor.focused .view-overlays .current-line {


### PR DESCRIPTION
The default current-line highlight was only a faint outline. Give it a subtle neutral background in both dark and light themes, and preserve the fill when the editor loses focus. The desktop theme bridge derives its fill from the app palette so theme changes propagate automatically through the existing Viewer API.

Add a browser regression covering default rendering, caret-line geometry, dark/light switching, and blur; visually inspect screenshots of both themes.

Validation:
- `just test`, `just build`, and `just editor-test` passed.
- All 105 Playwright smoke/component tests passed; the final caret-movement assertion also passed in a focused rerun.
- Root/editor `moon info` and `moon fmt` passed, with no generated interface changes.
- Strict root/editor checks are blocked by existing unused-package warnings in unchanged MoonBit manifests.
- `just editor-test-browser` hit a local C compiler error in the script-mode async 0.21.3 dependency (`switch` on `atomic_int32_t`). Running the same asset-staging scripts on Wasm succeeded, then the full Playwright suite passed.
