### PR TITLE
chore: make just recipes work on Windows

### DIFF
--- a/README.mbt.md
+++ b/README.mbt.md
@@ -33,9 +33,9 @@ The root [`moon.work`](moon.work) develops OpenSeek, the desktop app, and the
 smaller `editor/moon.work` as a scoped entry point for editor-only builds and
 browser tests; root Moon commands are the integration gate across both projects.
 
-A fresh checkout needs the MoonBit toolchain and `just`; `just check` also
-requires `jq` to inspect structured compiler diagnostics. The root integration
-gates are:
+A fresh checkout needs the MoonBit toolchain and `just`. Recipes use Windows
+PowerShell on Windows and the default POSIX shell on macOS/Linux. The root
+integration gates are:
 
 ```sh
 just check              # native + JS workspace checks and formatting
@@ -45,6 +45,12 @@ just editor-build       # editor web distribution and server
 just editor-test        # editor-only tests on every supported target
 just editor-test-browser
 ```
+
+The CLI lifecycle test (`just test-turn-finish`, also included in `just test`)
+needs Python 3. It uses `python` on Windows and `python3` on macOS/Linux;
+override it with, for example, `just PYTHON="py -3" test-turn-finish`.
+When passing editor paths containing spaces, quote the whole assignment:
+`just --justfile editor/justfile "ROOT=C:/Users/me/My Project" dev`.
 
 The editor browser suites additionally need Node.js 18 or newer, the locked npm
 dependencies, and a Playwright-managed Chromium installation:

--- a/README.mbt.md
+++ b/README.mbt.md
@@ -52,6 +52,15 @@ override it with, for example, `just PYTHON="py -3" test-turn-finish`.
 When passing editor paths containing spaces, quote the whole assignment:
 `just --justfile editor/justfile "ROOT=C:/Users/me/My Project" dev`.
 
+The cram documentation tests (`just test-cram`, included in `just test`) use
+Bash. On Windows, `just test` selects Git for Windows' Bash at
+`%ProgramFiles%/Git/bin/bash.exe`, avoiding the WSL launcher on `PATH`.
+For a custom Git installation, set
+`just "CRAM_SHELL=D:/Git/bin/bash.exe" test`.
+
+Windows installer packaging (`just desktop-package`) also needs NSIS with
+`makensis.exe` on `PATH` (usually under `C:/Program Files (x86)/NSIS`).
+
 The editor browser suites additionally need Node.js 18 or newer, the locked npm
 dependencies, and a Playwright-managed Chromium installation:
 

--- a/cmd/viz_app/justfile
+++ b/cmd/viz_app/justfile
@@ -1,7 +1,9 @@
+set windows-shell := ["powershell.exe", "-NoLogo", "-NoProfile", "-Command"]
+
 default:
     just --list
 
 # Build the session viewer and run its Playwright suite.
 test-browser:
     moon build --target js
-    npm --prefix e2e test
+    {{ if os() == "windows" { "npm.cmd" } else { "npm" } }} --prefix e2e test

--- a/desktop/justfile
+++ b/desktop/justfile
@@ -1,3 +1,5 @@
+set windows-shell := ["powershell.exe", "-NoLogo", "-NoProfile", "-Command"]
+
 default:
     just --list
 
@@ -19,4 +21,4 @@ dev:
 # Build the Desktop browser application and run Playwright.
 test-browser:
     moon run package/browser --target native
-    npm --prefix e2e test
+    {{ if os() == "windows" { "npm.cmd" } else { "npm" } }} --prefix e2e test

--- a/editor/justfile
+++ b/editor/justfile
@@ -1,3 +1,5 @@
+set windows-shell := ["powershell.exe", "-NoLogo", "-NoProfile", "-Command"]
+
 default: dev
 
 list:
@@ -63,12 +65,12 @@ TARGET := "wasm"
 
 serve:
     moon run --target {{ TARGET }} server/host/main -- \
-      --root "$(cd '{{ ROOT }}' && pwd)" \
+      --root '{{ absolute_path(ROOT) }}' \
       --host "{{ if HOST == '' { '127.0.0.1' } else { HOST } }}" \
       --port {{ PORT }} \
-      --asset-dir "$(cd '{{ ASSET_DIR }}' && pwd)" \
+      --asset-dir '{{ absolute_path(ASSET_DIR) }}' \
       --moon-command "{{ MOON_COMMAND }}" \
-      --browse-root "{{ BROWSE_ROOT }}"
+      {{ if BROWSE_ROOT == '' { '' } else { '--browse-root "' + BROWSE_ROOT + '"' } }}
 
 dev: build
     just ROOT='{{ ROOT }}' PORT='{{ PORT }}' ASSET_DIR='{{ ASSET_DIR }}' \
@@ -79,7 +81,7 @@ dev: build
 test-browser: test-browser-smoke
 
 test-browser-smoke: build build-browser-tests
-    ./node_modules/.bin/playwright test tests/browser/smoke tests/browser/component
+    node node_modules/@playwright/test/cli.js test tests/browser/smoke tests/browser/component
 
 test-browser-component: build build-browser-tests
-    ./node_modules/.bin/playwright test tests/browser/component
+    node node_modules/@playwright/test/cli.js test tests/browser/component

--- a/justfile
+++ b/justfile
@@ -2,6 +2,7 @@
 set windows-shell := ["powershell.exe", "-NoLogo", "-NoProfile", "-Command"]
 
 PYTHON := if os() == "windows" { "python" } else { "python3" }
+CRAM_SHELL := if os() == "windows" { env_var("ProgramFiles") / "Git/bin/bash.exe" } else { "bash" }
 
 default:
     just --list
@@ -32,9 +33,11 @@ inspect *args:
     moon run inspect -- {{ args }}
 
 # Run workspace MoonBit tests plus the offline OpenSeek CLI documentation tests.
-test: test-moon
-    moon cram test tests/cram
-    just test-turn-finish
+test: test-moon test-cram test-turn-finish
+
+# Run the offline CLI documentation tests (Git Bash on Windows).
+test-cram:
+    moon cram test tests/cram --shell '{{ CRAM_SHELL }}'
 
 # Real CLI lifecycle regression with an offline scripted model (Python 3).
 test-turn-finish:

--- a/justfile
+++ b/justfile
@@ -1,3 +1,8 @@
+# Use Windows PowerShell without requiring Git Bash or WSL.
+set windows-shell := ["powershell.exe", "-NoLogo", "-NoProfile", "-Command"]
+
+PYTHON := if os() == "windows" { "python" } else { "python3" }
+
 default:
     just --list
 
@@ -34,7 +39,7 @@ test: test-moon
 # Real CLI lifecycle regression with an offline scripted model (Python 3).
 test-turn-finish:
     moon build cmd/openseek --target native
-    python3 tests/integration/turn_finish.py _build/native/debug/build/bobzhang/openseek/cmd/openseek/openseek.exe
+    {{ PYTHON }} tests/integration/turn_finish.py _build/native/debug/build/bobzhang/openseek/cmd/openseek/openseek.exe
 
 test-moon:
     moon test --target native


### PR DESCRIPTION
Windows recipes currently depend on POSIX shell behavior and launchers, so normal `just` commands fail before reaching the underlying tools. This change runs all four justfiles with Windows PowerShell on Windows while preserving the default shell on macOS/Linux.

- Resolve editor paths with `absolute_path`, preserve paths containing spaces, and omit an empty optional `--browse-root` argument.
- Invoke Playwright through Node and select `npm.cmd` on Windows.
- Select `python` on Windows for the existing Python lifecycle test, with a `PYTHON` override.
- Add `test-cram` and select Git for Windows' Bash explicitly, avoiding the WSL launcher on PATH. Keep the root test steps as ordered dependencies so overrides propagate.
- Document Python, Git Bash, path overrides, and the NSIS packaging prerequisite; remove the stale jq prerequisite.

### Windows validation

Executed real recipes using Windows PowerShell, just 1.37.0, the repository-pinned MoonBit v0.10.12+1634b282e in an isolated toolchain, the VS 2022 amd64 environment, Node 23.11.0, and Python 3.11.9.

Passed:
- `just build` (native and JS), `just editor-build`, `just cef-setup`, and `just desktop-build-scripts-check`.
- `just test-cram`: 24/24; `just viz-test-browser`: 13/13.
- `just desktop-package`: ZIP and installer generated after adding the installed NSIS directory to the process PATH. The installer was not run.
- Supplementary JS checks and tests: strict check passed, 3217/3217 tests passed.
- Inspector and editor serve/dev startup returned HTTP 200, including editor paths containing spaces. Desktop dev created a window and reported renderer bridge ready; native UI interaction was not tested. All validation services were stopped.
- `moon info`, `moon fmt`, `moon fmt --check`, and `git diff --check`; no generated interface changes.

The full Windows suite is **not green**:
- `just check`: native `--deny-warn` rejects five unused fields/variables in bgjobs and worktree code.
- `just test` and `just test-moon`: native `deepseek/client` diagnostics tests hung and were manually interrupted. Later root test stages were therefore exercised separately.
- `just test-turn-finish`: the run case passes; the serve process does not exit after `agent_finished` and is terminated by the 120-second test timer.
- `just editor-test`: JS 1875/1875; Wasm 1086/1090 and native 1220/1224, with the same four diagnostics-refresh failures; wasm-gc has no test entry.
- `just editor-test-browser`: 105/107; the component-only rerun is 68/70, reproducing the same read_api/viewer_api geometry failures.
- `just desktop-test-browser`: 56/57; the transcript Markdown local-file-link locator fails.

These failures remain unresolved in this PR; they have not been compared against a separate base-branch run. Tests that self-skip for missing online credentials or `sh` are not counted as coverage. Validation above is on Windows; macOS/Linux were not rerun.