### PR TITLE
fix(agent_tool): point read tool's directory hint at mbtx

### DIFF
--- a/agent_tool/read/README.mbt.md
+++ b/agent_tool/read/README.mbt.md
@@ -10,8 +10,7 @@ single-file `read` tool calls in one assistant response. The tool accepts one
 file per call so ranges, errors, and output budgets stay tied to a specific
 file.
 
-Do not use `read` for directories. Inspect directories with `ls` or `tree`, then
-read specific files.
+Do not use `read` for directories. List them with `mbtx` (`@fs.readdir`/`@shell.glob`), then read specific files.
 
 ## Design Rationale
 
@@ -101,7 +100,7 @@ test "read tool advertises the expected schema" {
     content=(
       #|{
       #|  name: "read",
-      #|  description: "Read arguments.path as text. For several known independent files, batch separate\nread tool calls in one assistant response when possible. Do not use read for\ndirectories: inspect them with `ls` or `tree`, then read specific files. Supports\noptional start_line, max_lines, and max_output_chars for focused single-file\nreads. Output is right-aligned `<line-number> |<content>` numbered lines followed\nby a `<system>` status footer.",
+      #|  description: "Read arguments.path as text. For several known independent files, batch separate\nread tool calls in one assistant response when possible. Do not use read for\ndirectories: list them with `mbtx` (`@fs.readdir`/`@shell.glob`), then read\nspecific files. Supports optional start_line, max_lines, and max_output_chars for\nfocused single-file reads. Output is right-aligned `<line-number> |<content>`\nnumbered lines followed by a `<system>` status footer.",
       #|  schema: JsonSchema(
       #|    Object(
       #|      {
@@ -112,7 +111,7 @@ test "read tool advertises the expected schema" {
       #|            "path": Object(
       #|              {
       #|                "type": String("string"),
-      #|                "description": String("Text file path to read. Directories are not supported; use `ls` or `tree` first, then read specific files."),
+      #|                "description": String("Text file path to read. Directories are not supported; list them with `mbtx` (`@fs.readdir`/`@shell.glob`), then read specific files."),
       #|              },
       #|            ),
       #|            "start_line": Object({ "type": String("number") }),

--- a/agent_tool/read/read.mbt
+++ b/agent_tool/read/read.mbt
@@ -6,7 +6,8 @@
 ///
 /// ## Arguments
 /// - `path` (string): filesystem path to read. Required. Directories are not
-///   supported; use `ls` or `tree` first, then read specific files.
+///   supported; list them with `mbtx` (`@fs.readdir`/`@shell.glob`), then read
+///   specific files.
 /// - `start_line` (number, optional): 1-based first line to return. Defaults
 ///   to 1. Single-file calls only.
 /// - `max_lines` (number, optional): maximum number of lines to return.
@@ -41,10 +42,10 @@ pub fn definition(
     description=(
       #|Read arguments.path as text. For several known independent files, batch separate
       #|read tool calls in one assistant response when possible. Do not use read for
-      #|directories: inspect them with `ls` or `tree`, then read specific files. Supports
-      #|optional start_line, max_lines, and max_output_chars for focused single-file
-      #|reads. Output is right-aligned `<line-number> |<content>` numbered lines followed
-      #|by a `<system>` status footer.
+      #|directories: list them with `mbtx` (`@fs.readdir`/`@shell.glob`), then read
+      #|specific files. Supports optional start_line, max_lines, and max_output_chars for
+      #|focused single-file reads. Output is right-aligned `<line-number> |<content>`
+      #|numbered lines followed by a `<system>` status footer.
     ),
     schema=JsonSchema({
       "type": "object",
@@ -52,7 +53,7 @@ pub fn definition(
       "properties": {
         "path": {
           "type": "string",
-          "description": "Text file path to read. Directories are not supported; use `ls` or `tree` first, then read specific files.",
+          "description": "Text file path to read. Directories are not supported; list them with `mbtx` (`@fs.readdir`/`@shell.glob`), then read specific files.",
         },
         "start_line": { "type": "number" },
         "max_lines": { "type": "number" },
@@ -91,7 +92,7 @@ async fn read_file(
   }
   if is_directory {
     return @agent_tool.respond(
-      "error reading \{path}: path is a directory; use the shell tool with `ls` or `tree` to inspect directories, then read specific files.",
+      "error reading \{path}: path is a directory; list it with `mbtx` (`@fs.readdir`/`@shell.glob`), then read the specific file.",
       is_error=true,
       brief~,
     )
@@ -489,7 +490,8 @@ async test "read reports directories with an actionable hint" {
     guard result is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
     assert_true(output.content.contains("path is a directory"))
-    assert_true(output.content.contains("`ls` or `tree`"))
+    assert_true(output.content.contains("`mbtx`"))
+    assert_true(output.content.contains("@fs.readdir"))
   })
 }
 


### PR DESCRIPTION
## What

When `read` is called on a directory, its error told the agent to "use the shell tool with `ls` or `tree`" - but the standard tool registry has no shell tool: commands run through `mbtx`, which refuses `ls`/`tree`, so the hint was unactionable.

The runtime error, plus every model-facing surface of the tool (description, path schema, module doc, README), now tells the agent to list the directory with `mbtx` via `@fs.readdir`/`@shell.glob`.

## Validation

- `moon test agent_tool/read` - 22/22 pass (directory-hint test updated to assert the new wording)
- `moon check` (module root) - clean
- `moon fmt --check agent_tool/read` - clean
- CI - all checks pass (check js/native/wasm, desktop e2e, desktop package Windows ZIP, viz e2e, GitGuardian)

Generated with SeekMoon