### PR TITLE
style(editor): remove documentation block tint

### DIFF
--- a/editor/tests/browser/smoke/viewer.spec.js
+++ b/editor/tests/browser/smoke/viewer.spec.js
@@ -265,7 +265,7 @@ test('renders MoonBit documentation comments through the real workbench', async 
   );
 });
 
-test('keeps documentation colors consistent across folding states', async ({ page }, testInfo) => {
+test('blends documentation into the editor across themes and folding states', async ({ page }, testInfo) => {
   await page.goto('/');
   await openWorkspaceFile(page, 'src/documentation.mbt');
   const comments = page.locator('.moonbit-viewer-markdown-comment');
@@ -283,7 +283,7 @@ test('keeps documentation colors consistent across folding states', async ({ pag
       await page.getByRole('button', { name: 'Toggle color theme' }).click();
     }
     await expect(page.locator('.editor-shell')).toHaveAttribute('data-theme', theme);
-    const background = await single.evaluate(
+    const background = await page.locator('.overflow-guard').evaluate(
       (node) => getComputedStyle(node).backgroundColor,
     );
     const foreground = await singleText.evaluate(
@@ -295,6 +295,7 @@ test('keeps documentation colors consistent across folding states', async ({ pag
       path: screenshot,
       contentType: 'image/png',
     });
+    await expect(single).toHaveCSS('background-color', background);
     await expect(multiline).toHaveCSS('background-color', background);
     await expect(preview).toHaveCSS('color', foreground);
     await multiline.getByRole('button', { name: 'Expand API documentation' }).click();
@@ -304,10 +305,7 @@ test('keeps documentation colors consistent across folding states', async ({ pag
     await multiline.getByRole('button', { name: 'Collapse API documentation' }).click();
     await expect(preview).toHaveCSS('color', foreground);
     await expect(multiline).toHaveCSS('background-color', background);
-    const editorBackground = await page.locator('.overflow-guard').evaluate(
-      (node) => getComputedStyle(node).backgroundColor,
-    );
-    await expect(separator).toHaveCSS('background-color', editorBackground);
+    await expect(separator).toHaveCSS('background-color', background);
   }
 });
 

--- a/editor/viewer/contrib/markdown_comments/browser/markdown_comments.css
+++ b/editor/viewer/contrib/markdown_comments/browser/markdown_comments.css
@@ -10,22 +10,10 @@
    * Markdown input above it, but below editor cursors (4) and widgets (50+). */
   z-index: 2;
   color: var(--vscode-editor-foreground);
-  background: color-mix(
-    in srgb,
-    var(--vscode-editor-foreground) 3%,
-    var(--vscode-editor-background)
-  );
+  background: var(--vscode-editor-background);
   font-family: var(--ui-font-family, var(--editor-font-family));
   font-size: calc(var(--editor-font-size) * 0.92);
   line-height: 1.5;
-}
-
-/* Bare item separators are spacing, not documentation panels. Keep source
- * inspection on the tinted surface even for a separator-only source block. */
-.moonbit-viewer-markdown-comment[data-source-visible="false"]:has(
-  .moonbit-viewer-markdown-comment-full > hr:only-child
-) {
-  background: var(--vscode-editor-background);
 }
 
 /* Vertical and trailing padding belong to the measured inner target, so


### PR DESCRIPTION
Documentation comment blocks now use the editor background, removing the tinted panels in both light and dark themes. The shared Viewer stylesheet applies to OpenSeek and the reference shell; the existing browser test verifies single-line, folded, expanded, and separator blocks against the editor background.

Validation:
- Passed `just check`, `just test`, `just build`, `just editor-test`, and the editor all-target check with warnings denied.
- Passed the focused documentation theme/folding browser test and visually checked `agent_tool/mbtx/mbtx.mbt` in the reference shell.
- Ran `moon info && moon fmt`; generated interfaces are unchanged.
- Full `just editor-test-browser`: 109 passed, 2 failed on the initial run (F4 definition-preview focus and Markdown-document diagnostics/hover). Both passed standalone reruns; the initial full-suite result remains a failure.
