### PR TITLE
fix(desktop): remove redundant tool result label

### DIFF
--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -449,7 +449,7 @@ fn result_row_view(
     (None, _, _) => name
     (_, _, true) => "Tool output · \{name}"
     _ if is_error => "Tool error · \{name}"
-    _ => "Tool result · \{name}"
+    _ => name
   }
   let error_class = (if is_error { " error" } else { "" }) +
     failure_stage_class(name, brief, is_error)


### PR DESCRIPTION
Successful tool results in the desktop transcript repeat “Tool result” even though the return arrow already identifies the row. Show just the tool name in the row and its tooltip: `← Tool result · mbtx` becomes `← mbtx`.

Validation: `moon info && moon fmt`, `just check`, `just test`, and `just build` passed. Native and JS suites passed 3,275 and 3,237 tests respectively; the 24 offline cram cases and CLI lifecycle tests passed. All 3 existing desktop tool-status browser tests passed. Generated interfaces are unchanged.
