### PR TITLE
fix(editor): balance folded body placeholder spacing

### DIFF
--- a/editor/viewer/contrib/folding/browser/folding.css
+++ b/editor/viewer/contrib/folding/browser/folding.css
@@ -39,6 +39,7 @@
 }
 
 .inline-folded-body:after {
+  margin-left: 1ch;
   content: "\2026  }";
 }
 


### PR DESCRIPTION
Function-body folds displayed `{ … }` with the ellipsis crowded against the opening brace: its left margin was `0.2em`, while the right side contained a full space. Set the body placeholder's left margin to `1ch` so the spacing matches and scales with the editor font.

Validation:
- Verified light/dark rendering, suffix-click unfolding, refolding, and spacing at 12/16/20px in the editor shell.
- All 111 browser tests passed.
- `just test`, `just build`, and `just editor-test` passed.
- `moon info`, `moon fmt`, and `git diff --check` passed with no interface changes.
- Strict root/editor checks remain blocked by existing unused-import warnings in unchanged packages.
