### PR TITLE
fix(desktop): decode percent-encoded Markdown file links

### DIFF
--- a/desktop/e2e/tests/rabbita_dom.spec.js
+++ b/desktop/e2e/tests/rabbita_dom.spec.js
@@ -901,6 +901,7 @@ test('transcript Markdown keeps links safe and loads local raster bytes through 
             '[External docs](https://example.test/docs)',
             '[Source](src/main.mbt:12)',
             '[Local URI](file:///Users/me/My%20Project/main.mbt#L7)',
+            '[Bundled guide](/Users/me/Library/Application%20Support/SeekMoon/gmachine-3.md)',
             '[Unsafe](javascript:alert(1))',
             '![Fixture image](diagram.png)',
           ].join('\n\n'),
@@ -1004,6 +1005,13 @@ test('transcript Markdown keeps links safe and loads local raster bytes through 
   await expect.poll(() => app.requests.find(request =>
     request.method === 'host.open_path' &&
     request.params?.path === '/Users/me/My Project/main.mbt#L7'))
+    .toBeTruthy();
+  const guidePath = '/Users/me/Library/Application Support/SeekMoon/gmachine-3.md';
+  const guide = markdown.getByRole('button', { name: 'Bundled guide', exact: true });
+  await expect(guide).toHaveAttribute('data-context-file', guidePath);
+  await guide.click();
+  await expect.poll(() => app.requests.find(request =>
+    request.method === 'host.open_path' && request.params?.path === guidePath))
     .toBeTruthy();
   expect(app.pageErrors).toEqual([]);
 });

--- a/desktop/frontend/markdown/markdown.mbt
+++ b/desktop/frontend/markdown/markdown.mbt
@@ -569,11 +569,18 @@ fn MarkdownRender::file_destination(
     return Some(path)
   }
   if !@cmark.InlineLink::is_unsafe(destination) && is_local_path(destination) {
-    Some(destination)
+    Some(decode_local_link_path(destination))
   } else {
     None
   }
 }
+
+///|
+/// Markdown destinations are URI references. Decode exactly once at this
+/// boundary; prose/code paths and host filesystem paths remain literal.
+/// Malformed escapes retain their original spelling, as in URI parsing.
+extern "js" fn decode_local_link_path(destination : String) -> String =
+  #| value => { try { return decodeURIComponent(value) } catch { return value } }
 
 ///|
 /// A local raster image destination. Explicit `file://` URIs use the same

--- a/desktop/frontend/markdown/markdown_wbtest.mbt
+++ b/desktop/frontend/markdown/markdown_wbtest.mbt
@@ -3,6 +3,49 @@
 // on the pure text helpers.
 
 ///|
+test "markdown file actions decode URI destinations exactly once" {
+  let paths : Array[String] = []
+  let open = path => {
+    paths.push(path)
+    @cmd.none
+  }
+  let root = "/Users/me/Library/Application"
+  ignore(
+    markdown_nodes(
+      "[guide](\{root}%20Support/SeekMoon/gmachine-3.md)",
+      open_file=open,
+    ),
+  )
+  ignore(
+    markdown_nodes(
+      "[guide][doc]\n\n[doc]: ./docs/%E4%B8%AD%E6%96%87%20guide.md#L12",
+      open_file=open,
+    ),
+  )
+  ignore(
+    markdown_nodes(
+      "[percent](./docs/100%25.md) [literal](./docs/a%2520b.md:12:3) [plus](./docs/a+b.md) [malformed](./docs/100%zz.md)",
+      open_file=open,
+    ),
+  )
+  ignore(
+    markdown_nodes(
+      "[file](file:///tmp/Application%20Support/guide.md) `./docs/a%20b.md:12`",
+      open_file=open,
+    ),
+  )
+  assert_eq(paths, [
+    "\{root} Support/SeekMoon/gmachine-3.md",
+    "./docs/中文 guide.md#L12",
+    "./docs/100%.md",
+    "./docs/a%20b.md:12:3",
+    "./docs/a+b.md",
+    "./docs/100%zz.md",
+    "/tmp/Application Support/guide.md",
+  ])
+}
+
+///|
 test "markdown renders block structure" {
   inspect(markdown_nodes("").length(), content="0")
   inspect(markdown_nodes("just a paragraph").length(), content="1")


### PR DESCRIPTION
Markdown links such as `[guide](/Users/me/Library/Application%20Support/SeekMoon/gmachine-3.md)` passed `%20` literally to the host, causing a false “File does not exist” error. Decode local Markdown destinations exactly once before constructing file actions, so the host receives `Application Support`.

Adds renderer coverage for reference links, Unicode, percent signs, malformed escapes, and existing file URIs, plus a browser regression that checks the decoded context-menu path and `host.open_path` request. The existing checkout restriction for opening external text files remains unchanged.

Validation:
- Markdown package: 13 tests passed.
- `env -u DEEPSEEK just test`: 3,248 native tests, 3,218 JS tests, 24 cram cases, and CLI lifecycle integration passed. Live API tests disabled after the initial run stalled on them.
- `just build`, `moon info`, `moon fmt --check`, and the targeted Playwright Markdown test passed; no generated interface changes.
- `just check` is blocked by existing unused-import warnings in unrelated packages under `--deny-warn`.
