### PR TITLE
perf(desktop): skip off-screen transcript rows in style, layout and paint

### DIFF
--- a/desktop/frontend/transcript/component/component.mbt
+++ b/desktop/frontend/transcript/component/component.mbt
@@ -284,6 +284,7 @@ pub fn component(
           images: ImageCache::empty(),
         },
         @cmd.batch([
+          render_rows_once_after_mount(),
           match input.scroll {
             Pinned => scroll_after_render()
             Unpinned(top~) => restore_scroll_after_render(top)
@@ -395,6 +396,37 @@ fn scroll_after_render() -> @cmd.Cmd {
     kind=@cmd.after_render,
   )
 }
+
+///|
+/// Render every row in the transcript's first frame, then let rows outside
+/// the viewport be skipped again (`content-visibility: auto`, see
+/// `transcript.css`). A skipped row keeps the height it was last rendered
+/// at, so after this frame no row stands in at a guessed height: scroll
+/// offsets saved earlier map to the same content, and scrolling through
+/// history never shifts as rows first render.
+fn render_rows_once_after_mount() -> @cmd.Cmd {
+  @cmd.custom_cmd(
+    _ => {
+      guard @dom.document().get_element_by_id("stream").to_option()
+        is Some(stream) &&
+        stream.to_html_element() is Some(stream) else {
+        return
+      }
+      let style = stream.get_style()
+      style.set(STREAM_ROWS_VISIBILITY, "visible")
+      @dom.window().request_animation_frame(_ => {
+        style.remove_property(STREAM_ROWS_VISIBILITY) |> ignore
+      })
+      |> ignore
+    },
+    kind=@cmd.after_render,
+  )
+}
+
+///|
+/// The custom property `transcript.css` reads for the rows' content
+/// visibility; `visible` on `#stream` renders every row.
+const STREAM_ROWS_VISIBILITY = "--stream-rows-visibility"
 
 ///|
 /// Put a returning conversation back where its reader left it. Lazily loaded

--- a/desktop/styles/transcript.css
+++ b/desktop/styles/transcript.css
@@ -31,6 +31,20 @@
   margin: 0 auto;
 }
 
+/* Rows outside the viewport skip style, layout and paint. A long transcript
+   otherwise re-lays out every row whenever the column width changes (the
+   editor panel animating open, a window resize), and every render walks
+   them for style. A skipped row keeps the height it had when last rendered
+   (`auto`); the component renders every row once when the transcript
+   mounts (see render_rows_once_after_mount), so the 120px guess never
+   stands in and scroll offsets stay exact. The turn rule is a zero-height
+   row whose time stamp hangs outside it, and the empty state is one row
+   that is always on screen: neither wants the containment. */
+.stream > :not(.turn-rule):not(.empty) {
+  content-visibility: var(--stream-rows-visibility, auto);
+  contain-intrinsic-size: auto 120px;
+}
+
 /* Floating "jump to latest" over the transcript's bottom edge, shown
    only while auto-follow is unpinned. Sticky inside the scroller; zero
    height so it never adds scroll length, the transform lifts the button


### PR DESCRIPTION
## Summary

Follow-up to #1409, which made Rabbita's diff cheap for settled rows. The remaining per-frame cost on a long transcript is the browser's: whenever the conversation column changes width (the editor panel animating open, a window resize), every stream row is re-styled, re-laid out and repainted. A DevTools trace of one right-panel toggle over a long OpenSeek transcript showed each animation frame at 35–40 ms, all of it style recalculation (7.7k elements), layout (10k objects) and paint on the main thread; Rabbita's own render in those frames was ~4 ms.

- Each stream row gets `content-visibility: auto`, so rows outside the viewport skip style, layout and paint until they scroll near. The turn rule (a zero-height row whose time stamp hangs outside it) and the empty state are left out of the containment.
- A skipped row keeps the height it was last rendered at; a row never rendered would stand in at a guessed height, and scroll offsets would drift as rows first render. So the component renders every row in the transcript's first frame (one full layout, what every render cost before) and releases them the frame after. From then on no row is a guess: a saved scroll offset restores exactly, and scrolling through history does not shift.

`ScrollPosition`, the departure/restore logic and the E2E tests are unchanged.

## Verification

- `moon check --target js --deny-warn`, `moon test --target js` (3235) in `desktop/`.
- `just test-browser`: 65 passed, full run on this branch over current `main`. The A→B→A restore test still asserts `scrollTop` is restored exactly.
- Frame cost measured on the real app is the user's call; the number to compare is the per-frame `UpdateLayoutTree` + `Layout` + `Paint` during the panel animation.

Things to keep an eye on: `contain: paint` clips a row's descendants to the row box, so anything inside a row that intentionally overflows it (outlines with a positive offset, absolutely positioned decorations) would be cut; the row roots themselves are not clipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dp6jf4fKxaVzVq2heQR6dX
