### PR TITLE
refactor(mbtx): render the spawn allowlist instead of restating it

### DIFF
--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -1654,8 +1654,10 @@ fn schema(escalation~ : Bool, hosting~ : Bool) -> Json {
 /// `moonbitlang/async/shell` tutorial and worked examples; those teach one
 /// role's workflow rather than describing what the tool enforces.
 ///
-/// The spawn list is prose about `spawnable_commands`, kept by hand so the
-/// groupings survive; adding an entry there means editing this text too.
+/// The spawn list is RENDERED from `spawnable_commands` by
+/// `spawn_list_markdown`, not restated here: a command admitted to that table
+/// appears in this description by construction, and the system prompt points
+/// at this description rather than carrying a third copy.
 ///
 /// `background` selects the execution-time contract the caller actually wired:
 /// automatic handoff with a job runtime, or a longer cancelling timeout without
@@ -1754,28 +1756,15 @@ fn description(
     #|with the same sandbox and isolated imports as inline source.
     #|Diagnostics cite `source:LINE:COL` or the supplied filename and line/column.
     #|`target` defaults to wasm, the sandboxed backend.
-    #|
-    #|## Which programs a snippet may start
-    #|
-    #|These, and nothing else:
-    #|
-    #|- `moon` — check, test, build, bench, run, fmt, info, add, remove, update,
-    #|  install, tree, search, clean, new, ide, doc, explain, coverage, cram,
-    #|  package, version, plus `publish --dry-run`. (Not plain `publish`, `login` or `register`.)
-    #|- `proton_cli` — `--version`, `--help`, new, dev, build, package, doctor,
-    #|  cef, and updater. Set `Cmd.cwd` for the project directory; the global
-    #|  `-C`/`--cwd` options before the subcommand are refused.
-    #|- `git` — status, log, diff, show, blame, describe, rev-parse, rev-list,
-    #|  show-ref, for-each-ref, cat-file, check-ignore, merge-base, range-diff,
-    #|  ls-files, ls-tree, ls-remote, shortlog, grep, branch, tag, remote, reflog,
-    #|  add, commit, checkout, switch, restore, reset, revert, rm, init, fetch,
-    #|  push, rebase; plus `submodule update|status`, `worktree list|add|prune`,
-    #|  `stash list|show`. Not `config`. A global option BEFORE the subcommand
-    #|  (`-c`, `-C`, `--git-dir`, `--work-tree`) is refused.
-    #|- `gh` — pr, issue, run, `repo view`, api, `auth status`.
-    #|- `codex` — review (read-only review of the current branch/diff; not
-    #|  `exec`, `install`, or a bare `codex`).
-    #|- `rg` and `diff`.
+  // Rendered from `spawnable_commands`, the table that also builds the
+  // moonrun policy: the list the model reads and the list moonrun enforces
+  // cannot disagree, because there is only one.
+  let spawn_section =
+    $|## Which programs a snippet may start
+    $|
+    $|These, and nothing else:
+    $|
+    $|\{spawn_list_markdown()}
   let base_tail =
     #|## Isolation and limits
     #|
@@ -1802,6 +1791,8 @@ fn description(
   // would try to evaluate.
   let base =
     $|\{base_head}
+    $|
+    $|\{spawn_section}
     $|
     $|\{refusal_advice}
     $|

--- a/agent_tool/mbtx/mbtx_test.mbt
+++ b/agent_tool/mbtx/mbtx_test.mbt
@@ -992,10 +992,35 @@ test "a definition without a job runtime describes its hard timeout" {
 }
 
 ///|
-/// The command policy and its model-facing description are maintained
-/// separately, so pin the Proton entry at the public definition boundary too.
+/// Collapse every run of whitespace to one space, so a `contains` check reads
+/// the description's WORDS and not the column its generated bullets happen to
+/// wrap at. Without this, admitting one more command reflows a bullet and
+/// fails an assertion about text that is still there.
+fn flatten_whitespace(text : String) -> String {
+  let flattened = StringBuilder()
+  let mut in_space = false
+  for char in text {
+    if char is (' ' | '\n' | '\t' | '\r') {
+      if !in_space {
+        flattened.write_char(' ')
+        in_space = true
+      }
+    } else {
+      flattened.write_char(char)
+      in_space = false
+    }
+  }
+  flattened.to_string()
+}
+
+///|
+/// The Proton entry is rendered from the command policy rather than written
+/// beside it, so this pins that the render reaches the public definition
+/// boundary carrying both the verbs and the caveat no prefix can express.
 test "the description advertises the Proton CLI command surface" {
-  let description = @mbtx.definition(workspace_root=".").description
+  let description = flatten_whitespace(
+    @mbtx.definition(workspace_root=".").description,
+  )
   assert_true(description.contains("`proton_cli`"))
   assert_true(description.contains("doctor"))
   assert_true(description.contains("cef"))

--- a/agent_tool/mbtx/mbtx_wbtest.mbt
+++ b/agent_tool/mbtx/mbtx_wbtest.mbt
@@ -139,10 +139,126 @@ test "the spawn policy admits Proton subcommands but not global cwd options" {
   assert_false(proton_prefixes.contains(["--cwd"]))
 }
 
-// The spawn allowlist is taught by each role's system prompt now, and that
-// prose is NOT pinned by a test: asserting a prompt contains particular words
-// only breaks on rewrites. Keeping the list and the prompts in step is a
-// review-time job, not a test-time one.
+///|
+/// The prose that teaches the spawn allowlist is RENDERED from it, so a
+/// command admitted to `spawnable_commands` reaches the model without a
+/// second edit. This pins that: every program and every verb in the table has
+/// to appear in the rendered list, which is the property the old hand-written
+/// prose could not hold — `moon --version` and `moonx` had both drifted out
+/// of a copy by the time it was replaced.
+///
+/// The wording around the list is deliberately not asserted; that only breaks
+/// on rewrites.
+test "the rendered spawn list covers every admitted command" {
+  for entry in spawnable_commands {
+    let (program, args_prefix) = entry
+    let bullet = spawn_bullet(program)
+    match args_prefix {
+      // A program admitted with no prefix takes any arguments; there is no
+      // verb to look for.
+      [] => assert_true(bullet.contains("any arguments"))
+      // Checked inside this program's OWN bullet and delimited, so a dropped
+      // `moon add` cannot be covered by the `add` in `worktree list|add|prune`.
+      [single] => assert_true(bullet_lists_verb(bullet, single))
+      // Longer prefixes are grouped under their first token, so the whole
+      // prefix is never one substring: check the group the parts land in.
+      [head, .. rest] =>
+        assert_true(
+          bullet.contains("`\{head} ") && bullet.contains(rest.join("|")),
+        )
+    }
+  }
+}
+
+///|
+/// The rendered bullet for `program`, whitespace flattened so a wrap cannot
+/// split a verb list, and with the following bullets cut off so a check reads
+/// only this program's grant. Fails the test when the program has no bullet
+/// at all, which is the coverage gap worth reporting by name.
+fn spawn_bullet(program : String) -> String raise {
+  let flattened = {
+    let builder = StringBuilder()
+    let mut in_space = false
+    for char in spawn_list_markdown() {
+      if char is (' ' | '\n') {
+        if !in_space {
+          builder.write_char(' ')
+          in_space = true
+        }
+      } else {
+        builder.write_char(char)
+        in_space = false
+      }
+    }
+    builder.to_string()
+  }
+  let opening = "- `\{program}` — "
+  guard flattened.find(opening) is Some(start) else {
+    fail("the rendered spawn list has no bullet for \{program}")
+  }
+  let body = flattened[start + opening.length():]
+  match body.find(" - `") {
+    Some(next) => body[:next].to_owned()
+    None => body.to_owned()
+  }
+}
+
+///|
+/// Whether `bullet` offers `verb` as a whole entry of its comma-separated verb
+/// list, rather than as a fragment of a longer word or of a grouped prefix.
+/// Flags render as code, so both spellings count.
+fn bullet_lists_verb(bullet : String, verb : String) -> Bool {
+  let verbs = spawn_verbs(bullet)
+  verbs.contains(verb) || verbs.contains("`\{verb}`")
+}
+
+///|
+/// The single-token verbs a bullet lists, split back out of the rendered
+/// prose. The verb list runs to whichever comes first: the `, plus ` that
+/// introduces the grouped multi-token prefixes, or the `. ` that ends the
+/// sentence and starts the note — so neither a grouped prefix nor a note's
+/// own commas can be mistaken for a verb.
+fn spawn_verbs(bullet : String) -> Array[String] {
+  let mut cut = bullet.length()
+  for marker in [", plus ", ". "] {
+    if bullet.find(marker) is Some(index) && index < cut {
+      cut = index
+    }
+  }
+  [
+    for part in bullet[:cut].split(", ").collect() => part.to_owned()
+  ]
+}
+
+///|
+/// Grouping is what lets one bullet describe several two-token prefixes, and
+/// getting it wrong would silently narrow what the model believes it may run.
+test "the rendered spawn list groups multi-token prefixes under one verb" {
+  let rendered = spawn_list_markdown()
+  assert_true(rendered.contains("`worktree list|add|prune`"))
+  assert_true(rendered.contains("`submodule update|status`"))
+  assert_true(rendered.contains("`stash list|show`"))
+  assert_true(rendered.contains("`publish --dry-run`"))
+  // `git stash` with no verb is a push, and stays out along with `pop`.
+  assert_false(rendered.contains("stash list|show|pop"))
+}
+
+///|
+/// The description is the one place the model reads the list, so the render
+/// has to actually reach it — under the heading the system prompt now cites
+/// by name instead of restating the list itself.
+test "the mbtx description carries the rendered spawn list" {
+  let text = description(
+    background=true,
+    escalation=false,
+    hosting=false,
+    auto_background_after_ms=5_000,
+    foreground_timeout_ms=120_000,
+    build_timeout_ms=20_000,
+  )
+  assert_true(text.contains("## Which programs a snippet may start"))
+  assert_true(text.contains(spawn_list_markdown()))
+}
 
 ///|
 /// Codex CLI is admitted one verb only: the read-only `review`. There is no

--- a/agent_tool/mbtx/wasm_policy.mbt
+++ b/agent_tool/mbtx/wasm_policy.mbt
@@ -17,10 +17,11 @@
 /// A prefix matches whole argument tokens from the front, so `moon` with
 /// `["test"]` allows `moon test --filter x` but not `moon build`.
 ///
-/// The mbtx tool description and the default system prompt
-/// (`prompt/default_prompt.mbt.md`, "Only these programs can be started")
-/// both carry this list in prose. Admitting a command here without adding it
-/// to both costs a turn steps: the model never learns it may use it.
+/// This table is the only place the vocabulary is written. The prose the
+/// model reads is rendered from it by `spawn_list_markdown` into the mbtx
+/// tool description, and the system prompt points at that description rather
+/// than restating it — so admitting a command is this edit and nothing else.
+/// Add the caveats a prefix cannot express to `spawn_notes` below.
 let spawnable_commands : Array[(String, Array[String])] = [
   // The MoonBit toolchain, which is most of what a turn runs. Listed per
   // subcommand rather than as a bare `moon` so the set is reviewable, and so
@@ -217,6 +218,149 @@ let spawnable_commands : Array[(String, Array[String])] = [
   // perimeter.
   ("moonx", []),
 ]
+
+///|
+/// The caveats about the spawn allowlist that no `args_prefix` can express:
+/// which forms are deliberately absent, and which options are refused for
+/// sitting before the subcommand where no prefix reaches them. Keyed by
+/// program; a program named here renders its note after its verbs, and one
+/// absent renders its verbs alone.
+///
+/// Only the caveats live here. The verbs do NOT: `spawn_list_markdown`
+/// derives those from `spawnable_commands` itself, so admitting a command is
+/// one edit to one table and the prose that teaches it cannot fall behind.
+let spawn_notes : Map[String, String] = {
+  "moon": "(Not plain `publish`, `login` or `register`.)",
+  "proton_cli": "Set `Cmd.cwd` for the project directory; the global `-C`/`--cwd` options before the subcommand are refused.",
+  "git": "Not `config`. A global option BEFORE the subcommand (`-c`, `-C`, `--git-dir`, `--work-tree`) is refused.",
+  "codex": "(A read-only review of the current branch/diff; not `exec`, `install`, or a bare `codex`.)",
+  "diff": "Structured comparison of two files.",
+  "rg": "Searches a whole tree faster than a snippet can walk it.",
+  "moonx": "Runs other MoonBit binaries in wasm/sandbox mode.",
+}
+
+///|
+/// Render `spawnable_commands` as the Markdown bullet list the model reads in
+/// the `mbtx` tool description.
+///
+/// This function is why that description no longer restates the allowlist by
+/// hand. The three renderings used to be maintained separately — the table
+/// here, the tool description, and the system prompt — and a command admitted
+/// to the table without both prose edits was a command the model never
+/// learned it could use. Two entries had already drifted that way when this
+/// was written: `moon --version`/`--help` (added to the table after a live
+/// run burned three attempts on the refusal) and `moonx` (present in the
+/// prompt, absent from the tool description).
+///
+/// One bullet per program, in first-appearance order. Single-token prefixes
+/// render as a bare verb list; longer ones group under their first token
+/// (`worktree list|add|prune`) after `plus`, since a multi-token prefix is a
+/// narrower grant than the verb alone and reads as one; a program admitted
+/// with an empty prefix renders as taking any arguments.
+fn spawn_list_markdown() -> String {
+  let order : Array[String] = []
+  let by_program : Map[String, Array[Array[String]]] = Map([])
+  for entry in spawnable_commands {
+    let (program, args_prefix) = entry
+    match by_program.get(program) {
+      Some(prefixes) => prefixes.push(args_prefix)
+      None => {
+        order.push(program)
+        by_program[program] = [args_prefix]
+      }
+    }
+  }
+  let lines = StringBuilder()
+  for index, program in order {
+    guard by_program.get(program) is Some(prefixes) else { continue }
+    let singles : Array[String] = []
+    // Multi-token prefixes, grouped under their shared first token in the
+    // order the table lists them: `submodule update` and `submodule status`
+    // become one `submodule update|status` entry rather than two bullets
+    // repeating the verb.
+    let heads : Array[String] = []
+    let tails : Map[String, Array[String]] = Map([])
+    let mut any_arguments = false
+    for args_prefix in prefixes {
+      match args_prefix {
+        [] => any_arguments = true
+        // A bare verb reads as prose; a bare `--flag` does not, so flags are
+        // set as code the way the surrounding text sets every other literal.
+        [single] =>
+          singles.push(
+            if single.has_prefix("-") {
+              "`\{single}`"
+            } else {
+              single
+            },
+          )
+        [head, .. rest] =>
+          match tails.get(head) {
+            Some(seen) => seen.push(rest.join(" "))
+            None => {
+              heads.push(head)
+              tails[head] = [rest.join(" ")]
+            }
+          }
+      }
+    }
+    let parts : Array[String] = []
+    if any_arguments {
+      parts.push("any arguments")
+    }
+    if singles.length() > 0 {
+      parts.push(singles.join(", "))
+    }
+    let grouped : Array[String] = []
+    for head in heads {
+      guard tails.get(head) is Some(rest) else { continue }
+      grouped.push("`\{head} \{rest.join("|")}`")
+    }
+    if grouped.length() > 0 {
+      parts.push("plus \{grouped.join(", ")}")
+    }
+    let note = match spawn_notes.get(program) {
+      Some(text) => " " + text
+      None => ""
+    }
+    if index > 0 {
+      lines.write_string("\n")
+    }
+    lines.write_string(
+      wrap_bullet("- `\{program}` — \{parts.join(", ")}.\{note}"),
+    )
+  }
+  lines.to_string()
+}
+
+///|
+/// Greedy-wrap one rendered bullet to the width the surrounding prose uses,
+/// continuing lines with the two-space indent that keeps them inside the
+/// bullet. Wrapping is cosmetic — the model reads either form — but an
+/// unwrapped generated bullet beside hand-wrapped prose reads as a defect.
+fn wrap_bullet(bullet : String) -> String {
+  let width = 78
+  let wrapped = StringBuilder()
+  let mut column = 0
+  for index, word in bullet.split(" ").collect() {
+    let word = word.to_owned()
+    if index == 0 {
+      wrapped.write_string(word)
+      column = word.length()
+      continue
+    }
+    // `column + 1 + word.length()` is where this word would end on the
+    // current line; past the width it starts the next one instead.
+    if column + 1 + word.length() > width {
+      wrapped.write_string("\n  \{word}")
+      column = 2 + word.length()
+    } else {
+      wrapped.write_string(" \{word}")
+      column = column + 1 + word.length()
+    }
+  }
+  wrapped.to_string()
+}
 
 ///|
 /// Build the `moonrun --policy` document for one snippet run.

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -175,30 +175,14 @@ async fn main {
 }
 ```
 
-Use `@shell.Cmd` to run an external program and capture its output. Only
-these programs can be started:
-
-- `moon` — check, test, build, bench, run, fmt, info, add, remove, update,
-  install, tree, search, clean, new, ide, doc, explain, coverage, cram,
-  package, version, plus `publish --dry-run`. (Not plain `publish`, `login`
-  or `register`.)
-- `proton_cli` — `--version`, `--help`, new, dev, build, package, doctor,
-  cef, and updater. Set `Cmd.cwd` for the project directory; the global
-  `-C`/`--cwd` options before the subcommand are refused.
-- `git` — status, log, diff, show, blame, describe, rev-parse, rev-list,
-  show-ref, for-each-ref, cat-file, check-ignore, merge-base, range-diff,
-  ls-files, ls-tree, ls-remote, shortlog, grep, branch, tag, remote, reflog,
-  add, commit, checkout, switch, restore, reset, revert, rm, init, fetch,
-  push, rebase; plus `submodule update|status`, `worktree list|add|prune`,
-  `stash list|show`. Not `config`. A global option BEFORE the subcommand
-  (`-c`, `-C`, `--git-dir`, `--work-tree`) is refused.
-- `gh` — pr, issue, run, `repo view`, api, `auth status`.
-- `codex` — review (read-only review of the current branch/diff; not
-  `exec`, `install`, or a bare `codex`).
-- `rg` and `diff`.
-- `moonx` — runs other MoonBit binaries in wasm/sandbox mode; see
-  [Structural search with `moongrep`](#structural-search-with-moongrep) below
-  for AST-based code search.
+Use `@shell.Cmd` to run an external program and capture its output. Which
+programs a snippet may start is listed in the `mbtx` tool description, under
+"Which programs a snippet may start" — that list is rendered from the
+allowlist the sandbox enforces, so it is the current one; read it there rather
+than working from memory. `moonx` is on it, and runs other MoonBit binaries in
+wasm/sandbox mode; see
+[Structural search with `moongrep`](#structural-search-with-moongrep) below
+for AST-based code search.
 
 Anything else is refused, including the obvious ones such as `ls`, `cat`, and
 `sh`. Each of those is a line of MoonBit here, which also works on Windows,

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -199,30 +199,14 @@ fn default_prompt() -> String {
     #|}
     #|```
     #|
-    #|Use `@shell.Cmd` to run an external program and capture its output. Only
-    #|these programs can be started:
-    #|
-    #|- `moon` — check, test, build, bench, run, fmt, info, add, remove, update,
-    #|  install, tree, search, clean, new, ide, doc, explain, coverage, cram,
-    #|  package, version, plus `publish --dry-run`. (Not plain `publish`, `login`
-    #|  or `register`.)
-    #|- `proton_cli` — `--version`, `--help`, new, dev, build, package, doctor,
-    #|  cef, and updater. Set `Cmd.cwd` for the project directory; the global
-    #|  `-C`/`--cwd` options before the subcommand are refused.
-    #|- `git` — status, log, diff, show, blame, describe, rev-parse, rev-list,
-    #|  show-ref, for-each-ref, cat-file, check-ignore, merge-base, range-diff,
-    #|  ls-files, ls-tree, ls-remote, shortlog, grep, branch, tag, remote, reflog,
-    #|  add, commit, checkout, switch, restore, reset, revert, rm, init, fetch,
-    #|  push, rebase; plus `submodule update|status`, `worktree list|add|prune`,
-    #|  `stash list|show`. Not `config`. A global option BEFORE the subcommand
-    #|  (`-c`, `-C`, `--git-dir`, `--work-tree`) is refused.
-    #|- `gh` — pr, issue, run, `repo view`, api, `auth status`.
-    #|- `codex` — review (read-only review of the current branch/diff; not
-    #|  `exec`, `install`, or a bare `codex`).
-    #|- `rg` and `diff`.
-    #|- `moonx` — runs other MoonBit binaries in wasm/sandbox mode; see
-    #|  [Structural search with `moongrep`](#structural-search-with-moongrep) below
-    #|  for AST-based code search.
+    #|Use `@shell.Cmd` to run an external program and capture its output. Which
+    #|programs a snippet may start is listed in the `mbtx` tool description, under
+    #|"Which programs a snippet may start" — that list is rendered from the
+    #|allowlist the sandbox enforces, so it is the current one; read it there rather
+    #|than working from memory. `moonx` is on it, and runs other MoonBit binaries in
+    #|wasm/sandbox mode; see
+    #|[Structural search with `moongrep`](#structural-search-with-moongrep) below
+    #|for AST-based code search.
     #|
     #|Anything else is refused, including the obvious ones such as `ls`, `cat`, and
     #|`sh`. Each of those is a line of MoonBit here, which also works on Windows,


### PR DESCRIPTION
## The duplication

`spawnable_commands` (`agent_tool/mbtx/wasm_policy.mbt`) builds the moonrun
process policy, and the same vocabulary was written out twice more by hand —
in the `mbtx` tool description and in the default system prompt. The table's
own doc comment named the hazard:

> The mbtx tool description and the default system prompt both carry this list
> in prose. Admitting a command here without adding it to both costs a turn
> steps: the model never learns it may use it.

**Both copies had already drifted:**

| Entry | In the table | Tool description | System prompt |
| --- | --- | --- | --- |
| `moon --version` / `--help` | ✅ | ❌ | ❌ |
| `moonx` | ✅ | ❌ | ✅ |

The `moon --version` entry is the pointed one: it was added to the table
*because* a live run burned three attempts on the refusal — plain, then with a
rebuilt `PATH`, then by absolute path — reading each one as a broken toolchain
rather than as the allowlist. The fix landed in the table and in neither place
the model reads.

## The change

`spawn_list_markdown()` renders the bullet list from the table itself. Verbs
come from the prefixes; multi-token prefixes group under their shared first
token (`worktree list|add|prune`); a new `spawn_notes` map carries **only** the
caveats no prefix can express (`Not \`config\``, the refused pre-subcommand
globals). Admitting a command is now one edit to one table.

Three copies became one:

- `agent_tool/mbtx/mbtx.mbt` interpolates the render into the tool description.
- `prompt/default_prompt.mbt.md` cites that description by heading instead of
  restating it — which also stops the model paying for the same ~25 lines
  twice in one context window. The MoonBit-alternatives table and the
  `moongrep` cross-reference stay in the prompt, where the teaching belongs.

Both drifts correct themselves as output. **The table is untouched, so the
policy moonrun enforces is byte-for-byte unchanged.**

## Tests

- `the rendered spawn list covers every admitted command` — every program and
  verb in the table must appear in the render, checked **inside that program's
  own bullet**. The loose version of this passed with `moon add` deleted,
  because `add` also occurs in `worktree list|add|prune`; `spawn_bullet`
  isolates one bullet and `bullet_lists_verb` splits the verb region so a
  grouped prefix or a note's commas cannot satisfy it. Mutation-tested:
  dropping a verb from the render fails the test, restoring it passes.
- `the rendered spawn list groups multi-token prefixes under one verb`
- `the mbtx description carries the rendered spawn list`
- `the description advertises the Proton CLI command surface` (existing) now
  flattens whitespace before matching — it was pinning exact line breaks that
  a generated bullet reflows whenever a verb is admitted.

This replaces the review-time discipline the old comment settled for:

> Keeping the list and the prompts in step is a review-time job, not a
> test-time one.

## Verification

`moon check --deny-warn` (root) clean · mbtx suite 106/106 · prompt 5/5 ·
cram 38/38 · `just check-prompt` fresh · `moon fmt` stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CcSFBB6Pd7Pkj5Xw6Ups9J
