### PR TITLE
refactor(desktop): decode URI components in pure MoonBit

### DIFF
--- a/desktop/frontend/action_menu/browser_dom.mbt
+++ b/desktop/frontend/action_menu/browser_dom.mbt
@@ -56,7 +56,3 @@ extern "js" fn anchor_href(anchor : @dom.Element) -> String =
 ///|
 extern "js" fn anchor_protocol(anchor : @dom.Element) -> String =
   #| anchor => anchor.protocol
-
-///|
-extern "js" fn decode_uri_component(text : String) -> String =
-  #| text => decodeURIComponent(text)

--- a/desktop/frontend/action_menu/context_menu.mbt
+++ b/desktop/frontend/action_menu/context_menu.mbt
@@ -146,11 +146,7 @@ fn element_context(element : @dom.Element) -> ContextTarget {
     "mailto:" => {
       let href = anchor.get_attribute("href").unwrap_or(anchor_href(anchor))
       let raw = href[7:].split("?").next().unwrap_or(href[7:]).to_owned()
-      let address = @js.Error_::wrap(() => {
-        @js.Value::cast_from(decode_uri_component(raw))
-      }) catch {
-        _ => raw
-      }
+      let address = @uri.decode_component(raw)
       EmailLink(url=anchor_href(anchor), address~)
     }
     _ => NoTarget

--- a/desktop/frontend/action_menu/moon.pkg
+++ b/desktop/frontend/action_menu/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "openseek_desktop/internal/uri",
   "moonbitlang/core/math",
   "moonbit-community/rabbita",
   "moonbit-community/rabbita/clipboard",

--- a/desktop/frontend/interop/moon.pkg
+++ b/desktop/frontend/interop/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "openseek_desktop/internal/uri",
   "moonbit-community/rabbita/dom",
   "moonbit-community/rabbita/js",
   "moonbitlang/core/deque",

--- a/desktop/frontend/interop/query.mbt
+++ b/desktop/frontend/interop/query.mbt
@@ -4,9 +4,6 @@
 // Retired `/d/<device>/` routes redirect into this query shape.
 
 ///|
-extern "js" fn js_decode_uri_component(value : String) -> String = "(v) => { try { return decodeURIComponent(v) } catch { return v } }"
-
-///|
 /// The named parameter in the page's own query string, decoded; `None`
 /// when absent or empty.
 pub fn page_query_param(name : String) -> String? {
@@ -24,7 +21,7 @@ pub fn page_query_param(name : String) -> String? {
   for pair in query.split("&") {
     guard pair.find("=") is Some(index) else { continue }
     if pair[:index].to_owned() == name {
-      let value = js_decode_uri_component(pair[index + 1:].to_owned())
+      let value = @uri.decode_component(pair[index + 1:])
       return if value.is_empty() { None } else { Some(value) }
     }
   }

--- a/desktop/frontend/markdown/markdown.mbt
+++ b/desktop/frontend/markdown/markdown.mbt
@@ -569,18 +569,12 @@ fn MarkdownRender::file_destination(
     return Some(path)
   }
   if !@cmark.InlineLink::is_unsafe(destination) && is_local_path(destination) {
-    Some(decode_local_link_path(destination))
+    // Decode URI destinations once here; prose and host paths stay literal.
+    Some(@uri.decode_component(destination))
   } else {
     None
   }
 }
-
-///|
-/// Markdown destinations are URI references. Decode exactly once at this
-/// boundary; prose/code paths and host filesystem paths remain literal.
-/// Malformed escapes retain their original spelling, as in URI parsing.
-extern "js" fn decode_local_link_path(destination : String) -> String =
-  #| value => { try { return decodeURIComponent(value) } catch { return value } }
 
 ///|
 /// A local raster image destination. Explicit `file://` URIs use the same

--- a/desktop/frontend/markdown/moon.pkg
+++ b/desktop/frontend/markdown/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "openseek_desktop/internal/uri",
   "moonbit-community/cmark/cmark",
   "moonbit-community/rabbita/cmd",
   "moonbit-community/rabbita/html",

--- a/desktop/internal/uri/pkg.generated.mbti
+++ b/desktop/internal/uri/pkg.generated.mbti
@@ -4,6 +4,8 @@ package "openseek_desktop/internal/uri"
 // Values
 pub fn decode(StringView) -> String
 
+pub fn decode_component(StringView) -> String
+
 pub fn encode_component(StringView) -> String
 
 // Errors

--- a/desktop/internal/uri/uri.mbt
+++ b/desktop/internal/uri/uri.mbt
@@ -12,6 +12,44 @@ pub fn encode_component(text : StringView) -> String {
 }
 
 ///|
+/// Decode one URI component, retaining the entire input if any escape or
+/// escaped UTF-8 sequence is malformed. This matches `decodeURIComponent`
+/// with a keep-original catch. A plus stays a plus, and escapes decode once.
+///
+/// ```mbt check
+/// test {
+///   assert_eq(@uri.decode_component("a%20b%2520"), "a b%20")
+///   assert_eq(@uri.decode_component("a%20b%zz"), "a%20b%zz")
+/// }
+/// ```
+pub fn decode_component(text : StringView) -> String {
+  let out = StringBuilder()
+  let mut rest = text
+  while !rest.is_empty() {
+    if rest is ['%', ..] {
+      let bytes = @buffer.Buffer()
+      while rest is ['%', ..] {
+        guard rest is ['%', high, low, .. tail] &&
+          hex_value(high) is Some(high) &&
+          hex_value(low) is Some(low) else {
+          return text.to_owned()
+        }
+        bytes.write_byte(((high << 4) | low).to_byte())
+        rest = tail
+      }
+      let decoded = @utf8.decode(bytes.contents(), ignore_bom=false) catch {
+        _ => return text.to_owned()
+      }
+      out.write_string(decoded)
+    } else if rest is [ch, .. tail] {
+      out.write_char(ch)
+      rest = tail
+    }
+  }
+  out.to_string()
+}
+
+///|
 /// Decode percent-escapes into UTF-8 bytes and everything else as-is. A
 /// malformed escape (`%` without two hex digits) stays literal rather than
 /// failing, and invalid UTF-8 decodes lossily — URIs sent by other programs

--- a/desktop/internal/uri/uri_test.mbt
+++ b/desktop/internal/uri/uri_test.mbt
@@ -18,3 +18,57 @@ test "decode leaves malformed escapes literal" {
   assert_eq(@uri.decode("a%zz"), "a%zz")
   assert_eq(@uri.decode("a%"), "a%")
 }
+
+///|
+test "component decoding preserves URI component semantics" {
+  for
+    (encoded, decoded) in [
+      ("Application%20Support", "Application Support"),
+      ("%e4%b8%ad%E6%96%87%F0%9F%8C%99", "中文🌙"),
+      ("中文%20🌙", "中文 🌙"),
+      ("a+b%2Bc", "a+b+c"),
+      ("%2520", "%20"),
+      ("%2F%3F%23%26%3D%3A", "/?#&=:"),
+      ("%EF%BB%BFx%EF%BB%BF", "\u{FEFF}x\u{FEFF}"),
+      ("%00", "\u{0}"),
+      ("", ""),
+    ] {
+    assert_eq(@uri.decode_component(encoded), decoded)
+  }
+}
+
+///|
+test "component decoding keeps all input on malformed escapes or UTF8" {
+  for
+    malformed in [
+      "%", "%2", "%zz", "%0g", "%g0", "%80", "%BF", "%C0%AF", "%C1%BF", "%C2", "%C2x%A0",
+      "%E0%80%AF", "%ED%A0%80", "%ED%BF%BF", "%E2%82", "%F0%80%80%AF", "%F4%90%80%80",
+      "%F5%80%80%80", "%FF",
+    ] {
+    // Earlier valid escapes must not be decoded when a later escape fails.
+    let input = "prefix%20\{malformed}%20suffix"
+    assert_eq(@uri.decode_component(input), input)
+  }
+}
+
+///|
+test "pure component encoding and decoding round trip Unicode and ASCII" {
+  for
+    text in [
+      "", "Application Support", "中文🌙", "a+b/c?d#e&f=g", "100%", "\u{0}\u{7F}\u{80}\u{7FF}\u{800}\u{D7FF}\u{E000}\u{FFFF}\u{10000}\u{10FFFF}",
+      "\u{FEFF}BOM",
+    ] {
+    assert_eq(@uri.decode_component(@uri.encode_component(text)), text)
+  }
+  assert_eq(
+    @uri.encode_component("中文🌙"),
+    "%E4%B8%AD%E6%96%87%F0%9F%8C%99",
+  )
+  // Desktop's encoder uses the RFC 3986 unreserved set, which is stricter
+  // than JavaScript's encoder; retain the established authentication URLs.
+  assert_eq(@uri.encode_component("!'()*+"), "%21%27%28%29%2A%2B")
+  for code in 0..<128 {
+    let text = code.unsafe_to_char().to_string()
+    assert_eq(@uri.decode_component(@uri.encode_component(text)), text)
+  }
+}


### PR DESCRIPTION
Desktop's Markdown file links, page query parameters, and mailto context menus used JavaScript decoding shims. Replace all three with a shared pure MoonBit `decode_component` in `desktop/internal/uri`, alongside its existing pure MoonBit `encode_component`.

The new decoder preserves the previous all-or-nothing behavior: malformed escapes or invalid escaped UTF-8 keep the entire original input. It decodes once, preserves plus signs and BOMs, and leaves the existing tolerant authentication decoder and RFC 3986 encoder unchanged. This follows #1407.

Adds cross-target tests for Unicode, ASCII round trips, malformed escapes, overlong and out-of-range UTF-8, surrogates, and BOMs, plus an executable documentation example.

Validation:
- `env -u DEEPSEEK just test`: 3,252 native tests, 3,222 JS tests, 24 cram cases, and CLI lifecycle integration passed; live API tests disabled.
- `just build`, `moon info`, `moon fmt`, and the targeted Playwright Markdown regression passed.
- The generated interface adds only `decode_component(StringView) -> String`.
- `just check` remains blocked by existing unused-import warnings in unrelated packages under `--deny-warn`.
