### PR TITLE
fix(desktop): remove project picker backdrop blur

### DIFF
--- a/desktop/styles/sidebar.css
+++ b/desktop/styles/sidebar.css
@@ -626,12 +626,12 @@ button.row-twisty:hover {
 /* The host-backed project picker: a compact native-dialog treatment around
    the location bar, directory browser, and inline folder creation. */
 .picker-backdrop {
+  /* Use a tint alone to separate the picker from the page on every platform. */
   background: color-mix(
     in srgb,
     var(--color-text-primary) 20%,
     transparent
   );
-  backdrop-filter: blur(7px) saturate(0.9);
 }
 .modal.picker-modal {
   display: flex;


### PR DESCRIPTION
The backdrop of project picker on Windows causes severe performance drop.

Remove the project picker's backdrop blur and saturation filter on all platforms. The existing translucent tint continues to separate the dialog from the page, without adding Windows-specific platform detection.

Validation: `git diff --check` passed. CSS-only change; no Windows device testing was performed.
