### PR TITLE
fix(desktop): restore Codex app-server on Windows

### DIFF
--- a/desktop/frontend/codex/completion.mbt
+++ b/desktop/frontend/codex/completion.mbt
@@ -587,6 +587,7 @@ test "Codex draft skills wait for the host-confirmed project root" {
   assert_true(pending.active_context() is None)
   let confirmed = pending.with_open_draft("draft-1", {
     "draftId": "draft-1",
+    "cwd": "/canonical/project",
     "projectRoot": "/canonical/project",
   })
   guard confirmed.active_context() is Some(context) else {

--- a/desktop/frontend/codex/model.mbt
+++ b/desktop/frontend/codex/model.mbt
@@ -1049,18 +1049,6 @@ pub fn State::active_id(self : State) -> String? {
 }
 
 ///|
-/// Codex reports native paths for the owning host. Convert Windows drive
-/// spellings explicitly, without consulting the browser machine's OS.
-fn cwd_resource(channel : @interop.ChannelId, cwd : String) -> @common.Uri? {
-  let path = match cwd {
-    ['a'..='z' | 'A'..='Z', ':', '/' | '\\', ..] =>
-      "/" + cwd.replace_all(old="\\", new="/")
-    _ => cwd
-  }
-  @resource.of_path(channel, path)
-}
-
-///|
 /// The selected task's complete host-authorized placement. Stored tasks get
 /// their cwd from app-server and their managed-worktree annotation from the
 /// native host; local drafts get their project from `codex.draft.open`.
@@ -1074,7 +1062,7 @@ pub fn State::active_placement(
     CodexNoTask => None
     CodexDraftTask(draft) =>
       draft.project_root
-      .bind(root => cwd_resource(channel, root))
+      .bind(root => @resource.of_path(channel, root))
       .map(root => @interop.WorkspaceRoot(root~))
     CodexStoredTask(thread) => thread.placement(channel)
   }
@@ -1131,7 +1119,7 @@ pub fn State::worktree_launch_workspace(
 ) -> @common.Uri? {
   guard self.active_draft() is Some(draft) &&
     draft.project_root is Some(root) &&
-    cwd_resource(channel, root) is Some(workspace) else {
+    @resource.of_path(channel, root) is Some(workspace) else {
     return None
   }
   Some(workspace)
@@ -1184,20 +1172,20 @@ fn State::with_open_draft(
 }
 
 ///|
-test "Codex draft adopts the host cwd after resolving a Windows resource path" {
+test "Codex draft adopts the host-confirmed resource path" {
   let draft = State().select_draft("desktop-windows", "/c:/work/project")
   let opened = draft.with_open_draft("desktop-windows", {
     "draftId": "desktop-windows",
-    "cwd": "C:\\work\\project",
-    "projectRoot": "C:\\work\\project",
+    "cwd": "/C:/work/canonical-project",
+    "projectRoot": "/C:/work/canonical-project",
   })
   guard opened.active_draft() is Some(draft) else { fail("expected a draft") }
-  assert_eq(draft.cwd, "C:\\work\\project")
-  assert_eq(draft.project_root, Some("C:\\work\\project"))
+  assert_eq(draft.cwd, "/C:/work/canonical-project")
+  assert_eq(draft.project_root, Some("/C:/work/canonical-project"))
   let channel = @interop.ChannelId::Local
   assert_eq(
     opened.worktree_launch_workspace(channel),
-    @resource.of_path(channel, "/c:/work/project"),
+    @resource.of_path(channel, "/c:/work/canonical-project"),
   )
 }
 
@@ -1381,7 +1369,7 @@ fn CodexThread::placement(
   match self.worktree {
     Some(worktree) => {
       guard self.project_root is Some(project_path) &&
-        cwd_resource(channel, project_path) is Some(project) else {
+        @resource.of_path(channel, project_path) is Some(project) else {
         return None
       }
       if !worktree.present {
@@ -1389,7 +1377,7 @@ fn CodexThread::placement(
       }
       guard self.cwd is Some(cwd) &&
         !cwd.trim().is_empty() &&
-        cwd_resource(channel, cwd) is Some(root) else {
+        @resource.of_path(channel, cwd) is Some(root) else {
         return None
       }
       Some(@interop.Worktree(project~, name=worktree.name, root~))
@@ -1397,7 +1385,9 @@ fn CodexThread::placement(
     None =>
       match self.cwd {
         Some(cwd) if !cwd.trim().is_empty() =>
-          cwd_resource(channel, cwd).map(root => @interop.WorkspaceRoot(root~))
+          @resource.of_path(channel, cwd).map(root => {
+            @interop.WorkspaceRoot(root~)
+          })
         // app-server tasks created without cwd still own a host-lazy scratch
         // terminal. The host does not disclose its path, so keep `root=None`:
         // Terminal can use the task id while Files and language services stay

--- a/desktop/frontend/codex/model.mbt
+++ b/desktop/frontend/codex/model.mbt
@@ -1049,6 +1049,18 @@ pub fn State::active_id(self : State) -> String? {
 }
 
 ///|
+/// Codex reports native paths for the owning host. Convert Windows drive
+/// spellings explicitly, without consulting the browser machine's OS.
+fn cwd_resource(channel : @interop.ChannelId, cwd : String) -> @common.Uri? {
+  let path = match cwd {
+    ['a'..='z' | 'A'..='Z', ':', '/' | '\\', ..] =>
+      "/" + cwd.replace_all(old="\\", new="/")
+    _ => cwd
+  }
+  @resource.of_path(channel, path)
+}
+
+///|
 /// The selected task's complete host-authorized placement. Stored tasks get
 /// their cwd from app-server and their managed-worktree annotation from the
 /// native host; local drafts get their project from `codex.draft.open`.
@@ -1062,7 +1074,7 @@ pub fn State::active_placement(
     CodexNoTask => None
     CodexDraftTask(draft) =>
       draft.project_root
-      .bind(root => @resource.of_path(channel, root))
+      .bind(root => cwd_resource(channel, root))
       .map(root => @interop.WorkspaceRoot(root~))
     CodexStoredTask(thread) => thread.placement(channel)
   }
@@ -1119,7 +1131,7 @@ pub fn State::worktree_launch_workspace(
 ) -> @common.Uri? {
   guard self.active_draft() is Some(draft) &&
     draft.project_root is Some(root) &&
-    @resource.of_path(channel, root) is Some(workspace) else {
+    cwd_resource(channel, root) is Some(workspace) else {
     return None
   }
   Some(workspace)
@@ -1156,14 +1168,37 @@ fn State::with_open_draft(
     value is Object(fields) &&
     @jsonx.json_text(fields, "draftId") is Some(reply_draft_id) &&
     reply_draft_id == draft_id &&
+    @jsonx.json_text(fields, "cwd") is Some(cwd) &&
     @jsonx.json_text(fields, "projectRoot") is Some(project_root) else {
     return { ..self, notice: "Malformed Codex draft workspace reply", }
   }
   {
     ..self,
-    selection: CodexDraftTask({ ..draft, project_root: Some(project_root), }),
+    selection: CodexDraftTask({
+      ..draft,
+      cwd,
+      project_root: Some(project_root),
+    }),
     notice: "",
   }
+}
+
+///|
+test "Codex draft adopts the host cwd after resolving a Windows resource path" {
+  let draft = State().select_draft("desktop-windows", "/c:/work/project")
+  let opened = draft.with_open_draft("desktop-windows", {
+    "draftId": "desktop-windows",
+    "cwd": "C:\\work\\project",
+    "projectRoot": "C:\\work\\project",
+  })
+  guard opened.active_draft() is Some(draft) else { fail("expected a draft") }
+  assert_eq(draft.cwd, "C:\\work\\project")
+  assert_eq(draft.project_root, Some("C:\\work\\project"))
+  let channel = @interop.ChannelId::Local
+  assert_eq(
+    opened.worktree_launch_workspace(channel),
+    @resource.of_path(channel, "/c:/work/project"),
+  )
 }
 
 ///|
@@ -1346,7 +1381,7 @@ fn CodexThread::placement(
   match self.worktree {
     Some(worktree) => {
       guard self.project_root is Some(project_path) &&
-        @resource.of_path(channel, project_path) is Some(project) else {
+        cwd_resource(channel, project_path) is Some(project) else {
         return None
       }
       if !worktree.present {
@@ -1354,7 +1389,7 @@ fn CodexThread::placement(
       }
       guard self.cwd is Some(cwd) &&
         !cwd.trim().is_empty() &&
-        @resource.of_path(channel, cwd) is Some(root) else {
+        cwd_resource(channel, cwd) is Some(root) else {
         return None
       }
       Some(@interop.Worktree(project~, name=worktree.name, root~))
@@ -1362,9 +1397,7 @@ fn CodexThread::placement(
     None =>
       match self.cwd {
         Some(cwd) if !cwd.trim().is_empty() =>
-          @resource.of_path(channel, cwd).map(root => {
-            @interop.WorkspaceRoot(root~)
-          })
+          cwd_resource(channel, cwd).map(root => @interop.WorkspaceRoot(root~))
         // app-server tasks created without cwd still own a host-lazy scratch
         // terminal. The host does not disclose its path, so keep `root=None`:
         // Terminal can use the task id while Files and language services stay

--- a/desktop/frontend/codex/sidebar_test.mbt
+++ b/desktop/frontend/codex/sidebar_test.mbt
@@ -1,4 +1,37 @@
 ///|
+test "Windows Codex resource paths match registered sidebar projects" {
+  let channel = @interop.ChannelId::Local
+  // The host's to_uri_path canonicalizes the drive before publishing either
+  // draft/thread metadata or registered projects. URI parsing preserves it.
+  let root = "/c:/Users/mbt/Workspace/tty"
+  guard @resource.of_path(channel, root) is Some(project) else {
+    fail("expected a Windows project resource")
+  }
+  let state = @codex.State::from_thread_snapshot({
+    "thread": {
+      "id": "windows-thread",
+      "cwd": root + "/.worktrees/wt-1",
+      "projectRoot": root,
+      "preview": "New chat",
+      "turns": [],
+    },
+  })
+  let context : @codex.SidebarContext = {
+    channel,
+    selected: true,
+    registered_projects: [project.path],
+  }
+  let rows = state.project_conversations(context, project.path)
+  assert_eq(rows.length(), 1)
+  assert_true(rows[0].input.nested)
+  assert_eq(
+    state.project_activation(context, project.path),
+    Some("windows-thread"),
+  )
+  assert_eq(state.loose_entries(context).length(), 0)
+}
+
+///|
 test "Codex threads nest under their registered project row" {
   let state = @codex.State::from_thread_snapshot({
     "thread": {

--- a/desktop/internal/api/api.mbt
+++ b/desktop/internal/api/api.mbt
@@ -813,10 +813,9 @@ async fn ApiState::codex_file_search(
   self : ApiState,
   payload : @protocol.CodexFileSearchPayload,
 ) -> @protocol.CodexFileSearchReply {
-  guard @work_dir.resolve_in_workspace(
+  guard @work_dir.resolve_host_workspace_authorization(
       payload.thread_id,
-      "",
-      workspace=payload.cwd,
+      payload.cwd,
     )
     is Some(root) else {
     raise @host.HostError("Codex workspace is not authorized")
@@ -842,12 +841,9 @@ async fn ApiState::open_codex_draft(
       payload.cwd.trim().to_owned(),
     )
     is Some(requested) {
-    let normalized = requested.normalize()
-    if @workspaces.registered().contains(normalized) {
-      Some(normalized.to_string())
-    } else {
-      None
-    }
+    // Resource URIs lowercase Windows drive letters; the registry owns the
+    // canonical filesystem spelling, including drive case and symlinks.
+    @workspaces.registered_dir(requested).map(root => root.to_string())
   } else {
     None
   }
@@ -880,9 +876,7 @@ async fn ApiState::codex_thread_start(
       guard @protocol.CodexDraftClosePayload::{ draft_id, }.validated_id()
         is Some(validated) &&
         @work_dir.resolve_host_workspace_authorization(validated, cwd)
-        is Some(authorized) &&
-        @pathx.Absolute::from_uri_path(cwd) is Some(requested) &&
-        authorized.normalize() == requested.normalize() else {
+        is Some(_) else {
         raise @host.HostError("Codex draft workspace is not authorized")
       }
     }
@@ -924,9 +918,7 @@ async fn ApiState::codex_turn_start(
 ) -> @protocol.CodexTurnReply {
   if request.cwd is Some(cwd) {
     guard @work_dir.resolve_host_workspace_authorization(request.thread_id, cwd)
-      is Some(authorized) &&
-      @pathx.Absolute::from_uri_path(cwd) is Some(requested) &&
-      authorized.normalize() == requested.normalize() else {
+      is Some(_) else {
       raise @host.HostError("Codex turn workspace is not authorized")
     }
   }
@@ -1005,10 +997,9 @@ async fn ApiState::codex_skills_list(
   self : ApiState,
   payload : @protocol.CodexSkillsListPayload,
 ) -> @protocol.CodexDataReply {
-  guard @work_dir.resolve_in_workspace(
+  guard @work_dir.resolve_host_workspace_authorization(
       payload.thread_id,
-      "",
-      workspace=payload.cwd,
+      payload.cwd,
     )
     is Some(root) else {
     raise @host.HostError("Codex workspace is not authorized")

--- a/desktop/internal/api/api.mbt
+++ b/desktop/internal/api/api.mbt
@@ -166,17 +166,24 @@ fn CodexWorktreeCatalog::CodexWorktreeCatalog(
 fn CodexWorktreeCatalog::annotate_thread(
   self : CodexWorktreeCatalog,
   value : Json,
-) -> Json {
+) -> Json raise {
   guard value is Object(thread) && thread.get("id") is Some(String(thread_id)) else {
     return value
+  }
+  let annotated = thread.copy()
+  // App-server paths are native; Desktop paths are resource URI components.
+  // Registry worktree annotations below already use the Desktop convention.
+  for key in ["cwd", "projectRoot"] {
+    if thread.get(key) is Some(String(path)) {
+      annotated[key] = Json(codex_resource_path(path))
+    }
   }
   guard self.bindings
     .iter()
     .find_first(binding => binding.thread_id == thread_id)
     is Some(binding) else {
-    return value
+    return Json(annotated)
   }
-  let annotated = thread.copy()
   // The registry retains the owning project even after its checkout is gone;
   // Git cannot recover that relationship from a deleted cwd.
   annotated["projectRoot"] = Json(binding.workspace)
@@ -188,7 +195,7 @@ fn CodexWorktreeCatalog::annotate_thread(
 fn CodexWorktreeCatalog::annotate(
   self : CodexWorktreeCatalog,
   reply : Json,
-) -> Json {
+) -> Json raise {
   guard reply is Object(fields) else { return reply }
   let annotated = fields.copy()
   if fields.get("data") is Some(Array(threads)) {
@@ -234,8 +241,14 @@ fn CodexWorkspaceBinding::decode_reply(value : Json) -> CodexWorkspaceBinding? {
 /// Terminal request caused by that render can resolve the cwd immediately.
 async fn CodexWorkspaceBinding::authorize(self : CodexWorkspaceBinding) -> Unit {
   match self.workspace {
-    Some(workspace) if !workspace.trim().is_empty() =>
-      @work_dir.authorize_host_workspace(self.session, workspace)
+    Some(workspace) => {
+      guard @pathx.Absolute::from_uri_path(workspace) is Some(path) else {
+        raise @host.HostError(
+          "invalid Codex workspace resource path: " + workspace,
+        )
+      }
+      @work_dir.authorize_host_workspace(self.session, path.to_string())
+    }
     _ => @work_dir.revoke_host_workspace(self.session)
   }
 }
@@ -634,7 +647,10 @@ pub fn endpoints(
           info.name == reply.name
         })
         is Some(info) {
-        @work_dir.authorize_host_workspace(thread_id, info.path)
+        CodexWorkspaceBinding::{
+          session: thread_id,
+          workspace: Some(info.path),
+        }.authorize()
       }
       WorktreeCreatedReply(reply)
     }),
@@ -859,6 +875,7 @@ async fn ApiState::open_codex_draft(
     raise @host.PayloadError("invalid Codex draft project")
   }
   @work_dir.authorize_host_workspace(draft_id, project_root)
+  let project_root = codex_resource_path(project_root)
   { draft_id, cwd: project_root, project_root, }
 }
 
@@ -871,22 +888,26 @@ async fn ApiState::codex_thread_start(
   self : ApiState,
   request : @protocol.CodexThreadStartPayload,
 ) -> @protocol.CodexThreadReply {
-  match (request.cwd, request.draft_id) {
+  let cwd = match (request.cwd, request.draft_id) {
     (Some(cwd), Some(draft_id)) => {
       guard @protocol.CodexDraftClosePayload::{ draft_id, }.validated_id()
         is Some(validated) &&
         @work_dir.resolve_host_workspace_authorization(validated, cwd)
-        is Some(_) else {
+        is Some(authorized) else {
         raise @host.HostError("Codex draft workspace is not authorized")
       }
+      Some(authorized.to_string())
     }
-    (None, Some(draft_id)) =>
+    (None, Some(draft_id)) => {
       if @protocol.CodexDraftClosePayload::{ draft_id, }.validated_id() is None {
         raise @host.PayloadError("invalid Codex draft id")
       }
-    (None, None) => ()
+      None
+    }
+    (None, None) => None
     _ => raise @host.PayloadError("Codex thread cwd requires its draft id")
   }
+  let request = { ..request, cwd, }
   if self.codex_draft_threads.cached(request) is Some(reply) {
     return reply
   }
@@ -916,12 +937,16 @@ async fn ApiState::codex_turn_start(
   self : ApiState,
   request : @protocol.CodexTurnStartPayload,
 ) -> @protocol.CodexTurnReply {
-  if request.cwd is Some(cwd) {
+  let cwd = if request.cwd is Some(cwd) {
     guard @work_dir.resolve_host_workspace_authorization(request.thread_id, cwd)
-      is Some(_) else {
+      is Some(authorized) else {
       raise @host.HostError("Codex turn workspace is not authorized")
     }
+    Some(authorized.to_string())
+  } else {
+    None
   }
+  let request = { ..request, cwd, }
   @json.from_json(
     self.codex_request("codex.turn.start", request.app_server_params()),
   )
@@ -945,8 +970,8 @@ async fn ApiState::codex_worktree_project(
     reply_fields.get("thread") is Some(Object(thread)) &&
     thread.get("id") is Some(reply_id) &&
     reply_id == Json(thread_id) &&
-    thread.get("projectRoot") is Some(reply_root) &&
-    reply_root == Json(requested) else {
+    thread.get("projectRoot") is Some(String(reply_root)) &&
+    codex_same_workspace(reply_root, requested) else {
     raise @host.HostError(
       "Codex worktree requires an empty task at its main project root",
     )
@@ -956,11 +981,13 @@ async fn ApiState::codex_worktree_project(
   // app-server cwd at the missing checkout; the registry's exact owner/project
   // pair is the authority needed to recreate that same placement.
   if @worktree.list_codex_worktree_bindings().any(binding => {
-      binding.thread_id == thread_id && binding.workspace == requested
+      binding.thread_id == thread_id &&
+      codex_same_workspace(binding.workspace, requested)
     }) {
     return requested
   }
-  guard thread.get("cwd") is Some(reply_cwd) && reply_cwd == Json(requested) else {
+  guard thread.get("cwd") is Some(String(reply_cwd)) &&
+    codex_same_workspace(reply_cwd, requested) else {
     raise @host.HostError(
       "Codex worktree requires an empty task at its main project root",
     )

--- a/desktop/internal/api/codex_paths.mbt
+++ b/desktop/internal/api/codex_paths.mbt
@@ -1,0 +1,71 @@
+///|
+/// Encode app-server's native paths on the owning host, using the same
+/// reversible resource-path convention as the rest of the Desktop protocol.
+fn codex_resource_path(path : String) -> String raise @host.HostError {
+  guard @pathx.Path(path).to_absolute().bind(path => path.to_uri_path())
+    is Some(resource) else {
+    raise HostError("unsupported Codex workspace path: " + path)
+  }
+  resource
+}
+
+///|
+fn codex_same_workspace(left : String, right : String) -> Bool {
+  @pathx.Absolute::from_uri_path(left) is Some(path) &&
+  @pathx.Absolute::from_uri_path(right) is Some(root) &&
+  path.relative_to(root~) is Some(relative) &&
+  relative.is_root()
+}
+
+///|
+async test "Codex thread resources roundtrip through host workspace grants" {
+  let native = if @platform.win32 || @platform.win64 {
+    "C:\\work\\project"
+  } else {
+    "/work/project"
+  }
+  let resource = if @platform.win32 || @platform.win64 {
+    "/C:/work/project"
+  } else {
+    "/work/project"
+  }
+  let frontend = if @platform.win32 || @platform.win64 {
+    "/c:/work/project"
+  } else {
+    resource
+  }
+  let thread : Json = {
+    "id": "codex-path-roundtrip",
+    "cwd": native,
+    "projectRoot": native,
+  }
+  let catalog = CodexWorktreeCatalog([])
+  let reply = catalog.annotate({ "thread": thread })
+  assert_eq(reply, {
+    "thread": {
+      "id": "codex-path-roundtrip",
+      "cwd": resource,
+      "projectRoot": resource,
+    },
+  })
+  assert_eq(catalog.annotate({ "data": [thread] }), {
+    "data": [
+      { "id": "codex-path-roundtrip", "cwd": resource, "projectRoot": resource },
+    ],
+  })
+  assert_true(codex_same_workspace(resource, frontend))
+  assert_true(!codex_same_workspace(resource, frontend + "/child"))
+  guard CodexWorkspaceBinding::decode_reply(reply) is Some(binding) else {
+    fail("expected a thread workspace binding")
+  }
+  defer @work_dir.revoke_host_workspace(binding.session)
+  binding.authorize()
+  guard @work_dir.resolve_host_workspace_authorization(
+      binding.session,
+      frontend,
+    )
+    is Some(authorized) else {
+    fail("expected the frontend resource to resolve to the native cwd")
+  }
+  assert_eq(authorized.to_path().normalize(), @pathx.Path(native).normalize())
+}

--- a/desktop/internal/api/codex_paths.mbt
+++ b/desktop/internal/api/codex_paths.mbt
@@ -25,12 +25,12 @@ async test "Codex thread resources roundtrip through host workspace grants" {
     "/work/project"
   }
   let resource = if @platform.win32 || @platform.win64 {
-    "/C:/work/project"
+    "/c:/work/project"
   } else {
     "/work/project"
   }
   let frontend = if @platform.win32 || @platform.win64 {
-    "/c:/work/project"
+    "/C:/work/project"
   } else {
     resource
   }
@@ -67,5 +67,10 @@ async test "Codex thread resources roundtrip through host workspace grants" {
     is Some(authorized) else {
     fail("expected the frontend resource to resolve to the native cwd")
   }
-  assert_eq(authorized.to_path().normalize(), @pathx.Path(native).normalize())
+  guard @pathx.Path(native).to_absolute() is Some(root) else {
+    fail("expected a native absolute path")
+  }
+  assert_true(
+    authorized.relative_to(root~) is Some(relative) && relative.is_root(),
+  )
 }

--- a/desktop/internal/api/moon.pkg
+++ b/desktop/internal/api/moon.pkg
@@ -16,6 +16,7 @@ import {
   "openseek_desktop/internal/worktree",
   "moonbitlang/async",
   "moonbitlang/core/json",
+  "tonyfettes/platform",
   "tonyfettes/xlog",
 }
 

--- a/desktop/internal/codex/actor.mbt
+++ b/desktop/internal/codex/actor.mbt
@@ -387,10 +387,6 @@ async fn[G] Actor::run_connection(
       self.signal()
     },
   )
-  guard connection is Some(connection) else {
-    self.report_unavailable("Codex app-server is unavailable", pending, emit)
-    return
-  }
   self.state = Ready
   emit("codex.status_changed", self.status())
   if pending is Some(input) {

--- a/desktop/internal/codex/command.mbt
+++ b/desktop/internal/codex/command.mbt
@@ -10,3 +10,18 @@ const DefaultCodexCommand : String = "codex"
 pub fn command() -> String {
   DefaultCodexCommand
 }
+
+///|
+/// Windows npm installs a codex.cmd shim. Native process spawning only
+/// searches for .exe, so let cmd resolve the fixed default command through
+/// PATH/PATHEXT. Explicit executable paths still use direct spawning.
+fn app_server_launch(
+  command : String,
+  windows~ : Bool,
+) -> (String, Array[String]) {
+  if windows && command == DefaultCodexCommand {
+    ("cmd.exe", ["/d", "/c", "codex", "app-server"])
+  } else {
+    (command, ["app-server"])
+  }
+}

--- a/desktop/internal/codex/connection.mbt
+++ b/desktop/internal/codex/connection.mbt
@@ -10,7 +10,6 @@ const HandshakeTimeoutMs : Int = 30000
 /// the task group passed to `connect`; `shutdown` is an eager, idempotent close.
 struct Connection {
   rpc : @jsonrpc.Client
-  teardown : () -> Unit
 }
 
 ///|
@@ -48,13 +47,13 @@ pub fn Connection::is_closed(self : Connection) -> Bool {
 
 ///|
 pub fn Connection::shutdown(self : Connection) -> Unit {
-  (self.teardown)()
+  self.rpc.close()
 }
 
 ///|
 /// Spawn `codex app-server`, install the two inbound event receivers before
-/// the handshake, then send the required initialize/initialized pair. Returns
-/// `None` after fully tearing down any spawn, protocol, or timeout failure.
+/// the handshake, then send the required initialize/initialized pair. Raises
+/// the failure after tearing down any spawn, protocol, or timeout failure.
 pub async fn[X] connect(
   group : @async.TaskGroup[X],
   command~ : String,
@@ -64,33 +63,7 @@ pub async fn[X] connect(
   version~ : String,
   home~ : @pathx.Path?,
   handshake_timeout_ms? : Int = HandshakeTimeoutMs,
-) -> Connection? {
-  let (child_stdin, stdin_writer) = @process.write_to_process() catch {
-    error if @async.is_being_cancelled() => raise error
-    _ => return None
-  }
-  let (stdout_reader, child_stdout) = @process.read_from_process() catch {
-    error if @async.is_being_cancelled() => {
-      stdin_writer.close()
-      raise error
-    }
-    _ => {
-      stdin_writer.close()
-      return None
-    }
-  }
-  let (stderr_reader, child_stderr) = @process.read_from_process() catch {
-    error if @async.is_being_cancelled() => {
-      stdout_reader.close()
-      stdin_writer.close()
-      raise error
-    }
-    _ => {
-      stdout_reader.close()
-      stdin_writer.close()
-      return None
-    }
-  }
+) -> Connection {
   // The Desktop's isolated CODEX_HOME must win over anything the login-shell
   // environment inherited. Every process the app-server later spawns inherits
   // it too, so nested codex calls, sandbox approvals, and tool runs agree
@@ -99,45 +72,59 @@ pub async fn[X] connect(
     Some(home) => Map([("CODEX_HOME", home.to_string())])
     None => Map([])
   }
-  let process = @process.spawn(
-    group,
+  let (executable, args) = app_server_launch(
     command,
-    ["app-server"],
-    inherit_env=true,
-    extra_env=env,
-    stdin=child_stdin,
-    stdout=child_stdout,
-    stderr=child_stderr,
-    no_console_window=true,
-    cancel_handler=@process.graceful_cancel(timeout=1000),
-    no_wait=true,
-  ) catch {
-    error if @async.is_being_cancelled() => {
-      stderr_reader.close()
-      stdout_reader.close()
-      stdin_writer.close()
-      raise error
-    }
-    _ => {
-      stderr_reader.close()
-      stdout_reader.close()
-      stdin_writer.close()
-      return None
-    }
+    windows=@platform.win32 || @platform.win64,
+  )
+  let (stdin_writer, stdout_reader, stderr_reader, process) = try {
+    let (child_stdin, stdin_writer) = @process.write_to_process()
+    errdefer stdin_writer.close()
+    let (stdout_reader, child_stdout) = @process.read_from_process()
+    errdefer stdout_reader.close()
+    let (stderr_reader, child_stderr) = @process.read_from_process()
+    errdefer stderr_reader.close()
+    let process = @process.spawn(
+      group,
+      executable,
+      args,
+      inherit_env=true,
+      extra_env=env,
+      stdin=child_stdin,
+      stdout=child_stdout,
+      stderr=child_stderr,
+      no_console_window=true,
+      cancel_handler=@process.graceful_cancel(timeout=1000),
+      no_wait=true,
+    )
+    (stdin_writer, stdout_reader, stderr_reader, process)
+  } catch {
+    error if @async.is_being_cancelled() => raise error
+    error =>
+      raise CodexError::Unavailable(
+        "Could not start \{command} app-server via \{executable}: \{error}",
+      )
   }
-  let closed : Ref[Bool] = { val: false, }
-  let teardown_action : Ref[() -> Unit] = {
-    val: () => {
-      stderr_reader.close()
-      stdout_reader.close()
-      stdin_writer.close()
-      process.cancel()
-    },
-  }
+  // As in MCP stdio, each task owns its pipe. Cancel pending IO before the
+  // owner closes the handle, so Windows can still deliver its completion.
+  let mut torn_down = false
+  let mut reader_task : @async.Task[Unit]? = None
+  let mut writer_task : @async.Task[Unit]? = None
+  let mut stderr_task : @async.Task[Unit]? = None
   let teardown = () => {
-    if !closed.val {
-      closed.val = true
-      (teardown_action.val)()
+    if !torn_down {
+      torn_down = true
+      if reader_task is Some(task) {
+        task.cancel()
+      }
+      if writer_task is Some(task) {
+        task.cancel()
+      }
+      if stderr_task is Some(task) {
+        task.cancel()
+      }
+      // Closing the writer supplies stdin EOF; process cancellation is the
+      // backstop for a server that does not exit on EOF, matching MCP stdio.
+      process.cancel()
       on_closed()
     }
   }
@@ -145,43 +132,57 @@ pub async fn[X] connect(
   let rpc = @jsonrpc.Client(transport)
   rpc.set_notification_handler(notification_handler)
   rpc.set_request_handler(request_handler)
-  group.spawn_bg(() => rpc.run_message_pump(), no_wait=true, allow_failure=true)
-  group.spawn_bg(() => rpc.run_writer(), no_wait=true, allow_failure=true)
+  reader_task = Some(
+    group.spawn(
+      () => {
+        defer stdout_reader.close()
+        rpc.run_message_pump()
+      },
+      no_wait=true,
+      allow_failure=true,
+    ),
+  )
+  writer_task = Some(
+    group.spawn(
+      () => {
+        defer stdin_writer.close()
+        rpc.run_writer()
+      },
+      no_wait=true,
+      allow_failure=true,
+    ),
+  )
   // Drain stderr independently for the process lifetime. App-server can emit
   // model-refresh, network, and crash diagnostics there; retain each complete
   // line in the Desktop JSONL log while keeping the pipe from backpressuring
   // protocol progress on stdout.
-  group.spawn_bg(
-    () => {
-      for ;; {
-        let line = stderr_reader.read_until("\n") catch {
-          error if @async.is_being_cancelled() => raise error
-          error => {
-            @xlog.warn(category="codex") <?
-              {
-                "event": "codex_app_server_stderr_read_failed",
-                "error": "\{error}",
-              }
-            None
+  stderr_task = Some(
+    group.spawn(
+      () => {
+        defer stderr_reader.close()
+        for ;; {
+          let line = stderr_reader.read_until("\n") catch {
+            error if @async.is_being_cancelled() => raise error
+            error => {
+              @xlog.warn(category="codex") <?
+                {
+                  "event": "codex_app_server_stderr_read_failed",
+                  "error": "\{error}",
+                }
+              None
+            }
           }
+          guard line is Some(line) else { break }
+          @xlog.debug(category="codex") <?
+            { "event": "codex_app_server_stderr", "line": line }
         }
-        guard line is Some(line) else { break }
-        @xlog.debug(category="codex") <?
-          { "event": "codex_app_server_stderr", "line": line }
-      }
-    },
-    no_wait=true,
-    allow_failure=true,
+      },
+      no_wait=true,
+      allow_failure=true,
+    ),
   )
-  teardown_action.val = () => {
-    // Closing the three pipes wakes the background tasks. They remain owned
-    // by `group`, so the task group waits for their unwind before reconnecting.
-    stderr_reader.close()
-    stdout_reader.close()
-    stdin_writer.close()
-    process.cancel()
-  }
-  let initialized = @async.with_timeout_opt(handshake_timeout_ms, () => {
+  errdefer rpc.close()
+  let _ = @async.with_timeout(handshake_timeout_ms, () => {
     rpc.request(method_="initialize", params={
       "clientInfo": {
         "name": "openseek_desktop",
@@ -194,34 +195,23 @@ pub async fn[X] connect(
       "capabilities": { "experimentalApi": true },
     })
   }) catch {
-    error if @async.is_being_cancelled() => {
-      teardown()
+    error if @async.is_being_cancelled() => raise error
+    error => {
+      let error : CodexError = match error {
+        @jsonrpc.Failed(code~, message~, data~) =>
+          JsonRpc(method_="initialize", code~, message~, data~)
+        @jsonrpc.Closed => TransportClosed(method_="initialize")
+        @async.TimeoutError =>
+          RequestFailed(
+            method_="initialize",
+            detail="timed out after \{handshake_timeout_ms} ms",
+          )
+        error => RequestFailed(method_="initialize", detail="\{error}")
+      }
+      error.log()
       raise error
     }
-    @jsonrpc.Failed(code~, message~, data~) => {
-      JsonRpc(method_="initialize", code~, message~, data~).log()
-      teardown()
-      return None
-    }
-    @jsonrpc.Closed => {
-      TransportClosed(method_="initialize").log()
-      teardown()
-      return None
-    }
-    error => {
-      RequestFailed(method_="initialize", detail="\{error}").log()
-      teardown()
-      return None
-    }
-  }
-  guard initialized is Some(_) else {
-    RequestFailed(
-      method_="initialize",
-      detail="timed out after \{handshake_timeout_ms} ms",
-    ).log()
-    teardown()
-    return None
   }
   rpc.notify(method_="initialized", params=Json::empty_object())
-  Some({ rpc, teardown, })
+  { rpc, }
 }

--- a/desktop/internal/codex/home.mbt
+++ b/desktop/internal/codex/home.mbt
@@ -69,7 +69,14 @@ pub async fn prepared_home(runtime_dir : @pathx.Path) -> @pathx.Path? {
 ///|
 test "codex home is a codex subdirectory of the runtime dir" {
   let home = home_dir(Path("/tmp/openseek-state"))
-  assert_eq(home.to_string(), "/tmp/openseek-state/codex")
+  assert_eq(
+    home.to_string(),
+    if @platform.win32 || @platform.win64 {
+      "\\tmp\\openseek-state\\codex"
+    } else {
+      "/tmp/openseek-state/codex"
+    },
+  )
 }
 
 ///|

--- a/desktop/internal/codex/pkg.generated.mbti
+++ b/desktop/internal/codex/pkg.generated.mbti
@@ -11,7 +11,7 @@ import {
 // Values
 pub fn command() -> String
 
-pub async fn[X] connect(@async.TaskGroup[X], command~ : String, notification_handler~ : (String, Json) -> Unit, request_handler~ : (@jsonrpc.PeerRequest) -> Bool raise, on_closed~ : () -> Unit, version~ : String, home~ : @pathx.Path?, handshake_timeout_ms? : Int) -> Connection?
+pub async fn[X] connect(@async.TaskGroup[X], command~ : String, notification_handler~ : (String, Json) -> Unit, request_handler~ : (@jsonrpc.PeerRequest) -> Bool raise, on_closed~ : () -> Unit, version~ : String, home~ : @pathx.Path?, handshake_timeout_ms? : Int) -> Connection
 
 pub fn home_dir(@pathx.Path) -> @pathx.Path
 

--- a/desktop/internal/codex/project_catalog.mbt
+++ b/desktop/internal/codex/project_catalog.mbt
@@ -81,18 +81,24 @@ async fn ProjectCatalog::resolve(
 
 ///|
 /// Confirm that an add action names a project previously learned from an
-/// app-server thread reply. Existence alone is not authority: a remote page
+/// app-server thread reply. `cwd` is the frontend resource path; cached
+/// projects retain their native spelling. Existence alone is not authority: a remote page
 /// must not turn an arbitrary directory spelling into a Desktop grant.
 pub fn ProjectCatalog::main_project(
   self : ProjectCatalog,
   cwd : String,
 ) -> String? {
-  let cwd = cwd.trim().to_owned()
-  if self.known_projects.get(cwd) is Some(true) {
-    Some(cwd)
-  } else {
-    None
+  guard @pathx.Absolute::from_uri_path(cwd.trim().to_owned()) is Some(requested) else {
+    return None
   }
+  for project, _ in self.known_projects {
+    if @pathx.Path(project).to_absolute() is Some(root) &&
+      requested.relative_to(root~) is Some(relative) &&
+      relative.is_root() {
+      return Some(project)
+    }
+  }
+  None
 }
 
 ///|
@@ -168,16 +174,22 @@ async test "Codex project catalog rechecks a missing cwd on later refreshes" {
 ///|
 async test "Codex draft projects accept only the main checkout" {
   let catalog = ProjectCatalog()
-  catalog.roots["/workspace/project"] = "/workspace/project"
-  catalog.roots["/worktrees/a/project"] = "/workspace/project"
+  let project = if @platform.win32 || @platform.win64 {
+    "C:\\workspace\\project"
+  } else {
+    "/workspace/project"
+  }
+  let resource = if @platform.win32 || @platform.win64 {
+    "/c:/workspace/project"
+  } else {
+    "/workspace/project"
+  }
+  catalog.roots[project] = project
   // A cached filesystem lookup alone is not enough to grant a browser path.
-  assert_true(catalog.main_project("/workspace/project") is None)
-  catalog.known_projects["/workspace/project"] = true
-  assert_eq(
-    catalog.main_project("/workspace/project"),
-    Some("/workspace/project"),
-  )
-  assert_true(catalog.main_project("/worktrees/a/project") is None)
+  assert_true(catalog.main_project(resource) is None)
+  catalog.known_projects[project] = true
+  assert_eq(catalog.main_project(resource), Some(project))
+  assert_true(catalog.main_project(resource + "/child") is None)
 }
 
 ///|

--- a/desktop/internal/pathx/pathx.mbt
+++ b/desktop/internal/pathx/pathx.mbt
@@ -85,7 +85,8 @@ pub fn Absolute::to_path(self : Absolute) -> Path {
 ///|
 /// Encode this host-native absolute path as the slash-rooted path component
 /// carried by frontend resource URIs. POSIX paths already have that form;
-/// Windows drive paths gain the URI root slash (`C:\\work` -> `/C:/work`).
+/// Windows drive paths gain the URI root slash and a lowercase drive letter
+/// (`C:\\Work` -> `/c:/Work`), matching frontend URI serialization.
 ///
 /// UNC and Windows root-relative paths return `None`: a frontend resource URI
 /// uses its authority for the owning device, so it has no second authority in
@@ -101,10 +102,11 @@ pub fn Absolute::to_uri_path(self : Absolute) -> String? {
   let normalized = @path.Path(self.0).normalize().to_string()
   if @path.sep == '\\' {
     let normalized = normalized.replace_all(old="\\", new="/")
-    guard normalized is [drive, ':', '/', ..] && drive.is_ascii_path_drive() else {
+    guard normalized is [drive, ':', '/', .. rest] &&
+      drive.is_ascii_path_drive() else {
       return None
     }
-    Some("/" + normalized)
+    Some("/\{drive.to_ascii_lowercase()}:/\{rest}")
   } else {
     Some(normalized)
   }

--- a/desktop/internal/pathx/pathx_test.mbt
+++ b/desktop/internal/pathx/pathx_test.mbt
@@ -242,7 +242,15 @@ test "resource URI conversion rejects double-rooted POSIX paths" {
 #cfg(platform="windows")
 test "Windows drive paths round-trip through URI paths" {
   let absolute = absolute_fixture("C:\\work\\a b\\#file.mbt")
-  assert_eq(absolute.to_uri_path(), Some("/C:/work/a b/#file.mbt"))
+  assert_eq(absolute.to_uri_path(), Some("/c:/work/a b/#file.mbt"))
+  assert_eq(
+    absolute_fixture("c:\\work\\a b\\#file.mbt").to_uri_path(),
+    absolute.to_uri_path(),
+  )
+  assert_eq(
+    absolute_fixture("C:\\Users\\mbt\\Workspace\\tty").to_uri_path(),
+    Some("/c:/Users/mbt/Workspace/tty"),
+  )
   assert_true(
     @pathx.Absolute::from_uri_path("/C:/work/a b/#file.mbt") is Some(decoded) &&
     decoded.normalize() == absolute.normalize(),

--- a/desktop/internal/protocol/codex_commands.mbt
+++ b/desktop/internal/protocol/codex_commands.mbt
@@ -147,6 +147,7 @@ pub(all) struct CodexStatusReply {
 ///|
 pub(all) struct CodexDraftOpenReply {
   draft_id : String
+  // Desktop resource URI paths, encoded by the host from native Codex paths.
   cwd : String
   project_root : String
 } derive(Debug, Eq)

--- a/desktop/internal/work_dir/work_dir.mbt
+++ b/desktop/internal/work_dir/work_dir.mbt
@@ -95,13 +95,12 @@ pub async fn revoke_host_workspace(session : String) -> Unit {
 /// native subsystem. Unlike `resolve_in_workspace`, this does not let a safe
 /// session id select any registered OpenSeek project; draft and turn mutation
 /// endpoints use it to verify the cwd they previously authorized themselves.
-/// `workspace` is the host-native cwd returned by that subsystem, not a
-/// frontend resource URI path.
+/// `workspace` is a frontend resource URI path, decoded on its owning host.
 pub async fn resolve_host_workspace_authorization(
   session : String,
   workspace : String,
 ) -> @pathx.Absolute? {
-  guard @pathx.Path(workspace).to_absolute() is Some(requested) &&
+  guard @pathx.Absolute::from_uri_path(workspace) is Some(requested) &&
     host_workspace_authorizations.resolve(session, requested)
     is Some(authorized) else {
     return None
@@ -345,7 +344,6 @@ async test "host-authorized workspaces are exact and session-scoped" {
   let session = "codex-authorized-workspace-test"
   revoke_host_workspace(session)
   authorize_host_workspace(session, root)
-  let exact = resolve_host_workspace_authorization(session, root)
   guard @pathx.Path(root).to_absolute().bind(path => path.to_uri_path())
     is Some(resource) else {
     fail("expected a resource path")
@@ -355,6 +353,7 @@ async test "host-authorized workspaces are exact and session-scoped" {
       "/" + drive.to_ascii_lowercase().to_string() + ":/" + rest.to_owned()
     _ => resource
   }
+  let exact = resolve_host_workspace_authorization(session, resource)
   let authorized = resolve_in_workspace(
     session,
     "src/main.mbt",
@@ -368,7 +367,7 @@ async test "host-authorized workspaces are exact and session-scoped" {
   let escape = resolve_in_workspace(session, "../outside", workspace=resource)
   revoke_host_workspace(session)
   let revoked = resolve_in_workspace(session, "", workspace=resource)
-  let exact_revoked = resolve_host_workspace_authorization(session, root)
+  let exact_revoked = resolve_host_workspace_authorization(session, resource)
   @fs.rmdir(root, recursive=true) catch {
     _ => ()
   }

--- a/desktop/internal/work_dir/work_dir.mbt
+++ b/desktop/internal/work_dir/work_dir.mbt
@@ -8,7 +8,7 @@
 /// a web client cannot turn an arbitrary workspace hint into filesystem access.
 priv struct HostWorkspaceAuthorizations {
   lock : @async.Mutex
-  paths : Map[String, String]
+  paths : Map[String, @pathx.Absolute]
 }
 
 ///|
@@ -27,11 +27,13 @@ async fn HostWorkspaceAuthorizations::authorize(
   workspace : String,
 ) -> Unit {
   let trimmed = workspace.trim().to_owned()
-  let candidate = @pathx.Path(trimmed).normalize().to_absolute()
+  let candidate = @pathx.Path(trimmed)
+    .to_absolute()
+    .map(path => path.normalize())
   self.lock.acquire()
   defer self.lock.release()
   if @session_store.safe_session_id(session) && candidate is Some(candidate) {
-    self.paths[session] = candidate.0
+    self.paths[session] = candidate
   } else {
     self.paths.remove(session)
   }
@@ -59,8 +61,12 @@ async fn HostWorkspaceAuthorizations::resolve(
   let normalized = hint.normalize()
   self.lock.acquire()
   defer self.lock.release()
-  if self.paths.get(session) is Some(stored) && stored == normalized.0 {
-    Some(normalized.to_path())
+  // The host path library owns equality: Windows drive/component case may
+  // differ after a frontend URI roundtrip, while POSIX stays case-sensitive.
+  if self.paths.get(session) is Some(stored) &&
+    normalized.relative_to(root=stored) is Some(relative) &&
+    relative.is_root() {
+    Some(stored.to_path())
   } else {
     None
   }
@@ -89,11 +95,13 @@ pub async fn revoke_host_workspace(session : String) -> Unit {
 /// native subsystem. Unlike `resolve_in_workspace`, this does not let a safe
 /// session id select any registered OpenSeek project; draft and turn mutation
 /// endpoints use it to verify the cwd they previously authorized themselves.
+/// `workspace` is the host-native cwd returned by that subsystem, not a
+/// frontend resource URI path.
 pub async fn resolve_host_workspace_authorization(
   session : String,
   workspace : String,
 ) -> @pathx.Absolute? {
-  guard @pathx.Absolute::from_uri_path(workspace) is Some(requested) &&
+  guard @pathx.Path(workspace).to_absolute() is Some(requested) &&
     host_workspace_authorizations.resolve(session, requested)
     is Some(authorized) else {
     return None
@@ -338,22 +346,38 @@ async test "host-authorized workspaces are exact and session-scoped" {
   revoke_host_workspace(session)
   authorize_host_workspace(session, root)
   let exact = resolve_host_workspace_authorization(session, root)
-  let authorized = resolve_in_workspace(session, "src/main.mbt", workspace=root)
+  guard @pathx.Path(root).to_absolute().bind(path => path.to_uri_path())
+    is Some(resource) else {
+    fail("expected a resource path")
+  }
+  let resource = match resource {
+    ['/', drive, ':', '/', .. rest] =>
+      "/" + drive.to_ascii_lowercase().to_string() + ":/" + rest.to_owned()
+    _ => resource
+  }
+  let authorized = resolve_in_workspace(
+    session,
+    "src/main.mbt",
+    workspace=resource,
+  )
   let other_session = resolve_in_workspace(
     "codex-other-workspace-test",
     "src/main.mbt",
-    workspace=root,
+    workspace=resource,
   )
-  let escape = resolve_in_workspace(session, "../outside", workspace=root)
+  let escape = resolve_in_workspace(session, "../outside", workspace=resource)
   revoke_host_workspace(session)
-  let revoked = resolve_in_workspace(session, "", workspace=root)
+  let revoked = resolve_in_workspace(session, "", workspace=resource)
   let exact_revoked = resolve_host_workspace_authorization(session, root)
   @fs.rmdir(root, recursive=true) catch {
     _ => ()
   }
-  assert_true(
-    authorized is Some(path) &&
-    @pathx.Path(root).join(Relative("src/main.mbt")).to_absolute() == Some(path),
+  assert_eq(
+    authorized,
+    @pathx.Path(root)
+    .join(Relative("src/main.mbt"))
+    .to_absolute()
+    .map(path => path.normalize()),
   )
   assert_true(other_session is None)
   assert_true(exact is Some(_))

--- a/docs/codex-app-server.md
+++ b/docs/codex-app-server.md
@@ -1,7 +1,12 @@
 # Codex app-server in OpenSeek Desktop
 
-OpenSeek Desktop starts one `codex app-server` child process. Codex and OpenSeek
-conversation lists share the global left sidebar; selecting either source swaps
+OpenSeek Desktop starts one `codex app-server` child process. On Windows the
+default command runs through `cmd.exe /d /c` so npm's `codex.cmd` shim resolves
+through `PATH`/`PATHEXT`; explicit executable paths spawn directly. As in MCP
+stdio, shutdown cancels the IO tasks, which close their own pipes, and cancels
+the child process. Startup failures retain their
+underlying pipe, process, or handshake error in the status and Desktop log.
+Codex and OpenSeek conversation lists share the global left sidebar; selecting either source swaps
 the main transcript and composer without creating a second nested application
 shell. Codex remains the owner of its account and thread data, separate from
 OpenSeek's existing engine and conversation store.

--- a/docs/codex-app-server.md
+++ b/docs/codex-app-server.md
@@ -6,6 +6,10 @@ through `PATH`/`PATHEXT`; explicit executable paths spawn directly. As in MCP
 stdio, shutdown cancels the IO tasks, which close their own pipes, and cancels
 the child process. Startup failures retain their
 underlying pipe, process, or handshake error in the status and Desktop log.
+The host converts app-server's native cwd and project roots to Desktop resource
+paths before sending them to the frontend, and resolves incoming resource paths
+back to native paths before starting a thread or turn. This matches worktree
+replies and broadcasts and keeps platform handling out of the frontend.
 Codex and OpenSeek conversation lists share the global left sidebar; selecting either source swaps
 the main transcript and composer without creating a second nested application
 shell. Codex remains the owner of its account and thread data, separate from


### PR DESCRIPTION
Windows npm installations expose `codex.cmd`, which native process spawning cannot resolve as an executable. Launch the default command through `cmd.exe /d /c`, and follow MCP stdio's task-owned pipe lifecycle so shutdown cancels pending IO before closing its handles. Preserve startup and handshake errors in the desktop status and logs.

Opening a registered project could also fail with `invalid Codex draft project` because frontend URI paths and native Windows paths differed in separators and drive-letter case. Resolve projects through the registry and use the owning host's path rules for workspace matching. The host converts native Codex cwd/project roots to Desktop resource paths in draft and thread replies, then resolves incoming paths back to native cwd before calling app-server. This uses the same convention as worktree replies and broadcasts; the frontend no longer detects Windows paths or performs platform-specific conversion. The shared host path encoder emits lowercase Windows drive letters to match frontend URI serialization, so sidebar grouping recognizes the registered workspace.

Validation:
- Codex frontend JS tests: 72 passed, including Windows project sidebar grouping.
- Native path, API and Codex tests: 47 passed, including thread catalog/reply resource-path conversion and workspace grant roundtrips.
- Host workspace authorization regression: passed.
- Live npm-installed Codex 0.140.0: initialize/initialized handshake and shutdown passed.
- Native desktop and JS frontend builds passed using a separate build directory.
- `moon info`, `moon fmt`, and `git diff --check` passed.

Full repository gates remain limited by existing Windows issues: `just check` reports unused declarations in unchanged bgjobs/worktree code, and `just test` hangs in unrelated native tests. A repeat of `just build` hit a locked Windows packaging executable; the separate desktop/frontend builds above passed.

