### PR TITLE
fix(desktop): publish Windows NSIS installers

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -310,6 +310,14 @@ jobs:
         with:
           arch: x64
 
+      - name: Install NSIS
+        run: |
+          choco install nsis --version=3.12.0 --yes --no-progress
+          if ($LASTEXITCODE -ne 0) { throw "NSIS installation failed: $LASTEXITCODE" }
+          $nsisDir = "${env:ProgramFiles(x86)}\NSIS"
+          $nsisDir >> $env:GITHUB_PATH
+          & "$nsisDir\makensis.exe" /VERSION
+
       # Stable, matching CI, for the same reason as the macOS job below.
       - name: Set up MoonBit
         run: |
@@ -351,15 +359,15 @@ jobs:
         shell: bash
         run: node desktop/scripts/release.mjs stamp "$RELEASE_VERSION"
 
-      - name: Build Windows ZIP
+      - name: Build Windows installer
         env:
           # Generated desktop C can exceed MSVC's default object section limit.
           CL: /bigobj
         # Keep the unpacked application for the version check below. Proton
-        # removes it after packaging when only the ZIP format is requested.
-        run: moon run ./desktop/package/windows --target native -- --release --target app --target zip
+        # removes it after packaging when only the installer is requested.
+        run: moon run ./desktop/package/windows --target native -- --release --target app --target installer
 
-      # Proton names the portable ZIP after the executable. The release keeps
+      # Proton names the installer after the executable. The release keeps
       # the platform in the filename, matching the other download names.
       - name: Verify packaged application version
         shell: bash
@@ -373,16 +381,16 @@ jobs:
               throw new Error(`packaged ${manifest.version} (bundle ${manifest.bundle_version}), expected ${version}`);
             }
           '
-          mv desktop/dist/seekmoon.zip desktop/dist/SeekMoon-windows-x64.zip
+          mv desktop/dist/seekmoon-setup.exe desktop/dist/SeekMoon-windows-x64-setup.exe
 
       # Only a hand-off to the publish job. The downloadable release artifact
       # is uploaded there, after OSS has settled which bytes are canonical.
-      - name: Hand Windows ZIP to the publish job
+      - name: Hand Windows installer to the publish job
         uses: actions/upload-artifact@v4
         with:
           name: SeekMoon-windows-x64-v${{ needs.release-needed.outputs.version }}-build
           overwrite: true
-          path: desktop/dist/SeekMoon-windows-x64.zip
+          path: desktop/dist/SeekMoon-windows-x64-setup.exe
           if-no-files-found: error
           compression-level: 0
           retention-days: 1
@@ -438,7 +446,7 @@ jobs:
           name: SeekMoon-macos-arm64-v${{ needs.release-needed.outputs.version }}-build
           path: desktop/dist
 
-      - name: Collect Windows ZIP
+      - name: Collect Windows installer
         uses: actions/download-artifact@v4
         with:
           name: SeekMoon-windows-x64-v${{ needs.release-needed.outputs.version }}-build
@@ -479,7 +487,7 @@ jobs:
         with:
           name: SeekMoon-windows-x64-v${{ needs.release-needed.outputs.version }}
           overwrite: true
-          path: desktop/dist/SeekMoon-windows-x64.zip
+          path: desktop/dist/SeekMoon-windows-x64-setup.exe
           if-no-files-found: error
           compression-level: 0
           retention-days: 14

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -18,6 +18,7 @@ on:
       - "moon.mod"
       - "moon.work"
       - ".github/workflows/desktop.yml"
+      - ".github/workflows/desktop-release.yml"
   pull_request:
     paths:
       - "desktop/**"
@@ -30,6 +31,7 @@ on:
       - "moon.mod"
       - "moon.work"
       - ".github/workflows/desktop.yml"
+      - ".github/workflows/desktop-release.yml"
 
 # A newer PR head supersedes its older run. Keep main runs complete so every
 # relevant merged commit still receives Desktop E2E and packaging results.
@@ -39,7 +41,7 @@ concurrency:
 
 jobs:
   desktop-package-windows:
-    name: desktop package (Windows ZIP)
+    name: desktop package (Windows NSIS)
     runs-on: windows-latest
     timeout-minutes: 60
     permissions:
@@ -60,6 +62,14 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: x64
+
+      - name: Install NSIS
+        run: |
+          choco install nsis --version=3.12.0 --yes --no-progress
+          if ($LASTEXITCODE -ne 0) { throw "NSIS installation failed: $LASTEXITCODE" }
+          $nsisDir = "${env:ProgramFiles(x86)}\NSIS"
+          $nsisDir >> $env:GITHUB_PATH
+          & "$nsisDir\makensis.exe" /VERSION
 
       - name: Test release script
         run: node --test desktop/scripts/release.test.mjs
@@ -95,14 +105,16 @@ jobs:
           }
           moonx "moonbit-community/proton_cli@$($Matches[1])" cef setup
 
-      - name: Build Windows ZIP
-        run: moon run ./desktop/package/windows --target native -- --target zip
+      - name: Build Windows installer
+        env:
+          CL: /bigobj
+        run: moon run ./desktop/package/windows --target native -- --release --target installer
 
-      - name: Upload Windows ZIP
+      - name: Upload Windows installer
         uses: actions/upload-artifact@v4
         with:
           name: SeekMoon-windows-x64
-          path: desktop/dist/*.zip
+          path: desktop/dist/seekmoon-setup.exe
           if-no-files-found: error
           compression-level: 0
           retention-days: 7

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -41,7 +41,7 @@ concurrency:
 
 jobs:
   desktop-package-windows:
-    name: desktop package (Windows NSIS)
+    name: desktop package (Windows app)
     runs-on: windows-latest
     timeout-minutes: 60
     permissions:
@@ -62,14 +62,6 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: x64
-
-      - name: Install NSIS
-        run: |
-          choco install nsis --version=3.12.0 --yes --no-progress
-          if ($LASTEXITCODE -ne 0) { throw "NSIS installation failed: $LASTEXITCODE" }
-          $nsisDir = "${env:ProgramFiles(x86)}\NSIS"
-          $nsisDir >> $env:GITHUB_PATH
-          & "$nsisDir\makensis.exe" /VERSION
 
       - name: Test release script
         run: node --test desktop/scripts/release.test.mjs
@@ -105,16 +97,17 @@ jobs:
           }
           moonx "moonbit-community/proton_cli@$($Matches[1])" cef setup
 
-      - name: Build Windows installer
+      - name: Build Windows app
         env:
           CL: /bigobj
-        run: moon run ./desktop/package/windows --target native -- --release --target installer
+        run: moon run ./desktop/package/windows --target native -- --release --target app
 
-      - name: Upload Windows installer
+      - name: Upload Windows app
         uses: actions/upload-artifact@v4
         with:
           name: SeekMoon-windows-x64
-          path: desktop/dist/seekmoon-setup.exe
+          path: desktop/dist/seekmoon/
+          include-hidden-files: true
           if-no-files-found: error
           compression-level: 0
           retention-days: 7

--- a/desktop/BUILD.md
+++ b/desktop/BUILD.md
@@ -57,8 +57,9 @@ moon run ./desktop/package/browser -- --release
 moon run ./desktop/package/dev
 ```
 
-Windows installer builds require NSIS (`makensis.exe` on `PATH`). Both Windows
-CI jobs install NSIS 3.12.0 through Chocolatey and set `CL=/bigobj` for MSVC.
+Windows installer builds require NSIS (`makensis.exe` on `PATH`). Only the
+release workflow installs NSIS 3.12.0 through Chocolatey; ordinary Windows CI
+builds and uploads the unpacked app. Both jobs set `CL=/bigobj` for MSVC.
 The release workflow retains the unpacked app for its version check and
 publishes `SeekMoon-windows-x64-setup.exe`; `--target zip` remains available
 for local portable builds.

--- a/desktop/BUILD.md
+++ b/desktop/BUILD.md
@@ -47,7 +47,7 @@ moon run ./desktop/package/macos -- \
 
 # Windows; defaults to ZIP and installer
 moon run ./desktop/package/windows
-moon run ./desktop/package/windows -- --release --target zip
+moon run ./desktop/package/windows --target native -- --release --target app --target installer
 
 # Linux AppImage
 moon run ./desktop/package/linux -- --release
@@ -56,6 +56,12 @@ moon run ./desktop/package/linux -- --release
 moon run ./desktop/package/browser -- --release
 moon run ./desktop/package/dev
 ```
+
+Windows installer builds require NSIS (`makensis.exe` on `PATH`). Both Windows
+CI jobs install NSIS 3.12.0 through Chocolatey and set `CL=/bigobj` for MSVC.
+The release workflow retains the unpacked app for its version check and
+publishes `SeekMoon-windows-x64-setup.exe`; `--target zip` remains available
+for local portable builds.
 
 Browser inputs and the standalone esbuild executable are fixed-version
 upstream distributions with checked-in SHA-256 digests. Builds cache only

--- a/desktop/scripts/release.mjs
+++ b/desktop/scripts/release.mjs
@@ -33,10 +33,10 @@ const Artifacts = [
   { platform: "macos-arm64-dmg", label: "Installer DMG", file: "SeekMoon.dmg", contentType: "application/x-apple-diskimage" },
   // Also uploaded to the API: `/console/` serves it from the API origin.
   { platform: "browser", label: "Browser bundle", file: "SeekMoon.browser.tar.gz", contentType: "application/gzip" },
-  // Renamed from Proton's `seekmoon.zip` by the release workflow. Versions
-  // released before Windows shipped have none, which a rollback tolerates.
-  { platform: "windows-x64", label: "Windows ZIP", file: "SeekMoon-windows-x64.zip", contentType: "application/zip",
-    optionalOnRollback: true },
+  // Renamed from Proton's `seekmoon-setup.exe` by the release workflow.
+  // Rollbacks preserve older ZIP downloads or releases without Windows.
+  { platform: "windows-x64", label: "Windows installer", file: "SeekMoon-windows-x64-setup.exe", contentType: "application/octet-stream",
+    optionalOnRollback: true, rollbackFiles: ["SeekMoon-windows-x64.zip"] },
 ];
 const Browser = Artifacts.find(artifact => artifact.platform === "browser");
 
@@ -236,7 +236,7 @@ export class Release {
     }
 
     // `/console/` remains on the API origin, so only the much smaller Browser
-    // archive is uploaded twice. The ZIPs and the DMG exist only in OSS.
+    // archive is uploaded twice. Desktop packages exist only in OSS.
     const recorded = await this.fetchJson(`/desktop/releases/${version}/${Browser.file}?platform=browser`, {
       method: "PUT", body: await readFile(join(this.dist, Browser.file)),
     });
@@ -262,10 +262,15 @@ export class Release {
     if (fromCheckout) await this.checkoutVersion(version);
     else if (!/^v[A-Za-z0-9][A-Za-z0-9_.-]*$/.test(version)) throw new Error(`invalid rollback version: ${version}`);
     const platforms = {};
-    for (const artifact of Artifacts) {
-      if (!fromCheckout && artifact.optionalOnRollback && this.headObject(version, artifact).missing) {
-        console.log(`${artifact.platform} was never uploaded for ${version}; republishing without it`);
-        continue;
+    for (let artifact of Artifacts) {
+      if (!fromCheckout && artifact.optionalOnRollback) {
+        const file = [artifact.file, ...(artifact.rollbackFiles ?? [])].find(file =>
+          !this.headObject(version, { ...artifact, file }).missing);
+        if (file === undefined) {
+          console.log(`${artifact.platform} was never uploaded for ${version}; republishing without it`);
+          continue;
+        }
+        artifact = { ...artifact, file };
       }
       const local = fromCheckout ? await this.localArtifact(artifact) : undefined;
       const served = await this.verifyServed(version, artifact, local);

--- a/desktop/scripts/release.test.mjs
+++ b/desktop/scripts/release.test.mjs
@@ -89,7 +89,7 @@ test("verify distinguishes missing Location, non-redirects, and wrong destinatio
     "macos-arm64": "SeekMoon.app.zip",
     "macos-arm64-dmg": "SeekMoon.dmg",
     browser: "SeekMoon.browser.tar.gz",
-    "windows-x64": "SeekMoon-windows-x64.zip",
+    "windows-x64": "SeekMoon-windows-x64-setup.exe",
   };
   const bytes = Buffer.from("release artifact fixture");
   const sha256 = createHash("sha256").update(bytes).digest("hex");
@@ -143,4 +143,93 @@ test("missing artifacts have a useful message and retain the filesystem cause", 
     assert.equal(actual.cause, error);
     return true;
   });
+});
+
+for (const scenario of [
+  { name: "publish installs the NSIS artifact in the Windows manifest", fromCheckout: true, windowsFile: "SeekMoon-windows-x64-setup.exe" },
+  { name: "rollback prefers NSIS when both Windows formats exist", fromCheckout: false, windowsFile: "SeekMoon-windows-x64-setup.exe" },
+  { name: "rollback preserves a legacy Windows ZIP", fromCheckout: false, windowsFile: "SeekMoon-windows-x64.zip" },
+  { name: "rollback supports releases predating Windows", fromCheckout: false, windowsFile: null },
+]) {
+  test(scenario.name, async t => {
+    const release = new Release();
+    const sha256 = "a".repeat(64);
+    t.mock.method(release, "moduleVersion", async () => "0.1.9");
+    const local = t.mock.method(release, "localArtifact", async () => ({ size: 123, sha256 }));
+    const head = t.mock.method(release, "headObject", (_version, artifact) => {
+      if (artifact.platform === "windows-x64" && (scenario.windowsFile === null ||
+        (scenario.windowsFile.endsWith(".zip") && artifact.file.endsWith(".exe")))) {
+        return { missing: true };
+      }
+      return { size: "123", sha256, crc64: "1" };
+    });
+    let published;
+    t.mock.method(release, "fetchJson", async (path, options) => {
+      if (path === "/desktop/releases/v0.1.9/publish") {
+        assert.equal(options.method, "POST");
+        const { platforms } = JSON.parse(options.body);
+        published = { version: "0.1.9", platforms: Object.fromEntries(
+          Object.entries(platforms).map(([platform, { file, sha256 }]) =>
+            [platform, { url: `https://downloads.example.com/v0.1.9/${file}`, sha256 }])) };
+        return { published };
+      }
+      assert.equal(path, "/desktop/releases/latest.json");
+      return published;
+    });
+    await release.publish("v0.1.9", { fromCheckout: scenario.fromCheckout });
+    if (scenario.windowsFile === null) {
+      assert.equal(Object.hasOwn(published.platforms, "windows-x64"), false);
+    } else {
+      assert.deepEqual(published.platforms["windows-x64"], {
+        url: `https://downloads.example.com/v0.1.9/${scenario.windowsFile}`, sha256,
+      });
+    }
+    assert.equal(Object.keys(published.platforms).length, scenario.windowsFile === null ? 3 : 4);
+    if (scenario.fromCheckout) {
+      assert.equal(local.mock.calls.at(-1).arguments[0].file, "SeekMoon-windows-x64-setup.exe");
+    } else {
+      assert.equal(local.mock.callCount(), 0);
+    }
+    if (scenario.windowsFile?.endsWith(".exe")) {
+      assert.equal(head.mock.calls.some(call => call.arguments[1].file === "SeekMoon-windows-x64.zip"), false);
+    }
+  });
+}
+
+test("rollback does not hide OSS failures by falling back to ZIP", async t => {
+  const release = new Release();
+  const error = new Error("OSS access denied");
+  const head = t.mock.method(release, "headObject", (_version, artifact) => {
+    if (artifact.platform === "windows-x64") throw error;
+    return { size: "123", sha256: "a".repeat(64), crc64: "1" };
+  });
+  const request = t.mock.method(release, "fetchJson", async () => assert.fail("must not publish"));
+  await assert.rejects(release.publish("v0.1.9", { fromCheckout: false }), actual => actual === error);
+  assert.equal(request.mock.callCount(), 0);
+  assert.equal(head.mock.calls.some(call => call.arguments[1].file === "SeekMoon-windows-x64.zip"), false);
+});
+
+test("upload sends the Windows installer to OSS as an executable download", async t => {
+  const release = new Release();
+  release.dist = await fs.mkdtemp(join(tmpdir(), "openseek-release-upload-"));
+  t.after(() => fs.rm(release.dist, { recursive: true, force: true }));
+  const bytes = Buffer.from("release artifact fixture");
+  const sha256 = createHash("sha256").update(bytes).digest("hex");
+  for (const file of ["SeekMoon.app.zip", "SeekMoon.dmg", "SeekMoon.browser.tar.gz", "SeekMoon-windows-x64-setup.exe"]) {
+    await fs.writeFile(join(release.dist, file), bytes);
+  }
+  t.mock.method(release, "moduleVersion", async () => "0.1.9");
+  t.mock.method(release, "oss", () => ({ bucket: "test", region: "test", prefix: "releases" }));
+  t.mock.method(release, "fetch", async () => new Response(null, { status: 404 }));
+  t.mock.method(release, "verifyServed", async () => ({ sha256 }));
+  t.mock.method(release, "fetchJson", async () => ({ sha256 }));
+  t.mock.method(release, "unpackBrowser", async () => {});
+  const commands = t.mock.method(release, "commandRun", () => {});
+  await release.upload("v0.1.9");
+  assert.equal(commands.mock.callCount(), 4);
+  const [program, args] = commands.mock.calls.at(-1).arguments;
+  assert.equal(program, "ossutil");
+  assert.equal(args[args.indexOf("--content-type") + 1], "application/octet-stream");
+  assert.equal(args.at(-2), join(release.dist, "SeekMoon-windows-x64-setup.exe"));
+  assert.equal(args.at(-1), "oss://test/releases/v0.1.9/SeekMoon-windows-x64-setup.exe");
 });


### PR DESCRIPTION
Windows releases currently publish a portable ZIP. Build and publish the NSIS installer as `SeekMoon-windows-x64-setup.exe`, and point the `windows-x64` release manifest entry to that executable with its SHA-256 digest.

Only the release workflow installs NSIS 3.12.0 and adds `makensis` to PATH. Ordinary Windows CI builds and uploads the unpacked app, including when the release workflow changes. Both jobs retain `CL=/bigobj`. The release job retains the unpacked app for version verification before handing the installer to the publish job.

Rollback prefers an existing installer, preserves ZIP downloads for older Windows releases, and still supports releases predating Windows. Only a missing OSS object permits the legacy fallback; other failures stop publication.

Validation:
- Built the complete Windows release installer locally with Node 22.23.2, MoonBit v0.10.12+1634b282e, MSVC 14.44, and NSIS 3.12.
- Checked the packaged app and installer versions (0.1.94) and verified the installer contents with `7z t`.
- All 16 release-script tests passed, including installer upload/publish and rollback compatibility.
- Both workflows passed actionlint.
- `just desktop-build-scripts-check`, `moon info`, `moon fmt`, and `git diff --check` passed. No generated interface changes; `moon info` reports five existing unused-field/value warnings.
