### PR TITLE
Visualize background jobs with live logs and browser coverage

### DIFF
--- a/desktop/e2e/tests/background_jobs.spec.js
+++ b/desktop/e2e/tests/background_jobs.spec.js
@@ -1,0 +1,188 @@
+import { test, expect } from '@playwright/test';
+import { readFileSync } from 'node:fs';
+import { BackgroundJobsHarness } from './support/background_jobs_harness.js';
+
+let app;
+test.afterEach(async () => { if (app) await app.cleanup(); app = null; });
+
+async function mount(page) {
+  app = new BackgroundJobsHarness(page);
+  await app.install(); await app.goto(); await app.openSession(); await app.openJobs();
+  await expect(page.getByRole('region', { name: 'Job output' })).toContainText('ready 你好🙂');
+}
+
+test('real background output follows, pauses, resumes, copies its file and stops', async ({ page, context }, testInfo) => {
+  await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+  await mount(page);
+  const output = page.getByRole('region', { name: 'Job output' });
+  app.write('stdout without newline'); app.write('\nstderr captured\n', true);
+  await expect(output).toContainText('stdout without newline');
+  await expect(output).toContainText('stderr captured');
+  await page.getByRole('button', { name: 'Pause', exact: true }).click();
+  app.write('while paused\n');
+  await expect.poll(() => readFileSync(app.livePath, 'utf8')).toContain('while paused');
+  await expect(output).not.toContainText('while paused');
+  await page.getByRole('button', { name: 'Follow output', exact: true }).click();
+  await expect(output).toContainText('while paused');
+  await page.getByRole('button', { name: 'Copy path', exact: true }).click();
+  await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toBe(app.livePath);
+  await page.getByRole('button', { name: 'Copy tail command', exact: true }).click();
+  await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toContain("'\\''");
+  app.write(Array.from({ length: 150 }, (_, i) => `build step ${i} passed\n`).join(''));
+  await expect(output).toContainText('build step 149 passed');
+  await expect.poll(() => output.evaluate(el => el.scrollHeight - el.scrollTop - el.clientHeight)).toBeLessThan(25);
+  await output.evaluate(el => { el.scrollTop = 0; });
+  await expect(page.getByRole('button', { name: 'Follow output', exact: true })).toBeVisible();
+  const top = await output.evaluate(el => el.scrollTop);
+  app.write('new output while reading earlier lines\n');
+  await expect.poll(() => readFileSync(app.livePath, 'utf8')).toContain('new output while reading');
+  await expect.poll(() => output.evaluate(el => el.scrollTop)).toBe(top);
+  await page.screenshot({ path: testInfo.outputPath('jobs-light.png'), fullPage: true });
+  await page.emulateMedia({ colorScheme: 'dark' });
+  await page.screenshot({ path: testInfo.outputPath('jobs-dark.png'), fullPage: true });
+  await page.getByRole('button', { name: 'Stop job', exact: true }).click();
+  await expect(page.locator('.jobs-detail-title')).toContainText('Stopped');
+  await expect(page.getByRole('button', { name: 'Stop job', exact: true })).toBeDisabled();
+  expect(app.child.signalCode).not.toBeNull();
+  expect(readFileSync(app.livePath, 'utf8')).toContain('stderr captured');
+  const stop = app.requests.find(r => r.method === 'jobs.stop');
+  expect(stop.params).toMatchObject({ scope: { session: 'session-1', workspace: '/workspace' }, generation: 'runtime-new', job_id: 'bg-1' });
+  expect(app.requests.filter(r => r.method === 'jobs.read').every(r => r.params.limit <= 65536)).toBe(true);
+  expect(app.pageErrors).toEqual([]);
+});
+
+test('historical selection rejects late reads, reports errors and fits a narrow panel', async ({ page }, testInfo) => {
+  await mount(page);
+  app.rpcDelays.set('jobs.read', 1200);
+  app.write('must stay with the live job\n');
+  await expect.poll(() => app.requests.filter(r => r.method === 'jobs.read').length).toBeGreaterThan(1);
+  app.rpcDelays.delete('jobs.read');
+  await page.getByRole('button', { name: /Earlier failing test run/ }).click();
+  const output = page.getByRole('region', { name: 'Job output' });
+  await expect(output).toContainText('old failed job output');
+  await expect(page.locator('.jobs-detail-title')).toContainText('Failed · exit 7');
+  await expect(page.getByRole('button', { name: 'Stop job', exact: true })).toBeDisabled();
+  await page.waitForTimeout(1400); // The deliberately delayed obsolete reply must arrive.
+  await expect(output).not.toContainText('must stay with the live job');
+  app.rpcErrors.set('jobs.read', 'Output file is missing: ENOENT');
+  await page.getByRole('button', { name: 'Reload tail', exact: true }).click();
+  await expect(page.getByRole('alert')).toContainText('Output file is missing');
+  await expect(page.locator('.jobs-output-note')).toHaveText('Output unavailable · reload to retry.');
+  app.rpcErrors.delete('jobs.read');
+  await page.getByRole('button', { name: 'Reload tail', exact: true }).click();
+  await expect(output).toContainText('old failed job output');
+  await page.setViewportSize({ width: 1000, height: 850 });
+  await expect.poll(() => page.locator('.jobs-panel').evaluate(el => el.scrollWidth <= el.clientWidth + 1)).toBe(true);
+  await expect(page.getByRole('button', { name: 'Copy tail command', exact: true })).toBeInViewport();
+  await page.screenshot({ path: testInfo.outputPath('jobs-narrow.png'), fullPage: true });
+  expect(app.pageErrors).toEqual([]);
+});
+
+test('page reconnect recovers retained job identity and history', async ({ page }) => {
+  await mount(page);
+  app.write('persist across reconnect\n');
+  await expect(page.getByRole('region', { name: 'Job output' })).toContainText('persist across reconnect');
+  await page.reload(); await app.openSession(); await app.openJobs();
+  await expect(page.getByRole('region', { name: 'Job output' })).toContainText('persist across reconnect');
+  await expect(page.getByRole('button', { name: /Earlier failing test run/ })).toBeVisible();
+  expect(app.pageErrors).toEqual([]);
+});
+
+test('switching conversations cannot display a late log from the previous session', async ({ page }) => {
+  app = new BackgroundJobsHarness(page);
+  app.liveSessions.push({ id: 'session-2', title: 'Another conversation', updated_at_ms: 2 });
+  await app.install(); await app.goto(); await app.openSession(); await app.openJobs();
+  await expect(page.getByRole('region', { name: 'Job output' })).toContainText('ready 你好🙂');
+  app.rpcDelays.set('jobs.read', 1200);
+  const before = app.requests.filter(r => r.method === 'jobs.read').length;
+  await page.getByRole('button', { name: 'Reload tail', exact: true }).click();
+  await expect.poll(() => app.requests.filter(r => r.method === 'jobs.read').length).toBeGreaterThan(before);
+  await page.locator('.conversation-row[title="session-2"]').click();
+  await app.openJobs();
+  await expect(page.locator('.jobs-panel')).toContainText('No background jobs yet');
+  await page.waitForTimeout(1400); // Deliver the first conversation's obsolete reply.
+  await expect(page.locator('.jobs-panel')).not.toContainText('ready 你好🙂');
+  app.rpcDelays.delete('jobs.read');
+  await page.locator('.conversation-row[title="session-1"]').click();
+  await expect(page.getByRole('region', { name: 'Job output' })).toContainText('ready 你好🙂');
+  expect(app.requests.some(r => r.method === 'jobs.list' && r.params.scope.session === 'session-2')).toBe(true);
+  expect(app.pageErrors).toEqual([]);
+});
+
+
+test('selected job beyond the first history page keeps receiving terminal state', async ({ page }) => {
+  app = new BackgroundJobsHarness(page);
+  for (let i = 2; i <= 101; i++) {
+    const view = app.view('runtime-new', `bg-${i}`, app.oldPath, { kind: 'exited', code: 0 });
+    view.job.description = `Completed build ${i}`;
+    app.jobs.splice(1, 0, view);
+  }
+  await app.install(); await app.goto(); await app.openSession(); await app.openJobs();
+  await page.getByRole('button', { name: 'Load older jobs', exact: true }).click();
+  await page.getByRole('button', { name: /Earlier failing test run/ }).click();
+  await page.getByRole('button', { name: 'Pause', exact: true }).click();
+  const selected = app.jobs.find(v => v.job.generation === 'runtime-old');
+  selected.job.state = { kind: 'stopped', reason: 'user' };
+  selected.job.revision++;
+  await expect(page.locator('.jobs-detail-title')).toContainText('Stopped');
+  expect(app.requests.some(r => r.method === 'jobs.list' && r.params.offset === 0 && r.params.selected?.generation === 'runtime-old')).toBe(true);
+  expect(app.pageErrors).toEqual([]);
+});
+
+test('follow catches up with a large completed burst without waiting one tick per page', async ({ page }) => {
+  await mount(page);
+  const output = page.getByRole('region', { name: 'Job output' });
+  app.write('x'.repeat(65536 * 9) + '\nBURST FINISHED\n');
+  await expect.poll(() => readFileSync(app.livePath, 'utf8').endsWith('BURST FINISHED\n')).toBe(true);
+  await page.getByRole('button', { name: 'Stop job', exact: true }).click();
+  await expect(output).toContainText('BURST FINISHED', { timeout: 5000 });
+  await expect(page.locator('.jobs-detail-title')).toContainText('Stopped');
+  expect(await output.evaluate(el => el.textContent.length)).toBeLessThanOrEqual(262144);
+  expect(app.pageErrors).toEqual([]);
+});
+
+test('pause resume and reload serialize reads and preserve manual paused refresh', async ({ page }) => {
+  await mount(page);
+  const original = app.replyFor.bind(app);
+  let release;
+  const gate = new Promise(resolve => { release = resolve; });
+  let held = false;
+  let readCount = 0;
+  app.replyFor = async request => {
+    if (request.method === 'jobs.read') {
+      readCount++;
+      if (!held) { held = true; await gate; }
+    }
+    return original(request);
+  };
+  try {
+    await expect.poll(() => held).toBe(true);
+    await page.getByRole('button', { name: 'Pause', exact: true }).click();
+    await page.getByRole('button', { name: 'Follow output', exact: true }).click();
+    expect(readCount).toBe(1);
+    await page.getByRole('button', { name: 'Pause', exact: true }).click();
+    app.write('manual paused reload\n');
+    await expect.poll(() => readFileSync(app.livePath, 'utf8')).toContain('manual paused reload');
+    await page.getByRole('button', { name: 'Reload tail', exact: true }).click();
+    expect(readCount).toBe(1);
+    release();
+    await expect(page.getByRole('region', { name: 'Job output' })).toContainText('manual paused reload');
+    await expect(page.getByRole('button', { name: 'Follow output', exact: true })).toBeVisible();
+    expect(readCount).toBe(2);
+    expect(app.pageErrors).toEqual([]);
+  } finally { release(); }
+});
+
+test('a controllable job without a log still exposes Stop', async ({ page }) => {
+  app = new BackgroundJobsHarness(page);
+  app.jobs[0].output_path = null;
+  app.jobs[0].job.output_file = null;
+  await app.install(); await app.goto(); await app.openSession(); await app.openJobs();
+  await expect(page.getByRole('button', { name: 'Copy path', exact: true })).toHaveCount(0);
+  await expect(page.locator('.jobs-output-note')).toHaveText('No retained log file for this job.');
+  await expect(page.getByRole('region', { name: 'Job output' })).toHaveCount(0);
+  await page.getByRole('button', { name: 'Stop job', exact: true }).click();
+  await expect(page.locator('.jobs-detail-title')).toContainText('Stopped');
+  expect(app.child.signalCode).not.toBeNull();
+  expect(app.pageErrors).toEqual([]);
+});

--- a/desktop/e2e/tests/support/background_jobs_harness.js
+++ b/desktop/e2e/tests/support/background_jobs_harness.js
@@ -1,0 +1,107 @@
+import { DesktopBrowserHarness } from './desktop_browser_harness.js';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { mkdtempSync, writeFileSync, appendFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Real subprocess output and retained files behind the existing transport
+// seam. The browser is the production bundle; native host tests cover the
+// matching metadata, ownership and UTF-8 byte-page implementation.
+export class BackgroundJobsHarness extends DesktopBrowserHarness {
+  constructor(page) {
+    super(page);
+    this.directory = mkdtempSync(join(tmpdir(), "OpenSeek jobs 'test "));
+    this.livePath = join(this.directory, 'live.out');
+    this.oldPath = join(this.directory, 'old.out');
+    writeFileSync(this.livePath, '');
+    writeFileSync(this.oldPath, 'old failed job output\n');
+    this.jobs = [this.view('runtime-new', 'bg-1', this.livePath, { kind: 'running' }),
+      this.view('runtime-old', 'bg-1', this.oldPath, { kind: 'exited', code: 7 })];
+    this.child = spawn(process.execPath, ['-e', `
+      process.stdout.write('ready 你好🙂\\n');
+      let input = ''; process.stdin.setEncoding('utf8');
+      process.stdin.on('data', chunk => { input += chunk; for (;;) {
+        const index = input.indexOf('\\n'); if (index < 0) break;
+        const command = JSON.parse(input.slice(0, index)); input = input.slice(index + 1);
+        (command.stderr ? process.stderr : process.stdout).write(command.text);
+      }});
+    `], { stdio: ['pipe', 'pipe', 'pipe'] });
+    const append = chunk => appendFileSync(this.livePath, chunk);
+    this.child.stdout.on('data', append);
+    this.child.stderr.on('data', append);
+    this.child.on('exit', () => {
+      this.jobs[0].job.state = { kind: 'stopped', reason: 'user' };
+      this.jobs[0].job.finished_at_ms = Date.now();
+      this.jobs[0].job.revision += 1;
+      this.jobs[0].controllable = false;
+    });
+  }
+  view(generation, id, path, state) {
+    const now = Date.now();
+    return { job: { schema_version: 1, generation, id, revision: 1,
+      command: generation === 'runtime-new' ? 'node worker.js --watch' : 'just test',
+      description: generation === 'runtime-new' ? 'Watch build output' : 'Earlier failing test run',
+      cwd: '/workspace', state, started_at_ms: now - 6000, backgrounded_at_ms: now - 5000,
+      finished_at_ms: state.kind === 'exited' ? now - 2000 : null,
+      last_output_at_ms: now, output_file: generation === 'runtime-new' ? 'live.out' : 'old.out',
+      output_persistent: true, output_bytes: 0, output_chars: 0,
+      output_truncated: false, invalid_utf8: false,
+      output_error: null, persistence_error: null, cleanup_error: null,
+    }, output_path: path, controllable: state.kind === 'running', error: null };
+  }
+  write(text, stderr = false) { this.child.stdin.write(JSON.stringify({ text, stderr }) + '\n'); }
+  async replyFor(request) {
+    const p = request.params;
+    if (request.method === 'session.load') {
+      const result = super.replyFor(request);
+      result.session.id = p.session;
+      return result;
+    }
+    if (request.method === 'jobs.list') {
+      const jobs = p.scope.session === 'session-1' ? this.jobs : [];
+      for (const view of jobs) {
+        if (view.output_path == null) continue;
+        const bytes = readFileSync(view.output_path);
+        view.job.output_bytes = bytes.length;
+        view.job.output_chars = [...bytes.toString()].length;
+      }
+      const selected = p.selected ? jobs.find(v => v.job.generation === p.selected.generation && v.job.id === p.selected.job_id) : null;
+      return { jobs: jobs.slice(p.offset, p.offset + 100), selected,
+        next_offset: p.offset + 100 < jobs.length ? p.offset + 100 : null, errors: [] };
+    }
+    if (request.method === 'jobs.read') {
+      const view = this.jobs.find(v => v.job.generation === p.target.generation && v.job.id === p.target.job_id);
+      const bytes = readFileSync(view.output_path);
+      let start = p.offset ?? Math.max(0, bytes.length - p.limit);
+      if (p.offset == null && start > 0) while (start < bytes.length && (bytes[start] & 0xc0) === 0x80) start++;
+      let end = Math.min(start + p.limit, bytes.length);
+      while (end < bytes.length && (bytes[end] & 0xc0) === 0x80) end--;
+      return { text: bytes.subarray(start, end).toString(), start_offset: start, next_offset: end,
+        size: bytes.length, more: end < bytes.length, output_path: view.output_path };
+    }
+    if (request.method === 'jobs.stop') {
+      if (p.generation !== 'runtime-new') return { outcome: 'wrong_runtime' };
+      if (this.child.exitCode === null && this.child.signalCode === null) {
+        const exited = once(this.child, 'exit'); this.child.kill(); await exited;
+      }
+      return { outcome: 'stopped' };
+    }
+    return super.replyFor(request);
+  }
+  async openJobs() {
+    const show = this.page.getByRole('button', { name: 'Show panel', exact: true });
+    if (await show.isVisible()) await show.click();
+    await this.page.getByRole('button', { name: /Jobs Follow background/ }).click();
+    await this.page.locator('.jobs-panel').waitFor();
+  }
+  async cleanup() {
+    // Stop browser polling before removing files used by the transport fixture.
+    // The page fixture normally closes after afterEach, leaving a small race.
+    if (!this.page.isClosed()) await this.page.close();
+    if (this.child.exitCode === null && this.child.signalCode === null) {
+      const exited = once(this.child, 'exit'); this.child.kill(); await exited;
+    }
+    rmSync(this.directory, { recursive: true, force: true });
+  }
+}

--- a/desktop/e2e/tests/support/desktop_browser_harness.js
+++ b/desktop/e2e/tests/support/desktop_browser_harness.js
@@ -486,7 +486,7 @@ export class DesktopBrowserHarness {
     // browser layout, DOM events, and focus behavior running unchanged.
     await this.page.routeWebSocket('**/v1/devices/device-a/ws', socket => {
       this.socket = socket;
-      socket.onMessage(message => {
+      socket.onMessage(async message => {
         const request = JSON.parse(message.toString());
         this.requests.push(request);
         if (request.id === undefined) {
@@ -497,7 +497,7 @@ export class DesktopBrowserHarness {
           ? {
               jsonrpc: '2.0',
               id: request.id,
-              result: this.replyFor(request),
+              result: await this.replyFor(request),
             }
           : {
               jsonrpc: '2.0',

--- a/desktop/frontend/boot.mbt
+++ b/desktop/frontend/boot.mbt
@@ -512,6 +512,7 @@ pub fn boot() -> Unit {
             emit.map(msg => FileEditor(msg)),
           ),
         )
+        subs.push(@jobs.subscriptions(model.jobs, emit.map(msg => Jobs(msg))))
         @sub.batch(subs)
       },
     )
@@ -524,6 +525,8 @@ pub fn boot() -> Unit {
       files: emit(ExplorerRequested(ExplorerFiles)),
       review: emit(ExplorerRequested(ExplorerChanges)),
       workflows: emit(WorkflowsRequested),
+      jobs: emit(JobsRequested),
+      job_events: emit.map(msg => Jobs(msg)),
       open_child: child => emit(OpenSessionHere(child)),
       browser_input: emit.map(value => BrowserAddressEdited(value)),
       browser_submit: emit(BrowserNavigateSubmitted),

--- a/desktop/frontend/bridge.mbt
+++ b/desktop/frontend/bridge.mbt
@@ -774,6 +774,9 @@ fn session_event_msg(
 ///|
 fn engine_msg(payload : @protocol.AgentEventPayload) -> DeviceMsg? {
   guard !payload.session.is_empty() else { return None }
+  if payload.event.event is @wire.JobChanged(..) {
+    return Some(JobsChanged(payload.session))
+  }
   guard @transcript.decode_engine_event(payload.event) is Some(event) else {
     return None
   }

--- a/desktop/frontend/component_jobs.mbt
+++ b/desktop/frontend/component_jobs.mbt
@@ -1,0 +1,16 @@
+///|
+fn Model::jobs_owner(self : Model) -> @jobs.Owner? {
+  guard self.screen is Chat &&
+    self.active_conversation() is Some(conv) &&
+    conv.has_begun() else {
+    return None
+  }
+  Some({
+    channel: conv.device,
+    scope: {
+      session: conv.session_id,
+      workspace: Some(conv.project().path),
+      archived: conv.is_archived_read_only(),
+    },
+  })
+}

--- a/desktop/frontend/component_right_panel.mbt
+++ b/desktop/frontend/component_right_panel.mbt
@@ -3,6 +3,7 @@
 fn Model::right_panel_input(self : Model) -> @right_panel.Input {
   @right_panel.Input(
     dock=self.dock,
+    jobs=self.jobs,
     file_panel=self.file_panel,
     preview=self.preview,
     file_ctx=file_ctx(self),

--- a/desktop/frontend/dock/state.mbt
+++ b/desktop/frontend/dock/state.mbt
@@ -38,6 +38,7 @@ pub(all) enum DockTab {
   // conversation's snippets announced, one row per subagent, each a click
   // from that child's own transcript. At most one lives in the strip.
   Workflows
+  Jobs
 } derive(Eq)
 
 ///|

--- a/desktop/frontend/dock/update.mbt
+++ b/desktop/frontend/dock/update.mbt
@@ -137,3 +137,8 @@ pub fn sync(state : State, owner : @interop.ConversationKey) -> State {
   }
   { owner: Some(owner), tabs, active, remembered, }
 }
+
+///|
+pub fn open_jobs(state : State) -> State {
+  open_tab(state, Jobs)
+}

--- a/desktop/frontend/dock/view.mbt
+++ b/desktop/frontend/dock/view.mbt
@@ -76,6 +76,21 @@ fn icon_review() -> @html.Html {
 }
 
 ///|
+/// A command prompt and output lines for background job logs.
+fn icon_jobs() -> @html.Html {
+  @svg.svg(
+    width=16,
+    height=16,
+    view_box="0 0 16 16",
+    attrs=@svg.Attrs::build()
+      .fill("none")
+      .stroke("currentColor")
+      .stroke_linecap("round"),
+    [@svg.path(d="M2 4l3 3-3 3M7 10h6M7 4h6M7 7h6")],
+  )
+}
+
+///|
 /// One node fanning out to three: the launcher's Workflows row.
 fn icon_workflows() -> @html.Html {
   @svg.svg(
@@ -117,6 +132,7 @@ pub(all) struct LauncherActions {
   files : @cmd.Cmd
   review : @cmd.Cmd
   workflows : @cmd.Cmd
+  jobs : @cmd.Cmd
 }
 
 ///|
@@ -161,6 +177,16 @@ fn launcher_rows(actions : LauncherActions) -> Array[@html.Html] {
       @html.span(
         class="dock-launcher-hint",
         "Subagents this conversation delegated to",
+      ),
+    ]),
+  )
+  rows.push(
+    @html.button(class="dock-launcher-row", on_click=actions.jobs, [
+      @icons.icon(icon_jobs),
+      @html.span(class="dock-launcher-name", "Jobs"),
+      @html.span(
+        class="dock-launcher-hint",
+        "Follow background commands and their logs",
       ),
     ]),
   )

--- a/desktop/frontend/jobs/moon.pkg
+++ b/desktop/frontend/jobs/moon.pkg
@@ -1,0 +1,12 @@
+import {
+  "moonbit-community/rabbita/cmd",
+  "moonbit-community/rabbita/sub",
+  "moonbit-community/rabbita/html",
+  "moonbit-community/rabbita/clipboard",
+  "openseek_desktop/frontend/interop",
+  "openseek_desktop/internal/commands",
+  "openseek_desktop/internal/protocol",
+  "bobzhang/openseek_protocol" @wire,
+}
+
+supported_targets = "js"

--- a/desktop/frontend/jobs/state.mbt
+++ b/desktop/frontend/jobs/state.mbt
@@ -1,0 +1,473 @@
+///|
+pub(all) struct Owner {
+  channel : @interop.ChannelId
+  scope : @protocol.JobsScope
+} derive(Eq)
+
+///|
+pub(all) struct State {
+  owner : Owner?
+  active : Bool
+  epoch : Int
+  jobs : Array[@protocol.JobView]
+  selected : (String, String)?
+  listing : Bool
+  next_offset : Int?
+  error : String?
+  warnings : Array[String]
+  text : String
+  cursor : Int64?
+  reading : Bool
+  read_serial : Int
+  read_budget : Int
+  catching_up : Bool
+  reload_pending : Bool
+  manual_read : Bool
+  read_error : String?
+  follow : Bool
+  clipped : Bool
+  control_error : String?
+  stopping : Bool
+} derive(Eq)
+
+///|
+pub fn State::empty() -> State {
+  {
+    owner: None,
+    active: false,
+    epoch: 0,
+    jobs: [],
+    selected: None,
+    listing: false,
+    next_offset: None,
+    error: None,
+    warnings: [],
+    text: "",
+    cursor: None,
+    reading: false,
+    read_serial: 0,
+    read_budget: 4,
+    catching_up: false,
+    reload_pending: false,
+    manual_read: false,
+    read_error: None,
+    follow: true,
+    clipped: false,
+    control_error: None,
+    stopping: false,
+  }
+}
+
+///|
+pub(all) enum Msg {
+  Poll
+  More
+  Select(String, String)
+  ToggleFollow
+  Pause
+  Reload
+  Stop
+  Listed(Int, Int, Result[@protocol.JobsListReply, String])
+  Read(Int, Int, Result[@protocol.JobReadReply, String])
+  Stopped(Int, (String, String), Result[@protocol.JobStopReply, String])
+}
+
+///|
+fn selected_job(state : State) -> @protocol.JobView? {
+  state.jobs
+  .iter()
+  .find_first(view => Some((view.job.generation, view.job.id)) == state.selected)
+}
+
+///|
+fn target(owner : Owner, key : (String, String)) -> @protocol.JobTarget {
+  { scope: owner.scope, generation: key.0, job_id: key.1, }
+}
+
+///|
+fn request_list(
+  emit : @cmd.Emit[Msg],
+  state : State,
+  offset : Int,
+) -> (@cmd.Cmd, State) {
+  guard state.active && !state.listing && state.owner is Some(owner) else {
+    return (@cmd.none, state)
+  }
+  let cmd = @cmd.attempt(
+    result => {
+      emit(
+        Listed(state.epoch, offset, result.map_err(@interop.bridge_error_text)),
+      )
+    },
+    () => {
+      @interop.bridge_request(owner.channel, @commands.jobs_list, {
+        scope: owner.scope,
+        offset,
+        selected: state.selected.map(key => target(owner, key)),
+      })
+    },
+  )
+  (cmd, { ..state, listing: true, })
+}
+
+///|
+fn request_read(emit : @cmd.Emit[Msg], state : State) -> (@cmd.Cmd, State) {
+  guard state.active &&
+    !state.reading &&
+    state.read_budget > 0 &&
+    state.owner is Some(owner) &&
+    state.selected is Some(key) &&
+    selected_job(state) is Some(view) &&
+    view.output_path is Some(_) else {
+    return (@cmd.none, state)
+  }
+  let serial = state.read_serial + 1
+  let cmd = @cmd.attempt(
+    result => {
+      emit(
+        Read(state.epoch, serial, result.map_err(@interop.bridge_error_text)),
+      )
+    },
+    () => {
+      @interop.bridge_request(owner.channel, @commands.jobs_read, {
+        target: target(owner, key),
+        offset: state.cursor,
+        limit: 65536,
+      })
+    },
+  )
+  (
+    cmd,
+    {
+      ..state,
+      reading: true,
+      read_serial: serial,
+      read_budget: state.read_budget - 1,
+    },
+  )
+}
+
+///|
+/// Scope and visibility changes invalidate outstanding replies, including a
+/// reused session name on a different channel. Hidden panels have no polling.
+pub fn reconcile(
+  emit : @cmd.Emit[Msg],
+  state : State,
+  owner : Owner?,
+  active : Bool,
+) -> (@cmd.Cmd, State) {
+  if state.owner != owner {
+    let state = { ..State::empty(), owner, active, epoch: state.epoch + 1, }
+    return request_list(emit, state, 0)
+  }
+  if state.active != active {
+    let state = {
+      ..state,
+      active,
+      epoch: state.epoch + 1,
+      listing: false,
+      reading: false,
+      reload_pending: false,
+      manual_read: false,
+      read_budget: 4,
+      read_error: if active {
+        None
+      } else {
+        state.read_error
+      },
+      stopping: false,
+    }
+    return request_list(emit, state, 0)
+  }
+  (@cmd.none, state)
+}
+
+///|
+pub fn subscriptions(state : State, emit : @cmd.Emit[Msg]) -> @sub.Sub {
+  if state.active && state.owner is Some(_) {
+    @sub.every(1000, emit(Poll))
+  } else {
+    @sub.none
+  }
+}
+
+///|
+pub fn update(
+  emit : @cmd.Emit[Msg],
+  msg : Msg,
+  state : State,
+) -> (@cmd.Cmd, State) {
+  match msg {
+    Poll => {
+      let state = { ..state, read_budget: 4, }
+      let (list, state) = request_list(emit, state, 0)
+      let (read, state) = if state.follow && state.read_error is None {
+        request_read(emit, state)
+      } else {
+        (@cmd.none, state)
+      }
+      (@cmd.batch([list, read]), state)
+    }
+    More =>
+      match state.next_offset {
+        Some(offset) => request_list(emit, state, offset)
+        None => (@cmd.none, state)
+      }
+    Listed(epoch, offset, result) => {
+      guard epoch == state.epoch else { return (@cmd.none, state) }
+      match result {
+        Err(error) =>
+          (@cmd.none, { ..state, listing: false, error: Some(error), })
+        Ok(reply) => {
+          let jobs = if offset == 0 && reply.next_offset is None {
+            []
+          } else {
+            state.jobs.copy()
+          }
+          for view in reply.jobs {
+            upsert_job(jobs, view)
+          }
+          if reply.selected is Some(view) {
+            upsert_job(jobs, view)
+          }
+          // Put the refreshed first page first while retaining loaded history.
+          if offset == 0 {
+            let ordered = reply.jobs.copy()
+            for view in jobs {
+              if !ordered.any(existing => {
+                  existing.job.generation == view.job.generation &&
+                  existing.job.id == view.job.id
+                }) {
+                ordered.push(view)
+              }
+            }
+            jobs.clear()
+            jobs.append(ordered)
+          }
+          let selected = match state.selected {
+            Some(_) => state.selected
+            None => jobs.get(0).map(view => (view.job.generation, view.job.id))
+          }
+          let next_offset = if offset == 0 &&
+            reply.next_offset is Some(_) &&
+            state.jobs.length() > 100 {
+            state.next_offset
+          } else {
+            reply.next_offset
+          }
+          let changed = selected != state.selected
+          let state = {
+            ..state,
+            jobs,
+            selected,
+            listing: false,
+            error: None,
+            warnings: reply.errors,
+            next_offset,
+          }
+          if changed {
+            request_read(emit, state)
+          } else {
+            (@cmd.none, state)
+          }
+        }
+      }
+    }
+    Select(generation, id) => {
+      let state = {
+        ..state,
+        selected: Some((generation, id)),
+        text: "",
+        cursor: None,
+        read_error: None,
+        reading: false,
+        read_serial: state.read_serial + 1,
+        read_budget: 4,
+        catching_up: false,
+        reload_pending: false,
+        manual_read: false,
+        clipped: false,
+        follow: true,
+        control_error: None,
+        stopping: false,
+      }
+      request_read(emit, state)
+    }
+    Read(epoch, serial, result) => {
+      guard epoch == state.epoch && serial == state.read_serial else {
+        return (@cmd.none, state)
+      }
+      if state.reload_pending {
+        return request_read(emit, {
+          ..state,
+          reading: false,
+          reload_pending: false,
+        })
+      }
+      if !state.follow && !state.manual_read {
+        return (@cmd.none, { ..state, reading: false, })
+      }
+      match result {
+        Err(error) =>
+          (
+            @cmd.none,
+            {
+              ..state,
+              reading: false,
+              manual_read: false,
+              catching_up: false,
+              read_error: Some(error),
+            },
+          )
+        Ok(page) => {
+          let combined = state.text + page.text
+          // <= 262144 characters keeps even four-byte UTF-8 below 1 MiB.
+          let trimmed = combined.length() > 262144
+          let text = if trimmed {
+            let start = combined.length() - 262144
+            let start = if combined.code_units()[start].is_trailing_surrogate() {
+              start + 1
+            } else {
+              start
+            }
+            combined[start:].to_owned()
+          } else {
+            combined
+          }
+          let state = {
+            ..state,
+            text,
+            cursor: Some(page.next_offset),
+            catching_up: page.more,
+            reading: false,
+            manual_read: false,
+            read_error: None,
+            clipped: state.clipped ||
+            trimmed ||
+            (state.cursor is None && page.start_offset > 0L),
+          }
+          let scroll = if state.follow { scroll_to_end() } else { @cmd.none }
+          // At most four pages per refresh cycle. A partial UTF-8 suffix may report
+          // more without cursor progress; always wait for the next tick then.
+          if state.follow && page.more && page.next_offset > page.start_offset {
+            let (read, state) = request_read(emit, state)
+            (@cmd.batch([scroll, read]), state)
+          } else {
+            (scroll, state)
+          }
+        }
+      }
+    }
+    Pause =>
+      (
+        @cmd.none,
+        { ..state, follow: false, manual_read: false, reload_pending: false, },
+      )
+    ToggleFollow =>
+      if state.follow {
+        update(emit, Pause, state)
+      } else {
+        let (cmd, state) = request_read(emit, {
+          ..state,
+          follow: true,
+          read_budget: 4,
+          read_error: None,
+        })
+        (@cmd.batch([cmd, scroll_to_end()]), state)
+      }
+    Reload => {
+      let state = {
+        ..state,
+        text: "",
+        cursor: None,
+        clipped: false,
+        catching_up: false,
+        read_error: None,
+        manual_read: true,
+        read_budget: 4,
+      }
+      if state.reading {
+        (@cmd.none, { ..state, reload_pending: true, })
+      } else {
+        request_read(emit, state)
+      }
+    }
+    Stop => {
+      guard !state.stopping &&
+        state.owner is Some(owner) &&
+        state.selected is Some(key) &&
+        selected_job(state) is Some(view) &&
+        view.controllable else {
+        return (@cmd.none, state)
+      }
+      let cmd = @cmd.attempt(
+        result => {
+          emit(
+            Stopped(
+              state.epoch,
+              key,
+              result.map_err(@interop.bridge_error_text),
+            ),
+          )
+        },
+        () => {
+          @interop.bridge_request(
+            owner.channel,
+            @commands.jobs_stop,
+            target(owner, key),
+          )
+        },
+      )
+      (cmd, { ..state, stopping: true, control_error: None, })
+    }
+    Stopped(epoch, key, result) => {
+      guard epoch == state.epoch && state.selected == Some(key) else {
+        return (@cmd.none, state)
+      }
+      let error = match result {
+        Err(error) => Some(error)
+        Ok({ outcome: Stopped | AlreadyTerminal, }) => None
+        Ok({ outcome: NotFound, }) =>
+          Some(
+            "This job no longer belongs to the live engine. Refresh its history.",
+          )
+        Ok({ outcome: WrongRuntime, }) =>
+          Some(
+            "The engine restarted; this old job cannot be stopped from the new runtime.",
+          )
+      }
+      let (cmd, state) = request_list(emit, { ..state, stopping: false, }, 0)
+      (cmd, { ..state, control_error: error, })
+    }
+  }
+}
+
+///|
+extern "js" fn scroll_end() -> Unit =
+  #| () => { const el = document.getElementById("bg-job-output"); if (el) el.scrollTop = el.scrollHeight; }
+
+///|
+fn scroll_to_end() -> @cmd.Cmd {
+  @cmd.custom_cmd(_ => scroll_end(), kind=@cmd.after_render)
+}
+
+///|
+pub extend Owner with Eq::{equal, not_equal}
+
+///|
+pub extend State with Eq::{equal, not_equal}
+
+///|
+fn upsert_job(
+  jobs : Array[@protocol.JobView],
+  view : @protocol.JobView,
+) -> Unit {
+  for index in 0..<jobs.length() {
+    if jobs[index].job.generation == view.job.generation &&
+      jobs[index].job.id == view.job.id {
+      jobs[index] = view
+      return
+    }
+  }
+  jobs.push(view)
+}

--- a/desktop/frontend/jobs/state_wbtest.mbt
+++ b/desktop/frontend/jobs/state_wbtest.mbt
@@ -1,0 +1,283 @@
+///|
+fn fixture_owner(session : String) -> Owner {
+  {
+    channel: Remote("device-a"),
+    scope: { session, workspace: Some("/workspace"), archived: false, },
+  }
+}
+
+///|
+test "scope and selection changes reject stale log replies" {
+  let owner = fixture_owner("one")
+  let state = {
+    ..State::empty(),
+    owner: Some(owner),
+    active: true,
+    epoch: 1,
+    read_serial: 3,
+    reading: true,
+  }
+  let emit : @cmd.Emit[Msg] = Emit(_ => @cmd.none)
+  let (_, switched) = reconcile(emit, state, Some(fixture_owner("two")), true)
+  let page : @protocol.JobReadReply = {
+    text: "stale",
+    start_offset: 0L,
+    next_offset: 5L,
+    size: 5L,
+    more: false,
+    output_path: "/log",
+  }
+  let (_, ignored) = update(emit, Read(1, 3, Ok(page)), switched)
+  assert_eq(ignored.text, "")
+  let (_, paused) = update(emit, Pause, state)
+  let (_, ignored) = update(emit, Read(1, 3, Ok(page)), paused)
+  assert_eq(ignored.text, "")
+  assert_true(ignored.cursor is None)
+  let (_, hidden) = reconcile(emit, state, Some(owner), false)
+  let (_, ignored) = update(emit, Read(1, 3, Ok(page)), hidden)
+  assert_eq(ignored.text, "")
+  assert_false(ignored.active)
+}
+
+///|
+test "display buffer stays bounded and advances the absolute byte cursor" {
+  let emit : @cmd.Emit[Msg] = Emit(_ => @cmd.none)
+  let state = {
+    ..State::empty(),
+    text: "x".repeat(262140),
+    epoch: 1,
+    read_serial: 2,
+  }
+  let page : @protocol.JobReadReply = {
+    text: "你好🙂tail",
+    start_offset: 900000L,
+    next_offset: 900014L,
+    size: 900014L,
+    more: false,
+    output_path: "/log",
+  }
+  let (_, next) = update(emit, Read(1, 2, Ok(page)), state)
+  assert_eq(next.text.length(), 262144)
+  assert_true(next.text.has_suffix("你好🙂tail"))
+  assert_eq(next.cursor, Some(900014L))
+  assert_true(next.clipped)
+}
+
+///|
+test "tail command safely quotes host filesystem paths" {
+  assert_eq(
+    tail_command("//server/share/job.out"),
+    "Get-Content -LiteralPath '//server/share/job.out' -Tail 100 -Wait",
+  )
+  assert_eq(
+    tail_command("/tmp/a'b/log.out"),
+    "tail -n 100 -f -- '/tmp/a'\\''b/log.out'",
+  )
+  assert_eq(
+    tail_command("C:\\a'b\\log.out"),
+    "Get-Content -LiteralPath 'C:\\a''b\\log.out' -Tail 100 -Wait",
+  )
+}
+
+///|
+test "bounded output does not split a surrogate pair at its leading edge" {
+  let emit : @cmd.Emit[Msg] = Emit(_ => @cmd.none)
+  let state = { ..State::empty(), text: "🙂", epoch: 1, read_serial: 2, }
+  let page : @protocol.JobReadReply = {
+    text: "x".repeat(262143),
+    start_offset: 4L,
+    next_offset: 262147L,
+    size: 262147L,
+    more: false,
+    output_path: "/log",
+  }
+  let (_, next) = update(emit, Read(1, 2, Ok(page)), state)
+  assert_eq(next.text, "x".repeat(262143))
+}
+
+///|
+fn fixture_job(id : String, state : @wire.JobState) -> @protocol.JobView {
+  {
+    job: {
+      generation: "runtime",
+      id,
+      state,
+      revision: 2,
+      command: "worker",
+      description: None,
+      cwd: None,
+      started_at_ms: 1L,
+      backgrounded_at_ms: 2L,
+      finished_at_ms: None,
+      last_output_at_ms: None,
+      output_file: Some("job.out"),
+      output_persistent: true,
+      output_bytes: 0L,
+      output_chars: 0,
+      output_truncated: false,
+      invalid_utf8: false,
+      output_error: None,
+      persistence_error: None,
+      cleanup_error: None,
+    },
+    output_path: Some("/job.out"),
+    controllable: !state.is_terminal(),
+    error: None,
+  }
+}
+
+///|
+test "first-page polling refreshes a selected historical row while paused" {
+  let emit : @cmd.Emit[Msg] = Emit(_ => @cmd.none)
+  let old = fixture_job("old", Running)
+  let current = fixture_job("new", Running)
+  let state = {
+    ..State::empty(),
+    jobs: [current, old],
+    selected: Some(("runtime", "old")),
+    follow: false,
+  }
+  let reply : @protocol.JobsListReply = {
+    jobs: [current],
+    selected: Some(fixture_job("old", Stopped("user"))),
+    next_offset: Some(100),
+    errors: [],
+  }
+  let (_, next) = update(emit, Listed(0, 0, Ok(reply)), state)
+  assert_true(
+    selected_job(next) is Some(view) &&
+    view.job.state is Stopped("user") &&
+    !view.controllable,
+  )
+  assert_false(next.follow)
+  let (_, page) = update(
+    emit,
+    Listed(
+      0,
+      100,
+      Ok({
+        ..reply,
+        jobs: [fixture_job("old", Exited(7))],
+        selected: None,
+        next_offset: None,
+      }),
+    ),
+    next,
+  )
+  assert_true(selected_job(page) is Some(view) && view.job.state is Exited(7))
+}
+
+///|
+fn reading_fixture() -> State {
+  {
+    ..State::empty(),
+    owner: Some(fixture_owner("one")),
+    active: true,
+    jobs: [fixture_job("bg-1", Running)],
+    selected: Some(("runtime", "bg-1")),
+    reading: true,
+    read_serial: 1,
+    read_budget: 3,
+    cursor: Some(0L),
+  }
+}
+
+///|
+fn page_fixture(start : Int64, more : Bool) -> @protocol.JobReadReply {
+  {
+    text: "next",
+    start_offset: start,
+    next_offset: start + 4L,
+    size: start + 8L,
+    more,
+    output_path: "/job.out",
+  }
+}
+
+///|
+test "bursts drain within a finite page budget and wait on incomplete UTF8" {
+  let emit : @cmd.Emit[Msg] = Emit(_ => @cmd.none)
+  let mut state = reading_fixture()
+  for n in 0..<4 {
+    let (_, next) = update(
+      emit,
+      Read(0, state.read_serial, Ok(page_fixture(n.to_int64() * 4L, true))),
+      state,
+    )
+    state = next
+  }
+  assert_eq(state.cursor, Some(16L))
+  assert_eq(state.read_budget, 0)
+  assert_false(state.reading)
+  assert_true(state.catching_up)
+  let initial = reading_fixture()
+  let partial = { ..page_fixture(0L, true), text: "", next_offset: 0L, }
+  let (_, next) = update(emit, Read(0, 1, Ok(partial)), initial)
+  assert_false(next.reading)
+  assert_eq(next.read_budget, 3)
+  assert_true(next.catching_up)
+  let (_, failed) = update(emit, Read(0, 1, Err("missing file")), {
+    ..reading_fixture(),
+    catching_up: true,
+  })
+  assert_false(failed.catching_up)
+  assert_true(failed.read_error is Some(_))
+  let (_, polled) = update(emit, Poll, failed)
+  assert_false(polled.reading)
+}
+
+///|
+test "pause and resume keep the outstanding read accounted for" {
+  let emit : @cmd.Emit[Msg] = Emit(_ => @cmd.none)
+  let initial = reading_fixture()
+  let (_, paused) = update(emit, Pause, initial)
+  assert_true(paused.reading)
+  let (_, resumed) = update(emit, ToggleFollow, paused)
+  assert_true(resumed.reading)
+  assert_eq(resumed.read_serial, initial.read_serial)
+  let (_, ignored) = update(
+    emit,
+    Read(0, 1, Ok(page_fixture(0L, false))),
+    paused,
+  )
+  assert_false(ignored.reading)
+  assert_eq(ignored.cursor, Some(0L))
+  let (_, resumed) = update(emit, ToggleFollow, ignored)
+  assert_true(resumed.reading)
+  assert_eq(resumed.read_serial, 2)
+}
+
+///|
+test "reload queues behind an old read and can refresh a paused view" {
+  let emit : @cmd.Emit[Msg] = Emit(_ => @cmd.none)
+  let (_, pending) = update(emit, Reload, {
+    ..reading_fixture(),
+    follow: false,
+  })
+  assert_true(pending.reload_pending)
+  assert_eq(pending.read_serial, 1)
+  let (_, paused) = update(emit, Pause, pending)
+  assert_false(paused.reload_pending)
+  assert_false(paused.manual_read)
+  let (_, hidden) = reconcile(emit, pending, pending.owner, false)
+  assert_false(hidden.reload_pending)
+  assert_false(hidden.manual_read)
+  assert_false(hidden.reading)
+  let (_, reading) = update(
+    emit,
+    Read(0, 1, Ok(page_fixture(100L, false))),
+    pending,
+  )
+  assert_true(reading.reading)
+  assert_false(reading.reload_pending)
+  assert_eq(reading.text, "")
+  assert_true(reading.cursor is None)
+  let (_, result) = update(
+    emit,
+    Read(0, reading.read_serial, Ok(page_fixture(0L, false))),
+    reading,
+  )
+  assert_eq(result.text, "next")
+  assert_false(result.follow)
+  assert_false(result.reading)
+}

--- a/desktop/frontend/jobs/view.mbt
+++ b/desktop/frontend/jobs/view.mbt
@@ -1,0 +1,342 @@
+///|
+fn status_label(state : @wire.JobState) -> String {
+  match state {
+    Running => "Running"
+    Stopping => "Stopping"
+    Exited(0) => "Completed"
+    Exited(code) => "Failed · exit \{code}"
+    Stopped("user") => "Stopped"
+    Stopped("session_ended") => "Session ended"
+    Stopped("output_limit") => "Stopped · output limit reached"
+    Stopped("time_limit") => "Stopped · time limit reached"
+    Stopped("capture_failed") => "Stopped · output capture failed"
+    Stopped(reason) => "Stopped · \{reason}"
+    Interrupted => "Interrupted"
+  }
+}
+
+///|
+fn status_class(state : @wire.JobState) -> String {
+  match state {
+    Running | Stopping => "running"
+    Exited(0) => "completed"
+    Exited(_) | Stopped("capture_failed" | "output_limit" | "time_limit") =>
+      "failed"
+    _ => "stopped"
+  }
+}
+
+///|
+/// The host normalizes output paths: POSIX double-leading slashes collapse to
+/// one, so a normalized // prefix here denotes a Windows UNC path.
+fn tail_command(path : String) -> String {
+  if (path.length() >= 2 && path[1] == ':') ||
+    path.has_prefix("\\\\") ||
+    path.has_prefix("//") {
+    "Get-Content -LiteralPath '" +
+    path.replace_all(old="'", new="''") +
+    "' -Tail 100 -Wait"
+  } else {
+    "tail -n 100 -f -- '" + path.replace_all(old="'", new="'\\''") + "'"
+  }
+}
+
+///|
+extern "js" fn timestamp(value : Double) -> String =
+  #| value => new Date(value).toLocaleString()
+
+///|
+extern "js" fn away_from_end() -> Bool =
+  #| () => { const el = document.getElementById("bg-job-output"); return !!el && el.scrollHeight - el.scrollTop - el.clientHeight > 24; }
+
+///|
+pub fn panel(state : State, emit : @cmd.Emit[Msg]) -> @html.Html {
+  let running = state.jobs
+    .filter(view => !view.job.state.is_terminal())
+    .length()
+  let header = @html.div(class="jobs-heading", [
+    @html.div([
+      @html.h3("Background jobs"),
+      @html.span(
+        class="jobs-summary",
+        "\{running} active · \{state.jobs.length()} loaded",
+      ),
+    ]),
+    @html.button(
+      class="jobs-action",
+      on_click=emit(Poll),
+      disabled=state.listing,
+      "Refresh",
+    ),
+  ])
+  let body : Array[@html.Html] = [header]
+  if state.owner is Some(owner) {
+    body.push(
+      @html.div(
+        class="jobs-host",
+        "Host: \{owner.channel.uri_authority()} · \{owner.scope.session}",
+      ),
+    )
+  }
+  if state.owner is Some(_) && !state.active {
+    body.push(
+      @html.div(
+        class="jobs-error",
+        "Disconnected. Output remains on the host; reconnect to refresh.",
+      ),
+    )
+  }
+  if state.error is Some(error) {
+    body.push(
+      @html.div(
+        class="jobs-error",
+        attrs=@html.Attrs::build().role("alert"),
+        error,
+      ),
+    )
+  }
+  for warning in state.warnings {
+    body.push(@html.div(class="jobs-error", warning))
+  }
+  if state.jobs.is_empty() {
+    body.push(
+      @html.div(class="jobs-empty", [
+        @html.h3(
+          if state.listing {
+            "Loading jobs…"
+          } else {
+            "No background jobs yet"
+          },
+        ),
+        @html.p(
+          "Commands appear here when they move to the background. Their output files stay with this conversation.",
+        ),
+      ]),
+    )
+  } else {
+    let rows = state.jobs.map(view => {
+      let job = view.job
+      let selected = state.selected == Some((job.generation, job.id))
+      @html.button(
+        class="jobs-row" + (if selected { " selected" } else { "" }),
+        attrs=@html.Attrs::build().aria_pressed(selected.to_string()),
+        title=job.command,
+        on_click=emit(Select(job.generation, job.id)),
+        [
+          @html.div(class="jobs-row-head", [
+            @html.span(class="jobs-id", job.id),
+            @html.span(
+              class="jobs-status jobs-status-\{status_class(job.state)}",
+              status_label(job.state),
+            ),
+          ]),
+          @html.div(
+            class="jobs-command",
+            job.description.unwrap_or(job.command),
+          ),
+          @html.div(
+            class="jobs-row-meta",
+            "\{timestamp(job.backgrounded_at_ms.to_double())} · \{job.output_bytes} B",
+          ),
+        ],
+      )
+    })
+    if state.next_offset is Some(_) {
+      rows.push(
+        @html.button(
+          class="jobs-action jobs-more",
+          disabled=state.listing,
+          on_click=emit(More),
+          "Load older jobs",
+        ),
+      )
+    }
+    body.push(
+      @html.div(
+        class="jobs-list",
+        attrs=@html.Attrs::build().aria_label("Background jobs"),
+        rows,
+      ),
+    )
+    if selected_job(state) is Some(view) {
+      let job = view.job
+      let details : Array[@html.Html] = [
+        @html.div(class="jobs-detail-title", [
+          @html.strong(job.id),
+          @html.span(
+            class="jobs-status jobs-status-\{status_class(job.state)}",
+            status_label(job.state),
+          ),
+        ]),
+        @html.pre(class="jobs-full-command", job.command),
+        @html.div(
+          class="jobs-detail-meta",
+          "Started \{timestamp(job.started_at_ms.to_double())}",
+        ),
+      ]
+      if job.cwd is Some(cwd) {
+        details.push(
+          @html.div(class="jobs-detail-meta", "Working directory: \{cwd}"),
+        )
+      }
+      let end = job.finished_at_ms
+        .map(n => n.to_double())
+        .unwrap_or(@interop.now_ms())
+      let seconds = ((end - job.started_at_ms.to_double()).max(0) / 1000).to_int()
+      let activity = match job.last_output_at_ms {
+        Some(last) =>
+          "Last output \{((@interop.now_ms() - last.to_double()).max(0) / 1000).to_int()}s ago"
+        None => "No output yet"
+      }
+      details.push(
+        @html.div(
+          class="jobs-detail-meta",
+          "Elapsed \{seconds}s · \{activity}",
+        ),
+      )
+      let actions : Array[@html.Html] = []
+      if view.output_path is Some(path) {
+        details.push(
+          @html.div(class="jobs-path", [@html.code(title=path, path)]),
+        )
+        actions.append([
+          @html.button(
+            class="jobs-action",
+            on_click=@clipboard.copy(Text(path)),
+            "Copy path",
+          ),
+          @html.button(
+            class="jobs-action",
+            on_click=@clipboard.copy(Text(tail_command(path))),
+            "Copy tail command",
+          ),
+          @html.button(
+            class="jobs-action",
+            on_click=emit(ToggleFollow),
+            attrs=@html.Attrs::build().aria_pressed(state.follow.to_string()),
+            if state.follow {
+              "Pause"
+            } else {
+              "Follow output"
+            },
+          ),
+          @html.button(
+            class="jobs-action",
+            on_click=emit(Reload),
+            "Reload tail",
+          ),
+        ])
+      }
+      actions.push(
+        @html.button(
+          class="jobs-action jobs-stop",
+          disabled=!view.controllable || state.stopping,
+          on_click=emit(Stop),
+          if state.stopping {
+            "Stopping…"
+          } else {
+            "Stop job"
+          },
+        ),
+      )
+      details.push(@html.div(class="jobs-toolbar", actions))
+      for
+        error in [
+          view.error,
+          job.output_error,
+          job.persistence_error,
+          job.cleanup_error,
+          state.read_error,
+          state.control_error,
+        ] {
+        if error is Some(error) {
+          details.push(
+            @html.div(
+              class="jobs-error",
+              attrs=@html.Attrs::build().role("alert"),
+              error,
+            ),
+          )
+        }
+      }
+      if job.output_truncated {
+        details.push(
+          @html.div(
+            class="jobs-error",
+            "Output capture reached its limit; the retained log is truncated.",
+          ),
+        )
+      }
+      if job.invalid_utf8 {
+        details.push(
+          @html.div(
+            class="jobs-error",
+            "Output contained invalid UTF-8; replacement characters were saved.",
+          ),
+        )
+      }
+      let note = if view.output_path is None {
+        "No retained log file for this job."
+      } else if state.read_error is Some(_) {
+        "Output unavailable · reload to retry."
+      } else if state.follow {
+        if state.catching_up {
+          "Catching up with output…"
+        } else {
+          "Following output"
+        }
+      } else {
+        "Paused · output continues to the file"
+      }
+      let note = if state.clipped &&
+        view.output_path is Some(_) &&
+        state.read_error is None {
+        note +
+        " · Showing recent output. The file contains the full retained log."
+      } else {
+        note
+      }
+      details.push(@html.div(class="jobs-output-note", note))
+      if view.output_path is Some(_) {
+        details.push(
+          @html.div(
+            id="bg-job-output",
+            class="jobs-output",
+            attrs=@html.Attrs::build()
+              .tabindex(0)
+              .role("region")
+              .aria_label("Job output")
+              .on_scroll(_ => {
+                if state.follow && away_from_end() {
+                  emit(Pause)
+                } else {
+                  @cmd.none
+                }
+              }),
+            [
+              @html.pre(
+                if state.text.is_empty() {
+                  if state.reading {
+                    "Loading output…"
+                  } else {
+                    "No output yet."
+                  }
+                } else {
+                  state.text
+                },
+              ),
+            ],
+          ),
+        )
+      }
+      details.push(
+        @html.div(
+          class="jobs-footnote",
+          "Stop controls the direct process. Logs are retained with the session.",
+        ),
+      )
+      body.push(@html.div(class="jobs-detail", details))
+    }
+  }
+  @html.div(class="jobs-panel", body)
+}

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -1490,6 +1490,7 @@ priv struct Model {
   // Terminal tabs and their connection snapshots affect both the component
   // view and root layout. The root owns the opaque state once so neither side
   // reports a second visibility copy back to the other.
+  jobs : @jobs.State
   terminal : @terminal.State
   // The archive-discard confirmation, staged when the host refused an
   // archive because the conversation's worktree holds uncommitted changes;
@@ -2067,6 +2068,8 @@ priv enum Msg {
   ExplorerRequested(@fileeditor.ExplorerMode)
   // Open the Workflows tab in the right panel.
   WorkflowsRequested
+  JobsRequested
+  Jobs(@jobs.Msg)
   // The browser toolbar, acting on whatever Browser tab is active — the
   // messages carry no id so a stale click cannot outlive a tab switch.
   BrowserAddressEdited(String)
@@ -2400,6 +2403,7 @@ priv enum DeviceMsg {
   // stamp): idle events (the compaction lifecycle, background notices) route
   // by it, because a conversation compacted before its first prompt of this
   // app-lifetime has no run id to match.
+  JobsChanged(String)
   Engine(String?, @transcript.EngineEvent, session~ : String?)
   // The exact local start request returned its run result. `accepted` is the
   // prompt's ownership receipt and can recover a Started notification lost on
@@ -2626,6 +2630,7 @@ fn initial_model() -> Model {
     right_panel_open: false,
     right_panel_menu_open: false,
     right_panel_expanded: false,
+    jobs: @jobs.State::empty(),
     terminal: @terminal.State::empty(),
     active_session: "",
     loading_conversation: None,

--- a/desktop/frontend/moon.pkg
+++ b/desktop/frontend/moon.pkg
@@ -1,4 +1,6 @@
 import {
+  "bobzhang/openseek_protocol" @wire,
+  "openseek_desktop/frontend/jobs",
   "moonbitlang/core/cmp",
   "moonbitlang/core/debug",
   "moonbitlang/core/immut/sorted_map",

--- a/desktop/frontend/right_panel/component.mbt
+++ b/desktop/frontend/right_panel/component.mbt
@@ -10,6 +10,8 @@ struct Input {
   menu_open : Bool
   expanded : Bool
   reveal_label : String?
+  // Session-scoped jobs, including retained history and the selected log.
+  jobs : @jobs.State
   // The workflows the active conversation's snippets announced, for the
   // Workflows tab. Live-only state projected from the root's conversation.
   workflows : Array[@workflow.Run]
@@ -25,6 +27,7 @@ pub fn Input::Input(
   menu_open~ : Bool,
   expanded~ : Bool,
   reveal_label~ : String?,
+  jobs~ : @jobs.State,
   workflows~ : Array[@workflow.Run],
 ) -> Input {
   {
@@ -37,6 +40,7 @@ pub fn Input::Input(
     expanded,
     reveal_label,
     workflows,
+    jobs,
   }
 }
 
@@ -50,6 +54,8 @@ pub(all) struct Actions {
   search : @cmd.Cmd
   files : @cmd.Cmd
   review : @cmd.Cmd
+  jobs : @cmd.Cmd
+  job_events : @cmd.Emit[@jobs.Msg]
   workflows : @cmd.Cmd
   // Open one subagent's transcript: the child's session id, as its row
   // carries it.

--- a/desktop/frontend/right_panel/moon.pkg
+++ b/desktop/frontend/right_panel/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "openseek_desktop/frontend/jobs",
   "moonbit-community/rabbita",
   "moonbit-community/rabbita/cmd",
   "moonbit-community/rabbita/html",

--- a/desktop/frontend/right_panel/view.mbt
+++ b/desktop/frontend/right_panel/view.mbt
@@ -39,6 +39,13 @@ fn panel_view(
         }
         { tab, label, title, missing: false, }
       }
+      Jobs =>
+        {
+          tab,
+          label: "Jobs",
+          title: "Background jobs and retained output",
+          missing: false,
+        }
       Workflows =>
         {
           tab,
@@ -67,6 +74,7 @@ fn panel_view(
     search: @cmd.batch([actions.search, actions.close_menu]),
     files: @cmd.batch([actions.files, actions.close_menu]),
     review: @cmd.batch([actions.review, actions.close_menu]),
+    jobs: @cmd.batch([actions.jobs, actions.close_menu]),
     workflows: @cmd.batch([actions.workflows, actions.close_menu]),
   }
   // Every body remains mounted and CSS selects the active kind. This preserves
@@ -81,6 +89,7 @@ fn panel_view(
     Some(FilePicker) => "mode-picker"
     Some(File(_)) => "mode-file"
     Some(GitDiff(_)) => "mode-history"
+    Some(Jobs) => "mode-jobs"
     Some(Workflows) => "mode-workflows"
   }
   let active_page : @preview.PageState = match
@@ -141,6 +150,7 @@ fn panel_view(
           ([] : Array[@html.Html]),
         ),
       ]),
+      @jobs.panel(input.jobs, actions.job_events),
       @workflow.panel(input.workflows, { open_child: actions.open_child, }),
       @dock.launcher_pane(launcher),
     ],

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -835,7 +835,7 @@ fn reveal_local_directory(
 ) -> (@cmd.Cmd, Model) {
   let dock = match model.dock.active {
     Some(File(_)) | Some(FilePicker) => model.dock
-    None | Some(Browser(_)) | Some(GitDiff(_)) | Some(Workflows) =>
+    None | Some(Browser(_)) | Some(GitDiff(_)) | Some(Workflows) | Some(Jobs) =>
       @dock.open_picker(model.dock)
   }
   let model = {
@@ -1475,7 +1475,7 @@ fn file_ctx(model : Model) -> @fileeditor.Ctx {
   }
   let file_body_visible = match model.dock.active {
     Some(File(_)) | Some(GitDiff(_)) | Some(FilePicker) => true
-    None | Some(Browser(_)) | Some(Workflows) => false
+    None | Some(Browser(_)) | Some(Workflows) | Some(Jobs) => false
   }
   {
     // Keep the real identity even while placement is unresolved or missing.
@@ -1902,6 +1902,22 @@ fn update(
     terminal_emit, terminal_input,
   )
   let model = { ..model, terminal, }
+  let owner = model.jobs_owner()
+  let active = model.file_panel_visible() &&
+    model.dock.active is Some(Jobs) &&
+    owner is Some(owner) &&
+    model.devices.any(dev => {
+      dev.channel == owner.channel &&
+      dev.bridge is Connected &&
+      dev.reconnect_failures == 0
+    })
+  let (jobs_cmd, jobs) = @jobs.reconcile(
+    dispatch.map(msg => Jobs(msg)),
+    model.jobs,
+    owner,
+    active,
+  )
+  let model = { ..model, jobs, }
   let (model, browser_cmd) = sync_browser_view(dispatch, model)
   (
     @cmd.batch([
@@ -1911,6 +1927,7 @@ fn update(
       panel_visibility_cmd,
       panel_cmd,
       terminal_cmd,
+      jobs_cmd,
       browser_cmd,
       sync_dock_visibility(
         model.dock.active != previous.dock.active ||
@@ -4994,7 +5011,7 @@ fn update_msg(
               }
               // Neither tab owns a document: closing one while active hands
               // focus to a neighbouring file or diff, and otherwise nothing.
-              FilePicker | Workflows =>
+              FilePicker | Workflows | Jobs =>
                 if was_active && next_file is Some(path) {
                   let (cmd, panel) = @fileeditor.activate(
                     femit,
@@ -5058,6 +5075,24 @@ fn update_msg(
     ExplorerRequested(mode) => open_explorer(dispatch, model, mode)
     // The Workflows tab: opened like the explorer inventories, keeping the
     // right panel on screen with its launcher menu closed.
+    Jobs(msg) => {
+      let (cmd, jobs) = @jobs.update(
+        dispatch.map(msg => Jobs(msg)),
+        msg,
+        model.jobs,
+      )
+      (cmd, { ..model, jobs, })
+    }
+    JobsRequested =>
+      (
+        @cmd.none,
+        {
+          ..model,
+          dock: @dock.open_jobs(model.dock),
+          right_panel_open: true,
+          right_panel_menu_open: false,
+        },
+      )
     WorkflowsRequested =>
       (
         @cmd.none,
@@ -7600,6 +7635,19 @@ fn update_device_msg(
       })
       (@cmd.none, { ..model, conversations: settled, })
     }
+    JobsChanged(session) =>
+      if model.jobs.owner is Some(owner) &&
+        owner.channel == channel &&
+        owner.scope.session == session {
+        let (cmd, jobs) = @jobs.update(
+          dispatch.map(msg => Jobs(msg)),
+          Poll,
+          model.jobs,
+        )
+        (cmd, { ..model, jobs, })
+      } else {
+        (@cmd.none, model)
+      }
     Engine(run_id, event, session~) => {
       // Compaction and background notices happen between turns, so their
       // events arrive after the run that owned `run_id` cleared

--- a/desktop/styles/file_panel.css
+++ b/desktop/styles/file_panel.css
@@ -2862,3 +2862,41 @@ button.git-history-file.selected {
   cursor: default;
   opacity: 0.5;
 }
+
+/* Background jobs share the dock's stable body slots. */
+.editor .jobs-panel { display: none; }
+.editor.mode-jobs .viewer-breadcrumb,
+.editor.mode-jobs .editor-body,
+.editor.mode-jobs .browser-chrome { display: none; }
+.editor.mode-jobs .jobs-panel { display: flex; }
+.jobs-panel { flex: 1; min-height: 0; min-width: 0; flex-direction: column; overflow: auto; padding: 18px; gap: 12px; color: var(--color-text-primary); }
+.jobs-heading, .jobs-row-head, .jobs-detail-title { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.jobs-heading h3 { margin: 0 0 4px; font-size: 16px; font-weight: 600; }
+.jobs-summary, .jobs-host, .jobs-row-meta, .jobs-detail-meta, .jobs-output-note, .jobs-footnote { font-size: 11px; color: var(--color-text-secondary); overflow-wrap: anywhere; }
+.jobs-host { padding-bottom: 8px; border-bottom: 1px solid var(--color-border); }
+.jobs-list { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(220px,100%),1fr)); gap: 7px; max-height: 220px; flex-shrink: 0; overflow: auto; }
+.jobs-row { display: flex; flex-direction: column; gap: 7px; text-align: left; padding: 11px; border: 1px solid var(--color-border); background: var(--color-bg-surface); border-radius: 7px; color: inherit; min-width: 0; cursor: pointer; }
+.jobs-row.selected { border-color: var(--color-accent); background: color-mix(in srgb, var(--color-accent) 6%, var(--color-bg-surface)); }
+.jobs-row:hover { border-color: var(--color-accent); }
+.jobs-id { font-family: var(--font-family-mono); font-size: 12px; }
+.jobs-command { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 100%; font-size: 12px; }
+.jobs-status { font-size: 11px; font-weight: 500; white-space: nowrap; }
+.jobs-status-running { color: var(--color-accent); }
+.jobs-status-completed { color: light-dark(#227644,#7ccc98); }
+.jobs-status-failed, .jobs-stop { color: light-dark(#b33732,#f09d94); }
+.jobs-status-stopped { color: var(--color-text-secondary); }
+.jobs-detail { display: flex; flex-direction: column; gap: 9px; flex: 1; min-height: 290px; min-width: 0; }
+.jobs-detail-title { justify-content: flex-start; border-top: 1px solid var(--color-border); padding-top: 12px; }
+.jobs-full-command { margin: 0; padding: 9px 11px; font: 12px/1.5 var(--font-family-mono); white-space: pre-wrap; overflow-wrap: anywhere; background: var(--color-bg-surface); border-radius: 5px; max-height: 110px; overflow: auto; }
+.jobs-path { font-size: 11px; overflow-wrap: anywhere; line-height: 1.5; }
+.jobs-toolbar { display: flex; flex-wrap: wrap; gap: 6px; }
+.jobs-action { border: 1px solid var(--color-border); background: var(--color-bg-surface); color: inherit; border-radius: 5px; padding: 5px 8px; font-size: 11px; cursor: pointer; }
+.jobs-action:disabled { opacity: .45; cursor: default; }
+.jobs-action:hover:not(:disabled) { border-color: var(--color-accent); }
+.jobs-error { font-size: 12px; line-height: 1.5; padding: 8px 10px; border-radius: 5px; background: light-dark(#fff0e8,#452a20); color: light-dark(#934020,#edb798); overflow-wrap: anywhere; }
+.jobs-output { flex: 1; min-height: 170px; max-height: 60vh; overflow: auto; background: light-dark(#f7f8fa,#15181e); border: 1px solid var(--color-border); border-radius: 6px; padding: 12px; }
+.jobs-output pre { margin: 0; font: 12px/1.65 var(--font-family-mono); white-space: pre-wrap; overflow-wrap: anywhere; tab-size: 4; }
+.jobs-empty { margin: auto; max-width: 330px; text-align: center; padding: 40px 12px; }
+.jobs-empty h3 { font-size: 14px; }
+.jobs-empty p { color: var(--color-text-secondary); font-size: 12px; line-height: 1.7; }
+.jobs-panel > :not(.jobs-detail), .jobs-detail > :not(.jobs-output) { flex-shrink: 0; }

--- a/docs/plans/background-job-observability.md
+++ b/docs/plans/background-job-observability.md
@@ -1,6 +1,6 @@
 # Background job visibility and durable output
 
-Date: 2026-09-11. Status: proposed; based on inspection of the current code. No runtime or UI changes implemented.
+Date: 2026-09-11. Status: implemented in three stacked implementation PRs following merged plan #1465. Current validation is recorded in [Jobs UI PR #1469](https://github.com/moonbitlang/openseek/pull/1469); the original aggregate review evidence remains in [PR #1470](https://github.com/moonbitlang/openseek/pull/1470). The design and baseline findings below preserve the reviewed proposal; the final section records implementation decisions and evidence.
 
 ## Recommendation and scope
 
@@ -123,14 +123,14 @@ Begin with bounded request polling for the visible output view, roughly every 50
 | 1. Reliable files | Sink write/error semantics, guaranteed logs at background adoption, separate scratch/log ownership, generation directories, paths in `mbtx` handoff / `job_output`. | A quiet job immediately has an empty file; external tail sees small output and output without newline; adoption preserves pre-detach output and path; a completed adopted log remains after shutdown. |
 | 2. Durable lifecycle | Metadata, universal lifecycle observer, timestamps, session artifact API, structured events and live snapshot command. | Natural exit, stop, watchdog and shutdown each settle once; restart cannot overwrite or collide; lost ownership and persistence failure are visible; archive/unarchive resolves paths. |
 | 3. Host reads and recovery | `jobs.list` / `jobs.read`, bounded byte cursors, session routing and reconnect reconciliation. | Reads do not duplicate/skip data across UTF-8 boundaries; simultaneous sessions/hosts with `bg-1` stay separate; stale snapshots/events cannot resurrect terminal jobs; I/O failure differs from no new output. |
-| 4. Jobs UI | Panel, running count, row/details, Follow/Pause/Load earlier, copy path/tail command. | Browser coverage for empty/noisy/failed jobs, autoscroll behavior, remote paths, background tabs, reconnect and bounded buffers. |
+| 4. Jobs UI | Panel, running count, row/details, Follow/Pause/Reload tail, older-job pagination, copy path/tail command. | Browser coverage for empty/noisy/failed jobs, autoscroll behavior, remote paths, background tabs, reconnect and bounded buffers. |
 | 5. Direct controls and hardening | Host-to-engine stop, idempotent results, teardown barriers, history/resource limits. | Stop works during an active turn and while idle; stale generations are refused; stop/exit races preserve the outcome; engine loss does not claim descendants were killed. |
 
 Phase 1 is independently useful: the user can manually tail output before the UI lands. Phases 1–4 deliver the requested visibility. Phase 5 adds a useful control and completes the lifecycle hardening before presenting Stop in the product.
 
 Use focused sink/runtime tests and extend the offline real-engine fixture in `tests/integration/turn_finish.py`; gated child output can prove intermediate visibility without flaky sleep-based expectations. Inject file open/write failures and verify final output is drained before terminal reads claim completion. Exercise Unicode, invalid UTF-8, huge lines, output/deadline limits, and no-session mode. Benchmark concurrent noisy jobs and a burst of tiny foreground executions to verify they create no unnecessary files and check descriptor cleanup.
 
-For implementation, finish with `moon info && moon fmt` and review generated interfaces; run `just check`, `just test`, `just build`, and `just desktop-test-browser`. If shared editor code changes, also run `just editor-test` and `just editor-test-browser`. No tests were run for this planning-only change.
+For implementation, finish with `moon info && moon fmt` and review generated interfaces; run `just check`, `just test`, `just build`, and `just desktop-test-browser`. If shared editor code changes, also run `just editor-test` and `just editor-test-browser`. The original planning-only PR required no runtime tests; implementation evidence is recorded below.
 
 ## Difficulty and remaining implementation decisions
 
@@ -145,14 +145,47 @@ Before coding phase 1, settle the exact sink retention enum and public artifact-
 
 The user authorized the complete implementation through stacked PRs and independent `openseek review`, followed by a review of the full stack. Each branch is based on the previous branch; each PR targets that predecessor so its diff remains focused. Do not merge a partial stack during implementation.
 
-1. `codex/bg-jobs-plan` → main: this complete plan, reviewed before implementation.
-2. `codex/bg-jobs-logs` → plan: serialized adoption, honest I/O handling, retained files and discoverable paths.
-3. `codex/bg-jobs-lifecycle` → logs: typed durable records, structured events, snapshot/stop control, teardown and restart identity.
-4. `codex/bg-jobs-host` → lifecycle: list/read/control bridge with bounded cursors and recovery.
-5. `codex/bg-jobs-ui` → host: Jobs panel and complete user flow, browser validation.
+The plan (#1465) is merged. The implementation is reorganized into three independently buildable PRs, with each review fix included in the layer it corrects:
+
+1. `codex/bg-jobs-logs` → main (#1466): retained logs, durable lifecycle records and events, snapshot/stop controls, lazy storage preparation, teardown/restart identity, and real CLI regression coverage. Includes the two Desktop exhaustive-match adaptations required by the new wire variants.
+2. `codex/bg-jobs-host` → logs (#1468): scoped list/read/stop bridge, bounded cursors and history, ownership recovery and storage-error handling, plus Windows host verification.
+3. `codex/bg-jobs-ui` → host (#1469): Jobs panel, bounded Unicode-safe output, lifecycle/history refresh, and browser E2E.
+
+The former lifecycle PR (#1467) is absorbed into #1466. The former hardening PR (#1470) is distributed across all three layers; its review history remains available. Regrouping preserves the final implementation and all regression tests while retaining newer main changes.
 
 Run `openseek review --base <predecessor>` on each implementation slice; fix actionable findings and re-review changed slices. At the end run it against the original stack base, inspecting the complete feature and cross-layer contracts. Review reports and test evidence belong in the PR descriptions. A plan review is design feedback, not evidence that implementation works.
 
-Completion means all five PRs exist, implemented behavior passes the specified gates, independent review findings are resolved or explicitly accounted for, and a final aggregate review has run. Retention/owner verification/byte-cursor behavior are part of the implementation, not deferred placeholders. Optional nested subprocess instrumentation and push subscriptions remain out of scope.
+Completion means the three implementation PRs are ready, implemented behavior passes the specified gates, independent review findings are resolved or explicitly accounted for, and a final aggregate review has run. Retention/owner verification/byte-cursor behavior are part of the implementation, not deferred placeholders. Optional nested subprocess instrumentation and push subscriptions remain out of scope.
 
 Plan review completed with `openseek review --base 08739cc19a6ebefa273fea4210613d98216bb51c`: no blocking/design findings, three citation-precision comments fixed. Reviewer reported `moon check --target all` and `moon test` passing (wasm 99, JS 1907, native 1784 tests). References in the findings table describe the original base revision.
+
+
+## Implementation decisions and evidence
+
+The current implementation stack is [runtime #1466](https://github.com/moonbitlang/openseek/pull/1466) → [host #1468](https://github.com/moonbitlang/openseek/pull/1468) → [UI #1469](https://github.com/moonbitlang/openseek/pull/1469), following merged [plan #1465](https://github.com/moonbitlang/openseek/pull/1465). The original lifecycle and hardening PRs remain as historical review records.
+
+- `SessionStore::job_logs_dir` validates a prospective path without creating a session. The runtime prepares its canonical generation directory and exclusive owner lock on first retained execution, after the turn's first durable append. Tiny foreground output still allocates no output file. Background adoption creates/seeds the file under the sink mutex before publication.
+- `JobRecord` uses a relative output basename, a generation, a positive revision, explicit optional timestamps/errors, and `Running/Stopping/Exited/Stopped/Interrupted` state. `job_changed` carries `started/updated/finished/failed`; separate `jobs_snapshot` and `job_stop_result` messages support correlated host requests outside turns. Startup publication completes before live snapshots expose the new record. Metadata persistence failures remain explicit in live records.
+- An exclusive `owner.lock` lives until child joining and terminal metadata finalization finish. Historical running records become Interrupted only after the host acquires that lock; an unavailable lock or owner-check failure is not treated as a dead process. Metadata/output references survive archive moves because the host resolves paths from the current session placement.
+- Metadata history is ordered by stable runtime creation stamps and monotonic `bg-N` ids. The host enumerates names and decodes at most 100 requested records per page plus the selected record, instead of replaying every historical record each second. Corrupt entries are reported in the page that contains them. The live runtime snapshot is overlaid by full generation/id identity. A selected record outside the first page is refreshed independently, including while output following is paused. Page merges update existing rows instead of preserving stale states.
+- Output reads return at most 64 KiB with absolute byte cursors and complete UTF-8 boundaries. Truncation, missing files, and I/O errors are explicit failures. Managed restarts always allocate a new generation. Arbitrary external replacement of a log at the same path with equal-or-larger content is outside this cursor contract; there is no portable inode-based replacement detector in this change.
+- The initial UI uses chronological history with the active count inside the Jobs panel. Earlier output is available through the retained file and copied tail command; in-panel output starts at a bounded tail, with Reload tail and older-job pagination rather than an unbounded log browser. The Jobs tab uses the existing dock and a dedicated plain-text view. It polls while visible at one-second intervals, with one list and one selected-log read in flight. The display keeps at most 262,144 UTF-16 units and preserves surrogate boundaries; the complete retained log remains on disk. Pause stops display reads, manual scroll pauses following, and Reload tail returns to recent output. Copy path and shell-quoted tail commands work for POSIX and Windows host paths. Hidden panels stop polling, and channel/session/visibility epochs reject late replies.
+- Epoch timestamps are used for history and displayed elapsed time, clamped against backward clock changes. The existing execution watchdog remains based on the async library's epoch clock; this change does not introduce a new portable monotonic clock implementation. It also does not promise per-chunk fsync or process-tree termination.
+
+The log-slice review reported one medium, two low, and one wording finding. The runtime layer addresses the medium by delaying artifact-directory creation rather than hiding damaged sessions from listings; adds an actionable scratch-directory error without silent memory-only fallback; catches terminal diagnostic read errors; and restricts temporary-file wording to actual files.
+
+Browser evidence before final hardening: four Jobs scenarios passed against the production bundle with a real subprocess and retained files behind the test transport. They cover stdout/stderr, UTF-8, no-newline output, pause/resume, manual scrolling, clipboard, stop, stale reads, missing files, session switching and page reload. Light/dark/narrow screenshots were inspected; narrow command clipping was fixed. The complete existing Desktop Chromium suite passed 82 tests. Native host tests independently exercise the actual byte reader, owner checks, metadata decoding and page limits. The original final gate results, complete-stack review, and correction reviews are recorded in [PR #1470](https://github.com/moonbitlang/openseek/pull/1470).
+
+The hardening validation additionally covers a selected job beyond the first 100 history rows, 20 concurrent tiny foreground executions with no output files, eight concurrent 256 KiB output jobs, malformed UTF-8 cursors, and controller snapshots during an active model request. The real CLI fixture checks that the file exists with pre-adoption output before the start event, rejects stale generations, stops while idle, and retains identical output and terminal metadata after restart.
+
+
+The lifecycle review's immutable-revision finding is fixed: publication snapshots once, then uses that same value for the metadata and event (adding an explicit persistence error if needed). The host review's Windows separator issue is fixed with shared normalized ownership paths, including live metadata fallback; UTF-8 leading-byte skipping is restricted to a genuine mid-file tail. Windows CI runs the host job path/read tests. The UI review's surrogate-boundary issue has a regression test, and Jobs has its own launcher icon. UNC paths use the PowerShell tail command after host normalization. The original shared `/tmp/bg-1.out` test collision was removed by giving each test its own directory.
+
+
+### Follow-up review hardening
+
+The follow-up to Claude's review keeps the same runtime/host/UI boundaries. Runtime teardown removes a generation only when it adopted no jobs and contains only its owner lock; missing metadata never justifies deleting a retained log. Full-log reads snapshot the committed prefix under the sink mutex, then read outside it. A failed initial seed preserves the captured memory head and the partial file path for diagnosis.
+
+The host consumes correlated snapshot/stop replies without broadcasting them as conversation events. Stop has separate delivery (5 seconds) and settlement (30 seconds) budgets; a settlement timeout says completion is unconfirmed and never reports a merely requested stop as completed. Failed live refreshes report uncertain ownership while keeping controls conservative. Historical metadata byte counts remain unsuitable as a cap for actively growing log reads because metadata is published on lifecycle changes, not on every append.
+
+Following can drain up to four 64 KiB pages per refresh cycle, with a catching-up indicator and a progress check that defers incomplete UTF-8 suffixes to the next tick. Pause/resume and manual reload keep an outstanding selected-log read accounted for; a queued reload discards the obsolete reply before issuing a fresh tail read. Stop is available independently of the output path. Common stop reasons have readable labels. The additional browser scenarios cover a large completed burst, paused reload with a delayed response, and stopping a controllable job without a log path. Current test counts and fresh independent review results are maintained in #1469.


### PR DESCRIPTION
Add a Jobs tab to the existing Desktop panel launcher. Users can inspect active and retained jobs, follow or pause output, copy a log path or tail command, reload the latest output, load older jobs, and stop the tracked execution.

The view polls only while visible, bounds reads and displayed text, preserves Unicode boundaries, and rejects stale replies after session or visibility changes. History refresh and storage failures remain visible even when output following is paused. UI review fixes and the complete browser regressions are included in this PR.

## Follow-up hardening

- Drain at most four 64 KiB pages per refresh cycle while following, display catching-up status, and defer a partial UTF-8 suffix when its cursor cannot advance.
- Serialize pause/resume and queued manual reload behind the outstanding selected-log read; cancel pending refresh intent when pausing or hiding the panel.
- Keep Stop available without an output path, keep the toolbar compact, and show readable stop reasons.
- Add state regressions and three production-browser scenarios: a large completed output burst, paused reload with a held response, and stopping a controllable job without a log path.

The existing opt-in Jobs launcher remains the product scope. A persistent conversation-level running-count entry and history-cache work are separate improvements.

## Validation

Current-head `c64c70dba` [CI](https://github.com/moonbitlang/openseek/actions/runs/34664735968) and [Desktop/Windows](https://github.com/moonbitlang/openseek/actions/runs/34664736056) passed. This PR remains one commit and is mergeable.

- Local combined-stack `moon info`, `moon fmt`, `just check`, `just test`, and `just build` passed. Final focused native regressions passed 262/262; Jobs state tests passed 8/8.
- Independent `openseek review` of the 13-file hardening delta found no blockers and two low-severity UI status issues. Both were fixed in #1469. The final four-file correction review returned **zero findings**. Runtime and host code needed no further review corrections.
- Final-head GitHub tests passed: **3,095 native, 3,198 JS, 2,345 Wasm**, 38 cram cases, and offline CLI/workflow integration.
- The rebuilt production browser passed **86/86 E2E tests without retries locally**, and **86/86 in GitHub CI**. All eight Jobs scenarios passed, including the final read-error/no-log assertions. Windows packaging and all **8 native job-host regressions** passed. Light/dark/narrow screenshots were inspected.
- Browser tests use production frontend code with a transport fixture backed by real subprocesses and retained files. Native host and real CLI tests cover the actual backend separately.

An earlier UI-head native attempt failed with process-spawn EAGAIN and a child-output assertion. Identical backend code passed runtime/host CI, and all 31 relevant tests passed locally. Its retry was superseded by the final UI-only correction. The final native run passed all 3,095 tests with no backend change or weakened test.

## Limits

The panel retains bounded recent output and exposes the complete retained file. Stop controls the tracked execution/direct child. Retention ends with session deletion; streaming does not fsync each chunk. Same-path external replacement with equal-or-larger content is outside the byte-cursor contract.

## Stack and review history

Plan #1465 is merged. Review and merge the implementation in this order: #1466 (runtime) → #1468 (host) → #1469 (UI).

The former lifecycle PR #1467 is absorbed into #1466. The corrections from #1470 are included in the layer they fix. This regrouping preserves the reviewed implementation and regression tests, retains newer main changes, and updates the delivery documentation. The original independent `openseek review` findings, resolutions, and aggregate validation remain available in #1470.
