### PR TITLE
Expose retained job history and bounded Desktop controls

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -102,6 +102,18 @@ jobs:
           CL: /bigobj
         run: moon run ./desktop/package/windows --target native -- --release --target app
 
+      - name: Test Windows background job paths and retained reads
+        env:
+          CL: /bigobj
+        run: |
+          # The test executable lives outside the packaged app, so Windows
+          # cannot find its linked Proton/CEF DLLs beside the executable.
+          $runtimeDirs = Get-ChildItem desktop/dist/seekmoon -Recurse -Filter *.dll |
+            Select-Object -ExpandProperty DirectoryName -Unique
+          if (-not $runtimeDirs) { throw 'Packaged app contains no runtime DLLs' }
+          $env:PATH = ($runtimeDirs -join ';') + ';' + $env:PATH
+          moon test desktop/internal/engine/jobs_wbtest.mbt --target native
+
       - name: Upload Windows app
         uses: actions/upload-artifact@v4
         with:

--- a/desktop/internal/api/api.mbt
+++ b/desktop/internal/api/api.mbt
@@ -443,6 +443,15 @@ pub fn endpoints(
     @endpoint.Endpoint::remote(@commands.agent_compact, async fn(payload) {
       @engine.compact_run(state.manager, payload)
     }),
+    @endpoint.Endpoint::remote(@commands.jobs_list, payload => {
+      @engine.list_jobs(state.manager, payload)
+    }),
+    @endpoint.Endpoint::remote(@commands.jobs_read, payload => {
+      @engine.read_job(state.manager, payload)
+    }),
+    @endpoint.Endpoint::remote(@commands.jobs_stop, payload => {
+      @engine.stop_job(state.manager, payload)
+    }),
     @endpoint.Endpoint::remote(@commands.agent_goal, async fn(payload) {
       @engine.goal_run(state.manager, payload)
     }),

--- a/desktop/internal/commands/commands.mbt
+++ b/desktop/internal/commands/commands.mbt
@@ -751,3 +751,18 @@ pub let browser_close : Command[
   @protocol.BrowserIdPayload,
   @protocol.EmptyReply,
 ] = Command("browser.close")
+
+///|
+pub let jobs_list : Command[@protocol.JobsListPayload, @protocol.JobsListReply] = Command(
+  "jobs.list",
+)
+
+///|
+pub let jobs_read : Command[@protocol.JobReadPayload, @protocol.JobReadReply] = Command(
+  "jobs.read",
+)
+
+///|
+pub let jobs_stop : Command[@protocol.JobTarget, @protocol.JobStopReply] = Command(
+  "jobs.stop",
+)

--- a/desktop/internal/commands/pkg.generated.mbti
+++ b/desktop/internal/commands/pkg.generated.mbti
@@ -165,6 +165,12 @@ pub let host_open_path : Command[@protocol.OpenPathPayload, @protocol.OpenPathRe
 
 pub let host_reveal_path : Command[@protocol.OpenPathPayload, @protocol.RevealPathReply]
 
+pub let jobs_list : Command[@protocol.JobsListPayload, @protocol.JobsListReply]
+
+pub let jobs_read : Command[@protocol.JobReadPayload, @protocol.JobReadReply]
+
+pub let jobs_stop : Command[@protocol.JobTarget, @protocol.JobStopReply]
+
 pub let lsp_hover : Command[@protocol.LspHoverPayload, @protocol.LspHoverReply]
 
 pub let lsp_open : Command[@protocol.LspOpenPayload, @protocol.LspDiagnosticsReply]

--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -63,6 +63,7 @@ priv struct ServeEngine {
   // gone, so a start joins its close barrier instead of racing it.
   mut condemned : Bool
   steer_runs : SteerRunTracker
+  job_requests : Map[String, @async.Queue[@wire.Event]]
   queued_runs : Array[QueuedRun]
 }
 
@@ -247,6 +248,10 @@ fn ends_with_turn(command : @wire.Command) -> Bool {
 /// stay the writer's to flush; `discard_commands` is the variant that also
 /// refuses them.
 fn ServeEngine::condemn(self : ServeEngine) -> Unit {
+  for _, reply in self.job_requests {
+    reply.close()
+  }
+  self.job_requests.clear()
   self.condemned = true
   self.commands.close()
 }
@@ -1588,6 +1593,7 @@ async fn[G] start_serve_engine(
     condemned: false,
     steer_runs: SteerRunTracker(),
     queued_runs: [],
+    job_requests: Map([]),
   }
   startup_engine = Some(engine)
   // Spawned before the handle is reachable from any request, so stdin has an
@@ -1764,6 +1770,17 @@ async fn ServeEngine::consume(
         // wakeup (its poll only backstops this).
         manager.kick_follower(engine.session_key)
         let wire_event = @wire.parse(json)
+        match wire_event {
+          Some(JobsSnapshot(request_id~, ..) as event)
+          | Some(JobStopResult(request_id~, ..) as event) => {
+            if self.job_requests.get(request_id) is Some(reply) {
+              ignore(reply.try_put(event) catch { _ => false })
+            }
+            // Private request replies are not conversation stream events.
+            continue
+          }
+          _ => ()
+        }
         // The brackets are the only thing that knows a sub-run's lifetime;
         // the probe in between reads the child's own record, which is the
         // only place its progress is visible to this process.
@@ -2264,6 +2281,7 @@ fn test_serve_engine(
     condemned,
     steer_runs: SteerRunTracker(),
     queued_runs: [],
+    job_requests: Map([]),
   }
 }
 

--- a/desktop/internal/engine/jobs.mbt
+++ b/desktop/internal/engine/jobs.mbt
@@ -1,0 +1,564 @@
+///|
+/// Locate the exact store selected by the conversation, including archives.
+async fn jobs_directory(scope : @protocol.JobsScope) -> String {
+  guard @session_store.safe_session_id(scope.session) else {
+    raise EngineError("invalid session id")
+  }
+  let root = match scope.workspace {
+    Some(hint) => {
+      let store = @session_store.ArchivedStore::for_workspace(hint)
+      store.root
+    }
+    None => {
+      let root = if scope.archived {
+        @session_store.archived_root_of(scope.session)
+      } else {
+        @session_store.root_of(scope.session)
+      }
+      guard root is Some(root) else {
+        raise EngineError("no attached workspace holds this conversation")
+      }
+      root
+    }
+  }
+  let root = if scope.archived {
+    @session_store.archived_root(root)
+  } else {
+    root
+  }
+  let session = root.join("sessions").join(Relative(scope.session)).to_string()
+  guard @fs.kind(session) is Directory else {
+    raise EngineError("session directory is unavailable")
+  }
+  jobs_store_path(root, scope.session)
+}
+
+///|
+fn EngineManager::jobs_engine(
+  self : EngineManager,
+  scope : @protocol.JobsScope,
+) -> ServeEngine? {
+  guard !scope.archived &&
+    self.pump is Serving(sessions~) &&
+    sessions.get(scope.session) is Some(slot) else {
+    return None
+  }
+  slot.live()
+}
+
+///|
+/// Correlated replies belong to this exact engine handle. Retirement closes
+/// pending requests; neither a new turn nor a replacement process can answer.
+async fn ServeEngine::job_request(
+  self : ServeEngine,
+  request_id : String,
+  command : @wire.Command,
+  settlement? : Bool = false,
+) -> @wire.Event {
+  let reply : @async.Queue[@wire.Event] = Queue(kind=Blocking(1))
+  self.job_requests[request_id] = reply
+  defer self.job_requests.remove(request_id)
+  let ack : @async.Queue[EngineError?] = Queue(kind=Blocking(1))
+  guard self.submit(
+    command,
+    failure_reason="background job command could not be delivered",
+    ack~,
+  ) else {
+    raise EngineError("background job engine is unavailable")
+  }
+  @async.with_timeout(5000, () => if ack.get() is Some(error) { raise error })
+  if settlement {
+    await_job_settlement(reply)
+  } else {
+    @async.with_timeout(5000, () => reply.get())
+  }
+}
+
+///|
+async fn read_job_record(
+  directory : String,
+  generation : String,
+  id : String,
+) -> @wire.JobRecord {
+  guard @wire.valid_job_component(generation) && @wire.valid_job_component(id) else {
+    raise EngineError("invalid job identity")
+  }
+  let file = @fs.open("\{directory}/\{generation}/\{id}.json", mode=ReadOnly)
+  defer file.close()
+  guard file.kind() is Regular else {
+    raise EngineError("job metadata is not a regular file")
+  }
+  let size = file.size()
+  guard size <= 1048576L else {
+    raise EngineError("job metadata exceeds 1 MiB")
+  }
+  let bytes = file.read_exactly_at(size.to_int(), position=0L)
+  let record : @wire.JobRecord = @json.from_json(
+    @json.parse(@utf8.decode(bytes)),
+  )
+  guard record.generation == generation && record.id == id else {
+    raise EngineError("job metadata identity does not match its directory")
+  }
+  record
+}
+
+///|
+async fn job_view(
+  directory : String,
+  record : @wire.JobRecord,
+  live : Bool,
+  refresh_failed? : Bool = false,
+) -> @protocol.JobView {
+  let mut record = record
+  let mut error : String? = None
+  if !live && !record.state.is_terminal() {
+    try {
+      let owner = @fs.open(
+        "\{directory}/\{record.generation}/owner.lock",
+        mode=ReadWrite,
+      )
+      defer owner.close()
+      if owner.try_lock(Exclusive) {
+        record = { ..record, state: Interrupted, }
+      } else {
+        error = Some(
+          if refresh_failed {
+            "The live engine could not be refreshed; ownership and controls are not confirmed yet."
+          } else {
+            "The owner is running outside this Desktop connection; controls are unavailable."
+          },
+        )
+      }
+    } catch {
+      failure => error = Some("Cannot verify the job owner: \{failure}")
+    }
+  }
+  let output_path = record.output_file.map(name => {
+    "\{directory}/\{record.generation}/\{name}"
+  })
+  {
+    job: record,
+    output_path,
+    controllable: live && !record.state.is_terminal(),
+    error,
+  }
+}
+
+///|
+/// Page durable history and overlay an authoritative live-engine snapshot.
+pub async fn list_jobs(
+  manager : EngineManager,
+  payload : @protocol.JobsListPayload,
+) -> @protocol.JobsListReply {
+  let scope = payload.scope
+  let guard_record = manager.begin_record_read(scope.session)
+  defer manager.end_record_read(scope.session, guard_record)
+  let directory = jobs_directory(scope)
+  let errors : Array[String] = []
+  let records : Map[String, @wire.JobRecord] = Map([])
+  let mut refresh_failed = false
+  if manager.jobs_engine(scope) is Some(engine) {
+    // Verify workspace placement as well as the session id before requesting
+    // live data; duplicate session ids in different stores must stay isolated.
+    if engine.session_root is Some(root) &&
+      directory == jobs_store_path(root, scope.session) {
+      guard @uuid.mint() is Some(request_id) else {
+        raise EngineError("could not allocate a job request id")
+      }
+      try engine.job_request(request_id, JobsSnapshot(request_id~)) catch {
+        error => {
+          refresh_failed = true
+          errors.push("Live job refresh failed: \{error}")
+        }
+      } noraise {
+        JobsSnapshot(jobs~, ..) =>
+          for job in jobs {
+            let key = "\{job.generation}/\{job.id}"
+            records[key] = job
+          }
+        _ => {
+          refresh_failed = true
+          errors.push("Unexpected job snapshot reply")
+        }
+      }
+    }
+  }
+  let page = job_history_page(
+    directory,
+    records,
+    payload.offset,
+    errors,
+    refresh_failed~,
+  )
+  let selected = match payload.selected {
+    None => None
+    Some(target) => {
+      guard target.scope == scope else {
+        raise EngineError("selected job scope mismatch")
+      }
+      try
+        selected_job_view(
+          directory,
+          records,
+          target.generation,
+          target.job_id,
+          refresh_failed~,
+        )
+      catch {
+        error => {
+          errors.push("Cannot refresh selected job: \{error}")
+          None
+        }
+      } noraise {
+        view => Some(view)
+      }
+    }
+  }
+  { ..page, selected, }
+}
+
+///|
+/// Enumerate lightweight names, then decode only the requested page. Runtime
+/// creation stamps and monotonic bg-N ids keep completed records in stable
+/// order; output writes and terminal metadata updates cannot reshuffle pages.
+async fn job_history_page(
+  directory : String,
+  live : Map[String, @wire.JobRecord],
+  offset : Int,
+  errors : Array[String],
+  refresh_failed? : Bool = false,
+) -> @protocol.JobsListReply {
+  guard offset >= 0 else { raise EngineError("invalid history offset") }
+  let names = @fs.readdir(directory) catch {
+    @os_error.OSError(_) as error if error.is_ENOENT() => []
+    error => {
+      errors.push("Cannot list job history: \{error}")
+      []
+    }
+  }
+  for _, record in live {
+    if !names.contains(record.generation) {
+      names.push(record.generation)
+    }
+  }
+  let generations : Array[(String, (Int64, Int)?)] = []
+  for name in names {
+    if !@wire.valid_job_component(name) {
+      continue
+    }
+    let kind = Some(@fs.kind("\{directory}/\{name}")) catch {
+      error => {
+        errors.push("Cannot inspect runtime \{name}: \{error}")
+        None
+      }
+    }
+    // Reject only entries known to be invalid. An inspection error must not
+    // discard readable metadata or the authoritative live-engine overlay.
+    let stamp = match kind {
+      Some(Directory) =>
+        Some(@fs.mtime("\{directory}/\{name}/owner.lock")) catch {
+          @os_error.OSError(_) as error if error.is_ENOENT() => None
+          error => {
+            errors.push("Cannot inspect runtime \{name}: \{error}")
+            None
+          }
+        }
+      Some(_) => {
+        errors.push("Cannot inspect runtime \{name}: not a directory")
+        guard live.iter().any(entry => entry.1.generation == name) else {
+          continue
+        }
+        None
+      }
+      None => None
+    }
+    generations.push((name, stamp))
+  }
+  generations.sort_by((a, b) => {
+    match (a.1, b.1) {
+      (Some(x), Some(y)) => {
+        let seconds = y.0.compare(x.0)
+        if seconds != 0 {
+          seconds
+        } else {
+          let nanos = y.1.compare(x.1)
+          if nanos != 0 {
+            nanos
+          } else {
+            b.0.compare(a.0)
+          }
+        }
+      }
+      (Some(_), None) => -1
+      (None, Some(_)) => 1
+      (None, None) => b.0.compare(a.0)
+    }
+  })
+  let candidates : Array[(String, String)] = []
+  let mut skipped = 0
+  scan~: for (generation, _) in generations {
+    let files = @fs.readdir("\{directory}/\{generation}") catch {
+      error => {
+        errors.push("Cannot read generation \{generation}: \{error}")
+        []
+      }
+    }
+    let ids = files.filter_map(name => {
+      if name.has_suffix(".json") {
+        Some(name[:name.length() - 5].to_owned())
+      } else {
+        None
+      }
+    })
+    for _, record in live {
+      if record.generation == generation && !ids.contains(record.id) {
+        ids.push(record.id)
+      }
+    }
+    ids.sort_by((a, b) => {
+      let length = b.length().compare(a.length())
+      if length != 0 {
+        length
+      } else {
+        b.compare(a)
+      }
+    })
+    for id in ids {
+      if skipped < offset {
+        skipped += 1
+        continue
+      }
+      candidates.push((generation, id))
+      if candidates.length() > 100 {
+        break scan~
+      }
+    }
+  }
+  let jobs : Array[@protocol.JobView] = []
+  for index in 0..<candidates.length().min(100) {
+    let (generation, id) = candidates[index]
+    let key = "\{generation}/\{id}"
+    let record = match live.get(key) {
+      Some(record) => record
+      None =>
+        read_job_record(directory, generation, id) catch {
+          error => {
+            errors.push("Cannot read job \{key}: \{error}")
+            continue
+          }
+        }
+    }
+    jobs.push(job_view(directory, record, live.contains(key), refresh_failed~))
+  }
+  {
+    jobs,
+    errors,
+    selected: None,
+    next_offset: if candidates.length() > 100 {
+      Some(offset + 100)
+    } else {
+      None
+    },
+  }
+}
+
+///|
+async fn selected_job_view(
+  directory : String,
+  live : Map[String, @wire.JobRecord],
+  generation : String,
+  id : String,
+  refresh_failed? : Bool = false,
+) -> @protocol.JobView {
+  let key = "\{generation}/\{id}"
+  let record = match live.get(key) {
+    Some(record) => record
+    None => read_job_record(directory, generation, id)
+  }
+  job_view(directory, record, live.contains(key), refresh_failed~)
+}
+
+///|
+/// Trim a byte page to complete UTF-8 code points. Initial tail reads may
+/// begin inside a character; subsequent reads must begin on a boundary.
+fn job_utf8_window(bytes : Bytes, tail : Bool) -> (Int, Int) raise {
+  let mut start = 0
+  if tail {
+    while start < bytes.length() && (bytes[start].to_int() & 0xc0) == 0x80 {
+      start += 1
+    }
+  }
+  guard start == bytes.length() || (bytes[start].to_int() & 0xc0) != 0x80 else {
+    raise EngineError("log cursor is not on a UTF-8 boundary")
+  }
+  let mut end = bytes.length()
+  if end > start {
+    let mut lead = end - 1
+    while lead > start && (bytes[lead].to_int() & 0xc0) == 0x80 {
+      lead -= 1
+    }
+    let byte = bytes[lead].to_int()
+    guard byte < 0x80 || (byte >= 0xc2 && byte <= 0xf4) else {
+      raise EngineError("invalid UTF-8 in job output")
+    }
+    let width = if byte < 0x80 {
+      1
+    } else if byte < 0xe0 {
+      2
+    } else if byte < 0xf0 {
+      3
+    } else {
+      4
+    }
+    if lead + width > end {
+      end = lead
+    }
+  }
+  ignore(@utf8.decode(bytes[start:end]))
+  (start, end)
+}
+
+///|
+/// Read at most 64 KiB without waiting for a newline or loading the whole log.
+pub async fn read_job(
+  manager : EngineManager,
+  payload : @protocol.JobReadPayload,
+) -> @protocol.JobReadReply {
+  let scope = payload.target.scope
+  let record_guard = manager.begin_record_read(scope.session)
+  defer manager.end_record_read(scope.session, record_guard)
+  let directory = jobs_directory(scope)
+  let job = read_job_record(
+    directory,
+    payload.target.generation,
+    payload.target.job_id,
+  ) catch {
+    metadata_error => {
+      // A failed first metadata write must not make a retained live log
+      // unreadable. Only the exact owning engine may supply this fallback.
+      guard manager.jobs_engine(scope) is Some(engine) &&
+        engine.session_root is Some(root) &&
+        directory == jobs_store_path(root, scope.session) else {
+        raise metadata_error
+      }
+      guard @uuid.mint() is Some(request_id) else {
+        raise EngineError("could not allocate a job request id")
+      }
+      match engine.job_request(request_id, JobsSnapshot(request_id~)) {
+        JobsSnapshot(jobs~, ..) => {
+          guard jobs
+            .iter()
+            .find_first(job => {
+              job.generation == payload.target.generation &&
+              job.id == payload.target.job_id
+            })
+            is Some(job) else {
+            raise metadata_error
+          }
+          job
+        }
+        _ => raise EngineError("unexpected job snapshot reply")
+      }
+    }
+  }
+  guard job.output_file is Some(name) else {
+    raise EngineError("this job has no output file")
+  }
+  let path = "\{directory}/\{job.generation}/\{name}"
+  read_job_page(path, payload.offset, payload.limit)
+}
+
+///|
+async fn read_job_page(
+  path : String,
+  offset : Int64?,
+  limit : Int,
+) -> @protocol.JobReadReply {
+  guard limit >= 4 &&
+    limit <= 65536 &&
+    (offset is None || (offset is Some(n) && n >= 0L)) else {
+    raise EngineError("invalid log cursor or page limit")
+  }
+  let file = @fs.open(path, mode=ReadOnly)
+  defer file.close()
+  guard file.kind() is Regular else {
+    raise EngineError("job output is not a regular file")
+  }
+  let size = file.size()
+  let start = match offset {
+    Some(offset) => offset
+    None => (size - limit.to_int64()).max(0L)
+  }
+  guard start <= size else {
+    raise EngineError("job output was truncated; reload its tail")
+  }
+  let length = (size - start).min(limit.to_int64()).to_int()
+  let bytes = file.read_exactly_at(length, position=start)
+  let (skip, end) = job_utf8_window(bytes, offset is None && start > 0L)
+  let next = start + end.to_int64()
+  {
+    text: @utf8.decode(bytes[skip:end]),
+    start_offset: start + skip.to_int64(),
+    next_offset: next,
+    size,
+    more: next < size,
+    output_path: path,
+  }
+}
+
+///|
+/// Await the engine's settlement; a delivered request alone is not success.
+pub async fn stop_job(
+  manager : EngineManager,
+  target : @protocol.JobTarget,
+) -> @protocol.JobStopReply {
+  let record_guard = manager.begin_record_read(target.scope.session)
+  defer manager.end_record_read(target.scope.session, record_guard)
+  let directory = jobs_directory(target.scope)
+  guard manager.jobs_engine(target.scope) is Some(engine) &&
+    engine.session_root is Some(root) &&
+    directory == jobs_store_path(root, target.scope.session) else {
+    raise EngineError("job controls require its current live engine")
+  }
+  guard @uuid.mint() is Some(request_id) else {
+    raise EngineError("could not allocate a job request id")
+  }
+  match
+    engine.job_request(
+      request_id,
+      JobStop(request_id~, generation=target.generation, job_id=target.job_id),
+      settlement=true,
+    ) {
+    JobStopResult(generation~, job_id~, outcome~, ..) if generation ==
+      target.generation &&
+      job_id == target.job_id => { outcome, }
+    _ => raise EngineError("unexpected job stop reply")
+  }
+}
+
+///|
+/// Normalize both sides of ownership comparisons. Native joins use backslashes
+/// on Windows while stored engine roots use slash-normalized Absolute paths.
+fn jobs_store_path(root : @pathx.Absolute, session : String) -> String {
+  root
+  .join("sessions")
+  .join(Relative(session))
+  .join("jobs")
+  .normalize()
+  .to_string()
+}
+
+///|
+/// Delivery has already been acknowledged; timeout must not claim the stop failed.
+async fn await_job_settlement(
+  reply : @async.Queue[@wire.Event],
+  timeout_ms? : Int = 30000,
+) -> @wire.Event {
+  match @async.with_timeout_opt(timeout_ms, () => reply.get()) {
+    Some(event) => event
+    None =>
+      raise EngineError(
+        "Stop was delivered, but completion is not confirmed yet. The job may still be stopping; refresh its status.",
+      )
+  }
+}

--- a/desktop/internal/engine/jobs_wbtest.mbt
+++ b/desktop/internal/engine/jobs_wbtest.mbt
@@ -1,0 +1,322 @@
+///|
+async test "job log pages follow byte cursors across multibyte output and no newline" {
+  let root = @fs.tmpdir(prefix="job-page-")
+  defer @fs.rmdir(root, recursive=true)
+  let path = "\{root}/job.out"
+  @fs.write_file(path, "a你好🙂tail")
+  let first = read_job_page(path, Some(0L), 5)
+  assert_eq(first.text, "a你")
+  assert_eq(first.next_offset, 4L)
+  let second = read_job_page(path, Some(first.next_offset), 4)
+  assert_eq(second.text, "好")
+  let third = read_job_page(path, Some(second.next_offset), 4)
+  assert_eq(third.text, "🙂")
+  let tail = read_job_page(path, None, 7)
+  assert_eq(tail.text, "tail")
+  assert_eq(tail.next_offset, 15L)
+  @fs.write_file(path, "more", append=true, create_mode=OpenOrCreate)
+  let more = read_job_page(path, Some(tail.next_offset), 65536)
+  assert_eq(more.text, "more")
+  assert_false(more.more)
+  @fs.write_file(path, "short")
+  try read_job_page(path, Some(more.next_offset), 65536) catch {
+    EngineError(message) => assert_true(message.contains("truncated"))
+    error => fail("unexpected error: \{error}")
+  } noraise {
+    _ => fail("truncation must be explicit")
+  }
+  @fs.remove(path)
+  try read_job_page(path, None, 65536) catch {
+    @os_error.OSError(_) as error => assert_true(error.is_ENOENT())
+    error => fail("unexpected error: \{error}")
+  } noraise {
+    _ => fail("missing log must not read as empty")
+  }
+}
+
+///|
+async test "job output pages are bounded for a large retained file" {
+  let root = @fs.tmpdir(prefix="job-large-")
+  defer @fs.rmdir(root, recursive=true)
+  let path = "\{root}/large.out"
+  @fs.write_file(path, "x".repeat(200000))
+  let page = read_job_page(path, Some(0L), 65536)
+  assert_eq(page.text.length(), 65536)
+  assert_true(page.more)
+  let tail = read_job_page(path, None, 65536)
+  assert_eq(tail.text.length(), 65536)
+  assert_eq(tail.start_offset, 134464L)
+  assert_eq(tail.next_offset, 200000L)
+}
+
+///|
+fn job_record_fixture() -> @wire.JobRecord {
+  {
+    generation: "gen-1",
+    id: "bg-1",
+    revision: 1,
+    command: "sleep 30",
+    description: None,
+    cwd: None,
+    state: Running,
+    started_at_ms: 1L,
+    backgrounded_at_ms: 2L,
+    finished_at_ms: None,
+    last_output_at_ms: None,
+    output_file: Some("fg-1.out"),
+    output_persistent: true,
+    output_bytes: 0L,
+    output_chars: 0,
+    output_truncated: false,
+    invalid_utf8: false,
+    output_error: None,
+    persistence_error: None,
+    cleanup_error: None,
+  }
+}
+
+///|
+async test "job history distinguishes dead owner from disconnected client and malformed metadata" {
+  let root = @fs.tmpdir(prefix="job-history-")
+  defer @fs.rmdir(root, recursive=true)
+  @fs.mkdir("\{root}/gen-1")
+  let record = job_record_fixture()
+  @fs.write_file("\{root}/gen-1/bg-1.json", record.to_json().stringify())
+  assert_eq(read_job_record(root, "gen-1", "bg-1"), record)
+  let unknown = job_view(root, record, false)
+  assert_true(unknown.error is Some(_))
+  assert_true(unknown.job.state is Running)
+  let owner = @fs.open(
+    "\{root}/gen-1/owner.lock",
+    mode=ReadWrite,
+    create_mode=CreateNew,
+  )
+  owner.lock(Exclusive)
+  let external = job_view(root, record, false)
+  assert_true(external.job.state is Running)
+  assert_false(external.controllable)
+  let unavailable = job_view(root, record, false, refresh_failed=true)
+  assert_true(
+    unavailable.error is Some(message) &&
+    message.contains("could not be refreshed"),
+  )
+  assert_false(unavailable.controllable)
+  owner.close()
+  let interrupted = job_view(root, record, false)
+  assert_true(interrupted.job.state is Interrupted)
+  let live = job_view(root, record, true)
+  assert_true(live.controllable)
+  @fs.write_file("\{root}/gen-1/bg-1.json", "{}")
+  try read_job_record(root, "gen-1", "bg-1") catch {
+    _ => ()
+  } noraise {
+    _ => fail("corrupt metadata must not disappear silently")
+  }
+}
+
+///|
+async test "history decodes only its requested page and preserves runtime job order" {
+  let root = @fs.tmpdir(prefix="job-history-pages-")
+  defer @fs.rmdir(root, recursive=true)
+  @fs.mkdir("\{root}/gen-1")
+  @fs.write_file("\{root}/gen-1/owner.lock", "")
+  for index in 1..<=101 {
+    let record = {
+      ..job_record_fixture(),
+      id: "bg-\{index}",
+      state: Exited(0),
+    }
+    @fs.write_file(
+      "\{root}/gen-1/bg-\{index}.json",
+      if index == 1 {
+        "corrupt old metadata"
+      } else {
+        record.to_json().stringify()
+      },
+    )
+  }
+  let first = job_history_page(root, Map([]), 0, [])
+  assert_eq(first.jobs.length(), 100)
+  assert_eq(first.jobs[0].job.id, "bg-101")
+  assert_eq(first.jobs[99].job.id, "bg-2")
+  assert_eq(first.next_offset, Some(100))
+  assert_true(first.errors.is_empty())
+  let second = job_history_page(root, Map([]), 100, [])
+  assert_true(second.jobs.is_empty())
+  assert_true(second.next_offset is None)
+  assert_eq(second.errors.length(), 1)
+  assert_true(second.errors[0].contains("bg-1"))
+  // Selection is refreshed independently of the visible history page, and a
+  // live snapshot remains usable even if its metadata write failed.
+  let terminal = {
+    ..job_record_fixture(),
+    state: Stopped("user"),
+    revision: 3,
+  }
+  let selected = selected_job_view(
+    root,
+    Map([("gen-1/bg-1", terminal)]),
+    "gen-1",
+    "bg-1",
+  )
+  assert_eq(selected.job, terminal)
+  assert_false(selected.controllable)
+  // One malformed runtime entry produces one actionable diagnostic.
+  // Use an otherwise empty root so pagination cannot hide a second error.
+  let broken_root = @fs.tmpdir(prefix="job-broken-runtime-")
+  defer @fs.rmdir(broken_root, recursive=true)
+  @fs.write_file("\{broken_root}/stray-file", "not a runtime directory")
+  let broken = job_history_page(broken_root, Map([]), 0, [])
+  assert_eq(broken.errors.length(), 1)
+  assert_true(broken.errors[0].contains("stray-file"))
+  // Damaged or missing storage must not hide an authoritative live execution.
+  let displaced = { ..job_record_fixture(), generation: "stray-file", }
+  let missing = { ..job_record_fixture(), generation: "missing-generation", }
+  let active = job_history_page(
+    broken_root,
+    Map([("stray-file/bg-1", displaced), ("missing-generation/bg-1", missing)]),
+    0,
+    [],
+  )
+  assert_eq(active.jobs.length(), 2)
+  assert_true(
+    active.jobs.any(view => view.job == displaced && view.controllable),
+  )
+  assert_true(active.jobs.any(view => view.job == missing && view.controllable))
+  assert_false(active.errors.is_empty())
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "owner lock inspection failures preserve durable and live jobs" {
+  let root = @fs.tmpdir(prefix="job-owner-inspection-")
+  defer @fs.rmdir(root, recursive=true)
+  @fs.mkdir("\{root}/gen-1")
+  let record = job_record_fixture()
+  @fs.write_file("\{root}/gen-1/bg-1.json", record.to_json().stringify())
+  // A symlink loop produces a non-ENOENT stat failure even when run as root.
+  @fs.symlink(target="owner.lock", "\{root}/gen-1/owner.lock")
+  let durable = job_history_page(root, Map([]), 0, [])
+  assert_eq(durable.jobs.length(), 1)
+  assert_true(durable.jobs[0].job.state is Running)
+  assert_true(durable.jobs[0].error is Some(_))
+  assert_eq(durable.errors.length(), 1)
+  let live = job_history_page(root, Map([("gen-1/bg-1", record)]), 0, [])
+  assert_eq(live.jobs.length(), 1)
+  assert_true(live.jobs[0].controllable)
+  assert_eq(live.errors.length(), 1)
+}
+
+///|
+test "log cursors reject UTF8 continuation boundaries and invalid trailing leads" {
+  for bytes in [b"\x80", b"a\xc0", b"a\xff"] {
+    try job_utf8_window(bytes, false) catch {
+      _ => ()
+    } noraise {
+      _ => fail("invalid bytes must not produce a nonadvancing cursor")
+    }
+  }
+  assert_eq(job_utf8_window(b"a\xf0\x9f", false), (0, 1))
+}
+
+///|
+#cfg(platform="windows")
+test "job ownership paths normalize Windows joins and engine roots equally" {
+  let native = @pathx.Path("C:\\workspace\\.openseek").resolve()
+  assert_eq(
+    jobs_store_path(native, "s-1"),
+    "C:/workspace/.openseek/sessions/s-1/jobs",
+  )
+  assert_eq(
+    jobs_store_path(native, "s-1"),
+    jobs_store_path(native.normalize(), "s-1"),
+  )
+}
+
+///|
+#cfg(not(platform="windows"))
+test "job ownership paths normalize POSIX roots and joins equally" {
+  let root = @pathx.Path("/workspace/./.openseek").resolve()
+  assert_eq(
+    jobs_store_path(root, "s-1"),
+    "/workspace/.openseek/sessions/s-1/jobs",
+  )
+  assert_eq(
+    jobs_store_path(root, "s-1"),
+    jobs_store_path(root.normalize(), "s-1"),
+  )
+}
+
+///|
+async test "a tail at byte zero rejects corrupt leading UTF8 instead of hiding it" {
+  let root = @fs.tmpdir(prefix="job-invalid-tail-")
+  defer @fs.rmdir(root, recursive=true)
+  let path = "\{root}/output"
+  @fs.write_file(path, b"\x80a")
+  try read_job_page(path, None, 65536) catch {
+    _ => ()
+  } noraise {
+    _ => fail("invalid leading UTF8 must remain visible as a read error")
+  }
+}
+
+///|
+async test "stop confirmation distinguishes settled from still awaiting completion" {
+  let reply : @async.Queue[@wire.Event] = Queue(kind=Unbounded)
+  let event : @wire.Event = JobStopResult(
+    request_id="stop",
+    generation="gen",
+    job_id="bg-1",
+    outcome=Stopped,
+  )
+  reply.put(event)
+  assert_eq(await_job_settlement(reply, timeout_ms=10), event)
+  try await_job_settlement(reply, timeout_ms=1) catch {
+    EngineError(message) =>
+      assert_true(
+        message.contains("Stop was delivered") &&
+        message.contains("not confirmed"),
+      )
+    error => fail("unexpected error: \{error}")
+  } noraise {
+    _ => fail("an unconfirmed stop cannot be reported as settled")
+  }
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "correlated job replies reach their waiter but never the stream sink" {
+  let manager = new_engine_manager("/bin/sh")
+  let emitted : Array[EngineEvent] = []
+  let sink = EventSink(event => emitted.push(event))
+  @async.with_task_group(group => {
+    let (input, writer) = @process.write_to_process()
+    let (reader, output) = @process.read_from_process()
+    let snapshot : @wire.Event = JobsSnapshot(request_id="private", jobs=[])
+    let stopped : @wire.Event = JobStopResult(
+      request_id="late",
+      generation="g",
+      job_id="bg-1",
+      outcome=Stopped,
+    )
+    let process = @process.spawn(
+      group,
+      "/bin/echo",
+      [snapshot.to_json().stringify() + "\n" + stopped.to_json().stringify()],
+      stdin=input,
+      stdout=output,
+    )
+    let engine = test_serve_engine(
+      "reply-test",
+      writer,
+      process,
+      sink,
+      phase=Idle(last_run=None),
+    )
+    let reply : @async.Queue[@wire.Event] = Queue(kind=Unbounded)
+    engine.job_requests["private"] = reply
+    ignore(engine.consume(manager, reader))
+    assert_eq(reply.get(), snapshot)
+    assert_true(emitted.is_empty())
+  })
+}

--- a/desktop/internal/engine/moon.pkg
+++ b/desktop/internal/engine/moon.pkg
@@ -1,4 +1,6 @@
 import {
+  "moonbitlang/core/encoding/utf8",
+  "moonbitlang/async/os_error",
   "bobzhang/openseek/agent_session",
   "bobzhang/openseek/agent_session/store",
   "bobzhang/openseek/viz_export",

--- a/desktop/internal/engine/pkg.generated.mbti
+++ b/desktop/internal/engine/pkg.generated.mbti
@@ -31,6 +31,8 @@ pub async fn export_session_html(EngineManager, @protocol.SessionExportPayload, 
 
 pub async fn goal_run(EngineManager, @protocol.GoalPayload) -> @protocol.GoalReply
 
+pub async fn list_jobs(EngineManager, @protocol.JobsListPayload) -> @protocol.JobsListReply
+
 pub async fn list_sessions(EngineManager) -> @protocol.SessionsReply
 
 pub async fn list_workspaces() -> @protocol.WorkspacesReply
@@ -47,6 +49,8 @@ pub async fn pattern_repair_environment(EngineManager) -> Map[String, String] ra
 
 pub fn queue_run(EngineManager, @protocol.QueuePayload) -> @protocol.QueueReply raise EngineError
 
+pub async fn read_job(EngineManager, @protocol.JobReadPayload) -> @protocol.JobReadReply
+
 pub async fn remote_server_base(EngineManager) -> String?
 
 pub async fn rename_session(EngineManager, @protocol.SessionRenamePayload) -> Unit
@@ -56,6 +60,8 @@ pub async fn settings_status(EngineManager) -> @protocol.SettingsStatusPayload
 pub async fn start_run(EventSink, EngineManager, @protocol.StartPayload) -> @protocol.StartReply
 
 pub fn steer_run(EngineManager, @protocol.SteerPayload) -> @protocol.SteerReply
+
+pub async fn stop_job(EngineManager, @protocol.JobTarget) -> @protocol.JobStopReply
 
 pub async fn unarchive_session(EngineManager, String, (String, String) -> Unit) -> @protocol.SessionsReply
 

--- a/desktop/internal/protocol/jobs.mbt
+++ b/desktop/internal/protocol/jobs.mbt
@@ -1,0 +1,444 @@
+// Background job requests are scoped to a conversation and host command channel.
+// Optional values accept missing/null; malformed present fields are rejected.
+// Unknown object fields are ignored. Integers are exact nonnegative JSON numbers.
+
+///|
+fn jobs_uint(
+  value : Json,
+  path : @json.JsonPath,
+) -> Int64 raise @json.JsonDecodeError {
+  match value {
+    Number(n, ..) if n >= 0 &&
+      n <= 9007199254740991.0 &&
+      n.to_int64().to_double() == n => n.to_int64()
+    _ => raise JsonDecodeError((path, "expected exact nonnegative integer"))
+  }
+}
+
+///|
+pub(all) struct JobsScope {
+  session : String
+  workspace : String?
+  archived : Bool
+} derive(Eq, Debug)
+
+///|
+pub impl FromJson for JobsScope with fn from_json(json, path) {
+  let obj = JsonObject::decode(json, path, "JobsScope")
+  let session : String = @json.from_json(
+    obj.required_json("session"),
+    path=path.add_key("session"),
+  )
+  let workspace : String? = match obj.optional_json("workspace") {
+    None => None
+    Some(value) => Some(@json.from_json(value, path=path.add_key("workspace")))
+  }
+  let archived : Bool = @json.from_json(
+    obj.required_json("archived"),
+    path=path.add_key("archived"),
+  )
+  guard !session.is_empty() else {
+    raise JsonDecodeError((path, "empty session"))
+  }
+  { session, workspace, archived, }
+}
+
+///|
+pub impl ToJson for JobsScope with fn to_json(self) {
+  let fields : Map[String, Json] = Map([])
+  fields["session"] = self.session.to_json()
+  if self.workspace is Some(value) {
+    fields["workspace"] = value.to_json()
+  }
+  fields["archived"] = self.archived.to_json()
+  fields.to_json()
+}
+
+///|
+pub extend JobsScope with Eq::{equal, not_equal}
+
+///|
+pub extend JobsScope with Debug::{to_repr}
+
+///|
+pub extend JobsScope with ToJson::{to_json}
+
+///|
+pub extend JobsScope with FromJson::{from_json}
+
+///|
+pub(all) struct JobsListPayload {
+  scope : JobsScope
+  offset : Int
+  selected : JobTarget?
+} derive(Eq, Debug)
+
+///|
+pub impl FromJson for JobsListPayload with fn from_json(json, path) {
+  let obj = JsonObject::decode(json, path, "JobsListPayload")
+  let scope : JobsScope = @json.from_json(
+    obj.required_json("scope"),
+    path=path.add_key("scope"),
+  )
+  let offset : Int = {
+    let n = jobs_uint(obj.required_json("offset"), path.add_key("offset"))
+    guard n <= 2147483647L else {
+      raise JsonDecodeError((path, "integer too large"))
+    }
+    n.to_int()
+  }
+  let selected : JobTarget? = match obj.optional_json("selected") {
+    None => None
+    Some(value) => Some(@json.from_json(value, path=path.add_key("selected")))
+  }
+  guard selected is None || (selected is Some(target) && target.scope == scope) else {
+    raise JsonDecodeError(
+      (path, "selected job must belong to the listed scope"),
+    )
+  }
+  { scope, offset, selected, }
+}
+
+///|
+pub impl ToJson for JobsListPayload with fn to_json(self) {
+  let fields : Map[String, Json] = Map([])
+  fields["scope"] = self.scope.to_json()
+  fields["offset"] = self.offset.to_json()
+  if self.selected is Some(value) {
+    fields["selected"] = value.to_json()
+  }
+  fields.to_json()
+}
+
+///|
+pub extend JobsListPayload with Eq::{equal, not_equal}
+
+///|
+pub extend JobsListPayload with Debug::{to_repr}
+
+///|
+pub extend JobsListPayload with ToJson::{to_json}
+
+///|
+pub extend JobsListPayload with FromJson::{from_json}
+
+///|
+pub(all) struct JobTarget {
+  scope : JobsScope
+  generation : String
+  job_id : String
+} derive(Eq, Debug)
+
+///|
+pub impl FromJson for JobTarget with fn from_json(json, path) {
+  let obj = JsonObject::decode(json, path, "JobTarget")
+  let scope : JobsScope = @json.from_json(
+    obj.required_json("scope"),
+    path=path.add_key("scope"),
+  )
+  let generation : String = @json.from_json(
+    obj.required_json("generation"),
+    path=path.add_key("generation"),
+  )
+  let job_id : String = @json.from_json(
+    obj.required_json("job_id"),
+    path=path.add_key("job_id"),
+  )
+  guard @wire.valid_job_component(generation) &&
+    @wire.valid_job_component(job_id) else {
+    raise JsonDecodeError((path, "invalid job identity"))
+  }
+  { scope, generation, job_id, }
+}
+
+///|
+pub impl ToJson for JobTarget with fn to_json(self) {
+  let fields : Map[String, Json] = Map([])
+  fields["scope"] = self.scope.to_json()
+  fields["generation"] = self.generation.to_json()
+  fields["job_id"] = self.job_id.to_json()
+  fields.to_json()
+}
+
+///|
+pub extend JobTarget with Eq::{equal, not_equal}
+
+///|
+pub extend JobTarget with Debug::{to_repr}
+
+///|
+pub extend JobTarget with ToJson::{to_json}
+
+///|
+pub extend JobTarget with FromJson::{from_json}
+
+///|
+pub(all) struct JobReadPayload {
+  target : JobTarget
+  offset : Int64?
+  limit : Int
+} derive(Eq, Debug)
+
+///|
+pub impl FromJson for JobReadPayload with fn from_json(json, path) {
+  let obj = JsonObject::decode(json, path, "JobReadPayload")
+  let target : JobTarget = @json.from_json(
+    obj.required_json("target"),
+    path=path.add_key("target"),
+  )
+  let offset : Int64? = match obj.optional_json("offset") {
+    None => None
+    Some(value) => Some(jobs_uint(value, path.add_key("offset")))
+  }
+  let limit : Int = {
+    let n = jobs_uint(obj.required_json("limit"), path.add_key("limit"))
+    guard n <= 2147483647L else {
+      raise JsonDecodeError((path, "integer too large"))
+    }
+    n.to_int()
+  }
+  guard limit >= 4 && limit <= 65536 else {
+    raise JsonDecodeError((path, "log page limit must be 4..65536 bytes"))
+  }
+  { target, offset, limit, }
+}
+
+///|
+pub impl ToJson for JobReadPayload with fn to_json(self) {
+  let fields : Map[String, Json] = Map([])
+  fields["target"] = self.target.to_json()
+  if self.offset is Some(value) {
+    fields["offset"] = value.to_double().to_json()
+  }
+  fields["limit"] = self.limit.to_json()
+  fields.to_json()
+}
+
+///|
+pub extend JobReadPayload with Eq::{equal, not_equal}
+
+///|
+pub extend JobReadPayload with Debug::{to_repr}
+
+///|
+pub extend JobReadPayload with ToJson::{to_json}
+
+///|
+pub extend JobReadPayload with FromJson::{from_json}
+
+///|
+pub(all) struct JobView {
+  job : @wire.JobRecord
+  output_path : String?
+  controllable : Bool
+  error : String?
+} derive(Eq, Debug)
+
+///|
+pub impl FromJson for JobView with fn from_json(json, path) {
+  let obj = JsonObject::decode(json, path, "JobView")
+  let job : @wire.JobRecord = @json.from_json(
+    obj.required_json("job"),
+    path=path.add_key("job"),
+  )
+  let output_path : String? = match obj.optional_json("output_path") {
+    None => None
+    Some(value) =>
+      Some(@json.from_json(value, path=path.add_key("output_path")))
+  }
+  let controllable : Bool = @json.from_json(
+    obj.required_json("controllable"),
+    path=path.add_key("controllable"),
+  )
+  let error : String? = match obj.optional_json("error") {
+    None => None
+    Some(value) => Some(@json.from_json(value, path=path.add_key("error")))
+  }
+  { job, output_path, controllable, error, }
+}
+
+///|
+pub impl ToJson for JobView with fn to_json(self) {
+  let fields : Map[String, Json] = Map([])
+  fields["job"] = self.job.to_json()
+  if self.output_path is Some(value) {
+    fields["output_path"] = value.to_json()
+  }
+  fields["controllable"] = self.controllable.to_json()
+  if self.error is Some(value) {
+    fields["error"] = value.to_json()
+  }
+  fields.to_json()
+}
+
+///|
+pub extend JobView with Eq::{equal, not_equal}
+
+///|
+pub extend JobView with Debug::{to_repr}
+
+///|
+pub extend JobView with ToJson::{to_json}
+
+///|
+pub extend JobView with FromJson::{from_json}
+
+///|
+pub(all) struct JobsListReply {
+  jobs : Array[JobView]
+  next_offset : Int?
+  errors : Array[String]
+  selected : JobView?
+} derive(Eq, Debug)
+
+///|
+pub impl FromJson for JobsListReply with fn from_json(json, path) {
+  let obj = JsonObject::decode(json, path, "JobsListReply")
+  let jobs : Array[JobView] = @json.from_json(
+    obj.required_json("jobs"),
+    path=path.add_key("jobs"),
+  )
+  let next_offset : Int? = match obj.optional_json("next_offset") {
+    None => None
+    Some(value) =>
+      Some(
+        {
+          let n = jobs_uint(value, path.add_key("next_offset"))
+          guard n <= 2147483647L else {
+            raise JsonDecodeError((path, "integer too large"))
+          }
+          n.to_int()
+        },
+      )
+  }
+  let errors : Array[String] = @json.from_json(
+    obj.required_json("errors"),
+    path=path.add_key("errors"),
+  )
+  let selected : JobView? = match obj.optional_json("selected") {
+    None => None
+    Some(value) => Some(@json.from_json(value, path=path.add_key("selected")))
+  }
+  { jobs, next_offset, errors, selected, }
+}
+
+///|
+pub impl ToJson for JobsListReply with fn to_json(self) {
+  let fields : Map[String, Json] = Map([])
+  fields["jobs"] = self.jobs.to_json()
+  if self.next_offset is Some(value) {
+    fields["next_offset"] = value.to_json()
+  }
+  fields["errors"] = self.errors.to_json()
+  if self.selected is Some(value) {
+    fields["selected"] = value.to_json()
+  }
+  fields.to_json()
+}
+
+///|
+pub extend JobsListReply with Eq::{equal, not_equal}
+
+///|
+pub extend JobsListReply with Debug::{to_repr}
+
+///|
+pub extend JobsListReply with ToJson::{to_json}
+
+///|
+pub extend JobsListReply with FromJson::{from_json}
+
+///|
+pub(all) struct JobReadReply {
+  text : String
+  start_offset : Int64
+  next_offset : Int64
+  size : Int64
+  more : Bool
+  output_path : String
+} derive(Eq, Debug)
+
+///|
+pub impl FromJson for JobReadReply with fn from_json(json, path) {
+  let obj = JsonObject::decode(json, path, "JobReadReply")
+  let text : String = @json.from_json(
+    obj.required_json("text"),
+    path=path.add_key("text"),
+  )
+  let start_offset : Int64 = jobs_uint(
+    obj.required_json("start_offset"),
+    path.add_key("start_offset"),
+  )
+  let next_offset : Int64 = jobs_uint(
+    obj.required_json("next_offset"),
+    path.add_key("next_offset"),
+  )
+  let size : Int64 = jobs_uint(obj.required_json("size"), path.add_key("size"))
+  let more : Bool = @json.from_json(
+    obj.required_json("more"),
+    path=path.add_key("more"),
+  )
+  let output_path : String = @json.from_json(
+    obj.required_json("output_path"),
+    path=path.add_key("output_path"),
+  )
+  { text, start_offset, next_offset, size, more, output_path, }
+}
+
+///|
+pub impl ToJson for JobReadReply with fn to_json(self) {
+  let fields : Map[String, Json] = Map([])
+  fields["text"] = self.text.to_json()
+  fields["start_offset"] = self.start_offset.to_double().to_json()
+  fields["next_offset"] = self.next_offset.to_double().to_json()
+  fields["size"] = self.size.to_double().to_json()
+  fields["more"] = self.more.to_json()
+  fields["output_path"] = self.output_path.to_json()
+  fields.to_json()
+}
+
+///|
+pub extend JobReadReply with Eq::{equal, not_equal}
+
+///|
+pub extend JobReadReply with Debug::{to_repr}
+
+///|
+pub extend JobReadReply with ToJson::{to_json}
+
+///|
+pub extend JobReadReply with FromJson::{from_json}
+
+///|
+pub(all) struct JobStopReply {
+  outcome : @wire.JobStopOutcome
+} derive(Eq, Debug)
+
+///|
+pub impl FromJson for JobStopReply with fn from_json(json, path) {
+  let obj = JsonObject::decode(json, path, "JobStopReply")
+  let outcome : @wire.JobStopOutcome = @json.from_json(
+    obj.required_json("outcome"),
+    path=path.add_key("outcome"),
+  )
+  { outcome, }
+}
+
+///|
+pub impl ToJson for JobStopReply with fn to_json(self) {
+  let fields : Map[String, Json] = Map([])
+  fields["outcome"] = self.outcome.to_json()
+  fields.to_json()
+}
+
+///|
+pub extend JobStopReply with Eq::{equal, not_equal}
+
+///|
+pub extend JobStopReply with Debug::{to_repr}
+
+///|
+pub extend JobStopReply with ToJson::{to_json}
+
+///|
+pub extend JobStopReply with FromJson::{from_json}

--- a/desktop/internal/protocol/jobs_test.mbt
+++ b/desktop/internal/protocol/jobs_test.mbt
@@ -1,0 +1,42 @@
+///|
+test "jobs API codecs retain identity and reject ambiguous cursors" {
+  let request : @protocol.JobReadPayload = {
+    target: {
+      scope: {
+        session: "session-1",
+        workspace: Some("/work"),
+        archived: false,
+      },
+      generation: "runtime-1",
+      job_id: "bg-1",
+    },
+    offset: None,
+    limit: 65536,
+  }
+  assert_eq(@json.from_json(request.to_json()), request)
+  for
+    invalid in [
+      "{\"target\":{\"scope\":{\"session\":\"s\",\"archived\":false},\"generation\":\"..\",\"job_id\":\"bg-1\"},\"limit\":65536}",
+      "{\"target\":{\"scope\":{\"session\":\"s\",\"archived\":false},\"generation\":\"r\",\"job_id\":\"bg-1\"},\"limit\":65537}",
+      "{\"target\":{\"scope\":{\"session\":\"s\",\"archived\":false},\"generation\":\"r\",\"job_id\":\"bg-1\"},\"limit\":65536,\"offset\":-1}",
+      "{\"target\":{\"scope\":{\"session\":\"s\",\"archived\":false},\"generation\":\"r\",\"job_id\":\"bg-1\"},\"limit\":65536,\"offset\":1.5}",
+    ] {
+    try @json.from_json(@json.parse(invalid)) catch {
+      _ => ()
+    } noraise {
+      (_ : @protocol.JobReadPayload) => fail("accepted malformed request")
+    }
+  }
+}
+
+///|
+test "selected history target must belong to the list scope" {
+  let raw =
+    #|{"scope":{"session":"one","archived":false},"offset":0,"selected":{"scope":{"session":"two","archived":false},"generation":"gen","job_id":"bg-1"}}
+  try @json.from_json(@json.parse(raw)) catch {
+    _ => ()
+  } noraise {
+    (_ : @protocol.JobsListPayload) =>
+      fail("cross-session selection must be rejected")
+  }
+}

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -1250,6 +1250,113 @@ pub fn InstalledSkillsReply::not_equal(Self, Self) -> Bool
 pub fn InstalledSkillsReply::to_json(Self) -> Json
 pub fn InstalledSkillsReply::to_repr(Self) -> @debug.Repr
 
+pub(all) struct JobReadPayload {
+  target : JobTarget
+  offset : Int64?
+  limit : Int
+} derive(Eq, @debug.Debug)
+pub fn JobReadPayload::equal(Self, Self) -> Bool
+pub fn JobReadPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn JobReadPayload::not_equal(Self, Self) -> Bool
+pub fn JobReadPayload::to_json(Self) -> Json
+pub fn JobReadPayload::to_repr(Self) -> @debug.Repr
+pub impl ToJson for JobReadPayload
+pub impl @json.FromJson for JobReadPayload
+
+pub(all) struct JobReadReply {
+  text : String
+  start_offset : Int64
+  next_offset : Int64
+  size : Int64
+  more : Bool
+  output_path : String
+} derive(Eq, @debug.Debug)
+pub fn JobReadReply::equal(Self, Self) -> Bool
+pub fn JobReadReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn JobReadReply::not_equal(Self, Self) -> Bool
+pub fn JobReadReply::to_json(Self) -> Json
+pub fn JobReadReply::to_repr(Self) -> @debug.Repr
+pub impl ToJson for JobReadReply
+pub impl @json.FromJson for JobReadReply
+
+pub(all) struct JobStopReply {
+  outcome : @openseek_protocol.JobStopOutcome
+} derive(Eq, @debug.Debug)
+pub fn JobStopReply::equal(Self, Self) -> Bool
+pub fn JobStopReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn JobStopReply::not_equal(Self, Self) -> Bool
+pub fn JobStopReply::to_json(Self) -> Json
+pub fn JobStopReply::to_repr(Self) -> @debug.Repr
+pub impl ToJson for JobStopReply
+pub impl @json.FromJson for JobStopReply
+
+pub(all) struct JobTarget {
+  scope : JobsScope
+  generation : String
+  job_id : String
+} derive(Eq, @debug.Debug)
+pub fn JobTarget::equal(Self, Self) -> Bool
+pub fn JobTarget::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn JobTarget::not_equal(Self, Self) -> Bool
+pub fn JobTarget::to_json(Self) -> Json
+pub fn JobTarget::to_repr(Self) -> @debug.Repr
+pub impl ToJson for JobTarget
+pub impl @json.FromJson for JobTarget
+
+pub(all) struct JobView {
+  job : @openseek_protocol.JobRecord
+  output_path : String?
+  controllable : Bool
+  error : String?
+} derive(Eq, @debug.Debug)
+pub fn JobView::equal(Self, Self) -> Bool
+pub fn JobView::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn JobView::not_equal(Self, Self) -> Bool
+pub fn JobView::to_json(Self) -> Json
+pub fn JobView::to_repr(Self) -> @debug.Repr
+pub impl ToJson for JobView
+pub impl @json.FromJson for JobView
+
+pub(all) struct JobsListPayload {
+  scope : JobsScope
+  offset : Int
+  selected : JobTarget?
+} derive(Eq, @debug.Debug)
+pub fn JobsListPayload::equal(Self, Self) -> Bool
+pub fn JobsListPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn JobsListPayload::not_equal(Self, Self) -> Bool
+pub fn JobsListPayload::to_json(Self) -> Json
+pub fn JobsListPayload::to_repr(Self) -> @debug.Repr
+pub impl ToJson for JobsListPayload
+pub impl @json.FromJson for JobsListPayload
+
+pub(all) struct JobsListReply {
+  jobs : Array[JobView]
+  next_offset : Int?
+  errors : Array[String]
+  selected : JobView?
+} derive(Eq, @debug.Debug)
+pub fn JobsListReply::equal(Self, Self) -> Bool
+pub fn JobsListReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn JobsListReply::not_equal(Self, Self) -> Bool
+pub fn JobsListReply::to_json(Self) -> Json
+pub fn JobsListReply::to_repr(Self) -> @debug.Repr
+pub impl ToJson for JobsListReply
+pub impl @json.FromJson for JobsListReply
+
+pub(all) struct JobsScope {
+  session : String
+  workspace : String?
+  archived : Bool
+} derive(Eq, @debug.Debug)
+pub fn JobsScope::equal(Self, Self) -> Bool
+pub fn JobsScope::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn JobsScope::not_equal(Self, Self) -> Bool
+pub fn JobsScope::to_json(Self) -> Json
+pub fn JobsScope::to_repr(Self) -> @debug.Repr
+pub impl ToJson for JobsScope
+pub impl @json.FromJson for JobsScope
+
 pub(all) struct KnownRunPayload {
   session : String
   run_id : String?


### PR DESCRIPTION
Desktop can list retained background jobs, read bounded log slices, and stop a live job through scoped host commands. The host overlays generation-specific live state on retained history, allowing controls to work independently of the model turn.

The PR includes ownership and recovery rules, 100-record history pages, 64 KiB UTF-8-safe byte reads, explicit missing/truncated/storage errors, and preservation of live jobs when metadata or directories are damaged. POSIX, Windows, and UNC path handling and all related review fixes live in this layer.

## Follow-up hardening

- Separate Stop delivery (5 s) from settlement (30 s). A settlement timeout explicitly reports unconfirmed completion; delivery alone never becomes Stopped.
- Consume correlated snapshot/stop replies after routing, including late replies, instead of broadcasting them to every browser.
- Distinguish a failed live refresh from an external owner while preserving generation-specific control checks.
- Add actual stream-consumer isolation and settlement-timeout tests, and extend owner diagnostics coverage.

The review's proposed clamp to persisted output_bytes is not applied: metadata changes on lifecycle events and would freeze reads of growing logs. The runtime already hard-cancels the direct process. Empty-generation cleanup belongs in #1466; generation caching and scan quotas remain separate optimizations.

## Validation

Current-head `4b254ce31` [CI](https://github.com/moonbitlang/openseek/actions/runs/34663737032) and [Desktop/Windows](https://github.com/moonbitlang/openseek/actions/runs/34663737041) passed. This PR remains one commit and is mergeable.

- Local combined-stack `moon info`, `moon fmt`, `just check`, `just test`, and `just build` passed. Final focused native regressions passed 262/262; Jobs state tests passed 8/8.
- Independent `openseek review` of the 13-file hardening delta found no blockers and two low-severity UI status issues. Both were fixed in #1469. The final four-file correction review returned **zero findings**. Runtime and host code needed no further review corrections.
- The complete final stack also passed 86 browser E2E scenarios and eight Windows job-host regressions; final aggregate evidence is recorded in #1469.

## Stack and review history

Plan #1465 is merged. Review and merge the implementation in this order: #1466 (runtime) → #1468 (host) → #1469 (UI).

The former lifecycle PR #1467 is absorbed into #1466. The corrections from #1470 are included in the layer they fix. This regrouping preserves the reviewed implementation and regression tests, retains newer main changes, and updates the delivery documentation. The original independent `openseek review` findings, resolutions, and aggregate validation remain available in #1470.
