### PR TITLE
refactor: drop redundant `.iter()` before collection predicates

### DIFF
--- a/agent_subtask/provision.mbt
+++ b/agent_subtask/provision.mbt
@@ -221,7 +221,7 @@ async fn rollback_provision(geometry : Geometry, entry : SubtaskEntry) -> Unit {
 fn is_valid_name(name : String) -> Bool {
   name.length() <= 40 &&
   name is ['a'..='z' | '0'..='9', .. rest] &&
-  rest.iter().all(ch => ch is ('a'..='z' | '0'..='9' | '-'))
+  rest.all(ch => ch is ('a'..='z' | '0'..='9' | '-'))
 }
 
 ///|

--- a/agent_tool/plan/plan.mbt
+++ b/agent_tool/plan/plan.mbt
@@ -156,9 +156,9 @@ fn render(input : @steps.PlanInput) -> @agent_tool.ToolAction {
     .iter()
     .find_first(step => step.status is InProgress)
     .map(step => step.title)
-  let has_verification = input.steps
-    .iter()
-    .any(step => is_verification_title(step.title))
+  let has_verification = input.steps.any(step => {
+    is_verification_title(step.title)
+  })
   let mut content = match in_progress {
     Some(title) =>
       "Plan updated: \{completed}/\{total} done · in progress: \{title}."

--- a/agent_tool/read/html/read_output.mbt
+++ b/agent_tool/read/html/read_output.mbt
@@ -100,10 +100,10 @@ fn is_moonbit_source(path : StringView) -> Bool {
 fn numbered_line(line : String) -> (String, String)? {
   guard line.split_once("|") is Some((left, source)) else { return None }
   let number = left.trim()
-  if number.is_empty() || !number.iter().all(char => char.is_ascii_digit()) {
+  if number.is_empty() || !number.all(char => char.is_ascii_digit()) {
     return None
   }
-  if !left.iter().all(char => char == ' ' || char.is_ascii_digit()) {
+  if !left.all(char => char == ' ' || char.is_ascii_digit()) {
     return None
   }
   Some((number.to_owned(), source.to_owned()))

--- a/agent_tool/web_search/web_search.mbt
+++ b/agent_tool/web_search/web_search.mbt
@@ -335,7 +335,7 @@ fn parse_search_response(
         url != "" else {
         continue
       }
-      if sources.iter().any(source => source.url == url) {
+      if sources.any(source => source.url == url) {
         continue
       }
       if sources.length() >= max_results {

--- a/cmd/openseek/concurrent.mbt
+++ b/cmd/openseek/concurrent.mbt
@@ -385,9 +385,9 @@ async fn print_fleet_summary(
   session_root_value : String,
 ) -> Unit {
   let total = outcomes.length()
-  let finished = outcomes
-    .iter()
-    .count_if(outcome => outcome is Some(result) && result.ok)
+  let finished = outcomes.count_if(outcome => {
+    outcome is Some(result) && result.ok
+  })
   // Each row writes its own leading newline, so a fleet with no rows leaves
   // the scaffold untouched.
   fn rows(out : StringBuilder) {

--- a/cmd/openseek/subrun.mbt
+++ b/cmd/openseek/subrun.mbt
@@ -167,7 +167,7 @@ fn child_session_ordinal(id : String, parent : String) -> Int? {
   guard id.strip_prefix("\{parent}-sr-") is Some(digits) else { return None }
   guard !digits.is_empty() &&
     digits.length() <= 9 &&
-    digits.iter().all(c => c.is_ascii_digit()) else {
+    digits.all(c => c.is_ascii_digit()) else {
     return None
   }
   let value = for c in digits; value = 0 {

--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -995,7 +995,7 @@ fn session_url(id : String) -> String {
 /// server resolves as a legacy key but a standalone export's embedded data
 /// map does not.
 fn resolve_session_key(sessions : Array[SessionRow], value : String) -> String? {
-  if sessions.iter().any(row => row.key == value) {
+  if sessions.any(row => row.key == value) {
     return Some(value)
   }
   sessions.iter().find_first(row => row.id == value).map(row => row.key)

--- a/desktop/frontend/codex/model.mbt
+++ b/desktop/frontend/codex/model.mbt
@@ -753,7 +753,7 @@ fn State::with_selected_effort(self : State, effort : String) -> State {
     return { ..self, selected_effort: effort, }
   }
   guard self.selected_model_option() is Some(model) &&
-    model.reasoning_efforts.iter().any(option => option.value == effort) else {
+    model.reasoning_efforts.any(option => option.value == effort) else {
     return self
   }
   { ..self, selected_effort: effort, }
@@ -770,11 +770,11 @@ fn CodexModelOption::reasoning_effort(
   preferred : String,
 ) -> String {
   let preferred = preferred.trim().to_owned()
-  if self.reasoning_efforts.iter().any(option => option.value == preferred) {
+  if self.reasoning_efforts.any(option => option.value == preferred) {
     return preferred
   }
   if self.default_reasoning_effort is Some(default_) &&
-    self.reasoning_efforts.iter().any(option => option.value == default_) {
+    self.reasoning_efforts.any(option => option.value == default_) {
     return default_
   }
   self.reasoning_efforts.get(0).map(option => option.value).unwrap_or("")
@@ -1315,7 +1315,7 @@ fn CodexThread::decode(value : Json) -> CodexThread? {
   }
   let runtime = match CodexThreadRuntime::decode(fields.get("status")) {
     Some(runtime) => Some(runtime)
-    None if turns.iter().any(turn => turn.is_running()) => Some(ThreadActive)
+    None if turns.any(turn => turn.is_running()) => Some(ThreadActive)
     None => None
   }
   Some({
@@ -1496,7 +1496,7 @@ fn State::with_models(self : State, value : Json) -> State {
     })
   }
   let selected_model = if self.selected_model.is_empty() ||
-    !models.iter().any(model => model.id == self.selected_model) {
+    !models.any(model => model.id == self.selected_model) {
     if !default_model.is_empty() {
       default_model
     } else {
@@ -1536,14 +1536,14 @@ fn State::with_threads(
     let next = {
       ..self,
       threads: self.threads.filter(live => {
-        !threads.iter().any(archived => archived.id == live.id)
+        !threads.any(archived => archived.id == live.id)
       }),
       archived_threads: threads,
       activity,
       notice: "",
     }
     if next.active_thread() is Some(active) &&
-      next.archived_threads.iter().any(thread => thread.id == active.id) {
+      next.archived_threads.any(thread => thread.id == active.id) {
       return next.without_thread(active.id)
     }
     return next
@@ -1553,8 +1553,8 @@ fn State::with_threads(
   // newer and authoritative, so do not let an older list snapshot erase the
   // active row from the navigation rail.
   let visible = if self.active_thread() is Some(active) &&
-    !threads.iter().any(thread => thread.id == active.id) &&
-    !self.archived_threads.iter().any(thread => thread.id == active.id) {
+    !threads.any(thread => thread.id == active.id) &&
+    !self.archived_threads.any(thread => thread.id == active.id) {
     // The list snapshot has no stamp for this thread; carry the one its
     // previous row held (the `thread/start` reply's), so the fresh thread
     // does not sink below stamped history until the next refresh.
@@ -1947,7 +1947,7 @@ fn State::with_login(self : State, value : Json) -> State {
 ///|
 fn State::is_running(self : State) -> Bool {
   guard self.active_thread() is Some(active) else { return false }
-  active.turns.iter().any(turn => turn.is_running())
+  active.turns.any(turn => turn.is_running())
 }
 
 ///|
@@ -2075,7 +2075,7 @@ fn CodexTurn::merged_onto(self : CodexTurn, existing : CodexTurn) -> CodexTurn {
     .unwrap_or(item)
   })
   for incoming in self.items {
-    if !existing.items.iter().any(item => item.id == incoming.id) {
+    if !existing.items.any(item => item.id == incoming.id) {
       items.push(incoming)
     }
   }
@@ -2274,9 +2274,7 @@ fn State::with_pending_request(
     return { ..self, request_generation: generation, }
   }
   let key = request_id.stringify()
-  if self.pending_requests
-    .iter()
-    .any(request => request.request_id.stringify() == key) {
+  if self.pending_requests.any(request => request.request_id.stringify() == key) {
     return { ..self, request_generation: generation, }
   }
   let pending_requests = self.pending_requests.copy()

--- a/desktop/frontend/codex/steer_receipt.mbt
+++ b/desktop/frontend/codex/steer_receipt.mbt
@@ -28,7 +28,7 @@ fn CodexThread::has_item_id(
 ) -> Bool {
   for turn in self.turns {
     if turn.id == turn_id {
-      return turn.items.iter().any(item => item.id == item_id)
+      return turn.items.any(item => item.id == item_id)
     }
   }
   false

--- a/desktop/frontend/codex/update.mbt
+++ b/desktop/frontend/codex/update.mbt
@@ -569,7 +569,7 @@ fn State::with_turn_start_reply(self : State, value : Json) -> State {
     { ..self, draft: "", }
   }
   let next = match next.active_thread() {
-    Some(active) if active.turns.iter().any(turn => turn.is_running()) =>
+    Some(active) if active.turns.any(turn => turn.is_running()) =>
       { ..next, activity: next.activity.started(active.id), }
     _ => next
   }
@@ -1133,8 +1133,8 @@ test "Codex steer receipts reconcile duplicate text by item id and FIFO" {
   assert_true(observed_second.pending_steers.is_empty())
   let items = observed_second.transcript_items()
   assert_eq(items.length(), 3)
-  assert_true(items.iter().all(item => item.kind is @transcript.User(_)))
-  assert_true(items.iter().all(item => item.text() == Some("same text")))
+  assert_true(items.all(item => item.kind is @transcript.User(_)))
+  assert_true(items.all(item => item.text() == Some("same text")))
 }
 
 ///|

--- a/desktop/frontend/composer/state.mbt
+++ b/desktop/frontend/composer/state.mbt
@@ -150,9 +150,9 @@ fn Draft::reconciled(self : Draft, source~ : Draft, incoming~ : Draft) -> Draft 
   } else {
     let mut merged = { ..self, task, }
     for mention in incoming.mentions {
-      let externally_added = source.mentions
-        .iter()
-        .all(existing => existing.ref_ != mention.ref_)
+      let externally_added = source.mentions.all(existing => {
+        existing.ref_ != mention.ref_
+      })
       if externally_added {
         merged = merged.with_mention(mention)
       }

--- a/desktop/frontend/composer_input.mbt
+++ b/desktop/frontend/composer_input.mbt
@@ -116,14 +116,12 @@ fn Model::composer_input(self : Model) -> @composer.Input {
   let queued_items : Array[@composer.QueuedInput] = []
   let interactive = conv.run is Open(stage~, ..) && !(stage is Cancelling)
   for item in conv.queued_inputs {
-    if steering.iter().any(input => input.submission_id == item.id) {
+    if steering.any(input => input.submission_id == item.id) {
       continue
     }
-    let queueing = conv.pending_steers
-      .iter()
-      .any(input => {
-        input.behavior is FollowupQueue && input.submission_id == item.id
-      })
+    let queueing = conv.pending_steers.any(input => {
+      input.behavior is FollowupQueue && input.submission_id == item.id
+    })
     queued_items.push({
       id: item.id,
       content: user_display_text(item.content),

--- a/desktop/frontend/goal.mbt
+++ b/desktop/frontend/goal.mbt
@@ -701,9 +701,7 @@ test "a kept goal draft is a conversation you can get back to" {
       listed=_ => false,
       archived=_ => false,
     )
-    assert_true(
-      rows.iter().any(row => row.1.id().conversation() == "desktop-fresh"),
-    )
+    assert_true(rows.any(row => row.1.id().conversation() == "desktop-fresh"))
   }
 }
 

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -3221,7 +3221,7 @@ fn Model::can_reload_transcript(self : Model, conv : Conversation) -> Bool {
     return true
   }
   match self.device_state(conv.device) {
-    Some(dev) => dev.sessions.iter().any(item => item.id == conv.session_id)
+    Some(dev) => dev.sessions.any(item => item.id == conv.session_id)
     None => false
   }
 }
@@ -3365,9 +3365,9 @@ fn Model::conversation_is_new_chat(self : Model, conv : Conversation) -> Bool {
     return false
   }
   guard self.device_state(conv.device) is Some(dev) else { return true }
-  !dev.sessions
-  .iter()
-  .any(item => item.id == conv.session_id && item.workspace == conv.project())
+  !dev.sessions.any(item => {
+    item.id == conv.session_id && item.workspace == conv.project()
+  })
 }
 
 ///|
@@ -4152,7 +4152,7 @@ fn Conversation::has_seen_durable_sequence(
   }
   match self.sync {
     Reloading(buffered~, ..) | ReloadFailed(buffered~, ..) =>
-      buffered.iter().any(commit => commit.sequence == sequence)
+      buffered.any(commit => commit.sequence == sequence)
     Synced => false
   }
 }

--- a/desktop/frontend/self_update.mbt
+++ b/desktop/frontend/self_update.mbt
@@ -199,7 +199,7 @@ fn download_update(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
 ///|
 /// Whether restarting now would cut a conversation off mid-run.
 fn Model::any_conversation_busy(self : Model) -> Bool {
-  self.conversations
-  .iter()
-  .any(conv => conv.is_running() || !(conv.compaction is NotCompacting))
+  self.conversations.any(conv => {
+    conv.is_running() || !(conv.compaction is NotCompacting)
+  })
 }

--- a/desktop/frontend/terminal/update.mbt
+++ b/desktop/frontend/terminal/update.mbt
@@ -285,9 +285,7 @@ fn update(
           (@cmd.batch(cmds), state)
         }
         None =>
-          if state.tabs
-            .iter()
-            .any(tab => {
+          if state.tabs.any(tab => {
               tab.workspace.channel() == channel && tab.status is TabOpening
             }) {
             let owner = (channel, id)

--- a/desktop/frontend/transcript/sessions.mbt
+++ b/desktop/frontend/transcript/sessions.mbt
@@ -200,7 +200,7 @@ pub fn subrun_child_sessions(
     let digits = token.view(start_offset=3)
     guard !digits.is_empty() &&
       digits.length() <= 9 &&
-      digits.iter().all(c => c.is_ascii_digit()) else {
+      digits.all(c => c.is_ascii_digit()) else {
       continue
     }
     let child = "\{parent}-\{token}"
@@ -1114,9 +1114,7 @@ test "transcript mapping renders goal markers as cards and reduces the standing 
   assert_true(view.goal_markers[0] == (2, GoalSet("ship the feature")))
   assert_true(view.goal_markers[1] == (4, GoalBlocked("needs a decision")))
   // The goal-family notices that are not markers stay out of it.
-  assert_true(
-    view.goal_markers.iter().all(entry => entry.0 != 1 && entry.0 != 3),
-  )
+  assert_true(view.goal_markers.all(entry => entry.0 != 1 && entry.0 != 3))
 }
 
 ///|

--- a/desktop/frontend/transcript_overview/types.mbt
+++ b/desktop/frontend/transcript_overview/types.mbt
@@ -101,7 +101,7 @@ pub fn entries(
       }
       match item.kind {
         Assistant(calls~, ..) =>
-          if calls.iter().any(call => call.outcome is Done(is_error=true, ..)) {
+          if calls.any(call => call.outcome is Done(is_error=true, ..)) {
             failed = true
           }
         Notice(is_error=true, ..) => failed = true

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -426,9 +426,7 @@ fn adopt_projects(
   })
   let loading_conversation = if model.loading_conversation is Some(owner) &&
     owner.channel == channel &&
-    !conversations
-    .iter()
-    .any(conv => {
+    !conversations.any(conv => {
       conv.device == owner.channel && conv.session_id == owner.session
     }) {
     None
@@ -2260,9 +2258,7 @@ fn update_msg(
               }
               guard conv.queued_inputs.search_by(item => item.id == id)
                 is Some(index) &&
-                !conv.pending_steers
-                .iter()
-                .any(input => input.submission_id == id) else {
+                !conv.pending_steers.any(input => input.submission_id == id) else {
                 return (@cmd.none, model)
               }
               let item = conv.queued_inputs[index]
@@ -2848,7 +2844,7 @@ fn update_msg(
         file_ctx(model).owner == owner else {
         return (@cmd.none, model)
       }
-      if model.notifications.iter().any(toast => toast.message == message) {
+      if model.notifications.any(toast => toast.message == message) {
         (@cmd.none, model)
       } else {
         model.notify_error(dispatch, message)
@@ -2876,7 +2872,7 @@ fn update_msg(
       let next = { ..model, file_panel: panel, }
       if panel.watch_error == Some(message) &&
         model.file_panel.watch_error != Some(message) &&
-        !model.notifications.iter().any(toast => toast.message == message) {
+        !model.notifications.any(toast => toast.message == message) {
         let (toast, next) = next.notify_error(dispatch, message)
         (@cmd.batch([cmd, toast]), next)
       } else {
@@ -4446,7 +4442,7 @@ fn update_msg(
       // the current archived index and use its placement rather than opening
       // a stale archived target or trusting an obsolete workspace hint.
       let key : ArchiveRecordKey = { session, workspace, }
-      guard dev.archived.iter().any(item => key.matches(item)) &&
+      guard dev.archived.any(item => key.matches(item)) &&
         !(dev.archive_override(key) is Some(ArchiveLive)) else {
         return (@cmd.none, model)
       }
@@ -6016,7 +6012,7 @@ fn update_device_msg(
       })
       for fact in dev.archive_overrides {
         if fact.disposition is ArchiveLive &&
-          !items.iter().any(item => fact.key.matches(item)) {
+          !items.any(item => fact.key.matches(item)) {
           for current in dev.sessions {
             if fact.key.matches(current) {
               items.push(current)
@@ -6074,7 +6070,7 @@ fn update_device_msg(
         }
         if conv.device == channel &&
           conv.is_archived_read_only() &&
-          items.iter().any(item => key.matches(item)) {
+          items.any(item => key.matches(item)) {
           let foreground = channel == next.focused &&
             next.active_session == conv.session_id
           next = next.with_archive_override(channel, key, ArchiveLive)
@@ -6113,7 +6109,7 @@ fn update_device_msg(
         if conv.device == channel &&
           conv.awaits_durable_proof() &&
           !(conv.sync is Reloading(..)) &&
-          items.iter().any(item => item.id == conv.session_id) {
+          items.any(item => item.id == conv.session_id) {
           let (updated, generation) = next.begin_transcript_reload(conv)
           next = updated
           if generation is Some(generation) {
@@ -6415,7 +6411,7 @@ fn update_device_msg(
         Some(confirm) if confirm.channel == channel &&
           next.find_conversation(channel, confirm.session) is Some(conv) &&
           conv.project() == workspace &&
-          !rows.iter().any(row => row.session == Some(confirm.session)) => None
+          !rows.any(row => row.session == Some(confirm.session)) => None
         other => other
       }
       let next = { ..next, conversations, archive_confirm, }
@@ -6472,7 +6468,7 @@ fn update_device_msg(
       })
       for fact in dev.archive_overrides {
         if fact.disposition is ArchiveStored &&
-          !items.iter().any(item => fact.key.matches(item)) {
+          !items.any(item => fact.key.matches(item)) {
           for current in dev.archived {
             if fact.key.matches(current) {
               items.push(current)
@@ -6494,7 +6490,7 @@ fn update_device_msg(
         }
       }
       let archived_now = (id : String, workspace : @common.Uri) => {
-        items.iter().any(item => item.id == id && item.workspace == workspace)
+        items.any(item => item.id == id && item.workspace == workspace)
       }
       // The selected row may still be loading while another conversation is
       // active. Its exact store-qualified identity, not `active_session`, owns
@@ -6683,7 +6679,7 @@ fn update_device_msg(
         let archived = dev.archived.filter(item => !key.matches(item))
         let sessions = dev.sessions.copy()
         if restored is Some(item) &&
-          !sessions.iter().any(current => key.matches(current)) {
+          !sessions.any(current => key.matches(current)) {
           sessions.push(item)
         }
         let next = model
@@ -6759,7 +6755,7 @@ fn update_device_msg(
         conv.is_archived_read_only()
       })
       let archived = dev.archived.copy()
-      if !archived.iter().any(item => key.matches(item)) {
+      if !archived.any(item => key.matches(item)) {
         let mut item : @transcript.SessionListItem = {
           id: key.session,
           title: None,
@@ -6866,7 +6862,7 @@ fn update_device_msg(
       let archived = match dev.archive_override(key) {
         Some(ArchiveStored | ArchiveDeleted) => true
         Some(ArchiveLive) => false
-        None => dev.archived.iter().any(item => key.matches(item))
+        None => dev.archived.any(item => key.matches(item))
       }
       if archived {
         return (@cmd.none, model)
@@ -6884,9 +6880,9 @@ fn update_device_msg(
       // The listing is store-qualified, so ask whether THIS record is listed:
       // a same-id row from another store is a different durable record and
       // must not suppress the reload that gives this one its sidebar row.
-      let listed = dev.sessions
-        .iter()
-        .any(item => item.id == session && item.workspace == commit_project)
+      let listed = dev.sessions.any(item => {
+        item.id == session && item.workspace == commit_project
+      })
       let refresh_sessions = sequence == 1 && !listed && first_commit_unseen
       // A short foreign run can commit and finish before either the session
       // list or run resync reaches this page. Materialize hidden client state
@@ -7175,7 +7171,7 @@ fn update_device_msg(
       // ordinary Started boundary. Retire its in-memory queue row here; the
       // corresponding User commit is the first durable representation of it.
       let existing = if submission_id is Some(id) &&
-        existing.queued_inputs.iter().any(item => item.id == id) {
+        existing.queued_inputs.any(item => item.id == id) {
         let (without_queue, _) = existing.remove_queued_input(id)
         {
           ..without_queue,
@@ -7341,9 +7337,7 @@ fn update_device_msg(
       let accepted_settlements : Array[RecoveredSettlement] = []
       let settled_sessions : Array[String] = []
       for settlement in settled {
-        if !accepted_settlements
-          .iter()
-          .any(item => item.run_id == settlement.run_id) &&
+        if !accepted_settlements.any(item => item.run_id == settlement.run_id) &&
           model.matched_settlement_frontier(channel, frontier, settlement)
           is Some(_) {
           accepted_settlements.push(settlement)
@@ -7359,9 +7353,9 @@ fn update_device_msg(
       let accepted_runs : Array[RecoveredRun] = []
       let admitted_run_sessions : Array[String] = []
       for run in runs {
-        let duplicates_settlement = accepted_settlements
-          .iter()
-          .any(item => item.session == run.session && item.run_id == run.run_id)
+        let duplicates_settlement = accepted_settlements.any(item => {
+          item.session == run.session && item.run_id == run.run_id
+        })
         if !duplicates_settlement &&
           !admitted_run_sessions.contains(run.session) &&
           model.matches_run_snapshot_frontier(channel, frontier, run.session) {
@@ -7513,7 +7507,7 @@ fn update_device_msg(
         guard captured.pending_approval_id is Some(captured_id) else {
           continue
         }
-        if approvals.iter().any(item => item.approval.id == captured_id) {
+        if approvals.any(item => item.approval.id == captured_id) {
           continue
         }
         guard seeded.find_conversation(channel, captured.session) is Some(conv) else {
@@ -12467,9 +12461,9 @@ test "a failed Stop becomes retryable instead of staying Stopping" {
   )
   assert_true(next.active().run is Open(run_id="r7", stage=AtStep(None)))
   assert_true(
-    next.notifications
-    .iter()
-    .any(item => item.message.contains("cancel transport failed")),
+    next.notifications.any(item => {
+      item.message.contains("cancel transport failed")
+    }),
   )
 }
 
@@ -15470,9 +15464,7 @@ test "a new Started incarnation retires its exact deleted tombstone" {
     fail("the recreated conversation disappeared after its snapshot")
   }
   assert_true(
-    recreated.messages
-    .iter()
-    .any(message => message.text() == Some("new incarnation")),
+    recreated.messages.any(message => message.text() == Some("new incarnation")),
   )
 }
 
@@ -15670,11 +15662,9 @@ test "archive broadcast invalidates the active send target before list replies" 
   assert_true(invalidated.active().worktree_mode)
   inspect(invalidated.active().task, content="")
   assert_true(invalidated.active().mentions.is_empty())
-  assert_true(
-    invalidated.dev().archived.iter().any(item => item.id == "desktop-test"),
-  )
+  assert_true(invalidated.dev().archived.any(item => item.id == "desktop-test"))
   assert_false(
-    invalidated.dev().sessions.iter().any(item => item.id == "desktop-test"),
+    invalidated.dev().sessions.any(item => item.id == "desktop-test"),
   )
   // Even before either sidebar refresh returns, the next submit belongs to
   // the replacement conversation; no live state can target the archived id.
@@ -15793,10 +15783,8 @@ test "an archive notification wins over a stale live-list reply" {
     sessions_loaded([item], request_generation=1),
     invalidated,
   )
-  assert_false(
-    stale.dev().sessions.iter().any(current => current.id == item.id),
-  )
-  assert_true(stale.dev().archived.iter().any(current => current.id == item.id))
+  assert_false(stale.dev().sessions.any(current => current.id == item.id))
+  assert_true(stale.dev().archived.any(current => current.id == item.id))
   inspect(stale.active_session, content="desktop-safe")
 }
 
@@ -15870,10 +15858,8 @@ test "an unarchive notification wins over a stale archived-list reply" {
     archived_loaded([item], request_generation=1),
     restored,
   )
-  assert_false(
-    stale.dev().archived.iter().any(current => current.id == item.id),
-  )
-  assert_true(stale.dev().sessions.iter().any(current => current.id == item.id))
+  assert_false(stale.dev().archived.any(current => current.id == item.id))
+  assert_true(stale.dev().sessions.any(current => current.id == item.id))
 }
 
 ///|
@@ -15990,9 +15976,7 @@ test "BridgeReady replaces archive overrides with fresh-list truth" {
     ),
     stale_archived,
   )
-  assert_true(
-    reconciled.dev().sessions.iter().any(current => current.id == item.id),
-  )
+  assert_true(reconciled.dev().sessions.any(current => current.id == item.id))
   inspect(reconciled.dev().archived.length(), content="0")
   let (_, stale) = update_dev(
     dispatch,

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -374,11 +374,11 @@ fn Model::sidebar_component_sections(
   self : Model,
   dev : DeviceState,
 ) -> Array[@section.Input] {
-  let listed = (id : String) => dev.sessions.iter().any(item => item.id == id)
+  let listed = (id : String) => dev.sessions.any(item => item.id == id)
   // An archived record has moved out of the live store, so the live list
   // normally cannot contain it; the filter covers the moment between the
   // archive reply and the list refetch that follows it.
-  let archived = (id : String) => dev.archived.iter().any(item => item.id == id)
+  let archived = (id : String) => dev.archived.any(item => item.id == id)
   let channel = dev.channel.uri_authority()
   let chat_selected = self.screen is Chat && dev.channel == self.focused
   // The activation identity handed to sections and projects: which

--- a/desktop/frontend/workflow/state.mbt
+++ b/desktop/frontend/workflow/state.mbt
@@ -96,7 +96,7 @@ fn ordinal_of(id : String) -> Int? {
   // a sub-run id.
   guard !digits.is_empty() &&
     digits.length() <= 9 &&
-    digits.iter().all(c => c.is_ascii_digit()) else {
+    digits.all(c => c.is_ascii_digit()) else {
     return None
   }
   let ordinal = for c in digits; ordinal = 0 {

--- a/desktop/frontend/worktrees.mbt
+++ b/desktop/frontend/worktrees.mbt
@@ -487,7 +487,7 @@ fn Model::conversation_placement(
   match conv.workspace {
     Project(root~) => {
       guard self.device_state(conv.device) is Some(dev) &&
-        dev.worktrees.iter().any(group => group.project == root) else {
+        dev.worktrees.any(group => group.project == root) else {
         return None
       }
       Some(@interop.WorkspaceRoot(root~))
@@ -497,7 +497,7 @@ fn Model::conversation_placement(
       // exposing a live placement so no file or terminal request can combine
       // that name with the project's main checkout.
       guard self.device_state(conv.device) is Some(dev) else { return None }
-      guard dev.worktrees.iter().any(group => group.project == project) else {
+      guard dev.worktrees.any(group => group.project == project) else {
         return None
       }
       guard dev.worktree_row(project, conv.session_id) is Some(row) else {

--- a/desktop/internal/api/api.mbt
+++ b/desktop/internal/api/api.mbt
@@ -959,9 +959,7 @@ async fn ApiState::codex_worktree_project(
   // operation as well as first creation. Existing tasks can have turns and an
   // app-server cwd at the missing checkout; the registry's exact owner/project
   // pair is the authority needed to recreate that same placement.
-  if @worktree.list_codex_worktree_bindings()
-    .iter()
-    .any(binding => {
+  if @worktree.list_codex_worktree_bindings().any(binding => {
       binding.thread_id == thread_id && binding.workspace == requested
     }) {
     return requested

--- a/desktop/internal/engine/follower.mbt
+++ b/desktop/internal/engine/follower.mbt
@@ -1062,7 +1062,7 @@ async test "workspace detach drains an orphaned pending follower before commit" 
     let drained_before_commit : Ref[Bool] = Ref(false)
     let detached = detach_workspace(manager, workspace.to_string(), fn(_) {
       drained_before_commit.val = follower.retired &&
-        emitted.iter().any(event => event is SessionCommit({ sequence: 1, .. }))
+        emitted.any(event => event is SessionCommit({ sequence: 1, .. }))
     })
     assert_true(drained_before_commit.val)
     assert_true(detached is Workspaces([]))

--- a/desktop/internal/engine/ops.mbt
+++ b/desktop/internal/engine/ops.mbt
@@ -485,7 +485,7 @@ pub fn queue_run(
         return { accepted: false, }
       }
       guard !text.is_blank() else { return { accepted: false, } }
-      guard !live.queued_runs.iter().any(queued => queued.id == id) else {
+      guard !live.queued_runs.any(queued => queued.id == id) else {
         return { accepted: false, }
       }
       live.queued_runs.push({ id, run_id: mint_run_id(), content: text, })

--- a/desktop/internal/entropy/entropy_test.mbt
+++ b/desktop/internal/entropy/entropy_test.mbt
@@ -8,7 +8,7 @@ test "random_bytes returns OS entropy on native" {
 test "random_hex returns lowercase hex of the requested size" {
   guard @entropy.random_hex(16) is Some(hex) else { fail("no OS entropy") }
   assert_eq(hex.length(), 32)
-  assert_true(hex.iter().all(c => c is ('0'..='9' | 'a'..='f')))
+  assert_true(hex.all(c => c is ('0'..='9' | 'a'..='f')))
 }
 
 ///|

--- a/desktop/internal/extension/browser_views.mbt
+++ b/desktop/internal/extension/browser_views.mbt
@@ -431,18 +431,18 @@ test "native window ops are absent from the relay method catalog" {
   let catalog = @api.endpoints(state, connection)
   let window_only = window_endpoints(BrowserViews())
   assert_true(
-    window_only
-    .iter()
-    .any(endpoint => endpoint.name() == @commands.app_toggle_maximized.name()),
+    window_only.any(endpoint => {
+      endpoint.name() == @commands.app_toggle_maximized.name()
+    }),
   )
   assert_true(
-    window_only
-    .iter()
-    .any(endpoint => endpoint.name() == @commands.app_set_titlebar_theme.name()),
+    window_only.any(endpoint => {
+      endpoint.name() == @commands.app_set_titlebar_theme.name()
+    }),
   )
   for endpoint in window_only {
     let name = endpoint.name()
-    assert_false(catalog.iter().any(shared => shared.name() == name))
+    assert_false(catalog.any(shared => shared.name() == name))
   }
 }
 

--- a/desktop/internal/extension/external_link.mbt
+++ b/desktop/internal/extension/external_link.mbt
@@ -60,8 +60,8 @@ test "external link opener is absent from the relay method catalog" {
   let state = @api.ApiState(engine="unused")
   let connection = @host.HostConnection()
   assert_false(
-    @api.endpoints(state, connection)
-    .iter()
-    .any(endpoint => endpoint.name() == @commands.shell_open_external.name()),
+    @api.endpoints(state, connection).any(endpoint => {
+      endpoint.name() == @commands.shell_open_external.name()
+    }),
   )
 }

--- a/desktop/internal/host/text_search.mbt
+++ b/desktop/internal/host/text_search.mbt
@@ -613,7 +613,7 @@ fn text_search_unicode_escapes_to_pcre2(pattern : String) -> String {
     let mut converted = false
     if after_slashes + 4 < chars.length() {
       let digits = chars[after_slashes + 1:after_slashes + 5]
-      if digits.iter().all(char => char.is_ascii_hexdigit()) {
+      if digits.all(char => char.is_ascii_hexdigit()) {
         output.write_string("x{")
         for digit in digits {
           output.write_char(digit)
@@ -628,7 +628,7 @@ fn text_search_unicode_escapes_to_pcre2(pattern : String) -> String {
       chars[after_slashes + 1] == '{' &&
       chars[after_slashes + 6] == '}' {
       let digits = chars[after_slashes + 2:after_slashes + 6]
-      if digits.iter().all(char => char.is_ascii_hexdigit()) {
+      if digits.all(char => char.is_ascii_hexdigit()) {
         output.write_string("x{")
         for digit in digits {
           output.write_char(digit)

--- a/desktop/internal/skillmarket/archive.mbt
+++ b/desktop/internal/skillmarket/archive.mbt
@@ -86,7 +86,7 @@ fn safe_archive_path(path : String) -> Bool {
     if segment.is_empty() || segment == "." || segment == ".." {
       return false
     }
-    if segment.iter().any(ch => ch is ('\\' | ':' | '\u{0}')) {
+    if segment.any(ch => ch is ('\\' | ':' | '\u{0}')) {
       return false
     }
   }

--- a/desktop/internal/skillmarket/library.mbt
+++ b/desktop/internal/skillmarket/library.mbt
@@ -52,7 +52,7 @@ fn valid_slug(name : String) -> Bool {
   if name.is_empty() || name.length() > 64 {
     return false
   }
-  name.iter().all(ch => ch is ('a'..='z' | '0'..='9' | '-'))
+  name.all(ch => ch is ('a'..='z' | '0'..='9' | '-'))
 }
 
 ///|

--- a/desktop/internal/update/update.mbt
+++ b/desktop/internal/update/update.mbt
@@ -199,7 +199,7 @@ fn normalized_sha256(text : String) -> String? {
   }
   let hex = text.to_lower()
   guard hex.length() == 64 else { return None }
-  guard hex.iter().all(ch => ch is ('0'..='9' | 'a'..='f')) else { return None }
+  guard hex.all(ch => ch is ('0'..='9' | 'a'..='f')) else { return None }
   Some(hex)
 }
 

--- a/desktop/internal/workspaces/registry.mbt
+++ b/desktop/internal/workspaces/registry.mbt
@@ -220,7 +220,7 @@ pub async fn add(
   // dialog buffer once slipped through the is_dir check below — C-level
   // filesystem calls truncate at the first NUL while the MoonBit string
   // keeps the rest — and poisoned the registry, so refuse them outright.
-  guard !path.iter().any(ch => ch.is_control()) else {
+  guard !path.any(ch => ch.is_control()) else {
     raise WorkspaceError("workspace path contains control characters")
   }
   let dir = expanded_path(path)

--- a/desktop/internal/worktree/worktree.mbt
+++ b/desktop/internal/worktree/worktree.mbt
@@ -241,7 +241,7 @@ async fn read_worktrees_unlocked(
     guard fields.get("name") is Some(String(name)) && valid_worktree_name(name) else {
       continue
     }
-    if entries.iter().any(existing => existing.name == name) {
+    if entries.any(existing => existing.name == name) {
       continue
     }
     guard fields.get("branch") is Some(String(branch)) && !branch.is_empty() else {
@@ -687,7 +687,7 @@ async fn fresh_worktree_name(
 ) -> String {
   for n in 1..<=1000 {
     let name = "wt-\{n}"
-    if entries.iter().any(entry => entry.name == name) {
+    if entries.any(entry => entry.name == name) {
       continue
     }
     let occupied = @fsx.exists(worktree_dir(dir, name).to_path()) catch {
@@ -857,7 +857,7 @@ pub async fn create(
   // Refusals name the holder: the registry entry or the directory (a worker
   // slice can own `.worktrees/<name>` without any registry entry). The branch
   // is freshly salted, so nothing can hold it ahead of us.
-  if entries.iter().any(entry => entry.name == name) {
+  if entries.any(entry => entry.name == name) {
     raise WorktreeError("worktree \{name} already exists in this workspace")
   }
   let target = worktree_dir(dir, name)

--- a/editor/internal/viewer/contrib/folding/browser/folding_model.mbt
+++ b/editor/internal/viewer/contrib/folding/browser/folding_model.mbt
@@ -571,7 +571,7 @@ pub fn set_collapse_state_at_level(
   let filter = region_filter_with_level((region, level) => {
     level == fold_level &&
     region.is_collapsed() != do_collapse &&
-    !blocked_line_numbers.iter().any(line => region.contains_line(line))
+    !blocked_line_numbers.any(line => region.contains_line(line))
   })
   let to_toggle = folding_model.get_regions_inside(None, filter~)
   folding_model.toggle_collapse_state(to_toggle)

--- a/editor/server/host/native_host.mbt
+++ b/editor/server/host/native_host.mbt
@@ -643,9 +643,7 @@ fn mermaid_static_route(path : String) -> (String, String)? {
   guard path.has_prefix(prefix) && path.has_suffix(".mjs") else { return None }
   let name = path[prefix.length():]
   guard !name.is_empty() &&
-    name
-    .iter()
-    .all(char => {
+    name.all(char => {
       char.is_ascii_alphabetic() ||
       char.is_ascii_digit() ||
       char == '-' ||

--- a/editor/viewer/common/view_model/hidden_areas.mbt
+++ b/editor/viewer/common/view_model/hidden_areas.mbt
@@ -263,9 +263,7 @@ pub fn ViewModel::set_hidden_areas(
     let first_model_line_is_hidden = match
       stable_viewport.viewport_start_model_position {
       Some(position) =>
-        merged_ranges
-        .iter()
-        .any(range => {
+        merged_ranges.any(range => {
           range.start_line_number <= position.line_number &&
           position.line_number <= range.end_line_number
         })

--- a/eval/bgjobs_capability/main.mbt
+++ b/eval/bgjobs_capability/main.mbt
@@ -57,19 +57,17 @@ async fn scenario_overlap(engine : Engine) -> Unit {
   })
   // The marker inside a plain `mbtx` result means the slow program ran
   // (and blocked) in the foreground.
-  let blocked_foreground = seen
-    .iter()
-    .any(event => {
-      event
-      is {
-        "event": String("tool_result"),
-        "tool_name": String("mbtx"),
-        "content": String(content),
-        ..
-      } &&
-      content.contains("INTEG-OK-31337") &&
-      !content.contains("moved to the background")
-    })
+  let blocked_foreground = seen.any(event => {
+    event
+    is {
+      "event": String("tool_result"),
+      "tool_name": String("mbtx"),
+      "content": String(content),
+      ..
+    } &&
+    content.contains("INTEG-OK-31337") &&
+    !content.contains("moved to the background")
+  })
   // Any tool activity strictly between the job start and the marker retrieval
   // shows the wait was actually used for work.
   let retrieved_at = seen.search_by(event => {
@@ -131,13 +129,10 @@ async fn scenario_fire_and_forget(engine : Engine) -> Unit {
     event is { "event": String("agent_finished"), .. }
   })
   let wall_s = (@env.now().reinterpret_as_int64() - started_ms) / 1000
-  let backgrounded = seen
-    .iter()
-    .any(event => {
-      event
-      is { "event": String("tool_result"), "content": String(content), .. } &&
-      content.contains("moved to the background")
-    })
+  let backgrounded = seen.any(event => {
+    event is { "event": String("tool_result"), "content": String(content), .. } &&
+    content.contains("moved to the background")
+  })
   report("S2 automatically handed off the slow run", backgrounded)
   report(
     "S2 finished well before the 45s job (did not block)",

--- a/inspect/main.mbt
+++ b/inspect/main.mbt
@@ -123,7 +123,7 @@ async fn main {
       let scoped = rows.filter(row => {
         in_export_scope(row.id, config.export_session)
       })
-      guard scoped.iter().any(row => row.id == config.export_session) else {
+      guard scoped.any(row => row.id == config.export_session) else {
         fail(
           "openseek viz: no session '\{config.export_session}' in the scanned roots",
         )
@@ -1203,7 +1203,7 @@ fn in_export_scope(id : String, target : String) -> Bool {
     return true
   }
   guard id.strip_prefix("\{target}-sr-") is Some(digits) else { return false }
-  !digits.is_empty() && digits.iter().all(c => c.is_ascii_digit())
+  !digits.is_empty() && digits.all(c => c.is_ascii_digit())
 }
 
 ///|

--- a/protocol/subrun_session.mbt
+++ b/protocol/subrun_session.mbt
@@ -34,7 +34,7 @@ pub fn split_child_session_id(id : String) -> (String, Int)? {
   let digits = id[start + marker.length():]
   guard !digits.is_empty() &&
     digits.length() <= 9 &&
-    digits.iter().all(c => c.is_ascii_digit()) else {
+    digits.all(c => c.is_ascii_digit()) else {
     return None
   }
   let ordinal = for c in digits; ordinal = 0 {

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -2928,7 +2928,7 @@ fn subrun_child_id(
   guard tokens.get(1) is Some(token) else { return None }
   guard token.has_prefix("sr-") else { return None }
   let digits = token.view(start_offset=3)
-  guard !digits.is_empty() && digits.iter().all(c => c.is_ascii_digit()) else {
+  guard !digits.is_empty() && digits.all(c => c.is_ascii_digit()) else {
     return None
   }
   Some("\{parent}-\{token}")


### PR DESCRIPTION
## Summary

Drop the redundant `.iter()` hop in `x.iter().any(f)`-style calls: `Array`, `String`,
`StringView`, and the other collections here already expose the same `any`/`all`/`count_if`
predicates directly, so `x.any(f)` is equivalent and shorter.

- 42 files; ~97 call sites simplified (`any`/`all`/`count_if`, plus a `last` where valid).
- Every change is compiler-verified: sites whose receiver lacks a direct method (e.g.
  `@vector.Vector` in `viz/view.mbt`) are left as `x.iter().M(...)`.
- Chains that genuinely need `Iter` (`find_first`, `take`, `drop`, `filter`, `map`, `collect`) untouched.

## Validation

- `moon check` clean in all workspace modules (root, desktop, inspect, cmd/viz_app, editor,
  editor/server, protocol).
- `moon test`: all reported suites pass with 0 failures (root wasm/js, desktop, inspect,
  editor/server, protocol).

Generated with SeekMoon