### PR TITLE
refactor(agent_runtime): hide and deprecate derived trait-method promotions

### DIFF
--- a/agent_runtime/approval.mbt
+++ b/agent_runtime/approval.mbt
@@ -105,13 +105,21 @@ async test "a wired channel is handed over intact" {
 }
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend ApprovalAsk with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend ApprovalAsk with Eq::{equal, not_equal}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend ApprovalOutcome with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend ApprovalOutcome with Eq::{equal, not_equal}

--- a/agent_runtime/pkg.generated.mbti
+++ b/agent_runtime/pkg.generated.mbti
@@ -34,9 +34,6 @@ pub(all) struct ApprovalAsk {
   detail : String
   body : String?
 } derive(Eq, @debug.Debug)
-pub fn ApprovalAsk::equal(Self, Self) -> Bool
-pub fn ApprovalAsk::not_equal(Self, Self) -> Bool
-pub fn ApprovalAsk::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ApprovalChannel(async (ApprovalAsk) -> ApprovalOutcome)
 pub async fn ApprovalChannel::ask(Self, ApprovalAsk) -> ApprovalOutcome
@@ -47,9 +44,6 @@ pub(all) enum ApprovalOutcome {
   Cancelled
   Unavailable
 } derive(Eq, @debug.Debug)
-pub fn ApprovalOutcome::equal(Self, Self) -> Bool
-pub fn ApprovalOutcome::not_equal(Self, Self) -> Bool
-pub fn ApprovalOutcome::to_repr(Self) -> @debug.Repr
 
 pub(all) enum SteerInput {
   Prompt(String)


### PR DESCRIPTION
## What

Following `agent_review/types.mbt` and `agent_session/types.mbt`, this
shrinks `agent_runtime`'s public interface by hiding and deprecating the
four derived trait-method promotions on `ApprovalAsk` and `ApprovalOutcome`:

- `pub extend ApprovalAsk with Debug::{to_repr}`
- `pub extend ApprovalAsk with Eq::{equal, not_equal}`
- `pub extend ApprovalOutcome with Debug::{to_repr}`
- `pub extend ApprovalOutcome with Eq::{equal, not_equal}`

Each now carries `#doc(hidden)` + `#deprecated`. The trait impls stay
public -- `Debug` and `Eq` remain usable through the traits -- so only the
dot-callable promoted methods drop out of the generated `.mbti`.
`agent_runtime/pkg.generated.mbti` is regenerated via `moon info`
(6 lines removed).

## Verification

- `moon check --target native --deny-warn`: clean
- `moon check --target js --deny-warn`: clean
- `moon check --target wasm --deny-warn`: clean
- `moon test agent_runtime --target native`: 12 passed / 0 failed
- `moon fmt --check`: clean
- `moon ide analyze agent_runtime`: the four promotions no longer appear

Not verified: the analyzer only sees this workspace, so an external
consumer of the published module could still dot-call a promoted method --
such a call would now warn (E0020) rather than fail to compile. Nothing in
this repo did.

Generated with SeekMoon