### PR TITLE
refactor(desktop): share the workspace submodule timeout default

### DIFF
--- a/desktop/frontend/workspace_settings.mbt
+++ b/desktop/frontend/workspace_settings.mbt
@@ -7,11 +7,6 @@
 // override that never writes here.
 
 ///|
-/// Used only before an authoritative row exists or while an optimistic edit
-/// preserves a neighboring field. The host remains the persisted source.
-const DefaultWorkspaceSubmoduleCheckoutTimeoutSeconds : Int = 30
-
-///|
 /// One project's settings mirror, keyed like `ProjectWorktrees` and fenced
 /// by the same per-project generation rule: a reply carrying an older token
 /// is stale for that project alone.
@@ -157,7 +152,7 @@ fn DeviceState::with_workspace_settings(
       self
       .workspace_settings_row(project)
       .map(row => row.submodule_checkout_timeout_seconds)
-      .unwrap_or(DefaultWorkspaceSubmoduleCheckoutTimeoutSeconds)
+      .unwrap_or(@protocol.DefaultSubmoduleCheckoutTimeoutSeconds)
     },
   )
   let rows = self.workspace_settings.filter(row => row.project != project)
@@ -492,7 +487,8 @@ test "the workspace submodule select preserves its launch mode" {
   }
   assert_true(row.worktree_mode)
   assert_false(row.checkout_submodules)
-  // Unknown select values are ignored and cannot mutate either field.
+  assert_eq(row.submodule_checkout_timeout_seconds, 10)
+  // Unknown select values are ignored and cannot mutate the settings.
   let (_, unknown) = update(
     dispatch,
     WorkspaceSubmodulesChosen(Local, workspace, "unknown"),
@@ -555,6 +551,10 @@ test "a failed save pops a toast and re-reads under a fresh token" {
     attached,
   )
   let minted = chosen.dev().workspace_settings_request_generation
+  guard chosen.dev().workspace_settings_row(workspace) is Some(row) else {
+    fail("expected the optimistic workspace settings row")
+  }
+  assert_eq(row.submodule_checkout_timeout_seconds, 30)
   let (_, failed) = update_dev(
     dispatch,
     WorkspaceSettingsSaveFailed(workspace~, message="disk full"),

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -8,6 +8,8 @@ import {
 }
 
 // Values
+pub const DefaultSubmoduleCheckoutTimeoutSeconds : Int = 30
+
 pub fn approval(String, allow~ : Bool) -> @openseek_protocol.Command
 
 pub fn cancel() -> @openseek_protocol.Command

--- a/desktop/internal/protocol/workspace_settings.mbt
+++ b/desktop/internal/protocol/workspace_settings.mbt
@@ -1,0 +1,4 @@
+///|
+/// Default for missing or invalid workspace overrides and the frontend's
+/// settings mirror before an authoritative host value arrives.
+pub const DefaultSubmoduleCheckoutTimeoutSeconds : Int = 30

--- a/desktop/internal/workspaces/settings.mbt
+++ b/desktop/internal/workspaces/settings.mbt
@@ -9,11 +9,6 @@
 const WorkspaceSettingsFile = "settings.json"
 
 ///|
-/// Workspaces without an override and malformed hand-edited settings use
-/// the default checkout bound for conversation creation.
-const DefaultSubmoduleCheckoutTimeoutSeconds : Int = 30
-
-///|
 /// Reads and read-modify-write mutations share one process-wide lock, the
 /// `worktrees.json` discipline: without it two concurrent writes could both
 /// read the same old file and let the later one silently erase the earlier.
@@ -62,12 +57,12 @@ fn worktree_mode_of(fields : Map[String, Json]) -> Bool {
 fn submodule_timeout_of(fields : Map[String, Json]) -> Int {
   guard fields.get("submodule_checkout_timeout_seconds")
     is Some(Number(value, ..)) else {
-    return DefaultSubmoduleCheckoutTimeoutSeconds
+    return @protocol.DefaultSubmoduleCheckoutTimeoutSeconds
   }
   let seconds = value.to_int()
   match seconds {
     5 | 10 | 30 | 60 if value == seconds.to_double() => seconds
-    _ => DefaultSubmoduleCheckoutTimeoutSeconds
+    _ => @protocol.DefaultSubmoduleCheckoutTimeoutSeconds
   }
 }
 
@@ -191,16 +186,16 @@ test "workspace settings parse tolerantly and keep unknown fields" {
   assert_eq(payload.submodule_checkout_timeout_seconds, 30)
   fields["checkout_submodules"] = false.to_json()
   assert_false(settings_payload(workspace, fields).checkout_submodules)
-  fields["submodule_checkout_timeout_seconds"] = Json(30)
+  fields["submodule_checkout_timeout_seconds"] = Json(10)
   assert_eq(
     settings_payload(workspace, fields).submodule_checkout_timeout_seconds,
-    30,
+    10,
   )
   for invalid in [Json(0), Json(15), Json(1.5), Json("ten")] {
     fields["submodule_checkout_timeout_seconds"] = invalid
     assert_eq(
       settings_payload(workspace, fields).submodule_checkout_timeout_seconds,
-      DefaultSubmoduleCheckoutTimeoutSeconds,
+      @protocol.DefaultSubmoduleCheckoutTimeoutSeconds,
     )
   }
 }
@@ -216,12 +211,12 @@ async test "workspace settings survive a write/read round trip independently" {
   let fields = read_settings_unlocked(workspace)
   fields["worktree_mode"] = true.to_json()
   fields["checkout_submodules"] = false.to_json()
-  fields["submodule_checkout_timeout_seconds"] = Json(30)
+  fields["submodule_checkout_timeout_seconds"] = Json(10)
   write_settings(workspace, fields)
   let reread = read_settings_unlocked(workspace)
   assert_true(worktree_mode_of(reread))
   assert_eq(reread.get("checkout_submodules"), Some(false.to_json()))
-  assert_eq(reread.get("submodule_checkout_timeout_seconds"), Some(Json(30)))
+  assert_eq(reread.get("submodule_checkout_timeout_seconds"), Some(Json(10)))
   // The file lives below one workspace root, so an adjacent workspace keeps
   // both defaults when only this workspace is edited.
   let sibling_payload = settings_payload(
@@ -232,7 +227,7 @@ async test "workspace settings survive a write/read round trip independently" {
   assert_true(sibling_payload.checkout_submodules)
   assert_eq(
     sibling_payload.submodule_checkout_timeout_seconds,
-    DefaultSubmoduleCheckoutTimeoutSeconds,
+    @protocol.DefaultSubmoduleCheckoutTimeoutSeconds,
   )
   @fs.rmdir(dir, recursive=true) catch {
     _ => ()


### PR DESCRIPTION
The host default and frontend fallback each define the workspace submodule checkout timeout, so changing it requires keeping two constants in sync. Move the 30-second default into the shared desktop protocol package and use it from both callers. Existing workspace overrides continue to apply, and the wire payloads are unchanged.

Strengthen the existing settings tests to distinguish a saved 10-second override from the default and verify the frontend fallback and preservation of loaded settings.

Validation: `just check`, `just test`, `just build`, `moon info`, `moon fmt`, and `git diff --check` all passed. The generated interface only adds the shared constant.

Stacked on #1399; this PR targets `codex/default-worktree-timeout-30s` so its diff contains only the deduplication and regression assertions.
