### PR TITLE
feat(mbtx): support arguments for reusable scripts

### DIFF
--- a/agent/tool_definition.mbt
+++ b/agent/tool_definition.mbt
@@ -217,9 +217,11 @@ async test "the registry has no shell tool family" {
       fail("expected an object schema")
     }
     let names = properties.keys().collect()
-    assert_eq(names.length(), 6)
+    assert_eq(names.length(), 7)
     for
-      name in ["source", "filename", "description", "target", "cwd", "warning"] {
+      name in [
+        "source", "filename", "args", "description", "target", "cwd", "warning",
+      ] {
       assert_true(names.contains(name))
     }
     assert_false(mbtx.description.contains("run_in_background"))

--- a/agent/tool_definition.mbt
+++ b/agent/tool_definition.mbt
@@ -216,16 +216,10 @@ async test "the registry has no shell tool family" {
     guard schema is { "properties": Object(properties), .. } else {
       fail("expected an object schema")
     }
-    let names = properties.keys().collect()
-    assert_eq(names.length(), 7)
-    for
-      name in [
-        "source", "filename", "args", "description", "target", "cwd", "warning",
-      ] {
-      assert_true(names.contains(name))
-    }
-    assert_false(mbtx.description.contains("run_in_background"))
-    assert_true(mbtx.description.contains("AUTOMATICALLY"))
+    // New script options must not break this regression test. The mbtx
+    // package owns the complete schema contract; here only the removed
+    // background-mode field is relevant to the registry's shell-free API.
+    assert_false(properties.contains("run_in_background"))
   }
 }
 

--- a/agent_tool/mbtx/README.mbt.md
+++ b/agent_tool/mbtx/README.mbt.md
@@ -74,9 +74,8 @@ cancelled at that deadline.
 - `args` (array of strings, optional, default `[]`): script arguments passed
   verbatim, without shell expansion or splitting. Works with inline, saved,
   and save-and-run scripts. Import `moonbitlang/core/env` and read
-  `@env.args()[1:]` on wasm (excluding the executable name), or
-  `@env.args()[2:]` on js (excluding node and script paths). For reuse, call
-  `{"filename":"scripts/check.mbtx","args":["--target","js"]}` and vary
+  `@env.args()[1:]` on wasm (excluding the executable name). For reuse, call
+  `{"filename":"scripts/check.mbtx","args":["--deny-warn"]}` and vary
   `args` on subsequent runs. Explicit `null` and non-string elements are rejected.
 - `target` (string, optional, default `wasm`): one of `wasm`, `wasm-gc`, `js`,
   or `llvm`. The default wasm backend is the policy-bound command/IO surface;

--- a/agent_tool/mbtx/README.mbt.md
+++ b/agent_tool/mbtx/README.mbt.md
@@ -71,6 +71,13 @@ cancelled at that deadline.
   unavailable in read-only mode and obeys worker write scopes. Namespaced
   filenames cannot accompany source: bundled scripts are read-only.
   Use `source` alone for one-off snippets.
+- `args` (array of strings, optional, default `[]`): script arguments passed
+  verbatim, without shell expansion or splitting. Works with inline, saved,
+  and save-and-run scripts. Import `moonbitlang/core/env` and read
+  `@env.args()[1:]` on wasm (excluding the executable name), or
+  `@env.args()[2:]` on js (excluding node and script paths). For reuse, call
+  `{"filename":"scripts/check.mbtx","args":["--target","js"]}` and vary
+  `args` on subsequent runs. Explicit `null` and non-string elements are rejected.
 - `target` (string, optional, default `wasm`): one of `wasm`, `wasm-gc`, `js`,
   or `llvm`. The default wasm backend is the policy-bound command/IO surface;
   the other targets are intended for pure compute, reject explicit native FFI,

--- a/agent_tool/mbtx/internal/decode/README.mbt.md
+++ b/agent_tool/mbtx/internal/decode/README.mbt.md
@@ -3,7 +3,8 @@
 Argument decoding for the `mbtx` tool. `decode(Json) -> MbtxInput`
 reads `source` (a `.mbtx` program), `filename` (an existing script), or both
 (save and run a workspace script), represented by the `Program` enum. Namespaced
-filenames cannot accompany source. It also reads the optional
+filenames cannot accompany source. `args` is an optional array of strings,
+defaulting to `[]`; null and non-string elements are rejected. It also reads the optional
 `target` backend (default `wasm`, validated against
 `wasm`/`wasm-gc`/`js`/`llvm`), `cwd`, `warning`, and `escalated` fields. It names
 the offending field on failure so the error fed back to the model says exactly

--- a/agent_tool/mbtx/internal/decode/args_wbtest.mbt
+++ b/agent_tool/mbtx/internal/decode/args_wbtest.mbt
@@ -1,0 +1,29 @@
+///|
+test "script args default to empty and preserve string values" {
+  assert_eq(decode({ "source": "fn main {}" }).args, [])
+  assert_eq(decode({ "filename": "check.mbtx", "args": [] }).args, [])
+  for
+    program in [
+      Json({ "source": "fn main {}" }),
+      Json({ "filename": "check.mbtx" }),
+      Json({ "source": "fn main {}", "filename": "check.mbtx" }),
+    ] {
+    guard program is Object(fields) else { fail("expected object") }
+    fields["args"] = ["--flag", "two words", "", "你好", "$(echo nope)"]
+    assert_eq(decode(program).args, [
+      "--flag", "two words", "", "你好", "$(echo nope)",
+    ])
+  }
+}
+
+///|
+test "script args reject null and non-string values" {
+  let invalid : Array[Json] = [null, "x", 1, {}, ["ok", 3]]
+  for value in invalid {
+    try decode({ "source": "fn main {}", "args": value }) catch {
+      error => assert_true(error.to_string().contains("arguments.args"))
+    } noraise {
+      _ => fail("expected invalid args to fail")
+    }
+  }
+}

--- a/agent_tool/mbtx/internal/decode/decode.mbt
+++ b/agent_tool/mbtx/internal/decode/decode.mbt
@@ -10,6 +10,8 @@ pub enum Program {
 /// Decoded program and execution options. `None` cwd means workspace root.
 pub struct MbtxInput {
   program : Program
+  /// Script arguments, excluding the executable name. Defaults to empty.
+  args : Array[String]
   /// Presentation metadata, inherited by a background job.
   description : String?
   target : String
@@ -111,6 +113,17 @@ pub fn decode(arguments : Json) -> MbtxInput raise {
             "arguments.filename to be a string naming an existing script, for example {\"filename\":\"./check.mbtx\"}. For inline code, omit filename entirely and pass source; do not send filename: null",
           )
       }
+      let args : Array[String] = match fields.get("args") {
+        None => []
+        Some(Array(values)) =>
+          values.map(value => {
+            guard value is String(text) else {
+              fail("arguments.args to be an array of strings")
+            }
+            text
+          })
+        Some(_) => fail("arguments.args to be an array of strings")
+      }
       let description = match arguments {
         { "description": String(text), .. } => Some(text)
         { "description": Null, .. } => None
@@ -152,7 +165,7 @@ pub fn decode(arguments : Json) -> MbtxInput raise {
         { "subrun": _, .. } => fail("arguments.subrun to be a boolean")
         _ => false
       }
-      { program, description, target, cwd, warning, escalated, subrun, }
+      { program, args, description, target, cwd, warning, escalated, subrun, }
     }
     _ => fail("object arguments")
   }

--- a/agent_tool/mbtx/internal/decode/pkg.generated.mbti
+++ b/agent_tool/mbtx/internal/decode/pkg.generated.mbti
@@ -13,6 +13,7 @@ pub fn decode(Json) -> MbtxInput raise
 // Types and methods
 pub struct MbtxInput {
   program : Program
+  args : Array[String]
   description : String?
   target : String
   cwd : String?

--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -728,6 +728,7 @@ async fn execute(
           },
           artifact,
           "--",
+          ..input.args,
         ]
         Some(("moonrun", run_argv, notes))
       }
@@ -749,6 +750,8 @@ async fn execute(
         ..if !input.warning {
           ["--warn-list", WarnOffList]
         },
+        "--",
+        ..input.args,
       ],
       "",
     ),
@@ -1443,6 +1446,15 @@ fn schema(escalation~ : Bool, hosting~ : Bool) -> Json {
             },
           ),
           (
+            "args",
+            {
+              "type": "array",
+              "items": { "type": "string" },
+              "default": [],
+              "description": "Script arguments, defaulting to []. Passed verbatim after the runner's -- separator. Import moonbitlang/core/env and read @env.args()[1:] on wasm, or @env.args()[2:] on js. Works with source, filename, or both.",
+            },
+          ),
+          (
             "description",
             {
               "type": "string",
@@ -1595,6 +1607,11 @@ fn description(
     #|created. Identical existing content is reused; different content is never
     #|overwritten. Use the edit tool to change a saved script. Saving is limited
     #|to the writable workspace and is unavailable in read-only mode.
+    #|Pass `args` (an array of strings, default `[]`) to parameterize any script:
+    #|`{"filename":"scripts/check.mbtx","args":["--target","js"]}`.
+    #|Import "moonbitlang/core/env" and read `@env.args()[1:]` on the default
+    #|wasm target (`@env.args()[2:]` on js, which includes node and script paths).
+    #|Arguments are passed verbatim, without shell expansion or splitting.
     #|When OPENSEEK_REFERENCES is available, these scripts are already bundled:
     #|@builtin/check.mbtx (moon check), @builtin/test.mbtx (moon test),
     #|@builtin/check-test.mbtx (check then test), @builtin/info-fmt.mbtx (info

--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -1451,7 +1451,7 @@ fn schema(escalation~ : Bool, hosting~ : Bool) -> Json {
               "type": "array",
               "items": { "type": "string" },
               "default": [],
-              "description": "Script arguments, defaulting to []. Passed verbatim after the runner's -- separator. Import moonbitlang/core/env and read @env.args()[1:] on wasm, or @env.args()[2:] on js. Works with source, filename, or both.",
+              "description": "Script arguments, defaulting to []. Passed verbatim after the runner's -- separator. Import moonbitlang/core/env and read @env.args()[1:] to skip the executable name. Works with source, filename, or both.",
             },
           ),
           (
@@ -1608,9 +1608,9 @@ fn description(
     #|overwritten. Use the edit tool to change a saved script. Saving is limited
     #|to the writable workspace and is unavailable in read-only mode.
     #|Pass `args` (an array of strings, default `[]`) to parameterize any script:
-    #|`{"filename":"scripts/check.mbtx","args":["--target","js"]}`.
-    #|Import "moonbitlang/core/env" and read `@env.args()[1:]` on the default
-    #|wasm target (`@env.args()[2:]` on js, which includes node and script paths).
+    #|`{"filename":"scripts/check.mbtx","args":["--deny-warn"]}`.
+    #|The script runs on wasm. Import "moonbitlang/core/env" and read
+    #|`@env.args()[1:]` to skip the executable name.
     #|Arguments are passed verbatim, without shell expansion or splitting.
     #|When OPENSEEK_REFERENCES is available, these scripts are already bundled:
     #|@builtin/check.mbtx (moon check), @builtin/test.mbtx (moon test),

--- a/agent_tool/mbtx/mbtx_test.mbt
+++ b/agent_tool/mbtx/mbtx_test.mbt
@@ -39,6 +39,77 @@ async test "runs a pure-core program and returns its output" {
 }
 
 ///|
+async test "default prompt reusable check script forwards arguments" {
+  let prompt = @fs.read_file("prompt/default_prompt.mbt.md").text()
+  let example = prompt
+    .split("For example, save this source as `scripts/check.mbtx`")
+    .collect()
+  assert_eq(example.length(), 2)
+  let source = example[1].split("```mbtx\n").collect()[1].split("```").collect()[0]
+  @vfs.with_tmpdir(ws => {
+    @fs.write_file(
+      "\{ws}/moon.mod",
+      "name = \"test/args\"",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file("\{ws}/moon.pkg", "", create_mode=CreateOrTruncate)
+    @fs.write_file(
+      "\{ws}/main.mbt",
+      "fn answer() -> Int { 42 }",
+      create_mode=CreateOrTruncate,
+    )
+    let saved = run_in(ws, {
+      "source": source,
+      "filename": "scripts/check.mbtx",
+      "args": ["--target", "js"],
+    })
+    assert_false(saved.is_error, msg=saved.content)
+    let reused = run_in(ws, { "filename": "scripts/check.mbtx" })
+    assert_false(reused.is_error, msg=reused.content)
+    let invalid = run_in(ws, {
+      "filename": "scripts/check.mbtx",
+      "args": ["--not-a-moon-option"],
+    })
+    assert_true(invalid.is_error)
+    assert_true(invalid.content.contains("--not-a-moon-option"))
+  })
+}
+
+///|
+async test "script arguments reach inline and reused scripts verbatim on both runners" {
+  @vfs.with_tmpdir(ws => {
+    let values : Array[String] = [
+      "--policy", "two words", "", "你好", "$(echo nope)", "--",
+    ]
+    for target in ["wasm", "js"] {
+      let skip = if target == "js" { 2 } else { 1 }
+      let source =
+        $|import { "moonbitlang/core/env" }
+        $|fn main { println(@env.args()[\{skip}:].to_array().to_json().stringify()) }
+      let filename = "args-\{target}.mbtx"
+      let inline = run_in(ws, { "source": source, "target": target })
+      assert_false(inline.is_error, msg=inline.content)
+      assert_eq(inline.content, "[]\n")
+      let saved = run_in(ws, {
+        "source": source,
+        "filename": filename,
+        "target": target,
+        "args": values,
+      })
+      assert_false(saved.is_error, msg=saved.content)
+      assert_true(saved.content.contains(values.to_json().stringify()))
+      let reused = run_in(ws, {
+        "filename": filename,
+        "target": target,
+        "args": ["different input"],
+      })
+      assert_false(reused.is_error, msg=reused.content)
+      assert_eq(reused.content, "[\"different input\"]\n")
+    }
+  })
+}
+
+///|
 async test "save and run creates parents, suggests reuse, and preserves existing content" {
   @vfs.with_tmpdir(ws => {
     let state = @agent_tool.FileStateMap()
@@ -926,10 +997,19 @@ test "the schema advertises every decoded argument" {
   // MoonBit's String ordering is by length first, so a sorted expectation would
   // encode neither what this test means nor what a reader expects.
   let names = properties.keys().collect()
-  assert_eq(names.length(), 6)
-  for name in ["source", "filename", "description", "target", "cwd", "warning"] {
+  assert_eq(names.length(), 7)
+  for
+    name in [
+      "source", "filename", "args", "description", "target", "cwd", "warning",
+    ] {
     assert_true(names.contains(name))
   }
+  assert_true(
+    properties.get("args")
+    is Some(
+      { "type": "array", "items": { "type": "string", .. }, "default": [], .. }
+    ),
+  )
   assert_eq(
     choices,
     ([{ "required": ["source"] }, { "required": ["filename"] }] : Json),

--- a/agent_tool/mbtx/mbtx_test.mbt
+++ b/agent_tool/mbtx/mbtx_test.mbt
@@ -76,6 +76,33 @@ async test "default prompt reusable check script forwards arguments" {
 }
 
 ///|
+async test "default prompt argparse example reads process arguments implicitly" {
+  let prompt = @fs.read_file("prompt/default_prompt.mbt.md").text()
+  let example = prompt
+    .split("save this source as `scripts/greet.mbtx`")
+    .collect()
+  assert_eq(example.length(), 2)
+  let source = example[1].split("```mbtx\n").collect()[1].split("```").collect()[0]
+  @vfs.with_tmpdir(ws => {
+    let saved = run_in(ws, {
+      "source": source,
+      "filename": "scripts/greet.mbtx",
+      "args": ["--name", "Ada Lovelace"],
+    })
+    assert_false(saved.is_error, msg=saved.content)
+    assert_true(saved.content.contains("Hello, Ada Lovelace!\n"))
+    let defaults = run_in(ws, { "filename": "scripts/greet.mbtx" })
+    assert_false(defaults.is_error, msg=defaults.content)
+    assert_eq(defaults.content, "Hello, world!\n")
+    let invalid = run_in(ws, {
+      "filename": "scripts/greet.mbtx",
+      "args": ["--unknown"],
+    })
+    assert_true(invalid.is_error)
+  })
+}
+
+///|
 async test "script arguments reach inline and reused scripts verbatim on both runners" {
   @vfs.with_tmpdir(ws => {
     let values : Array[String] = [

--- a/agent_tool/mbtx/mbtx_test.mbt
+++ b/agent_tool/mbtx/mbtx_test.mbt
@@ -55,13 +55,13 @@ async test "default prompt reusable check script forwards arguments" {
     @fs.write_file("\{ws}/moon.pkg", "", create_mode=CreateOrTruncate)
     @fs.write_file(
       "\{ws}/main.mbt",
-      "fn answer() -> Int { 42 }",
+      "pub fn answer() -> Int { 42 }",
       create_mode=CreateOrTruncate,
     )
     let saved = run_in(ws, {
       "source": source,
       "filename": "scripts/check.mbtx",
-      "args": ["--target", "js"],
+      "args": ["--deny-warn"],
     })
     assert_false(saved.is_error, msg=saved.content)
     let reused = run_in(ws, { "filename": "scripts/check.mbtx" })

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -69,12 +69,11 @@ reserved. Use `./@builtin/check.mbtx` for a literal workspace path.
 One-off scripts can hard-code their inputs. For shared or reusable scripts,
 accept inputs through `args` (an array of strings, default `[]`) so callers
 can vary them without editing the source. Arguments retain spaces and empty
-strings; there is no shell expansion. On the default wasm target, import
-`moonbitlang/core/env` and read `@env.args()[1:]` to skip the executable name
-(`@env.args()[2:]` on js, which includes both node and script paths).
+strings; there is no shell expansion. The script runs on wasm. Import
+`moonbitlang/core/env` and read `@env.args()[1:]` to skip the executable name.
 
 For example, save this source as `scripts/check.mbtx` by calling `mbtx` with
-both `source` and `filename`, and `args=["--target", "js"]`:
+both `source` and `filename`, and `args=["--deny-warn"]`:
 
 ```mbtx
 import {
@@ -89,7 +88,7 @@ async fn main {
 }
 ```
 
-Reuse it with `{"filename":"scripts/check.mbtx","args":["--target","native"]}`,
+Reuse it with `{"filename":"scripts/check.mbtx","args":["--output-json"]}`,
 or `{"filename":"scripts/check.mbtx"}` for `moon check` with no extra arguments.
 
 There is no shell tool. Every command — `moon`, `git`, anything else — is

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -66,6 +66,32 @@ change a saved script. Namespaced scripts are read-only; never supply `source`
 with `@builtin/`. Only `@builtin/` is supported today; other namespaces are
 reserved. Use `./@builtin/check.mbtx` for a literal workspace path.
 
+One-off scripts can hard-code their inputs. For shared or reusable scripts,
+accept inputs through `args` (an array of strings, default `[]`) so callers
+can vary them without editing the source. Arguments retain spaces and empty
+strings; there is no shell expansion. On the default wasm target, import
+`moonbitlang/core/env` and read `@env.args()[1:]` to skip the executable name
+(`@env.args()[2:]` on js, which includes both node and script paths).
+
+For example, save this source as `scripts/check.mbtx` by calling `mbtx` with
+both `source` and `filename`, and `args=["--target", "js"]`:
+
+```mbtx
+import {
+  "moonbitlang/async",
+  "moonbitlang/async/shell",
+  "moonbitlang/core/env",
+}
+
+async fn main {
+  let code = @shell.Cmd("moon", ["check", ..@env.args()[1:]]).each_line(line => println(line))
+  if code != 0 { fail("moon check failed (exit=\{code})") }
+}
+```
+
+Reuse it with `{"filename":"scripts/check.mbtx","args":["--target","native"]}`,
+or `{"filename":"scripts/check.mbtx"}` for `moon check` with no extra arguments.
+
 There is no shell tool. Every command — `moon`, `git`, anything else — is
 spawned from a `mbtx` snippet through the shell-free
 `moonbitlang/async/shell` API. The `source` argument is a whole `.mbtx`

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -91,6 +91,35 @@ async fn main {
 Reuse it with `{"filename":"scripts/check.mbtx","args":["--output-json"]}`,
 or `{"filename":"scripts/check.mbtx"}` for `moon check` with no extra arguments.
 
+For scripts with their own options, prefer `argparse` and declare those options
+explicitly. Call `@argparse.parse(...)` without `argv`: it reads the process
+arguments and handles the executable prefix, so no `@env.args()` slicing is
+needed. For example, save this source as `scripts/greet.mbtx`:
+
+```mbtx
+import { "moonbitlang/core/argparse" }
+
+fn main raise {
+  let matches = @argparse.parse(
+    Command(
+      "greet",
+      options=[
+        OptionArg("name", long="name", default_values=["world"], about="Who to greet."),
+      ],
+    ),
+  )
+  guard matches.values.get("name") is Some([name]) else {
+    fail("expected one value for --name")
+  }
+  println("Hello, \{name}!")
+}
+```
+
+Call `{"filename":"scripts/greet.mbtx","args":["--name","Ada Lovelace"]}`
+to print `Hello, Ada Lovelace!`. Omitting `args` prints `Hello, world!`.
+The `args` field supplies script inputs; `argparse` handles option parsing,
+defaults, and validation without receiving an explicit argument array.
+
 There is no shell tool. Every command — `moon`, `git`, anything else — is
 spawned from a `mbtx` snippet through the shell-free
 `moonbitlang/async/shell` API. The `source` argument is a whole `.mbtx`

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -115,6 +115,35 @@ fn default_prompt() -> String {
     #|Reuse it with `{"filename":"scripts/check.mbtx","args":["--output-json"]}`,
     #|or `{"filename":"scripts/check.mbtx"}` for `moon check` with no extra arguments.
     #|
+    #|For scripts with their own options, prefer `argparse` and declare those options
+    #|explicitly. Call `@argparse.parse(...)` without `argv`: it reads the process
+    #|arguments and handles the executable prefix, so no `@env.args()` slicing is
+    #|needed. For example, save this source as `scripts/greet.mbtx`:
+    #|
+    #|```mbtx
+    #|import { "moonbitlang/core/argparse" }
+    #|
+    #|fn main raise {
+    #|  let matches = @argparse.parse(
+    #|    Command(
+    #|      "greet",
+    #|      options=[
+    #|        OptionArg("name", long="name", default_values=["world"], about="Who to greet."),
+    #|      ],
+    #|    ),
+    #|  )
+    #|  guard matches.values.get("name") is Some([name]) else {
+    #|    fail("expected one value for --name")
+    #|  }
+    #|  println("Hello, \{name}!")
+    #|}
+    #|```
+    #|
+    #|Call `{"filename":"scripts/greet.mbtx","args":["--name","Ada Lovelace"]}`
+    #|to print `Hello, Ada Lovelace!`. Omitting `args` prints `Hello, world!`.
+    #|The `args` field supplies script inputs; `argparse` handles option parsing,
+    #|defaults, and validation without receiving an explicit argument array.
+    #|
     #|There is no shell tool. Every command — `moon`, `git`, anything else — is
     #|spawned from a `mbtx` snippet through the shell-free
     #|`moonbitlang/async/shell` API. The `source` argument is a whole `.mbtx`

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -93,12 +93,11 @@ fn default_prompt() -> String {
     #|One-off scripts can hard-code their inputs. For shared or reusable scripts,
     #|accept inputs through `args` (an array of strings, default `[]`) so callers
     #|can vary them without editing the source. Arguments retain spaces and empty
-    #|strings; there is no shell expansion. On the default wasm target, import
-    #|`moonbitlang/core/env` and read `@env.args()[1:]` to skip the executable name
-    #|(`@env.args()[2:]` on js, which includes both node and script paths).
+    #|strings; there is no shell expansion. The script runs on wasm. Import
+    #|`moonbitlang/core/env` and read `@env.args()[1:]` to skip the executable name.
     #|
     #|For example, save this source as `scripts/check.mbtx` by calling `mbtx` with
-    #|both `source` and `filename`, and `args=["--target", "js"]`:
+    #|both `source` and `filename`, and `args=["--deny-warn"]`:
     #|
     #|```mbtx
     #|import {
@@ -113,7 +112,7 @@ fn default_prompt() -> String {
     #|}
     #|```
     #|
-    #|Reuse it with `{"filename":"scripts/check.mbtx","args":["--target","native"]}`,
+    #|Reuse it with `{"filename":"scripts/check.mbtx","args":["--output-json"]}`,
     #|or `{"filename":"scripts/check.mbtx"}` for `moon check` with no extra arguments.
     #|
     #|There is no shell tool. Every command — `moon`, `git`, anything else — is

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -90,6 +90,32 @@ fn default_prompt() -> String {
     #|with `@builtin/`. Only `@builtin/` is supported today; other namespaces are
     #|reserved. Use `./@builtin/check.mbtx` for a literal workspace path.
     #|
+    #|One-off scripts can hard-code their inputs. For shared or reusable scripts,
+    #|accept inputs through `args` (an array of strings, default `[]`) so callers
+    #|can vary them without editing the source. Arguments retain spaces and empty
+    #|strings; there is no shell expansion. On the default wasm target, import
+    #|`moonbitlang/core/env` and read `@env.args()[1:]` to skip the executable name
+    #|(`@env.args()[2:]` on js, which includes both node and script paths).
+    #|
+    #|For example, save this source as `scripts/check.mbtx` by calling `mbtx` with
+    #|both `source` and `filename`, and `args=["--target", "js"]`:
+    #|
+    #|```mbtx
+    #|import {
+    #|  "moonbitlang/async",
+    #|  "moonbitlang/async/shell",
+    #|  "moonbitlang/core/env",
+    #|}
+    #|
+    #|async fn main {
+    #|  let code = @shell.Cmd("moon", ["check", ..@env.args()[1:]]).each_line(line => println(line))
+    #|  if code != 0 { fail("moon check failed (exit=\{code})") }
+    #|}
+    #|```
+    #|
+    #|Reuse it with `{"filename":"scripts/check.mbtx","args":["--target","native"]}`,
+    #|or `{"filename":"scripts/check.mbtx"}` for `moon check` with no extra arguments.
+    #|
     #|There is no shell tool. Every command — `moon`, `git`, anything else — is
     #|spawned from a `mbtx` snippet through the shell-free
     #|`moonbitlang/async/shell` API. The `source` argument is a whole `.mbtx`


### PR DESCRIPTION
## Summary

Reusable `mbtx` scripts can now accept an optional `args` array of strings, defaulting to `[]`. Arguments pass verbatim after the runner's `--` separator for inline, saved, and save-and-run scripts, so callers can change inputs without rewriting the script. Invalid argument types are rejected before execution.

The default prompt includes a tested saved `scripts/check.mbtx` example, reused with different `moon check` arguments. The prompt teaches wasm argument handling with `@env.args()[1:]`; examples vary `--deny-warn` and `--output-json` without advertising JavaScript script execution.

## Validation

- All 84 `mbtx` package tests passed, including verbatim arguments on wasm/JS and execution of the exact default-prompt example.
- All 13 decoder tests passed on native and JS.
- `just build`, `just check-prompt`, `moon info`, `moon fmt`, and `git diff --check` passed.
- `just check` and `just test` are blocked by pre-existing tuple-pattern loop parse errors in unchanged tests under `deepseek/client`, `desktop/internal/uri`, and `editor/viewer/diff_provider/moondiff`.

