### PR TITLE
refactor: describe static json pattern content as the json it matches

### DIFF
--- a/agent_tool/mbtx/internal/decode/decode.mbt
+++ b/agent_tool/mbtx/internal/decode/decode.mbt
@@ -82,22 +82,22 @@ pub fn decode(arguments : Json) -> MbtxInput raise {
         _ => None
       }
       let warning = match arguments {
-        { "warning": String("on"), .. } => true
-        { "warning": String("off"), .. } => false
+        { "warning": "on", .. } => true
+        { "warning": "off", .. } => false
         { "warning": Null, .. } => false
         { "warning": _, .. } =>
           fail("arguments.warning to be \"on\" or \"off\"")
         _ => false
       }
       let escalated = match arguments {
-        { "escalated": True, .. } => true
-        { "escalated": False, .. } | { "escalated": Null, .. } => false
+        { "escalated": true, .. } => true
+        { "escalated": false, .. } | { "escalated": Null, .. } => false
         { "escalated": _, .. } => fail("arguments.escalated to be a boolean")
         _ => false
       }
       let subrun = match arguments {
-        { "subrun": True, .. } => true
-        { "subrun": False, .. } | { "subrun": Null, .. } => false
+        { "subrun": true, .. } => true
+        { "subrun": false, .. } | { "subrun": Null, .. } => false
         { "subrun": _, .. } => fail("arguments.subrun to be a boolean")
         _ => false
       }

--- a/agent_tool/multi_edit/internal/decode/decode.mbt
+++ b/agent_tool/multi_edit/internal/decode/decode.mbt
@@ -64,7 +64,6 @@ pub fn decode_args(arguments : Json) -> MultiEditArgs raise {
       }
       let revert_on_parse_errors = match fields {
         { "revert_on_parse_errors"? : Some(true) | Some(Null) | None, .. } =>
-
           true
         { "revert_on_parse_errors": false, .. } => false
         _ => fail("arguments.revert_on_parse_errors to be a boolean")

--- a/agent_tool/multi_edit/internal/decode/decode.mbt
+++ b/agent_tool/multi_edit/internal/decode/decode.mbt
@@ -63,9 +63,8 @@ pub fn decode_args(arguments : Json) -> MultiEditArgs raise {
         _ => fail("arguments.revert_when_errors_above to be an integer")
       }
       let revert_on_parse_errors = match fields {
-        { "revert_on_parse_errors"? : Some(True) | Some(Null) | None, .. } =>
-          true
-        { "revert_on_parse_errors": False, .. } => false
+        { "revert_on_parse_errors"? : Some(true) | Some(Null) | None, .. } => true
+        { "revert_on_parse_errors": false, .. } => false
         _ => fail("arguments.revert_on_parse_errors to be a boolean")
       }
       { inline, edits_file, revert_when_errors_above, revert_on_parse_errors, }

--- a/agent_tool/multi_edit/internal/decode/decode.mbt
+++ b/agent_tool/multi_edit/internal/decode/decode.mbt
@@ -63,7 +63,9 @@ pub fn decode_args(arguments : Json) -> MultiEditArgs raise {
         _ => fail("arguments.revert_when_errors_above to be an integer")
       }
       let revert_on_parse_errors = match fields {
-        { "revert_on_parse_errors"? : Some(true) | Some(Null) | None, .. } => true
+        { "revert_on_parse_errors"? : Some(true) | Some(Null) | None, .. } =>
+
+          true
         { "revert_on_parse_errors": false, .. } => false
         _ => fail("arguments.revert_on_parse_errors to be a boolean")
       }

--- a/agent_tool/plan/steps/decode.mbt
+++ b/agent_tool/plan/steps/decode.mbt
@@ -118,9 +118,9 @@ fn decode_step(index : Int, item : Json) -> PlanStep raise {
   }
   let title = normalize_title(index, raw_title)
   let status = match fields {
-    { "status": String("pending"), .. } => PlanStatus::Pending
-    { "status": String("in_progress"), .. } => InProgress
-    { "status": String("completed"), .. } => Completed
+    { "status": "pending", .. } => PlanStatus::Pending
+    { "status": "in_progress", .. } => InProgress
+    { "status": "completed", .. } => Completed
     { "status": String(_), .. } =>
       fail(
         "arguments.steps[\{index}].status to be one of pending|in_progress|completed",

--- a/agent_tool/write/internal/decode/decode.mbt
+++ b/agent_tool/write/internal/decode/decode.mbt
@@ -20,8 +20,8 @@ pub fn decode(arguments : Json) -> WriteInput raise {
   match arguments {
     { "path": String(path), "content": String(content), .. } => {
       let revert_on_parse_errors = match arguments {
-        { "revert_on_parse_errors": True, .. } => true
-        { "revert_on_parse_errors": False, .. } => false
+        { "revert_on_parse_errors": true, .. } => true
+        { "revert_on_parse_errors": false, .. } => false
         { "revert_on_parse_errors": Null, .. } => true
         { "revert_on_parse_errors": _, .. } =>
           fail("arguments.revert_on_parse_errors to be a boolean")

--- a/desktop/internal/api/api.mbt
+++ b/desktop/internal/api/api.mbt
@@ -749,7 +749,7 @@ async fn ApiState::codex_thread_history(
     reply_fields.get("thread") is Some(Object(thread_fields)) else {
     raise @host.PayloadError("malformed Codex thread metadata reply")
   }
-  let paginated = thread_fields.get("historyMode") is Some(String("paginated"))
+  let paginated = thread_fields.get("historyMode") is Some("paginated")
   if !paginated {
     let value = try
       self.codex_request("codex.thread.read", {

--- a/desktop/internal/protocol/engine_command.mbt
+++ b/desktop/internal/protocol/engine_command.mbt
@@ -69,53 +69,41 @@ pub fn approval(id : String, allow~ : Bool) -> @wire.Command {
 ///|
 test "the host's commands are the protocol's" {
   assert_true(
-    prompt("hello").to_json()
-    is { "command": String("prompt"), "text": String("hello"), .. },
+    prompt("hello").to_json() is { "command": "prompt", "text": "hello", .. },
   )
   assert_true(
     prompt("hello", submission_id="page-1-submission-2").to_json()
     is {
-      "command": String("prompt"),
-      "text": String("hello"),
-      "submission_id": String("page-1-submission-2"),
+      "command": "prompt",
+      "text": "hello",
+      "submission_id": "page-1-submission-2",
       ..
     },
   )
   assert_true(
     steer("go left").to_json()
-    is {
-      "command": String("steer"),
-      "kind": String("prompt"),
-      "text": String("go left"),
-      ..
-    },
+    is { "command": "steer", "kind": "prompt", "text": "go left", .. },
   )
-  assert_true(compact().to_json() is { "command": String("compact"), .. })
-  assert_true(cancel().to_json() is { "command": String("cancel"), .. })
+  assert_true(compact().to_json() is { "command": "compact", .. })
+  assert_true(cancel().to_json() is { "command": "cancel", .. })
   // A manual set omits `auto` on the wire entirely; arming spells it out.
   guard goal_set("ship the feature", auto=false).to_json()
-    is {
-      "command": String("goal"),
-      "action": String("set"),
-      "text": String("ship the feature"),
-      ..
-    } &&
+    is { "command": "goal", "action": "set", "text": "ship the feature", .. } &&
     !(goal_set("ship the feature", auto=false).to_json() is { "auto": _, .. }) else {
     fail("goal_set did not encode a manual set")
   }
   assert_true(
     goal_set("grind it out", auto=true).to_json()
     is {
-      "command": String("goal"),
-      "action": String("set"),
-      "text": String("grind it out"),
-      "auto": True,
+      "command": "goal",
+      "action": "set",
+      "text": "grind it out",
+      "auto": true,
       ..
     },
   )
   assert_true(
-    goal_clear().to_json()
-    is { "command": String("goal"), "action": String("clear"), .. },
+    goal_clear().to_json() is { "command": "goal", "action": "clear", .. },
   )
 }
 
@@ -124,7 +112,7 @@ test "engine commands encode one json line" {
   let line = prompt("quote \" newline\n").to_jsonl()
   assert_true(line.has_suffix("\n"))
   guard @json.parse(line.trim())
-    is { "command": String("prompt"), "text": String("quote \" newline\n"), .. } else {
+    is { "command": "prompt", "text": "quote \" newline\n", .. } else {
     fail("prompt command did not round-trip through json")
   }
 }

--- a/desktop/internal/remote/serve.mbt
+++ b/desktop/internal/remote/serve.mbt
@@ -335,7 +335,7 @@ fn classify(text : String) -> Inbound {
   let message = @json.parse(text) catch { _ => return Unparsable }
   guard message is Object(fields) else { return Invalid }
   // Reject protocol lookalikes before any catalog method can run.
-  guard fields.get("jsonrpc") is Some(String("2.0")) else { return Invalid }
+  guard fields.get("jsonrpc") is Some("2.0") else { return Invalid }
   guard fields.get("method") is Some(String(method_)) else { return Invalid }
   let id = fields.get("id")
   // JSON-RPC request ids may only be strings, numbers, or null. They remain

--- a/protocol/command.mbt
+++ b/protocol/command.mbt
@@ -137,15 +137,17 @@ pub fn Command::to_json(self : Command) -> Json {
 /// claims.
 pub fn Command::parse(line : Json) -> Result[Command, String] {
   match line {
+    {
+      "command": "prompt",
+      "text": String(text),
+      "submission_id": String(id),
+      ..
+    } => Ok(Prompt(text~, submission_id=Some(id)))
+    { "command": "prompt", "text": String(_), "submission_id": _, .. } =>
+      Err("expected a string \"submission_id\" field")
+    // An untagged prompt: see the absence rule above.
     { "command": "prompt", "text": String(text), .. } =>
-      match line {
-        { "submission_id": String(id), .. } =>
-          Ok(Prompt(text~, submission_id=Some(id)))
-        { "submission_id": _, .. } =>
-          Err("expected a string \"submission_id\" field")
-        // An untagged prompt: see the absence rule above.
-        _ => Ok(Prompt(text~, submission_id=None))
-      }
+      Ok(Prompt(text~, submission_id=None))
     { "command": "steer", .. } => parse_steer(line)
     { "command": "prompt", .. } => Err("expected a string \"text\" field")
     { "command": "compact", .. } => Ok(Compact)
@@ -156,8 +158,18 @@ pub fn Command::parse(line : Json) -> Result[Command, String] {
     // can hold, `to_json` can write, and `parse` then rejects — a round-trip
     // the type advertises and would not have. `serve` rejects it, in the same
     // words, where the policy lives.
+    // The armed line is its own static arm: absent and non-true `auto` both
+    // mean false (its default since goal shipped — see the absence rule above),
+    // so the two shapes are described rather than tested for twice.
+    {
+      "command": "goal",
+      "action": "set",
+      "text": String(text),
+      "auto": True,
+      ..
+    } => Ok(GoalSet(text~, auto=true))
     { "command": "goal", "action": "set", "text": String(text), .. } =>
-      Ok(GoalSet(text~, auto=line is { "auto": True, .. }))
+      Ok(GoalSet(text~, auto=false))
     { "command": "goal", "action": "clear", .. } => Ok(GoalClear)
     { "command": "goal", .. } =>
       Err(
@@ -181,19 +193,21 @@ pub fn Command::parse(line : Json) -> Result[Command, String] {
 
 ///|
 fn parse_steer(line : Json) -> Result[Command, String] {
-  // `text` is required whatever the kind says, so it is checked once here
-  // rather than restated in three arms, where the precedence between "no text"
-  // and "bad kind" was emergent from their order.
-  guard line is { "text": String(text), .. } else {
-    return Err("expected a string \"text\" field")
-  }
+  // `text` is required whatever the kind says, so each arm spells the full
+  // shape it accepts: the two kinds are static arms, a present kind that is
+  // not one of them is its own refusal, and a steer with no kind at all is a
+  // prompt steer (see the rule above) — spelled out, not a fallback tail.
   match line {
-    { "kind": String("prompt"), .. } => Ok(Steer(kind=Prompt, text~))
-    { "kind": String("command"), .. } => Ok(Steer(kind=Command, text~))
-    { "kind": String(other), .. } => Err("unknown steer kind: \{other}")
-    { "kind": _, .. } => Err("expected a string \"kind\" field")
-    // A steer with no kind at all is a prompt steer: see the rule above.
-    _ => Ok(Steer(kind=Prompt, text~))
+    { "kind": "prompt", "text": String(text), .. } =>
+      Ok(Steer(kind=Prompt, text~))
+    { "kind": "command", "text": String(text), .. } =>
+      Ok(Steer(kind=Command, text~))
+    { "kind": String(other), "text": String(_), .. } =>
+      Err("unknown steer kind: \{other}")
+    { "kind": _, "text": String(_), .. } =>
+      Err("expected a string \"kind\" field")
+    { "text": String(text), .. } => Ok(Steer(kind=Prompt, text~))
+    _ => Err("expected a string \"text\" field")
   }
 }
 

--- a/protocol/command.mbt
+++ b/protocol/command.mbt
@@ -165,7 +165,7 @@ pub fn Command::parse(line : Json) -> Result[Command, String] {
       "command": "goal",
       "action": "set",
       "text": String(text),
-      "auto": True,
+      "auto": true,
       ..
     } => Ok(GoalSet(text~, auto=true))
     { "command": "goal", "action": "set", "text": String(text), .. } =>
@@ -179,9 +179,9 @@ pub fn Command::parse(line : Json) -> Result[Command, String] {
     // with no `id` answers no particular question, and one with no `allow` is
     // a decision that did not decide — silently reading either as absent would
     // settle a permission prompt on a guess.
-    { "command": "approval", "id": String(id), "allow": True, .. } =>
+    { "command": "approval", "id": String(id), "allow": true, .. } =>
       Ok(ApprovalDecision(id~, allow=true))
-    { "command": "approval", "id": String(id), "allow": False, .. } =>
+    { "command": "approval", "id": String(id), "allow": false, .. } =>
       Ok(ApprovalDecision(id~, allow=false))
     { "command": "approval", "id": String(_), .. } =>
       Err("expected a boolean \"allow\" field")


### PR DESCRIPTION
## What

Two connected cleanups over JSON decodes, driven by one rule: **wherever a
JSON decode's content is static — a fixed command/kind/enum literal, a
`true`/`false` flag — describe it statically**; don't decode it through
dynamic machinery (nested `match` over the same Json, a second
`line is { ... }` boolean test, Option/Map plumbing), and don't spell it
through the enum (`String("prompt")`, `True`) when the pattern can read
like the json itself (`"prompt"`, `true`).

## 1. `Command::parse` / `parse_steer` — one static arm per wire shape

- `prompt` (`submission_id`): tagged / wrongly-tagged / untagged lines are
  three flat arms — the nested `match line { ... }` that restated the wire
  shape is gone.
- `goal` set (`auto`): the armed line (`"auto": true`) and the manual line
  are two static arms; absent and non-true both mean false. The previous
  `auto=line is { "auto": True, .. }` second test over the same Json is
  gone.
- `steer` (`kind`): each kind is its own static arm —
  `{ "kind": "prompt", "text": String(text), .. }` — a present kind that is
  neither is its own refusal, and the no-kind prompt steer is an explicit
  arm instead of a `_` fallback that duplicated the `"prompt"` result.
- `approval` (`allow`): the static `"allow": true` / `"allow": false`
  mirror arms, now spelled like the json.

## 2. Repo sweep — spell static pattern content as json

Static literals inside Json patterns spelled as `true`/`false` and bare
strings where the compiler accepts the json spelling (it does, for
object patterns over Json and over `Map[String, Json]`, and for
`Option[Json]` value matches):

- tool-argument decoders: `mbtx` (`warning` on/off, `escalated`,
  `subrun`), `write`, `multi_edit`, `plan` step statuses
  (`"pending"`/`"in_progress"`/`"completed"`).
- `desktop/internal/remote/serve.mbt`: `Some("2.0")` (JSON-RPC version
  guard); `desktop/internal/api/api.mbt`: `Some("paginated")`.
- `desktop/internal/protocol/engine_command.mbt`: the wire-shape
  assertions of `to_json()` output now read as the json the protocol
  writes.

Places with the same spelling pattern that were left out of this PR (to
keep the diff reviewable): eval harnesses (`eval/bgjobs_capability`,
`eval/file_edit/harness`), `agent_tool/internal/auto_check`,
`jsonrpc` tests, `viz/view.mbt`, host reply classifiers
(`desktop/internal/host`), and `agent_subrun/host/host_test.mbt`. They are
candidates for a follow-up spelling pass.

## Verification

- Spelling/restructure only: no behavior, error-string, or `.mbti`
  interface changes.
- `moon test`: protocol 24/24, mbtx/write/multi_edit decode 8/8/15,
  desktop `internal/remote` 9/9, `internal/protocol` engine-command 1/1.
- codex review sign-off posted on this PR.

Generated with SeekMoon