### PR TITLE
fix(editor): separate feedback and folding gutter controls

### DIFF
--- a/editor/internal/viewer/code_editor_widget/folding_host.mbt
+++ b/editor/internal/viewer/code_editor_widget/folding_host.mbt
@@ -268,17 +268,14 @@ fn CodeEditorWidget::folding_on_editor_mouse_down(
   }
   let mut icon_clicked = false
   match e.target {
-    MouseTargetMargin(type_=GutterLineDecorations, element~, detail~, ..) => {
+    MouseTargetMargin(type_=GutterLineDecorations, element~, ..) => {
       guard element is Some(element) else { return }
-      guard element.to_html_element() is Some(html_element) else { return }
-      let offset_left_in_gutter = html_element.get_offset_left()
-      let gutter_offset_x = detail.offset_x - offset_left_in_gutter
-
-      // TODO@joao TODO@alex TODO@martin this is such that we don't collide
-      // with dirty diff
-      if gutter_offset_x < 4.0 {
-        // the whitespace between the border and the real folding icon border
-        // is 4px
+      // Other contributions, including feedback, share the decoration lane.
+      // Only the folding icon owns the fold gesture.
+      guard element_class_list_contains(element, "codicon-folding-expanded") ||
+        element_class_list_contains(element, "codicon-folding-collapsed") ||
+        element_class_list_contains(element, "codicon-folding-manual-expanded") ||
+        element_class_list_contains(element, "codicon-folding-manual-collapsed") else {
         return
       }
       icon_clicked = true

--- a/editor/internal/viewer/contrib/markdown_comments/browser/markdown_comment_dom.mbt
+++ b/editor/internal/viewer/contrib/markdown_comments/browser/markdown_comment_dom.mbt
@@ -258,12 +258,9 @@ pub fn MarkdownCommentDom::pin_to_content_viewport(
 }
 
 ///|
-/// Pins the gutter chevron to the rendered line-decorations lane — the
-/// configured `lineDecorationsWidth` plus the folding-control reserve. The
-/// lane is right-aligned inside the margin ViewZone node, so this width keeps
-/// the chevron centered on the same column as the code-folding icons. The
-/// stylesheet default matches the default 10px + 16px reserve; the caller
-/// reapplies the live width whenever runtime options change that reserve.
+/// Bounds the gutter chevron by the available line-decorations lane. CSS caps
+/// its width at 16px and aligns it to the right, sharing the code-folding
+/// column without expanding into the feedback reservation.
 pub fn MarkdownCommentDom::set_margin_fold_lane_width(
   self : MarkdownCommentDom,
   width_px : Int,

--- a/editor/internal/viewer/contrib/markdown_comments/browser/markdown_comment_dom.mbt
+++ b/editor/internal/viewer/contrib/markdown_comments/browser/markdown_comment_dom.mbt
@@ -259,7 +259,7 @@ pub fn MarkdownCommentDom::pin_to_content_viewport(
 
 ///|
 /// Bounds the gutter chevron by the available line-decorations lane. CSS caps
-/// its width at 16px and aligns it to the right, sharing the code-folding
+/// its width at 16px and leaves 8px before content, sharing the code-folding
 /// column without expanding into the feedback reservation.
 pub fn MarkdownCommentDom::set_margin_fold_lane_width(
   self : MarkdownCommentDom,

--- a/editor/tests/browser/component/agent_feedback.spec.js
+++ b/editor/tests/browser/component/agent_feedback.spec.js
@@ -54,7 +54,9 @@ test('agent feedback: add and fold controls have separate hit targets', async ({
 
     const addBox = await boxOf(glyph);
     const foldBox = await boxOf(fold);
-    expect(addBox.x + addBox.width).toBeLessThanOrEqual(foldBox.x);
+    expect(foldBox.x - (addBox.x + addBox.width)).toBe(2);
+    const marginBox = await boxOf(page.locator('.monaco-editor .margin'));
+    expect(marginBox.x + marginBox.width - (foldBox.x + foldBox.width)).toBe(8);
     // Hit both edges of the visible plus, not only a tiny carrier's center.
     for (const offset of [2, addBox.width - 2]) {
       await header.hover();

--- a/editor/tests/browser/component/agent_feedback.spec.js
+++ b/editor/tests/browser/component/agent_feedback.spec.js
@@ -32,6 +32,50 @@ const boxOf = async (locator) => {
   return box;
 };
 
+test('agent feedback: add and fold controls have separate hit targets', async ({ page }) => {
+  await gotoBrowserScenario(page, 'agent-feedback');
+  const header = page.locator('.view-line', { hasText: 'quiet_area' });
+  const body = page.locator('.view-line', { hasText: 'untouched' }).first();
+  const glyph = page.locator('.cldr.agent-feedback-glyph.line-hover');
+  const input = page.locator('.agent-feedback-input-widget textarea');
+  await expect(header).toBeVisible();
+
+  for (const collapsed of [false, true]) {
+    await header.hover();
+    const row = glyph.locator('..');
+    const fold = row.locator('[class*="codicon-folding-"]');
+    await expect(fold).toHaveCount(1);
+    if (collapsed) {
+      await fold.click();
+      await expect(body).toHaveCount(0);
+      await expect(input).not.toBeVisible();
+      await header.hover();
+    }
+
+    const addBox = await boxOf(glyph);
+    const foldBox = await boxOf(fold);
+    expect(addBox.x + addBox.width).toBeLessThanOrEqual(foldBox.x);
+    // Hit both edges of the visible plus, not only a tiny carrier's center.
+    for (const offset of [2, addBox.width - 2]) {
+      await header.hover();
+      await glyph.click({ position: { x: offset, y: addBox.height / 2 } });
+      await expect(input).toBeFocused();
+      await expect(body).toHaveCount(collapsed ? 0 : 1);
+      await page.locator('.agent-feedback-input-action-cancel').click();
+      await expect(input).not.toBeVisible();
+      // Restore the viewport after the composer returns focus to the editor.
+      await page.mouse.move(300, 100);
+      await page.mouse.wheel(0, -1000);
+      await expect(header).toBeVisible();
+    }
+  }
+
+  await header.hover();
+  await glyph.locator('..').locator('[class*="codicon-folding-"]').click();
+  await expect(body).toHaveCount(1);
+  await expect(input).not.toBeVisible();
+});
+
 test('agent feedback: bubbles, glyph add flow, reply, remove, scroll', async ({ page }, testInfo) => {
   const reporter = await installMoonBitReporter(page);
   await gotoBrowserScenario(page, 'agent-feedback');

--- a/editor/tests/browser/component/diff_markdown_comments.spec.js
+++ b/editor/tests/browser/component/diff_markdown_comments.spec.js
@@ -97,7 +97,7 @@ async function expectDecorationsLane(pane, expectedWidth) {
       toggle: toggleRect.width,
       toggleRightInset: marginRect.right - toggleRect.right,
     };
-  })).toEqual({ lane: expectedWidth, toggle: 16, toggleRightInset: 0 });
+  })).toEqual({ lane: expectedWidth, toggle: 16, toggleRightInset: 8 });
 }
 
 test('keeps normal editor gutter room for comment and feedback controls', async ({ page }) => {

--- a/editor/tests/browser/component/diff_markdown_comments.spec.js
+++ b/editor/tests/browser/component/diff_markdown_comments.spec.js
@@ -91,11 +91,13 @@ async function expectDecorationsLane(pane, expectedWidth) {
     if (!margin || !lineNumber || !toggle) return null;
     const marginRect = margin.getBoundingClientRect();
     const lineNumberRect = lineNumber.getBoundingClientRect();
+    const toggleRect = toggle.getBoundingClientRect();
     return {
       lane: marginRect.right - lineNumberRect.right,
-      toggle: Number.parseFloat(getComputedStyle(toggle).width),
+      toggle: toggleRect.width,
+      toggleRightInset: marginRect.right - toggleRect.right,
     };
-  })).toEqual({ lane: expectedWidth, toggle: expectedWidth });
+  })).toEqual({ lane: expectedWidth, toggle: 16, toggleRightInset: 0 });
 }
 
 test('keeps normal editor gutter room for comment and feedback controls', async ({ page }) => {

--- a/editor/viewer/contrib/agent_feedback/browser/agent_feedback.css
+++ b/editor/viewer/contrib/agent_feedback/browser/agent_feedback.css
@@ -16,12 +16,9 @@
 }
 
 .margin-view-overlays .agent-feedback-glyph.line-hover {
-  margin-left: 12px;
-  /* Keep the lane element itself inside the gutter band: the upstream
-     20px-wide element would spill its click target past the gutter edge
-     into the text (the comments glyph's width recipe). The visible plus is
-     the ::before, drawn back over the lane. */
-  width: 4px !important;
+  /* The feedback reservation owns the first 18px of the decoration lane.
+     Keep the visible icon and its pointer target in the same box. */
+  width: 18px !important;
 }
 
 .margin-view-overlays .agent-feedback-glyph.line-hover::before {
@@ -30,8 +27,8 @@
   font-size: 14px;
   position: absolute;
   height: 100%;
-  width: 18px;
-  left: -8px;
+  width: 100%;
+  left: 0;
   z-index: 10;
   color: var(--vscode-editorGutter-commentGlyphForeground, var(--vscode-foreground));
   background-color: var(--vscode-editorGutter-commentRangeForeground);

--- a/editor/viewer/contrib/folding/browser/folding.css
+++ b/editor/viewer/contrib/folding/browser/folding.css
@@ -18,9 +18,9 @@
   align-items: center;
   justify-content: center;
   font-size: 140%;
-  /* Folding owns the trailing 16px, independently of other gutter controls. */
+  /* Keep the 16px folding target close to feedback, with 8px before code. */
   left: auto !important;
-  right: 0;
+  right: 8px;
   width: 16px !important;
 }
 

--- a/editor/viewer/contrib/folding/browser/folding.css
+++ b/editor/viewer/contrib/folding/browser/folding.css
@@ -18,7 +18,10 @@
   align-items: center;
   justify-content: center;
   font-size: 140%;
-  margin-left: 2px;
+  /* Folding owns the trailing 16px, independently of other gutter controls. */
+  left: auto !important;
+  right: 0;
+  width: 16px !important;
 }
 
 .margin-view-overlays:hover .codicon,
@@ -53,8 +56,6 @@
 .cldr.codicon.codicon-folding-manual-expanded,
 .cldr.codicon.codicon-folding-manual-collapsed {
   color: var(--vscode-editorGutter-foldingControlForeground) !important;
-  /* The Viewer currently has one shared line-decoration lane. Keep a fold
-     control above the hover-only agent-feedback affordance when both occupy
-     the same line; feedback remains clickable on every non-folding line. */
+  /* Keep the dedicated fold target above full-lane gutter decorations. */
   z-index: 11;
 }

--- a/editor/viewer/contrib/markdown_comments/browser/markdown_comments.css
+++ b/editor/viewer/contrib/markdown_comments/browser/markdown_comments.css
@@ -193,10 +193,8 @@
 }
 
 /* The margin ViewZone node spans the entire gutter for the zone's height.
- * The chevron mirrors the code-folding `.cldr` geometry: the icon box is the
- * line-decorations lane (right edge of the gutter, shifted the same 2px as
- * `folding.css` `margin-left`), flex-centered at 140% like the code icons,
- * so both fold controls share one column. */
+ * The chevron shares the trailing 16px folding column with code-folding
+ * controls, regardless of the feedback reservation. */
 .moonbit-viewer-markdown-comment-margin {
   pointer-events: none;
 }
@@ -204,14 +202,12 @@
 .moonbit-viewer-markdown-comment-margin-toggle.codicon {
   position: absolute;
   top: 4px;
-  right: -2px;
+  right: 0;
   /* The later `.margin-view-overlays` sibling otherwise paints above the
    * zones container and intercepts the click. */
   z-index: 1;
-  /* Default `lineDecorationsWidth` (10px) plus the 16px folding-control
-   * reserve; the contribution inlines the effective lane width at mount and
-   * resynchronizes it after runtime option changes. */
-  width: 26px;
+  width: 16px;
+  max-width: 16px;
   height: var(--editor-line-height, 18px);
   display: flex;
   align-items: center;

--- a/editor/viewer/contrib/markdown_comments/browser/markdown_comments.css
+++ b/editor/viewer/contrib/markdown_comments/browser/markdown_comments.css
@@ -193,8 +193,8 @@
 }
 
 /* The margin ViewZone node spans the entire gutter for the zone's height.
- * The chevron shares the trailing 16px folding column with code-folding
- * controls, regardless of the feedback reservation. */
+ * The chevron shares the code-folding column, leaving 8px before content
+ * regardless of the feedback reservation. */
 .moonbit-viewer-markdown-comment-margin {
   pointer-events: none;
 }
@@ -202,7 +202,7 @@
 .moonbit-viewer-markdown-comment-margin-toggle.codicon {
   position: absolute;
   top: 4px;
-  right: 0;
+  right: 8px;
   /* The later `.margin-view-overlays` sibling otherwise paints above the
    * zones container and intercepts the click. */
   z-index: 1;


### PR DESCRIPTION
On foldable lines, the Add feedback glyph overlapped the folding control, so clicking the visible plus could miss Feedback or trigger folding. Give the plus a full 18px hit target and restrict folding gestures to the folding icon itself.

Keep code and Markdown-comment folding controls in the same 16px column, with a 2px gap after the feedback button and 8px of space before code in the default gutter. Browser coverage checks both expanded and collapsed lines, clicks near both edges of the plus, and preserves the gutter reservation across Diff layout and folding-option changes.

Validation:

- Full editor browser suite: 111 tests passed; focused spacing and interaction suite: 14 tests passed.
- Editor all-target suite: 4,189 tests passed.
- Root `just test` and `just build` passed, including Native/JS tests, 24 cram cases, and CLI lifecycle checks.
- `moon info`, `moon fmt`, and `git diff --check` completed with no generated interface changes.
- Built the macOS Release SeekMoon.app; verified its signature and the packaged gutter CSS. The packaged app was not launched for this build.

Local strict-check limitation: `just check` and the editor strict check are blocked by existing warning 29 (`unused_package`) with the installed nightly toolchain. Builds and tests pass; remote CI is not yet verified.


Closes #1623