### PR TITLE
refactor(desktop): push the transcript diagram theme through a Cmd

### DIFF
--- a/desktop/e2e/tests/transcript_diagrams.spec.js
+++ b/desktop/e2e/tests/transcript_diagrams.spec.js
@@ -45,7 +45,7 @@ test('transcript renders editor diagram fences and retains them across updates a
   // System appearance is a real application input, exercising the full theme
   // projection and a fresh SVG/controller after the async renderer completes.
   await page.emulateMedia({ colorScheme: 'dark' });
-  await expect(transcript).toHaveAttribute('data-transcript-theme', 'dark');
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
   await expect.poll(() => originalSvg.evaluate(svg => svg.isConnected)).toBe(false);
   await expect(mermaid.locator('svg')).toContainText('Beta');
   await expect.poll(() => originalD2.evaluate(svg => svg.isConnected)).toBe(true);

--- a/desktop/frontend/component_transcript.mbt
+++ b/desktop/frontend/component_transcript.mbt
@@ -130,7 +130,6 @@ fn Model::transcript_input(self : Model) -> @transcript_component.Input {
         .bind(value => value.project_root())
         .map(project => @resource.label(project))
       @transcript_component.Input(
-        dark_mode=self.theme.is_dark(self.system_dark),
         source=@transcript_component.Codex,
         focused=self.focused,
         active_session=self.codex.active_id().unwrap_or("none"),
@@ -153,7 +152,6 @@ fn Model::transcript_input(self : Model) -> @transcript_component.Input {
       match self.active_conversation() {
         None =>
           @transcript_component.Input(
-            dark_mode=self.theme.is_dark(self.system_dark),
             source=@transcript_component.OpenSeek,
             focused=self.focused,
             active_session=self.active_session,
@@ -171,7 +169,6 @@ fn Model::transcript_input(self : Model) -> @transcript_component.Input {
           let (streaming_reasoning, reasoning_complete) = conversation.reasoning_for_render()
           let can_choose_project = self.can_choose_new_chat_project()
           @transcript_component.Input(
-            dark_mode=self.theme.is_dark(self.system_dark),
             source=@transcript_component.OpenSeek,
             focused=self.focused,
             active_session=self.active_session,

--- a/desktop/frontend/dom_helpers.mbt
+++ b/desktop/frontend/dom_helpers.mbt
@@ -49,7 +49,8 @@ fn Theme::apply(
   is_desktop : Bool,
   dispatch : @cmd.Emit[Msg],
 ) -> @cmd.Cmd {
-  let value = if self.is_dark(system_dark) { "dark" } else { "light" }
+  let dark = self.is_dark(system_dark)
+  let value = if dark { "dark" } else { "light" }
   @cmd.batch([
     @cmd.custom_cmd(_ => {
       if @dom.document().get_document_element() is Some(root) {
@@ -57,11 +58,12 @@ fn Theme::apply(
       }
     }),
     if is_desktop {
-      app_set_titlebar_theme(dispatch, value == "dark")
+      app_set_titlebar_theme(dispatch, dark)
     } else {
       @cmd.none
     },
     @fileeditor.apply_theme(value),
+    @transcript_component.apply_theme(dark),
   ])
 }
 

--- a/desktop/frontend/transcript/component/component.mbt
+++ b/desktop/frontend/transcript/component/component.mbt
@@ -67,7 +67,6 @@ pub(all) enum ScrollPosition {
 /// durable chronology and active-run ownership; this package owns only the
 /// transcript subtree and its scroll behavior.
 struct Input {
-  dark_mode : Bool
   source : Source
   focused : @interop.ChannelId
   active_session : String
@@ -104,7 +103,6 @@ struct Input {
 
 ///|
 pub fn Input::Input(
-  dark_mode? : Bool = false,
   source~ : Source,
   focused~ : @interop.ChannelId,
   active_session~ : String,
@@ -123,7 +121,6 @@ pub fn Input::Input(
   streaming_identity~ : String,
 ) -> Input {
   {
-    dark_mode,
     source,
     focused,
     active_session,
@@ -632,8 +629,9 @@ fn transcript_sub_loader(
 /// observer only finds the scroller element once Rabbita has inserted it (the
 /// subscription starts before the first paint); content growth and geometry
 /// are then observed directly on that element, so unrelated page mutations
-/// cannot feed back into component updates. Conversation identity is never
-/// read back from the DOM: it is fixed for the component's lifetime.
+/// cannot feed back into component updates. Neither conversation identity nor
+/// the theme is read back from the DOM: the former is fixed for the
+/// component's lifetime and the latter arrives through `apply_theme`.
 priv struct TranscriptObservers {
   document : @dom.MutationObserver
   content : @dom.MutationObserver
@@ -649,6 +647,7 @@ priv struct TranscriptDomMount {
   mut element : @dom.Element?
   mut diagrams : @diagram_viewport.DiagramViewports?
   mut rendered_diagrams : Array[TranscriptDiagram]
+  mut dark_mode : Bool
   images : TranscriptImageObserver
   on_size_changed : () -> Unit
 }
@@ -658,13 +657,16 @@ fn TranscriptDomMount::TranscriptDomMount(
   on_size_changed : () -> Unit,
   on_image : (String) -> Unit,
 ) -> Self {
-  {
+  let mount = {
     element: None,
     diagrams: None,
     rendered_diagrams: [],
+    dark_mode: transcript_theme.dark_mode,
     images: TranscriptImageObserver::install(on_image),
     on_size_changed,
   }
+  mount.register_theme()
+  mount
 }
 
 ///|
@@ -729,7 +731,7 @@ fn TranscriptDomMount::observe_content(
       character_data=true,
       subtree=true,
       attribute_filter=[
-        "data-transcript-diagram", "data-transcript-diagram-source", "data-transcript-theme",
+        "data-transcript-diagram", "data-transcript-diagram-source",
       ],
     )
   }
@@ -747,6 +749,7 @@ fn TranscriptDomMount::observe_resize(
 
 ///|
 fn TranscriptDomMount::dispose(self : Self) -> Unit {
+  self.unregister_theme()
   self.replace(None)
 }
 

--- a/desktop/frontend/transcript/component/diagrams.mbt
+++ b/desktop/frontend/transcript/component/diagrams.mbt
@@ -13,7 +13,6 @@ priv struct TranscriptDiagram {
   source : String
   language : String
   renderer : TranscriptDiagramRenderer
-  mut dark_mode : Bool
 }
 
 ///|
@@ -25,12 +24,66 @@ fn TranscriptDiagram::dispose(self : Self) -> Unit {
 }
 
 ///|
+/// Diago SVGs follow the chat palette through CSS variables; only Mermaid
+/// bakes its theme into the render and must be asked for a fresh one.
+fn TranscriptDiagram::set_dark_mode(self : Self, dark_mode : Bool) -> Unit {
+  match self.renderer {
+    Diago => ()
+    Mermaid(diagram) => diagram.set_dark_mode(dark_mode)
+  }
+}
+
+///|
+/// The effective application theme as the imperative diagram renderers need
+/// it. The root pushes it through `apply_theme`, the same way the file editor
+/// receives its theme, so the value never round-trips through the DOM. Live
+/// mounts register here for as long as they borrow a transcript element; a
+/// mount created after a change starts from the current value.
+priv struct TranscriptTheme {
+  mut dark_mode : Bool
+  mounts : Array[TranscriptDomMount]
+}
+
+///|
+let transcript_theme : TranscriptTheme = { dark_mode: false, mounts: [], }
+
+///|
+/// Re-theme every diagram rendered inside a mounted transcript. Batch it with
+/// the other theme commands whenever the effective theme changes.
+pub fn apply_theme(dark_mode : Bool) -> @cmd.Cmd {
+  @cmd.custom_cmd(_ => {
+    transcript_theme.dark_mode = dark_mode
+    for mount in transcript_theme.mounts {
+      mount.set_dark_mode(dark_mode)
+    }
+  })
+}
+
+///|
+fn TranscriptDomMount::register_theme(self : Self) -> Unit {
+  transcript_theme.mounts.push(self)
+}
+
+///|
+fn TranscriptDomMount::unregister_theme(self : Self) -> Unit {
+  transcript_theme.mounts.retain(mount => !physical_equal(mount, self))
+}
+
+///|
+fn TranscriptDomMount::set_dark_mode(self : Self, dark_mode : Bool) -> Unit {
+  guard self.dark_mode != dark_mode else { return }
+  self.dark_mode = dark_mode
+  for entry in self.rendered_diagrams {
+    entry.set_dark_mode(dark_mode)
+  }
+}
+
+///|
 fn TranscriptDomMount::refresh_diagrams(
   self : Self,
   root : @dom.Element,
 ) -> Unit {
   let elements = root.query_selector_all("[data-transcript-diagram]")
-  let dark_mode = root.get_attribute("data-transcript-theme") == Some("dark")
   let retained : Array[TranscriptDiagram] = []
   // Dispose removed/reused targets first, invalidating their pending Mermaid
   // work before any new diagram is installed into the same container.
@@ -61,22 +114,14 @@ fn TranscriptDomMount::refresh_diagrams(
     } nobreak {
       None
     }
-    if existing is Some(entry) {
-      if entry.dark_mode != dark_mode {
-        entry.dark_mode = dark_mode
-        match entry.renderer {
-          Diago => ()
-          Mermaid(diagram) => diagram.set_dark_mode(dark_mode)
-        }
-      }
-    } else {
+    if existing is None {
       let renderer = match language {
         "mermaid" =>
           TranscriptDiagramRenderer::Mermaid(
             @editor_viewer.MermaidDiagram(
               element,
               source,
-              dark_mode~,
+              dark_mode=self.dark_mode,
               on_size_changed=self.on_size_changed,
             ),
           )
@@ -92,7 +137,7 @@ fn TranscriptDomMount::refresh_diagrams(
         }
         _ => continue
       }
-      retained.push({ element, source, language, dark_mode, renderer, })
+      retained.push({ element, source, language, renderer, })
     }
   }
   self.rendered_diagrams = retained

--- a/desktop/frontend/transcript/component/pkg.generated.mbti
+++ b/desktop/frontend/transcript/component/pkg.generated.mbti
@@ -12,6 +12,8 @@ import {
 }
 
 // Values
+pub fn apply_theme(Bool) -> @cmd.Cmd
+
 pub fn component(@rabbita.Val[Input], Actions) -> @rabbita.Val[@html.Html]
 
 pub fn scroll_to_latest() -> @cmd.Cmd
@@ -32,7 +34,7 @@ pub(all) struct Actions {
 }
 
 type Input derive(Eq)
-pub fn Input::Input(dark_mode? : Bool, source~ : Source, focused~ : @interop.ChannelId, active_session~ : String, scroll? : ScrollPosition, project_label? : String, current_project~ : @common.Uri?, projects~ : Array[ProjectChoice], can_choose_project~ : Bool, project_menu_open~ : Bool, project_query~ : String, root~ : @common.Uri?, items~ : Array[VisibleRow], streaming_response~ : String?, streaming_reasoning? : String, reasoning_complete? : Bool, streaming_identity~ : String) -> Self
+pub fn Input::Input(source~ : Source, focused~ : @interop.ChannelId, active_session~ : String, scroll? : ScrollPosition, project_label? : String, current_project~ : @common.Uri?, projects~ : Array[ProjectChoice], can_choose_project~ : Bool, project_menu_open~ : Bool, project_query~ : String, root~ : @common.Uri?, items~ : Array[VisibleRow], streaming_response~ : String?, streaming_reasoning? : String, reasoning_complete? : Bool, streaming_identity~ : String) -> Self
 pub fn Input::equal(Self, Self) -> Bool
 pub fn Input::not_equal(Self, Self) -> Bool
 

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -1000,15 +1000,7 @@ fn transcript_view(
     attrs=@html.Attrs::build()
       .id("transcript")
       .class("transcript")
-      .data_set("transcript-session", input.active_session)
-      .data_set(
-        "transcript-theme",
-        if input.dark_mode {
-          "dark"
-        } else {
-          "light"
-        },
-      ),
+      .data_set("transcript-session", input.active_session),
     children,
   )
 }


### PR DESCRIPTION
## Why

#1379 rendered the effective theme as `data-transcript-theme` on the transcript root and watched that attribute with the content `MutationObserver` so Mermaid diagrams could re-render on a theme switch. That is the DOM used as a message bus between the root and the component's subscription, the pattern the last few transcript PRs have been removing.

Rabbita never re-runs a component's `subscriptions` on an input-only change ("Changing the input alone does not send a message, run `update`, or refresh subscriptions"), so the theme cannot reach the diagram mount through `Input` or the subscription payload either.

## What

- `Theme::apply` batches `@transcript_component.apply_theme(dark)` next to the existing `@fileeditor.apply_theme`, the same Cmd-push shape the file editor already uses for an imperative widget outside Model.
- The component package keeps a package-level `transcript_theme`: the current value plus a registry of live transcript mounts. A mount registers in its constructor and reads the current value there, unregisters on dispose, so the command and the first mount may run in either order. Only Mermaid is re-rendered; Diago SVGs follow the palette through CSS variables.
- Removed: `Input.dark_mode` and its three call sites, the rendered `data-transcript-theme` attribute, the `attribute_filter` entry, the `get_attribute` read-back, and the per-diagram `mut dark_mode`.
- The e2e now asserts the root `data-theme` projection written by the theme command instead of a component-rendered attribute.

## Verification

- `moon check --target js`
- `moon test --target js` for `frontend/transcript/component` (21) and `frontend` (467)
- `transcript_diagrams.spec.js` in Chromium: 6 passed, including the dark-mode re-render case
- `pkg.generated.mbti` synced from the js `_build` artifact; the diff is exactly the removed `dark_mode?` and the added `apply_theme`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018f26rE1L4kzBf5ddeqn99i
