### PR TITLE
fix(ci): enable bigobj for Windows release builds

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -352,6 +352,9 @@ jobs:
         run: node desktop/scripts/release.mjs stamp "$RELEASE_VERSION"
 
       - name: Build Windows ZIP
+        env:
+          # Generated desktop C can exceed MSVC's default object section limit.
+          CL: /bigobj
         # Keep the unpacked application for the version check below. Proton
         # removes it after packaging when only the ZIP format is requested.
         run: moon run ./desktop/package/windows --target native -- --release --target app --target zip


### PR DESCRIPTION
The scheduled Windows release failed while compiling generated `openseek_desktop.c` with MSVC C1128 (object section-count limit): https://github.com/moonbitlang/openseek/actions/runs/34317458119/job/102356608068.

Set `CL=/bigobj` on the Windows release build step. MSVC consumes this environment variable, and the packaging subprocesses inherit it, allowing the generated C to compile into extended COFF objects.

Validation on the failing source revision (`95960fda`):
- Ran the complete CI release command with `CL=/bigobj`, after removing the generated desktop object to force recompilation; app and ZIP packaging and the workflow's packaged-version check passed for 0.1.93.
- Confirmed the rebuilt desktop object is `EXTENDED COFF OBJECT`; ZIP CRC verification passed.
- `just desktop-build-scripts-check` (10 tests), `moon info`, `moon fmt`, and `git diff --check` passed; no generated interface changes. `moon info` reports five existing unused-field/value warnings.
- Local Node 22.23.2 and MoonBit v0.10.12+1634b282e match the failed run. Local MSVC is 14.44, while CI used 14.51. The baseline also builds locally (61,575 object sections), so this verifies the flag takes effect and packaging succeeds, but does not reproduce the original CI failure locally.
