### PR TITLE
refactor(agent_worker): hide and deprecate derived trait-method promotions

### DIFF
--- a/agent_worker/pkg.generated.mbti
+++ b/agent_worker/pkg.generated.mbti
@@ -22,10 +22,7 @@ pub struct WorkerInput {
   allowed_paths : Array[String]
   // private fields
 } derive(Eq, @debug.Debug)
-pub fn WorkerInput::equal(Self, Self) -> Bool
-pub fn WorkerInput::not_equal(Self, Self) -> Bool
 pub fn WorkerInput::parse(Json) -> Result[Self, String]
-pub fn WorkerInput::to_repr(Self) -> @debug.Repr
 
 pub struct WorkerReport {
   status : String
@@ -33,12 +30,8 @@ pub struct WorkerReport {
   verification : String
   // private fields
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
-pub fn WorkerReport::equal(Self, Self) -> Bool
-pub fn WorkerReport::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
-pub fn WorkerReport::not_equal(Self, Self) -> Bool
 pub fn WorkerReport::parse_validated(Json) -> Result[Self, String]
 pub fn WorkerReport::to_json(Self) -> Json
-pub fn WorkerReport::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/agent_worker/tool.mbt
+++ b/agent_worker/tool.mbt
@@ -198,7 +198,11 @@ pub async fn run_child(
 }
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend WorkerInput with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend WorkerInput with Eq::{equal, not_equal}

--- a/agent_worker/types.mbt
+++ b/agent_worker/types.mbt
@@ -126,12 +126,18 @@ pub fn WorkerReport::parse_validated(
 }
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend WorkerReport with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend WorkerReport with FromJson::{from_json}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend WorkerReport with Eq::{equal, not_equal}
 
 ///|


### PR DESCRIPTION
## What

Continues the derived-promotion sweep (`agent_subrun` #1463, `agent_runtime` #1471) with **agent_worker**. Five derived trait-method promotions now carry `#doc(hidden)` + `#deprecated`, per [shrink_package.md](shrink_package.md):

- `pub extend WorkerInput with Debug::{to_repr}`
- `pub extend WorkerInput with Eq::{equal, not_equal}`
- `pub extend WorkerReport with Debug::{to_repr}`
- `pub extend WorkerReport with FromJson::{from_json}`
- `pub extend WorkerReport with Eq::{equal, not_equal}`

The trait impls stay public — `Debug`, `Eq`, `FromJson` and `ToJson` remain usable through the traits — so only the dot-callable promoted methods drop out of the generated `.mbti` (7 lines removed; the `.mbti` diff is the review artifact). The file is regenerated with a module-wide `moon info`, exactly as CI's interface gate runs it: a scoped `moon info agent_worker` writes a different file and fails that gate.

`WorkerReport::to_json` is deliberately left un-deprecated: `cmd/openseek/subrun.mbt:390` calls `report.to_json()` across the package boundary, and `moon check --deny-warn` fails with E0020 without it. That is the same single exception `agent_review` made for `ReviewReport::to_json`.

## Verification

- `moon check --target native|js|wasm --deny-warn`: clean
- `moon test agent_worker --target native`: 8 passed / 0 failed
- `moon fmt --check`: clean
- `moon info` then `git status` / `git diff -- '*.mbti'`: no drift, no new `.mbti`
- `moon ide analyze agent_worker`: the five promotions no longer appear

Generated with SeekMoon