### PR TITLE
refactor(agent_review): one severity selector behind every severity check

### DIFF
--- a/agent_review/audit.mbt
+++ b/agent_review/audit.mbt
@@ -124,8 +124,8 @@ let digest_max_chars : Int = 4_000
 /// summary, and up to `digest_max_findings` one-line findings with an
 /// explicit omission count — never more than `digest_max_chars` total.
 pub fn ReviewReport::digest(self : ReviewReport) -> String {
-  let blockers = self.findings.count_if(f => f.severity == "blocker")
-  let highs = self.findings.count_if(f => f.severity == "high")
+  let blockers = self.findings_with_severity("blocker").length()
+  let highs = self.findings_with_severity("high").length()
   let out = StringBuilder()
   out <+ "[review] worktree audit: \{self.findings.length()} finding(s)"
   if blockers > 0 || highs > 0 {

--- a/agent_review/submit.mbt
+++ b/agent_review/submit.mbt
@@ -60,10 +60,7 @@ fn report_schema() -> Json {
           "properties": {
             "file": { "type": "string" },
             "line": { "type": "integer" },
-            "severity": {
-              "type": "string",
-              "enum": ["blocker", "high", "medium", "low", "nit"],
-            },
+            "severity": { "type": "string", "enum": severities() },
             "category": { "type": "string" },
             "title": { "type": "string" },
             "detail": { "type": "string" },

--- a/agent_review/types.mbt
+++ b/agent_review/types.mbt
@@ -56,13 +56,28 @@ pub fn ReviewReport::to_json_string(self : ReviewReport) -> String {
 /// verdict is that the reviewed claim does NOT hold. Callers use this for
 /// exit codes and error flags without reaching into the findings shape.
 pub fn ReviewReport::has_blockers(self : ReviewReport) -> Bool {
-  self.findings.any(f => f.severity == "blocker")
+  !self.findings_with_severity("blocker").is_empty()
 }
 
 ///|
 /// Number of findings carried by the report, for summaries and briefs.
 pub fn ReviewReport::finding_count(self : ReviewReport) -> Int {
   self.findings.length()
+}
+
+///|
+/// The findings at `severity`, in report order. The one place a severity
+/// string selects a subset of the report: the blocker gate here and the
+/// digest's tally in `audit.mbt` both read it, so the comparison against a
+/// severity literal is written once instead of respelled at every caller.
+/// `severity` is drawn from `severities()`; an unknown one selects nothing.
+fn ReviewReport::findings_with_severity(
+  self : ReviewReport,
+  severity : String,
+) -> Array[Finding] {
+  [
+    for finding in self.findings if finding.severity == severity => finding
+  ]
 }
 
 ///|
@@ -210,6 +225,58 @@ test "parse reports an error on malformed json" {
   guard ReviewReport::parse(Json::null()) is Err(_) else {
     fail("expected parse error")
   }
+}
+
+///|
+/// A minimal valid finding at `severity`, for the severity-selection tests.
+fn finding_at(severity : String) -> Finding {
+  {
+    file: "a.mbt",
+    line: Some(1),
+    severity,
+    category: "correctness",
+    title: "finding at \{severity}",
+    detail: "detail",
+    suggestion: None,
+  }
+}
+
+///|
+test "has_blockers tracks the blocker severity alone" {
+  assert_false(sample_report().has_blockers())
+  for severity in severities() {
+    let report = { ..sample_report(), findings: [finding_at(severity)], }
+    assert_eq(report.has_blockers(), severity == "blocker")
+  }
+}
+
+///|
+test "the submit schema offers exactly the severities validation accepts" {
+  // The schema is the model-facing contract, so its enum must be the very
+  // vocabulary `validate` enforces — not a second copy that can drift.
+  let enum_values = match report_schema() {
+    {
+      "properties": {
+        "findings": {
+          "items": {
+            "properties": { "severity": { "enum": Array(values), .. }, .. },
+            ..
+          },
+          ..
+        },
+        ..
+      },
+      ..
+    } =>
+      values.map(value => {
+        match value {
+          String(severity) => severity
+          _ => ""
+        }
+      })
+    _ => []
+  }
+  assert_eq(enum_values, severities())
 }
 
 ///|


### PR DESCRIPTION
## What

`agent_review` compared finding severities against string literals in three
places, and carried the severity vocabulary twice:

- `digest` tallied blockers and highs with two inline `count_if`s over
  `f.severity == "<literal>"`;
- `has_blockers` respelled the same `f.severity == "blocker"` comparison;
- the `submit_review` schema's `enum` was a second hand-written copy of the
  `blocker|high|medium|low|nit` list that `validate` already owns in
  `severities()`.

There is now one severity selector — `ReviewReport::findings_with_severity(severity)`,
written as a comprehension over the findings — and every severity check reads
it: the blocker gate (`has_blockers`) and both digest tallies. The schema's
`enum` now comes from the canonical `severities()` list, so the model-facing
contract and the validator cannot drift apart.

Behavior is unchanged: the digest notice text and the JSON contract are what
they were. The selector is package-private, so the public interface (and
`pkg.generated.mbti`) is unchanged.

## Verification

- `moon check` — clean.
- `moon test agent_review agent` — 123 tests, 0 failures.
- `moon fmt --check agent_review` — clean.
- `moon info agent_review` — no interface change.

New tests: `has_blockers` is exercised across the whole severity vocabulary
(it had no test before), and the submit schema is asserted to carry exactly
the severities `validate` accepts.

Generated with SeekMoon