### PR TITLE
feat(desktop): show tool outcomes with a pending spinner

### DIFF
--- a/desktop/e2e/tests/tool_status.spec.js
+++ b/desktop/e2e/tests/tool_status.spec.js
@@ -1,0 +1,96 @@
+import { test, expect } from '@playwright/test';
+import { DesktopBrowserHarness } from './support/desktop_browser_harness.js';
+
+test('Codex partial output and result-only calls retain pending status until completion', async ({ page }) => {
+  const app = new DesktopBrowserHarness(page);
+  app.codexModels = [{
+    id: 'gpt-5.4-codex', displayName: 'GPT-5.4 Codex', isDefault: true,
+    defaultReasoningEffort: 'medium',
+    supportedReasoningEfforts: [{ reasoningEffort: 'medium', description: 'Balanced' }],
+  }];
+  await app.install();
+  await app.goto();
+  await page.getByRole('button', { name: 'Model', exact: true }).click();
+  await page.getByRole('option', { name: 'GPT-5.4 Codex' }).click();
+  await expect.poll(() => app.requests.some(request => request.method === 'codex.draft.open')).toBe(true);
+  await page.locator('#task').fill('Check tool status');
+  await page.getByTitle('Send', { exact: true }).click();
+  await expect.poll(() => app.requests.some(request => request.method === 'codex.turn.start')).toBe(true);
+  const turn = { threadId: 'codex-thread-e2e', turnId: 'codex-turn-e2e' };
+  for (const type of ['commandExecution', 'fileChange']) {
+    const item = type === 'commandExecution'
+      ? { type, id: 'command', command: 'moon test', aggregatedOutput: 'Tests still running' }
+      : { type, id: 'change' }; // No recorded arguments: the result owns this status.
+    app.notify('codex.notification', {
+      generation: 1, method: 'item/started',
+      params: { ...turn, item: { ...item, status: 'inProgress' } },
+    });
+    const row = page.locator(type === 'commandExecution' ? '.tool-call-summary' : '.tool-result-summary').last();
+    await expect(row.getByRole('img', { name: 'Tool in progress' })).toBeVisible();
+    await row.click();
+    await expect(page.locator('.tool-result').last()).toContainText(type === 'commandExecution' ? 'Tests still running' : 'inProgress');
+    app.notify('codex.notification', {
+      generation: 1, method: 'item/completed',
+      params: { ...turn, item: { ...item, status: 'completed' } },
+    });
+    await expect(row.getByRole('img', { name: 'Tool succeeded' })).toBeVisible();
+    await expect(row.locator('.tool-status-spinner')).toHaveCount(0);
+  }
+  expect(app.pageErrors).toEqual([]);
+});
+
+for (const isError of [false, true]) {
+  test(`tool status changes from a spinner to ${isError ? 'failure' : 'success'} without closing its inputs`, async ({ page }) => {
+    const app = new DesktopBrowserHarness(page);
+    app.sessionEvents = [
+      { sequence: 1, item: { kind: 'user', payload: { content: 'Show the browser fixture tool status' } } },
+      { sequence: 2, item: { kind: 'assistant', payload: {
+        content: '',
+        tool_calls: [
+          { id: 'status-call', name: 'mbtx', arguments: JSON.stringify({
+            source: 'fn main { println("status") }', description: 'Check tool status',
+          }) },
+          { id: 'bodyless-call', name: 'shell', arguments: '{}' },
+        ],
+      } } },
+    ];
+    await app.install();
+    await app.goto();
+    await app.openSession();
+    const call = page.locator('#transcript details.tool-call');
+    const summary = call.locator('.tool-call-summary');
+    await expect(summary.getByRole('img', { name: 'Tool in progress' })).toBeVisible();
+    await expect(page.locator('.tool-call-label').getByRole('img', { name: 'Tool in progress' })).toBeVisible();
+    const spinner = summary.locator('.tool-status-spinner');
+    // Inspect a live animation, not only a CSS class that could remain static.
+    expect(await spinner.evaluate(node => node.getAnimations().some(animation =>
+      animation.playState === 'running' && animation.effect.getTiming().iterations === Infinity))).toBe(true);
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    await expect(spinner).toHaveCSS('animation-name', 'none');
+    await page.emulateMedia({ reducedMotion: 'no-preference' });
+
+    await summary.click();
+    await call.getByText('Original JSON', { exact: true }).click();
+    const originalJson = call.locator('.tool-call-tab-input').nth(1);
+    await expect(originalJson).toBeChecked();
+    app.notify('session.event', {
+      session: 'session-1', session_root: '/workspace/.openseek', sequence: 3,
+      event: { sequence: 3, item: { kind: 'tool_result', payload: {
+        tool_call_id: 'status-call', tool_name: 'mbtx',
+        content: isError ? 'Command failed' : 'status', is_error: isError,
+        brief: isError ? 'Check failed' : 'Check succeeded',
+      } } },
+    });
+    const status = summary.getByRole('img', { name: isError ? 'Tool failed' : 'Tool succeeded' });
+    await expect(status).toBeVisible();
+    await expect(status.locator('svg')).toHaveCount(1);
+    await expect(summary.locator('.tool-status-spinner')).toHaveCount(0);
+    await expect(call).toHaveAttribute('open', '');
+    await expect(originalJson).toBeChecked();
+    // Output has its own fold, but must not duplicate the request's state icon.
+    await expect(page.locator('.tool-result')).toHaveCount(1);
+    await expect(page.locator('.tool-result .tool-status')).toHaveCount(0);
+    await expect(page.locator('.tool-call-label .tool-status-spinner')).toBeVisible();
+    expect(app.pageErrors).toEqual([]);
+  });
+}

--- a/desktop/frontend/transcript/component/tool_status.mbt
+++ b/desktop/frontend/transcript/component/tool_status.mbt
@@ -1,0 +1,33 @@
+///|
+/// A call's recorded outcome, rendered independently of its disclosure body.
+/// Partial output still means pending; only a completed result earns a check.
+priv struct ToolStatus(@transcript.ToolOutcome)
+
+///|
+fn ToolStatus::view(self : ToolStatus) -> @html.Html {
+  let (label, class, icon) = match self.0 {
+    Pending(..) =>
+      (
+        "Tool in progress",
+        "tool-status pending",
+        @html.span(
+          class="tool-status-spinner",
+          attrs=@html.Attrs::build().aria_hidden("true"),
+          @html.nothing,
+        ),
+      )
+    Done(is_error=true, ..) =>
+      ("Tool failed", "tool-status failed", @icons.icon(@icons.icon_error))
+    Done(..) =>
+      (
+        "Tool succeeded",
+        "tool-status succeeded",
+        @icons.icon(@icons.icon_check),
+      )
+  }
+  @html.span(
+    class~,
+    attrs=@html.Attrs::build().role("img").aria_label(label).title(label),
+    icon,
+  )
+}

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -332,6 +332,7 @@ fn tool_request_view(
     line.push(marker)
   }
   line.push(@plan.fold_progress(call))
+  line.push(ToolStatus(call.outcome).view())
   let body : Array[@html.Html] = []
   // A `plan` call shows the checklist it recorded rather than its JSON, in
   // every state where that checklist is what the model asked for. A pending
@@ -398,6 +399,13 @@ fn tool_result_view(
   subrun? : SubrunLink,
 ) -> @html.Html {
   let key = tool_call_tabs_key(call.call_id, sequence)
+  // Calls without recorded arguments have no request row. Put their status
+  // on the result instead, so every call has exactly one visible status.
+  let status = if call.arguments is None {
+    Some(ToolStatus(call.outcome))
+  } else {
+    None
+  }
   match call.outcome {
     Pending(output~) =>
       result_row_view(
@@ -409,6 +417,7 @@ fn tool_result_view(
         output,
         key,
         subrun?,
+        status?,
       )
     Done(content~, is_error~, brief~) =>
       result_row_view(
@@ -425,6 +434,7 @@ fn tool_result_view(
         },
         key,
         subrun?,
+        status?,
       )
   }
 }
@@ -442,6 +452,7 @@ fn result_row_view(
   output : String?,
   key : String,
   subrun? : SubrunLink,
+  status? : ToolStatus,
 ) -> @html.Html {
   let label = match (arguments, brief, pending) {
     (None, Some(brief), _) if !brief.is_blank() => brief
@@ -469,6 +480,9 @@ fn result_row_view(
     )
     is Some(marker) {
     line.push(marker)
+  }
+  if status is Some(status) {
+    line.push(status.view())
   }
   let body : Array[@html.Html] = []
   // A sub-run result names the child session it spawned in its brief. The

--- a/desktop/styles/transcript.css
+++ b/desktop/styles/transcript.css
@@ -1070,6 +1070,40 @@
   color: var(--color-text-faint);
   text-align: center;
 }
+/* Reserve the trailing state column even for a long or wrapped caption.
+   The disclosure arrow remains a separate control beside it. */
+.tool-status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  align-self: center;
+  flex: 0 0 16px;
+  width: 16px;
+  height: 16px;
+  margin-left: auto;
+}
+.tool-status.failed {
+  color: var(--color-danger);
+}
+.tool-status-spinner {
+  box-sizing: border-box;
+  width: 12px;
+  height: 12px;
+  border: 1.5px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: tool-status-spin 0.8s linear infinite;
+}
+@keyframes tool-status-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .tool-status-spinner {
+    animation: none;
+  }
+}
 .tool-call-summary:hover,
 .tool-result-summary:hover {
   color: var(--color-text-secondary);

--- a/desktop/styles/transcript.css
+++ b/desktop/styles/transcript.css
@@ -1070,8 +1070,8 @@
   color: var(--color-text-faint);
   text-align: center;
 }
-/* Reserve the trailing state column even for a long or wrapped caption.
-   The disclosure arrow remains a separate control beside it. */
+/* Keep status at the far right, after the summary's ::after disclosure arrow.
+   The arrow stays beside the caption while the auto margin separates status. */
 .tool-status {
   display: inline-flex;
   align-items: center;
@@ -1081,6 +1081,7 @@
   width: 16px;
   height: 16px;
   margin-left: auto;
+  order: 1;
 }
 .tool-status.failed {
   color: var(--color-danger);
@@ -1141,10 +1142,9 @@
   min-width: 0;
   overflow-wrap: anywhere;
 }
-/* The trailing marker belongs to rows that own a fold; `.tool-call-label`
-   rows have nothing to disclose and stay bare. It is the summary's own last
-   flex item rather than part of the text span, so a truncated brief cannot
-   ellipsize it away. */
+/* The marker belongs to rows that own a fold; `.tool-call-label` rows have
+   nothing to disclose and stay bare. Its separate flex item follows the
+   caption but precedes status, and cannot be ellipsized with a long brief. */
 .tool-call-summary::after,
 .tool-result-summary::after {
   content: "▸";


### PR DESCRIPTION
Restores the tool outcome icons from #1351 after its revert in #1426. Each tool call shows a check for success, a circled cross for failure, or a rotating open ring while awaiting completion. Partial output keeps the spinner; a completed result replaces it. Reduced-motion preferences disable rotation.

The status sits at the right of the request row, or on the result for calls without recorded arguments. Request and result disclosures remain separate, with one status per call. This PR targets `main`, where #1426 has merged; the final-answer separator remains in #1429.

Validation:
- `just check`
- `just test`: 3272 native tests, 3233 JS tests, 24 cram cases, and the real CLI lifecycle checks passed.
- `just build`
- Full Desktop Playwright suite: 67 passed, including pending-to-success/failure, partial output, result-only calls, reduced motion, and preserving open inputs and the selected tab.
- Light and dark browser screenshots inspected locally.
- `moon info` and `moon fmt`; no generated public interface changes.
