### PR TITLE
fix(desktop): align sidebar toggle with native window controls

### DIFF
--- a/desktop/e2e/tests/close_shortcut.spec.js
+++ b/desktop/e2e/tests/close_shortcut.spec.js
@@ -55,10 +55,14 @@ test('fixed sidebar toggle respects native geometry across pages and fullscreen'
   const app = await installDesktop(page);
   const toggle = page.getByRole('button', { name: /^(Hide|Show) sidebar$/ });
   await page.evaluate(() => {
-    window.titlebarArea = { x: 88, y: 0, width: innerWidth - 88, height: 46 };
+    window.titlebarArea = { x: 88, y: 0, width: innerWidth - 88, height: 32 };
     window.desktopEvent('openseek.window.chrome_changed', {});
   });
   await expect.poll(async () => (await toggle.boundingBox()).x).toBe(88);
+  await expect.poll(async () => {
+    const box = await toggle.boundingBox();
+    return box.y + box.height / 2;
+  }).toBe(16);
   const original = await toggle.elementHandle();
   for (const name of ['Hide sidebar', 'Show sidebar']) {
     await expect(toggle).toHaveAccessibleName(name);
@@ -94,6 +98,12 @@ test('fixed sidebar toggle respects native geometry across pages and fullscreen'
     window.desktopEvent('openseek.window.chrome_changed', {});
   });
   await expect.poll(async () => (await toggle.boundingBox()).x).toBe(8);
+  await expect.poll(async () => {
+    const box = await toggle.boundingBox();
+    const headerHeight = await toggle.evaluate(button =>
+      parseFloat(getComputedStyle(button.closest('.app')).getPropertyValue('--app-header-height')));
+    return box.y + box.height / 2 - headerHeight / 2;
+  }).toBe(0);
   // A real click must reach the fixed control above the narrow drawer.
   await toggle.click();
   await expect(toggle).toHaveAccessibleName('Hide sidebar');

--- a/desktop/styles/main_header.css
+++ b/desktop/styles/main_header.css
@@ -36,8 +36,10 @@ main {
 
 .sidebar-toggle {
   position: fixed;
-  inset-block-start: calc(
-    (var(--topbar-height) - var(--sidebar-toggle-size)) / 2
+  /* Native controls can sit above the center of the taller app header. */
+  inset-block-start: max(
+    0px,
+    calc((var(--native-titlebar-height, var(--topbar-height)) - var(--sidebar-toggle-size)) / 2)
   );
   inset-inline-start: var(--sidebar-toggle-inline-inset);
   z-index: var(--z-titlebar-control);


### PR DESCRIPTION
The fixed sidebar toggle was centered in the 46px app header even when macOS placed its window controls in a shorter native titlebar, leaving the icon visibly too low. Center it using Proton's reported native titlebar height, with the existing app-header fallback for fullscreen and browser clients and a nonnegative inset for large touch controls.

Extend the existing browser regression to use a 32px native titlebar and check vertical alignment and fullscreen fallback. The regression fails against the old CSS (center 23px instead of 16px) and passes with this fix.

Validation:
- Targeted Playwright sidebar geometry regression passed.
- `just build` passed for native and JS.
- macOS development package built and visually checked; captured a native screenshot.
- `moon info` and `moon fmt` passed; no generated interface changes.
- `just check` and `just test` were attempted but fail on existing tuple-pattern loop parsing in unchanged tests, beginning at `deepseek/client/openrouter_wbtest.mbt:4`, with the installed MoonBit toolchain (moon 0.1.20260827). These failures are unrelated to this CSS change.
