### PR TITLE
fix: stabilize horizontal scrolling in semantic diff review

### DIFF
--- a/desktop/e2e/tests/semantic_diff_scroll.spec.js
+++ b/desktop/e2e/tests/semantic_diff_scroll.spec.js
@@ -1,0 +1,67 @@
+import { test, expect } from '@playwright/test';
+import { DesktopBrowserHarness } from './support/desktop_browser_harness.js';
+
+for (const mode of ['Token', 'Tree']) {
+  test(`${mode} split diff scrolls code while keeping item frames fixed`, async ({ page }) => {
+    const app = new DesktopBrowserHarness(page);
+    const source = (version) => Array.from({ length: 12 }, (_, index) =>
+      `///|\nfn section_${index}() -> String {\n  "${version} ${'long content '.repeat(50)}"\n}\n`,
+    ).join('\n');
+    app.workingFiles['src/main.mbt'] = source('modified');
+    app.gitFilesByRevision[app.gitBaseline]['src/main.mbt'] = source('original');
+    await app.install();
+    await app.goto();
+    await app.openSession();
+    await app.openReview();
+    await page.getByRole('button', { name: /View diff: src\/main\.mbt/ }).click();
+    await page.getByRole('button', { name: `${mode} diff`, exact: true }).click();
+    await page.getByRole('button', { name: 'Split diff layout', exact: true }).click();
+
+    const host = page.locator('#semantic-review-host');
+    const entry = host.locator('.semantic-diff-editor-host').first();
+    await expect(entry.locator('.moonbit-diff-editor').first())
+      .toHaveAttribute('data-render-mode', 'side-by-side');
+    await expect.poll(() => host.evaluate(node => node.scrollWidth - node.clientWidth))
+      .toBeGreaterThan(500);
+    await page.setViewportSize({ width: 1100, height: 800 });
+    await expect.poll(() => host.evaluate(node => Math.abs(
+      node.querySelector('.semantic-document').getBoundingClientRect().width - node.clientWidth,
+    ))).toBeLessThanOrEqual(1);
+
+    // Read geometry in the same task that changes scrollLeft, before a JS
+    // scroll listener can compensate. Native scrolling must never move frames.
+    const drift = await host.evaluate(node => {
+      const header = node.querySelector('.semantic-entry-header');
+      const pane = node.querySelector('.moonbit-diff-editor-modified');
+      const before = [header, pane].map(element => element.getBoundingClientRect().left);
+      node.scrollLeft = 200;
+      return [header, pane].map((element, index) =>
+        element.getBoundingClientRect().left - before[index]);
+    });
+    for (const offset of drift) expect(Math.abs(offset)).toBeLessThanOrEqual(1);
+    await host.evaluate(node => { node.scrollLeft = 0; });
+    const line = entry.locator('.moonbit-diff-editor-modified .view-line')
+      .filter({ hasText: 'modified long content' }).first();
+    await expect(line).toBeVisible();
+    const before = await line.boundingBox();
+    const frame = await entry.boundingBox();
+    await page.mouse.move(frame.x + frame.width * 0.75, frame.y + 35);
+    await page.mouse.wheel(250, 0);
+    await expect.poll(async () => (await line.boundingBox()).x)
+      .toBeLessThan(before.x - 100);
+    expect(Math.abs((await entry.boundingBox()).x - frame.x)).toBeLessThanOrEqual(1);
+
+    // Boundary gestures stay within this scroll plane; vertical gestures still
+    // navigate the aggregate document.
+    await page.mouse.wheel(100000, 0);
+    await expect.poll(() => host.evaluate(node =>
+      Math.abs(node.scrollLeft - (node.scrollWidth - node.clientWidth))))
+      .toBeLessThanOrEqual(1);
+    expect(Math.abs((await entry.boundingBox()).x - frame.x)).toBeLessThanOrEqual(1);
+    await page.mouse.wheel(-100000, 0);
+    await expect.poll(() => host.evaluate(node => node.scrollLeft)).toBe(0);
+    await page.mouse.wheel(0, 300);
+    await expect.poll(() => host.evaluate(node => node.scrollTop)).toBeGreaterThan(0);
+    expect(app.pageErrors).toEqual([]);
+  });
+}

--- a/desktop/frontend/fileeditor/semantic_review_view.mbt
+++ b/desktop/frontend/fileeditor/semantic_review_view.mbt
@@ -180,9 +180,6 @@ fn semantic_editor_host_id(key : String) -> String {
 }
 
 ///|
-const SemanticReviewScrollWidthId = "semantic-review-scroll-width"
-
-///|
 /// Semantic fragments use side-specific schemes so the language registry can
 /// expose current-checkout IDE actions on Modified without advertising them on
 /// an Original revision that the host cannot answer for.
@@ -436,20 +433,7 @@ pub fn semantic_review_view(
           "unified"
         },
       ),
-    [
-      semantic_plan_view(dispatch, plan, input, state.semantic_review_collapsed),
-      // VS Code's MultiDiffEditor owns one horizontal scroll extent. The
-      // imperative lifecycle sizes this otherwise invisible element from the
-      // widest local DiffEditor and mirrors the outer scrollLeft into all
-      // entries.
-      @html.div(
-        attrs=@html.Attrs::build()
-          .id(SemanticReviewScrollWidthId)
-          .class("semantic-review-scroll-width")
-          .aria_hidden("true"),
-        ([] : Array[@html.Html]),
-      ),
-    ],
+    [semantic_plan_view(dispatch, plan, input, state.semantic_review_collapsed)],
   )
 }
 
@@ -570,9 +554,7 @@ fn semantic_review_navigation_subscription(
 ///|
 fn update_semantic_review_scroll_width() -> Unit {
   guard @dom.document().get_element_by_id(SemanticReviewHostId).to_option()
-    is Some(host) &&
-    @dom.document().get_element_by_id(SemanticReviewScrollWidthId).to_option()
-    is Some(spacer) else {
+    is Some(host) else {
     return
   }
   let mut max_scroll = 0.0
@@ -582,9 +564,14 @@ fn update_semantic_review_scroll_width() -> Unit {
     }
   }
   @base_browser.set_style_property(
-    spacer,
-    "width",
-    "\{(host.get_client_width() + max_scroll).ceil()}px",
+    host,
+    "--semantic-review-viewport-width",
+    "\{host.get_client_width()}px",
+  )
+  @base_browser.set_style_property(
+    host,
+    "--semantic-review-scroll-width",
+    "\{max_scroll.ceil()}px",
   )
   sync_semantic_review_scroll_left(host.get_scroll_left())
 }
@@ -594,19 +581,9 @@ fn update_semantic_review_scroll_width() -> Unit {
 /// mirrors VS Code's `VirtualizedViewItem.setScrollLeft` without exposing each
 /// DiffEditor's own horizontal scrollbar.
 fn sync_semantic_review_scroll_left(scroll_left : Double) -> Unit {
-  // A native overflow element supplies the one visible scrollbar, but VS
-  // Code's SmoothScrollableElement does not translate the MultiDiff item DOM.
-  // Counter the browser's native translation, then project the offset into
-  // every DiffEditor so headers stay put and code moves exactly once.
-  if @dom.document().get_element_by_id(SemanticReviewHostId).to_option()
-    is Some(host) &&
-    host.query_selector(".semantic-document") is Some(document) {
-    @base_browser.set_style_property(
-      document,
-      "transform",
-      "translateX(\{scroll_left}px)",
-    )
-  }
+  // CSS pins the item DOM to the viewport during native scrolling. Only the
+  // editor contents need projection; a scroll-event transform would lag the
+  // compositor and briefly move the headers and split-pane frames.
   for _, entry in semantic_review_editors {
     entry.editor.set_scroll_left(scroll_left)
   }

--- a/desktop/styles/file_panel.css
+++ b/desktop/styles/file_panel.css
@@ -2459,25 +2459,22 @@ button.git-history-file.selected {
 .semantic-review-host .semantic-review {
   position: relative;
   box-sizing: border-box;
-  width: 100%;
+  width: calc(
+    var(--semantic-review-viewport-width, 100%) +
+      var(--semantic-review-scroll-width, 0px)
+  );
   min-height: 100%;
   min-width: 0;
 }
 
 .semantic-review-host .semantic-document {
-  position: relative;
-  z-index: 1;
-  width: 100%;
-  min-width: 0;
-}
-
-.semantic-review-host .semantic-review-scroll-width {
-  position: absolute;
-  top: 0;
+  /* Pin the item frames in the browser's scroll pass, before JS receives a
+     scroll event. The wider parent supplies the shared horizontal extent. */
+  position: sticky;
   left: 0;
-  height: 1px;
-  pointer-events: none;
-  visibility: hidden;
+  z-index: 1;
+  width: var(--semantic-review-viewport-width, 100%);
+  min-width: 0;
 }
 
 .semantic-review-host .semantic-diff-entry {

--- a/desktop/styles/file_panel.css
+++ b/desktop/styles/file_panel.css
@@ -2451,7 +2451,9 @@ button.git-history-file.selected {
   color: var(--vscode-editor-foreground, var(--color-text-primary));
   background: var(--vscode-editor-background, var(--color-bg-surface));
   font-family: var(--font-family-mono);
-  overscroll-behavior: contain;
+  /* `contain` still permits native rubber-banding. Keep horizontal boundary
+     gestures from visually shifting the shared diff container. */
+  overscroll-behavior: none contain;
 }
 
 .semantic-review-host .semantic-review {

--- a/editor/internal/viewer/diff_editor/widget.mbt
+++ b/editor/internal/viewer/diff_editor/widget.mbt
@@ -1483,14 +1483,22 @@ pub fn DiffEditorWidget::get_max_scroll_left(self : DiffEditorWidget) -> Double 
 }
 
 ///|
-/// Apply the MultiDiffEditor's shared horizontal offset to both panes. The
-/// existing pane synchronization absorbs any resulting scroll event echo.
+/// Drive the pane with the larger overflow, as VS Code's
+/// DiffEditorItemTemplate.setScrollLeft does (Original on a tie). Its normal
+/// synchronization clamps the other pane without feeding that clamp back.
 pub fn DiffEditorWidget::set_scroll_left(
   self : DiffEditorWidget,
   scroll_left : Double,
 ) -> Unit {
-  self.editors.original.set_scroll_left(scroll_left)
-  self.editors.modified.set_scroll_left(scroll_left)
+  let original = self.editors.original.get_scroll_width() -
+    self.editors.original.get_layout_info().content_width
+  let modified = self.editors.modified.get_scroll_width() -
+    self.editors.modified.get_layout_info().content_width
+  if modified > original {
+    self.editors.modified.set_scroll_left(scroll_left)
+  } else {
+    self.editors.original.set_scroll_left(scroll_left)
+  }
 }
 
 ///|

--- a/editor/tests/browser/README.md
+++ b/editor/tests/browser/README.md
@@ -28,6 +28,12 @@ the `smoke/` and `component/` directories.
   pass/fail. The shared harness records console messages and fails a passing
   test if it observed a console error, uncaught page error, failed request, or
   HTTP response at status 400 or above.
+- The `diff-editor-lifecycle` scenario exposes
+  `__diffEditorLifecycleControls.set_scroll_left` for MultiDiff host writes.
+  `horizontal-original`, `horizontal-modified`, and `horizontal-equal` select
+  unwrapped model pairs. Run `playwright test
+  tests/browser/component/diff_editor_lifecycle.spec.js --grep 'shared horizontal
+  scroll'` to check asymmetric clamping and repeated/reversed host offsets.
 - Every component case must state a browser-only contract. Headless Viewer
   tests own model, view-model, contribution, provider, cancellation, and
   event-order state. Component Playwright owns attachment, node ownership,

--- a/editor/tests/browser/component/diff_editor_lifecycle.spec.js
+++ b/editor/tests/browser/component/diff_editor_lifecycle.spec.js
@@ -68,6 +68,53 @@ async function disposeDiffLifecycle(page) {
   });
 }
 
+// Behavior port: VS Code 07c20d96cf3f2cbc8142ac7079ba9048cf7f6134,
+// multiDiffEditor/diffEditorItemTemplate.ts, setScrollLeft. The outer host
+// drives the pane with the larger overflow; the narrower pane clamps locally.
+// Chromium is required because the pane scroll echoes fire during rendering.
+for (const wider of ['original', 'modified', 'equal']) {
+  test(`shared horizontal scroll preserves each pane's limit (${wider})`, async ({ page }) => {
+    const root = await openDiffLifecycle(page);
+    await setDiffLifecycleFixture(page, `horizontal-${wider}`);
+    const readPanes = () => root.evaluate((node) =>
+      [...node.querySelectorAll('.moonbit-diff-editor-pane')].map((pane) => {
+        const lines = pane.querySelector('.view-lines');
+        const viewport = pane.querySelector('.monaco-scrollable-element');
+        const content = pane.querySelector('.lines-content');
+        return {
+          maxLeft: lines.clientWidth - viewport.clientWidth,
+          left: Math.max(0, -Number.parseFloat(content.style.left)),
+        };
+      }),
+    );
+    await expect.poll(async () => Math.min(...(await readPanes()).map(p => p.maxLeft)))
+      .toBeGreaterThan(100);
+    const initial = await readPanes();
+    const [originalMax, modifiedMax] = initial.map(p => p.maxLeft);
+    if (wider === 'equal') {
+      expect(originalMax).toBe(modifiedMax);
+    } else {
+      expect(wider === 'original' ? originalMax - modifiedMax : modifiedMax - originalMax)
+        .toBeGreaterThan(100);
+    }
+    const sharedMax = Math.min(originalMax, modifiedMax);
+    // Cross the short pane's limit, repeat the outer write (e.g. vertical
+    // host scrolling), overshoot both limits, then reverse into shared range.
+    for (const requested of [sharedMax + 80, sharedMax + 80, 100_000, 80, 0]) {
+      await page.evaluate(left =>
+        globalThis.__diffEditorLifecycleControls.set_scroll_left(left), requested,
+      );
+      await waitForAnimationFrames(page, 6);
+      const panes = await readPanes();
+      for (const [index, pane] of panes.entries()) {
+        expect(pane.left, `pane ${index}, request ${requested}`)
+          .toBe(Math.min(requested, initial[index].maxLeft));
+      }
+    }
+    await disposeDiffLifecycle(page);
+  });
+}
+
 async function modifiedScrollTop(root) {
   return root.evaluate((node) => {
     const content = node.querySelector(

--- a/editor/tests/browser/moonbit/component/diff_editor_lifecycle_scenario.mbt
+++ b/editor/tests/browser/moonbit/component/diff_editor_lifecycle_scenario.mbt
@@ -230,10 +230,24 @@ pub fn run_diff_editor_lifecycle_test() -> Unit {
     "new second hunk at line 100" +
     first_line_suffix,
   )
+  let horizontal_narrow = diff_editor_lifecycle_model(
+    "horizontal-narrow",
+    ("n".repeat(100) + "\n").repeat(40),
+  )
+  let horizontal_wide = diff_editor_lifecycle_model(
+    "horizontal-wide",
+    ("w".repeat(200) + "\n").repeat(40),
+  )
   widget.set_model(Some({ original, modified, })) |> ignore
   install_diff_editor_lifecycle_controls(
     fixture => {
       let pair : @diff_editor.DiffEditorModelData = match fixture {
+        "horizontal-original" =>
+          { original: horizontal_wide, modified: horizontal_narrow, }
+        "horizontal-modified" =>
+          { original: horizontal_narrow, modified: horizontal_wide, }
+        "horizontal-equal" =>
+          { original: horizontal_wide, modified: horizontal_wide, }
         "ignored" => { original: ignored_original, modified: ignored_modified, }
         "digits" => { original: digit_original, modified: digit_modified, }
         "indicators" =>
@@ -242,6 +256,17 @@ pub fn run_diff_editor_lifecycle_test() -> Unit {
         "first-line" =>
           { original: first_line_original, modified: first_line_modified, }
         _ => { original, modified, }
+      }
+      if fixture.has_prefix("horizontal-") {
+        widget.update_options(
+          @code_widget.CodeEditorOptions::default(),
+          DiffEditorOptions(
+            layout=SideBySide,
+            automatic_inline=false,
+            diff_word_wrap=Off,
+            handle_mouse_wheel=false,
+          ),
+        )
       }
       widget.set_model(Some(pair)) |> ignore
     },
@@ -285,8 +310,11 @@ pub fn run_diff_editor_lifecycle_test() -> Unit {
     },
     () => widget.reveal_first_diff(),
     () => widget.reveal_last_diff(),
+    left => widget.set_scroll_left(left),
     () => widget.dispose(),
     () => {
+      horizontal_narrow.dispose()
+      horizontal_wide.dispose()
       ignored_original.dispose()
       ignored_modified.dispose()
       original.dispose()
@@ -312,10 +340,11 @@ extern "js" fn install_diff_editor_lifecycle_controls(
   set_model_attached : (Bool) -> Unit,
   reveal_first_diff : () -> Unit,
   reveal_last_diff : () -> Unit,
+  set_scroll_left : (Double) -> Unit,
   dispose : () -> Unit,
   dispose_models : () -> Unit,
 ) -> Unit =
-  #| (setFixture, setDigitLineCount, setOptions, setProvider, setModelAttached, revealFirstDiff, revealLastDiff, dispose, disposeModels) => {
+  #| (setFixture, setDigitLineCount, setOptions, setProvider, setModelAttached, revealFirstDiff, revealLastDiff, setScrollLeft, dispose, disposeModels) => {
   #|   globalThis.__diffEditorLifecycleControls = Object.freeze({
   #|     set_fixture: setFixture,
   #|     set_digit_line_count: setDigitLineCount,
@@ -324,6 +353,7 @@ extern "js" fn install_diff_editor_lifecycle_controls(
   #|     set_model_attached: setModelAttached,
   #|     reveal_first_diff: revealFirstDiff,
   #|     reveal_last_diff: revealLastDiff,
+  #|     set_scroll_left: setScrollLeft,
   #|     dispose,
   #|     dispose_models: disposeModels,
   #|   });

--- a/editor/viewer/README.mbt.md
+++ b/editor/viewer/README.mbt.md
@@ -153,6 +153,24 @@ The public terminology is `SideBySide` and `Inline`. The implementation keeps
 no legacy single-column renderer, tail-height compensation, diff-owned
 correction scheduler, or compatibility alias.
 
+MultiDiff hosts use `get_max_scroll_left` and `set_scroll_left` for one outer
+horizontal scrollbar. The offset drives the pane with the larger horizontal
+overflow (Original on a tie); its normal scroll synchronization updates the
+other pane, which clamps at its own limit without feeding that clamp back.
+Repeating the host offset, including during vertical host scrolling, leaves
+both horizontal positions unchanged.
+
+This is a behavior port of VS Code
+[`DiffEditorItemTemplate.setScrollLeft` at `07c20d96`](https://github.com/microsoft/vscode/blob/07c20d96cf3f2cbc8142ac7079ba9048cf7f6134/src/vs/editor/browser/widget/multiDiffEditor/diffEditorItemTemplate.ts#L234-L240).
+The concrete `DiffEditor` API owns pane selection so hosts do not need child
+editor handles. The scope is shared horizontal projection; upstream item
+virtualization and vertical scrolling are outside this port.
+
+| Behavior | Evidence |
+| --- | --- |
+| Either pane may have the larger overflow; equal ranges stay synchronized | `shared horizontal scroll preserves each pane's limit` in `diff_editor_lifecycle.spec.js` (original, modified, equal) |
+| Local clamping, repeated host offsets, overshoot, and reverse scrolling | The same component cases exercise each transition after rendered scroll events |
+
 ## Public surfaces
 
 `Viewer` retains the readonly code API: model/options lifecycle, cursor and

--- a/editor/viewer/diff_editor_facade.mbt
+++ b/editor/viewer/diff_editor_facade.mbt
@@ -281,7 +281,8 @@ pub fn DiffEditor::get_max_scroll_left(self : DiffEditor) -> Double {
 }
 
 ///|
-/// Set the shared horizontal offset of both diff panes.
+/// Set the shared horizontal offset through the pane with the larger overflow.
+/// The other pane follows and clamps at its own limit.
 pub fn DiffEditor::set_scroll_left(
   self : DiffEditor,
   scroll_left : Double,


### PR DESCRIPTION
Horizontal scrolling in Token/Tree split review can briefly move the whole item frame before JavaScript compensates for native scrolling. When the panes have different overflow widths, synchronizing both panes can also feed the narrower pane's clamped position back into the wider one.

Keep item headers and split-pane frames pinned with CSS sticky positioning, and project the shared horizontal offset only into editor content. Drive pane synchronization from the pane with more overflow, and suppress native horizontal boundary rubber-banding.

Regression coverage checks unequal and equal pane widths, repeated writes beyond the shorter pane's limit, direction reversal, and Token/Tree split scrolling with resize and boundary gestures. The desktop test checks frame geometry before a scroll callback can compensate.

Validation:
- `just check`, `just test`, and `just build` passed.
- Editor all-target check and `just editor-test` passed.
- Token/Tree desktop scroll regressions and the existing Review workflow passed (3 browser cases).
- `just editor-test-browser` passed: 110/110 browser smoke and component tests.
- Release SeekMoon.app built with `--no-open`; strict signature verification and the bundled CLI smoke check passed. Packaged frontend assets match this build.
- Physical trackpad behavior in the packaged app has not been manually verified.
