### PR TITLE
refactor(agent_subrun): hide and deprecate derived trait-method promotions

### DIFF
--- a/agent_subrun/pkg.generated.mbti
+++ b/agent_subrun/pkg.generated.mbti
@@ -31,7 +31,6 @@ pub fn[T] SubrunResult::prompt_tokens(Self[T]) -> Int
 pub fn[T] SubrunResult::steps_used(Self[T]) -> Int
 pub fn[T] SubrunResult::subrun_id(Self[T]) -> String
 pub fn[T] SubrunResult::terminal(Self[T]) -> SubrunTerminal
-pub fn[T : @debug.Debug] SubrunResult::to_repr(Self[T]) -> @debug.Repr
 pub fn[T] SubrunResult::value(Self[T]) -> T?
 
 pub enum SubrunTerminal {
@@ -42,9 +41,6 @@ pub enum SubrunTerminal {
   TimedOut
   Failed(String)
 } derive(Eq, @debug.Debug)
-pub fn SubrunTerminal::equal(Self, Self) -> Bool
-pub fn SubrunTerminal::not_equal(Self, Self) -> Bool
-pub fn SubrunTerminal::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/agent_subrun/runner.mbt
+++ b/agent_subrun/runner.mbt
@@ -266,10 +266,16 @@ fn status_of(terminal : SubrunTerminal) -> String {
 }
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend SubrunResult with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend SubrunTerminal with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend SubrunTerminal with Eq::{equal, not_equal}


### PR DESCRIPTION
## What

Following `shrink_package.md` and `moon ide analyze`, this shrinks
`agent_subrun`'s public interface by hiding and deprecating the three
derived trait-method promotions:

- `pub extend SubrunResult with Debug::{to_repr}`
- `pub extend SubrunTerminal with Debug::{to_repr}`
- `pub extend SubrunTerminal with Eq::{equal, not_equal}`

Each now carries `#doc(hidden)` + `#deprecated`, matching the existing
convention in `agent_review/types.mbt` and `agent_session/types.mbt`. The
trait impls stay public — `Debug` and `Eq` remain usable through the traits
— so only the dot-callable promoted methods drop out of the generated
`.mbti`. `agent_subrun/pkg.generated.mbti` is regenerated via `moon info`
(4 lines removed).

## Verification

- `moon check -d --target native` (whole module, 649 tasks): clean
- `moon test agent_subrun --target native`: 23 passed / 0 failed
- `moon fmt --check agent_subrun`: clean
- `moon ide analyze agent_subrun`: the three promotions no longer appear

Not verified: the analyzer only sees this workspace, so an external
consumer of the published module could still dot-call a promoted method —
such a call would now warn (E0020) rather than fail to compile. Nothing in
this repo did.

Generated with SeekMoon