### PR TITLE
fix(desktop): default unlabelled code blocks to MoonBit

### DIFF
--- a/desktop/e2e/tests/transcript_highlighting.spec.js
+++ b/desktop/e2e/tests/transcript_highlighting.spec.js
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test';
+import { DesktopBrowserHarness } from './support/desktop_browser_harness.js';
+
+for (const language of ['', 'mbt']) {
+  test(`reasoning highlights ${language || 'unlabelled'} code only after completion`, async ({ page }) => {
+    const app = new DesktopBrowserHarness(page);
+    app.sessionEvents = [{
+      sequence: 1,
+      item: { kind: 'user', payload: { content: 'Show the browser fixture code' } },
+    }];
+    await app.install();
+    await app.goto();
+    await app.openSession();
+    const run = { run_id: 'highlight-run', session: 'session-1' };
+    app.notify('agent.started', {
+      ...run, session_root: '/workspace/.openseek', model: 'deepseek-v4-pro', max_steps: 1000,
+    });
+    const content = `\`\`\`${language}\nlet answer = 42\n\`\`\``;
+    app.notify('agent.event', { ...run, event: { event: 'reasoning_delta', content } });
+    const thought = page.locator('#transcript .work-thinking');
+    await thought.locator(':scope > summary').click();
+    const body = thought.locator('.work-thinking-body');
+    // Even a closed fence stays raw while more reasoning can arrive.
+    await expect(body).toHaveText(content);
+    await expect(body.locator('pre, code, [class^="mtk"]')).toHaveCount(0);
+    app.notify('agent.event', {
+      ...run, event: { event: 'reasoning_message', content },
+    });
+    await expect(body.locator('pre.moonbit-source code')).toHaveText('let answer = 42');
+    await expect(body.locator('span[class^="mtk"]').first()).toBeVisible();
+    // Further answer deltas must retain the completed reasoning's colors.
+    app.notify('agent.event', {
+      ...run, event: { event: 'assistant_delta', content: 'The answer is 42.' },
+    });
+    await expect(body.locator('pre.moonbit-source code')).toHaveText('let answer = 42');
+    expect(app.pageErrors).toEqual([]);
+  });
+}
+
+test('saved reasoning and answers default unlabelled code to MoonBit', async ({ page }) => {
+  const app = new DesktopBrowserHarness(page);
+  const content = [
+    '```\nlet answer = 42\n```',
+    '    let indented = 7',
+    '```javascript\nconst explicit = 1;\n```',
+  ].join('\n\n');
+  app.sessionEvents = [
+    { sequence: 1, item: { kind: 'user', payload: { content: 'Show the browser fixture code' } } },
+    { sequence: 2, item: { kind: 'assistant', payload: { content, reasoning_content: content } } },
+  ];
+  await app.install();
+  await app.goto();
+  await app.openSession();
+  for (const selector of ['.work-thinking-body', '.msg .msg-content']) {
+    const body = page.locator('#transcript').locator(selector);
+    await expect(body.locator('pre.moonbit-source')).toHaveCount(2);
+    await expect(body.locator('pre.moonbit-source').first().locator('span[class^="mtk"]').first()).toHaveText('let');
+    await expect(body.locator('code.language-javascript')).toHaveText('const explicit = 1;');
+    await expect(body.locator('code.language-javascript span')).toHaveCount(0);
+  }
+  expect(app.pageErrors).toEqual([]);
+});

--- a/desktop/frontend/markdown/markdown.mbt
+++ b/desktop/frontend/markdown/markdown.mbt
@@ -112,13 +112,15 @@ fn lines_text(lines : @cmark.Seq[@cmark.Node[String]]) -> String {
 ///|
 #warnings("-alert_xss_vulnerable")
 fn code_block(block : @cmark.CodeBlock) -> @html.Html {
+  // Unlabelled fences and indented code use MoonBit by default, including
+  // code inside completed reasoning. Explicit language labels still win.
   let language = match block.info_string {
     Some(info) =>
       match @cmark.CodeBlock::language_of_info_string(info.v) {
         Some((language, _)) => language
-        None => ""
+        None => "mbt"
       }
-    None => ""
+    None => "mbt"
   }
   let source = lines_text(block.code)
   // cmark also parses unfinished fences as code blocks. Only compile closed

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -31,6 +31,8 @@ fn assistant_view(
         ]),
         @html.div(
           class="work-thinking-body msg-content markdown",
+          // Keep growing reasoning as text; Markdown parsing and MoonBit
+          // tokenization start only once the reasoning is complete.
           if live && !reasoning_complete {
             [@html.text(text)]
           } else {


### PR DESCRIPTION
Unlabelled code blocks in transcript Markdown now default to MoonBit highlighting, including code in completed reasoning. Explicit language labels retain their existing behavior.

Preserve the existing completion gate: reasoning remains plain text while streaming, even when it contains a closed code fence, and receives Markdown rendering and syntax colors after completion. Add browser regressions for this transition, saved reasoning and answers, indented code, and explicit JavaScript fences.

Validation:
- `moon info` and `moon fmt`; no public interface changes.
- `just check` and `just build` passed.
- `just test` passed: 3267 native tests, 3233 JS tests, 24 cram cases, and CLI lifecycle checks. Run outside the sandbox with Git signing disabled only for test fixtures.
- Three Playwright cases in `transcript_highlighting.spec.js` passed against the built browser app.
