### PR TITLE
Retain background job logs and durable lifecycle controls

### DIFF
--- a/agent/job_lifecycle_wbtest.mbt
+++ b/agent/job_lifecycle_wbtest.mbt
@@ -1,0 +1,113 @@
+///|
+#cfg(not(platform="windows"))
+async test "job lifecycle publishes ordered durable start and failure with retained UTF8" {
+  let root = @fs.tmpdir(prefix="openseek-job-events-")
+  defer @fs.rmdir(root, recursive=true)
+  let events : Array[(@protocol.JobEventKind, @protocol.JobRecord)] = []
+  @async.with_timeout(5000, () => {
+    @async.with_task_group(group => {
+      let jobs = @bgjobs.BgJobRuntime(
+        AgentTaskScope(group),
+        spill_dir=root,
+        persistent_logs=true,
+        on_job_event=(kind, job) => events.push((kind, job)),
+      )
+      let id = jobs.start(
+        program="/bin/sh",
+        args=["-c", "printf '你好'; exit 7"],
+        command="failure",
+      )
+      ignore(jobs.wait_any([id]))
+      assert_eq(events.length(), 2)
+      assert_true(events[0].0 is Started)
+      assert_true(events[1].0 is Failed)
+      assert_eq(events[1].1.revision, 2)
+      assert_true(events[1].1.state is Exited(7))
+      assert_eq(events[1].1.output_bytes, 6L)
+      assert_true(events[1].1.finished_at_ms is Some(_))
+      let saved : @protocol.JobRecord = @json.from_json(
+        @json.parse(@fs.read_file("\{root}/\{id}.json").text()),
+      )
+      assert_eq(saved, events[1].1)
+      assert_eq(@fs.read_file("\{root}/\{id}.out").text(), "你好")
+      jobs.finalize()
+      assert_eq(events.length(), 2)
+    })
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "stop emits stopping before one settled terminal event" {
+  let events : Array[(@protocol.JobEventKind, @protocol.JobRecord)] = []
+  @async.with_timeout(5000, () => {
+    @async.with_task_group(group => {
+      let jobs = @bgjobs.BgJobRuntime(AgentTaskScope(group), on_job_event=(
+        kind,
+        job,
+      ) => events.push((kind, job)))
+      let id = jobs.start(program="/bin/sleep", args=["30"], command="sleep")
+      assert_true(jobs.stop(id))
+      assert_eq(events.length(), 3)
+      assert_true(events[0].0 is Started)
+      assert_true(events[1].0 is Updated)
+      assert_true(events[2].0 is Finished)
+      assert_true(events[2].1.state is Stopped("user"))
+      assert_true(jobs.stop(id))
+      assert_eq(events.length(), 3)
+    })
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "session cleanup persists a terminal record after cancellation" {
+  let root = @fs.tmpdir(prefix="openseek-job-finalize-")
+  defer @fs.rmdir(root, recursive=true)
+  let path = @async.with_timeout(5000, () => {
+    @async.with_task_group(group => {
+      let tools = build_tools(
+        AgentRuntime(),
+        AgentTaskScope(group),
+        job_log_dir=root,
+      )
+      guard tools.background_job_runtime() is Some(jobs) else {
+        fail("missing jobs")
+      }
+      let id = jobs.start(program="/bin/sleep", args=["30"], command="sleep")
+      "\{root}/\{jobs.generation()}/\{id}.json"
+    })
+  })
+  let saved : @protocol.JobRecord = @json.from_json(
+    @json.parse(@fs.read_file(path).text()),
+  )
+  assert_true(saved.state is Stopped("session_ended"))
+  assert_eq(saved.revision, 2)
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "metadata write failure remains visible and does not strand stop settlement" {
+  let root = @fs.tmpdir(prefix="openseek-job-metadata-fail-")
+  defer @fs.rmdir(root, recursive=true)
+  let events : Array[@protocol.JobRecord] = []
+  @async.with_timeout(5000, () => {
+    @async.with_task_group(group => {
+      let jobs = @bgjobs.BgJobRuntime(
+        AgentTaskScope(group),
+        spill_dir=root,
+        persistent_logs=true,
+        on_job_event=(_, record) => events.push(record),
+      )
+      let id = jobs.start(program="/bin/sleep", args=["30"], command="sleep")
+      @fs.mkdir("\{root}/\{id}.json.tmp")
+      assert_true(jobs.stop(id))
+      assert_true(
+        events.last() is Some(record) &&
+        record.state.is_terminal() &&
+        record.persistence_error is Some(_),
+      )
+      assert_true(jobs.pending().is_empty())
+    })
+  })
+}

--- a/agent/job_logs_wbtest.mbt
+++ b/agent/job_logs_wbtest.mbt
@@ -1,0 +1,267 @@
+///|
+#cfg(not(platform="windows"))
+async test "job files survive scope cleanup and a new runtime cannot overwrite them" {
+  let root = @fs.tmpdir(prefix="openseek-retained-jobs-")
+  defer @fs.rmdir(root, recursive=true)
+  let run : async () -> String = () => {
+    @async.with_timeout(5000, () => {
+      @async.with_task_group(group => {
+        let tools = build_tools(
+          AgentRuntime(),
+          AgentTaskScope(group),
+          job_log_dir=root,
+        )
+        guard tools.background_job_runtime() is Some(jobs) else {
+          fail("missing jobs")
+        }
+        let id = jobs.start(
+          program="/bin/sh",
+          args=["-c", "printf retained; sleep 30"],
+          command="retained",
+        )
+        guard jobs.snapshot(id) is Some(snapshot) &&
+          snapshot.output_file is Some(path) else {
+          fail("job was announced without a file")
+        }
+        assert_true(@fs.exists(path))
+        while jobs.read_output(id) != Some("retained") {
+          @async.sleep(5)
+        }
+        path
+      })
+    })
+  }
+  let first = run()
+  assert_eq(@fs.read_file(first).text(), "retained")
+  let second = run()
+  assert_true(first != second)
+  assert_eq(@fs.read_file(first).text(), "retained")
+  assert_eq(@fs.read_file(second).text(), "retained")
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "small foreground execution materializes all prior output at adoption" {
+  let root = @fs.tmpdir(prefix="openseek-adopt-jobs-")
+  defer @fs.rmdir(root, recursive=true)
+  @async.with_timeout(5000, () => {
+    @async.with_task_group(group => {
+      let jobs = @bgjobs.BgJobRuntime(AgentTaskScope(group), spill_dir=root)
+      let exec = jobs.spawn_foreground_retained(
+        "/bin/sh",
+        ["-c", "printf before; sleep 30"],
+        None,
+        100,
+      )
+      while exec.head() != "before" {
+        @async.sleep(5)
+      }
+      assert_true(exec.spill_path() is None)
+      let id = jobs.adopt(exec, command="adopted")
+      guard jobs.snapshot(id) is Some(snapshot) &&
+        snapshot.output_file is Some(path) else {
+        fail("missing output file")
+      }
+      assert_eq(@fs.read_file(path).text(), "before")
+      assert_true(jobs.stop(id))
+      assert_eq(@fs.read_file(path).text(), "before")
+    })
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "failed background adoption stops the execution and publishes no phantom job" {
+  let root = @fs.tmpdir(prefix="openseek-adopt-failure-")
+  defer @fs.rmdir(root, recursive=true)
+  @async.with_timeout(5000, () => {
+    @async.with_task_group(group => {
+      let jobs = @bgjobs.BgJobRuntime(
+        AgentTaskScope(group),
+        spill_dir="\{root}/missing",
+      )
+      let exec = jobs.spawn_foreground_retained("/bin/sleep", ["30"], None, 100)
+      try jobs.adopt(exec, command="cannot retain") catch {
+        _ => assert_true(exec.output_error() is Some(_))
+      } noraise {
+        _ => fail("adoption should fail")
+      }
+      exec.wait()
+      assert_true(exec.status() is Killed)
+      assert_true(jobs.list().is_empty())
+    })
+  })
+}
+
+///|
+async test "constructing session tools does not create a phantom durable session" {
+  let root = @fs.tmpdir(prefix="openseek-lazy-jobs-")
+  defer @fs.rmdir(root, recursive=true)
+  let session_dir = "\{root}/sessions/new-session"
+  @async.with_task_group(group => {
+    ignore(
+      build_tools(
+        AgentRuntime(),
+        AgentTaskScope(group),
+        job_log_dir="\{session_dir}/jobs",
+      ),
+    )
+    assert_false(@fs.exists(session_dir))
+  })
+  assert_false(@fs.exists(session_dir))
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "concurrent first jobs prepare one canonical runtime directory" {
+  let root = @fs.tmpdir(prefix="openseek-lazy-race-")
+  defer @fs.rmdir(root, recursive=true)
+  @async.with_timeout(5000, () => {
+    @async.with_task_group(group => {
+      let tools = build_tools(
+        AgentRuntime(),
+        AgentTaskScope(group),
+        job_log_dir="\{root}/jobs",
+      )
+      guard tools.background_job_runtime() is Some(jobs) else {
+        fail("missing jobs")
+      }
+      let ids = @async.all([
+        () => jobs.start(program="/bin/echo", args=["first"], command="first"),
+        () => jobs.start(program="/bin/echo", args=["second"], command="second"),
+      ])
+      assert_eq(@fs.readdir("\{root}/jobs").length(), 1)
+      for id in ids {
+        jobs.wait_any([id])
+        guard jobs.snapshot(id) is Some(snapshot) &&
+          snapshot.output_file is Some(path) else {
+          fail("missing file")
+        }
+        assert_eq(@fs.realpath(path), path)
+        assert_true(@fs.read_file(path).text().has_suffix("\n"))
+      }
+    })
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "tiny foreground burst leaves no log files and concurrent noisy jobs retain every byte" {
+  let root = @fs.tmpdir(prefix="openseek-job-load-")
+  defer @fs.rmdir(root, recursive=true)
+  @async.with_timeout(15000, () => {
+    @async.with_task_group(group => {
+      let tools = build_tools(
+        AgentRuntime(),
+        AgentTaskScope(group),
+        job_log_dir=root,
+      )
+      guard tools.background_job_runtime() is Some(jobs) else {
+        fail("missing jobs")
+      }
+      let tiny : Array[async () -> Unit] = []
+      for _ in 0..<20 {
+        tiny.push(() => {
+          let exec = jobs.spawn_foreground_retained(
+            "/bin/echo",
+            ["small"],
+            None,
+            100,
+          )
+          exec.wait()
+          assert_eq(exec.head(), "small\n")
+          assert_true(exec.spill_path() is None)
+          exec.discard()
+        })
+      }
+      ignore(@async.all(tiny))
+      let directory = "\{root}/\{jobs.generation()}"
+      assert_eq(@fs.readdir(directory), ["owner.lock"])
+      let noisy : Array[async () -> Unit] = []
+      for _ in 0..<8 {
+        noisy.push(() => {
+          let id = jobs.start(
+            program="/bin/sh",
+            args=["-c", "head -c 262144 /dev/zero | tr '\\000' x"],
+            command="noisy",
+          )
+          ignore(jobs.wait_any([id]))
+          guard jobs.snapshot(id) is Some(snapshot) &&
+            snapshot.output_file is Some(path) else {
+            fail("missing log")
+          }
+          assert_eq(@fs.read_file(path).text(), "x".repeat(262144))
+        })
+      }
+      ignore(@async.all(noisy))
+    })
+  })
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "foreground-only runtime generations are removed after shutdown" {
+  let root = @fs.tmpdir(prefix="openseek-empty-generations-")
+  defer @fs.rmdir(root, recursive=true)
+  for _ in 0..<3 {
+    @async.with_task_group(group => {
+      let tools = build_tools(
+        AgentRuntime(),
+        AgentTaskScope(group),
+        job_log_dir=root,
+      )
+      guard tools.background_job_runtime() is Some(jobs) else {
+        fail("missing runtime")
+      }
+      let exec = jobs.spawn_foreground_retained(
+        "/bin/echo",
+        ["short"],
+        None,
+        100,
+      )
+      exec.wait()
+      exec.discard()
+    })
+    assert_eq(@fs.readdir(root), [])
+  }
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "failed metadata persistence never prunes an adopted job log" {
+  let root = @fs.tmpdir(prefix="openseek-keep-failed-metadata-")
+  defer @fs.rmdir(root, recursive=true)
+  let path = @async.with_task_group(group => {
+    let tools = build_tools(
+      AgentRuntime(),
+      AgentTaskScope(group),
+      job_log_dir=root,
+    )
+    guard tools.background_job_runtime() is Some(jobs) else {
+      fail("missing runtime")
+    }
+    let id = jobs.start(
+      program="/bin/sh",
+      args=["-c", "printf retained; sleep 30"],
+      command="retained",
+    )
+    @async.with_timeout(10000, () => {
+      while jobs.read_output(id) != Some("retained") {
+        @async.sleep(5)
+      }
+    })
+    guard jobs.snapshot(id) is Some(snapshot) &&
+      snapshot.output_file is Some(path) else {
+      fail("missing log")
+    }
+    let metadata = "\{root}/\{jobs.generation()}/\{id}.json"
+    @fs.remove(metadata)
+    @fs.mkdir(metadata)
+    assert_true(jobs.stop(id))
+    assert_true(
+      jobs.records().any(record => record.persistence_error is Some(_)),
+    )
+    path
+  })
+  assert_eq(@fs.read_file(path).text(), "retained")
+}

--- a/agent/moon.pkg
+++ b/agent/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "moonbitlang/async/os_error",
   "bobzhang/openseek/agent_session",
   "moonbitlang/core/int",
   "bobzhang/openseek/agent_session/compact",

--- a/agent/pkg.generated.mbti
+++ b/agent/pkg.generated.mbti
@@ -10,7 +10,7 @@ import {
 }
 
 // Values
-pub async fn[X] build_tools(@agent_runtime.AgentRuntime, @agent_runtime.AgentTaskScope[X], on_background_wake? : () -> Unit, extra_tools? : Array[@agent_tool.AgentToolDefinition], mbtx_subrun? : @host.SubrunInjection) -> @agent_tool.Tools
+pub async fn[X] build_tools(@agent_runtime.AgentRuntime, @agent_runtime.AgentTaskScope[X], on_background_wake? : () -> Unit, job_log_dir? : String, extra_tools? : Array[@agent_tool.AgentToolDefinition], mbtx_subrun? : @host.SubrunInjection) -> @agent_tool.Tools
 
 pub let plan_reminder_after_steps : Int
 

--- a/agent/tool_definition.mbt
+++ b/agent/tool_definition.mbt
@@ -6,7 +6,9 @@ fn background_notice_text(snapshot : @bgjobs.BgJobSnapshot) -> String {
     Exited(0) => "exit=0"
     Exited(code) => "exit=\{code}"
     Stopped =>
-      if snapshot.killed_by_output_limit {
+      if snapshot.output_error is Some(error) {
+        "output capture failed: \{error}"
+      } else if snapshot.killed_by_output_limit {
         "killed: flooded past the output cap"
       } else if snapshot.killed_by_time_limit {
         "killed: outlived the wall-clock cap"
@@ -54,6 +56,7 @@ pub async fn[X] build_tools(
   runtime : @agent_runtime.AgentRuntime,
   scope : @agent_runtime.AgentTaskScope[X],
   on_background_wake? : () -> Unit,
+  job_log_dir? : String,
   extra_tools? : Array[@agent_tool.AgentToolDefinition] = [],
   mbtx_subrun? : @host.SubrunInjection,
 ) -> @agent_tool.Tools {
@@ -63,40 +66,106 @@ pub async fn[X] build_tools(
   // `remove` reads to tell an agent-created file (safe to delete) from a
   // pre-existing one.
   let file_state = @agent_tool.FileStateMap()
-  // One session temp dir, shared by the job runtime (which spills large job
-  // output to disk) and mbtx (whose detached snippets outlive the call
-  // that started them, so their directories cannot be reclaimed there).
-  let spill_dir : String? = Some(@fs.tmpdir(prefix="openseek-jobs-")) catch {
-    _ => None
+  // Scratch files follow the scope. Adopted job logs use separate storage so
+  // removing compiler/snippet scratch space cannot remove a user's log.
+  let scratch = @fs.tmpdir(prefix="openseek-jobs-") catch {
+    error =>
+      fail(
+        "cannot create background-job scratch directory; check temporary-directory space and permissions: \{error}",
+      )
   }
-  // Remove the session temp dir when the owning scope ends, so `/tmp` cannot
-  // accumulate spill files and snippet directories across turns or sessions.
-  // A GROUP defer, not a plain one: `build_tools` returns immediately while
-  // the dir must live as long as the session, and the group runs its defers
-  // only after every child task has terminated — so a background job still
-  // spilling output cannot have the directory pulled out from under it.
-  // `protect_from_cancel` because a group cancelled from outside cancels the
-  // async operations in its defers too.
-  if spill_dir is Some(dir) {
-    scope
-    .group()
-    .add_defer(() => {
-      @async.protect_from_cancel(() => {
-        @fs.rmdir(dir, recursive=true) catch {
-          _ => ()
-        }
-      })
+  scope
+  .group()
+  .add_defer(() => {
+    @async.protect_from_cancel(() => {
+      @fs.rmdir(scratch, recursive=true) catch {
+        _ => ()
+      }
     })
+  })
+  let spill_dir = match job_log_dir {
+    Some(root) => {
+      // tmpdir already reserved this unique runtime name. mkdir below is
+      // exclusive too: an unexpected collision fails rather than overwrites.
+      let normalized = scratch.replace_all(old="\\", new="/")
+      let parts = normalized.split("/").to_array()
+      guard parts.last() is Some(generation) else {
+        fail("missing runtime directory name")
+      }
+      "\{root}/\{generation}"
+    }
+    None => scratch
   }
   // When a background job exits on its own, push a completion notice into the
   // loop's lossless steer queue (surfaced to the model at the next step, or
   // persisted while idle) and poke the controller so an idle engine wakes to
   // drain it instead of leaving it until the next prompt.
-  let bg_runtime = @bgjobs.BgJobRuntime(scope, spill_dir?, on_job_exit=snapshot => {
-    runtime.queue_steer(Notice(background_notice_text(snapshot)))
-    if on_background_wake is Some(wake) {
-      wake()
-    }
+  let mut owner : @fs.File? = None
+  let prepare_output_dir : (async () -> String)? = match job_log_dir {
+    None => None
+    Some(root) =>
+      Some(() => {
+        @fs.mkdir(root, recursive=true, permission=0o700) catch {
+          @os_error.OSError(_) as error if error.is_EEXIST() => {
+            guard @fs.kind(root) is Directory else { raise error }
+          }
+          error => raise error
+        }
+        // Exclusive creation: a collision never reuses another engine's logs.
+        @fs.mkdir(spill_dir, permission=0o700)
+        errdefer @async.protect_from_cancel(() => {
+          @fs.rmdir(spill_dir, recursive=true) catch {
+            _ => ()
+          }
+        })
+        let canonical = @fs.realpath(spill_dir)
+        let file = @fs.open(
+          "\{canonical}/owner.lock",
+          mode=ReadWrite,
+          create_mode=CreateNew,
+          permission=0o600,
+        )
+        errdefer file.close()
+        file.lock(Exclusive)
+        owner = Some(file)
+        canonical
+      })
+  }
+  let bg_runtime = @bgjobs.BgJobRuntime(
+    scope,
+    spill_dir~,
+    persistent_logs=job_log_dir is Some(_),
+    prepare_output_dir?,
+    on_job_event=(kind, job) => @emit.emit(JobChanged(kind~, job~)),
+    on_job_exit=snapshot => {
+      runtime.queue_steer(Notice(background_notice_text(snapshot)))
+      if on_background_wake is Some(wake) {
+        wake()
+      }
+    },
+  )
+
+  scope
+  .group()
+  .add_defer(() => {
+    defer (if owner is Some(file) { file.close() })
+    @async.protect_from_cancel(() => {
+      bg_runtime.finalize()
+      // No adopted execution means this generation owns no retained job log.
+      // Do not infer that from missing JSON: metadata persistence can fail.
+      if bg_runtime.list().is_empty() && owner is Some(file) {
+        file.close()
+        owner = None
+        try {
+          if @fs.readdir(spill_dir) == ["owner.lock"] {
+            @fs.remove("\{spill_dir}/owner.lock")
+            @fs.rmdir(spill_dir)
+          }
+        } catch {
+          _ => () // Best effort; never remove unexpected files recursively.
+        }
+      }
+    })
   })
   Tools(
     [
@@ -120,7 +189,7 @@ pub async fn[X] build_tools(
         workspace_root~,
         file_state~,
         bg_runtime~,
-        job_dir?=spill_dir,
+        job_dir=scratch,
         approval?=runtime.approval_channel(),
         subrun?=mbtx_subrun,
       ),

--- a/agent_session/store/pkg.generated.mbti
+++ b/agent_session/store/pkg.generated.mbti
@@ -24,6 +24,7 @@ pub async fn SessionStore::append(Self, @agent_session.Session, @agent_session.S
 pub async fn SessionStore::compact(Self, @agent_session.Session, content~ : String, from_sequence~ : Int, to_sequence~ : Int) -> @agent_session.Session
 pub async fn SessionStore::create(Self, @agent_session.Session) -> Unit
 pub async fn SessionStore::exists(Self, @agent_session.SessionId) -> Bool
+pub fn SessionStore::job_logs_dir(Self, @agent_session.SessionId) -> String raise
 pub async fn SessionStore::latest(Self) -> @agent_session.SessionId?
 pub async fn SessionStore::list(Self) -> Array[@agent_session.SessionId]
 pub async fn SessionStore::listings(Self) -> Array[SessionListing]

--- a/agent_session/store/store.mbt
+++ b/agent_session/store/store.mbt
@@ -838,3 +838,14 @@ pub extend SessionListing with Debug::{to_repr}
 
 ///|
 pub extend SessionStore with Debug::{to_repr}
+
+///|
+/// Return the prospective job directory without creating a session. The
+/// runtime creates it on first execution, after the first durable append.
+/// Logs move with archives and are removed with explicit session deletion.
+pub fn SessionStore::job_logs_dir(
+  self : SessionStore,
+  id : @agent_session.SessionId,
+) -> String raise {
+  "\{self.session_dir(id)}/jobs"
+}

--- a/agent_session/store/store_test.mbt
+++ b/agent_session/store/store_test.mbt
@@ -905,3 +905,13 @@ async test "store compacts by appending a durable summary" {
   assert_eq(summary.content(), "first two events")
   assert_eq(loaded.chat_messages().length(), 2)
 }
+
+///|
+async test "job directory lookup does not create a new session" {
+  let store = new_store()
+  defer @fs.rmdir(store.root(), recursive=true)
+  let id : @agent_session.SessionId = SessionId("not-started")
+  assert_eq(store.job_logs_dir(id), "\{store.root()}/sessions/not-started/jobs")
+  assert_false(store.exists(id))
+  assert_eq(store.list().length(), 0)
+}

--- a/agent_tool/bgjobs/README.mbt.md
+++ b/agent_tool/bgjobs/README.mbt.md
@@ -51,10 +51,11 @@ memory-only jobs (bounded preview, rest dropped).
 ## Push-completion
 
 The per-job watcher awaits the execution and calls `on_job_exit` exactly once
-when the job ends *on its own* — a natural exit, the output watchdog, or the
-wall-clock reaper. A
-requested stop (`job_stop`, session teardown) fires nothing: it is already
-user-visible. The `agent` package wires `on_job_exit` to queue a
+for a natural exit, the output watchdog, the wall-clock reaper, or an output
+capture failure. A normal requested stop (`job_stop`, session teardown) fires
+nothing: it is already user-visible. Capture failures still produce a notice
+when they race a requested stop, so losing output is never hidden by that stop.
+The `agent` package wires `on_job_exit` to queue a
 `SteerInput::Notice` (lossless) and poke the serve loop, which is what makes
 job completion *push* into the conversation instead of requiring the model to
 poll — see the `mbtx` tool description and the system prompts, which teach
@@ -69,3 +70,16 @@ counter for change detection, and the error-semantics flags
 `job_output` report a background job with exactly the foreground path's error
 behavior. The sink's own sequence number stays private and is not copied into
 the snapshot.
+
+
+Background adoption now materializes a configured output file before returning
+its ID, including for an empty or small output. Foreground output stays in
+memory until its existing cap or adoption. `BgJobSnapshot.output_file` is the
+actual path (an adopted execution can keep its `fg-N.out` filename),
+`output_persistent` describes its lifetime, and `output_error` reports capture
+failures separately from the program outcome. File I/O errors are surfaced;
+they no longer silently return the initial output head.
+
+Standard durable `run`/`serve` sessions retain job logs below their session's
+`jobs/<runtime-generation>` directory. Compiler/snippet scratch files still
+follow the engine scope. No-session engines label their logs temporary.

--- a/agent_tool/bgjobs/bgjobs.mbt
+++ b/agent_tool/bgjobs/bgjobs.mbt
@@ -66,17 +66,25 @@ struct BgJobRuntime {
   spawn_watcher : (async () -> Unit) -> Unit
   // Directory for per-job spill files (full output beyond the inline preview).
   // None → memory-only jobs (no full-output file).
-  spill_dir : String?
+  mut spill_dir : String?
+  prepare_output_dir : (async () -> String)?
+  prepare_lock : @async.Mutex
+  mut output_prepared : Bool
+  persistent_logs : Bool
   // Wall-clock lifetime cap for any registered job, measured from process
   // start (an adopted job keeps its original deadline). Bounded lifetime,
   // not machine protection: the kill reaches the direct child only, so a
   // spinning grandchild can be orphaned — true process-group kill is
   // upstream work in moonbitlang/async. Tests shrink it to fire cheaply.
   hard_timeout_ms : Int
-  // Called once, with the terminal snapshot, when a job exits on its own (not on
-  // `stop`/teardown) — e.g. to push a completion notice into the agent loop.
+  // Called once for natural exits, watchdog kills, or capture failures. Normal
+  // stop/teardown is already user-visible; a capture failure is still reported
+  // even if it races a requested stop.
   on_job_exit : ((BgJobSnapshot) -> Unit)?
   jobs : Map[String, BgJob]
+  generation : String
+  publish_lock : @async.Mutex
+  on_job_event : ((@protocol.JobEventKind, @protocol.JobRecord) -> Unit)?
   settled : @async.CondVar
   mut next_index : Int
   // Separate counter for the spill files of detachable foreground executions
@@ -91,6 +99,12 @@ struct BgJobRuntime {
 /// `BgJobSnapshot`.
 priv struct BgJob {
   id : String
+  mut revision : Int
+  mut announced : Bool
+  backgrounded_at_ms : Int64
+  mut requested_stop : Bool
+  mut persistence_error : String?
+  mut cleanup_error : String?
   command : String
   description : String?
   exec : @shell_exec.ShellExecution
@@ -128,6 +142,9 @@ pub struct BgJobSnapshot {
   description : String?
   status : BgJobStatus
   priv output : String
+  output_file : String?
+  output_persistent : Bool
+  output_error : String?
   output_truncated : Bool
   priv over_inline_cap : Bool
   size : Int
@@ -156,9 +173,12 @@ pub struct BgJobSnapshot {
 pub fn[X] BgJobRuntime::BgJobRuntime(
   scope : @agent_runtime.AgentTaskScope[X],
   spill_dir? : String,
+  persistent_logs? : Bool = false,
+  prepare_output_dir? : async () -> String,
   hard_output_cap? : Int = @shell_exec.default_hard_cap,
   hard_timeout_ms? : Int = default_hard_timeout_ms,
   on_job_exit? : (BgJobSnapshot) -> Unit,
+  on_job_event? : (@protocol.JobEventKind, @protocol.JobRecord) -> Unit,
 ) -> BgJobRuntime {
   let group = scope.group()
   {
@@ -205,9 +225,19 @@ pub fn[X] BgJobRuntime::BgJobRuntime(
       group.spawn_bg(task, no_wait=true, allow_failure=true)
     },
     spill_dir,
+    prepare_output_dir,
+    prepare_lock: Mutex(),
+    output_prepared: prepare_output_dir is None,
+    persistent_logs,
     hard_timeout_ms,
     on_job_exit,
     jobs: Map([]),
+    generation: match spill_dir {
+      Some(dir) => artifact_basename(dir)
+      None => "memory-\{@env.now()}"
+    },
+    publish_lock: Mutex(),
+    on_job_event,
     settled: Cond(),
     next_index: 1,
     fg_index: 1,
@@ -235,6 +265,7 @@ pub async fn BgJobRuntime::spawn_foreground_retained(
   max_output_chars : Int,
   stdin? : &@process.ProcessInput,
 ) -> @shell_exec.ShellExecution {
+  self.prepare_output()
   let spill_path = self.spill_dir.map(dir => {
     let index = self.fg_index
     self.fg_index += 1
@@ -265,11 +296,15 @@ pub async fn BgJobRuntime::start(
 ) -> String {
   // Reserve one id and use it for both the spill file and the registry entry, so
   // the job id and its `<id>.out` file never diverge.
+  self.prepare_output()
   let id = self.next_id()
   let spill_path = self.spill_dir.map(dir => "\{dir}/\{id}.out")
   let exec = (self.spawn_exec)(
     program, args, cwd, max_output_chars, spill_path, stdin,
   )
+  errdefer exec.request_stop()
+  exec.materialize_output()
+  let _ = exec.background()
   self.register(
     id,
     exec,
@@ -289,7 +324,7 @@ pub async fn BgJobRuntime::start(
 /// its id. Used by detach-on-timeout: a foreground command that outlived its
 /// timeout is `background()`-ed and adopted here, so `job_output`/`job_stop`
 /// and the completion notice see it like any explicit background job.
-pub fn BgJobRuntime::adopt(
+pub async fn BgJobRuntime::adopt(
   self : BgJobRuntime,
   exec : @shell_exec.ShellExecution,
   command~ : String,
@@ -300,7 +335,11 @@ pub fn BgJobRuntime::adopt(
   moonrun_policy_active? : Bool = false,
   on_terminal? : async () -> Unit,
 ) -> String {
+  errdefer exec.request_stop()
+  self.prepare_output()
   let id = self.next_id()
+  exec.materialize_output()
+  let _ = exec.background()
   self.register(
     id,
     exec,
@@ -317,7 +356,7 @@ pub fn BgJobRuntime::adopt(
 
 ///|
 /// Add a job to the registry under `id` and start its exit watcher.
-fn BgJobRuntime::register(
+async fn BgJobRuntime::register(
   self : BgJobRuntime,
   id : String,
   exec : @shell_exec.ShellExecution,
@@ -331,6 +370,12 @@ fn BgJobRuntime::register(
 ) -> Unit {
   self.jobs[id] = {
     id,
+    revision: 1,
+    announced: false,
+    backgrounded_at_ms: @env.now().reinterpret_as_int64(),
+    requested_stop: false,
+    persistence_error: None,
+    cleanup_error: None,
     command,
     description,
     exec,
@@ -343,35 +388,12 @@ fn BgJobRuntime::register(
     denial_scanned: false,
     denial_feedback: None,
   }
-  // Watch for the job ending on its own and fire `on_job_exit` once: a natural
-  // exit, or the output-limit watchdog killing a flooding job — both must be
-  // surfaced (a watchdog kill silently eating an unwatched job would look like
-  // it just never finished). A requested stop (job_stop, session teardown) is
-  // already user-visible and fires nothing. The job entry is set above before
-  // the watcher runs (the watcher first awaits the exit, ≥ one tick later), so
-  // `snapshot(id)` always resolves.
+  // Persist and announce before starting the watcher: even a process that
+  // exited during adoption has one Started followed by one terminal event.
+  @async.protect_from_cancel(() => self.publish(id, Started))
   (self.spawn_watcher)(() => {
     exec.wait()
-    // Publish even if launcher cleanup fails. Keep the job pending until the
-    // notice is queued, then wake waiters; a terminal snapshot alone is too
-    // early for the loop's finish decision.
-    defer (if self.jobs.get(id) is Some(job) {
-      if self.on_job_exit is Some(callback) &&
-        self.snapshot(id) is Some(snapshot) &&
-        (
-          snapshot.status is Exited(_) ||
-          snapshot.killed_by_output_limit ||
-          snapshot.killed_by_time_limit
-        ) {
-        callback(snapshot)
-      }
-      job.completion_published = true
-      self.settled.broadcast()
-    })
-    if self.jobs.get(id) is Some(job) && job.on_terminal is Some(cleanup) {
-      job.on_terminal = None
-      cleanup()
-    }
+    self.finish_job(id)
   })
   // Wall-clock reaper: every registered job has a bounded lifetime measured
   // from its process start, so a detached job's foreground wait counts
@@ -399,13 +421,16 @@ fn bg_status(status : @shell_exec.ExecStatus) -> BgJobStatus {
 }
 
 ///|
-fn BgJob::to_snapshot(self : BgJob) -> BgJobSnapshot {
+fn BgJob::to_snapshot(self : BgJob, persistent_logs : Bool) -> BgJobSnapshot {
   {
     id: self.id,
     command: self.command,
     description: self.description,
     status: bg_status(self.exec.status()),
     output: self.exec.head(),
+    output_file: self.exec.spill_path(),
+    output_persistent: persistent_logs,
+    output_error: self.exec.output_error(),
     output_truncated: self.exec.output_truncated(),
     over_inline_cap: self.exec.over_inline_cap(),
     size: self.exec.size(),
@@ -471,7 +496,7 @@ pub fn BgJobRuntime::snapshot(
   self : BgJobRuntime,
   id : String,
 ) -> BgJobSnapshot? {
-  self.jobs.get(id).map(job => job.to_snapshot())
+  self.jobs.get(id).map(job => job.to_snapshot(self.persistent_logs))
 }
 
 ///|
@@ -480,7 +505,7 @@ pub fn BgJobRuntime::snapshot(
 /// runtime state through it.
 pub fn BgJobRuntime::list(self : BgJobRuntime) -> Array[BgJobSnapshot] {
   [
-    for _, job in self.jobs => job.to_snapshot()
+    for _, job in self.jobs => job.to_snapshot(self.persistent_logs)
   ]
 }
 
@@ -517,7 +542,13 @@ pub async fn BgJobRuntime::read_output_tail(
 /// already-terminal known job returns `true`; an unknown id returns `false`.
 pub async fn BgJobRuntime::stop(self : BgJobRuntime, id : String) -> Bool {
   guard self.jobs.get(id) is Some(job) else { return false }
-  let _ = job.exec.stop()
+  if bg_status(job.exec.status()) is Running && !job.requested_stop {
+    job.requested_stop = true
+    job.exec.request_stop()
+    self.publish(id, Updated)
+  }
+  job.exec.wait()
+  self.wait_any([id])
   true
 }
 
@@ -600,8 +631,13 @@ async test "stop terminates a running job" {
 ///|
 #cfg(not(platform="windows"))
 async test "a large-output job spills; snapshot previews, read_output is full" {
+  let directory = @fs.tmpdir(prefix="bg-job-test-")
+  defer @fs.rmdir(directory, recursive=true)
   @async.with_task_group(group => {
-    let rt = BgJobRuntime::BgJobRuntime(AgentTaskScope(group), spill_dir="/tmp")
+    let rt = BgJobRuntime::BgJobRuntime(
+      AgentTaskScope(group),
+      spill_dir=directory,
+    )
     let id = rt.start(
       program="sh",
       args=["-c", "seq 1 5000"],
@@ -720,8 +756,13 @@ async test "snapshot, read_output, and stop handle unknown ids" {
 ///|
 #cfg(not(platform="windows"))
 async test "start allocates one id per job (id matches its spill file)" {
+  let directory = @fs.tmpdir(prefix="bg-job-test-")
+  defer @fs.rmdir(directory, recursive=true)
   @async.with_task_group(group => {
-    let rt = BgJobRuntime::BgJobRuntime(AgentTaskScope(group), spill_dir="/tmp")
+    let rt = BgJobRuntime::BgJobRuntime(
+      AgentTaskScope(group),
+      spill_dir=directory,
+    )
     // The first started job is bg-1 (not bg-2): start must not reserve an id for
     // the spill path and then allocate a second one for the registry entry.
     let a = rt.start(program="sh", args=["-c", "printf a"], command="a")
@@ -835,3 +876,25 @@ async test "a requested stop is not blamed on the reaper" {
 
 ///|
 pub extend BgJobStatus with Eq::{equal, not_equal}
+
+///|
+/// Reserve durable storage lazily at the first execution, after the turn's
+/// first durable append. A failed serve setup therefore leaves no fake session.
+async fn BgJobRuntime::prepare_output(self : BgJobRuntime) -> Unit {
+  if self.output_prepared {
+    return
+  }
+  self.prepare_lock.acquire()
+  defer self.prepare_lock.release()
+  if self.output_prepared {
+    return
+  }
+  if self.prepare_output_dir is Some(prepare) {
+    let directory = prepare()
+    guard artifact_basename(directory) == self.generation else {
+      fail("job artifact preparation changed runtime identity")
+    }
+    self.spill_dir = Some(directory)
+  }
+  self.output_prepared = true
+}

--- a/agent_tool/bgjobs/moon.pkg
+++ b/agent_tool/bgjobs/moon.pkg
@@ -3,6 +3,8 @@ import {
   "bobzhang/openseek/agent_tool/internal/sandbox",
   "bobzhang/openseek/agent_tool/shell_exec",
   "moonbitlang/async",
+  "moonbitlang/async/fs",
+  "bobzhang/openseek_protocol" @protocol,
   "moonbitlang/async/process",
   "moonbitlang/core/env",
 }

--- a/agent_tool/bgjobs/pkg.generated.mbti
+++ b/agent_tool/bgjobs/pkg.generated.mbti
@@ -5,6 +5,7 @@ import {
   "bobzhang/openseek/agent_runtime",
   "bobzhang/openseek/agent_tool/internal/sandbox",
   "bobzhang/openseek/agent_tool/shell_exec",
+  "bobzhang/openseek_protocol",
   "moonbitlang/async/process",
 }
 
@@ -14,12 +15,15 @@ import {
 
 // Types and methods
 type BgJobRuntime
-pub fn[X] BgJobRuntime::BgJobRuntime(@agent_runtime.AgentTaskScope[X], spill_dir? : String, hard_output_cap? : Int, hard_timeout_ms? : Int, on_job_exit? : (BgJobSnapshot) -> Unit) -> Self
-pub fn BgJobRuntime::adopt(Self, @shell_exec.ShellExecution, command~ : String, description? : String, sandboxed_command? : @sandbox.SandboxedCommand, read_only_review? : Bool, output_rewrites? : Array[(String, String)], moonrun_policy_active? : Bool, on_terminal? : async () -> Unit) -> String
+pub fn[X] BgJobRuntime::BgJobRuntime(@agent_runtime.AgentTaskScope[X], spill_dir? : String, persistent_logs? : Bool, prepare_output_dir? : async () -> String, hard_output_cap? : Int, hard_timeout_ms? : Int, on_job_exit? : (BgJobSnapshot) -> Unit, on_job_event? : (@openseek_protocol.JobEventKind, @openseek_protocol.JobRecord) -> Unit) -> Self
+pub async fn BgJobRuntime::adopt(Self, @shell_exec.ShellExecution, command~ : String, description? : String, sandboxed_command? : @sandbox.SandboxedCommand, read_only_review? : Bool, output_rewrites? : Array[(String, String)], moonrun_policy_active? : Bool, on_terminal? : async () -> Unit) -> String
+pub async fn BgJobRuntime::finalize(Self) -> Unit
+pub fn BgJobRuntime::generation(Self) -> String
 pub fn BgJobRuntime::list(Self) -> Array[BgJobSnapshot]
 pub fn BgJobRuntime::pending(Self) -> Array[BgJobSnapshot]
 pub async fn BgJobRuntime::read_output(Self, String) -> String?
 pub async fn BgJobRuntime::read_output_tail(Self, String, Int) -> String?
+pub fn BgJobRuntime::records(Self) -> Array[@openseek_protocol.JobRecord]
 pub fn BgJobRuntime::snapshot(Self, String) -> BgJobSnapshot?
 pub async fn BgJobRuntime::spawn_foreground_retained(Self, String, Array[String], String?, Int, stdin? : &@process.ProcessInput) -> @shell_exec.ShellExecution
 pub async fn BgJobRuntime::start(Self, program~ : String, args~ : Array[String], command~ : String, description? : String, cwd? : String, max_output_chars? : Int, sandboxed_command? : @sandbox.SandboxedCommand, read_only_review? : Bool, output_rewrites? : Array[(String, String)], moonrun_policy_active? : Bool, stdin? : &@process.ProcessInput) -> String
@@ -32,6 +36,9 @@ pub struct BgJobSnapshot {
   command : String
   description : String?
   status : BgJobStatus
+  output_file : String?
+  output_persistent : Bool
+  output_error : String?
   output_truncated : Bool
   size : Int
   had_invalid_utf8 : Bool

--- a/agent_tool/bgjobs/records.mbt
+++ b/agent_tool/bgjobs/records.mbt
@@ -1,0 +1,176 @@
+///|
+fn artifact_basename(path : String) -> String {
+  let path = path.replace_all(old="\\", new="/")
+  match path.rev_split_once("/") {
+    Some((_, name)) => name.to_owned()
+    None => path
+  }
+}
+
+///|
+fn BgJob::record(self : BgJob, runtime : BgJobRuntime) -> @protocol.JobRecord {
+  let state : @protocol.JobState = match self.exec.status() {
+    Running | Backgrounded =>
+      if self.requested_stop {
+        Stopping
+      } else {
+        Running
+      }
+    Exited(code) => Exited(code)
+    Killed =>
+      Stopped(
+        if self.exec.output_error() is Some(_) {
+          "capture_failed"
+        } else if self.exec.killed_by_output_limit() {
+          "output_limit"
+        } else if self.exec.killed_by_time_limit() {
+          "time_limit"
+        } else if self.requested_stop {
+          "user"
+        } else {
+          "session_ended"
+        },
+      )
+  }
+  {
+    generation: runtime.generation,
+    id: self.id,
+    revision: self.revision,
+    command: self.command,
+    description: self.description,
+    cwd: self.exec.cwd(),
+    state,
+    started_at_ms: self.exec.started_at_ms(),
+    backgrounded_at_ms: self.backgrounded_at_ms,
+    finished_at_ms: self.exec.finished_at_ms(),
+    last_output_at_ms: self.exec.last_output_at_ms(),
+    output_file: self.exec.spill_path().map(artifact_basename),
+    output_persistent: runtime.persistent_logs,
+    output_bytes: self.exec.output_bytes(),
+    output_chars: self.exec.size(),
+    output_truncated: self.exec.output_truncated(),
+    invalid_utf8: self.exec.had_invalid_utf8(),
+    output_error: self.exec.output_error(),
+    persistence_error: self.persistence_error,
+    cleanup_error: self.cleanup_error,
+  }
+}
+
+///|
+/// The current runtime's opaque generation, used to reject stale controls.
+pub fn BgJobRuntime::generation(self : BgJobRuntime) -> String {
+  self.generation
+}
+
+///|
+/// Current-runtime snapshots whose first publication has been attempted.
+/// Unlike list()/snapshot(), this excludes jobs still being registered. The
+/// Desktop host reads durable history separately from session metadata files.
+pub fn BgJobRuntime::records(self : BgJobRuntime) -> Array[@protocol.JobRecord] {
+  [
+    for _, job in self.jobs if job.announced => job.record(self)
+  ]
+}
+
+///|
+async fn BgJobRuntime::publish(
+  self : BgJobRuntime,
+  id : String,
+  kind : @protocol.JobEventKind,
+) -> Unit {
+  self.publish_lock.acquire()
+  defer self.publish_lock.release()
+  guard self.jobs.get(id) is Some(job) else { return }
+  if kind != Started {
+    job.revision += 1
+  }
+  job.persistence_error = None
+  // One immutable revision is shared by persistence and the lifecycle event.
+  // Execution status/output may advance while filesystem writes are awaiting.
+  let record = job.record(self)
+  if self.persistent_logs && self.spill_dir is Some(dir) {
+    let path = "\{dir}/\{id}.json"
+    let temporary = "\{path}.tmp"
+    try {
+      @fs.write_file(
+        temporary,
+        record.to_json().stringify(),
+        create_mode=CreateOrTruncate,
+        sync=Data,
+        permission=0o600,
+      )
+      @fs.rename(temporary, path, replace=true)
+      sync_job_directories(dir)
+    } catch {
+      error => job.persistence_error = Some("failed to persist job: \{error}")
+    }
+  }
+  job.announced = true
+  if self.on_job_event is Some(publish) {
+    publish(kind, { ..record, persistence_error: job.persistence_error, })
+  }
+}
+
+///|
+/// Make the metadata rename and new generation/jobs directory entries durable
+/// where directory sync is supported, matching the session store's best-effort
+/// policy. This does not add per-chunk fsync to the output stream.
+async fn sync_job_directories(dir : String) -> Unit {
+  for path in [dir, "\{dir}/..", "\{dir}/../.."] {
+    let directory = @fs.open(path, mode=ReadOnly) catch { _ => continue }
+    defer directory.close()
+    directory.sync() catch {
+      _ => ()
+    }
+  }
+}
+
+///|
+async fn BgJobRuntime::finish_job(self : BgJobRuntime, id : String) -> Unit {
+  @async.protect_from_cancel(() => {
+    guard self.jobs.get(id) is Some(job) && !job.completion_published else {
+      return
+    }
+    if job.on_terminal is Some(cleanup) {
+      job.on_terminal = None
+      cleanup() catch {
+        error => job.cleanup_error = Some("\{error}")
+      }
+    }
+    let record = job.record(self)
+    let failed = match record.state {
+      Exited(code) => code != 0
+      Stopped(reason) => reason != "user" && reason != "session_ended"
+      _ => false
+    }
+    self.publish(
+      id,
+      if failed || job.cleanup_error is Some(_) {
+        Failed
+      } else {
+        Finished
+      },
+    )
+    if self.on_job_exit is Some(callback) &&
+      self.snapshot(id) is Some(snapshot) &&
+      (
+        snapshot.status is Exited(_) ||
+        snapshot.killed_by_output_limit ||
+        snapshot.killed_by_time_limit ||
+        snapshot.output_error is Some(_)
+      ) {
+      callback(snapshot)
+    }
+    job.completion_published = true
+    self.settled.broadcast()
+  })
+}
+
+///|
+/// Finalize after the owning group has joined its children, under cancellation
+/// protection. No live process or writer remains when terminal metadata is saved.
+pub async fn BgJobRuntime::finalize(self : BgJobRuntime) -> Unit {
+  for id, _ in self.jobs {
+    self.finish_job(id)
+  }
+}

--- a/agent_tool/bgjobs/wait.mbt
+++ b/agent_tool/bgjobs/wait.mbt
@@ -3,7 +3,9 @@
 /// Including the latter closes the exit/notice gap in a turn's finish check.
 pub fn BgJobRuntime::pending(self : BgJobRuntime) -> Array[BgJobSnapshot] {
   [
-    for _, job in self.jobs if !job.completion_published => job.to_snapshot()
+    for _, job in self.jobs if !job.completion_published => {
+      job.to_snapshot(self.persistent_logs)
+    }
   ]
 }
 

--- a/agent_tool/job_output/README.mbt.md
+++ b/agent_tool/job_output/README.mbt.md
@@ -55,3 +55,8 @@ Two invariants drove the implementation:
    job is terminal, the *full* retained output is scanned once and that
    classification is cached. This catches a denial line earlier than the final
    displayed tail, with the same guidance appended and the footer still last.
+
+The system footer includes the actual `output_file` path and
+`output_persistent` when file retention is configured. External readers can
+tail this file without polling the model. Read failures are tool errors, and
+capture failures explicitly identify incomplete logs.

--- a/agent_tool/job_output/internal/decode/decode.mbt
+++ b/agent_tool/job_output/internal/decode/decode.mbt
@@ -26,8 +26,8 @@ fn offset(arguments : Json) -> Int? raise {
   match arguments {
     { "offset": Number(value, ..), .. } => {
       let offset = value.to_int()
-      if offset < 0 {
-        fail("job_output offset must be zero or a positive number")
+      if offset < 0 || offset.to_double() != value {
+        fail("job_output offset must be a nonnegative integer")
       } else {
         Some(offset)
       }

--- a/agent_tool/job_output/internal/decode/decode_test.mbt
+++ b/agent_tool/job_output/internal/decode/decode_test.mbt
@@ -42,12 +42,22 @@ test "decode names the argument to repair in malformed arguments" {
   )
   assert_eq(
     decode_error({ "job_id": "bg-3", "offset": -1 }),
-    Some("job_output offset must be zero or a positive number"),
+    Some("job_output offset must be a nonnegative integer"),
   )
   assert_eq(
     decode_error({ "job_id": "bg-3", "offset": "0" }),
     Some("job_output offset must be a number"),
   )
+}
+
+///|
+test "decode rejects fractional and overflowing character offsets" {
+  for value in [1.5, -0.5, 2147483648.0] {
+    assert_eq(
+      decode_error({ "job_id": "bg-3", "offset": Json::number(value) }),
+      Some("job_output offset must be a nonnegative integer"),
+    )
+  }
 }
 
 ///|

--- a/agent_tool/job_output/job_output.mbt
+++ b/agent_tool/job_output/job_output.mbt
@@ -65,10 +65,18 @@ async fn execute(
   // job — so a result bigger than one window (a workflow's several reports)
   // is reachable in full; the default stays the tail, which is what a poll on
   // a running job wants.
-  let raw_output = match page {
-    Some(offset) =>
-      page_of(bg_runtime.read_output(job_id).unwrap_or(""), offset~, window~)
-    None => bg_runtime.read_output_tail(job_id, window).unwrap_or("")
+  let raw_output = try {
+    match page {
+      Some(offset) =>
+        page_of(bg_runtime.read_output(job_id).unwrap_or(""), offset~, window~)
+      None => bg_runtime.read_output_tail(job_id, window).unwrap_or("")
+    }
+  } catch {
+    error =>
+      return @agent_tool.respond(
+        "failed to read job \{job_id} output: \{error}",
+        is_error=true,
+      )
   }
   // Re-snapshot *after* the awaited read: the job may have appended more output
   // or exited while the read yielded, so size/status/binary/truncation in the
@@ -113,9 +121,16 @@ async fn execute(
       None
     }
   } else {
-    bg_runtime.terminal_denial_feedback(job_id)
+    bg_runtime.terminal_denial_feedback(job_id) catch {
+      error =>
+        return @agent_tool.respond(
+          "failed to read job \{job_id} output for terminal diagnostics: \{error}",
+          is_error=true,
+        )
+    }
   }
   let is_error = exit_error ||
+    snapshot.output_error is Some(_) ||
     snapshot.had_invalid_utf8 ||
     sandbox_denied is Some(_)
   // Truncated whenever what we show is less than what the job produced — this
@@ -142,7 +157,12 @@ async fn execute(
     Some(offset) => " window_offset=\{offset}"
     None => ""
   }
-  let footer = "<system>job=\{job_id} \{status_label}\{truncation}\{paging}\{binary}</system>"
+  let file_hint = match snapshot.output_file {
+    Some(path) =>
+      " output_file=\{path.to_json().stringify()} output_persistent=\{snapshot.output_persistent}"
+    None => ""
+  }
+  let footer = "<system>job=\{job_id} \{status_label}\{truncation}\{paging}\{binary}\{file_hint}</system>"
   // Assemble: output, then the source-write denial guidance (like the foreground
   // path), then the `<system>` footer LAST so it stays the trailing metadata line.
   let content = StringBuilder()
@@ -155,6 +175,9 @@ async fn execute(
   if sandbox_denied is Some(guidance) {
     content.write_string(guidance)
     content.write_string("\n")
+  }
+  if snapshot.output_error is Some(error) {
+    content.write_string("Output capture failed: \{error}\n")
   }
   content.write_string(footer)
   let content = content.to_string()

--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -856,7 +856,6 @@ async fn execute(
     })
     let saw_binary = exec.had_invalid_utf8()
     if finished is None {
-      let _ = exec.background()
       // A session- or lab-owned outer directory keeps only durable `tmp`
       // results. A standalone runtime has no later owner, so it reclaims the
       // whole fallback directory once the process is terminal.
@@ -900,6 +899,17 @@ async fn execute(
       } else {
         "mbtx: still running after \{duration_label(auto_background_after_ms)}, so it moved to the background as job \{id} (nothing was lost). Read its output with job_output (job_id=\"\{id}\") and stop it with job_stop (job_id=\"\{id}\")."
       }
+      let handoff = match exec.spill_path() {
+        Some(path) => "\{handoff}\nOutput file: \{path}"
+        None => "\{handoff}\nOutput retention: memory only."
+      }
+      let handoff = if exec.spill_path() is Some(_) &&
+        runtime.snapshot(id) is Some(snapshot) &&
+        !snapshot.output_persistent {
+        "\{handoff}\nThis output file is temporary and lasts until engine shutdown."
+      } else {
+        handoff
+      }
       // Explicitly requested compiler warnings must not vanish because the
       // program outlived the grace: they exist only in the build phase's
       // capture, so this response is their one ride to the model.
@@ -907,6 +917,9 @@ async fn execute(
         with_build_notes(build_notes, handoff),
         brief="mbtx → bg \{id}",
       )
+    }
+    if exec.output_error() is Some(error) {
+      return @agent_tool.respond("mbtx: \{error}", is_error=true)
     }
     let raw = exec.head()
     let exit_code = exec.exit_code().unwrap_or(-1)

--- a/agent_tool/shell_exec/execution.mbt
+++ b/agent_tool/shell_exec/execution.mbt
@@ -62,10 +62,12 @@ struct ShellExecution {
   // above), so a consumer can tell a watchdog kill from a requested stop and
   // surface it rather than letting the job die silently.
   mut killed_by_output_limit : Bool
-  // Monotonic start stamp, so a wall-clock reaper measures a job's lifetime
+  // Epoch start stamp, so a wall-clock reaper measures a job's lifetime
   // from process start — a detached (adopted) job keeps its original
   // deadline, not one restarted at adoption.
   started_at_ms : Int64
+  cwd : String?
+  mut finished_at_ms : Int64?
   // Set when the child was cancelled by the wall-clock reaper, so consumers
   // can tell a lifetime kill from a requested stop.
   mut killed_by_time_limit : Bool
@@ -131,6 +133,11 @@ pub async fn[X] ShellExecution::start(
     kill_at_hard_cap,
     killed_by_output_limit: false,
     started_at_ms: @env.now().reinterpret_as_int64(),
+    cwd: match cwd {
+      Some(_) => cwd
+      None => @env.current_dir()
+    },
+    finished_at_ms: None,
     killed_by_time_limit: false,
   }
   group.spawn_bg(no_wait=true, allow_failure=true) <| () => {
@@ -150,12 +157,23 @@ async fn ShellExecution::monitor(
   reader : @process.ReadFromProcess,
   process : @process.Process,
 ) -> Unit {
+  defer self.sink.close()
+  errdefer self.set_terminal(Killed)
   let reader_done : @async.Queue[Unit] = Queue(kind=Unbounded)
   @async.with_task_group(reads => {
     reads.spawn_bg(no_wait=true, allow_failure=true) <| () => {
       defer ignore(reader_done.try_put(()) catch { _ => false })
+      errdefer self.request_stop()
       for ;; {
-        match (reader.read_some(max_len=1024) catch { _ => None }) {
+        match
+          (reader.read_some(max_len=1024) catch {
+            error if @async.is_being_cancelled() => raise error
+            error => {
+              let message = "failed to read process output: \{error}"
+              self.sink.failure = Some(message)
+              fail(message)
+            }
+          }) {
           None => break
           Some(bytes) => {
             self.sink.append_chunk(bytes)
@@ -213,8 +231,20 @@ async fn ShellExecution::monitor(
     // Surface leftover half-decoded bytes, then publish the terminal status — in
     // that order, so a poller can never observe a terminal execution missing the
     // job's final output.
-    self.sink.finish()
-    self.set_terminal(terminal)
+    self.sink.finish() catch {
+      error => {
+        let message = "failed to finish output log: \{error}"
+        self.sink.failure = Some(message)
+        fail(message)
+      }
+    }
+    self.set_terminal(
+      if self.sink.failure is Some(_) {
+        Killed
+      } else {
+        terminal
+      },
+    )
   })
 }
 
@@ -227,6 +257,7 @@ fn ShellExecution::set_terminal(
 ) -> Unit {
   guard !self.status.is_terminal() else { return }
   self.status = status
+  self.finished_at_ms = Some(@env.now().reinterpret_as_int64())
 }
 
 ///|
@@ -355,7 +386,7 @@ pub fn ShellExecution::killed_by_output_limit(self : ShellExecution) -> Bool {
 }
 
 ///|
-/// Monotonic timestamp (ms) when the child was spawned.
+/// Epoch timestamp (ms) when the child was spawned.
 pub fn ShellExecution::started_at_ms(self : ShellExecution) -> Int64 {
   self.started_at_ms
 }
@@ -560,3 +591,47 @@ pub extend ExecStatus with Debug::{to_repr}
 
 ///|
 pub extend ExecStatus with Eq::{equal, not_equal}
+
+///|
+/// Ensure a configured output file exists before announcing background adoption.
+/// Existing spill files are reused, including terminal executions adopted in a race.
+pub async fn ShellExecution::materialize_output(self : ShellExecution) -> Unit {
+  self.sink.materialize()
+  if self.status.is_terminal() {
+    self.sink.close()
+  }
+}
+
+///|
+/// A capture/write failure, distinct from a program's exit status.
+pub fn ShellExecution::output_error(self : ShellExecution) -> String? {
+  self.sink.failure
+}
+
+///|
+/// The effective working directory, when available.
+pub fn ShellExecution::cwd(self : ShellExecution) -> String? {
+  self.cwd
+}
+
+///|
+/// Epoch milliseconds when the direct execution became terminal.
+pub fn ShellExecution::finished_at_ms(self : ShellExecution) -> Int64? {
+  self.finished_at_ms
+}
+
+///|
+/// Epoch milliseconds of the last captured output, if any.
+pub fn ShellExecution::last_output_at_ms(self : ShellExecution) -> Int64? {
+  self.sink.last_output_at_ms
+}
+
+///|
+/// The number of committed UTF-8 output bytes.
+pub fn ShellExecution::output_bytes(self : ShellExecution) -> Int64 {
+  if self.sink.file_created {
+    self.sink.file_bytes
+  } else {
+    @utf8.encode(self.head()).length().to_int64()
+  }
+}

--- a/agent_tool/shell_exec/materialize_wbtest.mbt
+++ b/agent_tool/shell_exec/materialize_wbtest.mbt
@@ -1,0 +1,122 @@
+///|
+async test "background materialization seeds small output and preserves an empty file" {
+  let dir = @fs.tmpdir(prefix="openseek-materialize-")
+  defer @fs.rmdir(dir, recursive=true)
+  let path = "\{dir}/output.log"
+  let sink = ShellOutputSink(inline_cap=100, spill_path=path)
+  defer sink.close()
+  sink.materialize()
+  assert_true(@fs.exists(path))
+  assert_eq(@fs.read_file(path).text(), "")
+  sink.append_chunk(b"early")
+  assert_eq(@fs.read_file(path).text(), "early")
+  sink.materialize()
+  sink.append_text(" later")
+  assert_eq(@fs.read_file(path).text(), "early later")
+  sink.close()
+  assert_eq(sink.read_all(), "early later")
+  assert_eq(sink.read_tail(5), "later")
+}
+
+///|
+async test "materialization serializes with the writer and retains split UTF-8" {
+  let dir = @fs.tmpdir(prefix="openseek-materialize-race-")
+  defer @fs.rmdir(dir, recursive=true)
+  let path = "\{dir}/output.log"
+  let sink = ShellOutputSink(inline_cap=10000, spill_path=path)
+  defer sink.close()
+  sink.append_chunk(([0x63, 0x61, 0x66, 0xc3] : Bytes))
+  assert_false(@fs.exists(path))
+  @async.with_task_group(group => {
+    group.spawn_bg(() => sink.materialize())
+    group.spawn_bg(() => {
+      sink.append_chunk(([0xa9] : Bytes))
+      for _ in 0..<100 {
+        sink.append_text("\n进度")
+      }
+    })
+  })
+  sink.finish()
+  let expected = "café"
+  assert_true(@fs.read_file(path).text().has_prefix(expected))
+  assert_eq(@fs.read_file(path).text(), sink.head())
+  assert_eq(sink.size(), 304)
+}
+
+///|
+async test "a failed log write never advances the committed offset or hides the failure" {
+  let dir = @fs.tmpdir(prefix="openseek-log-error-")
+  defer @fs.rmdir(dir, recursive=true)
+  let path = "\{dir}/output.log"
+  let sink = ShellOutputSink(inline_cap=100, spill_path=path)
+  defer sink.close()
+  sink.append_text("before")
+  sink.materialize()
+  let committed = sink.file_bytes
+  sink.close()
+  sink.file = Some(@fs.open(path, mode=ReadOnly))
+  try sink.append_text("after") catch {
+    _ => assert_true(sink.failure is Some(_))
+  } noraise {
+    _ => fail("expected write failure")
+  }
+  assert_eq(sink.file_bytes, committed)
+  assert_eq(sink.read_all(), "before")
+}
+
+///|
+async test "file creation and read failures are distinct from an empty log" {
+  let dir = @fs.tmpdir(prefix="openseek-log-missing-")
+  defer @fs.rmdir(dir, recursive=true)
+  let bad = ShellOutputSink(inline_cap=100, spill_path="\{dir}/missing/out")
+  try bad.materialize() catch {
+    _ => assert_true(bad.failure is Some(_))
+  } noraise {
+    _ => fail("expected creation failure")
+  }
+  let path = "\{dir}/out"
+  let sink = ShellOutputSink(inline_cap=100, spill_path=path)
+  sink.materialize()
+  sink.close()
+  @fs.remove(path)
+  try sink.read_tail(100) catch {
+    _ => ()
+  } noraise {
+    _ => fail("expected read failure")
+  }
+}
+
+///|
+async test "full reads remain consistent while output is appended" {
+  let dir = @fs.tmpdir(prefix="openseek-read-prefix-")
+  defer @fs.rmdir(dir, recursive=true)
+  let sink = ShellOutputSink(inline_cap=100, spill_path="\{dir}/log")
+  defer sink.close()
+  let prefix = "你好🙂".repeat(100000)
+  sink.append_text(prefix)
+  @async.with_task_group(group => {
+    let read = group.spawn(() => sink.read_all())
+    sink.append_text("end")
+    let text = read.wait()
+    assert_true(text == prefix || text == prefix + "end")
+  })
+  assert_eq(sink.read_all(), prefix + "end")
+}
+
+///|
+async test "a failed seed keeps the captured head readable and partial path inspectable" {
+  let dir = @fs.tmpdir(prefix="openseek-seed-failure-")
+  defer @fs.rmdir(dir, recursive=true)
+  let path = "\{dir}/log"
+  let sink = ShellOutputSink(inline_cap=100, spill_path=path)
+  sink.append_text("captured before adoption")
+  // Inject the state left by a partial initial write: the path exists but
+  // no complete write was committed. Do not replace the retained memory head.
+  @fs.write_file(path, "captured")
+  sink.file_created = true
+  sink.failure = Some("seed write failed")
+  assert_eq(sink.file_bytes, 0L)
+  assert_eq(sink.spill_path(), Some(path))
+  assert_eq(sink.read_all(), "captured before adoption")
+  assert_true(sink.failure is Some(_))
+}

--- a/agent_tool/shell_exec/pkg.generated.mbti
+++ b/agent_tool/shell_exec/pkg.generated.mbti
@@ -25,13 +25,19 @@ pub fn ExecStatus::to_repr(Self) -> @debug.Repr
 
 type ShellExecution
 pub fn ShellExecution::background(Self) -> Bool
+pub fn ShellExecution::cwd(Self) -> String?
 pub async fn ShellExecution::discard(Self) -> Unit
 pub fn ShellExecution::exit_code(Self) -> Int?
+pub fn ShellExecution::finished_at_ms(Self) -> Int64?
 pub fn ShellExecution::had_invalid_utf8(Self) -> Bool
 pub fn ShellExecution::head(Self) -> String
 pub fn ShellExecution::kill_for_time_limit(Self) -> Unit
 pub fn ShellExecution::killed_by_output_limit(Self) -> Bool
 pub fn ShellExecution::killed_by_time_limit(Self) -> Bool
+pub fn ShellExecution::last_output_at_ms(Self) -> Int64?
+pub async fn ShellExecution::materialize_output(Self) -> Unit
+pub fn ShellExecution::output_bytes(Self) -> Int64
+pub fn ShellExecution::output_error(Self) -> String?
 pub fn ShellExecution::output_truncated(Self) -> Bool
 pub fn ShellExecution::over_inline_cap(Self) -> Bool
 pub async fn ShellExecution::read_all(Self) -> String

--- a/agent_tool/shell_exec/sink.mbt
+++ b/agent_tool/shell_exec/sink.mbt
@@ -25,6 +25,12 @@ pub let default_hard_cap : Int = 20_000_000
 /// large output, such as tests and runtimes without a spill directory.
 priv struct ShellOutputSink {
   // The first `inline_cap` characters, for inline rendering without a file read.
+  lock : @async.Mutex
+  // The path exists even if seeding fails; retain it for inspecting partial
+  // output. This does not assert that any bytes have committed successfully.
+  mut file_created : Bool
+  mut failure : String?
+  mut last_output_at_ms : Int64?
   head : StringBuilder
   mut head_chars : Int
   // Total decoded characters of full output (across memory + file), ≤ hard_cap.
@@ -42,7 +48,8 @@ priv struct ShellOutputSink {
   // Full-output spill file, opened lazily once output exceeds `inline_cap` and a
   // spill path is configured. None → memory-only (small output, or no path).
   mut file : @fs.File?
-  // Bytes written to the file so far (== full output byte length once spilled).
+  // Bytes covered by successful writes. A failed write may leave additional
+  // partial bytes on disk; failure stays explicit and this cursor does not move.
   mut file_bytes : Int64
   // Where to spill; None → never spill (memory-only, head kept, rest dropped).
   spill_path : String?
@@ -59,6 +66,10 @@ fn ShellOutputSink::ShellOutputSink(
   spill_path? : String,
 ) -> ShellOutputSink {
   {
+    lock: Mutex(),
+    file_created: false,
+    failure: None,
+    last_output_at_ms: None,
     head: StringBuilder(),
     head_chars: 0,
     total_chars: 0,
@@ -81,6 +92,8 @@ async fn ShellOutputSink::append_chunk(
   self : ShellOutputSink,
   chunk : Bytes,
 ) -> Unit {
+  self.lock.acquire()
+  defer self.lock.release()
   let buffer = Buffer()
   buffer.write_bytes(self.pending)
   buffer.write_bytes(chunk)
@@ -89,7 +102,7 @@ async fn ShellOutputSink::append_chunk(
   if invalid {
     self.had_invalid = true
   }
-  self.append_text(text)
+  self.append_locked(text)
 }
 
 ///|
@@ -101,6 +114,19 @@ async fn ShellOutputSink::append_text(
   self : ShellOutputSink,
   text : String,
 ) -> Unit {
+  self.lock.acquire()
+  defer self.lock.release()
+  self.append_locked(text)
+}
+
+///|
+async fn ShellOutputSink::append_locked(
+  self : ShellOutputSink,
+  text : String,
+) -> Unit {
+  if self.failure is Some(error) {
+    fail(error)
+  }
   guard text != "" else { return }
   guard !self.truncated else { return }
   let room_hard = self.hard_cap - self.total_chars
@@ -116,17 +142,27 @@ async fn ShellOutputSink::append_text(
   }
   // Full output → spill file. Open lazily the first time total output would pass
   // the inline cap, seeding the file with everything buffered so far (the head,
-  // which holds all output while total ≤ inline_cap). A file-open/write failure
-  // degrades to memory-only (the head) rather than losing the run.
+  // which holds all output while total ≤ inline_cap). A failed write is
+  // surfaced to the execution monitor, which stops the tracked process.
   if self.spill_path is Some(path) {
     if self.file is None &&
       self.total_chars + text.char_length() > self.inline_cap {
-      self.open_spill(path)
+      self.open_spill(path) catch {
+        error => {
+          let message = "failed to create output log: \{error}"
+          self.failure = Some(message)
+          fail(message)
+        }
+      }
     }
     if self.file is Some(file) {
       let bytes = @utf8.encode(text)
       file.write_at(bytes, position=self.file_bytes) catch {
-        _ => ()
+        error => {
+          let message = "failed to write output log: \{error}"
+          self.failure = Some(message)
+          fail(message)
+        }
       }
       self.file_bytes += bytes.length().to_int64()
     }
@@ -144,6 +180,7 @@ async fn ShellOutputSink::append_text(
   }
   self.total_chars += text.char_length()
   self.seq += 1
+  self.last_output_at_ms = Some(@env.now().reinterpret_as_int64())
 }
 
 ///|
@@ -155,16 +192,11 @@ async fn ShellOutputSink::open_spill(
   // ReadWrite so the same descriptor serves both the streaming writes and later
   // `read_all` reads (a create/write-only handle cannot be read). CreateOrTruncate
   // gives a fresh file (the path is unique per job id).
-  let file = @fs.open(path, mode=ReadWrite, create_mode=CreateOrTruncate) catch {
-    _ => return
-  }
+  let file = @fs.open(path, mode=ReadWrite, create_mode=CreateOrTruncate)
+  self.file_created = true
+  errdefer file.close()
   let seed = @utf8.encode(self.head.to_string())
-  file.write_at(seed, position=0) catch {
-    _ => {
-      file.close()
-      return
-    }
-  }
+  file.write_at(seed, position=0)
   self.file = Some(file)
   self.file_bytes = seed.length().to_int64()
 }
@@ -173,17 +205,19 @@ async fn ShellOutputSink::open_spill(
 /// Flush any incomplete trailing UTF-8 bytes at end of stream (decoded lossily),
 /// so a multi-byte character that never completed is surfaced rather than lost.
 async fn ShellOutputSink::finish(self : ShellOutputSink) -> Unit {
+  self.lock.acquire()
+  defer self.lock.release()
   guard self.pending.length() > 0 else { return }
   // A non-empty pending buffer at end of stream is an incomplete (or invalid)
   // sequence — strict decoding would have rejected it, so mark it binary.
   self.had_invalid = true
   let text = @utf8.decode_lossy(self.pending)
   self.pending = b""
-  self.append_text(text)
+  self.append_locked(text)
 }
 
 ///|
-/// Release the spill file descriptor. Reads after this fall back to the head.
+/// Release the write descriptor. Later reads reopen the retained file.
 fn ShellOutputSink::close(self : ShellOutputSink) -> Unit {
   if self.file is Some(file) {
     file.close()
@@ -196,8 +230,9 @@ fn ShellOutputSink::close(self : ShellOutputSink) -> Unit {
 /// the foreground (never adopted as a background job), so its temp file does not
 /// leak. Full output is no longer readable after this (the head remains).
 async fn ShellOutputSink::discard(self : ShellOutputSink) -> Unit {
-  guard self.file is Some(_) else { return }
+  guard self.file_created else { return }
   self.close()
+  self.file_created = false
   if self.spill_path is Some(path) {
     @fs.remove(path) catch {
       _ => ()
@@ -247,7 +282,7 @@ fn ShellOutputSink::over_inline_cap(self : ShellOutputSink) -> Bool {
 ///|
 /// The spill file's path, if output spilled to disk; `None` for memory-only.
 fn ShellOutputSink::spill_path(self : ShellOutputSink) -> String? {
-  if self.file is Some(_) {
+  if self.file_created {
     self.spill_path
   } else {
     None
@@ -257,41 +292,70 @@ fn ShellOutputSink::spill_path(self : ShellOutputSink) -> String? {
 ///|
 /// The full retained output. Reads the spill file when output spilled; otherwise
 /// returns the in-memory head (which is the full output for a small command). On
-/// a read error it degrades to the head rather than raising.
+/// a read error it raises rather than disguising a stale head as full output.
 async fn ShellOutputSink::read_all(self : ShellOutputSink) -> String {
-  match self.file {
-    Some(file) => {
-      let bytes = file.read_exactly_at(self.file_bytes.to_int(), position=0) catch {
-        _ => return self.head.to_string()
-      }
-      @utf8.decode_lossy(bytes)
+  let (path, committed, head) = {
+    self.lock.acquire()
+    defer self.lock.release()
+    let path = if self.file_bytes == 0L && self.failure is Some(_) {
+      None
+    } else {
+      self.spill_path()
     }
-    None => self.head.to_string()
+    (path, self.file_bytes, self.head.to_string())
+  }
+  match path {
+    Some(path) => {
+      // Only appenders advance the committed cursor. A separate reader can
+      // read this immutable prefix without backpressuring the pipe writer.
+      let file = @fs.open(path, mode=ReadOnly)
+      defer file.close()
+      @utf8.decode_lossy(file.read_exactly_at(committed.to_int(), position=0))
+    }
+    None => head
   }
 }
 
 ///|
 /// The last `n` characters of full output — a window onto the *recent* output of
 /// a (possibly still-running) job, read from the tail of the spill file so a
-/// poller sees progress rather than the unchanging prefix. Degrades to the head
-/// on a read error or a memory-only sink.
+/// poller sees progress rather than the unchanging prefix. Read errors raise.
 async fn ShellOutputSink::read_tail(self : ShellOutputSink, n : Int) -> String {
   guard n > 0 else { return "" }
-  match self.file {
-    Some(file) => {
-      // Read a byte window sized for `n` UTF-8 chars (≤ 4 bytes each) from the
-      // file tail, decode lossily (a partial lead byte at the window start
-      // becomes a replacement char, dropped when we keep the last `n`), then keep
-      // the last `n` characters.
-      let want = n.to_int64() * 4 + 4
-      let start = (self.file_bytes - want).max(0)
-      let len = (self.file_bytes - start).to_int()
-      let bytes = file.read_exactly_at(len, position=start) catch {
-        _ => return self.head.to_string()
+  self.lock.acquire()
+  defer self.lock.release()
+  if self.spill_path() is Some(path) {
+    let file = @fs.open(path, mode=ReadOnly)
+    defer file.close()
+    let want = n.to_int64() * 4 + 4
+    let start = (self.file_bytes - want).max(0)
+    let bytes = file.read_exactly_at(
+      (self.file_bytes - start).to_int(),
+      position=start,
+    )
+    last_chars(@utf8.decode_lossy(bytes), n)
+  } else {
+    last_chars(self.head.to_string(), n)
+  }
+}
+
+///|
+/// Serialize adoption with output writes. No configured path explicitly means
+/// a memory-only embedding; a configured path must be materialized successfully.
+async fn ShellOutputSink::materialize(self : ShellOutputSink) -> Unit {
+  self.lock.acquire()
+  defer self.lock.release()
+  if self.failure is Some(error) {
+    fail(error)
+  }
+  if !self.file_created && self.spill_path is Some(path) {
+    self.open_spill(path) catch {
+      error => {
+        let message = "failed to create output log: \{error}"
+        self.failure = Some(message)
+        fail(message)
       }
-      last_chars(@utf8.decode_lossy(bytes), n)
     }
-    None => last_chars(self.head.to_string(), n)
   }
 }
 

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -215,6 +215,7 @@ async fn run_task_command(matches : @argparse.Matches) -> Unit {
           matches,
           session,
           append_item=(session, item) => store.append(session, item),
+          job_log_dir=store.job_logs_dir(id),
           api_key~,
           model~,
           task~,
@@ -286,6 +287,7 @@ async fn run_task_turn(
   workspace_root~ : String,
   review_deadline_ms~ : Int?,
   child_session? : @agent_subrun.ChildSession,
+  job_log_dir? : String,
 ) -> Unit {
   @async.with_task_group() <| group => {
     // `run` reads no commands, so there is nobody to ask: `--approval ask` is
@@ -318,7 +320,13 @@ async fn run_task_turn(
         audit_criteria(latest_session.val)
       })
     })
-    let tools = @agent.build_tools(runtime, scope, extra_tools~, mbtx_subrun?)
+    let tools = @agent.build_tools(
+      runtime,
+      scope,
+      extra_tools~,
+      mbtx_subrun?,
+      job_log_dir?,
+    )
     let on_goal_met = if review_gate_enabled(matches) {
       Some(
         build_goal_met_gate(

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -6,6 +6,8 @@ priv enum ServeCommand {
   Steer(@agent_runtime.SteerInput)
   Compact
   Cancel
+  JobsSnapshot(request_id~ : String)
+  JobStop(request_id~ : String, generation~ : String, job_id~ : String)
   Goal(GoalAction)
   /// The answer to an `approval_requested` event: which question, and whether
   /// it is granted. Both labelled, because a bare positional pair reads as
@@ -137,6 +139,7 @@ priv enum ServeStep {
 
 ///|
 /// Decode one JSONL command line from the controller.
+/// `jobs_snapshot` and `job_stop` are correlated controls handled outside turns.
 ///
 /// `prompt` starts a turn, `steer` supplies typed step-boundary input, `compact`
 /// summarizes the current conversation once no work is active, and `cancel`
@@ -178,6 +181,9 @@ fn decode_serve_command(json : Json) -> Result[ServeCommand, String] {
           },
         ),
       )
+    JobsSnapshot(request_id~) => Ok(JobsSnapshot(request_id~))
+    JobStop(request_id~, generation~, job_id~) =>
+      Ok(JobStop(request_id~, generation~, job_id~))
     Compact => Ok(Compact)
     Cancel => Ok(Cancel)
     GoalSet(text~, auto~) =>
@@ -193,6 +199,19 @@ fn decode_serve_command(json : Json) -> Result[ServeCommand, String] {
 
 ///|
 test "serve commands decode and reject with actionable errors" {
+  assert_true(
+    decode_serve_command({ "command": "jobs_snapshot", "request_id": "list-1" })
+    is Ok(JobsSnapshot(request_id="list-1")),
+  )
+  assert_true(
+    decode_serve_command({
+      "command": "job_stop",
+      "request_id": "stop-1",
+      "generation": "runtime-1",
+      "job_id": "bg-1",
+    })
+    is Ok(JobStop(request_id="stop-1", generation="runtime-1", job_id="bg-1")),
+  )
   assert_true(
     decode_serve_command({ "command": "prompt", "text": "hi" })
     is Ok(Prompt("hi", submission_id=None)),
@@ -680,9 +699,14 @@ async fn run_serve(
     } else {
       None
     }
+    let job_log_dir = match store {
+      Some(store) => Some(store.job_logs_dir(initial_session.id()))
+      None => None
+    }
     let tools = @agent.build_tools(
       runtime,
       scope,
+      job_log_dir?,
       on_background_wake=() => {
         ignore(steps.try_put(BackgroundNotice) catch { _ => false })
       },
@@ -1061,6 +1085,37 @@ async fn run_serve(
                 runtime.queue_steer(Notice(text))
               }
           }
+        Wire(JobsSnapshot(request_id~)) => {
+          let jobs = match tools.background_job_runtime() {
+            Some(runtime) => runtime.records()
+            None => []
+          }
+          @emit.emit(JobsSnapshot(request_id~, jobs~))
+        }
+        Wire(JobStop(request_id~, generation~, job_id~)) => {
+          let _ = group.spawn(no_wait=true) <| () => {
+            let outcome : @protocol.JobStopOutcome = match
+              tools.background_job_runtime() {
+              None => NotFound
+              Some(jobs) =>
+                if jobs.generation() != generation {
+                  WrongRuntime
+                } else if jobs.snapshot(job_id) is None {
+                  NotFound
+                } else if jobs
+                  .records()
+                  .any(job => job.id == job_id && job.state.is_terminal()) {
+                  AlreadyTerminal
+                } else {
+                  ignore(jobs.stop(job_id))
+                  Stopped
+                }
+            }
+            @emit.emit(
+              JobStopResult(request_id~, generation~, job_id~, outcome~),
+            )
+          }
+        }
         Wire(Cancel) => {
           // A user interrupt stops the autonomous loop, not just one turn —
           // including any auto intent still queued behind pending work.

--- a/desktop/frontend/transcript/engine_event.mbt
+++ b/desktop/frontend/transcript/engine_event.mbt
@@ -101,6 +101,7 @@ pub fn decode_engine_event(
   stream : @desktop_protocol.AgentStreamEvent,
 ) -> EngineEvent? {
   match stream.event {
+    JobChanged(..) | JobsSnapshot(..) | JobStopResult(..) => None
     AgentStep(step~) => Some(AgentStep(Some(step)))
     StreamRetry(attempt~, max_attempts~, reason~) =>
       Some(StreamRetry(attempt~, max_attempts~, reason~))

--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -231,7 +231,12 @@ fn ends_with_turn(command : @wire.Command) -> Bool {
   // rather than being delivered into a turn that never asked.
   match command {
     Cancel | Steer(..) | ApprovalDecision(..) => true
-    Prompt(..) | Compact | GoalSet(..) | GoalClear => false
+    Prompt(..)
+    | Compact
+    | GoalSet(..)
+    | GoalClear
+    | JobsSnapshot(..)
+    | JobStop(..) => false
   }
 }
 

--- a/protocol/command.mbt
+++ b/protocol/command.mbt
@@ -36,6 +36,8 @@ pub(all) enum Command {
   Steer(kind~ : SteerKind, text~ : String)
   Compact
   Cancel
+  JobsSnapshot(request_id~ : String)
+  JobStop(request_id~ : String, generation~ : String, job_id~ : String)
   /// `auto` arms autonomous continuation toward the goal. No in-repo client
   /// sends it — the TUI's `/goal` always sets a manual goal — but `serve` is a
   /// protocol, not a private channel, and an external controller drives this.
@@ -75,6 +77,15 @@ pub fn Command::to_json(self : Command) -> Json {
           Command => "command"
         },
         "text": text,
+      }
+    JobsSnapshot(request_id~) =>
+      { "command": "jobs_snapshot", "request_id": request_id }
+    JobStop(request_id~, generation~, job_id~) =>
+      {
+        "command": "job_stop",
+        "request_id": request_id,
+        "generation": generation,
+        "job_id": job_id,
       }
     Compact => { "command": "compact" }
     Cancel => { "command": "cancel" }
@@ -150,6 +161,20 @@ pub fn Command::parse(line : Json) -> Result[Command, String] {
       Ok(Prompt(text~, submission_id=None))
     { "command": "steer", .. } => parse_steer(line)
     { "command": "prompt", .. } => Err("expected a string \"text\" field")
+    { "command": "jobs_snapshot", "request_id": String(request_id), .. } if !request_id.is_empty() =>
+      Ok(JobsSnapshot(request_id~))
+    {
+      "command": "job_stop",
+      "request_id": String(request_id),
+      "generation": String(generation),
+      "job_id": String(job_id),
+      ..
+    } if !request_id.is_empty() &&
+      valid_job_component(generation) &&
+      valid_job_component(job_id) =>
+      Ok(JobStop(request_id~, generation~, job_id~))
+    { "command": "jobs_snapshot" | "job_stop", .. } =>
+      Err("invalid background job command")
     { "command": "compact", .. } => Ok(Compact)
     { "command": "cancel", .. } => Ok(Cancel)
     // A blank goal decodes: `{"action":"set","text":"  "}` is a well-formed

--- a/protocol/command_test.mbt
+++ b/protocol/command_test.mbt
@@ -17,6 +17,8 @@ fn all_commands() -> Array[@openseek_protocol.Command] {
     Prompt(text="do it exactly once", submission_id=Some("page-1-submission-2")),
     Steer(kind=Prompt, text="also fix docs"),
     Steer(kind=Command, text="<user_shell_command>"),
+    JobsSnapshot(request_id="jobs-1"),
+    JobStop(request_id="stop-1", generation="runtime-1", job_id="bg-1"),
     Compact,
     Cancel,
     GoalSet(text="ship it", auto=false),

--- a/protocol/event.mbt
+++ b/protocol/event.mbt
@@ -85,6 +85,16 @@ pub(all) enum Event {
   SteerDropped(content~ : String)
   BackgroundNotice(content~ : String)
 
+  // Background execution events are session-scoped and may arrive between turns.
+  JobChanged(kind~ : JobEventKind, job~ : JobRecord)
+  JobsSnapshot(request_id~ : String, jobs~ : Array[JobRecord])
+  JobStopResult(
+    request_id~ : String,
+    generation~ : String,
+    job_id~ : String,
+    outcome~ : JobStopOutcome
+  )
+
   // ── goal ───────────────────────────────────────────────────────────────
   GoalUpdated(goal~ : String?)
   GoalBlocked(reason~ : String)

--- a/protocol/jobs.mbt
+++ b/protocol/jobs.mbt
@@ -1,0 +1,365 @@
+///|
+/// The tracked execution's state. Interrupted means its owner disappeared;
+/// it does not assert that every descendant process was terminated.
+pub(all) enum JobState {
+  Running
+  Stopping
+  Exited(Int)
+  Stopped(String)
+  Interrupted
+} derive(Eq, Debug)
+
+///|
+pub(all) enum JobEventKind {
+  Started
+  Updated
+  Finished
+  Failed
+} derive(Eq, Debug)
+
+///|
+pub(all) enum JobStopOutcome {
+  Stopped
+  AlreadyTerminal
+  NotFound
+  WrongRuntime
+} derive(Eq, Debug)
+
+///|
+/// A durable background execution record. output_file is a basename relative
+/// to jobs/<generation>; clients resolve its current host path via the store.
+pub(all) struct JobRecord {
+  generation : String
+  id : String
+  revision : Int
+  command : String
+  description : String?
+  cwd : String?
+  state : JobState
+  started_at_ms : Int64
+  backgrounded_at_ms : Int64
+  finished_at_ms : Int64?
+  last_output_at_ms : Int64?
+  output_file : String?
+  output_persistent : Bool
+  output_bytes : Int64
+  output_chars : Int
+  output_truncated : Bool
+  invalid_utf8 : Bool
+  output_error : String?
+  persistence_error : String?
+  cleanup_error : String?
+} derive(Eq, Debug)
+
+///|
+pub fn JobState::is_terminal(self : JobState) -> Bool {
+  match self {
+    Running | Stopping => false
+    _ => true
+  }
+}
+
+///|
+pub impl ToJson for JobState with fn to_json(self) {
+  match self {
+    Running => { "kind": "running" }
+    Stopping => { "kind": "stopping" }
+    Exited(code) => { "kind": "exited", "code": code }
+    Stopped(reason) => { "kind": "stopped", "reason": reason }
+    Interrupted => { "kind": "interrupted" }
+  }
+}
+
+///|
+pub impl FromJson for JobState with fn from_json(json, path) {
+  match json {
+    { "kind": "running", .. } => Running
+    { "kind": "stopping", .. } => Stopping
+    { "kind": "interrupted", .. } => Interrupted
+    { "kind": "stopped", "reason": String(reason), .. } if !reason.is_empty() =>
+      Stopped(reason)
+    { "kind": "exited", "code": Number(code, ..), .. } if code >= -2147483648.0 &&
+      code <= 2147483647.0 &&
+      code.to_int().to_double() == code => Exited(code.to_int())
+    _ => raise JsonDecodeError((path, "invalid background job state"))
+  }
+}
+
+///|
+fn job_field(
+  fields : Map[String, Json],
+  name : String,
+  path : @json.JsonPath,
+) -> Json raise @json.JsonDecodeError {
+  match fields.get(name) {
+    Some(value) => value
+    None => raise JsonDecodeError((path, "missing job field: " + name))
+  }
+}
+
+///|
+fn[T : FromJson] job_optional(
+  fields : Map[String, Json],
+  name : String,
+  path : @json.JsonPath,
+) -> T? raise @json.JsonDecodeError {
+  match fields.get(name) {
+    None | Some(Null) => None
+    Some(value) => Some(T::from_json(value, path))
+  }
+}
+
+///|
+fn[T : ToJson] job_optional_json(value : T?) -> Json {
+  match value {
+    Some(value) => value.to_json()
+    None => Json::null()
+  }
+}
+
+///|
+fn job_uint(
+  fields : Map[String, Json],
+  name : String,
+  path : @json.JsonPath,
+) -> Int64 raise @json.JsonDecodeError {
+  match job_field(fields, name, path) {
+    Number(value, ..) if value >= 0 &&
+      value <= 9007199254740991.0 &&
+      value.to_int64().to_double() == value => value.to_int64()
+    _ =>
+      raise JsonDecodeError((path, "invalid nonnegative job integer: " + name))
+  }
+}
+
+///|
+fn job_optional_uint(
+  fields : Map[String, Json],
+  name : String,
+  path : @json.JsonPath,
+) -> Int64? raise @json.JsonDecodeError {
+  match fields.get(name) {
+    None | Some(Null) => None
+    Some(_) => Some(job_uint(fields, name, path))
+  }
+}
+
+///|
+/// An artifact component, never a path supplied by output text.
+pub fn valid_job_component(value : String) -> Bool {
+  !value.is_empty() &&
+  value != "." &&
+  value != ".." &&
+  value.length() <= 200 &&
+  value
+  .iter()
+  .all(c => {
+    c is ('a'..='z' | 'A'..='Z' | '0'..='9') || c == '-' || c == '_' || c == '.'
+  })
+}
+
+///|
+pub impl ToJson for JobRecord with fn to_json(self) {
+  {
+    "schema_version": 1,
+    "cleanup_error": job_optional_json(self.cleanup_error),
+    "generation": self.generation.to_json(),
+    "id": self.id.to_json(),
+    "revision": self.revision.to_json(),
+    "command": self.command.to_json(),
+    "description": job_optional_json(self.description),
+    "cwd": job_optional_json(self.cwd),
+    "state": self.state.to_json(),
+    "started_at_ms": self.started_at_ms.to_double().to_json(),
+    "backgrounded_at_ms": self.backgrounded_at_ms.to_double().to_json(),
+    "finished_at_ms": job_optional_json(
+      self.finished_at_ms.map(value => value.to_double()),
+    ),
+    "last_output_at_ms": job_optional_json(
+      self.last_output_at_ms.map(value => value.to_double()),
+    ),
+    "output_file": job_optional_json(self.output_file),
+    "output_persistent": self.output_persistent.to_json(),
+    "output_bytes": self.output_bytes.to_double().to_json(),
+    "output_chars": self.output_chars.to_json(),
+    "output_truncated": self.output_truncated.to_json(),
+    "invalid_utf8": self.invalid_utf8.to_json(),
+    "output_error": job_optional_json(self.output_error),
+    "persistence_error": job_optional_json(self.persistence_error),
+  }
+}
+
+///|
+pub impl FromJson for JobRecord with fn from_json(json, path) {
+  guard json is Object(fields) &&
+    fields.get("schema_version") is Some(Number(1, ..)) else {
+    raise JsonDecodeError((path, "expected background job schema version 1"))
+  }
+  let cleanup_error : String? = job_optional(fields, "cleanup_error", path)
+  let generation : String = FromJson::from_json(
+    job_field(fields, "generation", path),
+    path,
+  )
+  let id : String = FromJson::from_json(job_field(fields, "id", path), path)
+  let revision = job_uint(fields, "revision", path)
+  let command : String = FromJson::from_json(
+    job_field(fields, "command", path),
+    path,
+  )
+  let description : String? = job_optional(fields, "description", path)
+  let cwd : String? = job_optional(fields, "cwd", path)
+  let state : JobState = FromJson::from_json(
+    job_field(fields, "state", path),
+    path,
+  )
+  let started_at_ms = job_uint(fields, "started_at_ms", path)
+  let backgrounded_at_ms = job_uint(fields, "backgrounded_at_ms", path)
+  let finished_at_ms : Int64? = job_optional_uint(
+    fields, "finished_at_ms", path,
+  )
+  let last_output_at_ms : Int64? = job_optional_uint(
+    fields, "last_output_at_ms", path,
+  )
+  let output_file : String? = job_optional(fields, "output_file", path)
+  let output_persistent : Bool = FromJson::from_json(
+    job_field(fields, "output_persistent", path),
+    path,
+  )
+  let output_bytes = job_uint(fields, "output_bytes", path)
+  let output_chars = job_uint(fields, "output_chars", path)
+  let output_truncated : Bool = FromJson::from_json(
+    job_field(fields, "output_truncated", path),
+    path,
+  )
+  let invalid_utf8 : Bool = FromJson::from_json(
+    job_field(fields, "invalid_utf8", path),
+    path,
+  )
+  let output_error : String? = job_optional(fields, "output_error", path)
+  let persistence_error : String? = job_optional(
+    fields, "persistence_error", path,
+  )
+  guard valid_job_component(generation) &&
+    valid_job_component(id) &&
+    revision > 0 &&
+    revision <= 2147483647L &&
+    output_chars <= 2147483647L &&
+    (match output_file {
+      Some(file) => valid_job_component(file)
+      None => true
+    }) else {
+    raise JsonDecodeError((path, "invalid background job identity or count"))
+  }
+  {
+    generation,
+    cleanup_error,
+    id,
+    revision: revision.to_int(),
+    command,
+    description,
+    cwd,
+    state,
+    started_at_ms,
+    backgrounded_at_ms,
+    finished_at_ms,
+    last_output_at_ms,
+    output_file,
+    output_persistent,
+    output_bytes,
+    output_chars: output_chars.to_int(),
+    output_truncated,
+    invalid_utf8,
+    output_error,
+    persistence_error,
+  }
+}
+
+///|
+pub extend JobState with Eq::{equal, not_equal}
+
+///|
+pub extend JobState with Debug::{to_repr}
+
+///|
+pub extend JobRecord with Eq::{equal, not_equal}
+
+///|
+pub extend JobRecord with Debug::{to_repr}
+
+///|
+pub extend JobEventKind with Eq::{equal, not_equal}
+
+///|
+pub extend JobEventKind with Debug::{to_repr}
+
+///|
+pub extend JobStopOutcome with Eq::{equal, not_equal}
+
+///|
+pub extend JobStopOutcome with Debug::{to_repr}
+
+///|
+pub impl ToJson for JobEventKind with fn to_json(self) {
+  match self {
+    Started => "started".to_json()
+    Updated => "updated".to_json()
+    Finished => "finished".to_json()
+    Failed => "failed".to_json()
+  }
+}
+
+///|
+pub impl FromJson for JobEventKind with fn from_json(json, path) {
+  match json {
+    String("started") => Started
+    String("updated") => Updated
+    String("finished") => Finished
+    String("failed") => Failed
+    _ => raise JsonDecodeError((path, "invalid JobEventKind"))
+  }
+}
+
+///|
+pub impl ToJson for JobStopOutcome with fn to_json(self) {
+  match self {
+    Stopped => "stopped".to_json()
+    AlreadyTerminal => "already_terminal".to_json()
+    NotFound => "not_found".to_json()
+    WrongRuntime => "wrong_runtime".to_json()
+  }
+}
+
+///|
+pub impl FromJson for JobStopOutcome with fn from_json(json, path) {
+  match json {
+    String("stopped") => Stopped
+    String("already_terminal") => AlreadyTerminal
+    String("not_found") => NotFound
+    String("wrong_runtime") => WrongRuntime
+    _ => raise JsonDecodeError((path, "invalid JobStopOutcome"))
+  }
+}
+
+///|
+pub extend JobRecord with ToJson::{to_json}
+
+///|
+pub extend JobState with ToJson::{to_json}
+
+///|
+pub extend JobEventKind with ToJson::{to_json}
+
+///|
+pub extend JobStopOutcome with ToJson::{to_json}
+
+///|
+pub extend JobState with FromJson::{from_json}
+
+///|
+pub extend JobRecord with FromJson::{from_json}
+
+///|
+pub extend JobEventKind with FromJson::{from_json}
+
+///|
+pub extend JobStopOutcome with FromJson::{from_json}

--- a/protocol/jobs_test.mbt
+++ b/protocol/jobs_test.mbt
@@ -1,0 +1,70 @@
+///|
+fn sample_job() -> @openseek_protocol.JobRecord {
+  {
+    generation: "runtime-1",
+    id: "bg-1",
+    revision: 1,
+    command: "echo hello",
+    description: None,
+    cwd: Some("/tmp"),
+    state: Running,
+    started_at_ms: 100L,
+    backgrounded_at_ms: 101L,
+    finished_at_ms: None,
+    last_output_at_ms: None,
+    output_file: Some("fg-1.out"),
+    output_persistent: true,
+    output_bytes: 0L,
+    output_chars: 0,
+    output_truncated: false,
+    invalid_utf8: false,
+    output_error: None,
+    persistence_error: None,
+    cleanup_error: None,
+  }
+}
+
+///|
+test "job records and lifecycle wire messages roundtrip" {
+  let job = sample_job()
+  let decoded : @openseek_protocol.JobRecord = @json.from_json(job.to_json())
+  assert_eq(decoded, job)
+  let events : Array[@openseek_protocol.Event] = [
+    JobChanged(kind=Started, job~),
+    JobsSnapshot(request_id="r1", jobs=[job]),
+    JobStopResult(
+      request_id="r2",
+      generation="runtime-1",
+      job_id="bg-1",
+      outcome=WrongRuntime,
+    ),
+  ]
+  for event in events {
+    assert_eq(@openseek_protocol.parse(event.to_json()), Some(event))
+  }
+}
+
+///|
+test "job record decoder rejects malformed optional fields and unsafe identities" {
+  for
+    (key, value) in [
+      ("output_file", "../secret".to_json()),
+      ("generation", "/tmp".to_json()),
+      ("revision", (0).to_json()),
+      ("output_bytes", (-1).to_json()),
+      ("description", (7).to_json()),
+      ("finished_at_ms", 1.5.to_json()),
+      ("schema_version", (2).to_json()),
+    ] {
+    guard sample_job().to_json() is Object(fields) else {
+      fail("expected object")
+    }
+    fields[key] = value
+    try @json.from_json(fields.to_json()) catch {
+      _ => ()
+    } noraise {
+      (_ : @openseek_protocol.JobRecord) =>
+        fail("accepted invalid field \{key}")
+    }
+  }
+}

--- a/protocol/parse.mbt
+++ b/protocol/parse.mbt
@@ -47,6 +47,37 @@ pub fn parse(line : Json) -> Event? {
   guard line is Object(fields) else { return None }
   guard text(fields, "event") is Some(name) else { return None }
   match name {
+    "job_changed" => {
+      let kind : JobEventKind = match fields.get("kind") {
+        Some(value) => @json.from_json(value) catch { _ => return None }
+        None => return None
+      }
+      let job : JobRecord = match fields.get("job") {
+        Some(value) => @json.from_json(value) catch { _ => return None }
+        None => return None
+      }
+      Some(JobChanged(kind~, job~))
+    }
+    "jobs_snapshot" => {
+      guard text(fields, "request_id") is Some(request_id) else { return None }
+      let jobs : Array[JobRecord] = match fields.get("jobs") {
+        Some(value) => @json.from_json(value) catch { _ => return None }
+        None => return None
+      }
+      Some(JobsSnapshot(request_id~, jobs~))
+    }
+    "job_stop_result" => {
+      guard text(fields, "request_id") is Some(request_id) &&
+        text(fields, "generation") is Some(generation) &&
+        text(fields, "job_id") is Some(job_id) else {
+        return None
+      }
+      let outcome : JobStopOutcome = match fields.get("outcome") {
+        Some(value) => @json.from_json(value) catch { _ => return None }
+        None => return None
+      }
+      Some(JobStopResult(request_id~, generation~, job_id~, outcome~))
+    }
     "agent_setup_failed" =>
       text(fields, "error").map(error => AgentSetupFailed(error~))
     "agent_step" => int(fields, "step").map(step => AgentStep(step~))

--- a/protocol/pkg.generated.mbti
+++ b/protocol/pkg.generated.mbti
@@ -3,12 +3,15 @@ package "bobzhang/openseek_protocol"
 
 import {
   "moonbitlang/core/debug",
+  "moonbitlang/core/json",
 }
 
 // Values
 pub fn parse(Json) -> Event?
 
 pub fn split_child_session_id(String) -> (String, Int)?
+
+pub fn valid_job_component(String) -> Bool
 
 // Errors
 
@@ -18,6 +21,8 @@ pub(all) enum Command {
   Steer(kind~ : SteerKind, text~ : String)
   Compact
   Cancel
+  JobsSnapshot(request_id~ : String)
+  JobStop(request_id~ : String, generation~ : String, job_id~ : String)
   GoalSet(text~ : String, auto~ : Bool)
   GoalClear
   ApprovalDecision(id~ : String, allow~ : Bool)
@@ -49,6 +54,9 @@ pub(all) enum Event {
   SteerApplied(kind~ : String, content~ : String)
   SteerDropped(content~ : String)
   BackgroundNotice(content~ : String)
+  JobChanged(kind~ : JobEventKind, job~ : JobRecord)
+  JobsSnapshot(request_id~ : String, jobs~ : Array[JobRecord])
+  JobStopResult(request_id~ : String, generation~ : String, job_id~ : String, outcome~ : JobStopOutcome)
   GoalUpdated(goal~ : String?)
   GoalBlocked(reason~ : String)
   GoalUnblocked
@@ -90,6 +98,80 @@ pub fn Event::equal(Self, Self) -> Bool
 pub fn Event::not_equal(Self, Self) -> Bool
 pub fn Event::to_json(Self) -> Json
 pub fn Event::to_repr(Self) -> @debug.Repr
+
+pub(all) enum JobEventKind {
+  Started
+  Updated
+  Finished
+  Failed
+} derive(Eq, @debug.Debug)
+pub fn JobEventKind::equal(Self, Self) -> Bool
+pub fn JobEventKind::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn JobEventKind::not_equal(Self, Self) -> Bool
+pub fn JobEventKind::to_json(Self) -> Json
+pub fn JobEventKind::to_repr(Self) -> @debug.Repr
+pub impl ToJson for JobEventKind
+pub impl @json.FromJson for JobEventKind
+
+pub(all) struct JobRecord {
+  generation : String
+  id : String
+  revision : Int
+  command : String
+  description : String?
+  cwd : String?
+  state : JobState
+  started_at_ms : Int64
+  backgrounded_at_ms : Int64
+  finished_at_ms : Int64?
+  last_output_at_ms : Int64?
+  output_file : String?
+  output_persistent : Bool
+  output_bytes : Int64
+  output_chars : Int
+  output_truncated : Bool
+  invalid_utf8 : Bool
+  output_error : String?
+  persistence_error : String?
+  cleanup_error : String?
+} derive(Eq, @debug.Debug)
+pub fn JobRecord::equal(Self, Self) -> Bool
+pub fn JobRecord::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn JobRecord::not_equal(Self, Self) -> Bool
+pub fn JobRecord::to_json(Self) -> Json
+pub fn JobRecord::to_repr(Self) -> @debug.Repr
+pub impl ToJson for JobRecord
+pub impl @json.FromJson for JobRecord
+
+pub(all) enum JobState {
+  Running
+  Stopping
+  Exited(Int)
+  Stopped(String)
+  Interrupted
+} derive(Eq, @debug.Debug)
+pub fn JobState::equal(Self, Self) -> Bool
+pub fn JobState::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn JobState::is_terminal(Self) -> Bool
+pub fn JobState::not_equal(Self, Self) -> Bool
+pub fn JobState::to_json(Self) -> Json
+pub fn JobState::to_repr(Self) -> @debug.Repr
+pub impl ToJson for JobState
+pub impl @json.FromJson for JobState
+
+pub(all) enum JobStopOutcome {
+  Stopped
+  AlreadyTerminal
+  NotFound
+  WrongRuntime
+} derive(Eq, @debug.Debug)
+pub fn JobStopOutcome::equal(Self, Self) -> Bool
+pub fn JobStopOutcome::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn JobStopOutcome::not_equal(Self, Self) -> Bool
+pub fn JobStopOutcome::to_json(Self) -> Json
+pub fn JobStopOutcome::to_repr(Self) -> @debug.Repr
+pub impl ToJson for JobStopOutcome
+pub impl @json.FromJson for JobStopOutcome
 
 pub(all) enum SteerKind {
   Prompt

--- a/protocol/to_json.mbt
+++ b/protocol/to_json.mbt
@@ -26,6 +26,22 @@ fn or_null(value : String?) -> Json {
 /// own fields as one line; `parse` reads them from the top level.
 pub fn Event::to_json(self : Event) -> Json {
   match self {
+    JobChanged(kind~, job~) =>
+      { "event": "job_changed", "kind": kind.to_json(), "job": job.to_json() }
+    JobsSnapshot(request_id~, jobs~) =>
+      {
+        "event": "jobs_snapshot",
+        "request_id": request_id,
+        "jobs": jobs.to_json(),
+      }
+    JobStopResult(request_id~, generation~, job_id~, outcome~) =>
+      {
+        "event": "job_stop_result",
+        "request_id": request_id,
+        "generation": generation,
+        "job_id": job_id,
+        "outcome": outcome.to_json(),
+      }
     AgentSetupFailed(error~) =>
       { "event": "agent_setup_failed", "error": error }
     AgentStep(step~) => { "event": "agent_step", "step": step }

--- a/tests/integration/turn_finish.py
+++ b/tests/integration/turn_finish.py
@@ -16,7 +16,7 @@ import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 
-def run_case(executable, serve=False, read_workflow=False):
+def run_case(executable, serve=False, read_workflow=False, job_controls=False):
     with tempfile.TemporaryDirectory(prefix="openseek-turn-finish-") as directory:
         release = Path(directory) / "release"
         source = '''import { "moonbitlang/async", "moonbitlang/async/fs" }
@@ -24,6 +24,12 @@ async fn main {
   while !@fs.exists("release") { @async.sleep(10) }
   println("BACKGROUND-RESULT")
 }'''
+        if job_controls:
+            source = source.replace('  while ', '  println("PERSISTED-PREFIX 你好🙂")\n  while ', 1)
+        session_id = "job-control-session"
+        store_root = Path(directory) / "store"
+        retained_path = None
+        active_snapshot_seen = threading.Event()
         requests = []
         errors = []
         process = None
@@ -78,6 +84,8 @@ async fn main {
                     elif step == 1:
                         name, args = "mbtx", {"source": source}
                     elif step == 2:
+                        if job_controls:
+                            assert active_snapshot_seen.wait(15), "controller snapshot blocked behind the active model request"
                         assert "moved to the background" in messages, messages
                         self.respond({"content": "Waiting for the test result."})
                         return
@@ -133,6 +141,9 @@ async fn main {
                 "--api-url", f"http://127.0.0.1:{server.server_port}/chat/completions",
                 "--max-steps", "8", "--mcp-config", "",
             ]
+            if job_controls:
+                command.remove("--no-session")
+                command.extend(["--session", session_id, "--session-root", str(store_root)])
             if serve:
                 with tempfile.TemporaryFile(mode="w+") as stderr:
                     process = subprocess.Popen(command, env=env, stdin=subprocess.PIPE,
@@ -145,9 +156,46 @@ async fn main {
                         lines = []
                         for line in process.stdout:
                             lines.append(line)
-                            if line.startswith("{") and json.loads(line).get("event") == "agent_finished":
-                                process.stdin.close()
-                                process.stdin = None
+                            if not line.startswith("{"):
+                                continue
+                            event = json.loads(line)
+                            def send(value):
+                                process.stdin.write(json.dumps(value) + "\n")
+                                process.stdin.flush()
+                            if job_controls and event.get("event") == "job_changed" and event["kind"] == "started":
+                                job = event["job"]
+                                retained_path = store_root / "sessions" / session_id / "jobs" / job["generation"] / job["output_file"]
+                                assert retained_path.exists(), "announced before materializing output"
+                                assert "PERSISTED-PREFIX 你好🙂" in retained_path.read_text()
+                                send({"command": "jobs_snapshot", "request_id": "active-snapshot"})
+                            if event.get("event") == "agent_finished":
+                                if job_controls:
+                                    send({"command": "jobs_snapshot", "request_id": "idle-snapshot"})
+                                else:
+                                    process.stdin.close()
+                                    process.stdin = None
+                            elif job_controls and event.get("event") == "jobs_snapshot":
+                                job = event["jobs"][0]
+                                if event["request_id"] == "active-snapshot":
+                                    assert job["state"]["kind"] == "running", job
+                                    send({"command": "job_stop", "request_id": "active-stale", "generation": "stale-runtime", "job_id": job["id"]})
+                                elif event["request_id"] == "idle-snapshot":
+                                    assert job["state"]["kind"] == "running", job
+                                    send({"command": "job_stop", "request_id": "stale-stop", "generation": "stale-runtime", "job_id": job["id"]})
+                                elif event["request_id"] == "final-snapshot":
+                                    assert job["state"] == {"kind": "stopped", "reason": "user"}, job
+                                    process.stdin.close()
+                                    process.stdin = None
+                            elif job_controls and event.get("event") == "job_stop_result":
+                                if event["request_id"] == "active-stale":
+                                    assert event["outcome"] == "wrong_runtime", event
+                                    active_snapshot_seen.set()
+                                elif event["request_id"] == "stale-stop":
+                                    assert event["outcome"] == "wrong_runtime", event
+                                    send({"command": "job_stop", "request_id": "valid-stop", "generation": retained_path.parent.name, "job_id": "bg-1"})
+                                elif event["request_id"] == "valid-stop":
+                                    assert event["outcome"] == "stopped", event
+                                    send({"command": "jobs_snapshot", "request_id": "final-snapshot"})
                         process.wait(timeout=10)
                         stderr.seek(0)
                         run = subprocess.CompletedProcess(command, process.returncode, "".join(lines), stderr.read())
@@ -168,6 +216,22 @@ async fn main {
             finishes = [event for event in events if event.get("event") == "agent_finished"]
             assert len(finishes) == 1, finishes
             assert finishes[0]["answer"] == ("checked the read workflow" if read_workflow else "checked the background result"), finishes
+            if job_controls:
+                assert retained_path is not None
+                assert retained_path.read_text() == "PERSISTED-PREFIX 你好🙂\n"
+                changes = [event for event in events if event.get("event") == "job_changed"]
+                assert [event["kind"] for event in changes] == ["started", "updated", "finished"], changes
+                saved = json.loads((retained_path.parent / "bg-1.json").read_text())
+                assert saved["state"] == {"kind": "stopped", "reason": "user"}, saved
+                restarted = subprocess.run(command, input=json.dumps({"command": "jobs_snapshot", "request_id": "restart"}) + "\n",
+                                           env=env, capture_output=True, text=True, timeout=30)
+                assert restarted.returncode == 0, (restarted.stdout, restarted.stderr)
+                snapshots = [json.loads(line) for line in restarted.stdout.splitlines() if line.startswith("{") and json.loads(line).get("event") == "jobs_snapshot"]
+                assert snapshots and snapshots[0]["jobs"] == [], snapshots
+                assert retained_path.read_text() == "PERSISTED-PREFIX 你好🙂\n"
+                assert json.loads((retained_path.parent / "bg-1.json").read_text()) == saved
+                assert len(list(retained_path.parent.parent.iterdir())) == 1, "idle restart created unnecessary artifact directories"
+                print("PASS: durable serve jobs materialize before announcement, reject stale controls, stop while idle, and survive restart")
             if read_workflow:
                 results = [event for event in events if event.get("event") == "tool_result"
                            and event.get("tool_name") == "mbtx"]
@@ -185,4 +249,5 @@ if __name__ == "__main__":
     executable = str(Path(sys.argv[1]).resolve())
     run_case(executable)
     run_case(executable, serve=True)
+    run_case(executable, serve=True, job_controls=True)
     run_case(executable, read_workflow=True)


### PR DESCRIPTION
Background commands now expose a retained output file before their handoff or Started event. Output produced before background adoption is seeded into the same file, and subsequent output remains available for external tailing and later inspection. Small foreground commands remain memory-first.

This PR includes the complete runtime contract: generation-scoped metadata and ownership, structured lifecycle events, correlated snapshot/stop commands outside model turns, and retention with the owning session. Storage failures remain explicit. Failure to create required scratch/log storage stops setup or adoption with an error; production does not silently degrade to memory-only retention. Runtime review fixes and real CLI regressions are included here, so correctness does not depend on a later hardening PR.

Two small Desktop exhaustive-match adaptations accompany the new wire variants so this PR builds on its own. Desktop job access and the Jobs panel follow in #1468 and #1469.

## Follow-up hardening

- Remove an unused generation after foreground-only execution, only when no job was adopted and no unexpected files remain. Missing metadata is never a reason to delete a retained log.
- Snapshot the committed output prefix under the sink mutex and read the file outside the writer lock. Preserve the captured memory head after a failed initial seed while retaining the partial path for inspection.
- Add foreground-only cleanup, failed-metadata retention, concurrent append/read, and failed-seed regressions.

The review's proposed cleanup based only on absent JSON was narrowed to protect logs after metadata failure. The suggested terminal-event race was not established under the existing cooperative scheduling and serialized publication; no speculative ordering rewrite is included.

## Validation

Current-head `47543fb72` [CI](https://github.com/moonbitlang/openseek/actions/runs/34663737012) and [Desktop/Windows](https://github.com/moonbitlang/openseek/actions/runs/34663737043) passed. This PR remains one commit and is mergeable.

- Local combined-stack `moon info`, `moon fmt`, `just check`, `just test`, and `just build` passed. Final focused native regressions passed 262/262; Jobs state tests passed 8/8.
- Independent `openseek review` of the 13-file hardening delta found no blockers and two low-severity UI status issues. Both were fixed in #1469. The final four-file correction review returned **zero findings**. Runtime and host code needed no further review corrections.
- The complete final stack also passed 86 browser E2E scenarios and eight Windows job-host regressions; final aggregate evidence is recorded in #1469.

## Stack and review history

Plan #1465 is merged. Review and merge the implementation in this order: #1466 (runtime) → #1468 (host) → #1469 (UI).

The former lifecycle PR #1467 is absorbed into #1466. The corrections from #1470 are included in the layer they fix. This regrouping preserves the reviewed implementation and regression tests, retains newer main changes, and updates the delivery documentation. The original independent `openseek review` findings, resolutions, and aggregate validation remain available in #1470.
