### PR TITLE
fix(mbtx): avoid oversized sandbox arguments in review agents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,67 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  sandbox-macos:
+    name: sandbox (macOS, native)
+    runs-on: macos-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    env:
+      # Fail if sandbox enforcement disappears; guarded tests must not silently
+      # turn this platform-specific regression job green without running.
+      OPENSEEK_REQUIRE_SANDBOX_TESTS: "1"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up MoonBit
+        run: |
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
+          echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
+          "$HOME/.moon/bin/moon" version --all
+
+      - name: Update MoonBit package registry
+        run: moon update
+
+      # Even package-scoped tests run the workspace's module prebuilds, so
+      # Proton needs its runtime although these tests never open Desktop.
+      - name: Resolve pinned Proton version
+        id: proton
+        run: |
+          version="$(sed -n 's/.*"moonbit-community\/proton@\([^"]*\)".*/\1/p' desktop/moon.mod)"
+          test -n "$version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Proton runtime
+        id: cef-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/.proton/store
+            ~/.proton/helpers
+          key: proton-runtime-${{ runner.os }}-${{ runner.arch }}-${{ steps.proton.outputs.version }}
+
+      - name: Assemble Proton CEF runtime
+        run: >-
+          moonx "moonbit-community/proton_cli@${{ steps.proton.outputs.version }}"
+          cef setup
+
+      - name: Save Proton runtime
+        if: github.event_name == 'push' && steps.cef-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.proton/store
+            ~/.proton/helpers
+          key: ${{ steps.cef-cache.outputs.cache-primary-key }}
+
+      - name: Test sandbox enforcement and oversized profiles
+        run: moon test agent_tool/internal/sandbox --target native
+
+      - name: Test reviewer printing and file reads
+        run: moon test agent_tool/mbtx --target native --filter 'read-only snippets can print and read workspace source'
+
   check:
     name: check (${{ matrix.moonbit-channel }}, ${{ matrix.target }})
     runs-on: ubuntu-latest

--- a/agent_tool/internal/sandbox/README.mbt.md
+++ b/agent_tool/internal/sandbox/README.mbt.md
@@ -22,10 +22,13 @@ Prepare, run, classify:
 ```mbt check
 ///|
 async test "prepare, run, and classify a shell command" {
+  let dir = @fs.tmpdir(prefix="sandbox-example-")
+  defer (@fs.rmdir(dir, recursive=true) catch { _ => () })
   let shell_text = "echo sandbox-ready"
   let prepared = @sandbox.SandboxedCommand::create_if_available(
     ".",
     Shell(shell_text),
+    profile_path="\{dir}/profile.sb",
   )
   let (program, args) = match prepared {
     Some(command) => (command.program(), command.args())
@@ -52,7 +55,10 @@ constructor, because the kernel matches profile rules against real paths.
 
 The profile is built from the tree as it exists at preparation; renaming the
 root or subtree afterwards makes the rules stale. Prepare close to where the
-command runs.
+command runs. The caller supplies `profile_path` in a temporary directory and
+keeps it until the command exits. The profile travels through `sandbox-exec -f`,
+so repository size does not consume the OS command-line argument limit. `mbtx`
+keeps this file in its per-call build directory, including background runs.
 
 ## Commands
 

--- a/agent_tool/internal/sandbox/README.mbt.md
+++ b/agent_tool/internal/sandbox/README.mbt.md
@@ -56,9 +56,15 @@ constructor, because the kernel matches profile rules against real paths.
 The profile is built from the tree as it exists at preparation; renaming the
 root or subtree afterwards makes the rules stale. Prepare close to where the
 command runs. The caller supplies `profile_path` in a temporary directory and
-keeps it until the command exits. The profile travels through `sandbox-exec -f`,
+prepares it again for each spawn. The profile is loaded by `sandbox-exec` at
+launch; keeping the file until the command exits avoids racing that load.
+The profile travels through `sandbox-exec -f`,
 so repository size does not consume the OS command-line argument limit. `mbtx`
 keeps this file in its per-call build directory, including background runs.
+The final profile rule denies writes to the profile itself, even when that
+temporary directory is inside a writable lab. Temporary test workspaces can
+also own the file; a separate temporary directory avoids changing the source
+scan's watched directory mtimes.
 
 ## Commands
 
@@ -101,6 +107,13 @@ The generated profile starts from `(allow default)` and then:
 - denies source-containing directories literally, preventing a direct rename
   or removal of those directories.
 
+The directory rules are intentional: the suffix regex alone would let a
+containing directory be moved outside the protected workspace. Their scan and
+mtime tracking skip `.worktrees` and `.claude/worktrees`, which contain separate
+checkouts rather than the active source tree. The source-file regex still
+covers these paths. An active workspace rooted inside either location is
+scanned normally, and ordinary directories named `worktrees` are not excluded.
+
 The base profile is cached by normalized workspace root; directory mtimes
 from the source-tree scan invalidate the cache when the tree changes. The
 `writable_subtree` variant is composed per command preparation and never cached.
@@ -111,13 +124,18 @@ the kernel profile protects is exactly what that policy calls source.
 
 ## Availability and limitations
 
-Preparation's availability gate is a cached behavioral probe, not an
+Preparation's availability gate is a cached behavioral probe using `-f`, not an
 existence check: it requires an allowed no-op to succeed and a denied
 temporary write to fail. Nested sandboxes that prohibit re-sandboxing
 therefore yield `None`, and the result is cached for the process — a probe
 that failed transiently stays failed, deliberately, because in the
 environments where it genuinely cannot pass (nested sandboxes), re-probing
 on every command would cost two spawns each and never succeed.
+
+CI runs the sandbox package and a reviewer read smoke test on macOS. That job
+sets `OPENSEEK_REQUIRE_SANDBOX_TESTS=1`, turning unavailable enforcement into a
+failure instead of silently skipping the kernel tests. Portable tests also pin
+the file-based argument vector and the worktree scan exclusions on Linux.
 
 The profile is a best-effort write guard, not a complete process-security
 boundary:

--- a/agent_tool/internal/sandbox/capability.mbt
+++ b/agent_tool/internal/sandbox/capability.mbt
@@ -21,7 +21,7 @@ struct SandboxedCommand {
   /// by either the platform-shell invocation or the requested `Exec`
   /// program/argv. For example, `Shell("moon check")` prepares approximately
   /// `program = "/usr/bin/sandbox-exec"` with
-  /// `args = ["-p", "<profile>", "sh", "-c", "moon check"]` on macOS.
+  /// `args = ["-f", "<profile path>", "sh", "-c", "moon check"]` on macOS.
   args : Array[String]
   /// The paths a denial from this profile may name — protected directories and
   /// basenames — which is how one is told apart from a permission error this
@@ -54,9 +54,16 @@ struct SandboxedCommand {
 /// throwaway build directory — via a last-match-wins allow rule. It is resolved
 /// too; when resolution fails the unresolved path is used, which can only
 /// under-allow, never over-allow.
+///
+/// `profile_path` is a caller-owned file in an existing temporary directory.
+/// The generated profile is written there and passed with `sandbox-exec -f`:
+/// source-containing directories can make it larger than the OS argv limit.
+/// Keep the file unchanged until the command exits, then remove it with the
+/// owning directory. A write failure raises rather than disabling protection.
 pub async fn SandboxedCommand::create_if_available(
   workspace_root : String,
   command : Command,
+  profile_path~ : String,
   writable_subtree? : String,
 ) -> SandboxedCommand? {
   // Inputs are validated BEFORE the availability probe, so a caller bug is
@@ -87,10 +94,16 @@ pub async fn SandboxedCommand::create_if_available(
     real_root,
     writable_lab?=subtree,
   )
-  let args = match command {
-    Shell(cmd) => sandbox_exec_args(data.profile, cmd)
-    Exec(program, args) => ["-p", data.profile, program, ..args]
-  }
+  @fs.write_file(profile_path, data.profile, create_mode=CreateOrTruncate)
+  let profile_path = @fs.realpath(profile_path)
+  let args = [
+    "-f",
+    profile_path,
+    ..match command {
+      Shell(cmd) => [@platform_shell.program, ..@platform_shell.args(cmd)]
+      Exec(program, args) => [program, ..args]
+    },
+  ]
   Some({
     program: SandboxExecPath,
     args,

--- a/agent_tool/internal/sandbox/capability.mbt
+++ b/agent_tool/internal/sandbox/capability.mbt
@@ -58,8 +58,10 @@ struct SandboxedCommand {
 /// `profile_path` is a caller-owned file in an existing temporary directory.
 /// The generated profile is written there and passed with `sandbox-exec -f`:
 /// source-containing directories can make it larger than the OS argv limit.
-/// Keep the file unchanged until the command exits, then remove it with the
-/// owning directory. A write failure raises rather than disabling protection.
+/// Keep the file until `sandbox-exec` has loaded it; retaining it until the
+/// command exits avoids racing that load. Its final rule denies writes to the
+/// profile even inside a writable lab. Prepare again before a new spawn.
+/// A write failure raises rather than disabling protection.
 pub async fn SandboxedCommand::create_if_available(
   workspace_root : String,
   command : Command,
@@ -94,16 +96,8 @@ pub async fn SandboxedCommand::create_if_available(
     real_root,
     writable_lab?=subtree,
   )
-  @fs.write_file(profile_path, data.profile, create_mode=CreateOrTruncate)
-  let profile_path = @fs.realpath(profile_path)
-  let args = [
-    "-f",
-    profile_path,
-    ..match command {
-      Shell(cmd) => [@platform_shell.program, ..@platform_shell.args(cmd)]
-      Exec(program, args) => [program, ..args]
-    },
-  ]
+  let profile_path = write_profile_file(data.profile, profile_path)
+  let args = sandbox_exec_file_args(profile_path, command)
   Some({
     program: SandboxExecPath,
     args,

--- a/agent_tool/internal/sandbox/capability_test.mbt
+++ b/agent_tool/internal/sandbox/capability_test.mbt
@@ -37,6 +37,7 @@ async test "sandbox denies a source write and the command reports it" {
     guard @sandbox.SandboxedCommand::create_if_available(
         dir,
         Shell("printf x > \{dir}/new.mbt"),
+        profile_path="\{dir}/denied.sb",
       )
       is Some(command) else {
       return
@@ -58,6 +59,7 @@ async test "a writable subtree is re-allowed; the rest stays denied" {
     guard @sandbox.SandboxedCommand::create_if_available(
         dir,
         Shell("printf x > \{dir}/lab/draft.mbt"),
+        profile_path="\{dir}/allowed.sb",
         writable_subtree="\{dir}/lab",
       )
       is Some(allowed) else {
@@ -69,6 +71,7 @@ async test "a writable subtree is re-allowed; the rest stays denied" {
     guard @sandbox.SandboxedCommand::create_if_available(
         dir,
         Shell("printf x > \{dir}/new.mbt"),
+        profile_path="\{dir}/denied.sb",
         writable_subtree="\{dir}/lab",
       )
       is Some(denied) else {
@@ -86,14 +89,16 @@ async test "exec command produces the argv shape without a shell" {
     guard @sandbox.SandboxedCommand::create_if_available(
         dir,
         Exec("moon", ["check", "--target", "native"]),
+        profile_path="\{dir}/profile.sb",
       )
       is Some(command) else {
       return
     }
     assert_eq(command.program(), "/usr/bin/sandbox-exec")
     let args = command.args()
-    // [-p, <profile>, moon, check, --target, native]
-    assert_eq(args[0], "-p")
+    // [-f, <profile path>, moon, check, --target, native]
+    assert_eq(args[0], "-f")
+    assert_eq(args[1], @fs.realpath("\{dir}/profile.sb"))
     assert_eq(args[2], "moon")
     assert_eq(args[3], "check")
     assert_eq(args.length(), 6)
@@ -123,6 +128,7 @@ async fn create_raises(root : String, writable_subtree~ : String) -> Bool {
       @sandbox.SandboxedCommand::create_if_available(
         root,
         Shell(":"),
+        profile_path="\{root}/profile.sb",
         writable_subtree~,
       ),
     )
@@ -145,7 +151,11 @@ async test "profile subjects flow into denial reporting" {
       "pub fn x() -> Int { 1 }\n",
       create_mode=CreateOrTruncate,
     )
-    guard @sandbox.SandboxedCommand::create_if_available(dir, Shell(":"))
+    guard @sandbox.SandboxedCommand::create_if_available(
+        dir,
+        Shell(":"),
+        profile_path="\{dir}/profile.sb",
+      )
       is Some(command) else {
       return
     }

--- a/agent_tool/internal/sandbox/capability_test.mbt
+++ b/agent_tool/internal/sandbox/capability_test.mbt
@@ -164,3 +164,70 @@ async test "profile subjects flow into denial reporting" {
     assert_true(command.output_reports_denial(canned))
   })
 }
+
+///|
+async test "a writable lab cannot overwrite or remove its sandbox profile" {
+  @vfs.with_tmpdir(prefix="sandbox-profile-protection-", dir => {
+    let workspace = "\{dir}/workspace"
+    let lab = "\{dir}/lab"
+    @fs.mkdir(workspace)
+    @fs.mkdir(lab)
+    let profile_path = "\{lab}/profile.sb"
+    for
+      operation in [
+        "printf corrupted > '\{profile_path}'",
+        "rm '\{profile_path}'",
+      ] {
+      guard @sandbox.SandboxedCommand::create_if_available(
+          workspace,
+          Shell(operation),
+          profile_path~,
+          writable_subtree=lab,
+        )
+        is Some(command) else {
+        return
+      }
+      let before = @fs.read_file(profile_path).text()
+      let (exit_code, _) = merged_output_text(command)
+      assert_true(exit_code != 0)
+      assert_eq(@fs.read_file(profile_path).text(), before)
+    }
+    guard @sandbox.SandboxedCommand::create_if_available(
+        workspace,
+        Shell("printf scratch > '\{lab}/scratch.mbt'"),
+        profile_path~,
+        writable_subtree=lab,
+      )
+      is Some(command) else {
+      return
+    }
+    let (exit_code, _) = merged_output_text(command)
+    assert_eq(exit_code, 0)
+    assert_eq(@fs.read_file("\{lab}/scratch.mbt").text(), "scratch")
+  })
+}
+
+///|
+async test "source directory cannot be moved outside the protected workspace" {
+  @vfs.with_tmpdir(prefix="sandbox-directory-rename-", dir => {
+    let workspace = "\{dir}/workspace"
+    @fs.mkdir("\{workspace}/src", recursive=true)
+    @fs.write_file(
+      "\{workspace}/src/main.mbt",
+      "source",
+      create_mode=CreateOrTruncate,
+    )
+    guard @sandbox.SandboxedCommand::create_if_available(
+        workspace,
+        Shell("mv '\{workspace}/src' '\{dir}/escaped'"),
+        profile_path="\{dir}/profile.sb",
+      )
+      is Some(command) else {
+      return
+    }
+    let (exit_code, _) = merged_output_text(command)
+    assert_true(exit_code != 0)
+    assert_eq(@fs.read_file("\{workspace}/src/main.mbt").text(), "source")
+    assert_false(@fs.exists("\{dir}/escaped"))
+  })
+}

--- a/agent_tool/internal/sandbox/moon.pkg
+++ b/agent_tool/internal/sandbox/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "moonbitlang/async",
   "moonbitlang/async/fs",
+  "moonbitlang/async/io",
   "moonbitlang/async/process",
   "moonbitlang/x/path",
   "bobzhang/openseek/agent_tool/internal/platform_shell",
@@ -10,6 +11,7 @@ import {
 
 import {
   "bobzhang/openseek/testkit/filesystem" @vfs,
+  "moonbitlang/core/env",
 } for "wbtest"
 
 import {

--- a/agent_tool/internal/sandbox/pkg.generated.mbti
+++ b/agent_tool/internal/sandbox/pkg.generated.mbti
@@ -18,7 +18,7 @@ pub(all) enum Command {
 
 type SandboxedCommand
 pub fn SandboxedCommand::args(Self) -> Array[String]
-pub async fn SandboxedCommand::create_if_available(String, Command, writable_subtree? : String) -> Self?
+pub async fn SandboxedCommand::create_if_available(String, Command, profile_path~ : String, writable_subtree? : String) -> Self?
 pub async fn SandboxedCommand::create_worker_if_available(Command, deny_roots~ : Array[String], worker_root~ : String, worker_admin_dir~ : String) -> Self?
 pub fn SandboxedCommand::denial_feedback(Self) -> String
 pub fn SandboxedCommand::output_reports_denial(Self, String) -> Bool

--- a/agent_tool/internal/sandbox/sandbox_exec.mbt
+++ b/agent_tool/internal/sandbox/sandbox_exec.mbt
@@ -8,6 +8,38 @@ const SandboxExecPath : String = "/usr/bin/sandbox-exec"
 let sandbox_exec_available_cache : Ref[Bool?] = { val: None, }
 
 ///|
+/// No availability probe or profile contents: this transport contract is
+/// testable on every platform, including the Linux CI targets.
+fn sandbox_exec_file_args(
+  profile_path : String,
+  command : Command,
+) -> Array[String] {
+  [
+    "-f",
+    profile_path,
+    ..match command {
+      Shell(cmd) => [@platform_shell.program, ..@platform_shell.args(cmd)]
+      Exec(program, args) => [program, ..args]
+    },
+  ]
+}
+
+///|
+/// Resolve the opened file before writing the final rule, so symlinked temp
+/// roots and existing profile files name the same path the kernel protects.
+/// The last deny wins over every writable-lab allow in the supplied profile.
+async fn write_profile_file(profile : String, path : String) -> String {
+  let file = @fs.open(path, mode=WriteOnly, create_mode=CreateOrTruncate)
+  defer file.close()
+  let real_path = @fs.realpath(path)
+  file.write(profile)
+  file.write(
+    "\n(deny file-write* (literal \"\{sbpl_string_escape(real_path)}\"))\n",
+  )
+  real_path
+}
+
+///|
 /// Build the argument vector passed to `SandboxExecPath` to interpret `cmd`
 /// under an inline SBPL `profile`.
 ///
@@ -61,6 +93,7 @@ async fn probe_sandbox_exec_available() -> Bool {
     error if @async.is_being_cancelled() => raise error
     _ => probe_dir
   }
+  defer cleanup_sandbox_probe(probe_dir)
   let blocked_path = @path.Path(probe_dir)
     .join(Path("blocked"))
     .normalize()
@@ -69,24 +102,28 @@ async fn probe_sandbox_exec_available() -> Bool {
     $|(version 1)
     $|(allow default)
     $|(deny file-write* (literal "\{sbpl_string_escape(blocked_path)}"))
+  let profile_path = write_profile_file(
+    probe_profile,
+    "\{probe_dir}/profile.sb",
+  ) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => return false
+  }
   let noop_exit = run_probe_exit(
     SandboxExecPath,
-    sandbox_exec_args(probe_profile, PlatformNoopCommand),
+    sandbox_exec_file_args(profile_path, Shell(PlatformNoopCommand)),
   )
   if noop_exit != Some(0) {
-    cleanup_sandbox_probe(probe_dir, blocked_path)
     return false
   }
   let write_exit = run_probe_exit(
     SandboxExecPath,
-    sandbox_exec_args(
-      probe_profile,
-      "printf probe > \{shell_quote(blocked_path)}",
+    sandbox_exec_file_args(
+      profile_path,
+      Shell("printf probe > \{shell_quote(blocked_path)}"),
     ),
   )
-  let denied = write_exit != Some(0) && !@fs.exists(blocked_path)
-  cleanup_sandbox_probe(probe_dir, blocked_path)
-  denied
+  write_exit != Some(0) && !@fs.exists(blocked_path)
 }
 
 ///|
@@ -118,10 +155,6 @@ fn shell_quote(text : String) -> String {
 }
 
 ///|
-async fn cleanup_sandbox_probe(
-  probe_dir : String,
-  blocked_path : String,
-) -> Unit {
-  ignore(@fs.remove(blocked_path) catch { _ => () })
-  ignore(@fs.rmdir(probe_dir) catch { _ => () })
+async fn cleanup_sandbox_probe(probe_dir : String) -> Unit {
+  ignore(@fs.rmdir(probe_dir, recursive=true) catch { _ => () })
 }

--- a/agent_tool/internal/sandbox/sandbox_wbtest.mbt
+++ b/agent_tool/internal/sandbox/sandbox_wbtest.mbt
@@ -95,3 +95,55 @@ async test "sandbox profile cache invalidates when source tree changes" {
     assert_true(second.contains("(literal \"\{root}/assets\")"))
   })
 }
+
+///|
+async test "oversized source profile launches reads and still denies writes" {
+  guard sandbox_exec_available() else { return }
+  @vfs.with_tmpdir(prefix="sandbox-large-profile-", dir => {
+    let root = @fs.realpath(dir)
+    let source = "\{root}/keep.mbt"
+    @fs.write_file(source, "readable", create_mode=CreateOrTruncate)
+    let data = source_write_readonly_profile_data(root)
+    // Exercise a repository-sized profile without creating thousands of source
+    // directories. Comments preserve its rules while exceeding macOS ARG_MAX.
+    let profile = data.profile +
+      "; padding for large repository\n".repeat(70_000)
+    source_write_profile_cache[root] = {
+      profile,
+      watched_dirs: [],
+      denial_subjects: data.denial_subjects,
+    }
+    defer source_write_profile_cache.remove(root)
+    let profile_path = "\{root}/profile.sb"
+    guard SandboxedCommand::create_if_available(
+        root,
+        Exec("/bin/cat", [source]),
+        profile_path~,
+      )
+      is Some(read) else {
+      fail("sandbox became unavailable")
+    }
+    assert_true(@fs.read_file(profile_path).text().length() > 2_000_000)
+    let (exit_code, output) = @process.collect_output_merged(
+      read.program(),
+      read.args(),
+    )
+    assert_eq(exit_code, 0, msg=output.text())
+    assert_eq(output.text(), "readable")
+    guard SandboxedCommand::create_if_available(
+        root,
+        Shell("printf changed > \{shell_quote(source)}"),
+        profile_path~,
+      )
+      is Some(write) else {
+      fail("sandbox became unavailable")
+    }
+    let (exit_code, output) = @process.collect_output_merged(
+      write.program(),
+      write.args(),
+    )
+    assert_true(exit_code != 0)
+    assert_true(write.output_reports_denial(output.text()))
+    assert_eq(@fs.read_file(source).text(), "readable")
+  })
+}

--- a/agent_tool/internal/sandbox/sandbox_wbtest.mbt
+++ b/agent_tool/internal/sandbox/sandbox_wbtest.mbt
@@ -147,3 +147,71 @@ async test "oversized source profile launches reads and still denies writes" {
     assert_eq(@fs.read_file(source).text(), "readable")
   })
 }
+
+///|
+async test "macOS CI requires an enforcing sandbox instead of skipping" {
+  if @env.get_env_var("OPENSEEK_REQUIRE_SANDBOX_TESTS") == Some("1") {
+    assert_true(
+      sandbox_exec_available(),
+      msg="macOS sandbox CI must enforce the profile",
+    )
+  }
+}
+
+///|
+async test "file profile transport keeps oversized contents out of argv on every platform" {
+  @vfs.with_tmpdir(prefix="sandbox-transport-", dir => {
+    let profile = "(version 1)\n(allow default)\n" +
+      "; padding\n".repeat(220_000)
+    let path = write_profile_file(profile, "\{dir}/profile with spaces.sb")
+    let saved = @fs.read_file(path).text()
+    assert_true(saved.has_prefix(profile))
+    assert_true(
+      saved.has_suffix(
+        "(deny file-write* (literal \"\{sbpl_string_escape(path)}\"))\n",
+      ),
+    )
+    assert_eq(
+      sandbox_exec_file_args(path, Exec("moon", ["check", "space in arg"])),
+      ["-f", path, "moon", "check", "space in arg"],
+    )
+    let command = "printf 'space in command'"
+    assert_eq(
+      sandbox_exec_file_args(path, Shell(command)),
+      ["-f", path, @platform_shell.program, ..@platform_shell.args(command)],
+    )
+  })
+}
+
+///|
+async test "source scan prunes nested agent worktrees but scans an active worktree" {
+  @vfs.with_tmpdir(prefix="sandbox-worktree-scan-", dir => {
+    let root = @fs.realpath(dir)
+    @vfs.FileSystem({
+      "src/main.mbt": "source",
+      "worktrees/pkg/main.mbt": "ordinary source directory",
+      ".claude/skills/helper.mbt": "keep non-worktree source",
+      ".worktrees/w1/pkg/main.mbt": "nested checkout",
+      ".claude/worktrees/w2/pkg/main.mbt": "nested checkout",
+    }).write_to(root)
+    let scan = protected_source_tree_profile_scan(root)
+    assert_eq(scan.literal_paths.length(), 5)
+    assert_eq(scan.watched_dirs.length(), 6)
+    for
+      relative in [
+        "src", "worktrees", "worktrees/pkg", ".claude", ".claude/skills",
+      ] {
+      assert_true(
+        scan.literal_paths.contains("\{root}/\{relative}"),
+        msg=relative,
+      )
+    }
+    // A review running IN one of these worktrees still protects its source.
+    for relative in [".worktrees/w1", ".claude/worktrees/w2"] {
+      let active = "\{root}/\{relative}"
+      let scan = protected_source_tree_profile_scan(active)
+      assert_eq(scan.literal_paths, ["\{active}/pkg"])
+      assert_eq(scan.watched_dirs.length(), 2)
+    }
+  })
+}

--- a/agent_tool/internal/sandbox/source_write_profile.mbt
+++ b/agent_tool/internal/sandbox/source_write_profile.mbt
@@ -117,6 +117,8 @@ async fn source_write_readonly_profile_base(
     $|(deny file-write* (regex "\{sbpl_string_escape(source_regex)}"))
     $|(allow file-write* (regex "\{sbpl_string_escape(build_carveout_regex)}"))
     $|
+  // The suffix regex protects files, not renames/removal of a containing
+  // directory. These literal rules cover those directory operations.
   for dir in scan.literal_paths {
     profile <+
       $|(deny file-write* (literal "\{sbpl_string_escape(dir)}"))
@@ -269,10 +271,17 @@ fn should_prune_profile_scan_path(root : String, path : String) -> Bool {
     return false
   }
   let relative = path[root.length() + 1:]
-  relative
-  .replace_all(old="\\", new="/")
-  .split("/")
-  .any(part => part is (".git" | ".hg" | ".svn" | ".jj" | "node_modules"))
+  let parts = relative.replace_all(old="\\", new="/").split("/").to_array()
+  for i, part in parts {
+    if part is (".git" | ".hg" | ".svn" | ".jj" | "node_modules" | ".worktrees") {
+      return true
+    }
+    // Do not prune an ordinary source directory named `worktrees`.
+    if part == "worktrees" && i > 0 && parts[i - 1] == ".claude" {
+      return true
+    }
+  }
+  false
 }
 
 ///|

--- a/agent_tool/internal/sandbox/worker_profile.mbt
+++ b/agent_tool/internal/sandbox/worker_profile.mbt
@@ -116,6 +116,9 @@ pub async fn SandboxedCommand::create_worker_if_available(
     worker_admin_dir~,
   )
   guard sandbox_exec_available() else { return None }
+  // This profile has one rule per provisioned deny root, with no recursive
+  // source scan. Keep its bounded inline form; source profiles use a file in
+  // create_if_available because nested source trees can exceed ARG_MAX.
   let args = match command {
     Shell(cmd) => sandbox_exec_args(data.profile, cmd)
     Exec(program, args) => ["-p", data.profile, program, ..args]

--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -708,6 +708,9 @@ async fn execute(
         @sandbox.SandboxedCommand::create_if_available(
           workspace_root,
           Exec(program, command_argv),
+          // Per-call storage outlives both compilation and any background run.
+          // Never put the repository-sized SBPL profile in the spawn argv.
+          profile_path="\{build_dir}/source-write.sb",
           writable_subtree~,
         )
       // The main agent runs with no kernel profile at all. Forbidding source

--- a/agent_tool/mbtx/mbtx_test.mbt
+++ b/agent_tool/mbtx/mbtx_test.mbt
@@ -521,6 +521,7 @@ async fn sandbox_enforcement_available() -> Bool {
   let available = @sandbox.SandboxedCommand::create_if_available(
       dir,
       Shell(":"),
+      profile_path="\{dir}/profile.sb",
     )
     is Some(_)
   @fs.rmdir(dir, recursive=true) catch {
@@ -853,6 +854,28 @@ async test "read_only denies source writes with no scratch lab wired" {
     })
     assert_true(output.content.contains("workspace=false"))
     assert_true(@fs.read_file("\{ws}/keep.mbt").text().contains("fn main {  }"))
+  })
+}
+
+///|
+async test "read-only snippets can print and read workspace source" {
+  @vfs.with_tmpdir(prefix="mbtx-review-read-", ws => {
+    @fs.write_file(
+      "\{ws}/keep.mbt",
+      "source contents",
+      create_mode=CreateOrTruncate,
+    )
+    let output = dispatch(@mbtx.definition(workspace_root=ws, read_only=true), {
+      "source": (
+        #|import { "moonbitlang/async", "moonbitlang/async/fs" }
+        #|async fn main {
+        #|  println(1)
+        #|  println(@fs.read_file("keep.mbt").text())
+        #|}
+      ),
+    })
+    assert_false(output.is_error, msg=output.content)
+    assert_eq(output.content, "1\nsource contents\n")
   })
 }
 


### PR DESCRIPTION
Review and explore agents can fail every `mbtx` call, including `fn main { println(1) }`, with `OSError("@process.run(): Argument list too long")`. Their source-write sandbox profile grows with the repository and was passed inline to `sandbox-exec -p`, exhausting the OS argument limit before the compiler or snippet starts. Scanning nested agent worktrees amplified that growth. Changing the backend or execution directory does not avoid the wrapper.

The source-write sandbox now:

- Writes its profile to a caller-owned temporary file and launches with `sandbox-exec -f`. `mbtx` retains the file in its per-call build directory through compilation and background execution, then uses the existing cleanup. Write errors propagate instead of disabling protection.
- Appends a final deny rule protecting the canonical profile path, even inside a writable scratch lab. The availability probe exercises the same file-based mechanism.
- Skips `.worktrees` and `.claude/worktrees` during directory enumeration and mtime tracking. A workspace rooted inside either location is still scanned normally; ordinary source directories named `worktrees` are preserved. The source-file regex remains in force, and literal directory rules remain necessary to prevent moving source directories outside the workspace.
- Runs a dedicated macOS native CI job for the sandbox package and a reviewer print/read smoke test. `OPENSEEK_REQUIRE_SANDBOX_TESTS=1` makes unavailable enforcement fail the job rather than silently skipping the kernel tests. Portable tests also check the file-based argv contract and worktree exclusions on Linux/Wasm.

Regression coverage includes a profile exceeding 2 MB, successful reads with denied source writes, blocked profile overwrite/removal inside a writable lab, and a blocked source-directory escape. The bounded worker profile remains inline, with its different growth bound documented. Constructor and lifecycle documentation describe profile creation and loading explicitly.

Validation:

- Reproduced errno 7 / `Argument list too long` with the original inline-profile launch.
- `OPENSEEK_REQUIRE_SANDBOX_TESTS=1 moon test agent_tool/internal/sandbox --target native` — 26 passed, enforcement required.
- `moon test agent_tool/internal/sandbox --target wasm` — 26 passed, including portable transport and scan checks.
- `just check`
- `just test` — 3,068 native tests, 3,186 JS tests, 38 cram cases, CLI lifecycle checks, and offline workflow cases passed.
- `just build`
- `moon info && moon fmt`
- CI workflow YAML parsed successfully.

The separately reported missing `OPENSEEK_REFERENCES` environment variable is not addressed by this change.
