### PR TITLE
feat(desktop): add contextual tab closing actions

### DIFF
--- a/desktop/e2e/tests/close_shortcut.spec.js
+++ b/desktop/e2e/tests/close_shortcut.spec.js
@@ -133,10 +133,12 @@ test('Selecting a dock tab moves focus out of the composer', async ({ page }) =>
   await page.getByRole('button', { name: /^Browse / }).click();
   await page.locator('#task').click();
   await review.click();
-  await expect(page.locator('.content.panel-open > .editor')).toBeFocused();
+  // Tabs are now keyboard targets for their context menus. Selecting one
+  // keeps focus on that tab, inside the dock's Close shortcut scope.
+  await expect(review).toBeFocused();
   await page.locator('#task').click();
   await review.click();
-  await expect(page.locator('.content.panel-open > .editor')).toBeFocused();
+  await expect(review).toBeFocused();
   await closeFocused(page);
   await expect(review).toHaveCount(0);
   await expect(page.locator('.editor-tab')).toHaveCount(1);

--- a/desktop/e2e/tests/dock_tab_actions.spec.js
+++ b/desktop/e2e/tests/dock_tab_actions.spec.js
@@ -93,12 +93,26 @@ for (const entry of ['menu', 'toolbar']) {
 test('tab and sidebar menus replace each other without changing selection', async ({ page }) => {
   const app = await openTabs(page, ['alpha', 'bravo']);
   const first = page.locator('.editor-tab').first();
+  const active = page.locator('.editor-tab.active');
+  const restingBackground = await first.evaluate(tab => getComputedStyle(tab).backgroundColor);
+  const selectedBackground = await active.evaluate(tab => getComputedStyle(tab).backgroundColor);
+  await first.hover();
+  const hoverBackground = await first.evaluate(tab => getComputedStyle(tab).backgroundColor);
   const workspace = page.locator('.workspace-row').first();
   await first.click({ button: 'right' });
   await expect(page.getByRole('menu', { name: 'Tab actions' })).toBeVisible();
+  await page.getByRole('menuitem', { name: 'Close Others', exact: true }).hover();
+  await expect(first).toHaveAttribute('aria-expanded', 'true');
+  await expect(first).toHaveCSS('background-color', hoverBackground);
+  await expect(active).toHaveCSS('background-color', selectedBackground);
+  await page.keyboard.press('Escape');
+  await expect(first).toHaveAttribute('aria-expanded', 'false');
+  await expect(first).toHaveCSS('background-color', restingBackground);
+  await first.click({ button: 'right' });
   await workspace.click({ button: 'right', position: { x: 24, y: 16 } });
   await expect(page.getByRole('menu', { name: 'Workspace actions' })).toBeVisible();
   await expect(page.getByRole('menu', { name: 'Tab actions' })).toBeHidden();
+  await expect(first).toHaveCSS('background-color', restingBackground);
   await first.click({ button: 'right' });
   await expect(page.getByRole('menu', { name: 'Workspace actions' })).toBeHidden();
   await expect(page.getByRole('menu', { name: 'Tab actions' })).toBeVisible();

--- a/desktop/e2e/tests/dock_tab_actions.spec.js
+++ b/desktop/e2e/tests/dock_tab_actions.spec.js
@@ -1,0 +1,87 @@
+import { test, expect } from '@playwright/test';
+import { DesktopBrowserHarness } from './support/desktop_browser_harness.js';
+
+async function openTabs(page, names) {
+  const app = new DesktopBrowserHarness(page);
+  app.searchFiles = names.map(name => `src/${name}.mbt`);
+  for (const path of app.searchFiles) app.workingFiles[path] = 'fn main {}\n';
+  await app.install();
+  await app.goto();
+  await app.openSession();
+  for (const name of names) {
+    await app.openQuickOpen();
+    await page.locator('#quick-open-input').fill(name);
+    await page.getByRole('option', { name: new RegExp(`${name}\\.mbt`) }).click();
+  }
+  return app;
+}
+
+for (const [action, remaining, active] of [
+  ['Close Others', ['bravo.mbt'], 'bravo.mbt'],
+  ['Close to the Left', ['bravo.mbt', 'charlie.mbt', 'Review Changes'], 'Review Changes'],
+  ['Close to the Right', ['alpha.mbt', 'bravo.mbt'], 'bravo.mbt'],
+]) {
+  test(`${action} is relative to the context tab, across file and picker tabs`, async ({ page }) => {
+    const app = await openTabs(page, ['alpha', 'bravo', 'charlie']);
+    await app.openReview();
+    await page.getByRole('button', { name: 'Expand panel', exact: true }).click();
+    const tabs = page.locator('.editor-tab');
+    await tabs.filter({ hasText: 'bravo.mbt' }).click({ button: 'right' });
+    await expect(page.locator('.editor-tab.active')).toContainText('Review Changes');
+    const menu = page.getByRole('menu', { name: 'Tab actions' });
+    await expect(menu).toBeVisible();
+    await menu.getByRole('menuitem', { name: action, exact: true }).click();
+    await expect(menu).toBeHidden();
+    await expect(tabs.locator('.tab-name')).toHaveText(remaining);
+    await expect(page.locator('.editor-tab.active')).toContainText(active);
+    await expect(page.locator('.content.panel-open > .editor')).toBeFocused();
+    await expect(page.getByRole('button', { name: 'Restore panel', exact: true })).toBeVisible();
+    expect(app.pageErrors).toEqual([]);
+  });
+}
+
+test('tab menu disables empty ranges and supports keyboard dismissal and Close All', async ({ page }) => {
+  const app = await openTabs(page, ['alpha', 'bravo']);
+  const tabs = page.locator('.editor-tab');
+  const menu = page.getByRole('menu', { name: 'Tab actions' });
+  await tabs.first().click({ button: 'right' });
+  await expect(menu.getByRole('menuitem', { name: 'Close to the Left' })).toBeDisabled();
+  await expect(menu.getByRole('menuitem', { name: 'Close to the Right' })).toBeEnabled();
+  await page.keyboard.press('Escape');
+  await tabs.last().focus();
+  await page.keyboard.press('Shift+F10');
+  await expect(menu).toBeVisible();
+  await expect(menu.getByRole('menuitem', { name: 'Close to the Right' })).toBeDisabled();
+  await page.keyboard.press('Escape');
+  await expect(tabs.last()).toBeFocused();
+  await page.keyboard.press('Shift+F10');
+  await menu.getByRole('menuitem', { name: 'Close Others', exact: true }).click();
+  await expect(tabs).toHaveCount(1);
+  await tabs.first().click({ button: 'right' });
+  for (const name of ['Close Others', 'Close to the Left', 'Close to the Right']) {
+    await expect(menu.getByRole('menuitem', { name, exact: true })).toBeDisabled();
+  }
+  await menu.getByRole('menuitem', { name: 'Close All', exact: true }).click();
+  await expect(tabs).toHaveCount(0);
+  await expect(page.locator('.dock-launcher')).toBeVisible();
+  expect(app.pageErrors).toEqual([]);
+});
+
+test('tab and sidebar menus replace each other without changing selection', async ({ page }) => {
+  const app = await openTabs(page, ['alpha', 'bravo']);
+  const first = page.locator('.editor-tab').first();
+  const workspace = page.locator('.workspace-row').first();
+  await first.click({ button: 'right' });
+  await expect(page.getByRole('menu', { name: 'Tab actions' })).toBeVisible();
+  await workspace.click({ button: 'right', position: { x: 24, y: 16 } });
+  await expect(page.getByRole('menu', { name: 'Workspace actions' })).toBeVisible();
+  await expect(page.getByRole('menu', { name: 'Tab actions' })).toBeHidden();
+  await first.click({ button: 'right' });
+  await expect(page.getByRole('menu', { name: 'Workspace actions' })).toBeHidden();
+  await expect(page.getByRole('menu', { name: 'Tab actions' })).toBeVisible();
+  await expect(page.locator('.editor-tab.active')).toContainText('bravo.mbt');
+  await page.getByRole('menuitem', { name: 'Close', exact: true }).click();
+  await expect(page.locator('.editor-tab .tab-name')).toHaveText(['bravo.mbt']);
+  await expect(page.locator('.content.panel-open > .editor')).toBeFocused();
+  expect(app.pageErrors).toEqual([]);
+});

--- a/desktop/e2e/tests/dock_tab_actions.spec.js
+++ b/desktop/e2e/tests/dock_tab_actions.spec.js
@@ -16,6 +16,42 @@ async function openTabs(page, names) {
   return app;
 }
 
+test('new-tab menu stays anchored to plus in split, expanded and narrow panels', async ({ page }) => {
+  const app = await openTabs(page, ['alpha']);
+  const add = page.getByRole('button', { name: 'New tab', exact: true });
+  const menu = page.locator('.dock-menu');
+  for (const layout of ['split', 'expanded', 'narrow']) {
+    if (layout === 'expanded') {
+      await page.getByRole('button', { name: 'Expand panel', exact: true }).click();
+    } else if (layout === 'narrow') {
+      await page.setViewportSize({ width: 390, height: 844 });
+    }
+    await add.click();
+    await expect(menu).toBeVisible();
+    await expect.poll(() => menu.evaluate(popup => {
+      const bounds = popup.getBoundingClientRect();
+      const bar = popup.closest('.editor-tabsbar');
+      const trigger = bar.querySelector('.tab-add').getBoundingClientRect();
+      return {
+        aligned: Math.abs(bounds.right - trigger.right) <= 1,
+        below: bounds.top >= trigger.bottom && bounds.top <= trigger.bottom + 10,
+        contained: bounds.left >= bar.getBoundingClientRect().left &&
+          bounds.right <= window.innerWidth && bounds.bottom <= window.innerHeight,
+        fits: popup.scrollWidth <= popup.clientWidth,
+      };
+    }), { message: `${layout} menu should open beneath plus and remain readable` }).toEqual({
+      aligned: true, below: true, contained: true, fits: true,
+    });
+    await add.click();
+    await expect(menu).toBeHidden();
+  }
+  await add.click();
+  await menu.getByRole('button', { name: 'Search', exact: false }).click();
+  await expect(menu).toBeHidden();
+  await expect(page.locator('.editor-tab.active')).toContainText('Search');
+  expect(app.pageErrors).toEqual([]);
+});
+
 for (const [action, remaining, active] of [
   ['Close Others', ['bravo.mbt'], 'bravo.mbt'],
   ['Close to the Left', ['bravo.mbt', 'charlie.mbt', 'Review Changes'], 'Review Changes'],

--- a/desktop/e2e/tests/dock_tab_actions.spec.js
+++ b/desktop/e2e/tests/dock_tab_actions.spec.js
@@ -67,6 +67,29 @@ test('tab menu disables empty ranges and supports keyboard dismissal and Close A
   expect(app.pageErrors).toEqual([]);
 });
 
+for (const entry of ['menu', 'toolbar']) {
+  test(`Close All from the ${entry} preserves the expanded launcher and the next tab`, async ({ page }) => {
+    const app = await openTabs(page, ['alpha', 'bravo']);
+    await page.getByRole('button', { name: 'Expand panel', exact: true }).click();
+    if (entry === 'menu') {
+      await page.locator('.editor-tab').first().click({ button: 'right' });
+      await page.getByRole('menuitem', { name: 'Close All', exact: true }).click();
+    } else {
+      await page.getByRole('button', { name: 'Close all tabs', exact: true }).click();
+    }
+    await expect(page.locator('.editor-tab')).toHaveCount(0);
+    await expect(page.locator('.dock-launcher')).toBeVisible();
+    const restore = page.getByRole('button', { name: 'Restore panel', exact: true });
+    await expect(restore).toHaveAttribute('aria-pressed', 'true');
+    await app.openQuickOpen();
+    await page.locator('#quick-open-input').fill('alpha');
+    await page.getByRole('option', { name: /alpha\.mbt/ }).click();
+    await expect(page.locator('.editor-tab.active')).toContainText('alpha.mbt');
+    await expect(restore).toHaveAttribute('aria-pressed', 'true');
+    expect(app.pageErrors).toEqual([]);
+  });
+}
+
 test('tab and sidebar menus replace each other without changing selection', async ({ page }) => {
   const app = await openTabs(page, ['alpha', 'bravo']);
   const first = page.locator('.editor-tab').first();

--- a/desktop/frontend/action_menu/action_menu.mbt
+++ b/desktop/frontend/action_menu/action_menu.mbt
@@ -159,6 +159,24 @@ pub fn context_attrs(target : String) -> @html.Attrs {
       restore_focus_id: remembered_context_focus(event),
     })
   })
+  .on_keydown(event => {
+    guard event.key() == "ContextMenu" ||
+      (event.key() == "F10" && event.shift_key()) else {
+      return @cmd.none
+    }
+    guard event.current_target().to_option() is Some(target_element) &&
+      target_element.to_element() is Some(element) else {
+      return @cmd.none
+    }
+    event.prevent_default()
+    event.stop_propagation()
+    let rect = element.get_bounding_client_rect()
+    dispatch_open({
+      target,
+      anchor: Pointer(rect.get_left().to_int(), rect.get_bottom().to_int()),
+      restore_focus_id: focused_element_id(),
+    })
+  })
 }
 
 ///|
@@ -691,7 +709,13 @@ pub fn[Input : Eq] component(
           }
           guard resolve(input, next.target) is Some(definition) &&
             definition.enabled_indices() is [_, ..] else {
-            return (state, @cmd.none)
+            // Another component may own this target. Only one shared menu
+            // surface should remain open across the sidebar and dock.
+            let command = match state.menu {
+              Some(current) => set_trigger_open(current.target, false)
+              None => @cmd.none
+            }
+            return ({ menu: None, }, command)
           }
           let close_previous = match state.menu {
             Some(current) if current.target != next.target =>

--- a/desktop/frontend/action_menu/action_menu.mbt
+++ b/desktop/frontend/action_menu/action_menu.mbt
@@ -146,7 +146,10 @@ pub fn button_attrs(target : String) -> @html.Attrs {
 /// Build the context-menu entry point for a stable target.
 pub fn context_attrs(target : String) -> @html.Attrs {
   @html.Attrs::build()
+  .id(target + ":context-trigger")
   .data_set("action-menu-context", target)
+  .aria_haspopup("menu")
+  .aria_controls(menu_id(target))
   .on_mousedown(event => remember_context_focus(event))
   .on_contextmenu(event => {
     event.prevent_default()
@@ -234,6 +237,12 @@ fn set_trigger_open(target : String, open : Bool) -> @cmd.Cmd {
   @cmd.custom_cmd(
     _ => {
       if @dom.document().get_element_by_id(trigger_id(target)).to_option()
+        is Some(trigger) {
+        trigger.set_attribute("aria-expanded", open.to_string())
+      }
+      if @dom.document()
+        .get_element_by_id(target + ":context-trigger")
+        .to_option()
         is Some(trigger) {
         trigger.set_attribute("aria-expanded", open.to_string())
       }

--- a/desktop/frontend/boot.mbt
+++ b/desktop/frontend/boot.mbt
@@ -535,7 +535,7 @@ pub fn boot() -> Unit {
       toggle_panel: emit(ToggleRightPanel),
       toggle_menu: emit(ToggleRightPanelMenu),
       toggle_expanded: emit(ToggleRightPanelExpanded),
-      close_all_tabs: emit(CloseAllTabs),
+      close_tabs: emit.map(selection => CloseDockTabs(selection)),
       close_menu: emit(CloseRightPanelMenu),
     })
     let terminal_input = state.map(model => model.terminal_input())

--- a/desktop/frontend/dock/dock_test.mbt
+++ b/desktop/frontend/dock/dock_test.mbt
@@ -13,6 +13,39 @@ fn file_tab(path : String) -> @dock.DockTab {
 }
 
 ///|
+test "bulk close selects relative to the clicked tab across tab kinds" {
+  let state = @dock.State::empty()
+    |> @dock.open_file(@pathx.Relative("a.mbt"))
+    |> @dock.open_browser(7)
+    |> @dock.open_picker()
+    |> @dock.open_workflows()
+  let anchor = @dock.DockTab::Browser(id=7)
+  assert_true(@dock.tabs_to_close(state, ToLeft(anchor)) == [file_tab("a.mbt")])
+  assert_true(
+    @dock.tabs_to_close(state, ToRight(anchor)) ==
+    [@dock.DockTab::FilePicker, @dock.DockTab::Workflows],
+  )
+  assert_true(
+    @dock.tabs_to_close(state, Others(anchor)) ==
+    [file_tab("a.mbt"), @dock.DockTab::FilePicker, @dock.DockTab::Workflows],
+  )
+  assert_true(@dock.tabs_to_close(state, All) == state.tabs)
+  assert_true(@dock.tabs_to_close(state, ToLeft(file_tab("a.mbt"))).is_empty())
+  assert_true(@dock.tabs_to_close(state, ToRight(Workflows)).is_empty())
+  assert_true(
+    @dock.tabs_to_close(state, Others(file_tab("missing"))).is_empty(),
+  )
+  assert_true(
+    @dock.tabs_to_close(state, ToLeft(file_tab("missing"))).is_empty(),
+  )
+  assert_true(
+    @dock.tabs_to_close(state, ToRight(file_tab("missing"))).is_empty(),
+  )
+  let single = @dock.State::empty() |> @dock.open_picker()
+  assert_true(@dock.tabs_to_close(single, Others(FilePicker)).is_empty())
+}
+
+///|
 test "open_file appends in order and activates" {
   let state = @dock.State::empty()
     |> @dock.open_file(@pathx.Relative("a.mbt"))

--- a/desktop/frontend/dock/moon.pkg
+++ b/desktop/frontend/dock/moon.pkg
@@ -5,6 +5,7 @@ import {
   "openseek_desktop/frontend/pathx",
   "openseek_desktop/frontend/interop",
   "openseek_desktop/frontend/icons",
+  "openseek_desktop/frontend/action_menu",
 }
 
 import {

--- a/desktop/frontend/dock/pkg.generated.mbti
+++ b/desktop/frontend/dock/pkg.generated.mbti
@@ -4,6 +4,8 @@ package "openseek_desktop/frontend/dock"
 import {
   "moonbit-community/rabbita/cmd",
   "moonbit-community/rabbita/html",
+  "moonbitlang/core/debug",
+  "openseek_desktop/frontend/action_menu",
   "openseek_desktop/frontend/interop",
   "openseek_desktop/frontend/pathx",
 }
@@ -13,7 +15,11 @@ pub fn active_browser(State) -> Int?
 
 pub fn active_file(State) -> @pathx.Relative?
 
+pub fn active_history_diff(State) -> GitHistoryDiff?
+
 pub fn file_paths(State) -> Array[@pathx.Relative]
+
+pub fn history_diffs(State) -> Array[GitHistoryDiff]
 
 pub fn launcher_pane(LauncherActions) -> @html.Html
 
@@ -21,30 +27,62 @@ pub fn open_browser(State, Int) -> State
 
 pub fn open_file(State, @pathx.Relative) -> State
 
+pub fn open_history_diff(State, GitHistoryDiff) -> State
+
 pub fn open_picker(State) -> State
+
+pub fn open_workflows(State) -> State
 
 pub fn resolve_pick(State, @pathx.Relative) -> State
 
 pub fn sync(State, @interop.ConversationKey) -> State
 
-pub fn tabs_bar(@cmd.Emit[Msg], State, Array[TabChip], LauncherActions, menu_open~ : Bool, expanded~ : Bool, toggle_menu~ : @cmd.Cmd, toggle_expanded~ : @cmd.Cmd, toggle_panel~ : @cmd.Cmd) -> @html.Html
+pub fn tab_menu(State, String, @cmd.Emit[Msg], @cmd.Emit[CloseSelection]) -> @action_menu.Definition?
+
+pub fn tabs_bar(@cmd.Emit[Msg], State, Array[TabChip], LauncherActions, menu_open~ : Bool, expanded~ : Bool, toggle_menu~ : @cmd.Cmd, close_tabs~ : @cmd.Emit[CloseSelection], toggle_expanded~ : @cmd.Cmd, toggle_panel~ : @cmd.Cmd) -> @html.Html
+
+pub fn tabs_to_close(State, CloseSelection) -> Array[DockTab]
 
 pub fn update(Msg, State) -> State
 
 // Errors
 
 // Types and methods
+pub(all) enum CloseSelection {
+  All
+  Others(DockTab)
+  ToLeft(DockTab)
+  ToRight(DockTab)
+}
+
 pub(all) enum DockTab {
   File(path~ : @pathx.Relative)
+  GitDiff(diff~ : GitHistoryDiff)
   Browser(id~ : Int)
   FilePicker
+  Workflows
 } derive(Eq)
+pub fn DockTab::equal(Self, Self) -> Bool
+pub fn DockTab::not_equal(Self, Self) -> Bool
+
+pub(all) struct GitHistoryDiff {
+  commit : String
+  parent : String?
+  path : @pathx.Relative
+  original_path : @pathx.Relative?
+  status : String
+  kind : String
+} derive(Eq, @debug.Debug)
+pub fn GitHistoryDiff::equal(Self, Self) -> Bool
+pub fn GitHistoryDiff::not_equal(Self, Self) -> Bool
+pub fn GitHistoryDiff::to_repr(Self) -> @debug.Repr
 
 pub(all) struct LauncherActions {
   browser : @cmd.Cmd?
   search : @cmd.Cmd
   files : @cmd.Cmd
   review : @cmd.Cmd
+  workflows : @cmd.Cmd
 }
 
 pub(all) enum Msg {
@@ -56,6 +94,8 @@ pub(all) struct RememberedStrip {
   tabs : Array[DockTab]
   active : DockTab?
 } derive(Eq)
+pub fn RememberedStrip::equal(Self, Self) -> Bool
+pub fn RememberedStrip::not_equal(Self, Self) -> Bool
 
 pub(all) struct State {
   owner : @interop.ConversationKey?
@@ -64,6 +104,8 @@ pub(all) struct State {
   remembered : Map[@interop.ConversationKey, RememberedStrip]
 } derive(Eq)
 pub fn State::empty() -> Self
+pub fn State::equal(Self, Self) -> Bool
+pub fn State::not_equal(Self, Self) -> Bool
 
 pub(all) struct TabChip {
   tab : DockTab

--- a/desktop/frontend/dock/tab_menu.mbt
+++ b/desktop/frontend/dock/tab_menu.mbt
@@ -1,0 +1,94 @@
+///|
+pub(all) enum CloseSelection {
+  All
+  Others(DockTab)
+  ToLeft(DockTab)
+  ToRight(DockTab)
+}
+
+///|
+/// Resolve against the current strip, not the active tab or a captured index.
+/// A menu whose tab has gone away cannot close unrelated tabs.
+pub fn tabs_to_close(
+  state : State,
+  selection : CloseSelection,
+) -> Array[DockTab] {
+  let anchor = match selection {
+    All => return state.tabs.copy()
+    Others(tab) | ToLeft(tab) | ToRight(tab) => tab
+  }
+  guard tab_index(state, anchor) is Some(index) else { return [] }
+  match selection {
+    All => state.tabs.copy()
+    Others(_) => state.tabs.filter(tab => tab != anchor)
+    ToLeft(_) => state.tabs[:index].to_owned()
+    ToRight(_) => state.tabs[index + 1:].to_owned()
+  }
+}
+
+///|
+fn tab_menu_target(state : State, tab : DockTab) -> String {
+  let owner = match state.owner {
+    None => "unowned"
+    Some(owner) => {
+      let channel = match owner.channel {
+        Local => "local"
+        Remote(id) => "remote:\{id.length()}:\{id}"
+      }
+      "\{channel}:\{owner.session.length()}:\{owner.session}"
+    }
+  }
+  let identity = match tab {
+    File(path~) => "file:\{path.0}"
+    GitDiff(diff~) => "history:\{diff.commit}:\{diff.path.0}"
+    Browser(id~) => "browser:\{id}"
+    FilePicker => "picker"
+    Workflows => "workflows"
+  }
+  "dock:\{owner}:\{identity}"
+}
+
+///|
+pub fn tab_menu(
+  state : State,
+  target : String,
+  dispatch : @cmd.Emit[Msg],
+  close : @cmd.Emit[CloseSelection],
+) -> @action_menu.Definition? {
+  guard state.tabs
+    .iter()
+    .find_first(tab => tab_menu_target(state, tab) == target)
+    is Some(tab) else {
+    return None
+  }
+  let entries : Array[@action_menu.Entry] = [
+    Action({
+      label: "Close",
+      title: "Close this tab",
+      icon: None,
+      enabled: true,
+      destructive: false,
+      command: dispatch(TabClosed(tab)),
+    }),
+    Separator,
+  ]
+  for
+    (label, selection) in [
+      ("Close Others", Others(tab)),
+      ("Close to the Left", ToLeft(tab)),
+      ("Close to the Right", ToRight(tab)),
+      ("Close All", All),
+    ] {
+    entries.push(
+      Action({
+        label,
+        title: label,
+        icon: None,
+        enabled: !tabs_to_close(state, selection).is_empty(),
+        destructive: false,
+        command: close(selection),
+      }),
+    )
+  }
+  Some({ label: "Tab actions", entries, })
+}

--- a/desktop/frontend/dock/view.mbt
+++ b/desktop/frontend/dock/view.mbt
@@ -191,8 +191,7 @@ pub fn tabs_bar(
   menu_open~ : Bool,
   expanded~ : Bool,
   toggle_menu~ : @cmd.Cmd,
-  close_all_tabs~ : @cmd.Cmd,
-  close_all_tabs_disabled~ : Bool,
+  close_tabs~ : @cmd.Emit[CloseSelection],
   toggle_expanded~ : @cmd.Cmd,
   toggle_panel~ : @cmd.Cmd,
 ) -> @html.Html {
@@ -206,10 +205,25 @@ pub fn tabs_bar(
       classes += " deleted"
     }
     let tab = chip.tab
+    let target = tab_menu_target(state, tab)
     tabs.push(
       @html.div(
         class=classes,
         title=chip.title,
+        attrs=@action_menu.context_attrs(target)
+          .id(target)
+          .tabindex(0)
+          .aria_haspopup("menu")
+          .on_keydown(event => {
+            if event.target().to_element() is Some(element) &&
+              element.get_attribute("id") == Some(target) &&
+              (event.key() == "Enter" || event.key() == " ") {
+              event.prevent_default()
+              dispatch(TabActivated(tab))
+            } else {
+              @cmd.none
+            }
+          }),
         on_click=dispatch(TabActivated(tab)),
         [
           @html.span(class="tab-name", chip.label),
@@ -236,8 +250,8 @@ pub fn tabs_bar(
       title="Close all tabs",
       attrs=@html.Attrs::build()
         .aria_label("Close all tabs")
-        .disabled(close_all_tabs_disabled)
-        .on_click(_ => close_all_tabs),
+        .disabled(state.tabs.is_empty())
+        .on_click(_ => close_tabs(All)),
       @icons.icon(@icons.icon_close_all),
     ),
     @html.button(

--- a/desktop/frontend/dock/view.mbt
+++ b/desktop/frontend/dock/view.mbt
@@ -195,7 +195,8 @@ pub fn tabs_bar(
   toggle_expanded~ : @cmd.Cmd,
   toggle_panel~ : @cmd.Cmd,
 ) -> @html.Html {
-  let tabs : Array[@html.Html] = []
+  // Keep each menu trigger's DOM identity when neighbouring tabs close.
+  let tabs : Map[String, @html.Html] = Map([])
   for chip in chips {
     let mut classes = "editor-tab"
     if state.active == Some(chip.tab) {
@@ -206,38 +207,34 @@ pub fn tabs_bar(
     }
     let tab = chip.tab
     let target = tab_menu_target(state, tab)
-    tabs.push(
-      @html.div(
-        class=classes,
-        title=chip.title,
-        attrs=@action_menu.context_attrs(target)
-          .id(target)
-          .tabindex(0)
-          .aria_haspopup("menu")
-          .on_keydown(event => {
-            if event.target().to_element() is Some(element) &&
-              element.get_attribute("id") == Some(target) &&
-              (event.key() == "Enter" || event.key() == " ") {
-              event.prevent_default()
-              dispatch(TabActivated(tab))
-            } else {
-              @cmd.none
-            }
+    tabs[target] = @html.div(
+      class=classes,
+      title=chip.title,
+      attrs=@action_menu.context_attrs(target)
+        .tabindex(0)
+        .on_keydown(event => {
+          if event.target().to_element() is Some(element) &&
+            element.get_attribute("data-action-menu-context") == Some(target) &&
+            (event.key() == "Enter" || event.key() == " ") {
+            event.prevent_default()
+            dispatch(TabActivated(tab))
+          } else {
+            @cmd.none
+          }
+        }),
+      on_click=dispatch(TabActivated(tab)),
+      [
+        @html.span(class="tab-name", chip.label),
+        @html.button(
+          class="tab-close",
+          title="Close",
+          attrs=@html.Attrs::build().on_click(event => {
+            event.stop_propagation()
+            dispatch(TabClosed(tab))
           }),
-        on_click=dispatch(TabActivated(tab)),
-        [
-          @html.span(class="tab-name", chip.label),
-          @html.button(
-            class="tab-close",
-            title="Close",
-            attrs=@html.Attrs::build().on_click(event => {
-              event.stop_propagation()
-              dispatch(TabClosed(tab))
-            }),
-            "×",
-          ),
-        ],
-      ),
+          "×",
+        ),
+      ],
     )
   }
   // With an empty strip the body already is the launcher, so the `+` hides

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -2016,9 +2016,8 @@ priv enum Msg {
   ToggleRightPanelMenu
   ToggleRightPanelExpanded
   CloseRightPanelMenu
-  // Close every dock tab through its ordinary teardown path, then keep the
-  // empty panel open on the New Tab launcher.
-  CloseAllTabs
+  // Close a selection through ordinary teardown; All keeps the launcher open.
+  CloseDockTabs(@dock.CloseSelection)
   // The composer's goal-editing mode over the active conversation: open
   // (prefilled with the mirrored standing goal), edit its draft, send a
   // set/clear to the engine, or dismiss. Each acts on the conversation on

--- a/desktop/frontend/right_panel/component.mbt
+++ b/desktop/frontend/right_panel/component.mbt
@@ -64,14 +64,13 @@ pub(all) struct Actions {
   toggle_panel : @cmd.Cmd
   toggle_menu : @cmd.Cmd
   toggle_expanded : @cmd.Cmd
-  close_all_tabs : @cmd.Cmd
+  close_tabs : @cmd.Emit[@dock.CloseSelection]
   close_menu : @cmd.Cmd
 }
 
 ///|
-/// Render the root-owned panel input directly. The panel has no local state or
-/// document listeners: app shortcuts, menu dismissal, and URL requests belong
-/// to the root application because their messages all change root state.
+/// Panel data stays root-owned; the shared action menu owns only its ephemeral
+/// opening and focus state, resolving tab commands from the latest input.
 pub fn component(
   input : @rabbita.Val[Input],
   actions : Actions,
@@ -79,8 +78,11 @@ pub fn component(
   let semantic_review = input.map(input => {
     @fileeditor.semantic_review_view(actions.file_editor, input.file_panel)
   })
-  input.view2(semantic_review, (input, semantic_review) => {
-    panel_view(input, actions, semantic_review~)
+  let tab_menu = @action_menu.component(input, (input, target) => {
+    @dock.tab_menu(input.dock, target, actions.dock, actions.close_tabs)
+  })
+  input.map3(semantic_review, tab_menu, (input, semantic_review, tab_menu) => {
+    panel_view(input, actions, semantic_review~, tab_menu~)
   })
 }
 

--- a/desktop/frontend/right_panel/moon.pkg
+++ b/desktop/frontend/right_panel/moon.pkg
@@ -3,6 +3,7 @@ import {
   "moonbit-community/rabbita/cmd",
   "moonbit-community/rabbita/html",
   "openseek_desktop/frontend/dock",
+  "openseek_desktop/frontend/action_menu",
   "openseek_desktop/frontend/workflow",
   "openseek_desktop/frontend/fileeditor",
   "openseek_desktop/frontend/preview",

--- a/desktop/frontend/right_panel/pkg.generated.mbti
+++ b/desktop/frontend/right_panel/pkg.generated.mbti
@@ -36,7 +36,7 @@ pub(all) struct Actions {
   toggle_panel : @cmd.Cmd
   toggle_menu : @cmd.Cmd
   toggle_expanded : @cmd.Cmd
-  close_all_tabs : @cmd.Cmd
+  close_tabs : @cmd.Emit[@dock.CloseSelection]
   close_menu : @cmd.Cmd
 }
 

--- a/desktop/frontend/right_panel/view.mbt
+++ b/desktop/frontend/right_panel/view.mbt
@@ -6,6 +6,7 @@ fn panel_view(
   input : Input,
   actions : Actions,
   semantic_review? : @html.Html = @html.nothing,
+  tab_menu? : @html.Html = @html.nothing,
 ) -> @html.Html {
   let chips : Array[@dock.TabChip] = input.dock.tabs.map(tab => {
     match tab {
@@ -111,8 +112,7 @@ fn panel_view(
         menu_open=input.menu_open,
         expanded=input.expanded,
         toggle_menu=actions.toggle_menu,
-        close_all_tabs=actions.close_all_tabs,
-        close_all_tabs_disabled=input.dock.tabs.is_empty(),
+        close_tabs=actions.close_tabs,
         toggle_expanded=actions.toggle_expanded,
         toggle_panel=actions.toggle_panel,
       ),
@@ -143,6 +143,7 @@ fn panel_view(
       ]),
       @workflow.panel(input.workflows, { open_child: actions.open_child, }),
       @dock.launcher_pane(launcher),
+      tab_menu,
     ],
   )
 }

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1908,6 +1908,11 @@ fn update(
       panel_cmd,
       terminal_cmd,
       browser_cmd,
+      if msg is Dock(TabClosed(_)) {
+        focus_dock_after_render()
+      } else {
+        @cmd.none
+      },
       sync_dock_visibility(
         model.dock.active != previous.dock.active ||
         model.dock.tabs != previous.dock.tabs ||
@@ -1937,11 +1942,12 @@ fn Msg::opens_file_before_panel_reconciliation(self : Msg) -> Bool {
 }
 
 ///|
-fn close_all_tabs(
+fn close_dock_tabs(
   dispatch : @cmd.Emit[Msg],
   model : Model,
+  selection : @dock.CloseSelection,
 ) -> (@cmd.Cmd, Model) {
-  let tabs = model.dock.tabs.copy()
+  let tabs = @dock.tabs_to_close(model.dock, selection)
   guard !tabs.is_empty() else { return (@cmd.none, model) }
   let active = model.dock.active
   let commands : Array[@cmd.Cmd] = []
@@ -1956,18 +1962,25 @@ fn close_all_tabs(
       next = updated
     }
   }
-  if active is Some(tab) {
+  if active is Some(tab) && tabs.contains(tab) {
     let (command, updated) = update_msg(dispatch, Dock(TabClosed(tab)), next)
     commands.push(command)
     next = updated
   }
+  // The menu disappears before its command runs. Keep subsequent keyboard
+  // actions in the dock rather than leaving focus on the document body.
+  commands.push(focus_dock_after_render())
   (
     @cmd.batch(commands),
     {
       ..next,
       right_panel_open: true,
       right_panel_menu_open: false,
-      right_panel_expanded: false,
+      right_panel_expanded: if selection is All {
+        false
+      } else {
+        next.right_panel_expanded
+      },
     },
   )
 }
@@ -4680,7 +4693,7 @@ fn update_msg(
     }
     CloseRightPanelMenu =>
       (@cmd.none, { ..model, right_panel_menu_open: false, })
-    CloseAllTabs => close_all_tabs(dispatch, model)
+    CloseDockTabs(selection) => close_dock_tabs(dispatch, model, selection)
     OpenGoalEditor => {
       guard model.active_conversation() is Some(conv) else {
         return (@cmd.none, model)
@@ -18844,7 +18857,7 @@ test "launcher rows open Browser and all Explorer destinations" {
 }
 
 ///|
-test "CloseAllTabs tears down mixed tabs and keeps the empty launcher open" {
+test "CloseDockTabs All tears down mixed tabs and keeps the empty launcher open" {
   let dispatch = test_dispatch()
   let (_, browser) = update(dispatch, BrowserTabRequested, {
     ..desktop_model(),
@@ -18859,13 +18872,44 @@ test "CloseAllTabs tears down mixed tabs and keeps the empty launcher open" {
   assert_true(
     mixed.dock.tabs == [@dock.DockTab::Browser(id=1), @dock.DockTab::FilePicker],
   )
-  let (_, closed) = update(dispatch, CloseAllTabs, mixed)
+  let (_, closed) = update(dispatch, CloseDockTabs(All), mixed)
   assert_true(closed.dock.tabs.is_empty())
   assert_true(closed.dock.active is None)
   assert_true(@preview.page(closed.preview, 1) is None)
   assert_true(closed.right_panel_open)
   assert_false(closed.right_panel_menu_open)
   assert_false(closed.right_panel_expanded)
+}
+
+///|
+test "relative tab close preserves survivors and tears down only selected pages" {
+  let dispatch = test_dispatch()
+  let (_, first) = update(dispatch, BrowserTabRequested, desktop_model())
+  let (_, picker) = update(dispatch, ExplorerRequested(ExplorerFiles), first)
+  let (_, second) = update(dispatch, BrowserTabRequested, picker)
+  let mixed = { ..second, right_panel_expanded: true, }
+  let (_, left) = update(dispatch, CloseDockTabs(ToLeft(FilePicker)), mixed)
+  assert_true(
+    left.dock.tabs == [@dock.DockTab::FilePicker, @dock.DockTab::Browser(id=2)],
+  )
+  assert_true(left.dock.active == Some(@dock.DockTab::Browser(id=2)))
+  assert_true(@preview.page(left.preview, 1) is None)
+  assert_true(@preview.page(left.preview, 2) is Some(_))
+  assert_true(left.right_panel_expanded)
+  let (_, right) = update(dispatch, CloseDockTabs(ToRight(FilePicker)), mixed)
+  assert_true(
+    right.dock.tabs == [@dock.DockTab::Browser(id=1), @dock.DockTab::FilePicker],
+  )
+  assert_true(right.dock.active == Some(@dock.DockTab::FilePicker))
+  assert_true(@preview.page(right.preview, 1) is Some(_))
+  assert_true(@preview.page(right.preview, 2) is None)
+  let (_, others) = update(dispatch, CloseDockTabs(Others(FilePicker)), mixed)
+  assert_true(others.dock.tabs == [@dock.DockTab::FilePicker])
+  assert_true(others.dock.active == Some(@dock.DockTab::FilePicker))
+  assert_true(@preview.page(others.preview, 1) is None)
+  assert_true(@preview.page(others.preview, 2) is None)
+  assert_true(others.right_panel_open)
+  assert_true(others.right_panel_expanded)
 }
 
 ///|

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1976,11 +1976,9 @@ fn close_dock_tabs(
       ..next,
       right_panel_open: true,
       right_panel_menu_open: false,
-      right_panel_expanded: if selection is All {
-        false
-      } else {
-        next.right_panel_expanded
-      },
+      // Closing the final tab resets the panel in the ordinary close path.
+      // Bulk close keeps the launcher open, so retain the user's chosen size.
+      right_panel_expanded: model.right_panel_expanded,
     },
   )
 }
@@ -18857,7 +18855,7 @@ test "launcher rows open Browser and all Explorer destinations" {
 }
 
 ///|
-test "CloseDockTabs All tears down mixed tabs and keeps the empty launcher open" {
+test "CloseDockTabs All keeps the empty launcher at the chosen panel size" {
   let dispatch = test_dispatch()
   let (_, browser) = update(dispatch, BrowserTabRequested, {
     ..desktop_model(),
@@ -18878,7 +18876,13 @@ test "CloseDockTabs All tears down mixed tabs and keeps the empty launcher open"
   assert_true(@preview.page(closed.preview, 1) is None)
   assert_true(closed.right_panel_open)
   assert_false(closed.right_panel_menu_open)
-  assert_false(closed.right_panel_expanded)
+  assert_true(closed.right_panel_expanded)
+  let (_, normal) = update(dispatch, CloseDockTabs(All), {
+    ..mixed,
+    right_panel_expanded: false,
+  })
+  assert_true(normal.right_panel_open)
+  assert_false(normal.right_panel_expanded)
 }
 
 ///|

--- a/desktop/styles/file_panel.css
+++ b/desktop/styles/file_panel.css
@@ -427,10 +427,13 @@ html:is(
 .editor.mode-picker.mode-search-picker .viewer-stack::after {
   content: "Select a search result to open";
 }
-/* The strip's new-tab button and its launcher popup. The tabsbar anchors
-   the popup; a click away closes it (see `dismiss_subscription`). */
+/* Keep the launcher attached to + as the panel and tab strip resize. */
 .editor-tabsbar {
   position: relative;
+  anchor-scope: --dock-new-tab;
+}
+.tab-add {
+  anchor-name: --dock-new-tab;
 }
 .tab-action {
   flex: 0 0 auto;
@@ -458,9 +461,16 @@ html:is(
 }
 .dock-menu {
   position: absolute;
-  top: calc(100% - 6px);
-  left: 12px;
-  min-width: 260px;
+  position-anchor: --dock-new-tab;
+  position-area: block-end span-inline-start;
+  /* The popup intentionally extends below its short tab-bar containing block. */
+  align-self: unsafe start;
+  inset: auto;
+  width: max-content;
+  /* 100% spans from the panel's leading edge to the button's trailing edge. */
+  min-width: min(260px, calc(100% - 8px));
+  max-width: calc(100% - 8px);
+  margin: 4px 0 0;
   padding: 5px;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);

--- a/desktop/styles/file_panel.css
+++ b/desktop/styles/file_panel.css
@@ -121,7 +121,8 @@ button.panel-toggle:not(:disabled):hover {
   cursor: pointer;
   white-space: nowrap;
 }
-.editor-tab:hover {
+.editor-tab:hover,
+.editor-tab[aria-expanded="true"]:not(.active) {
   background: var(--color-bg-subtle);
   color: var(--color-text-primary);
 }


### PR DESCRIPTION
Managing several right-panel tabs requires repeated individual closes. Close All also exits expanded mode, and the New Tab popup opens at the opposite end of the tab bar from its `+` button.

This PR adds **Close**, **Close Others**, **Close to the Left**, **Close to the Right**, and **Close All** to the tab context menu. Ranges follow the right-clicked tab, while an unrelated selected tab remains selected if it survives. Empty ranges are disabled, and a stale menu target cannot close unrelated tabs.

The menu reuses the shared action-menu component, including keyboard navigation and dismissal. Its owning tab retains a subtle highlight until dismissal, while the active tab keeps its selected appearance. Bulk closes use the existing per-tab teardown paths, preserve the panel's expanded state, and leave keyboard focus in the dock. The `+` popup uses a CSS anchor and fits the available panel width.

The changes are limited to dock actions, menu integration, positioning, and regression coverage. Broader consolidation of launcher and context-menu styling remains follow-up work. The [interactive prototype and capture fixture](https://github.com/moonbitlang/openseek/tree/2001370e6f8df829c1bd6bddc91f14086b17db7b/desktop/frontend/replay) stay on a separate branch.

## Before and after

Real production components with identical fixture files, events, and interactions. Before is main at `95960fd`; after is this PR at `944c5cd`. Both use a 1280 × 850 viewport; the menu comparisons show its top 420 pixels. No tools or agents ran in the fixture.

**Right-click README.md while Review Changes remains selected**

| Before — main | After — this PR |
| --- | --- |
| ![No tab action menu on main](https://raw.githubusercontent.com/moonbitlang/openseek/2001370e6f8df829c1bd6bddc91f14086b17db7b/desktop/frontend/replay/screenshots/before-tab-menu.jpg) | ![Tab actions and a persistent context-tab highlight](https://raw.githubusercontent.com/moonbitlang/openseek/2001370e6f8df829c1bd6bddc91f14086b17db7b/desktop/frontend/replay/screenshots/after-tab-menu.jpg) |

**Open New Tab using `+`**

| Before — main | After — this PR |
| --- | --- |
| ![New Tab popup at the panel's left edge](https://raw.githubusercontent.com/moonbitlang/openseek/2001370e6f8df829c1bd6bddc91f14086b17db7b/desktop/frontend/replay/screenshots/before-new-tab.jpg) | ![New Tab popup anchored beneath plus](https://raw.githubusercontent.com/moonbitlang/openseek/2001370e6f8df829c1bd6bddc91f14086b17db7b/desktop/frontend/replay/screenshots/after-new-tab.jpg) |

<details>
<summary>Close All from an expanded panel</summary>

| Before — main: returns to split view | After — this PR: stays expanded |
| --- | --- |
| ![Close All unexpectedly restores the split view](https://raw.githubusercontent.com/moonbitlang/openseek/2001370e6f8df829c1bd6bddc91f14086b17db7b/desktop/frontend/replay/screenshots/before-close-all.jpg) | ![Close All preserves the expanded launcher](https://raw.githubusercontent.com/moonbitlang/openseek/2001370e6f8df829c1bd6bddc91f14086b17db7b/desktop/frontend/replay/screenshots/after-close-all.jpg) |

</details>
