### PR TITLE
Simplify mbtx headers with rabbit labels and existing status markers

### DIFF
--- a/cmd/viz_app/e2e/tests/viz_dom.spec.js
+++ b/cmd/viz_app/e2e/tests/viz_dom.spec.js
@@ -49,7 +49,12 @@ test('build-error filter separates build diagnostics from other failures', async
   const buildFailure = page.locator('details.card').filter({ hasText: 'type mismatch' });
   const buildCall = page.locator('summary.tool-call-name').filter({ hasText: 'Check <compiler> diagnostics' });
   await expect(buildCall).toBeVisible();
-  await expect(buildCall).toContainText('mbtx (build failed, exit=1)');
+  await expect(buildCall.locator('strong')).toHaveText('🐇');
+  await expect(buildCall.locator('.tool-stage-build')).toHaveText('build error');
+  await expect(buildCall).not.toContainText('exit=');
+  await buildCall.click();
+  await expect(buildCall.locator('..').locator(':scope > .tool-call-brief'))
+    .toContainText('mbtx (build failed, exit=1)');
   const runtimeFailure = page.locator('details.card').filter({ hasText: 'runtime trap' });
   const shellFailure = page.locator('details.card').filter({ hasText: 'fixture failure' });
   await page.getByRole('button', { name: 'Build errors only', exact: true }).click();

--- a/desktop/frontend/transcript/component/tool_exchange.mbt
+++ b/desktop/frontend/transcript/component/tool_exchange.mbt
@@ -33,6 +33,9 @@ fn tool_exchange_view(
         Some(content),
       )
   }
+  let compact_mbtx = name == "mbtx" &&
+    !is_error &&
+    (brief is None || brief is Some("mbtx (exit=0)"))
   let label = if wait_label is Some(label) {
     label
   } else if pending_job_wait_label(call) is Some(label) {
@@ -43,9 +46,13 @@ fn tool_exchange_view(
     fields.get("path") is Some(String(path)) {
     "Read · " + path
   } else {
-    let label = match brief {
-      Some(text) if !text.is_blank() => text
-      _ => name
+    let label = if compact_mbtx {
+      "🐇"
+    } else {
+      match brief {
+        Some(text) if !text.is_blank() => text
+        _ => name
+      }
     }
     if name == "mbtx" &&
       call.arguments is Some(arguments) &&
@@ -128,6 +135,9 @@ fn tool_exchange_view(
     key,
     subrun?,
   )
+  if compact_mbtx && brief is Some(text) {
+    output_sections.insert(0, @html.div(class="tool-caption", text))
+  }
   if output_sections.is_empty() {
     output_sections.push(
       @html.div(class="tool-call-section", [
@@ -155,7 +165,14 @@ fn tool_exchange_view(
     [
       @html.summary(
         class="work-toggle tool-toggle",
-        attrs=@html.Attrs::build().aria_label(caption + " — " + status),
+        attrs=@html.Attrs::build()
+          .aria_label(
+            (if compact_mbtx { "mbtx · " } else { "" }) +
+            caption +
+            " — " +
+            status,
+          )
+          .title(name),
         [
           @html.span(class="work-chevron", @icons.icon_chevron_down()),
           @html.span(class="tool-call-text", caption),

--- a/desktop/frontend/transcript/component/tool_exchange.mbt
+++ b/desktop/frontend/transcript/component/tool_exchange.mbt
@@ -33,9 +33,6 @@ fn tool_exchange_view(
         Some(content),
       )
   }
-  let compact_mbtx = name == "mbtx" &&
-    !is_error &&
-    (brief is None || brief is Some("mbtx (exit=0)"))
   let label = if wait_label is Some(label) {
     label
   } else if pending_job_wait_label(call) is Some(label) {
@@ -46,7 +43,7 @@ fn tool_exchange_view(
     fields.get("path") is Some(String(path)) {
     "Read · " + path
   } else {
-    let label = if compact_mbtx {
+    let label = if name == "mbtx" {
       "🐇"
     } else {
       match brief {
@@ -135,9 +132,6 @@ fn tool_exchange_view(
     key,
     subrun?,
   )
-  if compact_mbtx && brief is Some(text) {
-    output_sections.insert(0, @html.div(class="tool-caption", text))
-  }
   if output_sections.is_empty() {
     output_sections.push(
       @html.div(class="tool-call-section", [
@@ -167,7 +161,7 @@ fn tool_exchange_view(
         class="work-toggle tool-toggle",
         attrs=@html.Attrs::build()
           .aria_label(
-            (if compact_mbtx { "mbtx · " } else { "" }) +
+            (if name == "mbtx" { "mbtx · " } else { "" }) +
             caption +
             " — " +
             status,
@@ -183,7 +177,9 @@ fn tool_exchange_view(
               brief,
               is_error,
               call.arguments,
-              brief_shown=brief is Some(text) && caption.contains(text),
+              brief_shown=name != "mbtx" &&
+                brief is Some(text) &&
+                caption.contains(text),
             ) {
             Some(marker) => marker
             None => @html.nothing

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -168,12 +168,16 @@ fn result_row_view(
   key : String,
   subrun? : SubrunLink,
 ) -> @html.Html {
-  let label = match (arguments, brief, pending) {
-    (None, Some(brief), _) if !brief.is_blank() => brief
-    (None, _, _) => name
-    (_, _, true) => "Tool output · \{name}"
-    _ if is_error => "Tool error · \{name}"
-    _ => "Tool result · \{name}"
+  let label = if name == "mbtx" {
+    "🐇"
+  } else {
+    match (arguments, brief, pending) {
+      (None, Some(brief), _) if !brief.is_blank() => brief
+      (None, _, _) => name
+      (_, _, true) => "Tool output · \{name}"
+      _ if is_error => "Tool error · \{name}"
+      _ => "Tool result · \{name}"
+    }
   }
   let error_class = (if is_error { " error" } else { "" }) +
     failure_stage_class(name, brief, is_error, arguments)
@@ -188,9 +192,12 @@ fn result_row_view(
       is_error,
       arguments,
       // The result row shows the brief as its label only for the
-      // argument-less shape (the first `label` arm above); the common
-      // "Tool error · mbtx" label carries no brief, so the stage word stays.
-      brief_shown=arguments is None && brief is Some(brief) && !brief.is_blank(),
+      // argument-less shape. The mbtx emoji carries no brief, so its
+      // failure marker always names the stage.
+      brief_shown=name != "mbtx" &&
+        arguments is None &&
+        brief is Some(brief) &&
+        !brief.is_blank(),
     )
     is Some(marker) {
     line.push(marker)
@@ -217,6 +224,9 @@ fn tool_output_sections(
   subrun? : SubrunLink,
 ) -> Array[@html.Html] {
   let body : Array[@html.Html] = []
+  if name == "mbtx" && brief is Some(text) {
+    body.push(@html.div(class="tool-caption", text))
+  }
   // A sub-run result names the child session it spawned in its brief. The
   // result owns the child report and therefore owns the way into its transcript.
   if subrun is Some(link) && brief is Some(brief) {

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -1041,9 +1041,11 @@ fn tool_call_view(
 ) -> @html.Html {
   let name_row : Array[@html.Html] = [
     @html.text("→ "),
-    @html.strong(call.name),
+    @html.strong(if call.name == "mbtx" { "🐇" } else { call.name }),
   ]
-  if briefs.get(call.id) is Some(brief) && !brief.is_blank() {
+  if call.name != "mbtx" &&
+    briefs.get(call.id) is Some(brief) &&
+    !brief.is_blank() {
     name_row.push(@html.span(class="tool-call-brief") <| " · \{brief}")
   }
   if call.name == "mbtx" {
@@ -1076,13 +1078,7 @@ fn tool_call_view(
     (false, true) => "tool-call tool-call-escalated"
     (true, true) => "tool-call tool-call-failed tool-call-escalated"
   }
-  // A failed mbtx call names its STAGE — a build error is fixed in the
-  // source, a runtime error in the program's behavior. A build-failed row
-  // says it through its own brief, which already reads "build failed" /
-  // "build timeout": appending a word there repeated the brief verbatim
-  // ("· mbtx (build failed, exit=1) build error"), so the stage rides the
-  // class alone and the stylesheet turns the brief amber. The runtime word
-  // stays — "exit=1" never names the stage.
+  // The compact mbtx title leaves failure details to the stage marker.
   let build_failed = tool_call_is_build_failed(call, briefs, failed, tags)
   let run_failed = !build_failed &&
     tool_call_is_run_failed(call, briefs, failed, tags)
@@ -1093,10 +1089,16 @@ fn tool_call_view(
   } else {
     cls
   }
-  if run_failed {
+  if call.name == "mbtx" && build_failed {
+    name_row.push(
+      @html.span(class="tool-stage tool-stage-build", " build error"),
+    )
+  } else if run_failed {
     name_row.push(
       @html.span(class="tool-stage tool-stage-run") <| " runtime error",
     )
+  } else if call.name == "mbtx" {
+    name_row.push(failed_flag(failed.contains(call.id)))
   }
   let original = pretty_json(call.arguments)
   if is_blank_args(original) {
@@ -1113,6 +1115,11 @@ fn tool_call_view(
   let open_by_default = plan_steps.map(_ => true)
   @html.details(open?=open_by_default, id?=anchor, class=cls) <| [
     @html.summary(class="tool-call-name") <| name_row,
+    if call.name == "mbtx" && briefs.get(call.id) is Some(brief) {
+      @html.div(class="tool-call-brief", brief)
+    } else {
+      @html.nothing
+    },
     rendered,
     @html.pre(class="tool-call-args tool-call-args-original") <| original,
   ]
@@ -1342,10 +1349,15 @@ fn tool_card(
   } else {
     kind
   }
-  let label = if is_error {
-    "Tool error · \{result.tool_name()}"
+  let display_name = if result.tool_name() == "mbtx" {
+    "🐇"
   } else {
-    "Tool result · \{result.tool_name()}"
+    result.tool_name()
+  }
+  let label = if is_error {
+    "Tool error · \{display_name}"
+  } else {
+    "Tool result · \{display_name}"
   }
   let flag = result_flag(result)
   // Pair this result back to the call that produced it (same `call N` tag).
@@ -2630,7 +2642,7 @@ fn model_tool_card(
 ) -> @html.Html {
   let is_error = shown is Some(r) && r.is_error()
   let name = match shown {
-    Some(r) => r.tool_name()
+    Some(r) => if r.tool_name() == "mbtx" { "🐇" } else { r.tool_name() }
     None => ""
   }
   let is_escalated = match message.role {


### PR DESCRIPTION
Tool headers repeat execution status already shown by their status markers. This change makes two presentation updates:

- Remove the redundant `(exit=0)` summary from collapsed mbtx headers.
- Always show `🐇` as the mbtx tool label, retaining any description. Existing status markers distinguish success, build errors, runtime errors, and other failures.

Apply this consistently to desktop transcript cards and the visualization's raw/model views. Keep full result summaries and exit codes in expanded details. Tool identities and failure classification remain unchanged; no success-specific label parsing or string replacement helpers are needed.

Validation: 44 transcript component and visualization tests, 13 visualization browser tests, `just build`, and `moon info && moon fmt` passed. No public interface changes. Full `just check` and `just test` remain blocked by existing syntax errors in `deepseek/client/openrouter_wbtest.mbt` and `editor/viewer/diff_provider/moondiff/semantic_review_plan_test.mbt`.
