### PR TITLE
fix(desktop): close transcript turns after final answers

### DIFF
--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -797,12 +797,9 @@ fn step_time_label(unix_ms : Double) -> String {
 }
 
 ///|
-/// The hairline closing a user's turn: everything below it until the next
-/// bubble is the agent's answer. Drawn after the bubble rather than before it
-/// because that is the boundary a reader needs — the bubble's own alignment
-/// already separates it from the answer above. The rule carries the prompt's
-/// send time at its right end, under the bubble it dates; a turn replayed
-/// from an unstamped store keeps the bare rule.
+/// The prompt's send time, aligned beneath its bubble. Unstamped history
+/// leaves this row empty; styling removes it from the layout. The separator
+/// belongs to the final assistant footer so it closes the whole exchange.
 fn turn_rule_view(ts? : Double) -> @html.Html {
   let children : Array[@html.Html] = []
   if ts is Some(ts) {

--- a/desktop/styles/transcript.css
+++ b/desktop/styles/transcript.css
@@ -500,21 +500,17 @@
   white-space: nowrap;
 }
 
-/* Closes the user's turn: a hairline running to the right edge, where a
-   trailing label (the send time) can sit under the bubble it belongs
-   to. Empty of children it is simply the full-width rule. */
+/* Keep the send time beneath its prompt without separating the prompt from
+   its answer. The final assistant footer draws the turn's closing rule. */
 .turn-rule {
   display: flex;
   align-items: center;
-  gap: 10px;
+  justify-content: flex-end;
   color: var(--color-text-faint);
   font-size: var(--font-size-xs);
 }
-.turn-rule::before {
-  content: "";
-  flex: 1;
-  height: 1px;
-  background: var(--color-border);
+.turn-rule:empty {
+  display: none;
 }
 
 .msg-body {
@@ -522,8 +518,8 @@
   min-width: 0;
 }
 
-/* A completed assistant answer closes with a left-aligned metadata row: the
-   raw-Markdown action first, followed by the durable event's completion time.
+/* A completed assistant answer closes with the raw-Markdown action on the
+   left and the durable event's completion time on the right.
    The icon stays visible instead of relying on hover so touch and keyboard
    users can discover it. */
 .assistant-message-actions {
@@ -532,6 +528,14 @@
   justify-content: flex-start;
   gap: 8px;
   margin-top: 4px;
+}
+/* Only final answers have this footer; intermediate and streaming messages
+   do not close the turn. */
+.assistant-message-actions::after {
+  content: "";
+  height: 1px;
+  flex: 1;
+  background: var(--color-border-subtle);
 }
 .assistant-message-copy {
   --icon-size: var(--icon-md);
@@ -547,6 +551,7 @@
   cursor: pointer;
 }
 .assistant-message-time {
+  order: 1;
   color: var(--color-text-muted);
   font-size: var(--font-size-xs);
   font-variant-numeric: tabular-nums;


### PR DESCRIPTION
Stacked on #1426 (`codex/revert-1351`). Restores only the separator placement from #1351 after that PR's revert.

Moves the horizontal separator from beneath the user prompt into the final assistant answer's footer, between the copy action and completion time. Prompt timestamps remain visible beneath their bubbles. Intermediate responses and streaming answers have no closing separator.

The implementation changes only transcript CSS and the comment describing the prompt timestamp row.

Validation:
- `just check`, `just test`, and `just build` passed (3272 native tests, 3233 JS tests, 24 cram cases, and the CLI lifecycle integration checks).
- Complete Desktop Playwright suite: 64 passed.
- Light/dark before-and-after checks verify separator placement, preserved prompt timestamps, and no final footer on streaming answers.
- `moon info`, `moon fmt`, and `git diff --check` passed.

## Before / after

Real browser bundle, identical synthetic conversation data, 1280 × 820 viewport, UTC timestamps, and the same 820 × 436 transcript crop. Before: #1426 at `7b1593ad6`. After: `46e114f72`.

### Light

Before — separator below each user prompt:

![Before: light theme](https://github.com/user-attachments/assets/efe42f9c-8429-4251-8e9d-10de5ba07289)

After — separator closes the final assistant answer:

![After: light theme](https://github.com/user-attachments/assets/20221c5d-9274-452c-94d2-6c21f0f04197)

<details>
<summary>Dark theme comparison</summary>

Before:

![Before: dark theme](https://github.com/user-attachments/assets/20c4a9cd-ea18-4616-925f-7037d320b8fc)

After:

![After: dark theme](https://github.com/user-attachments/assets/73359ad2-5971-4d76-bd26-93f213049341)

</details>
