### PR TITLE
perf(desktop): skip settled transcript rows in Rabbita's diff

### DIFF
--- a/desktop/frontend/transcript/component/component.mbt
+++ b/desktop/frontend/transcript/component/component.mbt
@@ -299,11 +299,27 @@ pub fn component(
   )
   // Every stream child renders in its own branch, keyed by the block within
   // its stream. A streaming delta then recomputes only the live block's Html;
-  // each settled row keeps the Html it already has, so the cost of a delta no
-  // longer grows with the length of the transcript.
+  // each settled row keeps the Html it already has.
+  //
+  // Keeping the Html is not enough on its own: Rabbita's diff still walks a
+  // node's subtree whenever the node is reached, so a delta would still cost
+  // a comparison of every settled row's DOM. Each branch therefore wraps its
+  // Html in `memo_by`, keyed by how many times the branch has rendered. The
+  // branch renders only when its block changes (blocks compare by value), so
+  // an unchanged key means an unchanged subtree, and the diff skips it. Stream
+  // children are keyed, so a counter never meets another branch's counter.
   let blocks = input.map(stream_blocks)
   let rendered = blocks.assoc_by(
-    (_, block) => block.map(block => (block.key.wire(), block.render(actions))),
+    (_, block) => {
+      let renders = Ref(0)
+      block.map(block => {
+        renders.val += 1
+        let html = @html.memo_by(block, block => block.render(actions), by=_ => {
+          renders.val
+        })
+        (block.key.wire(), html)
+      })
+    },
     by=block => block.branch_key(),
   )
   state.view3(input, rendered, (state, input, rendered) => {


### PR DESCRIPTION
## Summary

Replaces the approach of #1375. Rabbita 0.15.7 (#1335) exports `@html.memo` / `@html.memo_by`, a thunk that the VDOM diff skips while its key is unchanged, so the transcript no longer needs a DOM island to keep streaming deltas cheap.

Each `#stream` row's `assoc_by` branch wraps its Html in `memo_by`, keyed by how many times that branch has rendered. The branch renders only when its `Block` changes (blocks compare by value), so an unchanged key means an unchanged subtree and the diff returns the old node without walking it. Stream children are keyed, so one branch's counter never meets another's. A streaming delta now costs the page skeleton plus one `Int` comparison per settled row, instead of a comparison of every element under `#transcript`.

Live reasoning stays in the model and renders through the ordinary `update` path, as on `main`.

The observer / keyed-column / image-root fix that this PR carried at first is unrelated to streaming cost and moved to its own PR: #1415.

## Verification

- `moon check --target js --deny-warn`, `moon test --target js` (3233) in `desktop/`.
- `just test-browser`: 62 passed, two consecutive full runs on this commit alone over `main`. (The first run after a fresh `npm ci` failed `dock_visibility.spec.js` once; it passed alone and in both full reruns.)
- Not measured here: the actual frame cost on a long transcript. The CDP recipe from the 2026-09-04 profile applies (`Profiler` over the dev bundle's remote-debugging port); the number to compare is the `diff_node` share of a streaming-delta frame before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dp6jf4fKxaVzVq2heQR6dX
