### PR TITLE
feat(desktop): add Finder actions to the file panel

### DIFF
--- a/desktop/frontend/boot.mbt
+++ b/desktop/frontend/boot.mbt
@@ -531,6 +531,7 @@ pub fn boot() -> Unit {
       browser_forward: emit(BrowserForward),
       browser_reload: emit(BrowserReload),
       browser_open_external: emit(BrowserOpenExternal),
+      reveal_file: path => emit(RevealFile(path)),
       toggle_panel: emit(ToggleRightPanel),
       toggle_menu: emit(ToggleRightPanelMenu),
       toggle_expanded: emit(ToggleRightPanelExpanded),

--- a/desktop/frontend/component_right_panel.mbt
+++ b/desktop/frontend/component_right_panel.mbt
@@ -9,6 +9,13 @@ fn Model::right_panel_input(self : Model) -> @right_panel.Input {
     is_desktop=self.is_desktop,
     menu_open=self.right_panel_menu_open,
     expanded=self.right_panel_expanded,
+    reveal_label=match self.context_menu_input() {
+      { reveal_files: true, platform: MacOS, .. } => Some("Open in Finder")
+      { reveal_files: true, platform: Windows, .. } =>
+        Some("Open in File Explorer")
+      { reveal_files: true, platform: Linux, .. } => Some("Open in Folder")
+      _ => None
+    },
     workflows=self
       .active_conversation()
       .map(conv => conv.workflows)

--- a/desktop/frontend/fileeditor/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/pkg.generated.mbti
@@ -30,7 +30,7 @@ pub fn basename(@pathx.Relative) -> String
 
 pub fn body_view(@cmd.Emit[Msg], State, Ctx, semantic_review? : @html.Html) -> @html.Html
 
-pub fn breadcrumb_view(@cmd.Emit[Msg], State, Ctx) -> @html.Html
+pub fn breadcrumb_view(@cmd.Emit[Msg], State, Ctx, reveal? : (String, @cmd.Cmd)?) -> @html.Html
 
 pub fn close_document(@cmd.Emit[Msg], State, Ctx, @pathx.Relative, next~ : @pathx.Relative?, was_active~ : Bool) -> (@cmd.Cmd, State)
 
@@ -222,6 +222,13 @@ pub fn MbtiViewMode::not_equal(Self, Self) -> Bool
 pub struct ModelUri(String)
 pub fn ModelUri::of(@common.Uri) -> Self
 
+pub(all) enum MoonModViewMode {
+  MoonModDependencies
+  MoonModSource
+} derive(Eq)
+pub fn MoonModViewMode::equal(Self, Self) -> Bool
+pub fn MoonModViewMode::not_equal(Self, Self) -> Bool
+
 pub(all) enum Msg {
   RevealDirectory(@pathx.Relative)
   HighlightCleared(@pathx.Relative)
@@ -265,6 +272,9 @@ pub(all) enum Msg {
   RevealSemanticReviewSectionChange(String, Bool)
   ToggleReviewProgress
   MbtiViewModeSelected(MbtiViewMode)
+  MoonModViewModeSelected(MoonModViewMode)
+  PackageGraphRequestLoaded(owner~ : @interop.ConversationKey, epoch~ : Int, path~ : @pathx.Relative, generation~ : Int, source~ : String)
+  PackageGraphRequestFailed(owner~ : @interop.ConversationKey, epoch~ : Int, path~ : @pathx.Relative, generation~ : Int, message~ : String)
   GitOriginalLoaded(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, generation~ : Int, background~ : Bool, original~ : @protocol.GitOriginalFileReply)
   GitOriginalFailed(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, generation~ : Int, background~ : Bool, message~ : String)
   HistoryBlobLoaded(owner~ : @interop.ConversationKey, key~ : String, generation~ : Int, side~ : HistoryDiffSide, blob~ : @protocol.GitOriginalFileReply)
@@ -283,6 +293,14 @@ pub(all) enum Msg {
   ApplyAllFeedback
   DiffCommentAdded(file~ : @pathx.Relative, original_line_number~ : Int?, modified_line_number~ : Int?, quote~ : String, comment~ : String, resource~ : ModelUri?, feedback_id~ : String?)
 }
+
+pub(all) enum PackageGraphState {
+  PackageGraphLoading(Int)
+  PackageGraphReady(Int, String)
+  PackageGraphFailed(Int, String)
+} derive(Eq)
+pub fn PackageGraphState::equal(Self, Self) -> Bool
+pub fn PackageGraphState::not_equal(Self, Self) -> Bool
 
 pub(all) enum ReconciledPlacement {
   PlacementUnknown
@@ -402,6 +420,9 @@ pub(all) struct State {
   children : Map[@pathx.Relative, Array[FileEntry]]
   docs : Map[@pathx.Relative, Doc]
   mbti_view_modes : Map[@pathx.Relative, MbtiViewMode]
+  moon_mod_view_modes : Map[@pathx.Relative, MoonModViewMode]
+  package_graphs : Map[@pathx.Relative, PackageGraphState]
+  package_graph_generation : Int
   highlighted : @pathx.Relative?
   index : FileIndex
   error : String?

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -1738,6 +1738,7 @@ pub fn breadcrumb_view(
   dispatch : @cmd.Emit[Msg],
   state : State,
   ctx : Ctx,
+  reveal? : (String, @cmd.Cmd)? = None,
 ) -> @html.Html {
   if ctx.active_history_diff is Some(diff) {
     return @html.div(
@@ -1828,6 +1829,18 @@ pub fn breadcrumb_view(
   }
   if moon_mod_view_available(state, ctx) {
     path_row.push(moon_mod_view_toolbar(dispatch, state, ctx))
+  }
+  if reveal is Some((label, command)) {
+    path_row.push(
+      @html.button(
+        type_="button",
+        class="file-reveal-button",
+        title=label,
+        on_click=command,
+        attrs=@html.Attrs::build().aria_label(label),
+        [icon(@icons.icon_link_external), @html.text(label)],
+      ),
+    )
   }
   path_row.push(
     @html.button(
@@ -2814,7 +2827,10 @@ fn tree_row(
       class="tree-row tree-dir",
       style=[indent_style],
       on_click=dispatch(DirToggle(entry.path)),
-      attrs=@html.Attrs::build().data_set("path", entry.path.0),
+      attrs=@html.Attrs::build()
+        .data_set("path", entry.path.0)
+        .data_set("context-file", entry.path.0)
+        .tabindex(0),
       [
         @html.span(class="tree-chevron", chevron),
         @html.span(class="tree-name", entry.name),
@@ -2829,7 +2845,10 @@ fn tree_row(
       },
       style=[indent_style],
       on_click=dispatch(FileSelected(path=entry.path, name=entry.name)),
-      attrs=@html.Attrs::build().data_set("path", entry.path.0),
+      attrs=@html.Attrs::build()
+        .data_set("path", entry.path.0)
+        .data_set("context-file", entry.path.0)
+        .tabindex(0),
       [@html.span(class="tree-name", entry.name)],
     )
   }

--- a/desktop/frontend/right_panel/component.mbt
+++ b/desktop/frontend/right_panel/component.mbt
@@ -9,6 +9,7 @@ struct Input {
   is_desktop : Bool
   menu_open : Bool
   expanded : Bool
+  reveal_label : String?
   // The workflows the active conversation's snippets announced, for the
   // Workflows tab. Live-only state projected from the root's conversation.
   workflows : Array[@workflow.Run]
@@ -23,6 +24,7 @@ pub fn Input::Input(
   is_desktop~ : Bool,
   menu_open~ : Bool,
   expanded~ : Bool,
+  reveal_label~ : String?,
   workflows~ : Array[@workflow.Run],
 ) -> Input {
   {
@@ -33,6 +35,7 @@ pub fn Input::Input(
     is_desktop,
     menu_open,
     expanded,
+    reveal_label,
     workflows,
   }
 }
@@ -57,6 +60,7 @@ pub(all) struct Actions {
   browser_forward : @cmd.Cmd
   browser_reload : @cmd.Cmd
   browser_open_external : @cmd.Cmd
+  reveal_file : (String) -> @cmd.Cmd
   toggle_panel : @cmd.Cmd
   toggle_menu : @cmd.Cmd
   toggle_expanded : @cmd.Cmd

--- a/desktop/frontend/right_panel/pkg.generated.mbti
+++ b/desktop/frontend/right_panel/pkg.generated.mbti
@@ -8,6 +8,7 @@ import {
   "openseek_desktop/frontend/dock",
   "openseek_desktop/frontend/fileeditor",
   "openseek_desktop/frontend/preview",
+  "openseek_desktop/frontend/workflow",
 }
 
 // Values
@@ -23,20 +24,24 @@ pub(all) struct Actions {
   search : @cmd.Cmd
   files : @cmd.Cmd
   review : @cmd.Cmd
+  workflows : @cmd.Cmd
+  open_child : (String) -> @cmd.Cmd
   browser_input : @cmd.Emit[String]
   browser_submit : @cmd.Cmd
   browser_back : @cmd.Cmd
   browser_forward : @cmd.Cmd
   browser_reload : @cmd.Cmd
   browser_open_external : @cmd.Cmd
+  reveal_file : (String) -> @cmd.Cmd
   toggle_panel : @cmd.Cmd
   toggle_menu : @cmd.Cmd
   toggle_expanded : @cmd.Cmd
+  close_all_tabs : @cmd.Cmd
   close_menu : @cmd.Cmd
 }
 
 type Input derive(Eq)
-pub fn Input::Input(dock~ : @dock.State, file_panel~ : @fileeditor.State, preview~ : @preview.State, file_ctx~ : @fileeditor.Ctx, is_desktop~ : Bool, menu_open~ : Bool, expanded~ : Bool) -> Self
+pub fn Input::Input(dock~ : @dock.State, file_panel~ : @fileeditor.State, preview~ : @preview.State, file_ctx~ : @fileeditor.Ctx, is_desktop~ : Bool, menu_open~ : Bool, expanded~ : Bool, reveal_label~ : String?, workflows~ : Array[@workflow.Run]) -> Self
 pub fn Input::equal(Self, Self) -> Bool
 pub fn Input::not_equal(Self, Self) -> Bool
 

--- a/desktop/frontend/right_panel/view.mbt
+++ b/desktop/frontend/right_panel/view.mbt
@@ -120,6 +120,11 @@ fn panel_view(
         actions.file_editor,
         input.file_panel,
         input.file_ctx,
+        reveal=match (input.reveal_label, input.file_ctx.active_file) {
+          (Some(label), Some(path)) =>
+            Some((label, (actions.reveal_file)(path.0)))
+          _ => None
+        },
       ),
       @fileeditor.body_view(
         actions.file_editor,

--- a/desktop/styles/file_panel.css
+++ b/desktop/styles/file_panel.css
@@ -28,6 +28,26 @@ button.panel-toggle:not(:disabled):hover {
   color: var(--color-accent-strong);
 }
 
+.file-reveal-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  flex-shrink: 0;
+  padding: 4px 8px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.file-reveal-button:hover {
+  background: var(--color-bg-subtle);
+  color: var(--color-text-primary);
+}
+
 /* The editor part: a tab strip of open files over the viewer, with the
    file tree as a toggleable pane on the viewer's right. */
 .editor {


### PR DESCRIPTION
Add an Open in Finder button beside the active file path, including files such as PPTX that cannot be previewed as text. File and folder rows now expose the existing context menu, including Show in Finder and Copy Path.

Reuse the existing local-host reveal command and error reporting. The toolbar uses platform-specific labels on Windows and Linux and stays hidden for browser and remote-host sessions. Regenerate the affected package interfaces, also refreshing existing stale declarations.

Validation:
- `just build` passed for native and JS; launched the desktop development app.
- File editor and action menu JS tests: 154 passed.
- The initial `just test` run passed. The subsequent run had one failure in the real-network DeepSeek web-search test (3247/3248 native tests passed).
- `moon fmt --check` and `git diff --check` passed.
- `just check` is blocked by existing unused-import warnings outside this change.
