### PR TITLE
refactor: use strip_prefix/strip_suffix instead of has_* plus manual slices

### DIFF
--- a/agent_tool/mbtx/filename.mbt
+++ b/agent_tool/mbtx/filename.mbt
@@ -10,12 +10,12 @@ fn resolve_filename(
   references : String?,
 ) -> String raise {
   if filename.has_prefix("@") {
-    guard is_bundled_filename(filename) else {
+    guard filename.strip_prefix("@builtin/") is Some(name_view) else {
       fail(
         "unknown script namespace in \{filename}. Only @builtin/ is supported. Use ./\{filename} for a literal workspace path",
       )
     }
-    let name = filename[9:].to_owned()
+    let name = name_view.to_owned()
     guard !name.is_empty() &&
       !name.contains("\\") &&
       name

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -951,9 +951,14 @@ async fn prepare_workspace_root(
 ///|
 fn trim_trailing_path_separators(path : String) -> String {
   let mut result = path
-  while !is_path_root(result) &&
-        (result.has_suffix("/") || result.has_suffix("\\")) {
-    result = result[:result.length() - 1].to_owned()
+  while !is_path_root(result) {
+    if result.strip_suffix("/") is Some(rest) {
+      result = rest.to_owned()
+    } else if result.strip_suffix("\\") is Some(rest) {
+      result = rest.to_owned()
+    } else {
+      break
+    }
   }
   result
 }

--- a/desktop/frontend/quick_open/types.mbt
+++ b/desktop/frontend/quick_open/types.mbt
@@ -211,7 +211,11 @@ fn Open::current(self : Open) -> Item? {
 ///|
 /// Rewrite only the provider prefix, preserving the visible query suffix.
 fn value_for_provider(value : String, provider : Provider) -> String {
-  let suffix = if value.has_prefix("#") { value[1:].to_owned() } else { value }
+  let suffix = if value.strip_prefix("#") is Some(rest) {
+    rest.to_owned()
+  } else {
+    value
+  }
   provider.prefix() + suffix
 }
 

--- a/desktop/frontend/skills/document.mbt
+++ b/desktop/frontend/skills/document.mbt
@@ -16,8 +16,8 @@ fn parse_skill_document(source : String) -> SkillDocument {
     return { metadata: [], body: source, }
   }
   let first = first.trim()
-  let first = if first.has_prefix("\u{feff}") {
-    first[1:].trim()
+  let first = if first.strip_prefix("\u{feff}") is Some(rest) {
+    rest.trim()
   } else {
     first
   }

--- a/desktop/internal/host/semantic_search.mbt
+++ b/desktop/internal/host/semantic_search.mbt
@@ -282,8 +282,8 @@ fn normalize_semantic_path(path : String) -> String {
   } else {
     path
   }
-  if path.has_prefix("./") {
-    path[2:].to_owned()
+  if path.strip_prefix("./") is Some(rest) {
+    rest.to_owned()
   } else {
     path
   }
@@ -360,11 +360,11 @@ fn semantic_glob_matches(pattern : String, path : String) -> Bool {
 fn semantic_path_matches_globs(path : String, value : String) -> Bool {
   for glob in expand_text_search_view_globs(value) {
     for expanded in expand_text_search_braces(glob) {
-      if semantic_glob_matches(expanded, path) ||
-        (
-          expanded.has_prefix("**/") &&
-          semantic_glob_matches(expanded[3:].to_owned(), path)
-        ) {
+      if semantic_glob_matches(expanded, path) {
+        return true
+      }
+      if expanded.strip_prefix("**/") is Some(rest) &&
+        semantic_glob_matches(rest.to_owned(), path) {
         return true
       }
     }

--- a/desktop/internal/host/text_search.mbt
+++ b/desktop/internal/host/text_search.mbt
@@ -743,8 +743,8 @@ fn normalize_text_search_path(path : String) -> String {
   } else {
     path
   }
-  if path.has_prefix("./") {
-    path[2:].to_owned()
+  if path.strip_prefix("./") is Some(rest) {
+    rest.to_owned()
   } else {
     path
   }

--- a/editor/internal/shell/widgets/file_tree/tree_state.mbt
+++ b/editor/internal/shell/widgets/file_tree/tree_state.mbt
@@ -191,10 +191,10 @@ fn TreeNode::ancestor_uris(
 ) -> Array[@base_common.Uri]? {
   let root_raw = self.uri.to_string()
   let target_raw = target.to_string()
-  if !target_raw.has_prefix("\{root_raw}/") {
+  guard target_raw.strip_prefix("\{root_raw}/") is Some(relative_view) else {
     return None
   }
-  let relative = target_raw[root_raw.length() + 1:].to_owned()
+  let relative = relative_view.to_owned()
   let ancestors : Array[@base_common.Uri] = []
   let mut prefix = root_raw
   let segments = []

--- a/editor/internal/viewer/browser/markdown_document/markdown_document.mbt
+++ b/editor/internal/viewer/browser/markdown_document/markdown_document.mbt
@@ -312,12 +312,14 @@ fn render_semantic_tokenized_code_lines(
 ) -> String {
   let prefix = "<div class=\"monaco-tokenized-source\">"
   let suffix = "</div>"
-  guard tokenized.has_prefix(prefix) &&
-    tokenized.has_suffix(suffix) &&
-    tokenized.length() >= prefix.length() + suffix.length() else {
-    return tokenized
+  let inner = match tokenized.strip_prefix(prefix) {
+    Some(body) =>
+      match body.strip_suffix(suffix) {
+        Some(inner_view) => inner_view.to_owned()
+        None => return tokenized
+      }
+    None => return tokenized
   }
-  let inner = tokenized[prefix.length():tokenized.length() - suffix.length()].to_owned()
   let rendered_lines = split_tokenized_code_lines(inner)
   // `MarkdownCodeBlock::code` ends in one source newline. The shared
   // tokenizer must therefore produce exactly the projected lines plus one

--- a/editor/language/selectors.mbt
+++ b/editor/language/selectors.mbt
@@ -134,7 +134,11 @@ fn path_pattern_matches(pattern : String, path : String) -> Bool {
   if pattern == "*" {
     return true
   }
-  let path = if path.has_prefix("/") { path[1:].to_owned() } else { path }
+  let path = if path.strip_prefix("/") is Some(rest) {
+    rest.to_owned()
+  } else {
+    path
+  }
   match pattern.split_once("*") {
     Some((prefix, suffix)) => path.has_prefix(prefix) && path.has_suffix(suffix)
     None => path == pattern

--- a/editor/server/host/language_provider.mbt
+++ b/editor/server/host/language_provider.mbt
@@ -219,8 +219,8 @@ fn definition_uri_under_root(
   let root = normalize_host_path(root)
   let path = normalize_host_path(raw_path)
   let root_prefix = if root == "/" { "/" } else { "\{root}/" }
-  let relative = if path.has_prefix(root_prefix) {
-    path[root_prefix.length():].to_owned()
+  let relative = if path.strip_prefix(root_prefix) is Some(rest) {
+    rest.to_owned()
   } else if path.has_prefix("/") {
     return None
   } else {

--- a/editor/server/host/moon_check.mbt
+++ b/editor/server/host/moon_check.mbt
@@ -287,10 +287,10 @@ fn parse_moon_check_diagnostics_impl(
         }
       ) => {
         let normalized = normalize_host_path(path)
-        if !normalized.has_prefix(prefix) {
-          continue
+        let relative = match normalized.strip_prefix(prefix) {
+          Some(rest) => rest.to_owned()
+          None => continue
         }
-        let relative = normalized[prefix.length():].to_owned()
         match (parse_moon_loc(loc), @server.remote_document_uri(relative)) {
           (Some(range), Some(uri)) => {
             let diagnostic : @language.Diagnostic = {

--- a/editor/server/host/native_host.mbt
+++ b/editor/server/host/native_host.mbt
@@ -224,10 +224,9 @@ fn workspace_file_path(root : String, path : @workspace.SourcePath) -> String {
 ///|
 fn normalize_host_path(path : String) -> String {
   let normalized = path.replace_all(old="\\", new="/")
-  if normalized.has_suffix("/") && normalized.length() > 1 {
-    normalized[0:normalized.length() - 1].to_owned()
-  } else {
-    normalized
+  match normalized.strip_suffix("/") {
+    Some(rest) if normalized.length() > 1 => rest.to_owned()
+    _ => normalized
   }
 }
 
@@ -640,8 +639,11 @@ fn mermaid_static_route(path : String) -> (String, String)? {
     return Some(("mermaid/LICENSE", "text/plain; charset=utf-8"))
   }
   let prefix = "/mermaid/chunks/mermaid.esm.min/"
-  guard path.has_prefix(prefix) && path.has_suffix(".mjs") else { return None }
-  let name = path[prefix.length():]
+  let name = match path.strip_prefix(prefix) {
+    Some(rest) => rest
+    None => return None
+  }
+  guard name.has_suffix(".mjs") else { return None }
   guard !name.is_empty() &&
     name.all(char => {
       char.is_ascii_alphabetic() ||

--- a/editor/server/server/server.mbt
+++ b/editor/server/server/server.mbt
@@ -178,7 +178,7 @@ pub fn resolve_remote_document_uri(
 ) -> RemotePathResult {
   let raw = uri.to_string()
   let prefix = "readonly-remote://workspace/"
-  if !raw.has_prefix(prefix) {
+  guard raw.strip_prefix(prefix) is Some(relative) else {
     return RemotePathError(
       ProtocolError(
         ProtocolInvalidUri,
@@ -188,9 +188,7 @@ pub fn resolve_remote_document_uri(
     )
   }
   match
-    @workspace.SourcePath::normalize_root_relative_path(
-      raw[prefix.length():].to_owned(),
-    ) {
+    @workspace.SourcePath::normalize_root_relative_path(relative.to_owned()) {
     ParsedSourcePath(path) => ParsedRemotePath(path)
     SourcePathError(error) =>
       RemotePathError(
@@ -682,10 +680,9 @@ fn RemoteServer::missing_cached_document_error(
 ///|
 fn normalize_workspace_root(root : String) -> String {
   let normalized = root.replace_all(old="\\", new="/")
-  if normalized.has_suffix("/") && normalized.length() > 1 {
-    normalized[0:normalized.length() - 1].to_owned()
-  } else {
-    normalized
+  match normalized.strip_suffix("/") {
+    Some(rest) if normalized.length() > 1 => rest.to_owned()
+    _ => normalized
   }
 }
 

--- a/mcp/streamhttp/transport.mbt
+++ b/mcp/streamhttp/transport.mbt
@@ -443,8 +443,8 @@ async fn read_sse_stream(
       }
       continue
     }
-    if line.has_prefix("data:") {
-      let payload = line[5:].trim(chars=" ").to_owned()
+    if line.strip_prefix("data:") is Some(content) {
+      let payload = content.trim(chars=" ").to_owned()
       if has_data {
         data.write_string("\n")
       }


### PR DESCRIPTION
## Summary

Replaces the `has_prefix`/`has_suffix`-then-manual-slice idiom with the
`strip_prefix`/`strip_suffix` API in non-test code. A `has_*` check followed
by a slice that re-derives the prefix/suffix length is redundant work that
can silently drift (the check and the removal are two separate
expressions); `strip_*` performs the check and the removal as one
operation returning the remainder, so they can never disagree.

Sites were located with moongrep structural scans plus a same-receiver
slice scan across `.mbt` sources, then fixed one function at a time,
preserving each call's original semantics:

- `agent_tool/mbtx/filename.mbt` – resolve `@builtin/…` names with
  `strip_prefix("@builtin/")` instead of checking the prefix and slicing at
  offset 9.
- `cmd/openseek/main.mbt` – trailing path-separator trim loop now strips
  one `/` or `\` per iteration (root guard kept).
- `mcp/streamhttp/transport.mbt` – SSE `data:` payload parsed with
  `strip_prefix("data:")`.
- `editor/language/selectors.mbt` – leading `/` removed with
  `strip_prefix("/")`.
- `editor/server/server` + `editor/server/host` – workspace-root
  normalizers drop a trailing `/` with `strip_suffix("/")` (the
  `length() > 1` root guard kept via a match guard); the moon-check
  diagnostic rebasing uses `strip_prefix(prefix)`; the mermaid static
  route and the remote-document URI resolver use `strip_prefix`.
- `desktop/frontend/skills/document.mbt` – BOM removal with
  `strip_prefix("\u{feff}")`.
- `desktop/frontend/quick_open/types.mbt` – provider `#` prefix rewritten
  with `strip_prefix("#")`.
- `desktop/internal/host/text_search.mbt` & `semantic_search.mbt` – `./`
  prefix stripping and the `**/` glob fallback now use `strip_prefix`.
- `editor/internal/shell/widgets/file_tree/tree_state.mbt` – root-relative
  derivation uses `strip_prefix(root + "/")`.
- `editor/internal/viewer/browser/markdown_document/markdown_document.mbt`
  – tokenized wrapper inner text stripped with `strip_prefix` +
  `strip_suffix`.

A few `has_*` sites were inspected and intentionally left alone because
they are not prefix-length slices: colon-split comment parsing, a
reviewed tokenizer-shape guard, and a `nobreak` for-expression that
strips a repeated leading `#`.

## Verification

- `moon check --target native|js|wasm` all pass.
- Full `moon test` in a clean checkout of this branch: js green
  (3229/3229); native/wasm green apart from pre-existing local
  environment snapshot tests (`cmd/openseek` "environment section…") and
  flaky live-network tests (`web_search`, `deepseek` realworld) that fail
  identically on the pre-change baseline commit.

Generated with SeekMoon