### PR TITLE
fix(desktop): default submodule checkout timeout to 30 seconds

### DIFF
--- a/desktop/frontend/workspace_settings.mbt
+++ b/desktop/frontend/workspace_settings.mbt
@@ -9,7 +9,7 @@
 ///|
 /// Used only before an authoritative row exists or while an optimistic edit
 /// preserves a neighboring field. The host remains the persisted source.
-const DefaultWorkspaceSubmoduleCheckoutTimeoutSeconds : Int = 10
+const DefaultWorkspaceSubmoduleCheckoutTimeoutSeconds : Int = 30
 
 ///|
 /// One project's settings mirror, keyed like `ProjectWorktrees` and fenced

--- a/desktop/internal/workspaces/settings.mbt
+++ b/desktop/internal/workspaces/settings.mbt
@@ -9,9 +9,9 @@
 const WorkspaceSettingsFile = "settings.json"
 
 ///|
-/// Existing workspaces and malformed hand-edited settings retain the short
-/// checkout bound chosen for conversation creation.
-const DefaultSubmoduleCheckoutTimeoutSeconds : Int = 10
+/// Workspaces without an override and malformed hand-edited settings use
+/// the default checkout bound for conversation creation.
+const DefaultSubmoduleCheckoutTimeoutSeconds : Int = 30
 
 ///|
 /// Reads and read-modify-write mutations share one process-wide lock, the
@@ -188,10 +188,7 @@ test "workspace settings parse tolerantly and keep unknown fields" {
   }
   let payload = settings_payload(workspace, fields)
   assert_true(payload.checkout_submodules)
-  assert_eq(
-    payload.submodule_checkout_timeout_seconds,
-    DefaultSubmoduleCheckoutTimeoutSeconds,
-  )
+  assert_eq(payload.submodule_checkout_timeout_seconds, 30)
   fields["checkout_submodules"] = false.to_json()
   assert_false(settings_payload(workspace, fields).checkout_submodules)
   fields["submodule_checkout_timeout_seconds"] = Json(30)


### PR DESCRIPTION
Workspaces without a saved timeout now allow 30 seconds instead of 10 for submodule checkout when creating or repairing worktrees. Update both the host default and frontend fallback, and assert the default explicitly in the existing settings test. Saved workspace overrides continue to apply.

Validation: five focused workspace-settings tests passed, along with `just build`, `moon info`, `moon fmt`, and `git diff --check`. No public interface changes. `just check` and `just test` are blocked by existing tuple-loop syntax errors in `editor/viewer/diff_provider/moondiff/provider_wbtest.mbt` and `semantic_review_plan_test.mbt`.
