### PR TITLE
fix(desktop): resize code editor through panel animations

### DIFF
--- a/desktop/e2e/tests/editor_resize.spec.js
+++ b/desktop/e2e/tests/editor_resize.spec.js
@@ -1,6 +1,52 @@
 import { test, expect } from '@playwright/test';
 import { DesktopBrowserHarness } from './support/desktop_browser_harness.js';
 
+test('code editor follows expand and restore panel animations', async ({ page }) => {
+  const app = new DesktopBrowserHarness(page);
+  app.workingFiles['README.md'] = '# Resize fixture\n\nA Markdown view.\n';
+  await app.install();
+  await app.goto();
+  await app.openSession();
+  await app.openQuickOpen();
+  await page.getByRole('option', { name: /src\/main\.mbt/ }).click();
+  const host = page.locator('#viewer-host');
+  await expect(host.locator('.view-lines')).toBeVisible();
+  const expectViewportFits = async () => {
+    await expect.poll(() => host.evaluate(element => {
+      const editor = element.querySelector('.editor-scrollable');
+      return Math.abs(editor.offsetLeft + editor.getBoundingClientRect().width - element.clientWidth);
+    })).toBeLessThanOrEqual(1);
+    await expect.poll(() => host.evaluate(element => {
+      const editor = element.querySelector('.editor-scrollable');
+      return Math.abs(editor.getBoundingClientRect().height - element.clientHeight);
+    })).toBeLessThanOrEqual(1);
+  };
+  for (const name of ['Expand panel', 'Restore panel', 'Expand panel', 'Restore panel']) {
+    await page.getByRole('button', { name, exact: true }).click();
+    // Wait for the real CSS transition, without a window resize or another
+    // editor action that could accidentally repair stale widget geometry.
+    await expect.poll(() => page.locator('.content').evaluate(element =>
+      element.getAnimations().length,
+    )).toBe(0);
+    await expectViewportFits();
+  }
+  // Resizing a different surface must not leave source geometry stale when
+  // the code tab becomes visible again.
+  await app.openQuickOpen();
+  await page.getByRole('option', { name: /README\.md/ }).click();
+  await expect(page.locator('#markdown-viewer-host')).toBeVisible();
+  await expect(host).toBeHidden();
+  await page.getByRole('button', { name: 'Expand panel', exact: true }).click();
+  await expect.poll(() => page.locator('.content').evaluate(element =>
+    element.getAnimations().length,
+  )).toBe(0);
+  await app.openQuickOpen();
+  await page.getByRole('option', { name: /src\/main\.mbt/ }).click();
+  await expect(host.locator('.view-lines')).toBeVisible();
+  await expectViewportFits();
+  expect(app.pageErrors).toEqual([]);
+});
+
 for (const handleSelector of ['.editor-resize-handle', '.tree-resize-handle']) {
   test(`${handleSelector} suspends editor mouse events until the drag ends`, async ({ page }) => {
     const app = new DesktopBrowserHarness(page);

--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -75,6 +75,10 @@ priv struct ViewerHost {
   // batched behind a mount request whose after-render tick precedes the async
   // reply, so by the time a document arrives the viewer exists.
   mut viewer : @viewer.Viewer?
+  // The stable source host lives for the app's lifetime. Observe its box so
+  // CSS drawer animations keep the code viewport measured through the final
+  // frame, just as the Markdown and diff widgets observe their own hosts.
+  mut _viewer_resize_observer : @common.Disposable?
   // Kept separate from the source Viewer so a Diff/Source toggle preserves
   // the source model, selection, folding, and scroll state. DiffEditor owns
   // two code kernels directly rather than wrapping public Viewers.
@@ -152,6 +156,7 @@ priv struct ViewerHost {
 ///|
 let viewer_state : ViewerHost = {
   viewer: None,
+  _viewer_resize_observer: None,
   diff_editor: None,
   markdown_viewer: None,
   mbti_resource: None,
@@ -393,6 +398,10 @@ fn request_viewer_mount(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
           ),
         )
         viewer_state.viewer = Some(viewer)
+        viewer_state._viewer_resize_observer = @base_browser.observe_element_resize(
+          host,
+          () => if editor_surface_host_visible(ViewerHostId) { viewer.layout() },
+        )
         viewer_state.point_range_highlight = Some(
           viewer.create_decorations_collection(),
         )


### PR DESCRIPTION
Clicking **Expand panel** or **Restore panel** starts a CSS width animation, but the code editor previously measured only once. Its internal viewport could remain hundreds of pixels narrower than its host after the animation finished.

Observe the stable source-editor host and request layout whenever its size changes, while skipping hidden source surfaces. Add a browser regression that repeatedly expands and restores the panel and checks the internal content viewport's width and height after each animation, including returning to code after resizing a Markdown view.

Validation:
- Reproduced before the fix: the viewport remained 555 px narrower than its host.
- Final browser resize/drag suite: 9/9 passed across three repetitions.
- File-editor unit tests: 154/154 passed; targeted JS check with warnings denied passed.
- `just build` passed for native and JS; `moon info`, `moon fmt`, and `git diff --check` passed. No public interface changes.
- `just check` and `just test` are blocked by existing tuple-pattern loop syntax errors in `editor/viewer/diff_provider/moondiff/provider_wbtest.mbt` and `semantic_review_plan_test.mbt`.
- The separate dock-visibility test intermittently fails its manual-scroll assertion; the same failure reproduces with this observer disabled (2/3 passes in each comparison).

Independent review: a fresh Codex CLI found no correctness issues. Applied its simplifications to observer setup and visibility checks, and added its suggested hidden-source regression coverage.
