### PR TITLE
refactor(desktop): parse a read result's numbered lines once; print args as written

### DIFF
--- a/agent_tool/mbtx/html/read_output.mbt
+++ b/agent_tool/mbtx/html/read_output.mbt
@@ -12,13 +12,22 @@ pub fn read_workflow_output(content : String) -> @rhtml.Html? {
   while index < lines.length() {
     let line = lines[index]
     if file_heading(line) is Some(path) {
+      // The numbered body is parsed once, here, and handed to the renderer
+      // as gutters and source; the status line that ends the body is what
+      // makes the section a complete file result.
+      let numbered : Array[(String, String)] = []
       let mut end = index + 1
-      while end < lines.length() && numbered_line(lines[end]) is Some(_) {
-        end += 1
+      while end < lines.length() {
+        match numbered_line(lines[end]) {
+          Some(pair) => {
+            numbered.push(pair)
+            end += 1
+          }
+          None => break
+        }
       }
       if end < lines.length() &&
-        moonbit_output_for_path(path, lines[index + 1:end + 1].join("\n"))
-        is Some(rendered) {
+        moonbit_section(path, numbered, lines[end]) is Some(rendered) {
         children.push(@rhtml.span("\{line}\n"))
         children.push(rendered)
         if end + 1 < lines.length() {
@@ -56,34 +65,27 @@ fn file_heading(line : String) -> String? {
 }
 
 ///|
-/// Render a numbered result when `path` has a MoonBit source extension.
-fn moonbit_output_for_path(path : StringView, content : String) -> @rhtml.Html? {
-  // Keep rendering bounded even for malformed recorded output.
-  guard is_moonbit_source(path) && content.length() <= 40_000 else {
-    return None
-  }
-  let lines = content.split("\n").map(line => line.to_owned()).collect()
-  guard lines.last() is Some(status) &&
+/// Render one file section — its parsed numbered lines and the status line
+/// that closes it — when `path` has a MoonBit source extension.
+fn moonbit_section(
+  path : StringView,
+  numbered : Array[(String, String)],
+  status : String,
+) -> @rhtml.Html? {
+  guard is_moonbit_source(path) &&
+    !numbered.is_empty() &&
     status.has_prefix("<system>") &&
     status.has_suffix("</system>") else {
     return None
   }
-  let gutters : Array[String] = []
-  let source_lines : Array[String] = []
-  for line in lines[0:lines.length() - 1] {
-    guard numbered_line(line) is Some((gutter, source)) else { return None }
-    gutters.push(gutter)
-    source_lines.push(source)
-  }
-  if source_lines.is_empty() {
-    return None
-  }
-  let highlighted = @syntax_html.moonbit_source_lines(source_lines.join("\n"))
-  guard highlighted.length() == source_lines.length() else { return None }
+  let highlighted = @syntax_html.moonbit_source_lines(
+    numbered.map(pair => pair.1).join("\n"),
+  )
+  guard highlighted.length() == numbered.length() else { return None }
   let children = [
-    for index, gutter in gutters => {
+    for index, pair in numbered => {
       @rhtml.span(class="read-moonbit-line", [
-        @rhtml.span(class="read-moonbit-gutter", gutter),
+        @rhtml.span(class="read-moonbit-gutter", pair.0),
         @rhtml.code(class="language-moonbit read-moonbit-code", [
           highlighted[index],
         ]),

--- a/desktop/frontend/transcript/component/mbtx.mbt
+++ b/desktop/frontend/transcript/component/mbtx.mbt
@@ -27,7 +27,9 @@ priv enum MbtxProgram {
 /// A recorded `mbtx` call, decoded for display.
 priv struct MbtxCall {
   program : MbtxProgram
-  args : Array[String]?
+  // The `args` array as written, already validated as strings, for the card
+  // to print verbatim.
+  args : Json?
   /// The call's other scalar arguments, as `key: value` chip text.
   chips : Array[String]
 }
@@ -61,15 +63,8 @@ fn decode_mbtx_call(arguments : String) -> MbtxCall? {
     dramatized=["source", "filename", "args"],
   )
   let args = match fields.get("args") {
-    Some(Array(values)) if values.all(value => value is String(_)) =>
-      Some(
-        values.filter_map(value => {
-          match value {
-            String(text) => Some(text)
-            _ => None
-          }
-        }),
-      )
+    Some(Array(values) as args) if values.all(value => value is String(_)) =>
+      Some(args)
     _ => None
   }
   Some({ program, args, chips, })
@@ -112,10 +107,7 @@ fn mbtx_card(arguments : String) -> (String, @html.Html)? {
   }
   let args = match call.args {
     Some(args) =>
-      @html.pre(
-        class="tool-card-original-json",
-        args.to_json().stringify(indent=2),
-      )
+      @html.pre(class="tool-card-original-json", args.stringify(indent=2))
     None => @html.nothing
   }
   Some(

--- a/desktop/frontend/transcript/component/mbtx_wbtest.mbt
+++ b/desktop/frontend/transcript/component/mbtx_wbtest.mbt
@@ -40,7 +40,7 @@ test "named read workflows preserve all file selectors for display" {
     is Some(call) else {
     fail("expected named workflow")
   }
-  assert_eq(call.args, Some(["x.mbt:120:200", "path with spaces"]))
+  assert_eq(call.args, Some(["x.mbt:120:200", "path with spaces"].to_json()))
   assert_true(call.chips.is_empty())
 }
 


### PR DESCRIPTION
Two leftovers from #1446's transcript rendering, both behavior-neutral.

- **Parse once.** `read_workflow_output` walked a file section parsing every `N |` line to find its end, discarded the results, joined the lines back into a string, and handed it to `moonbit_output_for_path`, which split and parsed the same lines again. The first pass now collects gutters and source, and `moonbit_section` renders them with the closing status line. The inner 40,000-character bound goes with the re-join; the outer 48,000 bound on the whole result still applies.
- **Print args as written.** The mbtx card validated the `args` JSON array, extracted it to `Array[String]`, then converted it back to JSON for display. It keeps the validated `Json` value and prints that.

Validation: `moon test -p bobzhang/openseek/agent_tool/mbtx/html --target js` 2/2; in `desktop/`, `moon check frontend/transcript/component --target js --deny-warn` clean and `moon test -p openseek_desktop/frontend/transcript/component --target js` 24/24; `moon fmt` no-op. The desktop browser test that highlights a read result runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5VtKfp425u2tPHiBcB2Zh
