### PR TITLE
refactor(mbtx): drop redundant --target wasm from the build phase

### DIFF
--- a/agent_tool/mbtx/README.mbt.md
+++ b/agent_tool/mbtx/README.mbt.md
@@ -13,7 +13,7 @@ The `source` is a `.mbtx` **single-file script** — MoonBit's own one-file
 program format. Alternatively, `filename` loads a saved script. The tool
 writes the program into a throwaway directory and, for the
 default wasm target, runs it in **two phases**. The BUILD runs first,
-synchronously: `moon run <file>.mbtx --build-only --target wasm --target-dir
+synchronously: `moon run <file>.mbtx --build-only --target-dir
 <temp>`, bounded by its own wall clock (10s by default) so a hung dependency
 download cannot hold the turn. A nonzero exit here is reported immediately as
 `BUILD failed (exit N)` — a build failure **by construction**, since the run

--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -996,8 +996,6 @@ async fn build_snippet(
     "-q",
     "\{build_dir}/snippet.mbtx",
     "--build-only",
-    "--target",
-    "wasm",
     "--target-dir",
     "\{build_dir}/_build",
     ..if !warning {


### PR DESCRIPTION
## What

`build_snippet`'s BUILD phase ran
`moon run <file>.mbtx --build-only --target wasm --target-dir <temp>`.
The `--target wasm` is redundant: script mode (a bare `.mbtx` with no
module/package config) always defaults to wasm, independent of the
surrounding module's `preferred_target`.

## Why it is safe

Verified with the exact build command shape:

- run from a module root with `preferred_target = "native"` -> produced
  `_build/wasm/debug/build/single/single.wasm`
- script in a subdir of that module -> still `wasm`
- script outside the tree, cwd in a `moon.work` workspace whose only member
  is native-preferring -> still `wasm`

This workspace itself sets `preferred_target = "native"` (`moon.mod`) and
script mode still builds wasm. The repo already relies on the default:
`justfile` runs `moon run scripts/update-moonbit-docs.mbtx` with no
`--target`.

The staged path stays explicitly wasm by construction: `build_snippet` is
called only when `input.target == "wasm"`, the artifact is exec'd by
`moonrun` under the wasm policy, and the fallback artifact path is the wasm
layout.

## Verification

- `moon check` — clean
- `moon test agent_tool/mbtx` — 85/85 pass (the suite drives the real tool
  and spawns real `moon`, exercising the staged build/run path)
- `moon fmt --check agent_tool/mbtx` — clean

Generated with SeekMoon