### PR TITLE
fix(desktop): attach transcript observers after render and key the conversation column

### DIFF
--- a/desktop/e2e/tests/rabbita_dom.spec.js
+++ b/desktop/e2e/tests/rabbita_dom.spec.js
@@ -1897,6 +1897,9 @@ test('Codex creates a thread, sends its first turn, and stops it', async ({ page
     request.method === 'codex.draft.open'))
     .toMatchObject({ params: { cwd: '/workspace' } });
 
+  // The pick switches the page to Codex, whose composer is its own element;
+  // the draft-open request is sent before that render commits.
+  await expect(page.getByRole('textbox', { name: /Ask Codex/ })).toBeVisible();
   await page.locator('#task').fill('Run the Codex browser E2E turn');
   await page.getByTitle('Send', { exact: true }).click();
   await expect.poll(() => app.requests.find(request =>

--- a/desktop/frontend/transcript/component/component.mbt
+++ b/desktop/frontend/transcript/component/component.mbt
@@ -181,6 +181,9 @@ priv enum Msg {
   Pinned(Bool)
   JumpToLatest
   ContentRendered
+  // The conversation's image root changed (it resolves after the first
+  // render, or a worktree gets bound). Reads that waited for it are retried.
+  ImageRootChanged
   ImageRequested(String)
   ImageResolved(ImageOwner, String, ImageReadResult)
   Overview(@transcript_overview.Msg)
@@ -197,12 +200,26 @@ fn Model::update(
   // root can move (a worktree gets bound after the first send). Never project
   // the previous root's data URLs into a render for the new one.
   let image_owner = input.image_owner()
-  let self = if self.image_owner == image_owner {
-    self
+  let (self, retried) = if self.image_owner == image_owner {
+    (self, @cmd.none)
   } else {
-    { ..self, image_owner, images: ImageCache::empty(), }
+    let (images, retried) = self.images.rebase(image_owner, emit)
+    ({ ..self, image_owner, images, }, retried)
   }
+  let (next, command) = self.step(input, msg, emit)
+  (next, @cmd.batch([retried, command]))
+}
+
+///|
+fn Model::step(
+  self : Model,
+  input : Input,
+  msg : Msg,
+  emit : @cmd.Emit[Msg],
+) -> (Model, @cmd.Cmd) {
+  let image_owner = input.image_owner()
   match msg {
+    ImageRootChanged => (self, @cmd.none)
     Pinned(pinned) => ({ ..self, pinned, }, @cmd.none)
     JumpToLatest =>
       (
@@ -323,16 +340,39 @@ pub fn component(
     },
     by=block => block.branch_key(),
   )
-  state.view3(input, rendered, (state, input, rendered) => {
+  // The image root is a branch keyed by its value: a change delivers one
+  // message, which is what lets `update` retry reads that waited for it. The
+  // branch renders nothing; it lives in the view only so the graph keeps it
+  // alive.
+  let image_root = input
+    .map(input => input.root)
+    .switch_by(_ => message_on_create(emit(ImageRootChanged)), by=root => {
+      root.map(uri => uri.to_string()).unwrap_or("")
+    })
+  state.view4(input, rendered, image_root, (state, input, rendered, image_root) => {
     transcript_view(
       input,
       pinned=state.pinned,
       overview=state.overview,
       overview_emit=emit.map(msg => Overview(msg)),
       stream=keyed_stream(rendered),
+      image_root~,
       on_jump_latest=emit(JumpToLatest),
     )
   })
+}
+
+///|
+/// A branch body that sends one command when it is created and renders
+/// nothing. Under `switch_by` this turns a change of the branch key — an
+/// input transition the component cannot otherwise observe — into a message.
+fn message_on_create(command : @cmd.Cmd) -> @rabbita.Val[@html.Html] {
+  let (state, _) = @rabbita.create_state_with_init(init=_ => ((), command), update=(
+    state : Unit,
+    _ : Unit,
+    _,
+  ) => (state, @cmd.none))
+  state.map(_ => @html.nothing)
 }
 
 ///|
@@ -642,6 +682,7 @@ fn transcript_sub_loader(
         () => scheduler.add(emit(ContentRendered)),
         path => scheduler.add(emit(ImageRequested(path))),
       )
+      scheduler.add(observers.attach_after_render())
       Some({
         unload: scheduler => {
           target.remove_event_listener_with_options(
@@ -692,6 +733,7 @@ priv struct TranscriptObservers {
   content : @dom.MutationObserver
   resize : @dom.ResizeObserver
   mount : TranscriptDomMount
+  attach : () -> Unit
 }
 
 ///|
@@ -835,9 +877,15 @@ fn TranscriptObservers::install(
   if @dom.document().get_document_element() is Some(root) {
     document.observe(root.as_node(), child_list=true, subtree=true)
   }
-  // The component may already be mounted when its subscription starts.
-  attach()
-  { document, content, resize, mount, }
+  { document, content, resize, mount, attach, }
+}
+
+///|
+/// Look for the scroller once Rabbita has committed this component's DOM.
+/// The subscription starts during the graph read that creates the component,
+/// while the previous conversation's scroller may still be on screen.
+fn TranscriptObservers::attach_after_render(self : Self) -> @cmd.Cmd {
+  @cmd.custom_cmd(_ => (self.attach)(), kind=@cmd.after_render)
 }
 
 ///|

--- a/desktop/frontend/transcript/component/images.mbt
+++ b/desktop/frontend/transcript/component/images.mbt
@@ -39,6 +39,9 @@ extern "js" fn TranscriptImageObserver::disconnect(self : Self) -> Unit =
 
 ///|
 priv enum LocalImageState {
+  // A root-relative path seen before the conversation's root resolved. It is
+  // requested as soon as an owner with a root arrives (`rebase`).
+  ImageAwaitingRoot
   ImageLoading
   ImageReady(String)
   ImageUnavailable
@@ -74,23 +77,44 @@ fn ImageCache::empty() -> ImageCache {
 
 ///|
 /// Start at most one in-flight read for a path in this conversation. A
-/// root-relative path waits without entering the cache while the root is
-/// unresolved, so a later root update can rescan and request it.
+/// root-relative path waits in the cache while the root is unresolved;
+/// `rebase` requests it once an owner with a root arrives.
 fn ImageCache::begin_read(
   self : ImageCache,
   owner : ImageOwner,
   path : String,
   emit : @cmd.Emit[Msg],
 ) -> (ImageCache, @cmd.Cmd) {
-  guard owner.read_target(path) is Some(target) else {
-    return (self, @cmd.none)
-  }
   if self.0.get(path) is Some(ImageLoading) {
     return (self, @cmd.none)
   }
   let entries = self.0.copy()
+  guard owner.read_target(path) is Some(target) else {
+    entries[path] = ImageAwaitingRoot
+    return (ImageCache(entries), @cmd.none)
+  }
   entries[path] = ImageLoading
   (ImageCache(entries), owner.read_image(target, path, emit))
+}
+
+///|
+/// Move to a new owner: results and in-flight reads belonged to the previous
+/// root and are dropped, while paths that were waiting for a root are read
+/// now.
+fn ImageCache::rebase(
+  self : ImageCache,
+  owner : ImageOwner,
+  emit : @cmd.Emit[Msg],
+) -> (ImageCache, @cmd.Cmd) {
+  let mut images = ImageCache::empty()
+  let commands : Array[@cmd.Cmd] = []
+  for path, state in self.0 {
+    guard state is ImageAwaitingRoot else { continue }
+    let (next, command) = images.begin_read(owner, path, emit)
+    images = next
+    commands.push(command)
+  }
+  (images, @cmd.batch(commands))
 }
 
 ///|
@@ -105,7 +129,7 @@ fn ImageCache::apply_after_render(self : ImageCache) -> @cmd.Cmd {
         match state {
           ImageReady(source) => settle_transcript_image(path, source)
           ImageUnavailable => settle_transcript_image(path, "")
-          ImageLoading => ()
+          ImageLoading | ImageAwaitingRoot => ()
         }
       }
     },

--- a/desktop/frontend/transcript/component/rendering.mbt
+++ b/desktop/frontend/transcript/component/rendering.mbt
@@ -598,6 +598,7 @@ fn section_children(
   pinned~ : Bool,
   overview~ : @transcript_overview.State,
   overview_emit~ : @cmd.Emit[@transcript_overview.Msg],
+  image_root~ : @html.Html,
   on_jump_latest~ : @cmd.Cmd,
 ) -> Map[String, @html.Html] {
   let visible_items = input.items.map(row => row.item)
@@ -623,6 +624,9 @@ fn section_children(
     TranscriptSectionKey::stream(input).wire(),
     @html.div(id="stream", class="stream", stream),
   )
+  // Empty Html from the image root branch (see `component`): present so the
+  // branch is part of the rendered graph, never anything visible.
+  children.set("image-root", image_root)
   // Reading history unpins auto-follow (see `watch_transcript_scroll`); the
   // floating button is the way back to the live tail. Sticky inside the
   // scroller with zero height, so it never adds scroll length.

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -718,6 +718,7 @@ fn transcript_view(
   overview~ : @transcript_overview.State,
   overview_emit~ : @cmd.Emit[@transcript_overview.Msg],
   stream~ : Map[String, @html.Html],
+  image_root~ : @html.Html,
   on_jump_latest~ : @cmd.Cmd,
 ) -> @html.Html {
   let children = section_children(
@@ -726,6 +727,7 @@ fn transcript_view(
     pinned~,
     overview~,
     overview_emit~,
+    image_root~,
     on_jump_latest~,
   )
   // Nothing in the app reads the session back from the DOM: the component is

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -1706,45 +1706,55 @@ fn view(
     window_titlebar_page,
     model.is_desktop,
   )
-  let content = match model.screen {
+  // The column is keyed so its DOM identity follows what it shows: a new
+  // conversation gets a new transcript element rather than the previous
+  // one patched in place, which is what lets the transcript component's
+  // observers trust the element they attached to.
+  let content : Map[String, @html.Html] = Map([])
+  match model.screen {
     // `Model::chat_column` is the one fork that decides what the conversation
     // column is; the transcript component's lifetime follows the same value.
     Chat =>
       match model.chat_column() {
         LoadFailed(message~) =>
-          [conversation_load_failed_view(dispatch, message)]
-        Loading => [conversation_loading_view()]
-        Onboarding => [onboarding_view(dispatch, model)]
-        Transcript(conversation=conv, ..) =>
-          [
-            topbar_view(
-              dispatch, toggle_terminal, toggle_right_panel, model, conv,
-            ),
-            transcript_html,
-            if conv.is_archived_read_only() {
-              conv.archived_read_only_view(dispatch)
-            } else {
-              composer_html
-            },
-          ]
+          content["load-failed"] = conversation_load_failed_view(
+            dispatch, message,
+          )
+        Loading => content["loading"] = conversation_loading_view()
+        Onboarding => content["onboarding"] = onboarding_view(dispatch, model)
+        Transcript(slot~, conversation=conv) => {
+          content["topbar"] = topbar_view(
+            dispatch, toggle_terminal, toggle_right_panel, model, conv,
+          )
+          content["transcript\u{0}" + slot.key()] = transcript_html
+          content["composer"] = if conv.is_archived_read_only() {
+            conv.archived_read_only_view(dispatch)
+          } else {
+            composer_html
+          }
+        }
       }
     Codex =>
-      model.codex.page(
-        dispatch.map(msg => Codex(channel=model.focused, msg)),
-        model.focused,
-        terminal_panel_visible,
-        file_panel_visible,
-        @codex.PageActions::{
-          toggle_terminal,
-          toggle_files: toggle_right_panel,
-          workspace_label: workspace => @resource.label(workspace),
-          transcript: transcript_html,
-          composer: codex_composer_html,
-        },
-      )
-    Skills => [skills_html]
-    Settings => [settings_page(dispatch, model)]
-    WorkspaceSettings(..) => [workspace_settings_html]
+      for
+        index, html in model.codex.page(
+          dispatch.map(msg => Codex(channel=model.focused, msg)),
+          model.focused,
+          terminal_panel_visible,
+          file_panel_visible,
+          @codex.PageActions::{
+            toggle_terminal,
+            toggle_files: toggle_right_panel,
+            workspace_label: workspace => @resource.label(workspace),
+            transcript: transcript_html,
+            composer: codex_composer_html,
+          },
+        ) {
+        content["codex\{index}"] = html
+      }
+    Skills => content["skills"] = skills_html
+    Settings => content["settings"] = settings_page(dispatch, model)
+    WorkspaceSettings(..) =>
+      content["workspace-settings"] = workspace_settings_html
   }
   // The app is `sidebar | content`; `content` itself splits into the
   // conversation (left) and the editor (right) as two independent parts, so
@@ -1763,10 +1773,15 @@ fn view(
   if terminal_panel_visible {
     content_class += " terminal-open"
   }
-  let page_content = if window_titlebar_drag_strip {
-    [@html.div(class="window-titlebar-drag-strip", @html.nothing), ..content]
-  } else {
-    content
+  let page_content : Map[String, @html.Html] = Map([])
+  if window_titlebar_drag_strip {
+    page_content["window-titlebar-drag-strip"] = @html.div(
+      class="window-titlebar-drag-strip",
+      @html.nothing,
+    )
+  }
+  for key, html in content {
+    page_content[key] = html
   }
   let sidebar_toggle_label = if model.sidebar_open {
     "Hide sidebar"


### PR DESCRIPTION
## Summary

Split out of #1409 (and originally found while rebasing #1375). Two latent transcript bugs, independent of any rendering optimization:

- **Stale content observers after a conversation switch.** A new transcript component's subscription started during the graph read that created it, while the previous conversation's scroller was still on screen. Its first attach observed that scroller's `#stream`; Rabbita then patched the same `<section>` in place (same tag and position in the root's positional children) and only replaced the keyed `#stream`, so the section identity check never re-attached and content growth went unobserved. The root view now keys the conversation column (`Map[String, Html]` children), so a conversation's section is its own element, and the observers attach through an after-render command once this component's DOM is committed.
- **Image reads dropped while the root is unresolved.** With observers attaching right after render, an image placeholder enters the viewport before the conversation's checkout root resolves; `begin_read` used to drop that read, and nothing retried it unless some later content mutation happened to rescan. Such reads are now kept as `ImageAwaitingRoot`; the root is a `switch_by` branch keyed by its value, so its arrival reaches `update` as one `ImageRootChanged` message and `rebase` issues the waiting reads.

One E2E test needed a change: "Codex creates a thread, sends its first turn, and stops it" filled the composer as soon as the draft-open request was sent, before the Codex page had rendered. With positional children the OpenSeek textarea was patched into the Codex one, which hid the race; with the keyed column the fill landed in an element that was then replaced. The test now waits for the Codex composer.

## On the two Codex P1s raised against #1409

Both target the image-root change and describe behaviour that already exists on `main`:

- *Settled images keep the previous root's bytes when the root moves from one resolved path to another.* `main` never rebased the cache at all, and the settled `<img>` has already lost its `data-transcript-image` marker, so it is not re-requested there either. The transition this change handles is `None → Some` (a worktree bound after the first send); `checkout_root` offers no path from one resolved root to another.
- *A root that `path_for` rejects is classified as awaiting.* `ImageOwner` takes `channel` and `root` from the same `Input`, so a root owned by another channel cannot be produced by the app; `main` silently dropped that read as well. Not changed here.

## Verification

- `moon check --target js --deny-warn`, `moon test --target js` (3217), `moon test --target native` (3248) in `desktop/`.
- `just test-browser`: 58 passed, two consecutive full runs (on the #1409 tree that carried this commit together with the memo change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dp6jf4fKxaVzVq2heQR6dX
