### PR TITLE
refactor: drop 97 redundant view-to-owned conversions

### DIFF
--- a/agent_session/store/store.mbt
+++ b/agent_session/store/store.mbt
@@ -195,7 +195,7 @@ fn parse_session_file(
   text : String,
 ) -> ParsedSessionFile raise {
   let (first, rest) = match text.split_once("\n") {
-    Some((first, rest)) => (first.to_owned(), rest.to_owned())
+    Some((first, rest)) => (first, rest)
     None => (text, "")
   }
   let header_json = @json.parse(first) catch {
@@ -221,7 +221,7 @@ fn parse_session_file(
     )
   }
   let ends_with_newline = text.has_suffix("\n")
-  let segments = rest.split("\n").map(line => line.to_owned()).collect()
+  let segments = rest.split("\n").collect()
   let decoded : Array[@agent_session.SessionEvent] = []
   for index, line in segments {
     if line.is_blank() {

--- a/agent_subtask/lifecycle_test.mbt
+++ b/agent_subtask/lifecycle_test.mbt
@@ -448,7 +448,7 @@ async test "capture is re-entrant: resumed work stacks on the same branch" {
     }
     assert_true(commit1 != commit2)
     match @agent_subtask.git_require(["rev-parse", "\{commit2}^"], cwd=repo) {
-      Ok(parent) => assert_eq(parent.trim().to_owned(), commit1)
+      Ok(parent) => assert_eq(parent.trim(), commit1)
       Err(reason) => fail(reason)
     }
     // Integration lands BOTH captures' work.

--- a/agent_subtask/provision.mbt
+++ b/agent_subtask/provision.mbt
@@ -87,7 +87,6 @@ async fn provision_locked(
   match git_require(["ls-tree", "-r", "-z", base_oid], cwd=origin) {
     Ok(listing) =>
       for record in listing.split("\u{0}") {
-        let record = record.to_owned()
         guard record.contains(" 160000 ") || record.has_prefix("160000 ") else {
           continue
         }
@@ -161,7 +160,7 @@ async fn provision_locked(
   let worker_root = canonical(worker_root_spelled)
   let admin = match
     git_require(["rev-parse", "--absolute-git-dir"], cwd=worker_root) {
-    Ok(output) => canonical(output.trim().to_owned())
+    Ok(output) => canonical(output.trim())
     Err(reason) => {
       let _ = rollback_provision(geometry, entry)
       return Err(reason)

--- a/agent_tool/internal/auto_check/auto_check.mbt
+++ b/agent_tool/internal/auto_check/auto_check.mbt
@@ -107,7 +107,7 @@ fn tally_diagnostics(text : String, truncated~ : Bool) -> CheckErrors {
     if !raw.contains("\"level\"") {
       continue
     }
-    let json = @json.parse(raw.to_owned()) catch { _ => continue }
+    let json = @json.parse(raw) catch { _ => continue }
     match json {
       {
         "level": String("error"),

--- a/agent_tool/internal/auto_check/parse_gate.mbt
+++ b/agent_tool/internal/auto_check/parse_gate.mbt
@@ -202,7 +202,7 @@ fn decide_parse_gate(
     if !raw.contains("\"level\"") {
       continue
     }
-    let json = @json.parse(raw.to_owned()) catch { _ => continue }
+    let json = @json.parse(raw) catch { _ => continue }
     match json {
       {
         "level": String("error"),

--- a/agent_tool/internal/sandbox/source_write_profile.mbt
+++ b/agent_tool/internal/sandbox/source_write_profile.mbt
@@ -268,7 +268,7 @@ fn should_prune_profile_scan_path(root : String, path : String) -> Bool {
   guard @workspace_path.is_under_workspace_root(root, path) && path != root else {
     return false
   }
-  let relative = path[root.length() + 1:].to_owned()
+  let relative = path[root.length() + 1:]
   relative
   .replace_all(old="\\", new="/")
   .split("/")

--- a/agent_tool/internal/sandbox/worker_profile_test.mbt
+++ b/agent_tool/internal/sandbox/worker_profile_test.mbt
@@ -40,7 +40,7 @@ async test "the worker profile confines writes to the worker tree" {
     let worker_root = @fs.realpath("\{repo}/.worktrees/w1")
     let sibling = @fs.realpath("\{repo}/.worktrees/w2")
     let admin_raw = git_setup(["rev-parse", "--absolute-git-dir"], worker_root)
-    let worker_admin_dir = @fs.realpath(admin_raw.trim().to_owned())
+    let worker_admin_dir = @fs.realpath(admin_raw.trim())
     let common = @fs.realpath("\{origin}/.git")
     let deny_roots = [common, origin, sibling]
     async fn probe(cmd : String) -> @sandbox.SandboxedCommand? {
@@ -110,7 +110,7 @@ async test "the worker profile confines writes to the worker tree" {
     let (commit_exit, _) = merged_output_text(against_store)
     assert_true(commit_exit != 0)
     let log = git_setup(["log", "--oneline"], worker_root)
-    assert_eq(log.trim().to_owned().split("\n").count(), 1)
+    assert_eq(log.trim().split("\n").count(), 1)
   })
 }
 

--- a/agent_tool/job_output/job_output_test.mbt
+++ b/agent_tool/job_output/job_output_test.mbt
@@ -309,7 +309,7 @@ async test "offset pages through retained output from the start" {
     // The next page starts exactly where the first ended.
     let next = run_job_output(bg, { "job_id": id, "offset": 12000 })
     let full = bg.read_output(id).unwrap_or("")
-    let expected = full.view(start_offset=12000, end_offset=12040).to_owned()
+    let expected = full.view(start_offset=12000, end_offset=12040)
     assert_true(next.content.has_prefix(expected))
     assert_true(next.content.contains("window_offset=12000"))
     // Past the end: nothing but the footer. Negative: refused.

--- a/agent_tool/mbtx/filename.mbt
+++ b/agent_tool/mbtx/filename.mbt
@@ -15,7 +15,7 @@ fn resolve_filename(
         "unknown script namespace in \{filename}. Only @builtin/ is supported. Use ./\{filename} for a literal workspace path",
       )
     }
-    let name = name_view.to_owned()
+    let name = name_view
     guard !name.is_empty() &&
       !name.contains("\\") &&
       name

--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -1092,7 +1092,7 @@ fn parse_artifacts_path(output : String) -> String? {
   for line in output.split("\n") {
     let line = line.trim()
     guard line.has_prefix("{\"artifacts_path\"") else { continue }
-    let parsed = @json.parse(line.to_owned()) catch { _ => continue }
+    let parsed = @json.parse(line) catch { _ => continue }
     if parsed is { "artifacts_path": [String(path), ..], .. } {
       found = Some(path)
     }

--- a/cmd/openseek/concurrent.mbt
+++ b/cmd/openseek/concurrent.mbt
@@ -127,7 +127,7 @@ async fn resolve_run_dirs(dir : String, n : Int) -> (Array[String], String?) {
     let abs = @fs.realpath(dir)
     (
       @path.Path(abs).dirname().to_string(),
-      @path.Path(abs).basename().to_owned(),
+      @path.Path(abs).basename(),
       Some(abs),
     )
   } else {
@@ -139,7 +139,7 @@ async fn resolve_run_dirs(dir : String, n : Int) -> (Array[String], String?) {
     if @fs.kind(parent_raw) != Directory {
       fail("parent path for --dir is not a directory: \{parent_raw}")
     }
-    (@fs.realpath(parent_raw), @path.Path(dir).basename().to_owned(), None)
+    (@fs.realpath(parent_raw), @path.Path(dir).basename(), None)
   }
   if base.is_empty() {
     fail("cannot derive a run-directory name from --dir: \{dir}")

--- a/desktop/frontend/action_menu/context_menu.mbt
+++ b/desktop/frontend/action_menu/context_menu.mbt
@@ -145,7 +145,7 @@ fn element_context(element : @dom.Element) -> ContextTarget {
     "http:" | "https:" => WebLink(anchor_href(anchor))
     "mailto:" => {
       let href = anchor.get_attribute("href").unwrap_or(anchor_href(anchor))
-      let raw = href[7:].split("?").next().unwrap_or(href[7:]).to_owned()
+      let raw = href[7:].split("?").next().unwrap_or(href[7:])
       let address = @uri.decode_component(raw)
       EmailLink(url=anchor_href(anchor), address~)
     }

--- a/desktop/frontend/agent_model.mbt
+++ b/desktop/frontend/agent_model.mbt
@@ -23,7 +23,7 @@ fn AgentChoice::wire(self : AgentChoice) -> String {
 
 ///|
 fn AgentChoice::parse(value : String) -> AgentChoice? {
-  match value.trim().to_owned() {
+  match value.trim() {
     "openseek" => Some(OpenSeekAgent)
     "codex" => Some(CodexAgent)
     _ => None

--- a/desktop/frontend/codex/model.mbt
+++ b/desktop/frontend/codex/model.mbt
@@ -2395,7 +2395,7 @@ fn CodexPendingRequest::response(
     "item/tool/requestUserInput" => {
       let answers : Map[String, Json] = Map([])
       for question in self.questions() {
-        let text = self.answers.get(question.id).unwrap_or("").trim().to_owned()
+        let text = self.answers.get(question.id).unwrap_or("").trim()
         if text.is_empty() {
           return None
         }

--- a/desktop/frontend/composer/behavior.mbt
+++ b/desktop/frontend/composer/behavior.mbt
@@ -60,7 +60,7 @@ pub fn Trigger::draft_without_token(self : Trigger) -> String {
 /// Whether a result row survives this trigger's query. A blank query keeps
 /// every row; otherwise any supplied field may contain it, case-insensitively.
 pub fn Trigger::matches(self : Trigger, fields : Array[String]) -> Bool {
-  let query = self.query.trim().to_owned().to_lower()
+  let query = self.query.trim().to_lower()
   if query.is_empty() {
     return true
   }

--- a/desktop/frontend/grep_search/state.mbt
+++ b/desktop/frontend/grep_search/state.mbt
@@ -210,7 +210,7 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
       { ..self, page: { ..page, pattern_repair_instruction: instruction, }, }
     SubmitPatternRepair =>
       if page.pattern_repair_phase is PatternRepairComposer &&
-        !page.pattern_repair_instruction.trim().to_owned().is_empty() {
+        !page.pattern_repair_instruction.trim().is_empty() {
         {
           ..self,
           page: {

--- a/desktop/frontend/interop/query.mbt
+++ b/desktop/frontend/interop/query.mbt
@@ -20,7 +20,7 @@ pub fn page_query_param(name : String) -> String? {
   }
   for pair in query.split("&") {
     guard pair.split_once("=") is Some((key, encoded)) else { continue }
-    if key.to_owned() == name {
+    if key == name {
       let value = @uri.decode_component(encoded)
       return if value.is_empty() { None } else { Some(value) }
     }

--- a/desktop/frontend/mention_context/mention_context.mbt
+++ b/desktop/frontend/mention_context/mention_context.mbt
@@ -271,7 +271,7 @@ fn write_mention(parts : StringBuilder, mention : MentionRef) -> Unit {
 /// An element body, verbatim, ending in exactly one newline; an empty body
 /// contributes no lines (its tags close ranks).
 fn write_body(parts : StringBuilder, body : String) -> Unit {
-  let body = body.trim_end(chars="\n").to_owned()
+  let body = body.trim_end(chars="\n")
   if !body.is_empty() {
     parts <+ "\{body}\n"
   }

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -106,7 +106,7 @@ fn OpenSeekReasoning::protocol(
 
 ///|
 fn OpenSeekReasoning::parse(value : String) -> OpenSeekReasoning? {
-  match value.trim().to_owned() {
+  match value.trim() {
     "no" => Some(ReasoningOff)
     "high" => Some(ReasoningHigh)
     "max" => Some(ReasoningMax)
@@ -476,7 +476,7 @@ fn ApiProvider::wire(self : ApiProvider) -> String {
 /// (or a corrupted store) degrades to the BYOK default instead of wedging
 /// the app.
 fn ApiProvider::parse(value : String) -> ApiProvider {
-  match value.trim().to_owned() {
+  match value.trim() {
     "openseek" | "openseek-staging" | "deepseek" => Deepseek
     "glm" => Glm
     "openrouter" => OpenRouter

--- a/desktop/frontend/skills/view.mbt
+++ b/desktop/frontend/skills/view.mbt
@@ -286,7 +286,7 @@ fn detail_action(
 /// keeps everything, otherwise any listed field must contain it
 /// (case-insensitive).
 fn matches(query : String, fields : Array[String]) -> Bool {
-  let query = query.trim().to_owned().to_lower()
+  let query = query.trim().to_lower()
   query.is_empty() || fields.any(field => field.to_lower().contains(query))
 }
 

--- a/desktop/frontend/transcript/component/job_wait.mbt
+++ b/desktop/frontend/transcript/component/job_wait.mbt
@@ -56,7 +56,7 @@ fn collect_job_description(
     let args = @json.parse(arguments) catch { _ => return }
     guard args is { "job_id": String(id), .. } &&
       brief.strip_prefix("job \{id} (") is Some(rest) &&
-      rest.to_owned().split_once("): ") is Some((_, description)) &&
+      rest.split_once("): ") is Some((_, description)) &&
       !description.is_blank() else {
       return
     }

--- a/desktop/frontend/transcript/component/rendering.mbt
+++ b/desktop/frontend/transcript/component/rendering.mbt
@@ -70,7 +70,7 @@ priv struct EmptyProjectControl {
 
 ///|
 fn ProjectChoice::matches(self : ProjectChoice, query : String) -> Bool {
-  let query = query.trim().to_owned().to_lower()
+  let query = query.trim().to_lower()
   query.is_empty() ||
   self.label.to_lower().contains(query) ||
   self.root.path.to_lower().contains(query)

--- a/desktop/frontend/transcript/component/tool_card.mbt
+++ b/desktop/frontend/transcript/component/tool_card.mbt
@@ -76,7 +76,7 @@ fn chip_text(key : String, value : Json) -> String? {
     Object(_) | Array(_) => return None
   }
   let text = if text.length() > MAX_CHIP_CHARS {
-    text.clamped_view(end=MAX_CHIP_CHARS).to_owned() + "…"
+    text.clamped_view(end=MAX_CHIP_CHARS) + "…"
   } else {
     text
   }

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -530,7 +530,7 @@ fn truncate_output(content : String, line_prefix_width? : Int = 0) -> String {
       content, tail, line_prefix_width,
     )
     [
-      head.to_owned(),
+      head,
       "⋯ \{content.length() - head.length() - tail.length()} UTF-16 code units skipped ⋯",
       retained_tail,
     ].join("\n")

--- a/desktop/frontend/transcript/sessions.mbt
+++ b/desktop/frontend/transcript/sessions.mbt
@@ -195,7 +195,7 @@ pub fn subrun_child_sessions(
   for raw in brief.split(" ") {
     // A brief carrying several children joins them with punctuation, so a
     // token can arrive as `sr-3,` or `sr-3)`.
-    let token = raw.trim(chars=",()").to_owned()
+    let token = raw.trim(chars=",()")
     guard token.has_prefix("sr-") else { continue }
     let digits = token.view(start_offset=3)
     guard !digits.is_empty() &&
@@ -569,7 +569,7 @@ fn SessionTerminalProjection::append_to(
         message => "aborted: \{message}"
       }
     @desktop_protocol.Interrupted(message) =>
-      match message.trim().to_owned() {
+      match message.trim() {
         "" => "cancelled"
         message => "cancelled: \{message}"
       }
@@ -588,7 +588,7 @@ fn SessionTerminalProjection::append_to(
 /// marked when more follow.
 fn goal_brief(label : String, text : String) -> String {
   if text.split_once("\n") is Some((first, _)) {
-    "\{label}: \{first.to_owned()} …"
+    "\{label}: \{first} …"
   } else {
     "\{label}: \{text}"
   }

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1210,7 +1210,7 @@ fn apply_engine_event(
     // the sole durable source. The complete reasoning payload replaces any
     // accumulated fragments and seals their transient presentation.
     ReasoningMessage(content) => {
-      let normalized = content.trim().to_owned()
+      let normalized = content.trim()
       if normalized.is_empty() {
         // Remote delivery strips the complete payload because the durable
         // session event carries it. A remote client may have joined midway

--- a/desktop/internal/auth/pkce.mbt
+++ b/desktop/internal/auth/pkce.mbt
@@ -36,7 +36,7 @@ fn start_url(
   name~ : String,
 ) -> String {
   let origin = match server_url.strip_suffix("/") {
-    Some(origin) => origin.to_owned()
+    Some(origin) => origin
     None => server_url
   }
   "\{origin}/v1/auth/desktop/start" +
@@ -65,7 +65,7 @@ priv enum Callback {
 /// matching `state`, and either `code` or `error`.
 fn parse_callback(target : String, oauth_state~ : String) -> Callback {
   let (path, query) = match target.split_once("?") {
-    Some((path, query)) => (path.to_owned(), query)
+    Some((path, query)) => (path, query)
     None => (target, "".view())
   }
   guard path == "/cb" else { return Stray }
@@ -74,8 +74,8 @@ fn parse_callback(target : String, oauth_state~ : String) -> Callback {
   let mut state : String? = None
   for pair in query.split("&") {
     let (key, value) = match pair.split_once("=") {
-      Some((key, value)) => (key.to_owned(), @uri.decode(value))
-      None => (pair.to_owned(), "")
+      Some((key, value)) => (key, @uri.decode(value))
+      None => (pair, "")
     }
     match key {
       "code" => code = Some(value)

--- a/desktop/internal/auth/urls.mbt
+++ b/desktop/internal/auth/urls.mbt
@@ -32,7 +32,7 @@ pub fn device_url(
   app_version~ : String,
 ) -> String {
   let origin = match server_url.strip_suffix("/") {
-    Some(origin) => origin.to_owned()
+    Some(origin) => origin
     None => server_url
   }
   if app_version == "development" {

--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -2131,7 +2131,7 @@ async fn ServeEngine::retire(
       let cause = engine.pending_failure.unwrap_or(
         "engine exited during compaction",
       )
-      let diagnostics = stderr_task.wait().trim().to_owned()
+      let diagnostics = stderr_task.wait().trim()
       let reason = if diagnostics.is_empty() {
         cause
       } else {

--- a/desktop/internal/engine/settings.mbt
+++ b/desktop/internal/engine/settings.mbt
@@ -264,7 +264,7 @@ fn apply_text_patch(
   value : String?,
 ) -> Unit {
   guard value is Some(value) else { return }
-  let value = value.trim().to_owned()
+  let value = value.trim()
   if value.is_empty() {
     fields.remove(key)
   } else {

--- a/desktop/internal/host/semantic_search.mbt
+++ b/desktop/internal/host/semantic_search.mbt
@@ -690,7 +690,7 @@ async fn run_semantic_search(
           let length = chunk
             .length()
             .min(MaxSemanticSearchStderrBytes - retained_bytes)
-          retained.write_bytes(chunk[:length].to_owned())
+          retained.write_bytes(chunk[:length])
           retained_bytes += length
         }
       }

--- a/desktop/internal/host/text_search.mbt
+++ b/desktop/internal/host/text_search.mbt
@@ -322,7 +322,7 @@ fn expand_text_search_view_globs(value : String) -> Array[String] {
       }
       continue
     }
-    let without_forward_slash = entry.trim_end(chars="/").to_owned()
+    let without_forward_slash = entry.trim_end(chars="/")
     let pattern = without_forward_slash.trim_end(chars="\\").to_owned()
     if pattern.is_empty() {
       continue
@@ -1064,7 +1064,7 @@ async fn run_text_search(
           let length = chunk
             .length()
             .min(MaxTextSearchStderrBytes - retained_bytes)
-          retained.write_bytes(chunk[:length].to_owned())
+          retained.write_bytes(chunk[:length])
           retained_bytes += length
         }
       }

--- a/desktop/internal/moonbit/toolchain_resolve.mbt
+++ b/desktop/internal/moonbit/toolchain_resolve.mbt
@@ -104,10 +104,7 @@ async fn external_toolchain(
       // selected or re-exported.
       guard bin_dir.to_absolute() is Some(bin_dir) else {
         @xlog.debug() <?
-          {
-            "event": "desktop_moonbit_path_entry_relative",
-            "entry": entry.to_owned(),
-          }
+          { "event": "desktop_moonbit_path_entry_relative", "entry": entry }
         continue
       }
       if toolchain_at(bin_dir) is Some(toolchain) {

--- a/desktop/internal/pathx/pathx_test.mbt
+++ b/desktop/internal/pathx/pathx_test.mbt
@@ -204,8 +204,8 @@ test "other host path operations keep POSIX spellings" {
   let root = absolute_fixture("/a")
   assert_true(root.join(Relative("b/../c")) is Absolute("/a/c"))
   assert_eq(@pathx.Path("a/b.txt").dirname().0, "a")
-  assert_eq(@pathx.Path("a/b.txt").basename().to_owned(), "b.txt")
-  assert_eq(@pathx.Path("a/b.txt").extname().to_owned(), ".txt")
+  assert_eq(@pathx.Path("a/b.txt").basename(), "b.txt")
+  assert_eq(@pathx.Path("a/b.txt").extname(), ".txt")
 }
 
 ///|
@@ -215,8 +215,8 @@ test "other host path operations keep Windows spellings" {
   let root = absolute_fixture("C:\\a")
   assert_true(root.join(Relative("b/../c")) is Absolute("C:\\a\\c"))
   assert_eq(@pathx.Path("a\\b.txt").dirname().0, "a")
-  assert_eq(@pathx.Path("a\\b.txt").basename().to_owned(), "b.txt")
-  assert_eq(@pathx.Path("a\\b.txt").extname().to_owned(), ".txt")
+  assert_eq(@pathx.Path("a\\b.txt").basename(), "b.txt")
+  assert_eq(@pathx.Path("a\\b.txt").extname(), ".txt")
 }
 
 ///|

--- a/desktop/internal/session_record/record.mbt
+++ b/desktop/internal/session_record/record.mbt
@@ -348,7 +348,7 @@ fn Tail::consume(
         "the session record holds a line that is not UTF-8 at byte \{line.length() - rest.length()}: \{@debug.Repr(if rest.length() > 4 { rest[:4] } else { rest })}",
       )
   }
-  let text = text.trim(chars="\r\n \t").to_owned()
+  let text = text.trim(chars="\r\n \t")
   if text.is_empty() {
     return None
   }

--- a/desktop/internal/shellenv/shellenv.mbt
+++ b/desktop/internal/shellenv/shellenv.mbt
@@ -50,7 +50,7 @@ pub async fn apply_login_shell_env(executable : String) -> Unit {
   // csh/tcsh reject the separate `-l` flag; every other shell in practice
   // (bash, zsh, fish, dash) takes interactive+login+command this way.
   let shell_name = match shell.rev_after("/") {
-    Some(name) => name.to_owned()
+    Some(name) => name
     None => shell
   }
   let args : Array[String] = if shell_name is ("csh" | "tcsh") {
@@ -120,8 +120,8 @@ pub fn path_prepend_command(
   }
   let shell = shell_command.to_lower()
   let shell_name = match shell.rev_after("/") {
-    Some(name) => name.to_owned()
-    None => shell.rev_after("\\").map(name => name.to_owned()).unwrap_or(shell)
+    Some(name) => name
+    None => shell.rev_after("\\").unwrap_or(shell)
   }
   if shell_name is ("pwsh" | "pwsh.exe" | "powershell" | "powershell.exe") {
     let separator = if windows { ";" } else { ":" }

--- a/desktop/internal/skillmarket/archive.mbt
+++ b/desktop/internal/skillmarket/archive.mbt
@@ -82,7 +82,6 @@ fn safe_archive_path(path : String) -> Bool {
     return false
   }
   for segment in path.split("/") {
-    let segment = segment.to_owned()
     if segment.is_empty() || segment == "." || segment == ".." {
       return false
     }

--- a/desktop/internal/skillmarket/library.mbt
+++ b/desktop/internal/skillmarket/library.mbt
@@ -101,7 +101,7 @@ fn content_digest(content : Bytes) -> String {
 fn parse_frontmatter(text : String, fallback_name : String) -> (String, String) {
   let mut name = fallback_name
   let mut description = ""
-  let lines = text.split("\n").map(line => line.to_owned()).collect()
+  let lines = text.split("\n").collect()
   guard lines is [first, .. rest] && first.trim() == "---" else {
     return (name, description)
   }
@@ -110,7 +110,7 @@ fn parse_frontmatter(text : String, fallback_name : String) -> (String, String) 
       break
     }
     if line.split_once(":") is Some((key_text, value_text)) {
-      let key = key_text.to_owned().trim().to_owned()
+      let key = key_text.trim()
       let value = value_text.to_owned().trim().to_owned()
       match key {
         "name" => if !value.is_empty() { name = value }

--- a/desktop/internal/skillmarket/skillmarket_test.mbt
+++ b/desktop/internal/skillmarket/skillmarket_test.mbt
@@ -213,7 +213,6 @@ async fn fake_registry(
           // The real registry's download host hands the archive to its
           // object store through a redirect; mirror that, including one
           // entry that loops forever.
-          let entry = entry.to_owned()
           let location = if entry == LoopEntry {
             path
           } else {

--- a/desktop/internal/subrun/probe.mbt
+++ b/desktop/internal/subrun/probe.mbt
@@ -131,9 +131,7 @@ async fn SubrunProbeState::poll(self : SubrunProbeState) -> Bool {
 /// reader would see moved. The header line and any item this build does not
 /// know about are simply not progress.
 fn SubrunProbeState::consume(self : SubrunProbeState, line : BytesView) -> Bool {
-  let text = @utf8.decode_lossy(line.to_owned())
-    .trim(chars="\r\n \t")
-    .to_owned()
+  let text = @utf8.decode_lossy(line).trim(chars="\r\n \t").to_owned()
   if text.is_empty() {
     return false
   }

--- a/desktop/internal/workflow/tail.mbt
+++ b/desktop/internal/workflow/tail.mbt
@@ -105,7 +105,7 @@ async fn FileTail::poll(self : FileTail) -> Array[String] {
     if pending[index] != b'\n' {
       continue
     }
-    let text = @utf8.decode_lossy(pending[line_start:index].to_owned())
+    let text = @utf8.decode_lossy(pending[line_start:index])
       .trim(chars="\r\n \t")
       .to_owned()
     if !text.is_empty() {

--- a/desktop/internal/workspaces/registry.mbt
+++ b/desktop/internal/workspaces/registry.mbt
@@ -348,7 +348,7 @@ pub async fn exclude_from_git(dir : @pathx.Absolute, entry : String) -> Unit {
     _ => None
   }).unwrap_or("")
   for line in existing.split("\n") {
-    let line = line.trim().to_owned()
+    let line = line.trim()
     if line == entry || line == "\{entry}/" {
       return
     }

--- a/desktop/internal/worktree/worktree.mbt
+++ b/desktop/internal/worktree/worktree.mbt
@@ -571,7 +571,7 @@ const ArchiveDirtyPathPreviewLimit = 8
 /// NUL field as its source; only the current path is useful in the archive
 /// warning.
 fn archive_dirty_path_preview(status : String) -> (Array[String], Int) {
-  let fields = status.split("\u{0}").map(field => field.to_owned()).collect()
+  let fields = status.split("\u{0}").collect()
   let paths : Array[String] = []
   let mut count = 0
   let mut index = 0
@@ -581,8 +581,8 @@ fn archive_dirty_path_preview(status : String) -> (Array[String], Int) {
       index += 1
       continue
     }
-    let index_status = record.view(end_offset=1).to_owned()
-    let worktree_status = record.view(start_offset=1, end_offset=2).to_owned()
+    let index_status = record.view(end_offset=1)
+    let worktree_status = record.view(start_offset=1, end_offset=2)
     let path = record.view(start_offset=3).to_owned()
     count += 1
     if paths.length() < ArchiveDirtyPathPreviewLimit {
@@ -1020,7 +1020,7 @@ async fn worktree_checked_out_on(
   let suffix = "/\{WorktreesDirName}/\{name}"
   let mut at_target = false
   for line in output.split("\n") {
-    let line = line.trim().to_owned()
+    let line = line.trim()
     if line.has_prefix("worktree ") {
       at_target = line.has_suffix(suffix)
     } else if at_target && line == "branch refs/heads/\{branch}" {
@@ -1040,7 +1040,7 @@ async fn worktree_lock_reason(dir : @pathx.Absolute, name : String) -> String? {
   let suffix = "/\{WorktreesDirName}/\{name}"
   let mut at_target = false
   for line in output.split("\n") {
-    let line = line.trim().to_owned()
+    let line = line.trim()
     if line.has_prefix("worktree ") {
       at_target = line.has_suffix(suffix)
     } else if at_target && line == "locked" {

--- a/editor/internal/shell/widgets/file_tree/tree_state.mbt
+++ b/editor/internal/shell/widgets/file_tree/tree_state.mbt
@@ -194,12 +194,12 @@ fn TreeNode::ancestor_uris(
   guard target_raw.strip_prefix("\{root_raw}/") is Some(relative_view) else {
     return None
   }
-  let relative = relative_view.to_owned()
+  let relative = relative_view
   let ancestors : Array[@base_common.Uri] = []
   let mut prefix = root_raw
   let segments = []
   for segment_view in relative.split("/") {
-    let segment = segment_view.to_owned()
+    let segment = segment_view
     if segment != "" {
       segments.push(segment)
     }

--- a/editor/internal/shell/workbench/app.mbt
+++ b/editor/internal/shell/workbench/app.mbt
@@ -1392,7 +1392,7 @@ fn source_message(model : WorkbenchModel) -> String {
 ///|
 fn display_name_from_uri(uri : String) -> String {
   let path = match uri.find("://") {
-    Some(index) => uri[index + 3:].to_owned()
+    Some(index) => uri[index + 3:]
     None => uri
   }
   let segments = path.split("/")

--- a/editor/internal/viewer/browser/controller/mouse_target.mbt
+++ b/editor/internal/viewer/browser/controller/mouse_target.mbt
@@ -1511,7 +1511,7 @@ fn do_hit_test(ctx : HitTestContext, request : HitTestRequest) -> HitTestResult 
 /// word-boundary check over space-separated class names.
 fn class_name_has_word(class_name : String, word : String) -> Bool {
   for candidate in class_name.split(" ") {
-    if candidate.to_owned() == word {
+    if candidate == word {
       return true
     }
   }

--- a/editor/internal/viewer/code_editor_widget/moonbit_outline_folding.mbt
+++ b/editor/internal/viewer/code_editor_widget/moonbit_outline_folding.mbt
@@ -132,7 +132,7 @@ fn is_moonbit_leading_continuation_line(line : String) -> Bool {
             is_moonbit_outline_identifier_continue(line[end].to_int()) {
         end += 1
       }
-      let word = line[index:end].to_owned()
+      let word = line[index:end]
       return word == "else" ||
         word == "catch" ||
         word == "noraise" ||
@@ -173,7 +173,7 @@ fn moonbit_line_ends_with_continuation_word(
         is_moonbit_outline_identifier_continue(line[end].to_int()) {
     end += 1
   }
-  let word = line[last_code_index:end].to_owned()
+  let word = line[last_code_index:end]
   word == "is" ||
   word == "as" ||
   word == "with" ||
@@ -375,7 +375,7 @@ fn moonbit_source_folds(snapshot : @model.TextSnapshot) -> MoonbitSourceFolds {
               is_moonbit_outline_identifier_continue(line[index].to_int()) {
           index += 1
         }
-        let word = line[start:index].to_owned()
+        let word = line[start:index]
         if brace_depth == 0 && declaration_start_line == 0 {
           if word == "extern" {
             // An `extern "abi"` prefix may be split from its `fn`; the

--- a/editor/internal/viewer/markdown/sections.mbt
+++ b/editor/internal/viewer/markdown/sections.mbt
@@ -205,15 +205,15 @@ fn markdown_heading_text_from_source(
   let range = anchor.source_range
   let start = range.start.max(0).min(source.length())
   let end = range.end_exclusive.max(start).min(source.length())
-  let raw = source[start:end].to_owned()
+  let raw = source[start:end]
   let first_line = match raw.split_once("\n") {
-    Some((first, _)) => first.to_owned()
+    Some((first, _)) => first
     None => raw
   }
-  let trimmed = for trimmed = first_line.trim(chars=" \t\r").to_owned(); trimmed.has_prefix(
+  let trimmed = for trimmed = first_line.trim(chars=" \t\r"); trimmed.has_prefix(
                      "#",
                    ); {
-    continue trimmed[1:].to_owned()
+    continue trimmed[1:]
   } nobreak {
     trimmed
   }
@@ -226,7 +226,7 @@ fn markdown_heading_text_from_source(
   let trimmed = if hashes > 0 {
     let before = trimmed.length() - hashes
     if before == 0 || trimmed[before - 1] == ' ' || trimmed[before - 1] == '\t' {
-      trimmed[0:before].to_owned()
+      trimmed[0:before]
     } else {
       trimmed
     }

--- a/editor/language/selectors.mbt
+++ b/editor/language/selectors.mbt
@@ -134,11 +134,7 @@ fn path_pattern_matches(pattern : String, path : String) -> Bool {
   if pattern == "*" {
     return true
   }
-  let path = if path.strip_prefix("/") is Some(rest) {
-    rest.to_owned()
-  } else {
-    path
-  }
+  let path = if path.strip_prefix("/") is Some(rest) { rest } else { path }
   match pattern.split_once("*") {
     Some((prefix, suffix)) => path.has_prefix(prefix) && path.has_suffix(suffix)
     None => path == pattern

--- a/editor/server/host/moon_check.mbt
+++ b/editor/server/host/moon_check.mbt
@@ -271,7 +271,7 @@ fn parse_moon_check_diagnostics_impl(
   let prefix = "\{normalize_host_path(root)}/"
   let grouped : Map[String, Array[@language.Diagnostic]] = Map([])
   for line in raw.split("\n") {
-    let trimmed = line.trim(char_set="\r\n ").to_owned()
+    let trimmed = line.trim(char_set="\r\n ")
     if trimmed == "" {
       continue
     }

--- a/editor/shell/workspace/exports.mbt
+++ b/editor/shell/workspace/exports.mbt
@@ -68,7 +68,7 @@ pub fn SourcePath::normalize_root_relative_path(
 
   let segments = []
   for segment_view in slash_path.split("/") {
-    let segment = segment_view.to_owned()
+    let segment = segment_view
     if segment == ".." {
       return SourcePathError(InvalidPath)
     }

--- a/editor/syntax/lang_javascript/README.mbt.md
+++ b/editor/syntax/lang_javascript/README.mbt.md
@@ -23,7 +23,7 @@ fn annotate(
   for line in lines; state = tokenizer.initial_state() {
     let (tokens, next_state) = tokenizer.tokenize_line(line, state)
     for token in tokens {
-      rendered.push("\{line[token.start:token.end].to_owned()}|\{token.tag}")
+      rendered.push("\{line[token.start:token.end]}|\{token.tag}")
     }
     continue next_state
   }

--- a/editor/syntax/lang_javascript/lexer_test.mbt
+++ b/editor/syntax/lang_javascript/lexer_test.mbt
@@ -10,7 +10,7 @@ fn render_tokens(source : String) -> String {
     state = tokenizer.initial_state(), line_start = 0 {
     let (tokens, next_state) = tokenizer.tokenize_line(line, state)
     for token in tokens {
-      let text = line[token.start:token.end].to_owned()
+      let text = line[token.start:token.end]
       rendered.push(
         "\{line_start + token.start}-\{line_start + token.end} \{token.tag} \{text}",
       )

--- a/editor/syntax/lang_json/README.mbt.md
+++ b/editor/syntax/lang_json/README.mbt.md
@@ -19,7 +19,7 @@ fn annotate(
   for line in lines; state = tokenizer.initial_state() {
     let (tokens, next_state) = tokenizer.tokenize_line(line, state)
     for token in tokens {
-      rendered.push("\{line[token.start:token.end].to_owned()}|\{token.tag}")
+      rendered.push("\{line[token.start:token.end]}|\{token.tag}")
     }
     continue next_state
   }

--- a/editor/syntax/lang_json/lexer_test.mbt
+++ b/editor/syntax/lang_json/lexer_test.mbt
@@ -10,7 +10,7 @@ fn render_tokens(source : String) -> String {
     state = tokenizer.initial_state(), line_start = 0 {
     let (tokens, next_state) = tokenizer.tokenize_line(line, state)
     for token in tokens {
-      let text = line[token.start:token.end].to_owned()
+      let text = line[token.start:token.end]
       rendered.push(
         "\{line_start + token.start}-\{line_start + token.end} \{token.tag} \{text}",
       )

--- a/editor/syntax/lang_moon_config/lexer_test.mbt
+++ b/editor/syntax/lang_moon_config/lexer_test.mbt
@@ -9,7 +9,7 @@ fn render_tokens(source : String) -> String {
     state = tokenizer.initial_state(), line_start = 0 {
     let (tokens, next_state) = tokenizer.tokenize_line(line, state)
     for token in tokens {
-      let text = line[token.start:token.end].to_owned()
+      let text = line[token.start:token.end]
       rendered.push(
         "\{line_start + token.start}-\{line_start + token.end} \{token.tag} \{text}",
       )

--- a/editor/syntax/lang_moonbit/README.mbt.md
+++ b/editor/syntax/lang_moonbit/README.mbt.md
@@ -30,7 +30,7 @@ fn annotate(
   for line in lines; state = tokenizer.initial_state() {
     let (tokens, next_state) = tokenizer.tokenize_line(line, state)
     for token in tokens {
-      rendered.push("\{line[token.start:token.end].to_owned()}|\{token.tag}")
+      rendered.push("\{line[token.start:token.end]}|\{token.tag}")
     }
     continue next_state
   }

--- a/editor/syntax/lang_moonbit/lexer_test.mbt
+++ b/editor/syntax/lang_moonbit/lexer_test.mbt
@@ -10,7 +10,7 @@ fn render_tokens(source : String) -> String {
     state = tokenizer.initial_state(), line_start = 0 {
     let (tokens, next_state) = tokenizer.tokenize_line(line, state)
     for token in tokens {
-      let text = line[token.start:token.end].to_owned()
+      let text = line[token.start:token.end]
       rendered.push(
         "\{line_start + token.start}-\{line_start + token.end} \{token.tag} \{text}",
       )

--- a/editor/tests/browser/moonbit/component/diff_markdown_comments_scenario.mbt
+++ b/editor/tests/browser/moonbit/component/diff_markdown_comments_scenario.mbt
@@ -129,7 +129,7 @@ impl @language.MarkdownCommentProvider for DiffMarkdownCommentProvider with fn p
   let blocks : Array[@language.MarkdownCommentBlock] = []
   let mut line_number = 1
   while line_number <= snapshot.line_count() {
-    let line = snapshot.get_line_content(line_number).trim().to_owned()
+    let line = snapshot.get_line_content(line_number).trim()
     if !line.has_prefix("///") {
       line_number += 1
       continue

--- a/editor/viewer/common/render_line_ir_test.mbt
+++ b/editor/viewer/common/render_line_ir_test.mbt
@@ -186,7 +186,7 @@ fn count_occurrences(haystack : String, needle : String) -> Int {
     return 0
   }
   for index in 0..<=(haystack.length() - needle_len) {
-    if haystack[index:index + needle_len].to_owned() == needle {
+    if haystack[index:index + needle_len] == needle {
       count += 1
     }
   }

--- a/editor/viewer/diff_provider/moondiff/semantic_review_plan.mbt
+++ b/editor/viewer/diff_provider/moondiff/semantic_review_plan.mbt
@@ -132,7 +132,7 @@ fn normalized_source_lines(source : String) -> Array[String] {
   while index < chars.length() {
     match chars[index] {
       '\r' => {
-        lines.push(String::from_array(chars[line_start:index].to_owned()))
+        lines.push(String::from_array(chars[line_start:index]))
         index += 1
         if index < chars.length() && chars[index] == '\n' {
           index += 1
@@ -140,14 +140,14 @@ fn normalized_source_lines(source : String) -> Array[String] {
         line_start = index
       }
       '\n' => {
-        lines.push(String::from_array(chars[line_start:index].to_owned()))
+        lines.push(String::from_array(chars[line_start:index]))
         index += 1
         line_start = index
       }
       _ => index += 1
     }
   }
-  lines.push(String::from_array(chars[line_start:chars.length()].to_owned()))
+  lines.push(String::from_array(chars[line_start:chars.length()]))
   lines
 }
 

--- a/eval/prompt_task/harness/analyzer.mbt
+++ b/eval/prompt_task/harness/analyzer.mbt
@@ -538,7 +538,7 @@ fn probe_output_result(
     }
   }
   if spec.stdout_json {
-    let trimmed = stdout.trim().to_owned()
+    let trimmed = stdout.trim()
     let _ = @json.parse(trimmed) catch {
       error =>
         return ProbeResult(

--- a/tests/integration/workflows/ci.mbt
+++ b/tests/integration/workflows/ci.mbt
@@ -203,7 +203,7 @@ async fn verify_ci(root : String, temp : String, exe : String) -> Unit {
       let row = @json.parse(line)
       assert_true(
         row is { "url": Null | String(_), "workflow": Null | String(_), .. },
-        msg=line.to_owned(),
+        msg=line,
       )
       if row is { "result": String("FAIL"), .. } {
         assert_true(
@@ -220,7 +220,7 @@ async fn verify_ci(root : String, temp : String, exe : String) -> Unit {
             ],
             ..
           },
-          msg=line.to_owned(),
+          msg=line,
         )
       }
     }

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -1326,7 +1326,7 @@ fn call_brief_display(brief : String?, is_error : Bool) -> String? {
 /// Whether a tool call's (pretty-printed) arguments carry nothing worth folding
 /// away — empty text or an empty object.
 fn is_blank_args(args : String) -> Bool {
-  let trimmed = args.trim().to_owned()
+  let trimmed = args.trim()
   trimmed.is_empty() || trimmed == "{}"
 }
 


### PR DESCRIPTION
## What

Removes 97 redundant view-to-owned conversions - `.to_owned()` on a `StringView`, plus a couple of `BytesView`/`ArrayView` copies - across 64 files. No file gains one.

## Why

`StringView`/`BytesView`/`ArrayView` share their API with the owned types, so most `.to_owned()` calls at a use site only allocate a copy at hand: the value is read locally, or handed to something that already takes a view. Examples from the diff:

- `@json.parse(line.to_owned())` -> `@json.parse(line)` (`parse` takes a `StringView`)
- `(first.to_owned(), rest.to_owned())` -> `(first, rest)`
- `retained.write_bytes(chunk[:length].to_owned())` -> `retained.write_bytes(chunk[:length])`

## How it was verified

Not a text-level replace. Each candidate site's call was deleted, the compiler was asked what broke, and every site where an owned value is genuinely required (a struct field, a `String?` return, an `Array[String]` push, a `String`-taking callee, ...) was restored. Roughly 40% of the candidates needed their `.to_owned()` back.

- `moon check --target native|js|wasm|all --deny-warn` - clean
- `moon fmt --check` - clean (the formatter collapsed a few now-shorter calls)
- `moon info` - no interface change
- `moon test --target native` - 3071/3074; the three failures were two environment-sensitive snapshots in `cmd/openseek` (`environment_prompt_section` appends `OPENSEEK_REFERENCES` when set, and this sandbox sets it; they pass with the variable emptied) and one inline snapshot in `editor/viewer/common/languages/token_pipeline_test.mbt`, which is why that file keeps its two conversions.

## Notes for review

- Only `.to_owned()` calls were touched. A per-file check confirms none was added.
- A few leftovers of the mechanical sweep were tidied in the same commit: `map(field => field)` lost its identity `map`, and three `let x = x` shadows left behind by removing the copy were deleted.
- Behaviour is unchanged: a view borrows the same backing value, so the only difference is the copy that is no longer allocated (where a view is stored, the parent stays alive).

Generated with SeekMoon