### PR TITLE
chore(warnings): enable unnecessary_annotation module-wide and clear sites

### DIFF
--- a/agent_explore/child.mbt
+++ b/agent_explore/child.mbt
@@ -38,7 +38,7 @@ pub async fn run_child(
     system_prompt=explore_system_prompt(),
     task=explore_task(query, hints, scratch_dir),
     tools=captured => {
-      @agent_tool.Tools([
+      Tools([
         @read.definition(workspace_root~),
         @mbtx.definition(workspace_root~, read_only=true, scratch_dir?),
         submit_answer_tool(captured),

--- a/agent_kind/capture.mbt
+++ b/agent_kind/capture.mbt
@@ -39,7 +39,7 @@ pub fn[T] capture_tool(
   captured : Ref[T?],
   finished_note? : (T) -> String = _value => "submitted",
 ) -> @agent_tool.AgentToolDefinition {
-  @agent_tool.AgentToolDefinition(
+  AgentToolDefinition(
     name~,
     description~,
     schema~,

--- a/agent_kind/kind.mbt
+++ b/agent_kind/kind.mbt
@@ -33,10 +33,7 @@ pub async fn[T] execute_kind(
 ) -> T? {
   let captured : Ref[T?] = { val: None, }
   let tools = tools(captured)
-  let session = @agent_session.Session(
-    @agent_session.SessionId(session_id),
-    system_prompt~,
-  )
+  let session = @agent_session.Session(SessionId(session_id), system_prompt~)
   // Default: the transcript lives and dies with this process. A caller
   // wires a store-backed append (the `subrun` child mode when the parent
   // is durable) to make the child's transcript a first-class session.
@@ -46,8 +43,8 @@ pub async fn[T] execute_kind(
   }
   let _ : @agent_session.Session = @async.with_task_group() <| group => {
     @agent.run_turn_in_scope(
-      runtime=@agent_runtime.AgentRuntime(workspace_root~),
-      scope=@agent_runtime.AgentTaskScope(group),
+      runtime=AgentRuntime(workspace_root~),
+      scope=AgentTaskScope(group),
       api_key~,
       model~,
       session~,

--- a/agent_kind/kind_test.mbt
+++ b/agent_kind/kind_test.mbt
@@ -120,7 +120,7 @@ async fn run_answer_kind(
     system_prompt="You are a test subagent.",
     task="Answer via the submit tool.",
     tools=captured => {
-      @agent_tool.Tools([
+      Tools([
         @agent_kind.capture_tool(
           name="submit",
           description="Submit the final answer.",
@@ -265,7 +265,7 @@ async test "a store-backed append_item persists the child transcript" {
       system_prompt="You are a test subagent.",
       task="Answer via the submit tool.",
       tools=captured => {
-        @agent_tool.Tools([
+        Tools([
           @agent_kind.capture_tool(
             name="submit",
             description="Submit the final answer.",
@@ -287,7 +287,7 @@ async test "a store-backed append_item persists the child transcript" {
       append_item=(session, item) => store.append(session, item),
     )
     assert_true(value is Some("persisted"))
-    let loaded = store.load(@agent_session.SessionId("parent-sr-1"))
+    let loaded = store.load(SessionId("parent-sr-1"))
     assert_eq(loaded.system_prompt(), "You are a test subagent.")
     // The durable transcript holds the whole turn, not just a header.
     assert_true(loaded.events().length() >= 3)

--- a/agent_pattern_repair/submit.mbt
+++ b/agent_pattern_repair/submit.mbt
@@ -42,7 +42,7 @@ pub async fn run(
     session_id="pattern-repair",
     system_prompt=pattern_repair_system_prompt(),
     task=pattern_repair_task(pattern, instruction),
-    tools=captured => @agent_tool.Tools([submit_pattern_repair_tool(captured)]),
+    tools=captured => Tools([submit_pattern_repair_tool(captured)]),
     max_steps~,
     api_key~,
     model~,

--- a/agent_review/audit.mbt
+++ b/agent_review/audit.mbt
@@ -88,7 +88,7 @@ pub async fn run_goal_audit(
     system_prompt=audit_system_prompt(),
     task=audit_task(goal, baseline, scratch_dir),
     tools=captured => {
-      @agent_tool.Tools([
+      Tools([
         @read.definition(workspace_root~),
         @mbtx.definition(workspace_root~, read_only=true, scratch_dir?),
         submit_review_tool(captured),

--- a/agent_review/engine.mbt
+++ b/agent_review/engine.mbt
@@ -44,7 +44,7 @@ pub async fn run_review(
     system_prompt=review_system_prompt(),
     task=review_task(base, scratch_dir),
     tools=captured => {
-      @agent_tool.Tools([
+      Tools([
         @read.definition(workspace_root~),
         @mbtx.definition(workspace_root~, read_only=true, scratch_dir?),
         submit_review_tool(captured),

--- a/agent_subrun/host/host_test.mbt
+++ b/agent_subrun/host/host_test.mbt
@@ -4,7 +4,7 @@
 /// engine's counter; starting it above zero stands in for a resumed session
 /// whose floor an earlier process already pushed up.
 fn injection(issued : Ref[Int], model? : String) -> @host.SubrunInjection {
-  @host.SubrunInjection(
+  SubrunInjection(
     exe="/opt/openseek",
     session_root="/store",
     parent="run7",

--- a/agent_subrun/injection.mbt
+++ b/agent_subrun/injection.mbt
@@ -22,7 +22,7 @@ pub fn ChildSession::injection(
   api_url? : String,
 ) -> @host.SubrunInjection {
   let first_free = self.first_free
-  @host.SubrunInjection(
+  SubrunInjection(
     exe~,
     session_root=self.root,
     parent=self.parent,

--- a/agent_workflow/subrun_runner.mbt
+++ b/agent_workflow/subrun_runner.mbt
@@ -35,7 +35,7 @@ pub fn subrun_runner(
   extra_env? : Map[String, String],
   map_launch? : (@spawn.LaunchSpec, @workflow.AgentCall) -> @spawn.LaunchSpec,
 ) -> @workflow.Runner {
-  @workflow.Runner(call => {
+  Runner(call => {
     let canonical : @spawn.LaunchSpec = {
       command: exe,
       args: subrun_args(call, model, api_url),

--- a/agent_workflow/subrun_runner_test.mbt
+++ b/agent_workflow/subrun_runner_test.mbt
@@ -121,7 +121,7 @@ async test "a child that dies without a report fails typed WITH its cost" {
     #|printf '{"event":"usage","usage":{"prompt_tokens":90,"completion_tokens":10,"total_tokens":100,"prompt_cache_hit_tokens":0,"prompt_cache_miss_tokens":90}}\n'
   let wf = @workflow.Workflow(runner=scripted_subrun(script))
   guard @workflow.attempt(() => wf.agent(prompt="q", kind="explore"))
-    is Err(@workflow.AgentFailed(failure=NoReport, ..)) else {
+    is Err(AgentFailed(failure=NoReport, ..)) else {
     fail("expected a typed NoReport failure")
   }
   // The doomed child's spend still lands in the budget — the lossless
@@ -140,7 +140,7 @@ async test "an observed step exhaustion maps to MaxSteps" {
     #|printf '{"event":"max_steps_exhausted"}\n'
   let wf = @workflow.Workflow(runner=scripted_subrun(script))
   guard @workflow.attempt(() => wf.agent(prompt="q", kind="explore"))
-    is Err(@workflow.AgentFailed(failure=MaxSteps, ..)) else {
+    is Err(AgentFailed(failure=MaxSteps, ..)) else {
     fail("expected a typed MaxSteps failure")
   }
 }
@@ -155,10 +155,10 @@ async test "a spawn failure maps to Failed with a zero-cost attempt" {
     journal=@workflow.Journal::in_memory(),
   )
   match @workflow.attempt(() => wf.agent(prompt="q", kind="explore")) {
-    Err(@workflow.AgentFailed(failure=Failed(_), ..)) => ()
+    Err(AgentFailed(failure=Failed(_), ..)) => ()
     // Some sandboxes surface spawn refusal as an immediate empty exit:
     // accept NoReport there, but never a success or a crash.
-    Err(@workflow.AgentFailed(failure=NoReport, ..)) => ()
+    Err(AgentFailed(failure=NoReport, ..)) => ()
     _ => fail("expected the missing binary to fail typed")
   }
   assert_eq(wf.tokens_spent(), 0)

--- a/agent_workflow/worker_runner.mbt
+++ b/agent_workflow/worker_runner.mbt
@@ -40,7 +40,7 @@ pub fn openseek_runner(
     map_launch?,
   )
   let worker_slots : @async.Semaphore = Semaphore(max_workers)
-  @workflow.Runner(
+  Runner(
     call => {
       if call.kind == "worker" {
         worker_slots.acquire()

--- a/agent_workflow/worker_test.mbt
+++ b/agent_workflow/worker_test.mbt
@@ -33,7 +33,7 @@ fn worker_workflow(
   script : String,
   journal? : @workflow.Journal,
 ) -> @workflow.Workflow raise {
-  @workflow.Workflow(
+  Workflow(
     runner=@agent_workflow.openseek_runner(
       exe="unused",
       workspace_root=repo,
@@ -108,7 +108,7 @@ async test "an out-of-bounds edit is not mergeable and can be discarded" {
       task="edit outside the slice",
       allowed_paths=["src/"],
     )
-    is Err(@workflow.AgentFailed(failure=Failed(reason), ..)) else {
+    is Err(AgentFailed(failure=Failed(reason), ..)) else {
     fail("expected the out-of-bounds slice to fail typed")
   }
   assert_true(reason.contains("not mergeable"))
@@ -136,7 +136,7 @@ async test "overlapping slices are refused before any child spawns" {
   guard @agent_workflow.try_worker(wf, name="second", task="also edit src", allowed_paths=[
       "src/",
     ])
-    is Err(@workflow.AgentFailed(failure=Failed(reason), ..)) else {
+    is Err(AgentFailed(failure=Failed(reason), ..)) else {
     fail("expected the overlapping slice to be refused")
   }
   assert_true(reason.contains("provision"))
@@ -252,7 +252,7 @@ async test "a dead child cannot become a clean-tree success" {
   guard @agent_workflow.try_worker(wf, name="doomed", task="edit src", allowed_paths=[
       "src/",
     ])
-    is Err(@workflow.AgentFailed(..)) else {
+    is Err(AgentFailed(..)) else {
     fail("a spawn failure must never look like a completed slice")
   }
 }
@@ -269,12 +269,12 @@ async test "blank tasks and empty allowed_paths are refused pre-provision" {
   guard @agent_workflow.try_worker(wf, name="blank", task="  ", allowed_paths=[
       "src/",
     ])
-    is Err(@workflow.AgentFailed(failure=Failed(task_reason), ..)) else {
+    is Err(AgentFailed(failure=Failed(task_reason), ..)) else {
     fail("expected the blank task to be refused")
   }
   assert_true(task_reason.contains("task"))
   guard @agent_workflow.try_worker(wf, name="pathless", task="edit", allowed_paths=[])
-    is Err(@workflow.AgentFailed(failure=Failed(path_reason), ..)) else {
+    is Err(AgentFailed(failure=Failed(path_reason), ..)) else {
     fail("expected the empty allowed_paths to be refused")
   }
   assert_true(path_reason.contains("allowed_paths"))
@@ -354,7 +354,7 @@ async test "an invalid report shape fails the slice at the trust boundary" {
   guard @agent_workflow.try_worker(wf, name="garbled", task="edit src", allowed_paths=[
       "src/",
     ])
-    is Err(@workflow.AgentFailed(failure=Failed(reason), ..)) else {
+    is Err(AgentFailed(failure=Failed(reason), ..)) else {
     fail("expected the garbled report to fail the slice")
   }
   assert_true(reason.contains("salvaged commit"))
@@ -375,7 +375,7 @@ async test "a clean no-op the child disclaims is a failure" {
   guard @agent_workflow.try_worker(wf, name="gave-up", task="edit src", allowed_paths=[
       "src/",
     ])
-    is Err(@workflow.AgentFailed(failure=Failed(reason), ..)) else {
+    is Err(AgentFailed(failure=Failed(reason), ..)) else {
     fail("expected the disclaimed no-op to be a failure")
   }
   assert_true(reason.contains("reported failure"))
@@ -400,7 +400,7 @@ async test "a typed terminal with salvage names the salvaged commit" {
   guard @agent_workflow.try_worker(wf, name="truncated", task="edit src", allowed_paths=[
       "src/",
     ])
-    is Err(@workflow.AgentFailed(failure=Failed(reason), ..)) else {
+    is Err(AgentFailed(failure=Failed(reason), ..)) else {
     fail("expected the truncated slice to fail with salvage visibility")
   }
   assert_true(reason.contains("salvaged commit"))

--- a/desktop/frontend/fileeditor/feedback/service.mbt
+++ b/desktop/frontend/fileeditor/feedback/service.mbt
@@ -36,9 +36,9 @@ struct DesktopFeedbackService {
 ///|
 pub fn DesktopFeedbackService::DesktopFeedbackService() -> DesktopFeedbackService {
   {
-    did_change_feedback: @common.Emitter(),
-    did_change_navigation: @common.Emitter(),
-    did_add_feedback: @common.Emitter(),
+    did_change_feedback: Emitter(),
+    did_change_navigation: Emitter(),
+    did_add_feedback: Emitter(),
     did_submit_feedback: Emitter(),
     items_by_resource: Map([]),
     navigation_anchor_by_resource: Map([]),
@@ -52,7 +52,7 @@ pub fn DesktopFeedbackService::DesktopFeedbackService() -> DesktopFeedbackServic
 pub fn DesktopFeedbackService::agent_feedback_handle(
   self : DesktopFeedbackService,
 ) -> @agent_feedback_api.AgentFeedbackHandle {
-  @agent_feedback_api.AgentFeedbackHandle(
+  AgentFeedbackHandle(
     on_did_change_feedback=listener => self.did_change_feedback.event(listener),
     on_did_change_navigation=listener => {
       self.did_change_navigation.event(listener)
@@ -197,8 +197,8 @@ pub fn DesktopFeedbackService::add_feedback(
   resource : @common.Uri,
   range : @common.Range,
   text : String,
-  kind? : @agent_feedback_api.AgentFeedbackKind = @agent_feedback_api.UserReview,
-  state? : @agent_feedback_api.AgentFeedbackState = @agent_feedback_api.Accepted,
+  kind? : @agent_feedback_api.AgentFeedbackKind = UserReview,
+  state? : @agent_feedback_api.AgentFeedbackState = Accepted,
 ) -> @agent_feedback_api.AgentFeedback {
   let feedback : @agent_feedback_api.AgentFeedback = {
     id: "viewer-feedback-" + self.next_feedback_handle.to_string(),
@@ -214,7 +214,7 @@ pub fn DesktopFeedbackService::add_feedback(
   let has_existing_for_file = !items.is_empty()
   items.push(feedback)
   self.handle_items_changed(resource)
-  if state == @agent_feedback_api.Accepted {
+  if state == Accepted {
     self.did_add_feedback.fire({
       feedback,
       has_existing_feedback_for_file: has_existing_for_file,
@@ -233,10 +233,10 @@ fn DesktopFeedbackService::accept_feedback(
   guard self.feedback_by_id(resource, feedback_id) is Some(existing) else {
     return
   }
-  guard existing.state == @agent_feedback_api.Created else { return }
+  guard existing.state == Created else { return }
   let updated : @agent_feedback_api.AgentFeedback = {
     ..existing,
-    state: @agent_feedback_api.Accepted,
+    state: Accepted,
   }
   self.replace_item(resource, updated)
 }

--- a/desktop/frontend/fileeditor/feedback/service_test.mbt
+++ b/desktop/frontend/fileeditor/feedback/service_test.mbt
@@ -10,11 +10,7 @@ test "Desktop feedback backing connects host controls to the Viewer handle" {
   handle.on_did_change_feedback(_event => changes.val += 1) |> ignore
   service.set_feedback_enabled(resource, true)
   assert_true(handle.is_feedback_enabled(resource))
-  let item = handle.add_feedback(
-    resource,
-    @common.Range(2, 1, 2, 5),
-    "rename this",
-  )
+  let item = handle.add_feedback(resource, Range(2, 1, 2, 5), "rename this")
   assert_eq(added.val, Some(item.id))
   assert_eq(handle.get_feedback(resource).length(), 1)
   assert_true(changes.val >= 2)
@@ -34,9 +30,9 @@ test "Desktop feedback backing implements every stateful handle mutation" {
   let handle = service.agent_feedback_handle()
   let item = handle.add_feedback(
     resource,
-    @common.Range(4, 2, 4, 8),
+    Range(4, 2, 4, 8),
     "draft",
-    state=@agent_feedback_api.Created,
+    state=Created,
   )
   handle.accept_feedback(resource, item.id)
   handle.update_feedback(resource, item.id, "reworded")
@@ -45,7 +41,7 @@ test "Desktop feedback backing implements every stateful handle mutation" {
   let stored = handle.get_feedback(resource).get(0)
   assert_eq(stored.map(item => item.text), Some("reworded"))
   assert_eq(stored.map(item => item.replies), Some(["done"]))
-  assert_eq(stored.map(item => item.state), Some(@agent_feedback_api.Submitted))
+  assert_eq(stored.map(item => item.state), Some(Submitted))
   assert_eq(submitted_ids.val, [item.id])
   let navigation_id = "agentFeedback:" + item.id
   handle.set_navigation_anchor(resource, Some(navigation_id))

--- a/inspect/main.mbt
+++ b/inspect/main.mbt
@@ -405,7 +405,7 @@ async fn build_export_html(
   let sessions : Array[@viz_export.Session] = []
   for row in rows {
     sessions.push(
-      @viz_export.Session(
+      Session(
         key=row.key,
         id=row.id,
         root=row.root,

--- a/inspect/main_wbtest.mbt
+++ b/inspect/main_wbtest.mbt
@@ -254,7 +254,7 @@ async test "session_catalog serves a direct store named like the root marker" {
 async test "session_catalog serves a non-marker direct store without duplicates" {
   @vfs.with_tmpdir(prefix="openseek-viz-non-marker-store-", root => {
     let store = @store.SessionStore("\{root}/store")
-    store.create(@agent_session.Session(SessionId("only"), system_prompt=""))
+    store.create(Session(SessionId("only"), system_prompt=""))
     let catalog = session_catalog("\{root}/store", [], ".openseek")
     let rows = catalog.rows()
     guard rows is [row] else { fail("expected one direct-store row") }
@@ -267,9 +267,7 @@ async test "session_catalog serves a non-marker direct store without duplicates"
 async test "session listing uses jsonl files and ignores junk entries" {
   @vfs.with_tmpdir(prefix="openseek-viz-flat-jsonl-", root => {
     let source_store = @store.SessionStore("\{root}/source/.openseek")
-    source_store.create(
-      @agent_session.Session(SessionId("flat-a"), system_prompt=""),
-    )
+    source_store.create(Session(SessionId("flat-a"), system_prompt=""))
     source_store.create(
       @agent_session.Session(SessionId("flat-b"), system_prompt="").append(
         User(UserMessage("copied prompt")),
@@ -317,9 +315,7 @@ async test "session listing uses jsonl files and ignores junk entries" {
 async test "session_catalog serves a direct directory of copied jsonl files" {
   @vfs.with_tmpdir(prefix="openseek-viz-jsonl-dir-", root => {
     let source_store = @store.SessionStore("\{root}/source/.openseek")
-    source_store.create(
-      @agent_session.Session(SessionId("copied"), system_prompt=""),
-    )
+    source_store.create(Session(SessionId("copied"), system_prompt=""))
     let copied_dir = "\{root}/copied"
     @fs.mkdir(copied_dir, recursive=true)
     @fs.write_file(
@@ -343,9 +339,7 @@ async test "session_catalog serves a direct directory of copied jsonl files" {
 async test "session_catalog serves marker-named copied jsonl directories" {
   @vfs.with_tmpdir(prefix="openseek-viz-marker-jsonl-", root => {
     let source_store = @store.SessionStore("\{root}/source/.openseek")
-    source_store.create(
-      @agent_session.Session(SessionId("marker-copy"), system_prompt=""),
-    )
+    source_store.create(Session(SessionId("marker-copy"), system_prompt=""))
     let copied_dir = "\{root}/.openseek"
     @fs.mkdir(copied_dir, recursive=true)
     @fs.write_file(
@@ -365,12 +359,8 @@ async test "session catalog lookup supports stable and legacy keys" {
   @vfs.with_tmpdir(prefix="openseek-viz-lookup-", root => {
     let app_store = @store.SessionStore("\{root}/app/.openseek")
     let lib_store = @store.SessionStore("\{root}/lib/.openseek")
-    app_store.create(
-      @agent_session.Session(SessionId("legacy"), system_prompt=""),
-    )
-    lib_store.create(
-      @agent_session.Session(SessionId("demo"), system_prompt=""),
-    )
+    app_store.create(Session(SessionId("legacy"), system_prompt=""))
+    lib_store.create(Session(SessionId("demo"), system_prompt=""))
     let catalog : SessionCatalog = {
       roots: [
         marker_root(root, "app/.openseek"),
@@ -390,9 +380,7 @@ async test "session catalog lookup supports stable and legacy keys" {
     }
     inspect(row.root, content="\{root}/lib/.openseek")
     inspect(row.id, content="demo")
-    app_store.create(
-      @agent_session.Session(SessionId("newer"), system_prompt=""),
-    )
+    app_store.create(Session(SessionId("newer"), system_prompt=""))
     guard catalog.lookup(demo_key) is Some(row) else {
       fail("expected stable key lookup after file addition")
     }
@@ -414,12 +402,8 @@ async test "session_list_reply includes root metadata and stable keys" {
   @vfs.with_tmpdir(prefix="openseek-viz-list-", root => {
     let app_store = @store.SessionStore("\{root}/app/.openseek")
     let lib_store = @store.SessionStore("\{root}/lib/.openseek")
-    app_store.create(
-      @agent_session.Session(SessionId("same"), system_prompt="a"),
-    )
-    lib_store.create(
-      @agent_session.Session(SessionId("same"), system_prompt="b"),
-    )
+    app_store.create(Session(SessionId("same"), system_prompt="a"))
+    lib_store.create(Session(SessionId("same"), system_prompt="b"))
     let catalog : SessionCatalog = {
       roots: [
         marker_root(root, "app/.openseek"),

--- a/mcp/client_test.mbt
+++ b/mcp/client_test.mbt
@@ -126,7 +126,7 @@ fn[X] fake_client(
   let rpc = @jsonrpc.Client(transport)
   spawn_client(group, rpc)
   spawn_server(group, transport, reply)
-  @mcp.McpClient(rpc)
+  McpClient(rpc)
 }
 
 ///|

--- a/mcp/tools/tools.mbt
+++ b/mcp/tools/tools.mbt
@@ -157,7 +157,7 @@ pub async fn[X] build_grouped(
       seen[name] = ()
       total += 1
       mine.push(
-        @agent_tool.AgentToolDefinition(
+        AgentToolDefinition(
           name~,
           description=tool.description,
           schema=tool.schema,
@@ -190,7 +190,7 @@ async fn[X] connect_server(
       // A stdio server runs in the agent's workspace, not openseek's invocation
       // directory, so cwd-sensitive servers and relative args target the same
       // tree the built-in tools do.
-      @config.Stdio(command~, args~, env~, ..) =>
+      Stdio(command~, args~, env~, ..) =>
         @stdio.connect(
           scope.group(),
           command~,
@@ -200,7 +200,7 @@ async fn[X] connect_server(
           client_name~,
           client_version~,
         ).client()
-      @config.Http(url~, headers~, ..) =>
+      Http(url~, headers~, ..) =>
         @streamhttp.connect(
           scope.group(),
           url~,
@@ -268,11 +268,11 @@ fn bridge_tool(
   } else {
     { "type": "object" }
   }
-  @agent_tool.AgentToolDefinition(
+  AgentToolDefinition(
     name=tool_name(server, tool.name),
     description~,
-    schema=@agent_tool.JsonSchema(schema),
-    execute=@agent_tool.Async(args => call_tool(client, tool.name, args)),
+    schema=JsonSchema(schema),
+    execute=Async(args => call_tool(client, tool.name, args)),
   )
 }
 

--- a/mcp/tools/tools_test.mbt
+++ b/mcp/tools/tools_test.mbt
@@ -118,7 +118,7 @@ async test "tools_for_client bridges tools with namespaced names and schemas" {
     assert_eq(tools.length(), 1)
     assert_eq(tools[0].name, "mcp__srv__echo")
     assert_eq(tools[0].description, "Echoes")
-    let @agent_tool.JsonSchema(schema) = tools[0].schema
+    let JsonSchema(schema) = tools[0].schema
     assert_true(schema is { "type": "object", .. })
     // The control flag is a built-in-only privilege: the ceiling salvage
     // executes control-registered calls sight-unseen, so a server-supplied
@@ -135,10 +135,10 @@ async test "a bridged tool proxies tools/call and returns the result" {
     wire(group, transport, rpc)
     let client = @mcp.McpClient(rpc)
     let tools = @tools.tools_for_client("srv", client)
-    guard tools[0].execute is @agent_tool.Async(exec) else {
+    guard tools[0].execute is Async(exec) else {
       fail("expected an async executor")
     }
-    guard exec({ "text": "hi" }) is @agent_tool.Respond(output) else {
+    guard exec({ "text": "hi" }) is Respond(output) else {
       fail("expected a respond action")
     }
     assert_false(output.is_error)
@@ -323,10 +323,10 @@ async test "build bridges and dispatches tools from an http server" {
     assert_eq(tools[0].name, "mcp__remote__ping")
     // Full production path (build -> build_grouped re-wrap): still no control.
     assert_false(tools[0].is_control())
-    guard tools[0].execute is @agent_tool.Async(exec) else {
+    guard tools[0].execute is Async(exec) else {
       fail("expected an async executor")
     }
-    guard exec(Json::empty_object()) is @agent_tool.Respond(output) else {
+    guard exec(Json::empty_object()) is Respond(output) else {
       fail("expected a respond action")
     }
     assert_false(output.is_error)

--- a/moon.mod
+++ b/moon.mod
@@ -24,7 +24,7 @@ description = "DeepSeek-backed MoonBit coding agent"
 
 preferred_target = "native"
 
-warnings = "+missing_doc+unnecessary_view_op+test_unqualified_package+unused_default_value+implicit_impl_as_method+unused_optional_argument"
+warnings = "+missing_doc+unnecessary_view_op+test_unqualified_package+unused_default_value+implicit_impl_as_method+unused_optional_argument+unnecessary_annotation"
 
 rule(
   name: "md_to_mbt_string",


### PR DESCRIPTION
## What

Fixes all `moon check` warnings in the `unnecessary_annotation` class (E0073)
across the workspace, then enables the warning module-wide so `moon check`
stays at zero. The editor's deny-warn gate already enforces this warning via
`--warn-list +73`; the root workspace config did not.

## Changes

- Drop 63 redundant `@pkg.` qualifiers (20 files) where the annotated name is
  already in scope unqualified: `agent_*`, `mcp`, `inspect`, and
  `desktop/frontend/fileeditor/feedback`.
- Enable `+unnecessary_annotation` in the root `moon.mod` `warnings` line.

## Validation

- `moon check --target native|js|wasm --deny-warn` (root CI gates): clean.
- `moon check --target all --warn-list +73 --deny-warn` (editor gate): clean.
- `moon check --warn-list +73` from root/editor/desktop/inspect anchors:
  zero code-73 warnings.
- `moon fmt --check`: clean; `moon info`: no `.mbti` changes (internal-only).
- Targeted tests pass: mcp 23/23, agent_kind 6/6, agent_workflow 20/20,
  agent_explore 9/9, agent_review 12/12, agent_subrun 23/23,
  inspect 23/23 (wasm), desktop feedback 2/2.

Generated with SeekMoon