### PR TITLE
refactor: hide and deprecate derived trait-method promotions module-wide

### DIFF
--- a/agent_explore/pkg.generated.mbti
+++ b/agent_explore/pkg.generated.mbti
@@ -17,22 +17,12 @@ pub async fn run_child(Json, api_key~ : String, model~ : @deepseek.Model, max_st
 
 // Types and methods
 type Citation derive(Eq, ToJson, @debug.Debug, @json.FromJson)
-pub fn Citation::equal(Self, Self) -> Bool
-pub fn Citation::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
-pub fn Citation::not_equal(Self, Self) -> Bool
-pub fn Citation::to_json(Self) -> Json
-pub fn Citation::to_repr(Self) -> @debug.Repr
 
 pub struct ExploreReport {
   answer : String
   citations : Array[Citation]
   // private fields
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
-pub fn ExploreReport::equal(Self, Self) -> Bool
-pub fn ExploreReport::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
-pub fn ExploreReport::not_equal(Self, Self) -> Bool
-pub fn ExploreReport::to_json(Self) -> Json
-pub fn ExploreReport::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/agent_explore/types.mbt
+++ b/agent_explore/types.mbt
@@ -156,25 +156,41 @@ test "parse reports an error on malformed json" {
 }
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend Citation with Eq::{not_equal, equal}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend Citation with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend Citation with ToJson::{to_json}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend Citation with FromJson::{from_json}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend ExploreReport with Eq::{not_equal, equal}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend ExploreReport with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend ExploreReport with ToJson::{to_json}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend ExploreReport with FromJson::{from_json}

--- a/agent_pattern_repair/pkg.generated.mbti
+++ b/agent_pattern_repair/pkg.generated.mbti
@@ -14,11 +14,6 @@ pub async fn run(String, String, api_key~ : String, model~ : @deepseek.Model, ma
 
 // Types and methods
 type PatternRepairReport derive(Eq, ToJson, @debug.Debug, @json.FromJson)
-pub fn PatternRepairReport::equal(Self, Self) -> Bool
-pub fn PatternRepairReport::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
-pub fn PatternRepairReport::not_equal(Self, Self) -> Bool
-pub fn PatternRepairReport::to_json(Self) -> Json
-pub fn PatternRepairReport::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/agent_pattern_repair/types.mbt
+++ b/agent_pattern_repair/types.mbt
@@ -9,15 +9,23 @@ struct PatternRepairReport {
 } derive(Debug, Eq, ToJson, FromJson)
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend PatternRepairReport with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend PatternRepairReport with Eq::{equal, not_equal}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend PatternRepairReport with ToJson::{to_json}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend PatternRepairReport with FromJson::{from_json}
 
 ///|

--- a/agent_review/pkg.generated.mbti
+++ b/agent_review/pkg.generated.mbti
@@ -25,7 +25,6 @@ pub fn ReviewReport::digest(Self) -> String
 pub fn ReviewReport::finding_count(Self) -> Int
 pub fn ReviewReport::has_blockers(Self) -> Bool
 pub fn ReviewReport::parse(Json) -> Result[Self, String]
-pub fn ReviewReport::to_json(Self) -> Json
 pub fn ReviewReport::to_json_string(Self) -> String
 pub fn ReviewReport::validate(Self) -> Array[String]
 

--- a/agent_review/types.mbt
+++ b/agent_review/types.mbt
@@ -248,6 +248,8 @@ pub extend ReviewReport with FromJson::{from_json}
 pub extend ReviewReport with Eq::{equal, not_equal}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend ReviewReport with ToJson::{to_json}
 
 ///|

--- a/agent_session/README.mbt.md
+++ b/agent_session/README.mbt.md
@@ -496,7 +496,7 @@ test "session JSON round-trips events" {
     .append(User(UserMessage("hello")))
     .append(Terminal(Finished("done")))
 
-  let decoded : @agent_session.Session = @json.from_json(session.to_json())
+  let decoded : @agent_session.Session = @json.from_json(Json(session))
   debug_inspect(
     decoded,
     content=(

--- a/agent_session/goal.mbt
+++ b/agent_session/goal.mbt
@@ -257,13 +257,21 @@ pub fn Session::current_goal_baseline(self : Session) -> GoalBaseline? {
 }
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend GoalBaseline with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend GoalBaseline with Eq::{equal, not_equal}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend GoalMarker with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend StandingGoal with Debug::{to_repr}

--- a/agent_session/json.mbt
+++ b/agent_session/json.mbt
@@ -214,16 +214,26 @@ pub impl FromJson for Session with fn from_json(
 }
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend Session with FromJson::{from_json}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend Session with ToJson::{to_json}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend SessionId with FromJson::{from_json}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend SessionItem with FromJson::{from_json}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend TurnTerminal with FromJson::{from_json}

--- a/agent_session/log/exports.mbt
+++ b/agent_session/log/exports.mbt
@@ -79,7 +79,11 @@ pub fn parse_events(text : String) -> ParsedLog {
 }
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend ParsedLog with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend ParsedLog with Eq::{equal, not_equal}

--- a/agent_session/log/log.mbt
+++ b/agent_session/log/log.mbt
@@ -94,19 +94,31 @@ pub fn session_from_parse(
 }
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend HeaderParse with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend LineError with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend LineError with Eq::{equal, not_equal}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend SessionFileHeader with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend SessionFileHeader with Eq::{equal, not_equal}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend SessionFileHeader with ToJson::{to_json}

--- a/agent_session/log/log_test.mbt
+++ b/agent_session/log/log_test.mbt
@@ -164,7 +164,7 @@ test "parse lifts the header record from the first line" {
     id: "demo",
     system_prompt: "You are a helpful agent.",
   }
-  let text = "\{header.to_json().stringify()}\n\{events_jsonl(sample_session())}"
+  let text = "\{Json(header).stringify()}\n\{events_jsonl(sample_session())}"
   let parsed = @log.parse_events(text)
   debug_inspect(
     parsed.header,
@@ -176,7 +176,7 @@ test "parse lifts the header record from the first line" {
   assert_eq(parsed.errors.length(), 0)
   // A header record is only recognized on the first content line; later
   // header-shaped lines are ordinary bad lines.
-  let trailing = "\{events_jsonl(sample_session())}\{header.to_json().stringify()}\n"
+  let trailing = "\{events_jsonl(sample_session())}\{Json(header).stringify()}\n"
   let reparsed = @log.parse_events(trailing)
   debug_inspect(reparsed.header, content="None")
   assert_eq(reparsed.events.length(), 5)

--- a/agent_session/log/pkg.generated.mbti
+++ b/agent_session/log/pkg.generated.mbti
@@ -21,16 +21,12 @@ pub enum HeaderParse {
   UnsupportedVersion(Int)
   NotHeader
 } derive(@debug.Debug)
-pub fn HeaderParse::to_repr(Self) -> @debug.Repr
 
 pub struct LineError {
   line_number : Int
   content : String
   message : String
 } derive(Eq, @debug.Debug)
-pub fn LineError::equal(Self, Self) -> Bool
-pub fn LineError::not_equal(Self, Self) -> Bool
-pub fn LineError::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ParsedLog {
   header : SessionFileHeader?
@@ -38,18 +34,11 @@ pub(all) struct ParsedLog {
   errors : Array[LineError]
   partial_tail : Bool
 } derive(Eq, @debug.Debug)
-pub fn ParsedLog::equal(Self, Self) -> Bool
-pub fn ParsedLog::not_equal(Self, Self) -> Bool
-pub fn ParsedLog::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SessionFileHeader {
   id : String
   system_prompt : String
 } derive(Eq, @debug.Debug)
-pub fn SessionFileHeader::equal(Self, Self) -> Bool
-pub fn SessionFileHeader::not_equal(Self, Self) -> Bool
-pub fn SessionFileHeader::to_json(Self) -> Json
-pub fn SessionFileHeader::to_repr(Self) -> @debug.Repr
 pub impl ToJson for SessionFileHeader
 
 // Type aliases

--- a/agent_session/pkg.generated.mbti
+++ b/agent_session/pkg.generated.mbti
@@ -47,9 +47,6 @@ pub(all) struct GoalBaseline {
   sha : String
   dirty : Bool
 } derive(Eq, @debug.Debug)
-pub fn GoalBaseline::equal(Self, Self) -> Bool
-pub fn GoalBaseline::not_equal(Self, Self) -> Bool
-pub fn GoalBaseline::to_repr(Self) -> @debug.Repr
 
 pub enum GoalMarker {
   GoalSet(String)
@@ -57,7 +54,6 @@ pub enum GoalMarker {
   GoalBlocked(String)
   GoalUnblocked
 } derive(@debug.Debug)
-pub fn GoalMarker::to_repr(Self) -> @debug.Repr
 
 type RuntimeNotice derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn RuntimeNotice::RuntimeNotice(String) -> Self
@@ -72,12 +68,10 @@ pub fn Session::compact(Self, content~ : String, from_sequence~ : Int, to_sequen
 pub fn Session::current_goal(Self) -> StandingGoal?
 pub fn Session::current_goal_baseline(Self) -> GoalBaseline?
 pub fn Session::events(Self) -> @vector.Vector[SessionEvent]
-pub fn Session::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn Session::id(Self) -> SessionId
 pub fn Session::last_sequence(Self) -> Int
 pub fn Session::summary_item(Self, content~ : String, from_sequence~ : Int, to_sequence~ : Int) -> SessionItem raise
 pub fn Session::system_prompt(Self) -> String
-pub fn Session::to_json(Self) -> Json
 pub impl ToJson for Session
 pub impl @json.FromJson for Session
 
@@ -89,7 +83,6 @@ pub fn SessionEvent::unix_ms(Self) -> Int64
 
 type SessionId derive(Eq, @debug.Debug)
 pub fn SessionId::SessionId(String) -> Self
-pub fn SessionId::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SessionId::generated(prefix~ : String, now_ms~ : Int64, salt? : String) -> Self
 pub fn SessionId::value(Self) -> String
 pub impl @json.FromJson for SessionId
@@ -102,7 +95,6 @@ pub(all) enum SessionItem {
   Summary(SessionSummary)
   Terminal(TurnTerminal)
 } derive(Eq, @debug.Debug)
-pub fn SessionItem::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub impl @json.FromJson for SessionItem
 
 type SessionSummary derive(Eq, ToJson, @debug.Debug, @json.FromJson)
@@ -116,7 +108,6 @@ pub fn StandingGoal::answered_since_set(Self) -> Bool
 pub fn StandingGoal::blocked(Self) -> Bool
 pub fn StandingGoal::set_sequence(Self) -> Int
 pub fn StandingGoal::text(Self) -> String
-pub fn StandingGoal::to_repr(Self) -> @debug.Repr
 
 type ToolResult derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn ToolResult::ToolResult(tool_call_id~ : String, tool_name~ : String, content~ : String, is_error? : Bool, brief? : String) -> Self
@@ -132,7 +123,6 @@ pub(all) enum TurnTerminal {
   Interrupted(String)
   Failed(String)
 } derive(Eq, @debug.Debug)
-pub fn TurnTerminal::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub impl @json.FromJson for TurnTerminal
 
 type UserMessage derive(Eq, ToJson, @debug.Debug, @json.FromJson)

--- a/agent_session/session_test.mbt
+++ b/agent_session/session_test.mbt
@@ -162,7 +162,7 @@ test "session JSON round trips typed events" {
       ),
     )
     .append(Terminal(Finished("done")))
-  let encoded = session.to_json()
+  let encoded = Json(session)
   let decoded : @agent_session.Session = @json.from_json(encoded)
   assert_eq(decoded.id().value(), "s1")
   assert_eq(decoded.system_prompt(), "system")

--- a/agent_session/store/pkg.generated.mbti
+++ b/agent_session/store/pkg.generated.mbti
@@ -16,7 +16,6 @@ pub fn SessionListing::first_prompt(Self) -> String
 pub fn SessionListing::id(Self) -> @agent_session.SessionId
 pub fn SessionListing::last_active_unix_seconds(Self) -> Int64?
 pub fn SessionListing::title(Self) -> String?
-pub fn SessionListing::to_repr(Self) -> @debug.Repr
 
 type SessionStore derive(@debug.Debug)
 pub fn SessionStore::SessionStore(String) -> Self
@@ -32,7 +31,6 @@ pub fn SessionStore::root(Self) -> String
 pub fn SessionStore::session_file(Self, @agent_session.SessionId) -> String raise
 pub async fn SessionStore::set_title(Self, @agent_session.SessionId, String) -> Unit
 pub async fn SessionStore::title(Self, @agent_session.SessionId) -> String?
-pub fn SessionStore::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/agent_session/store/store.mbt
+++ b/agent_session/store/store.mbt
@@ -132,7 +132,7 @@ fn header_line(session : @agent_session.Session) -> String {
     id: session.id().value(),
     system_prompt: session.system_prompt(),
   }
-  "\{header.to_json().stringify()}\n"
+  "\{Json(header).stringify()}\n"
 }
 
 ///|
@@ -834,7 +834,11 @@ pub async fn SessionStore::compact(
 }
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend SessionListing with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend SessionStore with Debug::{to_repr}

--- a/agent_skill/pkg.generated.mbti
+++ b/agent_skill/pkg.generated.mbti
@@ -19,7 +19,6 @@ type Skill derive(@debug.Debug)
 pub fn Skill::description(Self) -> String
 pub fn Skill::name(Self) -> String
 pub fn Skill::path(Self) -> String
-pub fn Skill::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/agent_skill/skill.mbt
+++ b/agent_skill/skill.mbt
@@ -156,4 +156,6 @@ pub fn skills_prompt_section(skills : Array[Skill]) -> String? {
 }
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend Skill with Debug::{to_repr}

--- a/agent_subtask/pkg.generated.mbti
+++ b/agent_subtask/pkg.generated.mbti
@@ -37,9 +37,6 @@ pub struct CaptureOutcome {
 }
 
 type Change derive(Eq, @debug.Debug)
-pub fn Change::equal(Self, Self) -> Bool
-pub fn Change::not_equal(Self, Self) -> Bool
-pub fn Change::to_repr(Self) -> @debug.Repr
 
 pub struct Geometry {
   origin_root : String
@@ -71,11 +68,6 @@ pub struct SubtaskEntry {
   commit_oid : String?
   // private fields
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
-pub fn SubtaskEntry::equal(Self, Self) -> Bool
-pub fn SubtaskEntry::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
-pub fn SubtaskEntry::not_equal(Self, Self) -> Bool
-pub fn SubtaskEntry::to_json(Self) -> Json
-pub fn SubtaskEntry::to_repr(Self) -> @debug.Repr
 
 pub enum SubtaskState {
   Provisioning
@@ -87,12 +79,7 @@ pub enum SubtaskState {
   Discarded
   NoChanges
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
-pub fn SubtaskState::equal(Self, Self) -> Bool
-pub fn SubtaskState::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SubtaskState::is_terminal(Self) -> Bool
-pub fn SubtaskState::not_equal(Self, Self) -> Bool
-pub fn SubtaskState::to_json(Self) -> Json
-pub fn SubtaskState::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/agent_subtask/registry.mbt
+++ b/agent_subtask/registry.mbt
@@ -216,25 +216,41 @@ fn with_default_conflict_paths(json : Json) -> Json {
 }
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend SubtaskEntry with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend SubtaskEntry with FromJson::{from_json}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend SubtaskEntry with Eq::{equal, not_equal}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend SubtaskEntry with ToJson::{to_json}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend SubtaskState with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend SubtaskState with FromJson::{from_json}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend SubtaskState with Eq::{equal, not_equal}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend SubtaskState with ToJson::{to_json}

--- a/agent_subtask/scope.mbt
+++ b/agent_subtask/scope.mbt
@@ -161,7 +161,11 @@ test "gitlink introductions are detected from raw -z records" {
 }
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend Change with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend Change with Eq::{equal, not_equal}

--- a/agent_tool/agent_tool.mbt
+++ b/agent_tool/agent_tool.mbt
@@ -529,18 +529,28 @@ test "Tools::function_tools yields one entry per definition" {
 }
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend AgentControl with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend AgentToolDefinition with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend JsonSchema with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend ToolAction with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend ToolOutput with Debug::{to_repr}
 
 ///|

--- a/agent_tool/bgjobs/bgjobs.mbt
+++ b/agent_tool/bgjobs/bgjobs.mbt
@@ -834,4 +834,6 @@ async test "a requested stop is not blamed on the reaper" {
 }
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend BgJobStatus with Eq::{equal, not_equal}

--- a/agent_tool/bgjobs/pkg.generated.mbti
+++ b/agent_tool/bgjobs/pkg.generated.mbti
@@ -48,8 +48,6 @@ pub enum BgJobStatus {
   Exited(Int)
   Stopped
 } derive(Eq)
-pub fn BgJobStatus::equal(Self, Self) -> Bool
-pub fn BgJobStatus::not_equal(Self, Self) -> Bool
 
 // Type aliases
 

--- a/agent_tool/edit/internal/decode/decode.mbt
+++ b/agent_tool/edit/internal/decode/decode.mbt
@@ -123,4 +123,6 @@ fn required_positive_int(
 }
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend EditInput with Debug::{to_repr}

--- a/agent_tool/edit/internal/decode/pkg.generated.mbti
+++ b/agent_tool/edit/internal/decode/pkg.generated.mbti
@@ -21,7 +21,6 @@ pub struct EditInput {
   end_line : Int?
   revert_on_parse_errors : Bool
 } derive(@debug.Debug)
-pub fn EditInput::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/agent_tool/file_state.mbt
+++ b/agent_tool/file_state.mbt
@@ -259,7 +259,11 @@ test "distinct path spellings are distinct keys (a safe under-approximation)" {
 }
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend FileState with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend FileState with Eq::{equal, not_equal}

--- a/agent_tool/finish/internal/decode/decode.mbt
+++ b/agent_tool/finish/internal/decode/decode.mbt
@@ -20,4 +20,6 @@ pub fn decode(arguments : Json) -> FinishInput {
 }
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend FinishInput with Debug::{to_repr}

--- a/agent_tool/finish/internal/decode/pkg.generated.mbti
+++ b/agent_tool/finish/internal/decode/pkg.generated.mbti
@@ -14,7 +14,6 @@ pub fn decode(Json) -> FinishInput
 pub struct FinishInput {
   answer : String
 } derive(@debug.Debug)
-pub fn FinishInput::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/agent_tool/goal/goal.mbt
+++ b/agent_tool/goal/goal.mbt
@@ -79,4 +79,6 @@ fn execute(arguments : Json) -> @agent_tool.ToolAction {
 }
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend GoalStatus with Debug::{to_repr}

--- a/agent_tool/goal/internal/decode/decode.mbt
+++ b/agent_tool/goal/internal/decode/decode.mbt
@@ -47,4 +47,6 @@ pub fn decode(arguments : Json) -> GoalStatus raise {
 }
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend GoalStatus with Debug::{to_repr}

--- a/agent_tool/goal/internal/decode/pkg.generated.mbti
+++ b/agent_tool/goal/internal/decode/pkg.generated.mbti
@@ -16,7 +16,6 @@ pub enum GoalStatus {
   Continuing(String)
   Blocked(String)
 } derive(@debug.Debug)
-pub fn GoalStatus::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/agent_tool/goal/pkg.generated.mbti
+++ b/agent_tool/goal/pkg.generated.mbti
@@ -19,7 +19,6 @@ pub enum GoalStatus {
   Continuing(String)
   Blocked(String)
 } derive(@debug.Debug)
-pub fn GoalStatus::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/agent_tool/internal/auto_check/auto_check.mbt
+++ b/agent_tool/internal/auto_check/auto_check.mbt
@@ -342,6 +342,8 @@ test "tally keeps a diagnostic without a path as an unlocated site" {
 }
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend CheckErrors with Debug::{to_repr}
 
 ///|
@@ -363,7 +365,11 @@ test "identity prefers path:loc#code and falls back to the rendered line" {
 }
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend ErrorSite with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend ErrorSite with Eq::{equal, not_equal}

--- a/agent_tool/internal/auto_check/package_graph.mbt
+++ b/agent_tool/internal/auto_check/package_graph.mbt
@@ -275,6 +275,8 @@ pub fn PackageGraph::depends_on(
 }
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend PackageGraph with Debug::{to_repr}
 
 ///|

--- a/agent_tool/internal/auto_check/parse_gate.mbt
+++ b/agent_tool/internal/auto_check/parse_gate.mbt
@@ -589,7 +589,11 @@ test "loc_line_span accepts every lenient loc form" {
 }
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend ParseGate with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend ParseGateError with Debug::{to_repr}

--- a/agent_tool/internal/auto_check/pkg.generated.mbti
+++ b/agent_tool/internal/auto_check/pkg.generated.mbti
@@ -30,7 +30,6 @@ pub(all) struct CheckErrors {
   truncated : Bool
 } derive(@debug.Debug)
 pub fn CheckErrors::first_errors(Self) -> Array[String]
-pub fn CheckErrors::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ErrorSite {
   path : String?
@@ -38,11 +37,8 @@ pub(all) struct ErrorSite {
   code : Int?
   message : String
 } derive(Eq, @debug.Debug)
-pub fn ErrorSite::equal(Self, Self) -> Bool
 pub fn ErrorSite::identity(Self) -> String
 pub fn ErrorSite::line(Self) -> String
-pub fn ErrorSite::not_equal(Self, Self) -> Bool
-pub fn ErrorSite::to_repr(Self) -> @debug.Repr
 
 pub(all) struct PackageGraph {
   dirs : Array[String?]
@@ -50,20 +46,17 @@ pub(all) struct PackageGraph {
 } derive(@debug.Debug)
 pub fn PackageGraph::depends_on(Self, Int, Array[Int]) -> Bool
 pub fn PackageGraph::package_of(Self, String) -> Int?
-pub fn PackageGraph::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ParseGate {
   errors : Array[ParseGateError]
   truncated : Bool
 } derive(@debug.Debug)
-pub fn ParseGate::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ParseGateError {
   loc : String
   message : String
   context : String
 } derive(@debug.Debug)
-pub fn ParseGateError::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/agent_tool/job_output/internal/decode/decode.mbt
+++ b/agent_tool/job_output/internal/decode/decode.mbt
@@ -39,4 +39,6 @@ fn offset(arguments : Json) -> Int? raise {
 }
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend JobOutputInput with Debug::{to_repr}

--- a/agent_tool/job_output/internal/decode/pkg.generated.mbti
+++ b/agent_tool/job_output/internal/decode/pkg.generated.mbti
@@ -15,7 +15,6 @@ pub struct JobOutputInput {
   job_id : String
   offset : Int?
 } derive(@debug.Debug)
-pub fn JobOutputInput::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/agent_tool/multi_edit/internal/decode/decode.mbt
+++ b/agent_tool/multi_edit/internal/decode/decode.mbt
@@ -186,7 +186,11 @@ fn optional_positive_int(
 }
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend MultiEditArgs with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend MultiEditItem with Debug::{to_repr}

--- a/agent_tool/multi_edit/internal/decode/pkg.generated.mbti
+++ b/agent_tool/multi_edit/internal/decode/pkg.generated.mbti
@@ -19,7 +19,6 @@ pub struct MultiEditArgs {
   revert_when_errors_above : Int?
   revert_on_parse_errors : Bool
 } derive(@debug.Debug)
-pub fn MultiEditArgs::to_repr(Self) -> @debug.Repr
 
 pub struct MultiEditItem {
   file : String
@@ -28,7 +27,6 @@ pub struct MultiEditItem {
   start_line : Int
   end_line : Int?
 } derive(@debug.Debug)
-pub fn MultiEditItem::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/agent_tool/pkg.generated.mbti
+++ b/agent_tool/pkg.generated.mbti
@@ -26,7 +26,6 @@ pub enum AgentControl {
   Abort(String)
   WaitJobs(Array[String])
 } derive(@debug.Debug)
-pub fn AgentControl::to_repr(Self) -> @debug.Repr
 
 pub struct AgentToolCall {
   name : String
@@ -45,15 +44,11 @@ pub struct AgentToolDefinition {
 pub fn AgentToolDefinition::AgentToolDefinition(name~ : String, description~ : String, schema~ : JsonSchema, execute~ : ToolExecutor, control? : Bool, concurrent_safe? : Bool) -> Self
 pub fn AgentToolDefinition::is_concurrent_safe(Self) -> Bool
 pub fn AgentToolDefinition::is_control(Self) -> Bool
-pub fn AgentToolDefinition::to_repr(Self) -> @debug.Repr
 
 pub enum FileState {
   Created
   Modified
 } derive(Eq, @debug.Debug)
-pub fn FileState::equal(Self, Self) -> Bool
-pub fn FileState::not_equal(Self, Self) -> Bool
-pub fn FileState::to_repr(Self) -> @debug.Repr
 
 type FileStateMap
 pub fn FileStateMap::FileStateMap() -> Self
@@ -65,14 +60,12 @@ pub fn FileStateMap::record_edited(Self, String, String, String) -> Unit
 pub fn FileStateMap::record_modified(Self, String, String) -> Unit
 
 pub(all) struct JsonSchema(Json) derive(@debug.Debug)
-pub fn JsonSchema::to_repr(Self) -> @debug.Repr
 
 pub enum ToolAction {
   Respond(ToolOutput)
   Control(AgentControl)
 } derive(@debug.Debug)
 pub fn ToolAction::finish(String) -> Self
-pub fn ToolAction::to_repr(Self) -> @debug.Repr
 pub fn ToolAction::wait_jobs(Array[String]) -> Self
 
 pub(all) enum ToolExecutor {
@@ -85,7 +78,6 @@ pub struct ToolOutput {
   is_error : Bool
   brief : String?
 } derive(@debug.Debug)
-pub fn ToolOutput::to_repr(Self) -> @debug.Repr
 
 type Tools
 pub fn Tools::Tools(Array[AgentToolDefinition], background_jobs? : @bgjobs.BgJobRuntime) -> Self raise

--- a/agent_tool/plan/steps/decode.mbt
+++ b/agent_tool/plan/steps/decode.mbt
@@ -159,13 +159,21 @@ fn normalize_title(index : Int, raw_title : String) -> String raise {
 }
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend PlanInput with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend PlanStatus with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend PlanStatus with Eq::{equal, not_equal}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend PlanStep with Debug::{to_repr}

--- a/agent_tool/plan/steps/pkg.generated.mbti
+++ b/agent_tool/plan/steps/pkg.generated.mbti
@@ -18,23 +18,18 @@ pub fn decode(Json) -> PlanInput raise
 pub struct PlanInput {
   steps : Array[PlanStep]
 } derive(@debug.Debug)
-pub fn PlanInput::to_repr(Self) -> @debug.Repr
 
 pub enum PlanStatus {
   Pending
   InProgress
   Completed
 } derive(Eq, @debug.Debug)
-pub fn PlanStatus::equal(Self, Self) -> Bool
 pub fn PlanStatus::label(Self) -> String
-pub fn PlanStatus::not_equal(Self, Self) -> Bool
-pub fn PlanStatus::to_repr(Self) -> @debug.Repr
 
 pub struct PlanStep {
   title : String
   status : PlanStatus
 } derive(@debug.Debug)
-pub fn PlanStep::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/agent_tool/remove/internal/decode/decode.mbt
+++ b/agent_tool/remove/internal/decode/decode.mbt
@@ -33,4 +33,6 @@ pub fn decode(arguments : Json) -> RemoveInput raise {
 }
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend RemoveInput with Debug::{to_repr}

--- a/agent_tool/remove/internal/decode/pkg.generated.mbti
+++ b/agent_tool/remove/internal/decode/pkg.generated.mbti
@@ -15,7 +15,6 @@ pub struct RemoveInput {
   path : String
   reason : String
 } derive(@debug.Debug)
-pub fn RemoveInput::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/agent_tool/shell_exec/execution.mbt
+++ b/agent_tool/shell_exec/execution.mbt
@@ -556,7 +556,11 @@ async test "execution child sees an immediately-closed stdin pipe on Windows" {
 }
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend ExecStatus with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend ExecStatus with Eq::{equal, not_equal}

--- a/agent_tool/shell_exec/pkg.generated.mbti
+++ b/agent_tool/shell_exec/pkg.generated.mbti
@@ -19,9 +19,6 @@ pub enum ExecStatus {
   Exited(Int)
   Killed
 } derive(Eq, @debug.Debug)
-pub fn ExecStatus::equal(Self, Self) -> Bool
-pub fn ExecStatus::not_equal(Self, Self) -> Bool
-pub fn ExecStatus::to_repr(Self) -> @debug.Repr
 
 type ShellExecution
 pub fn ShellExecution::background(Self) -> Bool

--- a/agent_tool/write/internal/decode/decode.mbt
+++ b/agent_tool/write/internal/decode/decode.mbt
@@ -36,4 +36,6 @@ pub fn decode(arguments : Json) -> WriteInput raise {
 }
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend WriteInput with Debug::{to_repr}

--- a/agent_tool/write/internal/decode/pkg.generated.mbti
+++ b/agent_tool/write/internal/decode/pkg.generated.mbti
@@ -16,7 +16,6 @@ pub struct WriteInput {
   content : String
   revert_on_parse_errors : Bool
 } derive(@debug.Debug)
-pub fn WriteInput::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/agent_worker/pkg.generated.mbti
+++ b/agent_worker/pkg.generated.mbti
@@ -31,7 +31,6 @@ pub struct WorkerReport {
   // private fields
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn WorkerReport::parse_validated(Json) -> Result[Self, String]
-pub fn WorkerReport::to_json(Self) -> Json
 
 // Type aliases
 

--- a/agent_worker/types.mbt
+++ b/agent_worker/types.mbt
@@ -141,4 +141,6 @@ pub extend WorkerReport with FromJson::{from_json}
 pub extend WorkerReport with Eq::{equal, not_equal}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend WorkerReport with ToJson::{to_json}

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -436,7 +436,7 @@ async fn sessions_list(matches : @argparse.Matches) -> Unit {
 async fn sessions_show(matches : @argparse.Matches) -> Unit {
   let workspace_root = prepare_workspace_root(matches, log_created=false)
   let store = @store.SessionStore(session_root(matches, workspace_root~))
-  println(store.load(sessions_target_id(matches)).to_json().stringify())
+  println(ToJson::to_json(store.load(sessions_target_id(matches))).stringify())
 }
 
 ///|

--- a/cmd/openseek/subrun.mbt
+++ b/cmd/openseek/subrun.mbt
@@ -320,7 +320,7 @@ async fn dispatch_kind(
         append_item?,
         scratch_dir~,
       )
-      report.map(report => report.to_json())
+      report.map(report => Json(report))
     }
     "review" => {
       guard input is { "goal": String(goal), .. } && !goal.is_blank() else {
@@ -356,7 +356,7 @@ async fn dispatch_kind(
         append_item?,
         scratch_dir~,
       )
-      report.map(report => report.to_json())
+      report.map(report => Json(report))
     }
     "worker" => {
       // Input first, key second: a malformed input line reports its exact
@@ -387,7 +387,7 @@ async fn dispatch_kind(
           session_id?,
           append_item?,
         ) {
-        Ok(report) => report.map(report => report.to_json())
+        Ok(report) => report.map(report => Json(report))
         Err(reason) => {
           @emit.emit(CommandError(error="subrun worker: \{reason}"))
           None
@@ -425,7 +425,7 @@ async fn dispatch_kind(
         retry_backoff_ms?,
         workspace_root~,
       )
-      report.map(report => report.to_json())
+      report.map(report => Json(report))
     }
     "echo" => {
       // Modelless probe: two canned events plus the input echoed back —

--- a/deepseek/client/client.mbt
+++ b/deepseek/client/client.mbt
@@ -391,4 +391,6 @@ async fn Client::chat_stream_attempt(
 }
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend Client with Debug::{to_repr}

--- a/deepseek/client/pkg.generated.mbti
+++ b/deepseek/client/pkg.generated.mbti
@@ -22,7 +22,6 @@ pub struct Client {
 } derive(@debug.Debug)
 pub fn Client::Client(api_key~ : String, model? : @deepseek.Model, api_url? : String, thinking? : @deepseek.ThinkingMode, retry_attempts? : Int, retry_backoff_ms? : Int, idle_timeout_ms? : Int) -> Self
 pub async fn Client::chat(Self, Array[@deepseek.ChatMessage], tools? : Array[@deepseek.ToolDefinition], response_format? : @deepseek.ResponseFormat, stream? : StreamHandler) -> @deepseek.ChatResponse
-pub fn Client::to_repr(Self) -> @debug.Repr
 
 type StreamHandler
 pub fn StreamHandler::StreamHandler(on_content_delta~ : async (String) -> Unit, on_reasoning_delta? : async (String) -> Unit, on_retry? : (Int, Int, String) -> Unit) -> Self

--- a/deepseek/deepseek.mbt
+++ b/deepseek/deepseek.mbt
@@ -247,61 +247,97 @@ test "chat message constructor" {
 }
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend ChatMessage with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend ChatResponse with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend DsVariant with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend DsVariant with Eq::{equal, not_equal}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend KimiVariant with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend KimiVariant with Eq::{equal, not_equal}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend GlmVariant with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend GlmVariant with Eq::{equal, not_equal}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend Model with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend Model with Eq::{equal, not_equal}
 
 ///|
 pub extend Model with Show::{output, to_string}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend ResponseFormat with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend ResponseFormat with Eq::{equal, not_equal}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend Role with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend Role with Eq::{equal, not_equal}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend ThinkingMode with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend ThinkingMode with Eq::{equal, not_equal}
 
 ///|
 pub extend ThinkingMode with Show::{output, to_string}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend Usage with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend Usage with ToJson::{to_json}

--- a/deepseek/exports.mbt
+++ b/deepseek/exports.mbt
@@ -14,4 +14,6 @@ pub impl FromJson for Usage with fn from_json(
 }
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend Usage with FromJson::{from_json}

--- a/deepseek/json_decode.mbt
+++ b/deepseek/json_decode.mbt
@@ -233,4 +233,6 @@ test "parse chat response extracts native tool calls" {
 }
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend ChatResponse with FromJson::{from_json}

--- a/deepseek/pkg.generated.mbti
+++ b/deepseek/pkg.generated.mbti
@@ -21,7 +21,6 @@ pub struct ChatMessage {
   reasoning_content : String?
 } derive(@debug.Debug)
 pub fn ChatMessage::ChatMessage(Role, content~ : String, tool_calls? : Array[ToolCall], reasoning_content? : String) -> Self
-pub fn ChatMessage::to_repr(Self) -> @debug.Repr
 
 pub struct ChatResponse {
   content : String
@@ -29,8 +28,6 @@ pub struct ChatResponse {
   tool_calls : Array[ToolCall]
   usage : Usage
 } derive(@debug.Debug)
-pub fn ChatResponse::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
-pub fn ChatResponse::to_repr(Self) -> @debug.Repr
 pub impl @json.FromJson for ChatResponse
 
 pub(all) enum DsVariant {
@@ -38,25 +35,16 @@ pub(all) enum DsVariant {
   V4Pro
   V41Flash
 } derive(Eq, @debug.Debug)
-pub fn DsVariant::equal(Self, Self) -> Bool
-pub fn DsVariant::not_equal(Self, Self) -> Bool
-pub fn DsVariant::to_repr(Self) -> @debug.Repr
 
 pub(all) enum GlmVariant {
   G53
   G53Flash
 } derive(Eq, @debug.Debug)
-pub fn GlmVariant::equal(Self, Self) -> Bool
-pub fn GlmVariant::not_equal(Self, Self) -> Bool
-pub fn GlmVariant::to_repr(Self) -> @debug.Repr
 
 pub(all) enum KimiVariant {
   K27Code
   K27CodeHighSpeed
 } derive(Eq, @debug.Debug)
-pub fn KimiVariant::equal(Self, Self) -> Bool
-pub fn KimiVariant::not_equal(Self, Self) -> Bool
-pub fn KimiVariant::to_repr(Self) -> @debug.Repr
 
 pub(all) enum Model {
   Deepseek(DsVariant)
@@ -65,20 +53,14 @@ pub(all) enum Model {
 } derive(Eq, @debug.Debug)
 pub fn Model::api_key(Self, Map[String, Array[String]]) -> String?
 pub fn Model::context_window(Self) -> Int
-pub fn Model::equal(Self, Self) -> Bool
-pub fn Model::not_equal(Self, Self) -> Bool
 pub fn Model::output(Self, &Logger) -> Unit
 pub fn Model::parse(String) -> Self raise
-pub fn Model::to_repr(Self) -> @debug.Repr
 pub fn Model::to_string(Self) -> String
 pub impl Show for Model
 
 pub(all) enum ResponseFormat {
   JsonObject
 } derive(Eq, @debug.Debug)
-pub fn ResponseFormat::equal(Self, Self) -> Bool
-pub fn ResponseFormat::not_equal(Self, Self) -> Bool
-pub fn ResponseFormat::to_repr(Self) -> @debug.Repr
 
 pub(all) enum Role {
   System
@@ -86,20 +68,14 @@ pub(all) enum Role {
   Assistant
   Tool(String)
 } derive(Eq, @debug.Debug)
-pub fn Role::equal(Self, Self) -> Bool
-pub fn Role::not_equal(Self, Self) -> Bool
-pub fn Role::to_repr(Self) -> @debug.Repr
 
 pub(all) enum ThinkingMode {
   No
   High
   Max
 } derive(Eq, @debug.Debug)
-pub fn ThinkingMode::equal(Self, Self) -> Bool
-pub fn ThinkingMode::not_equal(Self, Self) -> Bool
 pub fn ThinkingMode::output(Self, &Logger) -> Unit
 pub fn ThinkingMode::parse(String) -> Self raise
-pub fn ThinkingMode::to_repr(Self) -> @debug.Repr
 pub fn ThinkingMode::to_string(Self) -> String
 pub impl Show for ThinkingMode
 
@@ -109,7 +85,6 @@ pub struct ToolCall {
   arguments : String
 } derive(@debug.Debug)
 pub fn ToolCall::ToolCall(id~ : String, name~ : String, arguments~ : String) -> Self
-pub fn ToolCall::to_repr(Self) -> @debug.Repr
 
 pub struct ToolDefinition {
   name : String
@@ -118,7 +93,6 @@ pub struct ToolDefinition {
   strict : Bool
 } derive(@debug.Debug)
 pub fn ToolDefinition::ToolDefinition(String, String, Json, strict? : Bool) -> Self
-pub fn ToolDefinition::to_repr(Self) -> @debug.Repr
 
 pub struct Usage {
   prompt_tokens : Int
@@ -127,9 +101,6 @@ pub struct Usage {
   prompt_cache_hit_tokens : Int
   prompt_cache_miss_tokens : Int
 } derive(ToJson, @debug.Debug)
-pub fn Usage::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
-pub fn Usage::to_json(Self) -> Json
-pub fn Usage::to_repr(Self) -> @debug.Repr
 pub impl @json.FromJson for Usage
 
 // Type aliases

--- a/deepseek/tool.mbt
+++ b/deepseek/tool.mbt
@@ -66,7 +66,11 @@ pub fn ToolCall::ToolCall(
 }
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend ToolCall with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend ToolDefinition with Debug::{to_repr}

--- a/mcp/config/config.mbt
+++ b/mcp/config/config.mbt
@@ -126,7 +126,11 @@ fn decode_string_map(
 }
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend McpServer with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend McpServer with Eq::{equal, not_equal}

--- a/mcp/config/pkg.generated.mbti
+++ b/mcp/config/pkg.generated.mbti
@@ -18,10 +18,7 @@ pub(all) enum McpServer {
   Stdio(name~ : String, command~ : String, args~ : Array[String], env~ : Map[String, String])
   Http(name~ : String, url~ : String, headers~ : Map[String, String])
 } derive(Eq, @debug.Debug)
-pub fn McpServer::equal(Self, Self) -> Bool
 pub fn McpServer::name(Self) -> String
-pub fn McpServer::not_equal(Self, Self) -> Bool
-pub fn McpServer::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/mcp/pkg.generated.mbti
+++ b/mcp/pkg.generated.mbti
@@ -19,10 +19,7 @@ pub struct CallToolResult {
   structured_content : Json?
   is_error : Bool
 } derive(Eq, @debug.Debug)
-pub fn CallToolResult::equal(Self, Self) -> Bool
-pub fn CallToolResult::not_equal(Self, Self) -> Bool
 pub fn CallToolResult::render_text(Self) -> String
-pub fn CallToolResult::to_repr(Self) -> @debug.Repr
 
 pub enum ContentBlock {
   Text(String)
@@ -30,9 +27,6 @@ pub enum ContentBlock {
   Resource(uri~ : String, text~ : String?)
   Other(kind~ : String)
 } derive(Eq, @debug.Debug)
-pub fn ContentBlock::equal(Self, Self) -> Bool
-pub fn ContentBlock::not_equal(Self, Self) -> Bool
-pub fn ContentBlock::to_repr(Self) -> @debug.Repr
 
 pub struct InitializeResult {
   protocol_version : String
@@ -40,9 +34,6 @@ pub struct InitializeResult {
   server_version : String
   instructions : String?
 } derive(Eq, @debug.Debug)
-pub fn InitializeResult::equal(Self, Self) -> Bool
-pub fn InitializeResult::not_equal(Self, Self) -> Bool
-pub fn InitializeResult::to_repr(Self) -> @debug.Repr
 
 type McpClient
 pub fn McpClient::McpClient(@jsonrpc.Client) -> Self
@@ -56,9 +47,6 @@ pub struct McpTool {
   description : String
   input_schema : Json
 } derive(Eq, @debug.Debug)
-pub fn McpTool::equal(Self, Self) -> Bool
-pub fn McpTool::not_equal(Self, Self) -> Bool
-pub fn McpTool::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/mcp/types.mbt
+++ b/mcp/types.mbt
@@ -209,25 +209,41 @@ fn optional_string(json : Json, key : String) -> String? {
 }
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend CallToolResult with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend CallToolResult with Eq::{equal, not_equal}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend ContentBlock with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend ContentBlock with Eq::{equal, not_equal}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend InitializeResult with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend InitializeResult with Eq::{equal, not_equal}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend McpTool with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend McpTool with Eq::{equal, not_equal}

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -3062,7 +3062,11 @@ pub fn subrun_child_ids(
 }
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend ViewMode with Debug::{to_repr}
 
 ///|
+#doc(hidden)
+#deprecated
 pub extend ViewMode with Eq::{equal, not_equal}


### PR DESCRIPTION
## What

Finishes the derived-promotion sweep (`agent_review`, `agent_session` #1187, `agent_subrun` #1463, `agent_runtime` #1471, `agent_worker` #1472) for the **whole root module**. Every remaining `pub extend T with Debug|Eq|ToJson|FromJson::{..}` promotion that no cross-package caller dot-calls now carries `#doc(hidden)` + `#deprecated`, per [shrink_package.md](shrink_package.md): **108 promotions across 36 files**.

The trait impls stay public — `Debug`, `Eq`, `FromJson` and `ToJson` remain usable through the traits — so only the dot-callable promoted methods drop out of the generated `.mbti`: **133 lines across 26 packages**, regenerated with a module-wide `moon info` exactly as CI's interface gate runs it.

## Call sites migrated

`moon check --deny-warn` named the promotions a consumer still called; ten sites in six files now go through the trait or the `Json` constructor:

| file | before | after |
| --- | --- | --- |
| `agent_session/README.mbt.md`, `agent_session/session_test.mbt` | `session.to_json()` | `Json(session)` |
| `agent_session/log/log_test.mbt` (×2), `agent_session/store/store.mbt` | `header.to_json()` | `Json(header)` |
| `cmd/openseek/subrun.mbt` (×4) | `report.to_json()` | `Json(report)` |
| `cmd/openseek/main.mbt` | `store.load(..).to_json()` | `ToJson::to_json(store.load(..))` — `Json` is shadowed there by the local `SessionListFormat.Json` variant |

## Known exception

`viz/pkg.generated.mbti` is deliberately untouched: `viz` is a JS-only package, so the canonical `moon info` run does not own its committed interface (`moon info --target js` only reports the difference). Its three `ViewMode` promotion lines linger in that one file.

## Verification

- `moon check --target native|js|wasm --deny-warn`: clean, 0 errors
- `moon fmt --check`: clean
- `moon info` then `git status` / `git diff -- '*.mbti'`: no drift, no new `.mbti`
- re-walk audit: 0 root-module promotions left un-annotated; `moon ide analyze` no longer lists them
- `moon test --target native` locally: 3060 of 3061. The one failure is `agent_tool/internal/sandbox/README.mbt.md` dying with `OSError("@process.run(): Argument list too long")` — an ARG_MAX limit of this local checkout, not of the change: the identical command fails the same way at `origin/main` in this same checkout (19/20) and passes in a fresh worktree at `origin/main` (20/20). CI's Linux native row, which runs the full suite, is green.

Generated with SeekMoon