### PR TITLE
docs(prompt): document in-place sort/rev semantics for arrays

### DIFF
--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -939,6 +939,16 @@ fn message(name : String, line : Int) -> String {
   It is deterministic, so it is fine when you only need stable output; when you
   need dictionary order (sorted JSON keys, for instance), sort with an explicit
   comparator instead of the default.
+- `Array::sort` and `Array::sort_by` sort **in place and return `Unit`**, so a
+  chain on the result is a type error — `xs.sort()[0]` fails with "Unit has no
+  method op_get", and so does `for x in xs.sort() { ... }`. Sort first, then
+  read the array (`xs.sort(); xs[0]`), or use the cascade operator `..`, which
+  runs the call and yields the array itself: `let sorted = xs..sort()`. For
+  sorted directory listings pass `sort=true` instead of chaining:
+  `@fs.readdir(dir, sort=true)`.
+- `Array::rev` and `String::rev` **return a new value** and leave the original
+  untouched: `let ys = xs.rev()`. To reverse in place use `Array::rev_in_place`
+  (returns `Unit`, like `sort`). There is no `Array::reverse` method.
 - `s[start:end]`, `s[:end]`, and `s[start:]` create zero-copy `StringView`s.
   Pass views directly to string APIs and parsers; use `.to_owned()` only when a
   callee stores or requires an owned `String`.

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -944,6 +944,16 @@ fn default_prompt() -> String {
     #|  It is deterministic, so it is fine when you only need stable output; when you
     #|  need dictionary order (sorted JSON keys, for instance), sort with an explicit
     #|  comparator instead of the default.
+    #|- `Array::sort` and `Array::sort_by` sort **in place and return `Unit`**, so a
+    #|  chain on the result is a type error — `xs.sort()[0]` fails with "Unit has no
+    #|  method op_get", and so does `for x in xs.sort() { ... }`. Sort first, then
+    #|  read the array (`xs.sort(); xs[0]`), or use the cascade operator `..`, which
+    #|  runs the call and yields the array itself: `let sorted = xs..sort()`. For
+    #|  sorted directory listings pass `sort=true` instead of chaining:
+    #|  `@fs.readdir(dir, sort=true)`.
+    #|- `Array::rev` and `String::rev` **return a new value** and leave the original
+    #|  untouched: `let ys = xs.rev()`. To reverse in place use `Array::rev_in_place`
+    #|  (returns `Unit`, like `sort`). There is no `Array::reverse` method.
     #|- `s[start:end]`, `s[:end]`, and `s[start:]` create zero-copy `StringView`s.
     #|  Pass views directly to string APIs and parsers; use `.to_owned()` only when a
     #|  callee stores or requires an owned `String`.


### PR DESCRIPTION
## What

Add two bullets to the built-in default prompt (`prompt/default_prompt.mbt.md`),
in the "Strings, Maps, JSON, And Tests" pitfalls list right after the SHORTLEX
ordering bullet, and regenerate `prompt/generated_default_prompt.mbt` with the
`md_to_mbt_string` dev-build rule.

## Why

Benchmark fleet sessions show the agent repeatedly chaining `.sort()`
(`xs.sort().first()`, `for x in xs.sort() { ... }`) and hitting
"Type Unit has no method ..." errors: `Array::sort`/`Array::sort_by` mutate
**in place and return `Unit`**, which the prompt never stated — the existing
SHORTLEX bullet even uses `.sort()` without mentioning the return type. The
new bullets document:

- `Array::sort` / `Array::sort_by` are in-place and return `Unit`; sort first,
  then use the array (or pass `@fs.readdir(dir, sort=true)`).
- `Array::rev` / `String::rev` return a new value; there is no
  `Array::reverse` method.

## Verification

- API signatures checked via `moon ide doc` (`Array::sort`, `Array::sort_by`,
  `Array::rev`, `String::rev`, `@fs.readdir`).
- Regeneration is idempotent; diff is exactly the two new bullets in both files.
- `moon check prompt` and `moon test prompt` (20/20) pass.

- Local moonc (2026-08-27) predates a `for (..) in [..]` tuple-destructuring
  used in `editor/viewer/.../provider_wbtest.mbt`, so the whole-repo check was
  not run locally; only the `prompt` package was verified.

Generated with SeekMoon