### PR TITLE
refactor: split fields with split_once/lexmatch instead of offset slicing

### DIFF
--- a/agent_session/goal.mbt
+++ b/agent_session/goal.mbt
@@ -221,7 +221,9 @@ pub fn parse_goal_baseline(content : String) -> GoalBaseline? {
     (re" dirty=false$", before=sha, after=_) => (sha, false)
     _ => return None
   }
-  if sha.is_empty() {
+  // The FIRST ` dirty=` is the field separator, so a prefix that still holds
+  // one means the line repeated the field — mangled, not a sha containing it.
+  if sha.is_empty() || sha.contains(" dirty=") {
     return None
   }
   Some({ sha: sha.to_owned(), dirty, })

--- a/agent_session/goal.mbt
+++ b/agent_session/goal.mbt
@@ -213,17 +213,18 @@ pub fn parse_goal_baseline(content : String) -> GoalBaseline? {
   guard content.strip_prefix("\{GoalBaselinePrefix} sha=") is Some(rest) else {
     return None
   }
-  guard rest.find(" dirty=") is Some(cut) else { return None }
-  let sha = rest[:cut].to_owned()
-  let dirty = match rest[cut + 7:].to_owned() {
-    "true" => true
-    "false" => false
+  // Either value literal ends the line, and the sha is the unmatched prefix:
+  // the `$` keeps the value the LAST field, so a line with trailing junk
+  // degrades to a plain notice instead of a half-parsed baseline.
+  let (sha, dirty) = lexmatch rest {
+    (re" dirty=true$", before=sha, after=_) => (sha, true)
+    (re" dirty=false$", before=sha, after=_) => (sha, false)
     _ => return None
   }
   if sha.is_empty() {
     return None
   }
-  Some({ sha, dirty, })
+  Some({ sha: sha.to_owned(), dirty, })
 }
 
 ///|

--- a/agent_session/goal_test.mbt
+++ b/agent_session/goal_test.mbt
@@ -122,6 +122,14 @@ test "goal baseline round-trips through its notice" {
     @agent_session.parse_goal_baseline("[goal baseline] sha=x dirty=true junk")
     is None,
   )
+  // A repeated field is mangled too: the FIRST ` dirty=` is the separator,
+  // so the value that follows it is never `true`/`false` on its own.
+  assert_true(
+    @agent_session.parse_goal_baseline(
+      "[goal baseline] sha=x dirty=true dirty=false",
+    )
+    is None,
+  )
 }
 
 ///|

--- a/agent_session/goal_test.mbt
+++ b/agent_session/goal_test.mbt
@@ -117,6 +117,11 @@ test "goal baseline round-trips through its notice" {
     @agent_session.parse_goal_baseline("[goal baseline] sha=x dirty=maybe")
     is None,
   )
+  // The `dirty` value must end the line: trailing text is not a baseline.
+  assert_true(
+    @agent_session.parse_goal_baseline("[goal baseline] sha=x dirty=true junk")
+    is None,
+  )
 }
 
 ///|

--- a/desktop/frontend/interop/query.mbt
+++ b/desktop/frontend/interop/query.mbt
@@ -19,9 +19,9 @@ pub fn page_query_param(name : String) -> String? {
     None => search.view()
   }
   for pair in query.split("&") {
-    guard pair.find("=") is Some(index) else { continue }
-    if pair[:index].to_owned() == name {
-      let value = @uri.decode_component(pair[index + 1:])
+    guard pair.split_once("=") is Some((key, encoded)) else { continue }
+    if key.to_owned() == name {
+      let value = @uri.decode_component(encoded)
       return if value.is_empty() { None } else { Some(value) }
     }
   }

--- a/desktop/frontend/skills/document.mbt
+++ b/desktop/frontend/skills/document.mbt
@@ -29,10 +29,10 @@ fn parse_skill_document(source : String) -> SkillDocument {
   for line in rest[0:index] {
     let line = line.trim()
     guard !line.is_empty() && !line.has_prefix("#") else { continue }
-    guard line.find(":") is Some(colon) else { continue }
-    let key = line[0:colon].trim().to_owned()
+    guard line.split_once(":") is Some((key_text, value)) else { continue }
+    let key = key_text.trim().to_owned()
     guard !key.is_empty() else { continue }
-    metadata.push((key, line[colon + 1:].trim().to_owned()))
+    metadata.push((key, value.trim().to_owned()))
   }
   { metadata, body: rest[index + 1:].join("\n"), }
 }

--- a/desktop/internal/auth/pkce.mbt
+++ b/desktop/internal/auth/pkce.mbt
@@ -64,8 +64,8 @@ priv enum Callback {
 /// Parse one request target against the expected redirect: path `/cb`,
 /// matching `state`, and either `code` or `error`.
 fn parse_callback(target : String, oauth_state~ : String) -> Callback {
-  let (path, query) = match target.find("?") {
-    Some(index) => (target[:index].to_owned(), target[index + 1:])
+  let (path, query) = match target.split_once("?") {
+    Some((path, query)) => (path.to_owned(), query)
     None => (target, "".view())
   }
   guard path == "/cb" else { return Stray }
@@ -73,8 +73,8 @@ fn parse_callback(target : String, oauth_state~ : String) -> Callback {
   let mut error_ : String? = None
   let mut state : String? = None
   for pair in query.split("&") {
-    let (key, value) = match pair.find("=") {
-      Some(index) => (pair[:index].to_owned(), @uri.decode(pair[index + 1:]))
+    let (key, value) = match pair.split_once("=") {
+      Some((key, value)) => (key.to_owned(), @uri.decode(value))
       None => (pair.to_owned(), "")
     }
     match key {

--- a/desktop/internal/host/git_ops.mbt
+++ b/desktop/internal/host/git_ops.mbt
@@ -439,12 +439,11 @@ fn parse_numstat(output : String) -> GitDiffStat {
   let mut files = 0
   for line in output.split("\n") {
     let line = line.trim_end(chars="\r")
-    guard line.find("\t") is Some(first) else { continue }
-    let rest = line.view(start_offset=first + 1)
-    guard rest.find("\t") is Some(second) else { continue }
+    guard line.split_once("\t") is Some((added_text, rest)) else { continue }
+    guard rest.split_once("\t") is Some((removed_text, _)) else { continue }
     files += 1
-    added += @string.parse_int(line.view(end_offset=first)) catch { _ => 0 }
-    removed += @string.parse_int(rest.view(end_offset=second)) catch { _ => 0 }
+    added += @string.parse_int(added_text) catch { _ => 0 }
+    removed += @string.parse_int(removed_text) catch { _ => 0 }
   }
   { added, removed, files, base: None, partial: false, }
 }
@@ -729,10 +728,11 @@ fn parse_git_mode_paths(
   let paths : Set[String] = Set([])
   let prefix = mode + " "
   for record in output.split("\u{0}") {
-    guard record.has_prefix(prefix) && record.find("\t") is Some(tab) else {
+    guard record.has_prefix(prefix) &&
+      record.split_once("\t") is Some((_, path)) else {
       continue
     }
-    let path = record.view(start_offset=tab + 1).to_owned()
+    let path = path.to_owned()
     if git_path_relative_to_workspace(path, workspace_prefix) is Some(relative) {
       paths.add(relative)
     }

--- a/desktop/internal/skillmarket/library.mbt
+++ b/desktop/internal/skillmarket/library.mbt
@@ -109,9 +109,9 @@ fn parse_frontmatter(text : String, fallback_name : String) -> (String, String) 
     if line.trim() == "---" {
       break
     }
-    if line.find(":") is Some(index) {
-      let key = line[0:index].to_owned().trim().to_owned()
-      let value = line[index + 1:].to_owned().trim().to_owned()
+    if line.split_once(":") is Some((key_text, value_text)) {
+      let key = key_text.to_owned().trim().to_owned()
+      let value = value_text.to_owned().trim().to_owned()
       match key {
         "name" => if !value.is_empty() { name = value }
         "description" => description = value

--- a/desktop/internal/skillmarket/registry.mbt
+++ b/desktop/internal/skillmarket/registry.mbt
@@ -122,15 +122,16 @@ fn redirect_target(
   if location.has_prefix("http://") || location.has_prefix("https://") {
     return location
   }
-  if location.has_prefix("/") && current.find("://") is Some(scheme_end) {
-    let host_start = scheme_end + 3
-    let origin_end = match current[host_start:].to_owned().find("/") {
-      Some(offset) => host_start + offset
-      None => current.length()
-    }
-    return "\{current[0:origin_end].to_owned()}\{location}"
+  guard location.has_prefix("/") &&
+    current.split_once("://") is Some((scheme, rest)) else {
+    raise SkillMarketError("the skill registry sent an unsupported redirect")
   }
-  raise SkillMarketError("the skill registry sent an unsupported redirect")
+  // Host-relative: keep `current`'s origin and take `location` as the path.
+  let origin = match rest.split_once("/") {
+    Some((host, _)) => "\{scheme}://\{host}"
+    None => current
+  }
+  "\{origin}\{location}"
 }
 
 ///|

--- a/desktop/internal/update/update.mbt
+++ b/desktop/internal/update/update.mbt
@@ -224,8 +224,8 @@ fn parse_version(text : String) -> (Int, Int, Int)? {
   }
   // `1.2.3-beta.1+build` compares by its numeric triple.
   for stop in ["-", "+"] {
-    if view.find(stop) is Some(index) {
-      view = view[:index]
+    if view.split_once(stop) is Some((before, _)) {
+      view = before
     }
   }
   let parts = [..view.split(".")]

--- a/desktop/internal/worktree/submodules.mbt
+++ b/desktop/internal/worktree/submodules.mbt
@@ -5,10 +5,11 @@
 fn gitlink_paths(metadata : String) -> Array[String] {
   let paths : Array[String] = []
   for record in metadata.split("\u{0}") {
-    guard record.has_prefix("160000 ") && record.find("\t") is Some(tab) else {
+    guard record.has_prefix("160000 ") &&
+      record.split_once("\t") is Some((_, path)) else {
       continue
     }
-    let path = record.view(start_offset=tab + 1).to_owned()
+    let path = path.to_owned()
     // A conflicted index can carry several stages for one gitlink.
     if !paths.contains(path) {
       paths.push(path)

--- a/editor/internal/viewer/browser/markdown_document/markdown_document.mbt
+++ b/editor/internal/viewer/browser/markdown_document/markdown_document.mbt
@@ -382,10 +382,10 @@ fn markdown_semantic_line_is_phrase_divider(
 /// not accepted as the synthetic trailing line.
 fn tokenized_line_segment_is_empty(segment : String) -> Bool {
   guard segment.has_prefix("<span class=\"") &&
-    segment.find("\">") is Some(content_start) else {
+    segment.split_once("\">") is Some((_, content)) else {
     return false
   }
-  segment[content_start + 2:] == "</span>"
+  content == "</span>"
 }
 
 ///|

--- a/editor/internal/viewer/markdown/sections.mbt
+++ b/editor/internal/viewer/markdown/sections.mbt
@@ -206,8 +206,8 @@ fn markdown_heading_text_from_source(
   let start = range.start.max(0).min(source.length())
   let end = range.end_exclusive.max(start).min(source.length())
   let raw = source[start:end].to_owned()
-  let first_line = match raw.find("\n") {
-    Some(index) => raw[0:index].to_owned()
+  let first_line = match raw.split_once("\n") {
+    Some((first, _)) => first.to_owned()
     None => raw
   }
   let trimmed = for trimmed = first_line.trim(chars=" \t\r").to_owned(); trimmed.has_prefix(

--- a/editor/server/host/language_provider.mbt
+++ b/editor/server/host/language_provider.mbt
@@ -234,12 +234,8 @@ fn definition_uri_under_root(
 
 ///|
 fn parse_moon_definition_range(raw : String) -> @base_common.Range? {
-  guard raw.find("-") is Some(dash) else { return None }
-  match
-    (
-      parse_positive_position(raw[0:dash]),
-      parse_positive_position(raw[dash + 1:]),
-    ) {
+  guard raw.split_once("-") is Some((start, end_)) else { return None }
+  match (parse_positive_position(start), parse_positive_position(end_)) {
     (Some(start), Some(end)) =>
       if start.is_before_or_equal(end) {
         Some(@base_common.Range::from_positions(start, end))
@@ -252,11 +248,13 @@ fn parse_moon_definition_range(raw : String) -> @base_common.Range? {
 
 ///|
 fn parse_positive_position(raw : StringView) -> @base_common.Position? {
-  guard raw.find(":") is Some(colon) else { return None }
+  guard raw.split_once(":") is Some((line_text, column_text)) else {
+    return None
+  }
   let parsed = Some(
     (
-      @string.parse_int(raw[0:colon], base=10),
-      @string.parse_int(raw[colon + 1:], base=10),
+      @string.parse_int(line_text, base=10),
+      @string.parse_int(column_text, base=10),
     ),
   ) catch {
     _ => None

--- a/editor/server/host/moon_check.mbt
+++ b/editor/server/host/moon_check.mbt
@@ -323,13 +323,9 @@ fn check_level_severity(level : String) -> @language.DiagnosticSeverity {
 /// Parses a `moon check` location: `line:col-line:col`, or a bare `line:col`
 /// which degrades to an empty range at that position.
 fn parse_moon_loc(loc : String) -> @base_common.Range? {
-  match loc.find("-") {
-    Some(dash) =>
-      match
-        (
-          parse_check_position(loc[0:dash]),
-          parse_check_position(loc[dash + 1:]),
-        ) {
+  match loc.split_once("-") {
+    Some((start_text, end_text)) =>
+      match (parse_check_position(start_text), parse_check_position(end_text)) {
         (Some(start), Some(end)) =>
           Some(@base_common.Range::from_positions(start, end))
         _ => None
@@ -345,12 +341,12 @@ fn parse_moon_loc(loc : String) -> @base_common.Range? {
 
 ///|
 fn parse_check_position(view : StringView) -> @base_common.Position? {
-  match view.find(":") {
-    Some(colon) => {
+  match view.split_once(":") {
+    Some((line_text, column_text)) => {
       let parsed = Some(
         (
-          @string.parse_int(view[0:colon], base=10),
-          @string.parse_int(view[colon + 1:], base=10),
+          @string.parse_int(line_text, base=10),
+          @string.parse_int(column_text, base=10),
         ),
       ) catch {
         _ => None

--- a/mcp/streamhttp/transport.mbt
+++ b/mcp/streamhttp/transport.mbt
@@ -282,13 +282,9 @@ impl @jsonrpc.Transport for HttpTransport with fn close(self) {
 /// client-initiated termination — is swallowed.
 async fn delete_session(url : String, headers : @http.Headers) -> Unit {
   // Split the MCP URL into origin (scheme + host[:port]) and path.
-  guard url.find("://") is Some(scheme_end) else { return }
-  let host_start = scheme_end + 3
-  let (origin, path) = match url[host_start:].find("/") {
-    Some(slash) => {
-      let cut = host_start + slash
-      (url[:cut].to_owned(), url[cut:].to_owned())
-    }
+  guard url.split_once("://") is Some((scheme, rest)) else { return }
+  let (origin, path) = match rest.split_once("/") {
+    Some((host, path)) => ("\{scheme}://\{host}", "/\{path}")
     None => (url, "/")
   }
   let client = @http.Client(origin) catch {


### PR DESCRIPTION
## What

`parse_goal_baseline` located its `dirty` field with `find` and then cut
the sha out as `rest[:cut]` / `rest[cut + 7:]` — that `+ 7` being the
width of the separator it had just searched for. The same
find-then-slice-by-offset shape, with its hand-rolled separator widths
and `view(start_offset=...)` arithmetic, appeared in a dozen more parsers
across `agent_session`, `mcp`, `desktop` and `editor`.

Each site now calls the library function that already means "split here":

- `agent_session/goal.mbt` — `find(" dirty=")` plus a `match` on
  `"true"`/`"false"` becomes an anchored `lexmatch` whose arms carry the
  sha as the unmatched `before=` prefix.
- `editor/server/host/{language_provider,moon_check}.mbt` — four
  `line:col` parsers use `split_once(":")` / `split_once("-")`.
- `desktop/internal/host/git_ops.mbt` and
  `desktop/internal/worktree/submodules.mbt` — tab-separated git records
  drop `view(start_offset=tab + 1)` for `split_once("\t")`.
- `desktop/internal/skillmarket/{library,registry}.mbt`,
  `desktop/frontend/{skills/document,interop/query}.mbt`,
  `desktop/internal/auth/pkce.mbt`, `desktop/internal/update/update.mbt` —
  `:`, `=`, `?` and `-` field splits.
- `mcp/streamhttp/transport.mbt` — the two-hop URL split
  (`find("://")`, `scheme_end + 3`, `host_start + slash`) rebuilds the
  origin as `"{scheme}://{host}"`, byte-identical to the slice it
  replaced.
- `editor/internal/viewer/markdown/sections.mbt` and
  `.../browser/markdown_document/markdown_document.mbt` — `+ 1` / `+ 2`
  separator cuts.

## Behavior

Unchanged. The goal-baseline `lexmatch` keeps the strict shape its doc
comment promises: the sha is the unmatched prefix and `$` keeps the value
the last field, so a line with trailing text is still not a baseline.
`agent_session/goal_test.mbt` pins that case, which the old code got from
requiring the value to be exactly `true`/`false`.

## Verification

- `moon check --deny-warn` — clean.
- `moon fmt --check` — clean.
- `moon test` for every touched package — `agent_session`,
  `mcp/streamhttp`, `editor/server/host`,
  `editor/internal/viewer/markdown`,
  `editor/internal/viewer/browser/markdown_document` (144 tests) and
  `desktop/internal/{host,worktree,skillmarket,auth,update}`,
  `desktop/frontend/{skills,interop}` (184 tests) — all pass.

Left alone deliberately: `editor/base/common/extpath.mbt` (a scan loop
ported from Monaco), `split_tokenized_code_lines` (its whole point is
keeping the trailing empty item), `desktop/internal/shellenv` (`find` plus
`rev_find` for text between the FIRST and LAST marker) and `agent_tool/edit`
(offsets needed for error reporting).

Generated with SeekMoon