### PR TITLE
feat(mbtx): per-session build cache for wasm scripts

### DIFF
--- a/agent_tool/mbtx/README.mbt.md
+++ b/agent_tool/mbtx/README.mbt.md
@@ -11,10 +11,10 @@ sandboxed automation surface.
 
 The `source` is a `.mbtx` **single-file script** — MoonBit's own one-file
 program format. Alternatively, `filename` loads a saved script. The tool
-writes the program into a throwaway directory and, for the
+stages the program outside the working tree and, for the
 default wasm target, runs it in **two phases**. The BUILD runs first,
 synchronously: `moon run <file>.mbtx --build-only --target-dir
-<temp>`, bounded by its own wall clock (10s by default) so a hung dependency
+<dir>`, bounded by its own wall clock (10s by default) so a hung dependency
 download cannot hold the turn. A nonzero exit here is reported immediately as
 `BUILD failed (exit N)` — a build failure **by construction**, since the run
 phase never starts; no exit-code or output archaeology is needed to tell the
@@ -31,6 +31,35 @@ run, not the build`. Compiler diagnostics are rewritten to stable
 `warning: "on"`) is kept apart from program output by construction. The
 non-wasm targets keep the single-shot `moon run` and their reports claim no
 stage.
+
+## Build cache
+
+The cost of a call is the build, and the cost of the build is compiling the
+packages the script imports: measured on the bundled read workflow, a cold
+build is ~570ms, a rebuild in a directory that already holds those packages
+is ~270ms when the script body changed and ~25ms when it did not, and running
+the program is ~20ms. So when the session has a place that outlives the call
+(its job directory, or a read-only role's scratch lab) wasm builds go to a
+per-session cache under it instead of a fresh temp dir, and the compiled
+packages are there for the next call. The cache is reclaimed with the session.
+
+The directory, not the file name, is the key: moon writes every single-file
+build's program to one fixed path under its target directory, so two scripts
+sharing a directory would overwrite each other's program. A **named script**
+(`filename`, saved or bundled) gets a directory of its own, keyed by its
+resolved path — its content rarely changes, and an unchanged staged file is a
+no-op rebuild. **Inline snippets** share one directory: they differ every
+call, and what they gain is the warm dependency compilation. The staged file
+is rewritten only when its content changed, because moon rebuilds on
+modification time. After a successful build the call copies the program into
+its own per-call directory and runs the copy, so a later rebuild of the shared
+directory, or a detached job's cleanup, never touches the file a running
+program was started from. A build stopped by its bound marks its directory,
+and the next call for that key discards the marked output before building.
+
+Nothing in the tool's result changes; the cache only changes how long a
+call takes. A definition with neither a job directory nor a lab keeps the
+per-call cold build.
 
 With the agent's background runtime, every call's RUN waits inline for up to
 five seconds — build time deliberately does not count against that allowance.

--- a/agent_tool/mbtx/README.mbt.md
+++ b/agent_tool/mbtx/README.mbt.md
@@ -14,7 +14,7 @@ program format. Alternatively, `filename` loads a saved script. The tool
 stages the program outside the working tree and, for the
 default wasm target, runs it in **two phases**. The BUILD runs first,
 synchronously: `moon run <file>.mbtx --build-only --target-dir
-<dir>`, bounded by its own wall clock (10s by default) so a hung dependency
+<dir>`, bounded by its own wall clock (20s by default) so a hung dependency
 download cannot hold the turn. A nonzero exit here is reported immediately as
 `BUILD failed (exit N)` — a build failure **by construction**, since the run
 phase never starts; no exit-code or output archaeology is needed to tell the

--- a/agent_tool/mbtx/README.mbt.md
+++ b/agent_tool/mbtx/README.mbt.md
@@ -54,8 +54,11 @@ is rewritten only when its content changed, because moon rebuilds on
 modification time. After a successful build the call copies the program into
 its own per-call directory and runs the copy, so a later rebuild of the shared
 directory, or a detached job's cleanup, never touches the file a running
-program was started from. A build stopped by its bound marks its directory,
-and the next call for that key discards the marked output before building.
+program was started from. A build stopped by its bound retires the key's
+generation: the next call builds in a fresh `gen-N` directory and sweeps the
+old one, because stopping `moon` does not stop the compilers it spawned. With
+`warning: "on"` the script is recompiled even when unchanged, since a no-op
+rebuild reports the artifact and nothing else.
 
 Nothing in the tool's result changes; the cache only changes how long a
 call takes. A definition with neither a job directory nor a lab keeps the

--- a/agent_tool/mbtx/build_cache.mbt
+++ b/agent_tool/mbtx/build_cache.mbt
@@ -65,14 +65,17 @@ fn cache_key(script_path : String?) -> String {
 ///|
 /// The directory a cached build actually runs in: `<key dir>/gen-N`, where N
 /// is the key's current generation. A generation is retired (N+1) when a
-/// build in it was stopped mid-way — see `retire_generation` — so the next
-/// call builds in a fresh directory rather than in one an orphaned compiler
-/// may still be writing to. Older generations are swept here, best-effort:
-/// by the time a later call arrives the orphan is long gone, and a sweep
-/// that still loses the race only leaves garbage the session reclaims.
-async fn open_generation(key_dir : String) -> String {
-  let n = current_generation(key_dir)
-  let name = "gen-\{n}"
+/// build in it was stopped mid-way, so the next call builds in a fresh
+/// directory rather than in one an orphaned compiler may still be writing
+/// to. The generation lives in the definition's memory, not on disk: the
+/// cache is the session's and so is the definition, and a retirement that
+/// cannot fail is the whole point — a metadata file that failed to write, or
+/// read back malformed, would have the next call reuse the directory it was
+/// meant to fence off. Older generations are swept here, best-effort: by the
+/// time a later call arrives the orphan is long gone, and a sweep that still
+/// loses the race only leaves garbage the session reclaims.
+async fn open_generation(key_dir : String, generation : Int) -> String {
+  let name = "gen-\{generation}"
   let dir = "\{key_dir}/\{name}"
   if !@fs.exists(dir) {
     @fs.mkdir(dir, recursive=true)
@@ -86,41 +89,6 @@ async fn open_generation(key_dir : String) -> String {
     }
   }
   dir
-}
-
-///|
-/// Retire the key's current generation so no later call reuses its build
-/// directory. Called when a build was stopped by its bound or by cancellation:
-/// `moon` is gone by then, but the compiler processes it spawned are not
-/// necessarily, and deleting or rebuilding under them could hand the next
-/// call their stale or half-written output.
-async fn retire_generation(key_dir : String) -> Unit {
-  @async.protect_from_cancel(() => {
-    let next = current_generation(key_dir) + 1
-    @fs.write_file(
-      "\{key_dir}/generation",
-      next.to_string(),
-      create_mode=CreateOrTruncate,
-    ) catch {
-      _ => ()
-    }
-  })
-}
-
-///|
-fn generation_file(key_dir : String) -> String {
-  "\{key_dir}/generation"
-}
-
-///|
-async fn current_generation(key_dir : String) -> Int {
-  let text = @fs.read_file(generation_file(key_dir)).text() catch {
-    error if @async.is_being_cancelled() => raise error
-    _ => return 0
-  }
-  @string.parse_int(text.trim()) catch {
-    _ => 0
-  }
 }
 
 ///|
@@ -142,8 +110,13 @@ fn fnv1a64(text : String) -> UInt64 {
 /// relink the program on every call — the ~270ms case — where leaving it
 /// alone is the ~25ms no-op. Returns whether the file was written.
 async fn stage_source(path : String, source : String) -> Bool {
+  // Only a genuinely absent file means "nothing staged yet"; a read that
+  // fails for any other reason is carried, not read as a stale file to
+  // overwrite. Non-UTF-8 content cannot equal `source`, so it is rewritten.
   let current : String? = try @fs.read_file(path).text() catch {
     error if @async.is_being_cancelled() => raise error
+    @os_error.OSError(_) as error if error.is_ENOENT() => None
+    @os_error.OSError(_) as error => raise error
     _ => None
   } noraise {
     text => Some(text)

--- a/agent_tool/mbtx/build_cache.mbt
+++ b/agent_tool/mbtx/build_cache.mbt
@@ -63,6 +63,67 @@ fn cache_key(script_path : String?) -> String {
 }
 
 ///|
+/// The directory a cached build actually runs in: `<key dir>/gen-N`, where N
+/// is the key's current generation. A generation is retired (N+1) when a
+/// build in it was stopped mid-way — see `retire_generation` — so the next
+/// call builds in a fresh directory rather than in one an orphaned compiler
+/// may still be writing to. Older generations are swept here, best-effort:
+/// by the time a later call arrives the orphan is long gone, and a sweep
+/// that still loses the race only leaves garbage the session reclaims.
+async fn open_generation(key_dir : String) -> String {
+  let n = current_generation(key_dir)
+  let name = "gen-\{n}"
+  let dir = "\{key_dir}/\{name}"
+  if !@fs.exists(dir) {
+    @fs.mkdir(dir, recursive=true)
+  }
+  for entry in @fs.readdir(key_dir) {
+    if entry.has_prefix("gen-") && entry != name {
+      @fs.rmdir("\{key_dir}/\{entry}", recursive=true) catch {
+        error if @async.is_being_cancelled() => raise error
+        _ => ()
+      }
+    }
+  }
+  dir
+}
+
+///|
+/// Retire the key's current generation so no later call reuses its build
+/// directory. Called when a build was stopped by its bound or by cancellation:
+/// `moon` is gone by then, but the compiler processes it spawned are not
+/// necessarily, and deleting or rebuilding under them could hand the next
+/// call their stale or half-written output.
+async fn retire_generation(key_dir : String) -> Unit {
+  @async.protect_from_cancel(() => {
+    let next = current_generation(key_dir) + 1
+    @fs.write_file(
+      "\{key_dir}/generation",
+      next.to_string(),
+      create_mode=CreateOrTruncate,
+    ) catch {
+      _ => ()
+    }
+  })
+}
+
+///|
+fn generation_file(key_dir : String) -> String {
+  "\{key_dir}/generation"
+}
+
+///|
+async fn current_generation(key_dir : String) -> Int {
+  let text = @fs.read_file(generation_file(key_dir)).text() catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => return 0
+  }
+  @string.parse_int(text.trim()) catch {
+    _ => 0
+  }
+}
+
+///|
 /// FNV-1a over the UTF-16 code units of `text`: deterministic across
 /// processes (a directory name must be the same in every session that reuses
 /// the cache), and short enough to read.

--- a/agent_tool/mbtx/build_cache.mbt
+++ b/agent_tool/mbtx/build_cache.mbt
@@ -1,0 +1,123 @@
+///|
+/// Where a session keeps compiled snippets between calls.
+///
+/// A wasm run is built in a persistent per-session directory rather than a
+/// fresh temp dir, so the dependency packages a snippet imports are compiled
+/// once per session instead of once per call — measured, that is the whole
+/// cost of a call: a cold build of the bundled read workflow is ~570ms, a
+/// warm one ~25ms when the source is unchanged and ~270ms when only the
+/// snippet body changed (the link step dominates that remainder).
+///
+/// The cache needs an OWNER whose teardown reclaims it: a session's job dir or
+/// a read-only role's scratch lab. The lab wins because the kernel profile
+/// those roles run under re-allows exactly one writable subtree, and pointing
+/// the cache anywhere else would have `moon` denied at its first write. A
+/// standalone definition with neither has no later owner, so it keeps the
+/// per-call cold build rather than leak a cache directory.
+fn build_cache_root(job_dir? : String, scratch_dir? : String) -> String? {
+  match (scratch_dir, job_dir) {
+    (Some(lab), _) => Some("\{lab}/mbtx-cache")
+    (None, Some(spill)) => Some("\{spill}/mbtx-cache")
+    (None, None) => None
+  }
+}
+
+///|
+/// The subdirectory of the cache root a program builds in.
+///
+/// Every script is staged under the same file name, so the DIRECTORY is the
+/// key: moon writes each single-file build's artifact to one fixed path under
+/// its target directory (`.../single/single.wasm`), and two scripts sharing a
+/// target directory would overwrite each other's program — the later build
+/// deciding what BOTH execute. Named scripts get a directory of their own,
+/// keyed by resolved path, because their content rarely changes and an
+/// unchanged staged file is a ~25ms no-op rebuild. Inline snippets, expected
+/// to differ every call, share one directory whose value is the warm
+/// dependency compilation, not artifact reuse.
+///
+/// The resolved path, not the filename the model wrote, is what is keyed: a
+/// workspace `check.mbtx` and `@builtin/check.mbtx` are different programs.
+/// The basename is kept in the name for a person reading the directory; the
+/// digest is what makes it unique.
+fn cache_key(script_path : String?) -> String {
+  match script_path {
+    None => "snippet"
+    Some(path) => {
+      let base = match path.rev_find("/") {
+        Some(i) => path[i + 1:]
+        None => path
+      }
+      let name = StringBuilder()
+      for c in base.iter().take(40) {
+        name.write_char(
+          if c is ('a'..='z' | 'A'..='Z' | '0'..='9' | '.' | '-' | '_') {
+            c
+          } else {
+            '_'
+          },
+        )
+      }
+      "named-\{name}-\{fnv1a64(path)}"
+    }
+  }
+}
+
+///|
+/// FNV-1a over the UTF-16 code units of `text`: deterministic across
+/// processes (a directory name must be the same in every session that reuses
+/// the cache), and short enough to read.
+fn fnv1a64(text : String) -> UInt64 {
+  let mut hash : UInt64 = 0xcbf29ce484222325
+  for c in text {
+    hash = (hash ^ c.to_int().to_uint64()) * 0x100000001b3
+  }
+  hash
+}
+
+///|
+/// Write `source` to `path` only when the file does not already hold exactly
+/// that text. moon decides what to rebuild by modification time, not content,
+/// so rewriting an unchanged staged file would recompile the snippet and
+/// relink the program on every call — the ~270ms case — where leaving it
+/// alone is the ~25ms no-op. Returns whether the file was written.
+async fn stage_source(path : String, source : String) -> Bool {
+  let current : String? = try @fs.read_file(path).text() catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => None
+  } noraise {
+    text => Some(text)
+  }
+  if current == Some(source) {
+    return false
+  }
+  @fs.write_file(path, source, create_mode=CreateOrTruncate)
+  true
+}
+
+///|
+test "cache root prefers the lab, then the job dir, then nothing" {
+  assert_eq(
+    build_cache_root(job_dir="/spill", scratch_dir="/lab"),
+    Some("/lab/mbtx-cache"),
+  )
+  assert_eq(build_cache_root(job_dir="/spill"), Some("/spill/mbtx-cache"))
+  assert_eq(build_cache_root(scratch_dir="/lab"), Some("/lab/mbtx-cache"))
+  assert_eq(build_cache_root(), None)
+}
+
+///|
+test "cache keys: one shared snippet dir, named scripts keyed by resolved path" {
+  assert_eq(cache_key(None), "snippet")
+  let a = cache_key(Some("/project/check.mbtx"))
+  let b = cache_key(Some("/share/workflow/check.mbtx"))
+  assert_true(a.has_prefix("named-check.mbtx-"))
+  assert_true(b.has_prefix("named-check.mbtx-"))
+  assert_not_eq(a, b)
+  assert_eq(a, cache_key(Some("/project/check.mbtx")))
+  // Unsafe characters never reach the directory name; long names are cut.
+  let odd = cache_key(Some("/p/we ird:name\\x.mbtx"))
+  assert_true(odd.has_prefix("named-we_ird_name_x.mbtx-"))
+  let long = cache_key(Some("/p/" + "a".repeat(60) + ".mbtx"))
+  assert_true(long.has_prefix("named-" + "a".repeat(40) + "-"))
+  assert_false(long.contains("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+}

--- a/agent_tool/mbtx/build_cache_test.mbt
+++ b/agent_tool/mbtx/build_cache_test.mbt
@@ -1,0 +1,226 @@
+///|
+/// The session cache is where a wired job dir (or lab) lets wasm builds keep
+/// their compiled dependencies between calls. Every test here binds a job dir
+/// so the cache is active; the tests in `mbtx_test.mbt` that build a bare
+/// definition exercise the no-owner path, which stays a cold per-call build.
+
+///|
+/// Negative control for the shared snippet directory: every inline snippet
+/// builds at the SAME artifact path, so a later call must never run an
+/// earlier call's program — the trap a shared build dir sets without the
+/// per-call copy.
+async test "cache: consecutive inline snippets each run their own program" {
+  @vfs.with_tmpdir(prefix="mbtx-cache-snippets-", ws => {
+    let spill = "\{ws}/spill"
+    @fs.mkdir(spill)
+    let definition = @mbtx.definition(workspace_root=ws, job_dir=spill)
+    let alice = dispatch(definition, {
+      "source": "fn main { println(\"I AM ALICE\") }",
+    })
+    assert_false(alice.is_error, msg=alice.content)
+    assert_true(alice.content.contains("I AM ALICE"))
+    let bob = dispatch(definition, {
+      "source": "fn main { println(\"I AM BOB\") }",
+    })
+    assert_false(bob.is_error, msg=bob.content)
+    assert_true(bob.content.contains("I AM BOB"))
+    assert_false(bob.content.contains("ALICE"))
+    // An exact repeat is the one inline case moon can serve as a no-op.
+    let again = dispatch(definition, {
+      "source": "fn main { println(\"I AM ALICE\") }",
+    })
+    assert_true(again.content.contains("I AM ALICE"))
+    // One shared directory holds the snippet's build; the per-call dirs are
+    // reclaimed as before, so nothing but the cache survives the calls.
+    assert_true(@fs.exists("\{spill}/mbtx-cache/snippet/_build"))
+    assert_eq(
+      @fs.read_file("\{spill}/mbtx-cache/snippet/snippet.mbtx").text(),
+      "fn main { println(\"I AM ALICE\") }",
+    )
+    assert_eq(@fs.readdir(spill), ["mbtx-cache"])
+    assert_eq(@fs.readdir("\{spill}/mbtx-cache"), ["snippet"])
+  })
+}
+
+///|
+/// A named script gets a directory of its own, keyed by its resolved path,
+/// and keeps it across calls; editing the script rebuilds in place.
+async test "cache: a named script builds in one keyed dir and follows edits" {
+  @vfs.with_tmpdir(prefix="mbtx-cache-named-", ws => {
+    let spill = "\{ws}/spill"
+    @fs.mkdir(spill)
+    @fs.mkdir("\{ws}/scripts")
+    let definition = @mbtx.definition(workspace_root=ws, job_dir=spill)
+    let v1 = "fn main { println(\"hello v1\") }"
+    @fs.write_file("\{ws}/scripts/hello.mbtx", v1, create_mode=CreateOrTruncate)
+    let first = dispatch(definition, { "filename": "scripts/hello.mbtx" })
+    assert_false(first.is_error, msg=first.content)
+    assert_true(first.content.contains("hello v1"))
+    let second = dispatch(definition, { "filename": "scripts/hello.mbtx" })
+    assert_true(second.content.contains("hello v1"))
+    // An inline snippet in between must not disturb the named script's dir.
+    let inline = dispatch(definition, {
+      "source": "fn main { println(\"inline\") }",
+    })
+    assert_true(inline.content.contains("inline"))
+    let keyed = @fs.readdir("\{spill}/mbtx-cache").filter(name => {
+      name.has_prefix("named-hello.mbtx-")
+    })
+    assert_eq(keyed.length(), 1)
+    let stage = "\{spill}/mbtx-cache/\{keyed[0]}"
+    assert_eq(@fs.read_file("\{stage}/snippet.mbtx").text(), v1)
+    assert_true(@fs.exists("\{stage}/_build"))
+    // Edit the script: the same directory is rebuilt, not a new one.
+    let v2 = "fn main { println(\"hello v2\") }"
+    @fs.write_file("\{ws}/scripts/hello.mbtx", v2, create_mode=CreateOrTruncate)
+    let third = dispatch(definition, { "filename": "scripts/hello.mbtx" })
+    assert_true(third.content.contains("hello v2"), msg=third.content)
+    assert_false(third.content.contains("v1"))
+    assert_eq(@fs.read_file("\{stage}/snippet.mbtx").text(), v2)
+    assert_eq(
+      @fs.readdir("\{spill}/mbtx-cache")
+      .filter(name => name.has_prefix("named-"))
+      .length(),
+      1,
+    )
+  })
+}
+
+///|
+/// Two scripts that share a basename but not a path are different programs
+/// and must not share a build directory.
+async test "cache: same basename at different paths keys separately" {
+  @vfs.with_tmpdir(prefix="mbtx-cache-basename-", ws => {
+    let spill = "\{ws}/spill"
+    @fs.mkdir(spill)
+    @fs.mkdir("\{ws}/a")
+    @fs.mkdir("\{ws}/b")
+    @fs.write_file(
+      "\{ws}/a/run.mbtx",
+      "fn main { println(\"from a\") }",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file(
+      "\{ws}/b/run.mbtx",
+      "fn main { println(\"from b\") }",
+      create_mode=CreateOrTruncate,
+    )
+    let definition = @mbtx.definition(workspace_root=ws, job_dir=spill)
+    let a = dispatch(definition, { "filename": "a/run.mbtx" })
+    let b = dispatch(definition, { "filename": "b/run.mbtx" })
+    let a_again = dispatch(definition, { "filename": "a/run.mbtx" })
+    assert_true(a.content.contains("from a"), msg=a.content)
+    assert_true(b.content.contains("from b"), msg=b.content)
+    assert_true(a_again.content.contains("from a"), msg=a_again.content)
+    assert_eq(
+      @fs.readdir("\{spill}/mbtx-cache")
+      .filter(name => name.has_prefix("named-run.mbtx-"))
+      .length(),
+      2,
+    )
+  })
+}
+
+///|
+/// Build diagnostics name the program as the model knows it, never the cache
+/// directory the compiler actually read.
+async test "cache: build errors are reported against the source, not the cache" {
+  @vfs.with_tmpdir(prefix="mbtx-cache-diag-", ws => {
+    let spill = "\{ws}/spill"
+    @fs.mkdir(spill)
+    let definition = @mbtx.definition(workspace_root=ws, job_dir=spill)
+    let out = dispatch(definition, {
+      "source": "fn main { let x : Int = \"not an int\" }",
+    })
+    assert_true(out.is_error)
+    assert_true(out.content.contains("BUILD failed"), msg=out.content)
+    assert_false(out.content.contains("mbtx-cache"), msg=out.content)
+    assert_false(out.content.contains("snippet.mbtx"), msg=out.content)
+  })
+}
+
+///|
+/// A build stopped by its bound must not leave its half-written output for the
+/// next call to trust. Stopping `moon` does not stop the compilers it spawned,
+/// so the stop only marks the directory; the next call on the same cache
+/// discards the marked output and builds cleanly.
+async test "cache: a build stopped by its bound is discarded at the next use" {
+  @vfs.with_tmpdir(prefix="mbtx-cache-abort-", ws => {
+    let spill = "\{ws}/spill"
+    @fs.mkdir(spill)
+    let bounded = @mbtx.definition(
+      workspace_root=ws,
+      job_dir=spill,
+      build_timeout_ms=1,
+    )
+    let stopped = dispatch(bounded, { "source": "fn main { println(1) }" })
+    assert_true(stopped.is_error)
+    assert_true(stopped.content.contains("BUILD did not finish"))
+    assert_true(@fs.exists("\{spill}/mbtx-cache/snippet/aborted"))
+    let definition = @mbtx.definition(workspace_root=ws, job_dir=spill)
+    let ok = dispatch(definition, { "source": "fn main { println(1) }" })
+    assert_false(ok.is_error, msg=ok.content)
+    assert_true(ok.content.contains("1"))
+    assert_false(@fs.exists("\{spill}/mbtx-cache/snippet/aborted"))
+    assert_true(@fs.exists("\{spill}/mbtx-cache/snippet/_build"))
+    // Once discarded, the cache serves the next call as usual.
+    let again = dispatch(definition, { "source": "fn main { println(2) }" })
+    assert_true(again.content.contains("2"), msg=again.content)
+  })
+}
+
+///|
+/// A run handed to the background reclaims its own per-call directory at
+/// terminal status. That must reclaim ONLY the per-call directory: the cache
+/// is the session's, and the program keeps running from its private copy.
+async test "cache: a detached job's cleanup keeps the cache and its own run" {
+  @vfs.with_tmpdir(prefix="mbtx-cache-bg-", ws => {
+    let spill = "\{ws}/spill"
+    @fs.mkdir(spill)
+    @async.with_task_group() <| group => {
+      let bg = @bgjobs.BgJobRuntime(AgentTaskScope(group), spill_dir=spill)
+      let definition = @mbtx.definition(
+        workspace_root=ws,
+        bg_runtime=bg,
+        job_dir=spill,
+        auto_background_after_ms=1,
+      )
+      let source =
+        #|import { "moonbitlang/async" }
+        #|
+        #|async fn main {
+        #|  @async.sleep(300)
+        #|  println("late")
+        #|}
+      let output = dispatch(definition, { "source": source })
+      assert_false(output.is_error, msg=output.content)
+      assert_true(output.content.contains("moved to the background"))
+      // Rebuild the shared snippet dir underneath the running job. With the
+      // 1ms handoff bound this run is adopted too, but its BUILD happened
+      // synchronously first, in the shared directory, while the job ran.
+      let other = dispatch(definition, {
+        "source": "fn main { println(\"other\") }",
+      })
+      assert_false(other.is_error, msg=other.content)
+      // The job's per-call build dir is reclaimed when it ends...
+      let mut reclaimed = false
+      for _ in 0..<200 {
+        if !@fs.exists("\{spill}/snippet-0/build") {
+          reclaimed = true
+          break
+        }
+        @async.sleep(50)
+      }
+      assert_true(
+        reclaimed,
+        msg="the job's terminal must reclaim its build dir",
+      )
+      // ...and the cache is still there for the next call.
+      assert_true(@fs.exists("\{spill}/mbtx-cache/snippet/_build"))
+      let after = dispatch(definition, {
+        "source": "fn main { println(\"after\") }",
+      })
+      assert_false(after.is_error, msg=after.content)
+    }
+  })
+}

--- a/agent_tool/mbtx/build_cache_test.mbt
+++ b/agent_tool/mbtx/build_cache_test.mbt
@@ -32,9 +32,9 @@ async test "cache: consecutive inline snippets each run their own program" {
     assert_true(again.content.contains("I AM ALICE"))
     // One shared directory holds the snippet's build; the per-call dirs are
     // reclaimed as before, so nothing but the cache survives the calls.
-    assert_true(@fs.exists("\{spill}/mbtx-cache/snippet/_build"))
+    assert_true(@fs.exists("\{spill}/mbtx-cache/snippet/gen-0/_build"))
     assert_eq(
-      @fs.read_file("\{spill}/mbtx-cache/snippet/snippet.mbtx").text(),
+      @fs.read_file("\{spill}/mbtx-cache/snippet/gen-0/snippet.mbtx").text(),
       "fn main { println(\"I AM ALICE\") }",
     )
     assert_eq(@fs.readdir(spill), ["mbtx-cache"])
@@ -67,7 +67,7 @@ async test "cache: a named script builds in one keyed dir and follows edits" {
       name.has_prefix("named-hello.mbtx-")
     })
     assert_eq(keyed.length(), 1)
-    let stage = "\{spill}/mbtx-cache/\{keyed[0]}"
+    let stage = "\{spill}/mbtx-cache/\{keyed[0]}/gen-0"
     assert_eq(@fs.read_file("\{stage}/snippet.mbtx").text(), v1)
     assert_true(@fs.exists("\{stage}/_build"))
     // Edit the script: the same directory is rebuilt, not a new one.
@@ -142,9 +142,9 @@ async test "cache: build errors are reported against the source, not the cache" 
 ///|
 /// A build stopped by its bound must not leave its half-written output for the
 /// next call to trust. Stopping `moon` does not stop the compilers it spawned,
-/// so the stop only marks the directory; the next call on the same cache
-/// discards the marked output and builds cleanly.
-async test "cache: a build stopped by its bound is discarded at the next use" {
+/// so the stop retires the key's generation; the next call builds in a fresh
+/// directory and sweeps the retired one.
+async test "cache: a build stopped by its bound retires its generation" {
   @vfs.with_tmpdir(prefix="mbtx-cache-abort-", ws => {
     let spill = "\{ws}/spill"
     @fs.mkdir(spill)
@@ -156,16 +156,39 @@ async test "cache: a build stopped by its bound is discarded at the next use" {
     let stopped = dispatch(bounded, { "source": "fn main { println(1) }" })
     assert_true(stopped.is_error)
     assert_true(stopped.content.contains("BUILD did not finish"))
-    assert_true(@fs.exists("\{spill}/mbtx-cache/snippet/aborted"))
+    assert_eq(
+      @fs.read_file("\{spill}/mbtx-cache/snippet/generation").text(),
+      "1",
+    )
     let definition = @mbtx.definition(workspace_root=ws, job_dir=spill)
     let ok = dispatch(definition, { "source": "fn main { println(1) }" })
     assert_false(ok.is_error, msg=ok.content)
     assert_true(ok.content.contains("1"))
-    assert_false(@fs.exists("\{spill}/mbtx-cache/snippet/aborted"))
-    assert_true(@fs.exists("\{spill}/mbtx-cache/snippet/_build"))
+    assert_true(@fs.exists("\{spill}/mbtx-cache/snippet/gen-1/_build"))
+    assert_false(@fs.exists("\{spill}/mbtx-cache/snippet/gen-0"))
     // Once discarded, the cache serves the next call as usual.
     let again = dispatch(definition, { "source": "fn main { println(2) }" })
     assert_true(again.content.contains("2"), msg=again.content)
+  })
+}
+
+///|
+/// A cache hit is a no-op rebuild that reports nothing but the artifact, so a
+/// caller asking for warnings must get a real recompile, or the second call
+/// would silently lose diagnostics the first one showed.
+async test "cache: requested warnings survive an unchanged script" {
+  @vfs.with_tmpdir(prefix="mbtx-cache-warn-", ws => {
+    let spill = "\{ws}/spill"
+    @fs.mkdir(spill)
+    let definition = @mbtx.definition(workspace_root=ws, job_dir=spill)
+    let source = "fn main { let unused = 1; println(\"ran\") }"
+    let first = dispatch(definition, { "source": source, "warning": "on" })
+    assert_false(first.is_error, msg=first.content)
+    assert_true(first.content.contains("nused"), msg=first.content)
+    let second = dispatch(definition, { "source": source, "warning": "on" })
+    assert_false(second.is_error, msg=second.content)
+    assert_true(second.content.contains("nused"), msg=second.content)
+    assert_true(second.content.contains("ran"))
   })
 }
 
@@ -216,7 +239,7 @@ async test "cache: a detached job's cleanup keeps the cache and its own run" {
         msg="the job's terminal must reclaim its build dir",
       )
       // ...and the cache is still there for the next call.
-      assert_true(@fs.exists("\{spill}/mbtx-cache/snippet/_build"))
+      assert_true(@fs.exists("\{spill}/mbtx-cache/snippet/gen-0/_build"))
       let after = dispatch(definition, {
         "source": "fn main { println(\"after\") }",
       })

--- a/agent_tool/mbtx/build_cache_test.mbt
+++ b/agent_tool/mbtx/build_cache_test.mbt
@@ -140,35 +140,55 @@ async test "cache: build errors are reported against the source, not the cache" 
 }
 
 ///|
-/// A build stopped by its bound must not leave its half-written output for the
+/// A build stopped mid-way must not leave its half-written output for the
 /// next call to trust. Stopping `moon` does not stop the compilers it spawned,
-/// so the stop retires the key's generation; the next call builds in a fresh
-/// directory and sweeps the retired one.
-async test "cache: a build stopped by its bound retires its generation" {
+/// so the stop retires the key's generation in the definition's memory; the
+/// next call through that definition builds in a fresh directory and sweeps
+/// the retired one. Cancellation is the stop used here because a definition's
+/// build bound is fixed for its lifetime, and the retirement must be observed
+/// through the SAME definition; the bound's path shares the retirement.
+async test "cache: a build stopped mid-way retires its generation" {
   @vfs.with_tmpdir(prefix="mbtx-cache-abort-", ws => {
     let spill = "\{ws}/spill"
     @fs.mkdir(spill)
-    let bounded = @mbtx.definition(
-      workspace_root=ws,
-      job_dir=spill,
-      build_timeout_ms=1,
-    )
-    let stopped = dispatch(bounded, { "source": "fn main { println(1) }" })
-    assert_true(stopped.is_error)
-    assert_true(stopped.content.contains("BUILD did not finish"))
-    assert_eq(
-      @fs.read_file("\{spill}/mbtx-cache/snippet/generation").text(),
-      "1",
-    )
     let definition = @mbtx.definition(workspace_root=ws, job_dir=spill)
+    // The stop must land while the BUILD is running for there to be anything
+    // to retire: a cold build of a script importing `moonbitlang/async` takes
+    // several hundred milliseconds, and what precedes it a few, so a bound in
+    // between lands inside the build.
+    let slow =
+      #|import { "moonbitlang/async" }
+      #|
+      #|async fn main {
+      #|  println(1)
+      #|}
+    let stopped = @async.with_timeout_opt(200, () => {
+      dispatch(definition, { "source": slow })
+    })
+    assert_true(stopped is None)
     let ok = dispatch(definition, { "source": "fn main { println(1) }" })
     assert_false(ok.is_error, msg=ok.content)
     assert_true(ok.content.contains("1"))
     assert_true(@fs.exists("\{spill}/mbtx-cache/snippet/gen-1/_build"))
     assert_false(@fs.exists("\{spill}/mbtx-cache/snippet/gen-0"))
-    // Once discarded, the cache serves the next call as usual.
+    // Once retired, the cache serves the next call as usual, in place.
     let again = dispatch(definition, { "source": "fn main { println(2) }" })
     assert_true(again.content.contains("2"), msg=again.content)
+    assert_eq(
+      @fs.readdir("\{spill}/mbtx-cache/snippet").filter(name => {
+        name.has_prefix("gen-")
+      }),
+      ["gen-1"],
+    )
+    // A bounded build is stopped the same way and reports it as the build's.
+    let bounded = @mbtx.definition(
+      workspace_root=ws,
+      job_dir=spill,
+      build_timeout_ms=1,
+    )
+    let timed_out = dispatch(bounded, { "source": "fn main { println(3) }" })
+    assert_true(timed_out.is_error)
+    assert_true(timed_out.content.contains("BUILD did not finish"))
   })
 }
 

--- a/agent_tool/mbtx/build_cache_wbtest.mbt
+++ b/agent_tool/mbtx/build_cache_wbtest.mbt
@@ -1,0 +1,10 @@
+///|
+async test "staging writes only when the content differs" {
+  @vfs.with_tmpdir(prefix="mbtx-stage-", dir => {
+    let path = "\{dir}/snippet.mbtx"
+    assert_true(stage_source(path, "fn main { }"))
+    assert_false(stage_source(path, "fn main { }"))
+    assert_true(stage_source(path, "fn main { println(1) }"))
+    assert_eq(@fs.read_file(path).text(), "fn main { println(1) }")
+  })
+}

--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -135,6 +135,9 @@ pub fn definition(
   // this call, so its snippet, build artifacts, and output log cannot be
   // removed here — the caller's scratch dir is what eventually reclaims them.
   let next_background = Ref(0)
+  // Per cache key, the generation a stopped build retired (see
+  // `open_generation`). Session memory, deliberately: see there.
+  let generations : Map[String, Int] = Map([])
   // Deliberately NOT `concurrent_safe`: wasm builds for one session share
   // build directories (see `build_cache_root`), and a call copies its program
   // out of the shared directory only after its own build returns. Two calls
@@ -170,6 +173,7 @@ pub fn definition(
         foreground_timeout_ms~,
         build_timeout_ms~,
         next_background~,
+        generations~,
         approval?,
         subrun?,
       )
@@ -232,6 +236,7 @@ async fn execute(
   foreground_timeout_ms~ : Int,
   build_timeout_ms~ : Int,
   next_background~ : Ref[Int],
+  generations~ : Map[String, Int],
   approval? : @agent_runtime.ApprovalChannel,
   subrun? : @host.SubrunInjection,
 ) -> @agent_tool.ToolAction {
@@ -522,13 +527,17 @@ async fn execute(
   }
   let stage_dir = match key_dir {
     Some(keyed) =>
-      open_generation(keyed) catch {
+      open_generation(keyed, generations.get(keyed).unwrap_or(0)) catch {
         error if @async.is_being_cancelled() => raise error
         _ => build_dir
       }
     None => build_dir
   }
   let cached = stage_dir != build_dir
+  // What a stopped build does to its key: the next call builds elsewhere.
+  let retire = key_dir.map(keyed => {
+    () => generations[keyed] = generations.get(keyed).unwrap_or(0) + 1
+  })
   // With warnings requested the program is recompiled even when unchanged:
   // moon's no-op rebuild reports the artifact and nothing else, so a cache
   // hit would silently drop the diagnostics the caller asked to see. Warning
@@ -739,7 +748,7 @@ async fn execute(
       build_snippet(
         build_dir~,
         stage_dir~,
-        retire=if cached { key_dir } else { None },
+        retire=if cached { retire } else { None },
         run_cwd~,
         warning=input.warning,
         build_timeout_ms~,
@@ -1041,7 +1050,7 @@ priv enum BuildOutcome {
 async fn build_snippet(
   build_dir~ : String,
   stage_dir~ : String,
-  retire~ : String?,
+  retire~ : (() -> Unit)?,
   run_cwd~ : String?,
   warning~ : Bool,
   build_timeout_ms~ : Int,
@@ -1068,9 +1077,9 @@ async fn build_snippet(
   // deleting nor rebuilding in that directory is safe at any later moment
   // this call can name: the generation is retired instead, and the next call
   // for this key builds in a fresh one (see `open_generation`).
-  async fn mark_aborted() -> Unit {
-    if retire is Some(key_dir) {
-      retire_generation(key_dir)
+  fn mark_aborted() -> Unit {
+    if retire is Some(retire) {
+      retire()
     }
   }
   let (prog, argv) = match confine("moon", build_argv) {

--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -69,9 +69,12 @@ fn duration_label(milliseconds : Int) -> String {
 /// `main`. It runs via `moon run` with your workspace as the working directory
 /// by default — so relative `@fs` paths (e.g. `@fs.read_file("data.json")`)
 /// resolve to workspace files, and any output the program writes lands in the
-/// workspace. Pass `cwd` to run somewhere else. Build artifacts stay in a
-/// throwaway temp directory (via `--target-dir`), so they never touch your
-/// `_build` and the working tree is left clean.
+/// workspace. Pass `cwd` to run somewhere else. Build artifacts never touch
+/// your `_build`: they go to a per-session cache directory (via
+/// `--target-dir`) when the session has one, so the packages a script imports
+/// are compiled once per session rather than once per call (see
+/// `build_cache_root`), and to a throwaway temp directory otherwise. Either
+/// way the working tree is left clean.
 ///
 /// Dependency resolution is still isolated: a local-package import resolves to
 /// the published registry snapshot, not your uncommitted edits (so this is for
@@ -129,6 +132,11 @@ pub fn definition(
   // this call, so its snippet, build artifacts, and output log cannot be
   // removed here — the caller's scratch dir is what eventually reclaims them.
   let next_background = Ref(0)
+  // Deliberately NOT `concurrent_safe`: wasm builds for one session share
+  // build directories (see `build_cache_root`), and a call copies its program
+  // out of the shared directory only after its own build returns. Two calls
+  // in flight could interleave a rebuild of the same directory between one
+  // call's build and its copy. Sequential execution is what rules that out.
   AgentToolDefinition(
     name="mbtx",
     description=description(
@@ -233,8 +241,8 @@ async fn execute(
   }
   // Read once, before validation/approval, then compile this same snapshot.
   // A saved script has the same isolation and execution path as inline code.
-  let (source, source_name) = match input.program {
-    Source(source) => (source, "source")
+  let (source, source_name, script_path) = match input.program {
+    Source(source) => (source, "source", None)
     Save(source, filename) => {
       if worker_sandbox is Some(_) && write_scope is None {
         return @agent_tool.respond(
@@ -258,7 +266,14 @@ async fn execute(
           )
       }
       saved.val = Some(filename)
-      (source, filename)
+      // The same resolution `save_script` used; a script that could be saved
+      // resolves, so a failure here only costs the cache its dedicated dir.
+      let path = try resolve_filename(workspace_root, filename, None) catch {
+        _ => None
+      } noraise {
+        path => Some(path)
+      }
+      (source, filename, path)
     }
     File(filename) => {
       let path = resolve_filename(
@@ -297,7 +312,7 @@ async fn execute(
           )
         }
       }
-      (source, filename)
+      (source, filename, Some(path))
     }
   }
   // Refuse FFI (`extern`), the one construct no mbtx target runs sandboxed.
@@ -333,10 +348,12 @@ async fn execute(
       )
     }
   }
-  // The snippet and all build artifacts live in a throwaway temp dir (passed as
-  // `--target-dir`), while the program itself runs with `run_cwd` as its working
-  // directory — so relative `@fs` paths reach workspace files yet nothing lands
-  // in the working tree. The temp dir is managed by hand (not `@vfs.with_tmpdir`)
+  // The snippet's run-time files live in a throwaway temp dir, and its build
+  // in the session cache when there is one (see `build_cache_root`) — that,
+  // not the workspace, is what moon gets as `--target-dir` — while the program
+  // itself runs with `run_cwd` as its working directory, so relative `@fs`
+  // paths reach workspace files yet nothing lands in the working tree. The
+  // temp dir is managed by hand (not `@vfs.with_tmpdir`)
   // so its cleanup can be shielded from cancellation — that helper re-raises on
   // cancel WITHOUT removing the dir, which would leak the snippet, artifacts, and
   // a possibly-large output log when a turn is cancelled mid-run. The timeout
@@ -487,11 +504,46 @@ async fn execute(
         is_error=true,
       )
   }
-  @fs.write_file(
-    "\{build_dir}/snippet.mbtx",
-    source,
-    create_mode=CreateOrTruncate,
-  )
+  // Where the program is staged and built. With a session cache the wasm
+  // build lands in a directory keyed by the program (see `cache_key`) that
+  // outlives this call, so its compiled dependencies are there for the next
+  // one; the staged source is rewritten only when it changed, because moon
+  // rebuilds on modification time. Without a cache — no owner, or a non-wasm
+  // target, which keeps the single-shot `moon run` — the program builds in
+  // this call's own directory as before. A cache directory that cannot be
+  // created costs this call the cache, not the run.
+  let stage_dir = match build_cache_root(job_dir?, scratch_dir?) {
+    Some(root) if input.target == "wasm" => {
+      let keyed = "\{root}/\{cache_key(script_path)}"
+      try {
+        if !@fs.exists(keyed) {
+          @fs.mkdir(keyed, recursive=true)
+        }
+        keyed
+      } catch {
+        error if @async.is_being_cancelled() => raise error
+        _ => build_dir
+      }
+    }
+    _ => build_dir
+  }
+  let cached = stage_dir != build_dir
+  // A build that was stopped mid-way left this marker (see `build_snippet`):
+  // its output is not to be trusted, and it may still have been receiving
+  // writes from an orphaned compiler when the marker was set, so it is
+  // discarded HERE, at the next use, rather than at the moment of the stop.
+  let abort_marker = "\{stage_dir}/aborted"
+  if cached && @fs.exists(abort_marker) {
+    @async.protect_from_cancel(() => {
+      @fs.rmdir("\{stage_dir}/_build", recursive=true) catch {
+        _ => ()
+      }
+      @fs.remove(abort_marker) catch {
+        _ => ()
+      }
+    })
+  }
+  stage_source("\{stage_dir}/snippet.mbtx", source) |> ignore
   let log = "\{build_dir}/output.log"
   // Pre-create the merged output file so both redirects open it; both append
   // so stdout and stderr interleave in write order.
@@ -506,6 +558,7 @@ async fn execute(
   // moon's diagnostics point at the copied source under the build dir; the
   // canonical path anchors the diagnostic path rewrite below.
   let real = @fs.realpath(build_dir) catch { _ => build_dir }
+  let stage_real = @fs.realpath(stage_dir) catch { _ => stage_dir }
   // The wasm backend is where moonrun's policy applies, so the policy file is
   // written for every run and passed alongside. `--wasm-policy` is silently
   // IGNORED on other backends, which is why `target` is not the model's choice
@@ -687,16 +740,42 @@ async fn execute(
     match
       build_snippet(
         build_dir~,
+        stage_dir~,
+        abort_marker=if cached { Some(abort_marker) } else { None },
         run_cwd~,
         warning=input.warning,
         build_timeout_ms~,
         empty_stdin~,
-        rewrite_bases=[real, build_dir],
+        rewrite_bases=[real, build_dir, stage_real, stage_dir],
         source_name~,
         confine~,
       ) {
       NotBuilt(action) => return action
-      Built(artifact~, notes~) => {
+      Built(artifact=built, notes~) => {
+        // A cached artifact is a shared file: the next build of the same key
+        // rewrites it in place. This call runs a private copy, so neither a
+        // later call nor a detached job's cleanup can touch the file a
+        // running program was started from. moonrun reads the whole program
+        // at startup, so the copy also decouples job lifetime from the cache.
+        let artifact = if cached {
+          let copy = "\{build_dir}/snippet.wasm"
+          @fs.write_file(
+            copy,
+            @fs.read_file(built),
+            create_mode=CreateOrTruncate,
+          ) catch {
+            error if @async.is_being_cancelled() => raise error
+            error =>
+              return @agent_tool.respond(
+                "mbtx: the build succeeded but its artifact could not be copied out of the session cache (\{error}) — a filesystem fault, not a problem in `source`.",
+                is_error=true,
+                brief="mbtx build",
+              )
+          }
+          copy
+        } else {
+          built
+        }
         // An approved escalation is exactly this: the policy file is still
         // written, and simply not passed. Widening the document instead was
         // not available — its `fs.write` roots are canonicalized existing
@@ -963,6 +1042,8 @@ priv enum BuildOutcome {
 /// without the report line.
 async fn build_snippet(
   build_dir~ : String,
+  stage_dir~ : String,
+  abort_marker~ : String?,
   run_cwd~ : String?,
   warning~ : Bool,
   build_timeout_ms~ : Int,
@@ -974,14 +1055,29 @@ async fn build_snippet(
   let build_argv = [
     "run",
     "-q",
-    "\{build_dir}/snippet.mbtx",
+    "\{stage_dir}/snippet.mbtx",
     "--build-only",
     "--target-dir",
-    "\{build_dir}/_build",
+    "\{stage_dir}/_build",
     ..if !warning {
       ["--warn-list", WarnOffList]
     },
   ]
+  // A build stopped mid-way — by its bound or by cancellation — can leave a
+  // half-written artifact behind. In a throwaway directory that is nobody's
+  // problem; in the session cache it would be the next call's. Stopping
+  // `moon` does not stop the compiler processes it spawned, so deleting the
+  // output now could race their last writes: the directory is marked instead,
+  // and the next call for this key discards it before building.
+  async fn mark_aborted() -> Unit {
+    if abort_marker is Some(marker) {
+      @async.protect_from_cancel(() => {
+        @fs.write_file(marker, "", create_mode=CreateOrTruncate) catch {
+          _ => ()
+        }
+      })
+    }
+  }
   let (prog, argv) = match confine("moon", build_argv) {
     Some(command) => (command.program(), command.args())
     None => ("moon", build_argv)
@@ -991,6 +1087,7 @@ async fn build_snippet(
   // policy-refusal scan never reads build chatter.
   let build_log = "\{build_dir}/build.log"
   @fs.write_file(build_log, "", create_mode=CreateOrTruncate)
+  errdefer mark_aborted()
   let result = @async.with_timeout_opt(build_timeout_ms, () => {
     let exit_code = @process.run(
       prog,
@@ -1005,6 +1102,7 @@ async fn build_snippet(
     (exit_code, read_capped(build_log))
   })
   guard result is Some((exit_code, raw)) else {
+    mark_aborted()
     return NotBuilt(
       @agent_tool.respond(
         "mbtx: the BUILD did not finish within \{duration_label(build_timeout_ms)} and was cancelled — the program never ran. Compilation or a dependency download stalled; retrying is faster than it looks (downloaded modules are cached).",
@@ -1034,7 +1132,7 @@ async fn build_snippet(
   // Older moon versions without an artifact report write directly under the
   // configured target directory; newer versions report their per-file path.
   let artifact = parse_artifacts_path(raw).unwrap_or(
-    "\{build_dir}/_build/wasm/debug/build/single/single.wasm",
+    "\{stage_dir}/_build/wasm/debug/build/single/single.wasm",
   )
   let artifact_present = @fs.exists(artifact) catch {
     error if @async.is_being_cancelled() => raise error

--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -515,38 +515,33 @@ async fn execute(
   // target, which keeps the single-shot `moon run` — the program builds in
   // this call's own directory as before. A cache directory that cannot be
   // created costs this call the cache, not the run.
-  let stage_dir = match build_cache_root(job_dir?, scratch_dir?) {
-    Some(root) if input.target == "wasm" => {
-      let keyed = "\{root}/\{cache_key(script_path)}"
-      try {
-        if !@fs.exists(keyed) {
-          @fs.mkdir(keyed, recursive=true)
-        }
-        keyed
-      } catch {
+  let key_dir = match build_cache_root(job_dir?, scratch_dir?) {
+    Some(root) if input.target == "wasm" =>
+      Some("\{root}/\{cache_key(script_path)}")
+    _ => None
+  }
+  let stage_dir = match key_dir {
+    Some(keyed) =>
+      open_generation(keyed) catch {
         error if @async.is_being_cancelled() => raise error
         _ => build_dir
       }
-    }
-    _ => build_dir
+    None => build_dir
   }
   let cached = stage_dir != build_dir
-  // A build that was stopped mid-way left this marker (see `build_snippet`):
-  // its output is not to be trusted, and it may still have been receiving
-  // writes from an orphaned compiler when the marker was set, so it is
-  // discarded HERE, at the next use, rather than at the moment of the stop.
-  let abort_marker = "\{stage_dir}/aborted"
-  if cached && @fs.exists(abort_marker) {
-    @async.protect_from_cancel(() => {
-      @fs.rmdir("\{stage_dir}/_build", recursive=true) catch {
-        _ => ()
-      }
-      @fs.remove(abort_marker) catch {
-        _ => ()
-      }
-    })
+  // With warnings requested the program is recompiled even when unchanged:
+  // moon's no-op rebuild reports the artifact and nothing else, so a cache
+  // hit would silently drop the diagnostics the caller asked to see. Warning
+  // runs are probes, and the recompile is the ~270ms case, not the cold one.
+  if input.warning {
+    @fs.write_file(
+      "\{stage_dir}/snippet.mbtx",
+      source,
+      create_mode=CreateOrTruncate,
+    )
+  } else {
+    stage_source("\{stage_dir}/snippet.mbtx", source) |> ignore
   }
-  stage_source("\{stage_dir}/snippet.mbtx", source) |> ignore
   let log = "\{build_dir}/output.log"
   // Pre-create the merged output file so both redirects open it; both append
   // so stdout and stderr interleave in write order.
@@ -744,7 +739,7 @@ async fn execute(
       build_snippet(
         build_dir~,
         stage_dir~,
-        abort_marker=if cached { Some(abort_marker) } else { None },
+        retire=if cached { key_dir } else { None },
         run_cwd~,
         warning=input.warning,
         build_timeout_ms~,
@@ -1046,7 +1041,7 @@ priv enum BuildOutcome {
 async fn build_snippet(
   build_dir~ : String,
   stage_dir~ : String,
-  abort_marker~ : String?,
+  retire~ : String?,
   run_cwd~ : String?,
   warning~ : Bool,
   build_timeout_ms~ : Int,
@@ -1069,16 +1064,13 @@ async fn build_snippet(
   // A build stopped mid-way — by its bound or by cancellation — can leave a
   // half-written artifact behind. In a throwaway directory that is nobody's
   // problem; in the session cache it would be the next call's. Stopping
-  // `moon` does not stop the compiler processes it spawned, so deleting the
-  // output now could race their last writes: the directory is marked instead,
-  // and the next call for this key discards it before building.
+  // `moon` does not stop the compiler processes it spawned, so neither
+  // deleting nor rebuilding in that directory is safe at any later moment
+  // this call can name: the generation is retired instead, and the next call
+  // for this key builds in a fresh one (see `open_generation`).
   async fn mark_aborted() -> Unit {
-    if abort_marker is Some(marker) {
-      @async.protect_from_cancel(() => {
-        @fs.write_file(marker, "", create_mode=CreateOrTruncate) catch {
-          _ => ()
-        }
-      })
+    if retire is Some(key_dir) {
+      retire_generation(key_dir)
     }
   }
   let (prog, argv) = match confine("moon", build_argv) {

--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -28,8 +28,11 @@ const BuildNotesCapChars : Int = 8_000
 /// dependency download must not hold the turn. Generous by an order of
 /// magnitude: a trivial wasm build measures ~100ms and one pulling several
 /// registry modules well under a second on a warm cache, and a timed-out
-/// build's retry is faster still (moon caches downloaded modules).
-const BuildTimeoutMs : Int = 10_000
+/// build's retry is faster still (moon caches downloaded modules). With the
+/// session cache only the FIRST build of a program in a session is cold, and
+/// parallel subruns each starting with the same bundled script are where cold
+/// builds contend for the machine, so the bound leaves room for that.
+const BuildTimeoutMs : Int = 20_000
 
 ///|
 /// Output is streamed to a file on disk, not buffered in memory, so a snippet

--- a/agent_tool/mbtx/moon.pkg
+++ b/agent_tool/mbtx/moon.pkg
@@ -14,7 +14,7 @@ import {
   "moonbitlang/core/json",
   "moonbitlang/core/env",
   "moonbitlang/core/encoding/utf8",
-  "moonbitlang/core/string",
+  "moonbitlang/async/os_error",
   "bobzhang/openseek_protocol",
   "bobzhang/openseek_protocol/emit",
 }

--- a/agent_tool/mbtx/moon.pkg
+++ b/agent_tool/mbtx/moon.pkg
@@ -14,6 +14,7 @@ import {
   "moonbitlang/core/json",
   "moonbitlang/core/env",
   "moonbitlang/core/encoding/utf8",
+  "moonbitlang/core/string",
   "bobzhang/openseek_protocol",
   "bobzhang/openseek_protocol/emit",
 }

--- a/agent_tool/mbtx/moon.pkg
+++ b/agent_tool/mbtx/moon.pkg
@@ -38,7 +38,7 @@ import {
 
 options(
   // Every test here compiles and runs a real snippet through `moon`, and the
-  // tool bounds that BUILD phase at 10s. Run unbounded, dozens of toolchain
+  // tool bounds that BUILD phase at 20s. Run unbounded, dozens of toolchain
   // builds compete for the same machine and the slower ones — the snippets
   // that import `moonbitlang/async` — cross that deadline, so the suite fails
   // on contention rather than on behaviour. Two at a time keeps every build


### PR DESCRIPTION
Every mbtx call compiled its script in a fresh temp dir, so the packages the script imports were rebuilt on every call. Measured on the bundled read workflow (#1446 makes it the read tool), that is the whole cost of a call: ~570 ms cold, of which ~20 ms is running the program. In the PR's TOML benchmark a run makes ~126 mbtx calls.

**What changes.** When the definition has an owner that outlives the call (the session's job dir, or a read-only role's scratch lab), wasm builds go to a per-session cache under it. The directory is the key, since moon writes every single-file build's artifact to one fixed path under its target dir:

- **Named scripts** (`filename`, saved or bundled) each get a directory keyed by resolved path. The staged file is rewritten only when its content changed, because moon rebuilds on mtime, so an unchanged script is a ~25 ms no-op rebuild.
- **Inline snippets** share one directory and keep the warm dependency compilation (~270 ms, the link step dominates).
- After a successful build the call copies the program into its own per-call dir and runs the copy, so a later rebuild of a shared dir, or a detached job's cleanup, never touches the file a running program was started from.
- A build stopped by its bound or by cancellation retires the key's generation (in the definition's memory) and the next call builds in a fresh `gen-N` dir, since stopping `moon` does not stop the compilers it spawned.
- `warning: "on"` always recompiles: a no-op rebuild reports nothing but the artifact.
- The build bound goes from 10 s to 20 s: only the first build of a program per session is cold now, and parallel subruns starting with the same bundled script are where cold builds contend.

The tool's result is unchanged. A definition with neither owner (the standalone/harness path) keeps the per-call cold build. mbtx stays non-concurrent-safe, which is what makes the shared directory sound; a comment on the definition says so.

**Measured through the real tool**, repeated named-script call: 551 ms before, 39 ms after.

**Validation.** `moon test -p bobzhang/openseek/agent_tool/mbtx --target native`: 96/96 (7 new cache tests: consecutive snippets each run their own program, keyed named dir following edits, same basename keyed apart, diagnostics name the source not the cache, requested warnings survive a cache hit, cancelled build retires its generation, detached job cleanup keeps the cache). `moon check --deny-warn` clean on native and wasm; `moon fmt`; `moon info` no drift. Three rounds of `codex review` (gpt-6-astra, medium): two P2 findings fixed (warnings on cache hits; orphaned-compiler race after abort), then a P2 on metadata-file failure modes fixed by moving the generation into session memory, then clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5VtKfp425u2tPHiBcB2Zh
