### PR TITLE
refactor: compare Option contents with `is Some(..)` instead of `== Some(..)`

### DIFF
--- a/agent_session/types.mbt
+++ b/agent_session/types.mbt
@@ -232,7 +232,7 @@ pub fn AssistantMessage::reasoning_content(self : AssistantMessage) -> String? {
 /// Whether this event only restores an already durable answer after a
 /// checkpoint. It remains model-visible but is not a new provider step.
 pub fn AssistantMessage::is_replay(self : AssistantMessage) -> Bool {
-  self.is_replay == Some(true)
+  self.is_replay is Some(true)
 }
 
 ///|

--- a/agent_tool/shell/internal/command_policy/command_policy.mbt
+++ b/agent_tool/shell/internal/command_policy/command_policy.mbt
@@ -15,7 +15,7 @@ pub fn moonbit_command_policy_error_for_parse(
     } else {
       None
     }
-  } else if first_command_word(shell_words(cmd)) == Some("moon_cmd") {
+  } else if first_command_word(shell_words(cmd)) is Some("moon_cmd") {
     // Too-complex parse (globs, expansions, heredocs): keep only the narrow
     // leading-word `moon_cmd` typo fallback. `sed -i` is blocked solely on the
     // precise `Simple` path above — a rough text scan of an unparseable command

--- a/agent_tool/shell/internal/shell_parse/lexer.mbt
+++ b/agent_tool/shell/internal/shell_parse/lexer.mbt
@@ -129,11 +129,11 @@ fn lex(command : String) -> LexResult {
           '&' => {
             let attached = !word.empty
             word.flush_and_reset(tokens)
-            if peek_char(chars, index + 1) == Some('&') {
+            if peek_char(chars, index + 1) is Some('&') {
               tokens.push(Op("&&", attached))
               index += 2
-            } else if peek_char(chars, index + 1) == Some('>') {
-              if peek_char(chars, index + 2) == Some('>') {
+            } else if peek_char(chars, index + 1) is Some('>') {
+              if peek_char(chars, index + 2) is Some('>') {
                 tokens.push(Op("&>>", attached))
                 index += 3
               } else {
@@ -147,7 +147,7 @@ fn lex(command : String) -> LexResult {
           '|' => {
             let attached = !word.empty
             word.flush_and_reset(tokens)
-            if peek_char(chars, index + 1) == Some('|') {
+            if peek_char(chars, index + 1) is Some('|') {
               tokens.push(Op("||", attached))
               index += 2
             } else {
@@ -164,13 +164,13 @@ fn lex(command : String) -> LexResult {
           '>' => {
             let attached = !word.empty
             word.flush_and_reset(tokens)
-            if peek_char(chars, index + 1) == Some('&') {
+            if peek_char(chars, index + 1) is Some('&') {
               tokens.push(Op(">&", attached))
               index += 2
-            } else if peek_char(chars, index + 1) == Some('>') {
+            } else if peek_char(chars, index + 1) is Some('>') {
               tokens.push(Op(">>", attached))
               index += 2
-            } else if peek_char(chars, index + 1) == Some('|') {
+            } else if peek_char(chars, index + 1) is Some('|') {
               tokens.push(Op(">|", attached))
               index += 2
             } else {
@@ -181,12 +181,12 @@ fn lex(command : String) -> LexResult {
           '<' => {
             let attached = !word.empty
             word.flush_and_reset(tokens)
-            if peek_char(chars, index + 1) == Some('<') {
+            if peek_char(chars, index + 1) is Some('<') {
               return LexTooComplex("here documents are not supported")
-            } else if peek_char(chars, index + 1) == Some('&') {
+            } else if peek_char(chars, index + 1) is Some('&') {
               tokens.push(Op("<&", attached))
               index += 2
-            } else if peek_char(chars, index + 1) == Some('>') {
+            } else if peek_char(chars, index + 1) is Some('>') {
               tokens.push(Op("<>", attached))
               index += 2
             } else {

--- a/agent_tool/shell/internal/shell_parse/query.mbt
+++ b/agent_tool/shell/internal/shell_parse/query.mbt
@@ -27,7 +27,9 @@ pub fn SimpleCommand::command_index(self : SimpleCommand) -> Int? {
 pub fn contains_command(result : ParseResult, name : String) -> Bool {
   match result {
     Simple(commands) =>
-      commands.any(command => command.command_name() == Some(name))
+      commands.any(command => {
+        command.command_name() is Some(cmd_name) && cmd_name == name
+      })
     _ => false
   }
 }

--- a/agent_tool/shell/moon_auto_check.mbt
+++ b/agent_tool/shell/moon_auto_check.mbt
@@ -190,7 +190,7 @@ fn next_command_is_guarded_by_and(
   index : Int,
 ) -> Bool {
   index + 1 < commands.length() &&
-  commands[index + 1].separator_before == Some("&&")
+  commands[index + 1].separator_before is Some("&&")
 }
 
 ///|

--- a/agent_tool/shell/worker_sandbox.mbt
+++ b/agent_tool/shell/worker_sandbox.mbt
@@ -85,10 +85,10 @@ async fn worker_cd_escapes(
       }
       _ => ()
     }
-    let in_pipeline = command.separator_before == Some("|") ||
+    let in_pipeline = command.separator_before is Some("|") ||
       (
         position + 1 < commands.length() &&
-        commands[position + 1].separator_before == Some("|")
+        commands[position + 1].separator_before is Some("|")
       )
     // The effective command name skips wrappers (`command`, `env`), so
     // `command cd ..` is still a cwd change.
@@ -138,7 +138,7 @@ async fn worker_cd_escapes(
             // profile remains the enforcement where one exists.
             if !in_pipeline {
               let next_is_and = position + 1 < commands.length() &&
-                commands[position + 1].separator_before == Some("&&")
+                commands[position + 1].separator_before is Some("&&")
               if next_is_and && interpretations > 0 && !viable.is_empty() {
                 for old in candidates {
                   if !suspended.contains(old) {

--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -1428,7 +1428,7 @@ fn sidebar_row(
   row : SessionRow,
   child? : Bool = false,
 ) -> @html.Html {
-  let selected = model.selected == Some(row.key)
+  let selected = model.selected is Some(current) && current == row.key
   let label = if row.first_prompt.is_blank() {
     row.id
   } else {

--- a/desktop/frontend/action_menu/action_menu.mbt
+++ b/desktop/frontend/action_menu/action_menu.mbt
@@ -198,7 +198,8 @@ fn focus_element(id : String, after_render : Bool) -> @cmd.Cmd {
         "focus",
         ([] : FixedArray[@js.Value]),
       )
-      if element.get_attribute(TemporaryFocusAttribute) == Some(id) {
+      if element.get_attribute(TemporaryFocusAttribute) is Some(focus_id) &&
+        focus_id == id {
         element.remove_attribute(TemporaryFocusAttribute)
         element.remove_attribute("id")
       }
@@ -448,7 +449,8 @@ fn render_menu(
         @cmd.none
       })
       .on_keydown(event => {
-        guard focused_element_id() == Some(menu_id(open.target)) else {
+        guard focused_element_id() is Some(focused_id) &&
+          focused_id == menu_id(open.target) else {
           return @cmd.none
         }
         let destination = match event.key() {

--- a/desktop/frontend/action_menu/context_menu.mbt
+++ b/desktop/frontend/action_menu/context_menu.mbt
@@ -157,7 +157,8 @@ fn element_context(element : @dom.Element) -> ContextTarget {
 fn discard_temporary_focus(element : @dom.Element?) -> Unit {
   if element is Some(element) &&
     element.get_attribute("id") is Some(id) &&
-    element.get_attribute(TemporaryFocusAttribute) == Some(id) {
+    element.get_attribute(TemporaryFocusAttribute) is Some(attr) &&
+    attr == id {
     element.remove_attribute(TemporaryFocusAttribute)
     element.remove_attribute("id")
   }

--- a/desktop/frontend/agent_model.mbt
+++ b/desktop/frontend/agent_model.mbt
@@ -209,7 +209,7 @@ fn Model::openseek_model_chip(
     groups,
     selected: ModelChoice::OpenSeekModel(conv.engine_model).wire(),
     disabled: false,
-    open: self.select_menu is Some(menu) && menu == OpenSeekModelMenu,
+    open: self.select_menu is Some(OpenSeekModelMenu),
     title: "Model: \{conv.engine_model.label()}",
   }
 }
@@ -240,7 +240,7 @@ fn Model::openseek_reasoning_chip(
     options,
     selected: reasoning.wire(),
     disabled: false,
-    open: self.select_menu is Some(menu) && menu == OpenSeekReasoningMenu,
+    open: self.select_menu is Some(OpenSeekReasoningMenu),
     title: "Reasoning effort: \{reasoning.label_for_model(conv.engine_model)}",
   })
 }
@@ -264,7 +264,7 @@ fn Model::codex_model_chip(self : Model) -> @composer.ModelSelect {
     groups,
     selected,
     disabled: false,
-    open: self.select_menu is Some(menu) && menu == CodexModelMenu,
+    open: self.select_menu is Some(CodexModelMenu),
     title: "Codex model",
   }
 }

--- a/desktop/frontend/agent_model.mbt
+++ b/desktop/frontend/agent_model.mbt
@@ -209,7 +209,7 @@ fn Model::openseek_model_chip(
     groups,
     selected: ModelChoice::OpenSeekModel(conv.engine_model).wire(),
     disabled: false,
-    open: self.select_menu == Some(OpenSeekModelMenu),
+    open: self.select_menu is Some(menu) && menu == OpenSeekModelMenu,
     title: "Model: \{conv.engine_model.label()}",
   }
 }
@@ -240,7 +240,7 @@ fn Model::openseek_reasoning_chip(
     options,
     selected: reasoning.wire(),
     disabled: false,
-    open: self.select_menu == Some(OpenSeekReasoningMenu),
+    open: self.select_menu is Some(menu) && menu == OpenSeekReasoningMenu,
     title: "Reasoning effort: \{reasoning.label_for_model(conv.engine_model)}",
   })
 }
@@ -264,7 +264,7 @@ fn Model::codex_model_chip(self : Model) -> @composer.ModelSelect {
     groups,
     selected,
     disabled: false,
-    open: self.select_menu == Some(CodexModelMenu),
+    open: self.select_menu is Some(menu) && menu == CodexModelMenu,
     title: "Codex model",
   }
 }

--- a/desktop/frontend/codex/model.mbt
+++ b/desktop/frontend/codex/model.mbt
@@ -1007,7 +1007,9 @@ fn State::begin_foreground(self : State, kind : CodexReplyKind) -> State {
 
 ///|
 fn State::owns_foreground(self : State, kind : CodexReplyKind) -> Bool {
-  kind.foreground() is Some(foreground) && self.foreground == Some(foreground)
+  kind.foreground() is Some(foreground) &&
+  self.foreground is Some(current) &&
+  current == foreground
 }
 
 ///|
@@ -1152,7 +1154,8 @@ fn State::with_open_draft(
   guard self.active_draft() is Some(draft) &&
     draft.id == draft_id &&
     value is Object(fields) &&
-    @jsonx.json_text(fields, "draftId") == Some(draft_id) &&
+    @jsonx.json_text(fields, "draftId") is Some(reply_draft_id) &&
+    reply_draft_id == draft_id &&
     @jsonx.json_text(fields, "projectRoot") is Some(project_root) else {
     return { ..self, notice: "Malformed Codex draft workspace reply", }
   }
@@ -1295,7 +1298,8 @@ fn CodexWorktree::from_create_reply(
 ) -> CodexWorktree? {
   for info in reply.worktrees {
     if info.name == reply.name &&
-      info.codex_thread == Some(thread_id) &&
+      info.codex_thread is Some(codex_thread) &&
+      codex_thread == thread_id &&
       info.present &&
       !info.path.trim().is_empty() {
       return Some({ name: info.name, path: info.path, present: true, })
@@ -1828,7 +1832,8 @@ fn State::with_git_reply(
   guard self.active_thread() is Some(active) &&
     active.id == thread_id &&
     generation == self.git_request_generation &&
-    active.cwd == Some(requested_cwd) else {
+    active.cwd is Some(active_cwd) &&
+    active_cwd == requested_cwd else {
     return self
   }
   {
@@ -1880,7 +1885,8 @@ fn State::without_thread(self : State, thread_id : String) -> State {
     } else {
       self.selection
     },
-    requested_thread: if self.requested_thread == Some(thread_id) {
+    requested_thread: if self.requested_thread is Some(requested) &&
+      requested == thread_id {
       None
     } else {
       self.requested_thread

--- a/desktop/frontend/codex/update.mbt
+++ b/desktop/frontend/codex/update.mbt
@@ -163,7 +163,7 @@ pub fn update(
         active.id == thread_id &&
         (
           state.requested_thread is None ||
-          state.requested_thread == Some(thread_id)
+          (state.requested_thread is Some(requested) && requested == thread_id)
         ) {
         // Clicking the selected sidebar row is navigation at the root shell,
         // not a request to reacquire history. Preserve its local composer and

--- a/desktop/frontend/codex/view.mbt
+++ b/desktop/frontend/codex/view.mbt
@@ -175,7 +175,8 @@ pub fn State::project_conversations(
   guard context.project_registered(root) else { return [] }
   let project = CodexProject(root)
   [
-    for thread in self.threads if thread.project_key() == Some(project) => {
+    for thread in self.threads if thread.project_key() is Some(thread_project) &&
+    thread_project == project => {
       CodexProjectRow::{
         input: thread.sidebar_input(self, context, true),
         updated_at_ms: thread.updated_at_ms,

--- a/desktop/frontend/component_transcript.mbt
+++ b/desktop/frontend/component_transcript.mbt
@@ -54,7 +54,8 @@ priv enum ChatColumn {
 ///|
 fn Model::chat_column(self : Model) -> ChatColumn {
   if self.conversation_load_failure is Some(failure) &&
-    self.selected_conversation == Some(failure.target) {
+    self.selected_conversation is Some(selected) &&
+    selected == failure.target {
     return LoadFailed(message=failure.message)
   }
   if !self.selected_conversation_loaded() {
@@ -181,7 +182,8 @@ fn Model::transcript_input(self : Model) -> @transcript_component.Input {
             projects~,
             can_choose_project~,
             project_menu_open=can_choose_project &&
-              self.select_menu == Some(ProjectMenu),
+              self.select_menu is Some(menu) &&
+              menu == ProjectMenu,
             project_query=self.project_menu_query,
             root=self
               .conversation_placement(conversation)

--- a/desktop/frontend/component_transcript.mbt
+++ b/desktop/frontend/component_transcript.mbt
@@ -182,8 +182,7 @@ fn Model::transcript_input(self : Model) -> @transcript_component.Input {
             projects~,
             can_choose_project~,
             project_menu_open=can_choose_project &&
-              self.select_menu is Some(menu) &&
-              menu == ProjectMenu,
+              self.select_menu is Some(ProjectMenu),
             project_query=self.project_menu_query,
             root=self
               .conversation_placement(conversation)

--- a/desktop/frontend/composer/component.mbt
+++ b/desktop/frontend/composer/component.mbt
@@ -56,8 +56,10 @@ fn FileCompletion::matches(
       ..
     ) =>
       remote_owner == owner &&
-      root == Some(remote_root) &&
-      query == Some(remote_query) &&
+      root is Some(root_value) &&
+      root_value == remote_root &&
+      query is Some(query_value) &&
+      query_value == remote_query &&
       remote_epoch == epoch
     Local(..) => false
   }
@@ -500,7 +502,8 @@ fn Entry::settled_file_completion(
   remote_files : Array[@pathx.Relative]?,
 ) -> Entry? {
   guard owner == self.owner &&
-    self.root == Some(root) &&
+    self.root is Some(entry_root) &&
+    entry_root == root &&
     epoch == input.file_index.epoch() &&
     Trigger::parse(self.draft.task, inline_markers="$#@") is Some(trigger) &&
     trigger.marker() == "@" &&
@@ -742,7 +745,8 @@ fn Model::update(
       // against the reconciled entry, so a menu closed by a context switch in
       // the same pass also rejects the reply instead of reopening.
       guard owner == entry.owner &&
-        entry.root == Some(root) &&
+        entry.root is Some(entry_root) &&
+        entry_root == root &&
         Trigger::parse(entry.draft.task, inline_markers="$#") is Some(trigger) &&
         trigger.marker() == "#" &&
         trigger.query() == query &&

--- a/desktop/frontend/composer_input.mbt
+++ b/desktop/frontend/composer_input.mbt
@@ -260,7 +260,7 @@ fn Model::codex_composer_input(self : Model) -> @composer.Input {
     // action still returns through the shared composer's typed route.
     model_control: self.codex_model_chip(),
     reasoning_control: self.codex.reasoning_effort_chip(
-      self.select_menu is Some(menu) && menu == CodexReasoningMenu,
+      self.select_menu is Some(CodexReasoningMenu),
     ),
     file_candidates: search.candidates,
     open_files: if workspace_ready {

--- a/desktop/frontend/composer_input.mbt
+++ b/desktop/frontend/composer_input.mbt
@@ -129,7 +129,7 @@ fn Model::composer_input(self : Model) -> @composer.Input {
         @composer.Queueing
       } else {
         @composer.Queued(
-          editing=conv.queue_edit_id == Some(item.id),
+          editing=conv.queue_edit_id is Some(id) && id == item.id,
           interactive~,
         )
       },
@@ -260,7 +260,7 @@ fn Model::codex_composer_input(self : Model) -> @composer.Input {
     // action still returns through the shared composer's typed route.
     model_control: self.codex_model_chip(),
     reasoning_control: self.codex.reasoning_effort_chip(
-      self.select_menu == Some(CodexReasoningMenu),
+      self.select_menu is Some(menu) && menu == CodexReasoningMenu,
     ),
     file_candidates: search.candidates,
     open_files: if workspace_ready {

--- a/desktop/frontend/dock/update.mbt
+++ b/desktop/frontend/dock/update.mbt
@@ -30,7 +30,7 @@ pub fn update(msg : Msg, state : State) -> State {
       match tab_index(state, tab) {
         Some(index) => {
           let tabs = state.tabs.filter(entry => entry != tab)
-          let active = if state.active == Some(tab) {
+          let active = if state.active is Some(active_tab) && active_tab == tab {
             // The right neighbor inherits the screen; at the strip's end,
             // the left one.
             match tabs.get(index) {
@@ -124,7 +124,7 @@ pub fn resolve_pick(state : State, path : @pathx.Relative) -> State {
 /// restored documents is the content subsystems' business, driven by their
 /// own sync against the fresh projection.
 pub fn sync(state : State, owner : @interop.ConversationKey) -> State {
-  if state.owner == Some(owner) {
+  if state.owner is Some(current) && current == owner {
     return state
   }
   let remembered = state.remembered.copy()

--- a/desktop/frontend/dock/view.mbt
+++ b/desktop/frontend/dock/view.mbt
@@ -199,7 +199,7 @@ pub fn tabs_bar(
   let tabs : Array[@html.Html] = []
   for chip in chips {
     let mut classes = "editor-tab"
-    if state.active == Some(chip.tab) {
+    if state.active is Some(active) && active == chip.tab {
       classes += " active"
     }
     if chip.missing {

--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -1077,8 +1077,10 @@ fn mount_generated_svg_viewport(
 /// with the source toggle still available in the breadcrumb.
 fn show_mbti_diagram(resource : @common.Uri, source : String) -> Unit {
   let resource_key = resource.to_string()
-  if viewer_state.mbti_resource == Some(resource_key) &&
-    viewer_state.mbti_source == Some(source) {
+  if viewer_state.mbti_resource is Some(resource_shown) &&
+    resource_shown == resource_key &&
+    viewer_state.mbti_source is Some(source_shown) &&
+    source_shown == source {
     return
   }
   guard @dom.document().get_element_by_id(MbtiDiagramHostId).to_option()
@@ -1146,7 +1148,7 @@ fn show_package_graph_in_viewer(state : PackageGraphState) -> @cmd.Cmd {
       is Some(host) else {
       return
     }
-    if viewer_state.package_graph == Some(state) {
+    if viewer_state.package_graph is Some(graph_shown) && graph_shown == state {
       return
     }
     viewer_state.package_graph = Some(state)

--- a/desktop/frontend/fileeditor/git_history.mbt
+++ b/desktop/frontend/fileeditor/git_history.mbt
@@ -191,7 +191,8 @@ fn refresh_git_graph(
   state : State,
   ctx : Ctx,
 ) -> (@cmd.Cmd, State) {
-  guard state.owner == Some(ctx.owner) &&
+  guard state.owner is Some(state_owner) &&
+    state_owner == ctx.owner &&
     ctx.checkout_ready() &&
     !ctx.owner.session.is_empty() else {
     return (@cmd.none, state)
@@ -223,7 +224,8 @@ fn load_more_git_history(
   state : State,
   ctx : Ctx,
 ) -> (@cmd.Cmd, State) {
-  guard state.owner == Some(ctx.owner) &&
+  guard state.owner is Some(state_owner) &&
+    state_owner == ctx.owner &&
     ctx.checkout_ready() &&
     state.git_graph
     is GitGraphReady(
@@ -269,7 +271,7 @@ fn select_git_commit(
   ctx : Ctx,
   commit : String,
 ) -> (@cmd.Cmd, State) {
-  if state.git_graph_selected == Some(commit) {
+  if state.git_graph_selected is Some(selected) && selected == commit {
     return (
       @cmd.none,
       {
@@ -308,7 +310,8 @@ fn retry_git_commit_changes(
   ctx : Ctx,
   commit : String,
 ) -> (@cmd.Cmd, State) {
-  guard state.git_graph_selected == Some(commit) &&
+  guard state.git_graph_selected is Some(selected_commit) &&
+    selected_commit == commit &&
     state.git_graph is GitGraphReady(repository=true, commits~, ..) &&
     commits.any(item => item.id == commit) else {
     return (@cmd.none, state)

--- a/desktop/frontend/fileeditor/navigation.mbt
+++ b/desktop/frontend/fileeditor/navigation.mbt
@@ -24,7 +24,8 @@ fn NavigationContext::relative_path(
   self : NavigationContext,
   absolute : @common.Uri,
 ) -> @pathx.Relative? {
-  guard model_uri_channel(absolute) == Some(self.owner.channel) &&
+  guard model_uri_channel(absolute) is Some(channel) &&
+    channel == self.owner.channel &&
     @resource.relative_to(absolute, self.root) is Some(relative) &&
     !relative.is_root() else {
     return None
@@ -62,8 +63,8 @@ fn navigation_context_for_file(
   relative : @pathx.Relative,
 ) -> NavigationContext? {
   let root = match root_hint {
-    Some(root) if @resource.relative_to(absolute, root) == Some(relative) =>
-      Some(root)
+    Some(root) if @resource.relative_to(absolute, root) is Some(rel) &&
+      rel == relative => Some(root)
     _ => navigation_root_from_file(absolute, relative)
   }
   root.map(root => { owner, root, })
@@ -98,7 +99,8 @@ fn moon_ide_model_projection(
   guard viewer_state.navigation is Some(context) else { return None }
   match model_uri_path(model.uri) {
     Some(absolute) => {
-      guard viewer_state.absolute == Some(absolute) &&
+      guard viewer_state.absolute is Some(stored_absolute) &&
+        stored_absolute == absolute &&
         context.relative_path(absolute) is Some(path) else {
         return None
       }
@@ -106,7 +108,8 @@ fn moon_ide_model_projection(
     }
     None => {
       guard semantic_modified_model_projection(model) is Some(semantic) &&
-        context.relative_path(semantic.resource) == Some(semantic.path) else {
+        context.relative_path(semantic.resource) is Some(rel) &&
+        rel == semantic.path else {
         return None
       }
       Some({ context, path: semantic.path, line_offset: semantic.line_offset, })
@@ -318,7 +321,8 @@ async fn resolve_navigation_preview(
     return None
   }
   guard viewer_state.navigation is Some(context) else { return None }
-  guard model_uri_channel(resource) == Some(context.owner.channel) &&
+  guard model_uri_channel(resource) is Some(channel) &&
+    channel == context.owner.channel &&
     model_uri_path(resource) is Some(absolute) &&
     @resource.relative_to(absolute, context.root) is Some(relative) &&
     !relative.is_root() else {

--- a/desktop/frontend/fileeditor/semantic_review_view.mbt
+++ b/desktop/frontend/fileeditor/semantic_review_view.mbt
@@ -1038,13 +1038,15 @@ fn schedule_semantic_review_reveal_scroll(
 ) -> Unit {
   @dom.window().request_animation_frame(_ => {
     guard semantic_review_navigation_generation.val == generation &&
-      semantic_review_active_key.val == Some(key) &&
+      semantic_review_active_key.val is Some(active_key) &&
+      active_key == key &&
       @base_browser.element_is_connected(editor_host) else {
       return
     }
     @dom.window().request_animation_frame(_ => {
       guard semantic_review_navigation_generation.val == generation &&
-        semantic_review_active_key.val == Some(key) &&
+        semantic_review_active_key.val is Some(active_key) &&
+        active_key == key &&
         @base_browser.element_is_connected(editor_host) &&
         @dom.document().get_element_by_id(SemanticReviewHostId).to_option()
         is Some(scroll_host) &&

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -141,7 +141,7 @@ fn Doc::diff_pending_generation(self : Doc) -> Int? {
 ///|
 fn State::shows_delayed_diff_loading(self : State, doc : Doc) -> Bool {
   guard doc.diff_pending_generation() is Some(generation) else { return false }
-  self.diff_loading_generation == Some(generation)
+  self.diff_loading_generation is Some(loading) && loading == generation
 }
 
 ///|
@@ -434,7 +434,7 @@ pub fn open_document(
   } else {
     state
   }
-  let clear_review = if ctx.active_file == Some(path) {
+  let clear_review = if ctx.active_file is Some(active) && active == path {
     // Always clear the displayed resource, even when this path has no cached
     // `Doc`: a reviewed tab can be closed while another dock kind is active,
     // leaving its hidden Viewer model alive until the next file opens. Do not
@@ -834,7 +834,7 @@ fn reconcile_reviews_after_changes(
             ),
           )
         }
-        if ctx.active_file == Some(path) {
+        if ctx.active_file is Some(active) && active == path {
           cmds.push(
             show_tab(
               dispatch,
@@ -858,7 +858,7 @@ fn reconcile_reviews_after_changes(
           stale: false,
         }
         docs[path] = ordinary
-        if ctx.active_file == Some(path) {
+        if ctx.active_file is Some(active) && active == path {
           cmds.push(
             show_tab(
               dispatch,
@@ -958,7 +958,9 @@ fn reconcile_reviews_after_changes(
           )
         }
         if has_working_file {
-          if ctx.active_file == Some(path) && !(doc.state is TabLoading) {
+          if ctx.active_file is Some(active) &&
+            active == path &&
+            !(doc.state is TabLoading) {
             // Keep the previous working text visible while its replacement is
             // in flight, but clear the old gutter until both new sides settle.
             cmds.push(
@@ -983,7 +985,7 @@ fn reconcile_reviews_after_changes(
               root=ctx.root(),
             ),
           )
-        } else if ctx.active_file == Some(path) {
+        } else if ctx.active_file is Some(active) && active == path {
           // Clear the old gutter immediately while the new HEAD side loads;
           // deleted previews switch back to their precise loading notice.
           cmds.push(
@@ -1570,7 +1572,8 @@ fn changes_live(state : State, ctx : Ctx) -> Bool {
 /// the host that lost it.
 fn changes_poll_wanted(state : State, ctx : Ctx) -> Bool {
   ctx.checkout_ready() &&
-  state.owner == Some(ctx.owner) &&
+  state.owner is Some(state_owner) &&
+  state_owner == ctx.owner &&
   !ctx.owner.session.is_empty() &&
   changes_live(state, ctx) &&
   state.changes is ChangeListReady(repository=true, refreshing=false, ..)
@@ -1731,7 +1734,9 @@ fn refresh_changes(
   state : State,
   ctx : Ctx,
 ) -> (@cmd.Cmd, State) {
-  guard state.owner == Some(ctx.owner) && !ctx.owner.session.is_empty() else {
+  guard state.owner is Some(state_owner) &&
+    state_owner == ctx.owner &&
+    !ctx.owner.session.is_empty() else {
     return (@cmd.none, state)
   }
   match state.changes {
@@ -1870,7 +1875,8 @@ pub fn sync(
   // may happen after that owner's initial transcript click. Every later owner
   // replacement is a real navigation boundary.
   let owner_replaced = state.owner is Some(_) && owner_changed
-  let same_owner = state.owner == Some(ctx.owner)
+  let same_owner = state.owner is Some(current_owner) &&
+    current_owner == ctx.owner
   // Missing/unresolved are availability changes, not automatically a new
   // checkout. A live managed worktree and its missing form share the same
   // project/name identity so reviews and dock documents can park and recover;
@@ -2401,7 +2407,8 @@ pub fn update(
       )
     }
     PackageGraphRequestLoaded(owner~, epoch~, path~, generation~, source~) =>
-      if state.owner == Some(owner) &&
+      if state.owner is Some(state_owner) &&
+        state_owner == owner &&
         state.request_epoch == epoch &&
         state.package_graphs.get(path) is Some(PackageGraphLoading(current)) &&
         current == generation {
@@ -2412,7 +2419,8 @@ pub fn update(
         (@cmd.none, state)
       }
     PackageGraphRequestFailed(owner~, epoch~, path~, generation~, message~) =>
-      if state.owner == Some(owner) &&
+      if state.owner is Some(state_owner) &&
+        state_owner == owner &&
         state.request_epoch == epoch &&
         state.package_graphs.get(path) is Some(PackageGraphLoading(current)) &&
         current == generation {
@@ -2423,10 +2431,13 @@ pub fn update(
         (@cmd.none, state)
       }
     DiffLoadingDue(owner~, path~, generation~) =>
-      if state.owner == Some(owner) &&
-        ctx.active_file == Some(path) &&
+      if state.owner is Some(state_owner) &&
+        state_owner == owner &&
+        ctx.active_file is Some(active) &&
+        active == path &&
         state.docs.get(path) is Some(doc) &&
-        doc.diff_pending_generation() == Some(generation) {
+        doc.diff_pending_generation() is Some(pending) &&
+        pending == generation {
         (@cmd.none, { ..state, diff_loading_generation: Some(generation), })
       } else {
         (@cmd.none, state)
@@ -2636,7 +2647,7 @@ pub fn update(
     ToggleGitGraphSection =>
       (@cmd.none, { ..state, git_graph_collapsed: !state.git_graph_collapsed, })
     RevealDirectory(path) =>
-      if state.highlighted == Some(path) {
+      if state.highlighted is Some(highlighted) && highlighted == path {
         (@cmd.none, { ..state, highlighted: None, })
       } else {
         let selected = { ..state, highlighted: Some(path), }
@@ -2660,7 +2671,7 @@ pub fn update(
         }
       }
     HighlightCleared(path) =>
-      if state.highlighted == Some(path) {
+      if state.highlighted is Some(highlighted) && highlighted == path {
         (@cmd.none, { ..state, highlighted: None, })
       } else {
         (@cmd.none, state)
@@ -2728,7 +2739,8 @@ pub fn update(
       } else {
         let children = state.children.copy()
         children[path] = entries
-        let breadcrumb_cmd = if state.highlighted == Some(path) {
+        let breadcrumb_cmd = if state.highlighted is Some(highlighted) &&
+          highlighted == path {
           focus_breadcrumb_entry_after_render(0)
         } else {
           @cmd.none
@@ -2885,9 +2897,11 @@ pub fn update(
       }
     GitCommitSelected(commit) => select_git_commit(dispatch, state, ctx, commit)
     GitCommitChangesLoaded(owner~, generation~, reply~) =>
-      if state.owner == Some(owner) &&
+      if state.owner is Some(state_owner) &&
+        state_owner == owner &&
         state.git_commit_files_generation == generation &&
-        state.git_graph_selected == Some(reply.commit) &&
+        state.git_graph_selected is Some(selected_commit) &&
+        selected_commit == reply.commit &&
         state.git_commit_files is GitCommitFilesLoading(commit=loading_commit) &&
         loading_commit == reply.commit {
         let commit = reply.commit
@@ -2904,9 +2918,11 @@ pub fn update(
         (@cmd.none, state)
       }
     GitCommitChangesFailed(owner~, generation~, commit~, message~) =>
-      if state.owner == Some(owner) &&
+      if state.owner is Some(state_owner) &&
+        state_owner == owner &&
         state.git_commit_files_generation == generation &&
-        state.git_graph_selected == Some(commit) {
+        state.git_graph_selected is Some(selected) &&
+        selected == commit {
         (
           @cmd.none,
           {
@@ -3140,14 +3156,16 @@ pub fn update(
     OpenNavigationLocation(..) => (@cmd.none, state)
     GitOriginalLoaded(owner~, path~, generation~, background~, original~) => {
       let background_review_requests = if background &&
-        state.background_review_requests.get(path) == Some(generation) {
+        state.background_review_requests.get(path) is Some(requested) &&
+        requested == generation {
         let requests = state.background_review_requests.copy()
         requests.remove(path)
         requests
       } else {
         state.background_review_requests
       }
-      guard state.owner == Some(owner) &&
+      guard state.owner is Some(state_owner) &&
+        state_owner == owner &&
         state.docs.get(path) is Some(doc) &&
         doc.review is Some(current_review) &&
         current_review.generation == generation &&
@@ -3169,7 +3187,8 @@ pub fn update(
       // A working-tree read may still be in flight. It will consume the
       // parked baseline when `FileLoaded` arrives; every settled document can
       // update immediately (including a deleted-file HEAD preview).
-      let cmd = if ctx.active_file == Some(path) &&
+      let cmd = if ctx.active_file is Some(active) &&
+        active == path &&
         working_side_ready_for_review(next_doc) {
         show_settled_review(
           dispatch,
@@ -3185,14 +3204,16 @@ pub fn update(
     }
     GitOriginalFailed(owner~, path~, generation~, background~, message~) => {
       let background_review_requests = if background &&
-        state.background_review_requests.get(path) == Some(generation) {
+        state.background_review_requests.get(path) is Some(requested) &&
+        requested == generation {
         let requests = state.background_review_requests.copy()
         requests.remove(path)
         requests
       } else {
         state.background_review_requests
       }
-      guard state.owner == Some(owner) &&
+      guard state.owner is Some(state_owner) &&
+        state_owner == owner &&
         state.docs.get(path) is Some(doc) &&
         doc.review is Some(current_review) &&
         current_review.generation == generation else {
@@ -3212,7 +3233,8 @@ pub fn update(
         review: Some({ ..current_review, baseline: ReviewFailed(message), }),
       }
       docs[path] = next_doc
-      let cmd = if ctx.active_file == Some(path) &&
+      let cmd = if ctx.active_file is Some(active) &&
+        active == path &&
         !(next_doc.state is TabLoading) {
         show_settled_review(
           dispatch,
@@ -3227,7 +3249,8 @@ pub fn update(
       (cmd, { ..state, docs, background_review_requests, })
     }
     HistoryBlobLoaded(owner~, key~, generation~, side~, blob~) => {
-      guard state.owner == Some(owner) &&
+      guard state.owner is Some(state_owner) &&
+        state_owner == owner &&
         state.history_docs.get(key) is Some(doc) &&
         doc.generation == generation else {
         return (@cmd.none, state)
@@ -3253,7 +3276,8 @@ pub fn update(
       (cmd, { ..state, history_docs, })
     }
     HistoryBlobFailed(owner~, key~, generation~, side~, message~) => {
-      guard state.owner == Some(owner) &&
+      guard state.owner is Some(state_owner) &&
+        state_owner == owner &&
         state.history_docs.get(key) is Some(doc) &&
         doc.generation == generation else {
         return (@cmd.none, state)
@@ -3336,7 +3360,7 @@ pub fn update(
         // show command's decision against what the Viewer actually displays.
         let reveal_range = if stale_file_link { None } else { range }
         let reveal_annotation = if stale_file_link { None } else { annotation }
-        let cmd = if ctx.active_file == Some(path) {
+        let cmd = if ctx.active_file is Some(active) && active == path {
           match file {
             // A real MoonBit file also gets a diagnostics request: the host
             // runs `moon check` over the file's module and returns its
@@ -3390,7 +3414,7 @@ pub fn update(
       }
     }
     RunSettled(owner~) =>
-      if state.owner == Some(owner) {
+      if state.owner is Some(state_owner) && state_owner == owner {
         // A completed agent run can write files outside the pruned watcher.
         // Git status alone cannot prove their content or path set is unchanged,
         // so review progress and a ready file index are conservatively
@@ -3463,7 +3487,8 @@ pub fn update(
     FsChanged(root~, generation~, changes~) =>
       if state.owner is Some(owner) &&
         owner.channel == ctx.owner.channel &&
-        ctx.root() == Some(root) &&
+        ctx.root() is Some(ctx_root) &&
+        ctx_root == root &&
         generation == ctx.watch_identity(state.watch_generation) {
         let reviewed_changes = match changes {
           Some(changes) =>
@@ -3499,7 +3524,10 @@ pub fn update(
                 (
                   directory.is_root() ||
                   state.expanded.contains(directory) ||
-                  state.highlighted == Some(directory)
+                  (
+                    state.highlighted is Some(highlighted) &&
+                    highlighted == directory
+                  )
                 ) &&
                 !state.loading.contains(directory) {
                 relist.push(directory)
@@ -3663,7 +3691,7 @@ pub fn update(
                   stale: false,
                 }
                 docs[stat.path] = deleted
-                if ctx.active_file == Some(stat.path) {
+                if ctx.active_file is Some(active) && active == stat.path {
                   cmds.push(
                     show_tab(
                       dispatch,
@@ -3715,7 +3743,7 @@ pub fn update(
                   stale: false,
                 }
                 docs[stat.path] = failed
-                if ctx.active_file == Some(stat.path) {
+                if ctx.active_file is Some(active) && active == stat.path {
                   cmds.push(
                     show_tab(
                       dispatch,
@@ -3753,7 +3781,7 @@ pub fn update(
             TabReadFailed(_) => true
           }
           if changed {
-            if ctx.active_file == Some(stat.path) {
+            if ctx.active_file is Some(active) && active == stat.path {
               // The document on screen reloads eagerly (scroll kept —
               // `FileLoaded` sees the previous content). The document keeps
               // its loaded state so that restore has its baseline.
@@ -3818,7 +3846,9 @@ pub fn update(
         (@cmd.batch(cmds), { ..state, docs, review_generation, })
       }
     DiagnosticsLoaded(owner~, epoch~, absolute~, diagnostics~) =>
-      if state.owner == Some(owner) && state.request_epoch == epoch {
+      if state.owner is Some(state_owner) &&
+        state_owner == owner &&
+        state.request_epoch == epoch {
         (apply_diagnostics(owner.channel, absolute, diagnostics), state)
       } else {
         (@cmd.none, state)
@@ -3862,7 +3892,9 @@ pub fn update(
             let docs = state.docs.copy()
             let failed = { ..doc, state: TabReadFailed(message), stale: false, }
             docs[path] = failed
-            let cmd = if !stale_file_link && ctx.active_file == Some(path) {
+            let cmd = if !stale_file_link &&
+              ctx.active_file is Some(active) &&
+              active == path {
               show_tab(
                 dispatch,
                 ctx,
@@ -3891,7 +3923,7 @@ pub fn update(
         let docs = state.docs.copy()
         let failed = { ..doc, state: TabReadFailed(message), stale: false, }
         docs[path] = failed
-        let cmd = if ctx.active_file == Some(path) {
+        let cmd = if ctx.active_file is Some(active) && active == path {
           show_tab(
             dispatch,
             ctx,
@@ -3919,7 +3951,8 @@ pub fn update(
     FileWatchFailed(channel~, root~, generation~, message~) =>
       if state.owner is Some(owner) &&
         owner.channel == channel &&
-        ctx.root() == Some(root) &&
+        ctx.root() is Some(ctx_root) &&
+        ctx_root == root &&
         generation == ctx.watch_identity(state.watch_generation) {
         // The Host reports request-time activation failures through the
         // `fs.watch` reply and reserves this event for a watcher that stopped

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -998,7 +998,8 @@ fn git_graph_placeholder(
   let paths : Array[@svg.Svg] = []
   for lane, column in columns {
     let x = graph_lane_x(lane)
-    let highlight_class = if highlight_index == Some(lane) {
+    let highlight_class = if highlight_index is Some(highlight) &&
+      highlight == lane {
       " git-graph-edge-highlight"
     } else {
       ""
@@ -1011,7 +1012,13 @@ fn git_graph_placeholder(
         class=path_class,
         d="M\{x} 0 V22",
         attrs=@svg.Attrs::build()
-          .stroke_width(if highlight_index == Some(lane) { "3" } else { "1" })
+          .stroke_width(
+            if highlight_index is Some(highlight) && highlight == lane {
+              "3"
+            } else {
+              "1"
+            },
+          )
           .stroke_linecap("round"),
       ),
     )
@@ -1224,11 +1231,12 @@ fn git_commit_row(
   index : Int,
   total : Int,
 ) -> @html.Html {
-  let expanded = state.git_graph_selected == Some(commit.id)
+  let expanded = state.git_graph_selected is Some(selected) &&
+    selected == commit.id
   let refs : Array[@html.Html] = []
   let mut head = false
   if state.git_graph is GitGraphReady(snapshot~, ..) {
-    head = snapshot.head == Some(commit.id)
+    head = snapshot.head is Some(selected) && selected == commit.id
     refs.push_iter(git_commit_refs(snapshot, commit.id).iter())
   }
   let mut row_class = "git-commit-row"
@@ -1365,7 +1373,8 @@ fn git_commit_files(
             status: file.status,
             kind: file.kind,
           }
-          let selected = ctx.active_history_diff == Some(diff)
+          let selected = ctx.active_history_diff is Some(active_diff) &&
+            active_diff == diff
           let contents : Array[@html.Html] = [
             git_graph_placeholder(columns, highlight_index),
             @html.span(class="git-history-file-path", file.path),
@@ -1664,7 +1673,9 @@ fn ChangedFile::is_selected(
   state : State,
   ctx : Ctx,
 ) -> Bool {
-  guard ctx.active_file == Some(self.path) else { return false }
+  guard ctx.active_file is Some(active) && active == self.path else {
+    return false
+  }
   match state.docs.get(self.path) {
     Some({ review: Some(review), .. }) => review.selected == self
     _ => true
@@ -1791,7 +1802,8 @@ pub fn breadcrumb_view(
           dispatch,
           "Workspace",
           @pathx.Relative::root(),
-          state.highlighted == Some(@pathx.Relative::root()),
+          state.highlighted is Some(highlight) &&
+          highlight == @pathx.Relative::root(),
         ),
       )
       let segments = path_segments(path)
@@ -1805,7 +1817,8 @@ pub fn breadcrumb_view(
               dispatch,
               segment,
               segments_prefix(segments, index + 1),
-              state.highlighted == Some(segments_prefix(segments, index + 1)),
+              state.highlighted is Some(highlight) &&
+              highlight == segments_prefix(segments, index + 1),
             ),
           )
         }
@@ -2509,7 +2522,9 @@ fn breadcrumb_picker_row(
   index : Int,
   total : Int,
 ) -> @html.Html {
-  let selected = !entry.is_dir && ctx.active_file == Some(entry.path)
+  let selected = !entry.is_dir &&
+    ctx.active_file is Some(active) &&
+    active == entry.path
   @html.button(
     type_="button",
     class=if selected {
@@ -2838,7 +2853,7 @@ fn tree_row(
     )
   } else {
     @html.div(
-      class=if ctx.active_file == Some(entry.path) {
+      class=if ctx.active_file is Some(active) && active == entry.path {
         "tree-row tree-file selected"
       } else {
         "tree-row tree-file"

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -1323,7 +1323,8 @@ fn ConversationSelection::matches_id(
   record_matches &&
   self.channel.uri_authority() == id.channel() &&
   self.session == id.conversation() &&
-  id.root() == Some(self.workspace.path)
+  id.root() is Some(root_path) &&
+  root_path == self.workspace.path
 }
 
 ///|
@@ -3814,7 +3815,7 @@ fn Conversation::remove_queued_input(
         {
           ..self,
           queued_inputs,
-          queue_edit_id: if self.queue_edit_id == Some(id) {
+          queue_edit_id: if self.queue_edit_id is Some(edit_id) && edit_id == id {
             None
           } else {
             self.queue_edit_id

--- a/desktop/frontend/preview/update.mbt
+++ b/desktop/frontend/preview/update.mbt
@@ -40,7 +40,7 @@ pub fn update(msg : Msg, state : State) -> State {
     // `loading` is driven by its own event, so the new load still ends.
     LoadFailed(id~, url~, text~) =>
       patch(id, page => {
-        if page.url == Some(url) {
+        if page.url is Some(page_url) && page_url == url {
           { ..page, loading: false, failure: Some("\{url}: \{text}"), }
         } else {
           page

--- a/desktop/frontend/preview/url.mbt
+++ b/desktop/frontend/preview/url.mbt
@@ -98,8 +98,7 @@ fn octet_value(text : StringView) -> Int? {
 fn is_loopback_ipv4(host : String) -> Bool {
   match host.split(".").collect() {
     [first, second, third, fourth] =>
-      octet_value(first) is Some(octet) &&
-      octet == 127 &&
+      octet_value(first) is Some(127) &&
       octet_value(second) is Some(_) &&
       octet_value(third) is Some(_) &&
       octet_value(fourth) is Some(_)

--- a/desktop/frontend/preview/url.mbt
+++ b/desktop/frontend/preview/url.mbt
@@ -98,7 +98,8 @@ fn octet_value(text : StringView) -> Int? {
 fn is_loopback_ipv4(host : String) -> Bool {
   match host.split(".").collect() {
     [first, second, third, fourth] =>
-      octet_value(first) == Some(127) &&
+      octet_value(first) is Some(octet) &&
+      octet == 127 &&
       octet_value(second) is Some(_) &&
       octet_value(third) is Some(_) &&
       octet_value(fourth) is Some(_)

--- a/desktop/frontend/quick_open/state.mbt
+++ b/desktop/frontend/quick_open/state.mbt
@@ -306,7 +306,10 @@ fn State::apply_cache_loaded(
   _generation : Int,
 ) -> (@cmd.Cmd, State) {
   let cache = self.cache
-  guard cache.owner == Some(owner) && cache.loading_key == Some(cache_key) else {
+  guard cache.owner is Some(cached_owner) &&
+    cached_owner == owner &&
+    cache.loading_key is Some(cached_key) &&
+    cached_key == cache_key else {
     return (@cmd.none, self)
   }
   let cmds : Array[@cmd.Cmd] = []
@@ -338,7 +341,10 @@ fn State::fail_cache_load(
   _generation : Int,
 ) -> (@cmd.Cmd, State) {
   let cache = self.cache
-  guard cache.owner == Some(owner) && cache.loading_key == Some(cache_key) else {
+  guard cache.owner is Some(cached_owner) &&
+    cached_owner == owner &&
+    cache.loading_key is Some(cached_key) &&
+    cached_key == cache_key else {
     return (@cmd.none, self)
   }
   let next = { ..self, cache: { ..cache, loading_key: None, }, }
@@ -366,7 +372,8 @@ fn State::apply_file_result(
   guard self.open is Some(open) &&
     open.owner == owner &&
     open.provider() is Files &&
-    self.cache.active_key == Some(cache_key) &&
+    self.cache.active_key is Some(active_key) &&
+    active_key == cache_key &&
     open.query() == query &&
     open.generation == generation else {
     return self
@@ -385,7 +392,8 @@ fn State::fail_file_request(
   guard self.open is Some(open) &&
     open.owner == owner &&
     open.provider() is Files &&
-    self.cache.active_key == Some(cache_key) &&
+    self.cache.active_key is Some(active_key) &&
+    active_key == cache_key &&
     open.query() == query &&
     open.generation == generation else {
     return self
@@ -555,7 +563,8 @@ fn State::ensure_cache(
   query_now : Bool,
 ) -> (@cmd.Cmd, State) {
   let previous = self.cache
-  let compatible = previous.owner == Some(open.owner) &&
+  let compatible = previous.owner is Some(cached_owner) &&
+    cached_owner == open.owner &&
     previous.root == input.root
   let cmds : Array[@cmd.Cmd] = []
   let mut cache = if compatible {

--- a/desktop/frontend/resource/resource.mbt
+++ b/desktop/frontend/resource/resource.mbt
@@ -52,7 +52,9 @@ pub fn channel(uri : @common.Uri) -> @interop.ChannelId? {
 /// Callers use this at the request boundary; checking the authority prevents
 /// an accidentally retained URI from being sent to another device.
 pub fn path_for(uri : @common.Uri, owner : @interop.ChannelId) -> String? {
-  guard channel(uri) == Some(owner) else { return None }
+  guard channel(uri) is Some(uri_owner) && uri_owner == owner else {
+    return None
+  }
   Some(uri.path)
 }
 
@@ -61,7 +63,7 @@ pub fn path_for(uri : @common.Uri, owner : @interop.ChannelId) -> String? {
 /// before they are encoded for a request, so a URI retained from another
 /// device can never be sent as this one's store.
 pub fn belongs_to(uri : @common.Uri, owner : @interop.ChannelId) -> Bool {
-  channel(uri) == Some(owner)
+  channel(uri) is Some(uri_owner) && uri_owner == owner
 }
 
 ///|

--- a/desktop/frontend/transcript/component/component.mbt
+++ b/desktop/frontend/transcript/component/component.mbt
@@ -572,8 +572,7 @@ fn transcript_sub_loader(
       let target = @dom.document().as_event_target()
       let listener : @dom.Listener = event => {
         guard event.target().to_element() is Some(element) &&
-          element.get_property("id").to_option() is Some(element_id) &&
-          element_id == "transcript" else {
+          element.get_property("id").to_option() is Some("transcript") else {
           return
         }
         // Report only what differs from the Model. Its next message brings

--- a/desktop/frontend/transcript/component/component.mbt
+++ b/desktop/frontend/transcript/component/component.mbt
@@ -572,7 +572,8 @@ fn transcript_sub_loader(
       let target = @dom.document().as_event_target()
       let listener : @dom.Listener = event => {
         guard event.target().to_element() is Some(element) &&
-          element.get_property("id").to_option() == Some("transcript") else {
+          element.get_property("id").to_option() is Some(element_id) &&
+          element_id == "transcript" else {
           return
         }
         // Report only what differs from the Model. Its next message brings

--- a/desktop/frontend/transcript/component/diagrams.mbt
+++ b/desktop/frontend/transcript/component/diagrams.mbt
@@ -30,8 +30,7 @@ fn TranscriptDomMount::refresh_diagrams(
   root : @dom.Element,
 ) -> Unit {
   let elements = root.query_selector_all("[data-transcript-diagram]")
-  let dark_mode = root.get_attribute("data-transcript-theme") is Some(theme) &&
-    theme == "dark"
+  let dark_mode = root.get_attribute("data-transcript-theme") is Some("dark")
   let retained : Array[TranscriptDiagram] = []
   // Dispose removed/reused targets first, invalidating their pending Mermaid
   // work before any new diagram is installed into the same container.

--- a/desktop/frontend/transcript/component/diagrams.mbt
+++ b/desktop/frontend/transcript/component/diagrams.mbt
@@ -30,7 +30,8 @@ fn TranscriptDomMount::refresh_diagrams(
   root : @dom.Element,
 ) -> Unit {
   let elements = root.query_selector_all("[data-transcript-diagram]")
-  let dark_mode = root.get_attribute("data-transcript-theme") == Some("dark")
+  let dark_mode = root.get_attribute("data-transcript-theme") is Some(theme) &&
+    theme == "dark"
   let retained : Array[TranscriptDiagram] = []
   // Dispose removed/reused targets first, invalidating their pending Mermaid
   // work before any new diagram is installed into the same container.
@@ -39,9 +40,10 @@ fn TranscriptDomMount::refresh_diagrams(
       .iter()
       .any(element => {
         entry.element.is_same_node(element.as_node()) &&
-        element.get_attribute("data-transcript-diagram-source") ==
-        Some(entry.source) &&
-        element.get_attribute("data-transcript-diagram") == Some(entry.language)
+        element.get_attribute("data-transcript-diagram-source") is Some(source) &&
+        source == entry.source &&
+        element.get_attribute("data-transcript-diagram") is Some(language) &&
+        language == entry.language
       }) {
       retained.push(entry)
     } else {

--- a/desktop/frontend/transcript/sessions.mbt
+++ b/desktop/frontend/transcript/sessions.mbt
@@ -336,7 +336,7 @@ pub fn apply_session_item(
       }
     }
     @desktop_protocol.Assistant(payload) => {
-      let is_replay = payload.is_replay == Some(true)
+      let is_replay = payload.is_replay is Some(true)
       // Thinking-mode turns store the reasoning alongside the answer (the
       // store omits the field entirely otherwise). A checkpoint replay
       // already has its reasoning on the original durable provider response,

--- a/desktop/frontend/transcript_overview/view.mbt
+++ b/desktop/frontend/transcript_overview/view.mbt
@@ -18,7 +18,7 @@ pub fn rail(
   let ticks : Array[@html.Html] = []
   for entry in entries {
     let mut tick_class = "overview-tick"
-    if state.active == Some(entry.key) {
+    if state.active is Some(key) && key == entry.key {
       tick_class += " active"
     }
     if state.hover is Some(hover) && hover.key == entry.key {

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1779,8 +1779,7 @@ fn update(
   // A registry refresh can retire the title control without changing the
   // active session. Do not leave its root menu flag hiding a native Browser
   // view after the control itself has disappeared.
-  let model = if model.select_menu is Some(open_menu) &&
-    open_menu == ProjectMenu &&
+  let model = if model.select_menu is Some(ProjectMenu) &&
     !model.can_choose_new_chat_project() {
     { ..model, select_menu: None, project_menu_query: "", }
   } else {
@@ -1789,9 +1788,7 @@ fn update(
   // The query has meaning only while its exact menu is open. Context changes,
   // covering overlays, and selections close menus in several handlers; keep
   // all of those paths from reviving an old filter on the next fresh draft.
-  let model = if (
-      model.select_menu is Some(open_menu) && open_menu == ProjectMenu
-    ) ||
+  let model = if model.select_menu is Some(ProjectMenu) ||
     model.project_menu_query.is_empty() {
     model
   } else {
@@ -2918,8 +2915,7 @@ fn update_msg(
     CloseSelectMenu =>
       (@cmd.none, { ..model, select_menu: None, project_menu_query: "", })
     ProjectMenuQueryChanged(query) =>
-      if model.select_menu is Some(menu) &&
-        menu == ProjectMenu &&
+      if model.select_menu is Some(ProjectMenu) &&
         model.screen is Chat &&
         model.composing_new_chat() {
         (@cmd.none, { ..model, project_menu_query: query, })
@@ -2927,8 +2923,7 @@ fn update_msg(
         (@cmd.none, model)
       }
     ProjectMenuProjectChosen(workspace) => {
-      let menu_open = model.select_menu is Some(open_menu) &&
-        open_menu == ProjectMenu
+      let menu_open = model.select_menu is Some(ProjectMenu)
       let closed = { ..model, select_menu: None, project_menu_query: "", }
       guard menu_open &&
         model.can_choose_new_chat_project() &&

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -123,7 +123,9 @@ fn open_session_on(
           @cmd.none,
           {
             ..base,
-            loading_conversation: if base.loading_conversation == Some(owner) {
+            loading_conversation: if base.loading_conversation
+              is Some(loading_owner) &&
+              loading_owner == owner {
               Some(owner)
             } else {
               None
@@ -611,7 +613,9 @@ fn retry_session_snapshot(
     let next = model.replace_conversation(failed)
     let scroll = @cmd.none
     let owner : @interop.ConversationKey = { channel, session, }
-    if activate_on_success && model.loading_conversation == Some(owner) {
+    if activate_on_success &&
+      model.loading_conversation is Some(loading_owner) &&
+      loading_owner == owner {
       let blocking_failure = !next.selected_conversation_loaded()
       let (toast, next) = next.notify_error(
         dispatch,
@@ -683,7 +687,9 @@ fn apply_session_snapshot(
   let mut next = model.replace_conversation(conv)
   let commands : Array[@cmd.Cmd] = []
   let owner : @interop.ConversationKey = { channel, session, }
-  if activate_on_success && model.loading_conversation == Some(owner) {
+  if activate_on_success &&
+    model.loading_conversation is Some(loading_owner) &&
+    loading_owner == owner {
     next = {
       ..next.activate(channel, session, conv.project()),
       loading_conversation: None,
@@ -1651,7 +1657,7 @@ fn sync_browser_view(
       }
     Some(_) => {
       let geo = browser_geometry(model)
-      if pane.geo == Some(geo) {
+      if pane.geo is Some(measured) && measured == geo {
         (model, @cmd.none)
       } else {
         (
@@ -1773,7 +1779,8 @@ fn update(
   // A registry refresh can retire the title control without changing the
   // active session. Do not leave its root menu flag hiding a native Browser
   // view after the control itself has disappeared.
-  let model = if model.select_menu == Some(ProjectMenu) &&
+  let model = if model.select_menu is Some(open_menu) &&
+    open_menu == ProjectMenu &&
     !model.can_choose_new_chat_project() {
     { ..model, select_menu: None, project_menu_query: "", }
   } else {
@@ -1782,7 +1789,9 @@ fn update(
   // The query has meaning only while its exact menu is open. Context changes,
   // covering overlays, and selections close menus in several handlers; keep
   // all of those paths from reviving an old filter on the next fresh draft.
-  let model = if model.select_menu == Some(ProjectMenu) ||
+  let model = if (
+      model.select_menu is Some(open_menu) && open_menu == ProjectMenu
+    ) ||
     model.project_menu_query.is_empty() {
     model
   } else {
@@ -2285,7 +2294,8 @@ fn update_msg(
               guard conv.run is Open(run_id~, stage~) && !(stage is Cancelling) else {
                 return (@cmd.none, model)
               }
-              let editing = conv.queue_edit_id == Some(id)
+              let editing = conv.queue_edit_id is Some(queued_id) &&
+                queued_id == id
               (
                 queue_openseek(
                   dispatch,
@@ -2813,7 +2823,8 @@ fn update_msg(
     // a reference pick) opens a dock tab before the document loads. The
     // owner stamp rejects a reply that outlived a conversation switch.
     FileEditor(OpenNavigationLocation(owner~, path~, range~)) => {
-      guard model.file_panel.owner == Some(owner) &&
+      guard model.file_panel.owner is Some(panel_owner) &&
+        panel_owner == owner &&
         file_ctx(model).owner == owner else {
         return (@cmd.none, model)
       }
@@ -2840,7 +2851,8 @@ fn update_msg(
     // callback by its original conversation and coalesce identical live
     // toasts: one user gesture can cause Viewer to ask more than once.
     FileEditor(@fileeditor.LanguageRequestFailed(owner~, message~)) => {
-      guard model.file_panel.owner == Some(owner) &&
+      guard model.file_panel.owner is Some(panel_owner) &&
+        panel_owner == owner &&
         file_ctx(model).owner == owner else {
         return (@cmd.none, model)
       }
@@ -2870,7 +2882,8 @@ fn update_msg(
         file_ctx(model),
       )
       let next = { ..model, file_panel: panel, }
-      if panel.watch_error == Some(message) &&
+      if panel.watch_error is Some(err) &&
+        err == message &&
         model.file_panel.watch_error != Some(message) &&
         !model.notifications.any(toast => toast.message == message) {
         let (toast, next) = next.notify_error(dispatch, message)
@@ -2885,7 +2898,8 @@ fn update_msg(
       if menu is ProjectMenu && !model.can_choose_new_chat_project() {
         return (@cmd.none, model)
       }
-      let select_menu = if model.select_menu == Some(menu) {
+      let select_menu = if model.select_menu is Some(open_menu) &&
+        open_menu == menu {
         None
       } else {
         Some(menu)
@@ -2904,7 +2918,8 @@ fn update_msg(
     CloseSelectMenu =>
       (@cmd.none, { ..model, select_menu: None, project_menu_query: "", })
     ProjectMenuQueryChanged(query) =>
-      if model.select_menu == Some(ProjectMenu) &&
+      if model.select_menu is Some(menu) &&
+        menu == ProjectMenu &&
         model.screen is Chat &&
         model.composing_new_chat() {
         (@cmd.none, { ..model, project_menu_query: query, })
@@ -2912,7 +2927,8 @@ fn update_msg(
         (@cmd.none, model)
       }
     ProjectMenuProjectChosen(workspace) => {
-      let menu_open = model.select_menu == Some(ProjectMenu)
+      let menu_open = model.select_menu is Some(open_menu) &&
+        open_menu == ProjectMenu
       let closed = { ..model, select_menu: None, project_menu_query: "", }
       guard menu_open &&
         model.can_choose_new_chat_project() &&
@@ -4866,7 +4882,8 @@ fn update_msg(
             // kinds activate directly.
             let next_file = @dock.active_file(dock)
             let next_history = @dock.active_history_diff(dock)
-            let was_active = before.active == Some(tab)
+            let was_active = before.active is Some(active_tab) &&
+              active_tab == tab
             // Closing any file tab is newer than a pending transcript link:
             // even an inactive tab must stay closed when that link's delayed
             // host lookup returns. Other tab kinds compete only when closing
@@ -4938,7 +4955,8 @@ fn update_msg(
                 // does not enqueue a hide behind the close; the ordered bridge
                 // lane would then try to hide a view the host already removed.
                 // Clearing `geo` also makes a successor Browser tab re-measure.
-                let browser_pane = if model.browser_pane.shown == Some(id) {
+                let browser_pane = if model.browser_pane.shown is Some(shown_id) &&
+                  shown_id == id {
                   { shown: None, rect: None, geo: None, }
                 } else {
                   model.browser_pane
@@ -5267,7 +5285,8 @@ fn update_msg(
         let reuse = for tab in model.dock.tabs {
           if tab is Browser(id~) &&
             @preview.page(model.preview, id) is Some(page) &&
-            page.url == Some(url) {
+            page.url is Some(page_url) &&
+            page_url == url {
             break Some(id)
           }
         } nobreak {
@@ -5396,7 +5415,9 @@ fn Model::apply_codex_worktree_snapshot(
     return (@cmd.none, self)
   }
   for row in rows {
-    if row.codex_thread == Some(thread_id) && row.path is Some(path) {
+    if row.codex_thread is Some(thread) &&
+      thread == thread_id &&
+      row.path is Some(path) {
       let (command, codex) = @codex.update(
         dispatch.map(msg => Codex(channel~, msg)),
         @codex.Msg::worktree_changed(
@@ -5757,7 +5778,7 @@ fn update_device_msg(
     }
     HostSettingsLoaded(settings, connection_generation~) => {
       guard connection_generation is None ||
-        connection_generation == Some(dev.connection_generation) else {
+        (connection_generation is Some(gen) && gen == dev.connection_generation) else {
         return (@cmd.none, model)
       }
       // The settings mirror is the focused host's. A generation-carrying
@@ -5885,7 +5906,7 @@ fn update_device_msg(
           }
           let queued_inputs = conv.queued_inputs.copy()
           queued_inputs[index] = { id, content, }
-          if conv.queue_edit_id == Some(id) {
+          if conv.queue_edit_id is Some(queued_id) && queued_id == id {
             {
               ..conv,
               queued_inputs,
@@ -6411,7 +6432,9 @@ fn update_device_msg(
         Some(confirm) if confirm.channel == channel &&
           next.find_conversation(channel, confirm.session) is Some(conv) &&
           conv.project() == workspace &&
-          !rows.any(row => row.session == Some(confirm.session)) => None
+          !rows.any(row => {
+            row.session is Some(session) && session == confirm.session
+          }) => None
         other => other
       }
       let next = { ..next, conversations, archive_confirm, }
@@ -6713,7 +6736,9 @@ fn update_device_msg(
           if generation is Some(generation) {
             let foreground = channel == next.focused &&
               next.active_session == key.session &&
-              next.session_project(channel, key.session) == Some(key.workspace)
+              next.session_project(channel, key.session)
+              is Some(session_workspace) &&
+              session_workspace == key.workspace
             let next = if foreground {
               {
                 ..next,
@@ -7482,7 +7507,8 @@ fn update_device_msg(
         // dismissed. A question only exists inside a turn, so a conversation
         // with no open run has none to restore.
         guard conv.run is Open(run_id~, ..) &&
-          recovered.approval.run_id == Some(run_id) else {
+          recovered.approval.run_id is Some(approval_run_id) &&
+          approval_run_id == run_id else {
           continue
         }
         // Already on screen unchanged: leave it, answered flag and all. This

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -28,7 +28,7 @@ fn SelectMenu::setting_control(
     groups: [{ label: aria_label, options, }],
     selected,
     disabled,
-    open: model.select_menu == Some(self),
+    open: model.select_menu is Some(menu) && menu == self,
     toggle: dispatch(ToggleSelectMenu(self)),
     dismiss: dispatch(CloseSelectMenu),
     change,
@@ -431,7 +431,9 @@ fn Model::sidebar_component_sections(
       codex_activation = self.codex.project_activation(context, root)
     }
     let conversations = ordered_by_recency(stamped)
-    let openseek_activation = activation(dev.active_project == Some(path))
+    let openseek_activation = activation(
+      dev.active_project is Some(project) && project == path,
+    )
     projects.push(
       @section.Project({
         id: @project.Id(source="openseek.projects", channel~, root=path.path),

--- a/desktop/frontend/workspace_settings/component.mbt
+++ b/desktop/frontend/workspace_settings/component.mbt
@@ -96,7 +96,7 @@ fn Model::update(
       (
         {
           ..self,
-          menu: if self.menu == Some(menu) {
+          menu: if self.menu is Some(current) && current == menu {
             None
           } else {
             Some(menu)
@@ -143,7 +143,9 @@ fn setting_select(
     // and the shared select dismisses on blur, so a page change takes the
     // trigger out of the DOM and closes the menu on the way. This keeps the
     // view honest if that ever stops holding.
-    open: state.menu == Some(menu) && state.key == input.page,
+    open: state.menu is Some(current) &&
+    current == menu &&
+    state.key == input.page,
     toggle: emit(ToggleMenu(menu)),
     dismiss: emit(CloseMenu),
     change,

--- a/desktop/frontend/worktrees.mbt
+++ b/desktop/frontend/worktrees.mbt
@@ -452,7 +452,7 @@ fn DeviceState::conversation_workspace(
   for group in self.worktrees {
     guard group.project == project else { continue }
     for row in group.rows {
-      if row.session == Some(session) {
+      if row.session is Some(row_session) && row_session == session {
         return Worktree(project~, name=row.name)
       }
     }

--- a/desktop/internal/api/api.mbt
+++ b/desktop/internal/api/api.mbt
@@ -470,7 +470,7 @@ pub fn endpoints(
         (moved, workspace) => {
           publish_session_changed(state, "archived", moved, workspace)
         },
-        force=payload.force == Some(true),
+        force=payload.force is Some(true),
         on_worktree_changed=(workspace, worktrees) => {
           publish_worktree_changed(state, workspace, worktrees)
         },
@@ -629,7 +629,9 @@ pub fn endpoints(
         reply.worktrees
         .iter()
         .find_first(info => {
-          info.codex_thread == Some(thread_id) && info.name == reply.name
+          info.codex_thread is Some(thread) &&
+          thread == thread_id &&
+          info.name == reply.name
         })
         is Some(info) {
         @work_dir.authorize_host_workspace(thread_id, info.path)
@@ -641,7 +643,7 @@ pub fn endpoints(
         state.manager.worktree_host(),
         payload.workspace,
         payload.name,
-        payload.force == Some(true),
+        payload.force is Some(true),
         worktrees => {
           publish_worktree_changed(state, payload.workspace, worktrees)
         },
@@ -949,8 +951,10 @@ async fn ApiState::codex_worktree_project(
   })
   guard metadata is Object(reply_fields) &&
     reply_fields.get("thread") is Some(Object(thread)) &&
-    thread.get("id") == Some(Json(thread_id)) &&
-    thread.get("projectRoot") == Some(Json(requested)) else {
+    thread.get("id") is Some(reply_id) &&
+    reply_id == Json(thread_id) &&
+    thread.get("projectRoot") is Some(reply_root) &&
+    reply_root == Json(requested) else {
     raise @host.HostError(
       "Codex worktree requires an empty task at its main project root",
     )
@@ -964,7 +968,7 @@ async fn ApiState::codex_worktree_project(
     }) {
     return requested
   }
-  guard thread.get("cwd") == Some(Json(requested)) else {
+  guard thread.get("cwd") is Some(reply_cwd) && reply_cwd == Json(requested) else {
     raise @host.HostError(
       "Codex worktree requires an empty task at its main project root",
     )

--- a/desktop/internal/api/hub.mbt
+++ b/desktop/internal/api/hub.mbt
@@ -222,7 +222,7 @@ fn settlement_matches(
   settlement.session == selector.session &&
   selector.run_id.map_or(true, run_id => settlement.run_id == run_id) &&
   selector.submission_id.map_or(true, submission_id => {
-    settlement.submission_id == Some(submission_id)
+    settlement.submission_id is Some(settled) && settled == submission_id
   })
 }
 

--- a/desktop/internal/codex/project_catalog.mbt
+++ b/desktop/internal/codex/project_catalog.mbt
@@ -88,7 +88,7 @@ pub fn ProjectCatalog::main_project(
   cwd : String,
 ) -> String? {
   let cwd = cwd.trim().to_owned()
-  if self.known_projects.get(cwd) == Some(true) {
+  if self.known_projects.get(cwd) is Some(true) {
     Some(cwd)
   } else {
     None

--- a/desktop/internal/host/git_ops.mbt
+++ b/desktop/internal/host/git_ops.mbt
@@ -204,7 +204,7 @@ async fn git_base_ref(dir : String, hint? : String) -> String? {
 /// names, rather than commits, keeps a feature branch made at the current
 /// default-branch tip eligible for its own pull request.
 async fn git_is_default_branch(dir : String, branch~ : String) -> Bool {
-  git_base_ref(dir) == Some("origin/\{branch}")
+  git_base_ref(dir) is Some(base) && base == "origin/\{branch}"
 }
 
 ///|
@@ -1330,7 +1330,8 @@ async fn validate_git_history_snapshot(
   }
   for tip in snapshot.tips {
     guard valid_commit_identity(tip) &&
-      git_revision_commit(dir, tip) == Some(tip) else {
+      git_revision_commit(dir, tip) is Some(resolved) &&
+      resolved == tip else {
       raise HostError("Git history snapshot contains an unavailable commit")
     }
   }
@@ -1338,14 +1339,16 @@ async fn validate_git_history_snapshot(
     guard ref_.name.length() <= 512 &&
       ["current", "upstream", "base", "head"].contains(ref_.kind) &&
       valid_commit_identity(ref_.revision) &&
-      git_revision_commit(dir, ref_.revision) == Some(ref_.revision) &&
+      git_revision_commit(dir, ref_.revision) is Some(resolved) &&
+      resolved == ref_.revision &&
       snapshot.tips.contains(ref_.revision) else {
       raise HostError("Git history snapshot contains an invalid ref")
     }
   }
   if snapshot.head is Some(head) {
     guard valid_commit_identity(head) &&
-      git_revision_commit(dir, head) == Some(head) else {
+      git_revision_commit(dir, head) is Some(resolved) &&
+      resolved == head else {
       raise HostError("Git history snapshot contains an unavailable HEAD")
     }
   }

--- a/desktop/internal/work_dir/work_dir.mbt
+++ b/desktop/internal/work_dir/work_dir.mbt
@@ -59,7 +59,7 @@ async fn HostWorkspaceAuthorizations::resolve(
   let normalized = hint.normalize()
   self.lock.acquire()
   defer self.lock.release()
-  if self.paths.get(session) == Some(normalized.0) {
+  if self.paths.get(session) is Some(stored) && stored == normalized.0 {
     Some(normalized.to_path())
   } else {
     None

--- a/desktop/internal/worktree/worktree.mbt
+++ b/desktop/internal/worktree/worktree.mbt
@@ -139,8 +139,8 @@ fn WorktreeEntry::belongs_to(
   owner : WorktreeOwner,
 ) -> Bool {
   match owner {
-    OpenSeekSession(id) => self.session == Some(id)
-    CodexThread(id) => self.codex_thread == Some(id)
+    OpenSeekSession(id) => self.session is Some(matched) && matched == id
+    CodexThread(id) => self.codex_thread is Some(matched) && matched == id
   }
 }
 
@@ -149,7 +149,8 @@ fn WorktreeEntry::belongs_to(
 /// The two products store that id in distinct registry fields, but checkout
 /// resolution must recognize either field without merging their lifecycles.
 fn WorktreeEntry::serves_id(self : WorktreeEntry, id : String) -> Bool {
-  self.session == Some(id) || self.codex_thread == Some(id)
+  (self.session is Some(session) && session == id) ||
+  (self.codex_thread is Some(codex_thread) && codex_thread == id)
 }
 
 ///|

--- a/editor/internal/viewer/browser/view/decorations.mbt
+++ b/editor/internal/viewer/browser/view/decorations.mbt
@@ -150,7 +150,8 @@ fn render_normal_decorations(
         get_line_max_column(range.end_line_number - 1),
       )
     }
-    if prev_class_name == Some(class_name) &&
+    if prev_class_name is Some(prev_class) &&
+      prev_class == class_name &&
       prev_show_if_collapsed == show_if_collapsed &&
       @base_common.Range::are_intersecting_or_touching(
         prev_range.unwrap(),

--- a/editor/internal/viewer/browser/view/margin_decorations.mbt
+++ b/editor/internal/viewer/browser/view/margin_decorations.mbt
@@ -85,7 +85,7 @@ fn dedup_whole_margin_decorations(
     } else {
       visible_end_line_number - visible_start_line_number
     }
-    if previous_class_name == Some(class_name) {
+    if previous_class_name is Some(prev_class) && prev_class == class_name {
       start_line_index = if previous_end_line_index + 1 > start_line_index {
         previous_end_line_index + 1
       } else {

--- a/editor/internal/viewer/browser/view/view_line.mbt
+++ b/editor/internal/viewer/browser/view/view_line.mbt
@@ -180,7 +180,9 @@ fn ViewLine::render_line(
     return false
   }
   self.is_maybe_invalid = false
-  if self.rendered_view_line.map(rendered => rendered.input) == Some(input) {
+  if self.rendered_view_line.map(rendered => rendered.input)
+    is Some(rendered_input) &&
+    rendered_input == input {
     return false
   }
   let output = @view_layout.render_view_line2(input)

--- a/editor/internal/viewer/browser/view/view_overlays.mbt
+++ b/editor/internal/viewer/browser/view/view_overlays.mbt
@@ -150,7 +150,7 @@ fn ViewOverlayLine::render_line(
     )
   }
   let content = content.to_string()
-  if self.rendered_content == Some(content) {
+  if self.rendered_content is Some(rendered) && rendered == content {
     return false
   }
   self.rendered_content = Some(content)

--- a/editor/internal/viewer/code_editor_widget/definition_contribution.mbt
+++ b/editor/internal/viewer/code_editor_widget/definition_contribution.mbt
@@ -235,7 +235,8 @@ fn CodeEditorWidget::symbol_navigation_anchor_is_current(
   anchor.surface_generation() == self.model_slot.generation &&
   anchor.model().same(model) &&
   anchor.model_is_current() &&
-  self.get_position() == Some(anchor.position())
+  self.get_position() is Some(position) &&
+  position == anchor.position()
 }
 
 ///|

--- a/editor/internal/viewer/contrib/agent_feedback/browser/agent_feedback_editor_widget.mbt
+++ b/editor/internal/viewer/contrib/agent_feedback/browser/agent_feedback_editor_widget.mbt
@@ -243,7 +243,7 @@ fn AgentFeedbackEditorWidget::build_items(
     // lose the composer.
     match self.drafts.get(comment.id) {
       Some(draft) => {
-        let refocus = focused_reply == Some(comment.id)
+        let refocus = focused_reply is Some(reply) && reply == comment.id
         self.open_reply_composer(comment, item, draft, focus=refocus)
       }
       None => ()

--- a/editor/internal/viewer/contrib/definition/browser/definition_message_widget.mbt
+++ b/editor/internal/viewer/contrib/definition/browser/definition_message_widget.mbt
@@ -108,7 +108,7 @@ fn DefinitionMessageWidget::after_render(
   preference : @view.ContentWidgetPositionPreference?,
 ) -> Unit {
   guard !self.disposed else { return }
-  let below = if preference == Some(Below) { " below" } else { "" }
+  let below = if preference is Some(Below) { " below" } else { "" }
   self.root.set_attribute(
     "class",
     "monaco-editor-overlaymessage moonbit-viewer-definition-message fadeIn\{below}",

--- a/editor/internal/viewer/contrib/folding/browser/folding_model.mbt
+++ b/editor/internal/viewer/contrib/folding/browser/folding_model.mbt
@@ -233,7 +233,8 @@ pub fn FoldingModel::update_post(
         is_collapsed,
         end_line_number <= last_hidden_line,
         is_manual,
-        new_regions.get_type(index) == Some(OUTLINE_BODY_FOLDING_RANGE_TYPE),
+        new_regions.get_type(index) is Some(fold_type) &&
+        fold_type == OUTLINE_BODY_FOLDING_RANGE_TYPE,
       ),
     })
     if is_collapsed && end_line_number > last_hidden_line {
@@ -345,7 +346,8 @@ fn FoldingModel::apply_memento(
       range.start_line_number + 1,
       range.end_line_number,
     )
-    if range.checksum is None || range.checksum == Some(checksum) {
+    if range.checksum is None ||
+      (range.checksum is Some(current) && current == checksum) {
       ranges_to_restore.push({
         start_line_number: range.start_line_number,
         end_line_number: range.end_line_number,

--- a/editor/internal/viewer/contrib/folding/browser/folding_model.mbt
+++ b/editor/internal/viewer/contrib/folding/browser/folding_model.mbt
@@ -233,8 +233,7 @@ pub fn FoldingModel::update_post(
         is_collapsed,
         end_line_number <= last_hidden_line,
         is_manual,
-        new_regions.get_type(index) is Some(fold_type) &&
-        fold_type == OUTLINE_BODY_FOLDING_RANGE_TYPE,
+        new_regions.get_type(index) is Some(OUTLINE_BODY_FOLDING_RANGE_TYPE),
       ),
     })
     if is_collapsed && end_line_number > last_hidden_line {

--- a/editor/internal/viewer/contrib/hover/browser/markdown_document_hover.mbt
+++ b/editor/internal/viewer/contrib/hover/browser/markdown_document_hover.mbt
@@ -713,8 +713,10 @@ fn MarkdownDocumentHoverBridge::on_pointer_move(
     self.invalidate_pointer_request()
     return
   }
-  if self.current_source_offset == Some(hit.source_offset) &&
-    self.current_block_index == Some(hit.line.block_index) {
+  if self.current_source_offset is Some(shown_offset) &&
+    shown_offset == hit.source_offset &&
+    self.current_block_index is Some(shown_block) &&
+    shown_block == hit.line.block_index {
     return
   }
   self.request_generation += 1

--- a/editor/internal/viewer/contrib/hover/hover_controller.mbt
+++ b/editor/internal/viewer/contrib/hover/hover_controller.mbt
@@ -836,7 +836,8 @@ fn HoverController::set_current_result(
     Some(existing) =>
       if existing.parts == sorted &&
         self.current_complete == is_complete &&
-        self.current_anchor == Some(result_anchor) {
+        self.current_anchor is Some(current) &&
+        current == result_anchor {
         return self
       }
     None => ()

--- a/editor/internal/viewer/contrib/references/browser/reference_results_tree.mbt
+++ b/editor/internal/viewer/contrib/references/browser/reference_results_tree.mbt
@@ -748,7 +748,9 @@ fn ReferenceResultsTree::update_row_states(self : ReferenceResultsTree) -> Unit 
       Some(row) => {
         row.set_attribute(
           "tabindex",
-          reference_results_tabindex(self.roving == Some(GroupRow(group_index))),
+          reference_results_tabindex(
+            self.roving is Some(GroupRow(row_index)) && row_index == group_index,
+          ),
         )
         row.set_attribute(
           "aria-expanded",
@@ -767,7 +769,8 @@ fn ReferenceResultsTree::update_row_states(self : ReferenceResultsTree) -> Unit 
         row.set_attribute(
           "tabindex",
           reference_results_tabindex(
-            self.roving == Some(ReferenceRow(reference.flat_index)) &&
+            self.roving is Some(ReferenceRow(row_index)) &&
+            row_index == reference.flat_index &&
             self.reference_is_visible(reference),
           ),
         )

--- a/editor/internal/viewer/contrib/references/browser/references_controller.mbt
+++ b/editor/internal/viewer/contrib/references/browser/references_controller.mbt
@@ -224,8 +224,10 @@ fn ReferencesController::session_is_open(
   key : @references.ReferencesSessionKey,
   mode : @references.ReferencesPeekMode,
 ) -> Bool {
-  self.session_key == Some(key) &&
-  self.mode == Some(mode) &&
+  self.session_key is Some(current_key) &&
+  current_key == key &&
+  self.mode is Some(current_mode) &&
+  current_mode == mode &&
   self.widget is Some(_) &&
   self.mount is Some(_) &&
   self.session_is_current(self.generation)
@@ -376,7 +378,7 @@ fn ReferencesController::install_locations(
   }
   self.group_preview_owners = owners
   if result_model.is_empty() {
-    if self.mode == Some(Definitions) {
+    if self.mode is Some(Definitions) {
       self.close(restore_focus=true)
       (self.host.show_message)(anchor, definition_no_result_message(anchor))
     } else {

--- a/editor/internal/viewer/contrib/references/references_model.mbt
+++ b/editor/internal/viewer/contrib/references/references_model.mbt
@@ -102,8 +102,10 @@ fn normalize_reference_locations(
   let mut previous_uri : String? = None
   let mut previous_range : @base_common.Range? = None
   for entry in sorted_indexed_reference_locations(locations) {
-    let duplicate = previous_uri == Some(entry.uri_string) &&
-      previous_range == Some(entry.location.range)
+    let duplicate = previous_uri is Some(uri) &&
+      uri == entry.uri_string &&
+      previous_range is Some(loc_range) &&
+      loc_range == entry.location.range
     if !duplicate {
       result.push(entry.location)
       previous_uri = Some(entry.uri_string)

--- a/editor/internal/viewer/diff_editor/widget.mbt
+++ b/editor/internal/viewer/diff_editor/widget.mbt
@@ -1240,7 +1240,7 @@ fn DiffEditorWidget::publish_content_height_if_changed(
   }
   let content_height = self.get_content_height()
   if content_height <= 0.0 ||
-    self.last_published_content_height == Some(content_height) {
+    (self.last_published_content_height is Some(last) && last == content_height) {
     return
   }
   self.last_published_content_height = Some(content_height)

--- a/editor/internal/viewer/markdown/source_projection.mbt
+++ b/editor/internal/viewer/markdown/source_projection.mbt
@@ -66,7 +66,7 @@ fn MarkdownCodeLine::displayed_boundary_at_source_offset(
   source_offset : Int,
 ) -> Int? {
   for displayed_boundary, mapped in self.displayed_boundary_to_source_offset {
-    if mapped == Some(source_offset) {
+    if mapped is Some(offset) && offset == source_offset {
       return Some(displayed_boundary)
     }
   }

--- a/editor/viewer/browser/diagram_viewport/diagram_viewport.mbt
+++ b/editor/viewer/browser/diagram_viewport/diagram_viewport.mbt
@@ -676,7 +676,9 @@ fn MarkdownDiagramViewport::install_listeners(
       return
     }
     let pointer_id = @base_browser.mouse_event_pointer_id(mouse)
-    if self.is_panning && self.pan_pointer_id == Some(pointer_id) {
+    if self.is_panning &&
+      self.pan_pointer_id is Some(captured) &&
+      captured == pointer_id {
       if mouse.get_buttons() == 0 {
         self.finish_pan(mouse)
         return
@@ -697,7 +699,9 @@ fn MarkdownDiagramViewport::install_listeners(
       self.apply_transform()
       return
     }
-    if self.is_resizing && self.resize_pointer_id == Some(pointer_id) {
+    if self.is_resizing &&
+      self.resize_pointer_id is Some(captured) &&
+      captured == pointer_id {
       if mouse.get_buttons() == 0 {
         self.finish_resize()
         return
@@ -713,12 +717,16 @@ fn MarkdownDiagramViewport::install_listeners(
   let finish_pointer_gesture = (event : @rdom.Event) => {
     guard event.to_mouse_event() is Some(mouse) else { return }
     let pointer_id = @base_browser.mouse_event_pointer_id(mouse)
-    if self.is_panning && self.pan_pointer_id == Some(pointer_id) {
+    if self.is_panning &&
+      self.pan_pointer_id is Some(captured) &&
+      captured == pointer_id {
       event.prevent_default()
       event.stop_propagation()
       self.finish_pan(mouse)
     }
-    if self.is_resizing && self.resize_pointer_id == Some(pointer_id) {
+    if self.is_resizing &&
+      self.resize_pointer_id is Some(captured) &&
+      captured == pointer_id {
       event.prevent_default()
       event.stop_propagation()
       self.finish_resize()

--- a/editor/viewer/common/view_layout/lines_layout.mbt
+++ b/editor/viewer/common/view_layout/lines_layout.mbt
@@ -845,7 +845,8 @@ pub fn LinesLayout::get_lines_viewport_data(
 
     // Next line starts immediately after this one.
     current_line_relative_offset += line_height.to_double()
-    while current_whitespace_after_line_number == Some(line_number) {
+    while current_whitespace_after_line_number is Some(matched) &&
+          matched == line_number {
       // Push down next line with the height of the current whitespace.
       current_line_relative_offset += current_whitespace_height.to_double()
 

--- a/editor/viewer/common/view_model/margin_decorations.mbt
+++ b/editor/viewer/common/view_model/margin_decorations.mbt
@@ -90,7 +90,7 @@ pub fn dedup_margin_decorations(
     let end_line_index = (decoration.end_line_number - visible_start_line_number).min(
       visible_end_line_number - visible_start_line_number,
     )
-    if prev_class_name == Some(class_name) {
+    if prev_class_name is Some(prev_class) && prev_class == class_name {
       // Here we avoid rendering the same className multiple times on the
       // same line.
       start_line_index = start_line_index.max(prev_end_line_index + 1)

--- a/editor/viewer/common/view_model/view_model_decorations.mbt
+++ b/editor/viewer/common/view_model/view_model_decorations.mbt
@@ -113,7 +113,8 @@ pub fn ViewModelDecorations::get_decorations_viewport_data(
 ) -> ViewDecorationsCollection {
   let mut cache_is_valid = self.cached_model_decorations_resolver is Some(_)
   cache_is_valid = cache_is_valid &&
-    self.cached_model_decorations_resolver_view_range == Some(view_range)
+    self.cached_model_decorations_resolver_view_range is Some(cached_range) &&
+    cached_range == view_range
   if !cache_is_valid {
     self.cached_model_decorations_resolver = Some(
       self.compute_decorations(view_range),

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -730,7 +730,7 @@ fn plan_baselines(
       continue
     }
     if call.id != "" &&
-      id_counts.get(call.id) == Some(1) &&
+      id_counts.get(call.id) is Some(1) &&
       previous is Some(prev) {
       baselines.set(call.id, prev)
     }


### PR DESCRIPTION
## Summary

`opt == Some(value)` materializes a fresh `Some` wrapper on every evaluation and
runs Option-level equality. When the payload only has to equal a known value, a
pattern match is allocation-free and spells the check directly:

- `opt is Some(v) && v == value` when the compared payload is an expression
- `opt is Some(Literal)` / `opt is Some(NullaryVariant)` when it is a constant

This starts from the shared settings-select render path
`SelectMenu::setting_control`, where `model.select_menu == Some(self)` previously
built a wrapper on every frame, and applies the same shape repo-wide wherever
non-test code compared an `Option` against a constructed `Some(..)`.

## Scope

- `desktop/` frontend (model/update/view, fileeditor, dock, codex, composer,
  quick_open, preview, transcript, workspace settings, action menus) and
  internal host/engine helpers (api, worktree, work_dir, git_ops, project catalog)
- `editor/` viewer (decorations, view line/overlay, diff/hover/references/folding
  contributions, diagram viewport, lines layout)
- root-module shell lexer/query/worker-sandbox/policy, `viz/`, `cmd/viz_app`,
  `agent_session/`

Left as-is on purpose: `== Some(..)` inside unit-test assertions (`assert_eq`/
`assert_true`) and the negated `!= Some(..)` family (MoonBit has no `is not`
operator, so its allocation-free spelling is not readable).

## Verification

- `moon check` (after `moon clean`) green for the desktop, editor, cmd/viz_app,
  and root modules
- `moon fmt` clean (diff is confined to the touched files)
- Tests: desktop frontend 463/463 (js), changed sibling frontend packages
  343/343 (js), agent_tool/shell+viz+agent_session 175/175, desktop internal
  work_dir/worktree/codex 33/33 (native)

No behavior change.

Generated with SeekMoon