### PR TITLE
fix(desktop): allow debugger attachment to macOS dev builds

### DIFF
--- a/desktop/package/README.md
+++ b/desktop/package/README.md
@@ -46,6 +46,15 @@ Do not resolve package files from the process working directory. Host features
 append canonical paths to `@proton.resource_dir()`. Installed lookup must fail
 closed rather than silently use a system copy.
 
+## macOS debugger attachment
+
+Development packages use `macos/SeekMoonDev.entitlements`, which includes
+`com.apple.security.get-task-allow` so LLDB can attach after launch with
+`xcrun lldb -p <PID>`. Release packages (`--release`) use
+`macos/SeekMoon.entitlements` without this permission. Rebuild and relaunch
+SeekMoonDev to apply entitlement changes; they do not change an already
+running process. macOS must also authorize the debugger as a developer tool.
+
 ## Process environment
 
 The intended `PATH` precedence is:

--- a/desktop/package/build.mjs
+++ b/desktop/package/build.mjs
@@ -396,7 +396,12 @@ class Build {
     if (options.sign) args.push("--sign");
     if (options.notarize) args.push("--notarize");
     const env = {};
-    if (this.command === "macos") env.PROTON_MACOS_ENTITLEMENTS = join(this.desktop, "package/macos/SeekMoon.entitlements");
+    if (this.command === "macos") {
+      // LLDB may attach to a running development app. Keep get-task-allow
+      // out of the shipped app by selecting its entitlements separately.
+      env.PROTON_MACOS_ENTITLEMENTS = join(this.desktop, "package/macos",
+        options.release ? "SeekMoon.entitlements" : "SeekMoonDev.entitlements");
+    }
     if (options.sign) env.PROTON_MACOS_SIGNING_IDENTITY = options.sign;
     if (options.notarize) env.PROTON_NOTARY_PROFILE = options.notarize;
     if (this.command === "macos") env.MACOSX_DEPLOYMENT_TARGET = "12.0";

--- a/desktop/package/macos/SeekMoonDev.entitlements
+++ b/desktop/package/macos/SeekMoonDev.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key><true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key><true/>
+  <key>com.apple.security.cs.disable-executable-page-protection</key><true/>
+  <key>com.apple.security.cs.disable-library-validation</key><true/>
+  <!-- Permit debugger attachment to SeekMoonDev after it has launched. -->
+  <key>com.apple.security.get-task-allow</key><true/>
+</dict>
+</plist>


### PR DESCRIPTION
macOS SeekMoonDev packages enable hardened runtime without `get-task-allow`, preventing LLDB from attaching to an already running development app when investigating hangs.

Use a dedicated `SeekMoonDev.entitlements` file for development packages, preserving the existing permissions and adding `com.apple.security.get-task-allow`. Release packages continue to use the existing `SeekMoon.entitlements` without debugger attachment permission. Document how to attach and the need to rebuild and relaunch after entitlement changes.

Validation:
- `just desktop-build-scripts-check` passed (rerun outside the sandbox because its HTTP tests bind to localhost).
- Both entitlement files passed `plutil -lint`; verified that the development file differs only by `get-task-allow = true`.
- After rebasing, verified the changed files were preserved byte-for-byte and reran JavaScript syntax, plist, and diff checks.

A newly packaged application and live LLDB attachment have not yet been validated. This change does not fix the underlying shutdown hang or alter system developer-tool authorization.
