### PR TITLE
Clarify background job states and polish the Jobs panel

### DIFF
--- a/desktop/e2e/tests/background_jobs.spec.js
+++ b/desktop/e2e/tests/background_jobs.spec.js
@@ -11,6 +11,11 @@ async function mount(page) {
   await expect(page.getByRole('region', { name: 'Job output' })).toContainText('ready 你好🙂');
 }
 
+async function expandHistory(page) {
+  const toggle = page.locator('.jobs-history-toggle');
+  if (await toggle.getAttribute('aria-expanded') === 'false') await toggle.click();
+}
+
 test('real background output follows, pauses, resumes, copies its file and stops', async ({ page, context }, testInfo) => {
   await context.grantPermissions(['clipboard-read', 'clipboard-write']);
   await mount(page);
@@ -61,6 +66,7 @@ test('historical selection rejects late reads, reports errors and fits a narrow 
   app.write('must stay with the live job\n');
   await expect.poll(() => app.requests.filter(r => r.method === 'jobs.read').length).toBeGreaterThan(1);
   app.rpcDelays.delete('jobs.read');
+  await expandHistory(page);
   await page.getByRole('button', { name: /Earlier failing test run/ }).click();
   const output = page.getByRole('region', { name: 'Job output' });
   await expect(output).toContainText('old failed job output');
@@ -88,6 +94,8 @@ test('page reconnect recovers retained job identity and history', async ({ page 
   await expect(page.getByRole('region', { name: 'Job output' })).toContainText('persist across reconnect');
   await page.reload(); await app.openSession(); await app.openJobs();
   await expect(page.getByRole('region', { name: 'Job output' })).toContainText('persist across reconnect');
+  await expect(page.getByRole('button', { name: /Earlier failing test run/ })).toHaveCount(0);
+  await expandHistory(page);
   await expect(page.getByRole('button', { name: /Earlier failing test run/ })).toBeVisible();
   expect(app.pageErrors).toEqual([]);
 });
@@ -124,7 +132,9 @@ test('selected job beyond the first history page keeps receiving terminal state'
   await app.install(); await app.goto(); await app.openSession(); await app.openJobs();
   const selected = app.jobs.find(v => v.job.generation === 'runtime-old');
   selected.job.state = { kind: 'running' };
+  await expandHistory(page);
   await page.getByRole('button', { name: 'Load older jobs', exact: true }).click();
+  await expandHistory(page);
   await page.getByRole('button', { name: /Earlier failing test run/ }).click();
   await page.getByRole('button', { name: 'Pause', exact: true }).click();
   selected.job.state = { kind: 'stopped', reason: 'user' };
@@ -205,6 +215,7 @@ test('UUID suffix collisions expand labels while selection and copying retain fu
   app.jobs.push(other);
   await app.install(); await app.goto(); await app.openSession(); await app.openJobs();
   await expect(page.locator('.jobs-id')).toHaveText(['bg-…0123456789ab', 'bg-1', 'bg-…abcd456789ab']);
+  await expandHistory(page);
   await page.getByRole('button', { name: /Same short suffix/ }).click();
   await expect(page.getByRole('region', { name: 'Job output' })).toContainText('old failed job output');
   await page.getByRole('button', { name: 'Copy job ID', exact: true }).click();
@@ -242,6 +253,8 @@ test('groups lifecycle states and defaults to an active job even after newer his
   await expect(active.locator('.jobs-row')).toHaveCount(2);
   await expect(history.locator('.jobs-row')).toHaveCount(5);
   expect(await page.locator('.jobs-group').evaluateAll(groups => groups.map(el => el.getAttribute('aria-label')))).toEqual(['In progress', 'History']);
+  await expect(page.locator('.jobs-history-toggle')).toHaveAttribute('aria-expanded', 'false');
+  await expandHistory(page);
   for (const [id, , label] of fixtures) {
     await page.getByRole('button', { name: new RegExp(`Lifecycle ${id}`) }).click();
     await expect(page.locator('.jobs-detail-title')).toContainText(label);
@@ -328,5 +341,52 @@ test('interrupted jobs drain final diagnostics despite stale persisted byte coun
   const lists = app.requests.filter(r => r.method === 'jobs.list').length;
   await expect.poll(() => app.requests.filter(r => r.method === 'jobs.list').length).toBeGreaterThan(lists + 1);
   expect(app.requests.filter(r => r.method === 'jobs.read')).toHaveLength(reads);
+  expect(app.pageErrors).toEqual([]);
+});
+
+
+test('history stays folded by default while active jobs remain visible across refreshes', async ({ page }, testInfo) => {
+  await mount(page);
+  const toggle = page.locator('.jobs-history-toggle');
+  const active = page.getByRole('group', { name: 'In progress', exact: true });
+  const oldJob = page.getByRole('button', { name: /Earlier failing test run/ });
+  await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+  await expect(active.getByRole('button', { name: /Watch build output/ })).toBeVisible();
+  await expect(oldJob).toHaveCount(0);
+  await page.locator('.jobs-panel').getByRole('button', { name: 'Refresh', exact: true }).click();
+  await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+  await toggle.focus(); await page.keyboard.press('Enter');
+  await expect(oldJob).toBeVisible();
+  const lists = app.requests.filter(r => r.method === 'jobs.list').length;
+  await expect.poll(() => app.requests.filter(r => r.method === 'jobs.list').length).toBeGreaterThan(lists);
+  await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+  await oldJob.click();
+  await expect(page.getByRole('region', { name: 'Job output' })).toContainText('old failed job output');
+  await toggle.click();
+  await expect(oldJob).toHaveCount(0);
+  await expect(active.getByRole('button', { name: /Watch build output/ })).toBeVisible();
+  await active.getByRole('button', { name: /Watch build output/ }).click();
+  await page.screenshot({ path: testInfo.outputPath('jobs-history-folded.png'), fullPage: true });
+  // A completing selection remains readable without opening its History group.
+  await page.getByRole('button', { name: 'Stop job', exact: true }).click();
+  await expect(page.locator('.jobs-detail-title')).toContainText('Stopped');
+  await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+  expect(app.pageErrors).toEqual([]);
+});
+
+test('history-only sessions wait for explicit selection before loading a log', async ({ page }) => {
+  app = new BackgroundJobsHarness(page);
+  const live = app.jobs.shift();
+  await app.install(); await app.goto(); await app.openSession(); await app.openJobs();
+  await expect(page.locator('.jobs-history-toggle')).toHaveAttribute('aria-expanded', 'false');
+  await expect(page.locator('.jobs-detail')).toHaveCount(0);
+  expect(app.requests.filter(r => r.method === 'jobs.read')).toHaveLength(0);
+  await expandHistory(page);
+  await page.getByRole('button', { name: /Earlier failing test run/ }).click();
+  await expect(page.getByRole('region', { name: 'Job output' })).toContainText('old failed job output');
+  app.jobs.unshift(live);
+  await expect(page.getByRole('group', { name: 'In progress', exact: true })).toBeVisible();
+  await expect(page.locator('.jobs-detail-title')).toContainText('Failed');
+  await expect(page.locator('.jobs-history-toggle')).toHaveAttribute('aria-expanded', 'true');
   expect(app.pageErrors).toEqual([]);
 });

--- a/desktop/e2e/tests/background_jobs.spec.js
+++ b/desktop/e2e/tests/background_jobs.spec.js
@@ -46,7 +46,7 @@ test('real background output follows, pauses, resumes, copies its file and stops
   await page.screenshot({ path: testInfo.outputPath('jobs-dark.png'), fullPage: true });
   await page.getByRole('button', { name: 'Stop job', exact: true }).click();
   await expect(page.locator('.jobs-detail-title')).toContainText('Stopped');
-  await expect(page.getByRole('button', { name: 'Stop job', exact: true })).toBeDisabled();
+  await expect(page.getByRole('button', { name: 'Stop job', exact: true })).toHaveCount(0);
   expect(app.child.signalCode).not.toBeNull();
   expect(readFileSync(app.livePath, 'utf8')).toContain('stderr captured');
   const stop = app.requests.find(r => r.method === 'jobs.stop');
@@ -65,7 +65,7 @@ test('historical selection rejects late reads, reports errors and fits a narrow 
   const output = page.getByRole('region', { name: 'Job output' });
   await expect(output).toContainText('old failed job output');
   await expect(page.locator('.jobs-detail-title')).toContainText('Failed · exit 7');
-  await expect(page.getByRole('button', { name: 'Stop job', exact: true })).toBeDisabled();
+  await expect(page.getByRole('button', { name: 'Stop job', exact: true })).toHaveCount(0);
   await page.waitForTimeout(1400); // The deliberately delayed obsolete reply must arrive.
   await expect(output).not.toContainText('must stay with the live job');
   app.rpcErrors.set('jobs.read', 'Output file is missing: ENOENT');
@@ -122,10 +122,11 @@ test('selected job beyond the first history page keeps receiving terminal state'
     app.jobs.splice(1, 0, view);
   }
   await app.install(); await app.goto(); await app.openSession(); await app.openJobs();
+  const selected = app.jobs.find(v => v.job.generation === 'runtime-old');
+  selected.job.state = { kind: 'running' };
   await page.getByRole('button', { name: 'Load older jobs', exact: true }).click();
   await page.getByRole('button', { name: /Earlier failing test run/ }).click();
   await page.getByRole('button', { name: 'Pause', exact: true }).click();
-  const selected = app.jobs.find(v => v.job.generation === 'runtime-old');
   selected.job.state = { kind: 'stopped', reason: 'user' };
   selected.job.revision++;
   await expect(page.locator('.jobs-detail-title')).toContainText('Stopped');
@@ -213,5 +214,89 @@ test('UUID suffix collisions expand labels while selection and copying retain fu
   await expect.poll(() => page.locator('.jobs-panel').evaluate(el => el.scrollWidth <= el.clientWidth + 1)).toBe(true);
   await expect(page.getByRole('button', { name: 'Copy job ID', exact: true })).toBeInViewport();
   await page.screenshot({ path: testInfo.outputPath('jobs-uuid-narrow.png'), fullPage: true });
+  expect(app.pageErrors).toEqual([]);
+});
+
+test('groups lifecycle states and defaults to an active job even after newer history', async ({ page }, testInfo) => {
+  app = new BackgroundJobsHarness(page);
+  const live = app.jobs[0];
+  const fixtures = [
+    ['completed', { kind: 'exited', code: 0 }, 'Completed'],
+    ['stopped', { kind: 'stopped', reason: 'user' }, 'Stopped'],
+    ['interrupted', { kind: 'interrupted' }, 'Interrupted'],
+    ['limited', { kind: 'stopped', reason: 'time_limit' }, 'Stopped · time limit reached'],
+    ['stopping', { kind: 'stopping' }, 'Stopping…'],
+  ];
+  for (const [id, state] of fixtures) {
+    const view = app.view('runtime-new', id, app.oldPath, state);
+    view.job.description = `Lifecycle ${id}`;
+    // Even a controllable stopping job must not offer a second stop request.
+    view.controllable = state.kind === 'stopping';
+    app.jobs.push(view);
+  }
+  app.jobs.splice(0, 1); app.jobs.splice(1, 0, live);
+  await app.install(); await app.goto(); await app.openSession(); await app.openJobs();
+  await expect(page.getByRole('region', { name: 'Job output' })).toContainText('ready 你好🙂');
+  const active = page.getByRole('group', { name: 'In progress', exact: true });
+  const history = page.getByRole('group', { name: 'History', exact: true });
+  await expect(active.locator('.jobs-row')).toHaveCount(2);
+  await expect(history.locator('.jobs-row')).toHaveCount(5);
+  expect(await page.locator('.jobs-group').evaluateAll(groups => groups.map(el => el.getAttribute('aria-label')))).toEqual(['In progress', 'History']);
+  for (const [id, , label] of fixtures) {
+    await page.getByRole('button', { name: new RegExp(`Lifecycle ${id}`) }).click();
+    await expect(page.locator('.jobs-detail-title')).toContainText(label);
+    if (id === 'stopping') {
+      await expect(page.getByRole('button', { name: 'Stopping…', exact: true })).toBeDisabled();
+      await expect(page.getByRole('button', { name: 'Pause', exact: true })).toBeVisible();
+    } else {
+      await expect(page.locator('.jobs-output-note')).toHaveText('Output ended');
+      await expect(page.getByRole('button', { name: /^(Stop job|Pause|Follow output)$/ })).toHaveCount(0);
+      if (id === 'interrupted') {
+        await expect(page.locator('.jobs-detail')).toContainText('End time unavailable');
+        await expect(page.locator('.jobs-detail')).not.toContainText('Running for');
+      }
+    }
+  }
+  await page.screenshot({ path: testInfo.outputPath('jobs-lifecycle-light.png'), fullPage: true });
+  await page.emulateMedia({ colorScheme: 'dark' });
+  await page.screenshot({ path: testInfo.outputPath('jobs-lifecycle-dark.png'), fullPage: true });
+  await page.setViewportSize({ width: 1000, height: 850 });
+  await page.getByRole('button', { name: /Lifecycle limited/ }).click();
+  await expect.poll(() => page.locator('.jobs-panel, .jobs-row, .jobs-status').evaluateAll(elements => elements.every(el => el.scrollWidth <= el.clientWidth + 1))).toBe(true);
+  await page.screenshot({ path: testInfo.outputPath('jobs-lifecycle-narrow.png'), fullPage: true });
+  expect(app.requests.filter(r => r.method === 'jobs.stop')).toHaveLength(0);
+  expect(app.pageErrors).toEqual([]);
+});
+
+test('completion drains paused output then stops log polling while history stays fresh', async ({ page, context }, testInfo) => {
+  await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+  await mount(page);
+  await page.getByRole('button', { name: 'Pause', exact: true }).click();
+  app.write('x'.repeat(65536 * 9) + '\nCOMPLETED WHILE PAUSED\n');
+  app.child.stdin.end();
+  const output = page.getByRole('region', { name: 'Job output' });
+  await expect(page.locator('.jobs-detail-title')).toContainText('Completed');
+  await expect(page.getByRole('group', { name: 'In progress', exact: true })).toHaveCount(0);
+  await expect(page.getByRole('group', { name: 'History', exact: true }).locator('.jobs-row.selected')).toContainText('Watch build output');
+  await expect(output).toContainText('COMPLETED WHILE PAUSED');
+  await expect(page.locator('.jobs-output-note')).toContainText('Output ended');
+  await expect(page.getByRole('button', { name: /^(Stop job|Pause|Follow output)$/ })).toHaveCount(0);
+  const timing = page.locator('.jobs-detail-meta').filter({ hasText: 'Ended' });
+  const finalTiming = await timing.textContent();
+  expect(finalTiming).toContain('Total');
+  const reads = app.requests.filter(r => r.method === 'jobs.read').length;
+  const lists = app.requests.filter(r => r.method === 'jobs.list').length;
+  await expect.poll(() => app.requests.filter(r => r.method === 'jobs.list').length).toBeGreaterThan(lists + 1);
+  expect(app.requests.filter(r => r.method === 'jobs.read')).toHaveLength(reads);
+  await expect(timing).toHaveText(finalTiming);
+  await page.getByRole('button', { name: 'Copy tail command', exact: true }).click();
+  expect(await page.evaluate(() => navigator.clipboard.readText())).not.toContain(' -f ');
+  await page.getByRole('button', { name: 'Reload tail', exact: true }).click();
+  await expect(output).toContainText('COMPLETED WHILE PAUSED');
+  await expect(page.locator('.jobs-output-note')).toContainText('Output ended');
+  expect(app.requests.filter(r => r.method === 'jobs.read').length).toBeGreaterThan(reads);
+  await page.setViewportSize({ width: 1000, height: 850 });
+  await expect.poll(() => page.locator('.jobs-panel').evaluate(el => el.scrollWidth <= el.clientWidth + 1)).toBe(true);
+  await page.screenshot({ path: testInfo.outputPath('jobs-completed-narrow.png'), fullPage: true });
   expect(app.pageErrors).toEqual([]);
 });

--- a/desktop/e2e/tests/background_jobs.spec.js
+++ b/desktop/e2e/tests/background_jobs.spec.js
@@ -300,3 +300,33 @@ test('completion drains paused output then stops log polling while history stays
   await page.screenshot({ path: testInfo.outputPath('jobs-completed-narrow.png'), fullPage: true });
   expect(app.pageErrors).toEqual([]);
 });
+
+test('interrupted jobs drain final diagnostics despite stale persisted byte counts', async ({ page }) => {
+  await mount(page);
+  await page.getByRole('button', { name: 'Pause', exact: true }).click();
+  const original = app.replyFor.bind(app);
+  app.replyFor = async request => {
+    const reply = await original(request);
+    if (request.method === 'jobs.list') {
+      for (const view of reply.jobs) {
+        if (view.job.state.kind === 'interrupted') view.job.output_bytes = 1;
+      }
+    }
+    return reply;
+  };
+  app.write('FINAL DIAGNOSTICS BEFORE ENGINE CRASH\n');
+  await expect.poll(() => readFileSync(app.livePath, 'utf8')).toContain('FINAL DIAGNOSTICS');
+  app.child.once('close', () => {
+    app.jobs[0].job.state = { kind: 'interrupted' };
+    app.jobs[0].job.finished_at_ms = null;
+  });
+  app.child.kill();
+  await expect(page.locator('.jobs-detail-title')).toContainText('Interrupted');
+  await expect(page.getByRole('region', { name: 'Job output' })).toContainText('FINAL DIAGNOSTICS BEFORE ENGINE CRASH');
+  await expect(page.locator('.jobs-output-note')).toHaveText('Output ended');
+  const reads = app.requests.filter(r => r.method === 'jobs.read').length;
+  const lists = app.requests.filter(r => r.method === 'jobs.list').length;
+  await expect.poll(() => app.requests.filter(r => r.method === 'jobs.list').length).toBeGreaterThan(lists + 1);
+  expect(app.requests.filter(r => r.method === 'jobs.read')).toHaveLength(reads);
+  expect(app.pageErrors).toEqual([]);
+});

--- a/desktop/e2e/tests/support/background_jobs_harness.js
+++ b/desktop/e2e/tests/support/background_jobs_harness.js
@@ -31,11 +31,12 @@ export class BackgroundJobsHarness extends DesktopBrowserHarness {
     const append = chunk => appendFileSync(this.livePath, chunk);
     this.child.stdout.on('data', append);
     this.child.stderr.on('data', append);
-    this.child.on('exit', () => {
-      this.jobs[0].job.state = { kind: 'stopped', reason: 'user' };
-      this.jobs[0].job.finished_at_ms = Date.now();
-      this.jobs[0].job.revision += 1;
-      this.jobs[0].controllable = false;
+    const live = this.jobs[0];
+    this.child.on('close', (code, signal) => {
+      live.job.state = signal ? { kind: 'stopped', reason: 'user' } : { kind: 'exited', code };
+      live.job.finished_at_ms = Date.now();
+      live.job.revision += 1;
+      live.controllable = false;
     });
   }
   view(generation, id, path, state) {
@@ -84,7 +85,7 @@ export class BackgroundJobsHarness extends DesktopBrowserHarness {
     if (request.method === 'jobs.stop') {
       if (p.generation !== 'runtime-new') return { outcome: 'wrong_runtime' };
       if (this.child.exitCode === null && this.child.signalCode === null) {
-        const exited = once(this.child, 'exit'); this.child.kill(); await exited;
+        const exited = once(this.child, 'close'); this.child.kill(); await exited;
       }
       return { outcome: 'stopped' };
     }
@@ -101,7 +102,7 @@ export class BackgroundJobsHarness extends DesktopBrowserHarness {
     // The page fixture normally closes after afterEach, leaving a small race.
     if (!this.page.isClosed()) await this.page.close();
     if (this.child.exitCode === null && this.child.signalCode === null) {
-      const exited = once(this.child, 'exit'); this.child.kill(); await exited;
+      const exited = once(this.child, 'close'); this.child.kill(); await exited;
     }
     rmSync(this.directory, { recursive: true, force: true });
   }

--- a/desktop/frontend/jobs/state.mbt
+++ b/desktop/frontend/jobs/state.mbt
@@ -10,6 +10,7 @@ pub(all) struct State {
   active : Bool
   epoch : Int
   jobs : Array[@protocol.JobView]
+  history_expanded : Bool
   selected : (String, String)?
   listing : Bool
   next_offset : Int?
@@ -39,6 +40,7 @@ pub fn State::empty() -> State {
     active: false,
     epoch: 0,
     jobs: [],
+    history_expanded: false,
     selected: None,
     listing: false,
     next_offset: None,
@@ -68,6 +70,7 @@ pub(all) enum Msg {
   More
   Select(String, String)
   ToggleFollow
+  ToggleHistory
   Pause
   Reload
   Stop
@@ -232,6 +235,8 @@ pub fn update(
       }
       (@cmd.batch([list, read]), state)
     }
+    ToggleHistory =>
+      (@cmd.none, { ..state, history_expanded: !state.history_expanded, })
     More =>
       match state.next_offset {
         Some(offset) => request_list(emit, state, offset)
@@ -270,14 +275,11 @@ pub fn update(
           }
           let selected = match state.selected {
             Some(_) => state.selected
-            None => {
-              let first = match
-                jobs.iter().find_first(view => !view.job.state.is_terminal()) {
-                Some(view) => Some(view)
-                None => jobs.get(0)
-              }
-              first.map(view => (view.job.generation, view.job.id))
-            }
+            None =>
+              jobs
+              .iter()
+              .find_first(view => !view.job.state.is_terminal())
+              .map(view => (view.job.generation, view.job.id))
           }
           let next_offset = if offset == 0 &&
             reply.next_offset is Some(_) &&

--- a/desktop/frontend/jobs/state.mbt
+++ b/desktop/frontend/jobs/state.mbt
@@ -80,6 +80,19 @@ fn selected_job(state : State) -> @protocol.JobView? {
 }
 
 ///|
+fn selected_terminal(state : State) -> Bool {
+  selected_job(state) is Some(view) && view.job.state.is_terminal()
+}
+
+///|
+fn output_complete(state : State, job : @wire.JobRecord) -> Bool {
+  job.state.is_terminal() &&
+  !state.catching_up &&
+  state.cursor is Some(cursor) &&
+  cursor >= job.output_bytes
+}
+
+///|
 fn target(owner : Owner, key : (String, String)) -> @protocol.JobTarget {
   { scope: owner.scope, generation: key.0, job_id: key.1, }
 }
@@ -118,7 +131,8 @@ fn request_read(emit : @cmd.Emit[Msg], state : State) -> (@cmd.Cmd, State) {
     state.owner is Some(owner) &&
     state.selected is Some(key) &&
     selected_job(state) is Some(view) &&
-    view.output_path is Some(_) else {
+    view.output_path is Some(_) &&
+    (!output_complete(state, view.job) || state.manual_read) else {
     return (@cmd.none, state)
   }
   let serial = state.read_serial + 1
@@ -201,7 +215,8 @@ pub fn update(
     Poll => {
       let state = { ..state, read_budget: 4, }
       let (list, state) = request_list(emit, state, 0)
-      let (read, state) = if state.follow && state.read_error is None {
+      let (read, state) = if (state.follow || selected_terminal(state)) &&
+        state.read_error is None {
         request_read(emit, state)
       } else {
         (@cmd.none, state)
@@ -246,7 +261,14 @@ pub fn update(
           }
           let selected = match state.selected {
             Some(_) => state.selected
-            None => jobs.get(0).map(view => (view.job.generation, view.job.id))
+            None => {
+              let first = match
+                jobs.iter().find_first(view => !view.job.state.is_terminal()) {
+                Some(view) => Some(view)
+                None => jobs.get(0)
+              }
+              first.map(view => (view.job.generation, view.job.id))
+            }
           }
           let next_offset = if offset == 0 &&
             reply.next_offset is Some(_) &&
@@ -304,7 +326,7 @@ pub fn update(
           reload_pending: false,
         })
       }
-      if !state.follow && !state.manual_read {
+      if !state.follow && !state.manual_read && !selected_terminal(state) {
         return (@cmd.none, { ..state, reading: false, })
       }
       match result {
@@ -349,7 +371,9 @@ pub fn update(
           let scroll = if state.follow { scroll_to_end() } else { @cmd.none }
           // At most four pages per refresh cycle. A partial UTF-8 suffix may report
           // more without cursor progress; always wait for the next tick then.
-          if state.follow && page.more && page.next_offset > page.start_offset {
+          if (state.follow || selected_terminal(state)) &&
+            page.more &&
+            page.next_offset > page.start_offset {
             let (read, state) = request_read(emit, state)
             (@cmd.batch([scroll, read]), state)
           } else {
@@ -397,7 +421,8 @@ pub fn update(
         state.owner is Some(owner) &&
         state.selected is Some(key) &&
         selected_job(state) is Some(view) &&
-        view.controllable else {
+        view.controllable &&
+        view.job.state is Running else {
         return (@cmd.none, state)
       }
       let cmd = @cmd.attempt(

--- a/desktop/frontend/jobs/state.mbt
+++ b/desktop/frontend/jobs/state.mbt
@@ -19,6 +19,8 @@ pub(all) struct State {
   cursor : Int64?
   reading : Bool
   read_serial : Int
+  reading_state : @wire.JobState?
+  eof_state : @wire.JobState?
   read_budget : Int
   catching_up : Bool
   reload_pending : Bool
@@ -46,6 +48,8 @@ pub fn State::empty() -> State {
     cursor: None,
     reading: false,
     read_serial: 0,
+    reading_state: None,
+    eof_state: None,
     read_budget: 4,
     catching_up: false,
     reload_pending: false,
@@ -85,8 +89,11 @@ fn selected_terminal(state : State) -> Bool {
 }
 
 ///|
+// Persisted byte counts can lag the retained file after an engine crash.
+// Only an EOF from a read requested in this terminal state can finish draining.
 fn output_complete(state : State, job : @wire.JobRecord) -> Bool {
   job.state.is_terminal() &&
+  state.eof_state == Some(job.state) &&
   !state.catching_up &&
   state.cursor is Some(cursor) &&
   cursor >= job.output_bytes
@@ -156,6 +163,7 @@ fn request_read(emit : @cmd.Emit[Msg], state : State) -> (@cmd.Cmd, State) {
       ..state,
       reading: true,
       read_serial: serial,
+      reading_state: Some(view.job.state),
       read_budget: state.read_budget - 1,
     },
   )
@@ -181,6 +189,7 @@ pub fn reconcile(
       epoch: state.epoch + 1,
       listing: false,
       reading: false,
+      reading_state: None,
       reload_pending: false,
       manual_read: false,
       read_budget: 4,
@@ -304,6 +313,8 @@ pub fn update(
         read_error: None,
         reading: false,
         read_serial: state.read_serial + 1,
+        reading_state: None,
+        eof_state: None,
         read_budget: 4,
         catching_up: false,
         reload_pending: false,
@@ -323,11 +334,12 @@ pub fn update(
         return request_read(emit, {
           ..state,
           reading: false,
+          reading_state: None,
           reload_pending: false,
         })
       }
       if !state.follow && !state.manual_read && !selected_terminal(state) {
-        return (@cmd.none, { ..state, reading: false, })
+        return (@cmd.none, { ..state, reading: false, reading_state: None, })
       }
       match result {
         Err(error) =>
@@ -336,6 +348,8 @@ pub fn update(
             {
               ..state,
               reading: false,
+              reading_state: None,
+              eof_state: None,
               manual_read: false,
               catching_up: false,
               read_error: Some(error),
@@ -360,6 +374,12 @@ pub fn update(
             ..state,
             text,
             cursor: Some(page.next_offset),
+            eof_state: if page.more {
+              None
+            } else {
+              state.reading_state
+            },
+            reading_state: None,
             catching_up: page.more,
             reading: false,
             manual_read: false,
@@ -404,6 +424,7 @@ pub fn update(
         ..state,
         text: "",
         cursor: None,
+        eof_state: None,
         clipped: false,
         catching_up: false,
         read_error: None,

--- a/desktop/frontend/jobs/state_wbtest.mbt
+++ b/desktop/frontend/jobs/state_wbtest.mbt
@@ -177,6 +177,7 @@ fn reading_fixture() -> State {
     selected: Some(("runtime", "bg-1")),
     reading: true,
     read_serial: 1,
+    reading_state: Some(Running),
     read_budget: 3,
     cursor: Some(0L),
   }
@@ -289,6 +290,7 @@ test "terminal jobs drain remaining pages while paused then stop reading" {
   let state = {
     ..reading_fixture(),
     jobs: [{ ..view, job: { ..view.job, output_bytes: 8L, }, }],
+    reading_state: Some(Exited(0)),
     follow: false,
   }
   let (_, next) = update(emit, Read(0, 1, Ok(page_fixture(0L, true))), state)
@@ -404,4 +406,57 @@ test "historical tail commands do not wait for more output" {
     job_timing(fixture_job("old", Interrupted).job),
     "End time unavailable",
   )
+}
+
+///|
+test "interruption requires a fresh EOF even when persisted bytes trail the cursor" {
+  let emit : @cmd.Emit[Msg] = Emit(_ => @cmd.none)
+  let live = fixture_job("bg-1", Running)
+  let state = {
+    ..reading_fixture(),
+    jobs: [{ ..live, job: { ..live.job, output_bytes: 5L, }, }],
+    cursor: Some(10L),
+    eof_state: Some(Running),
+  }
+  let interrupted = {
+    ..live,
+    job: { ..live.job, state: Interrupted, output_bytes: 5L, },
+  }
+  let reply : @protocol.JobsListReply = {
+    jobs: [interrupted],
+    selected: None,
+    next_offset: None,
+    errors: [],
+  }
+  let (_, ended) = update(emit, Listed(0, 0, Ok(reply)), state)
+  assert_false(output_complete(ended, interrupted.job))
+  // A pre-interruption read can arrive late with an old EOF; it cannot finish draining.
+  let stale_eof = {
+    ..page_fixture(10L, false),
+    text: "",
+    next_offset: 10L,
+    size: 10L,
+  }
+  let (_, stale) = update(emit, Read(0, 1, Ok(stale_eof)), ended)
+  assert_false(output_complete(stale, interrupted.job))
+  let (_, polled) = update(emit, Poll, { ..stale, follow: false, })
+  assert_true(polled.reading)
+  let final_page = {
+    ..page_fixture(10L, false),
+    text: "last error",
+    next_offset: 20L,
+    size: 20L,
+  }
+  let (_, drained) = update(
+    emit,
+    Read(0, polled.read_serial, Ok(final_page)),
+    polled,
+  )
+  assert_eq(drained.text, "last error")
+  assert_true(output_complete(drained, interrupted.job))
+  let (_, polled) = update(emit, Poll, drained)
+  assert_false(polled.reading)
+  let (_, selected) = update(emit, Select("runtime", "bg-1"), drained)
+  assert_true(selected.reading)
+  assert_true(selected.eof_state is None)
 }

--- a/desktop/frontend/jobs/state_wbtest.mbt
+++ b/desktop/frontend/jobs/state_wbtest.mbt
@@ -281,3 +281,127 @@ test "reload queues behind an old read and can refresh a paused view" {
   assert_false(result.follow)
   assert_false(result.reading)
 }
+
+///|
+test "terminal jobs drain remaining pages while paused then stop reading" {
+  let emit : @cmd.Emit[Msg] = Emit(_ => @cmd.none)
+  let view = fixture_job("bg-1", Exited(0))
+  let state = {
+    ..reading_fixture(),
+    jobs: [{ ..view, job: { ..view.job, output_bytes: 8L, }, }],
+    follow: false,
+  }
+  let (_, next) = update(emit, Read(0, 1, Ok(page_fixture(0L, true))), state)
+  assert_true(next.reading)
+  assert_false(next.follow)
+  let (_, finished) = update(
+    emit,
+    Read(0, next.read_serial, Ok(page_fixture(4L, false))),
+    next,
+  )
+  assert_eq(finished.text, "nextnext")
+  assert_false(finished.reading)
+  assert_true(output_complete(finished, view.job))
+  let (_, polled) = update(emit, Poll, finished)
+  assert_false(polled.reading)
+  assert_true(polled.listing)
+  let (_, reload) = update(emit, Reload, polled)
+  assert_true(reload.reading)
+  assert_true(reload.cursor is None)
+  // A later metadata refresh can expose bytes beyond a previously reached EOF.
+  let (_, grown) = update(emit, Poll, {
+    ..finished,
+    jobs: [{ ..view, job: { ..view.job, output_bytes: 12L, }, }],
+  })
+  assert_true(grown.reading)
+}
+
+///|
+test "an empty terminal log is read once and read failures require reload" {
+  let emit : @cmd.Emit[Msg] = Emit(_ => @cmd.none)
+  let state = {
+    ..reading_fixture(),
+    jobs: [fixture_job("bg-1", Interrupted)],
+    reading: false,
+    cursor: None,
+    follow: false,
+  }
+  let (_, started) = update(emit, Poll, state)
+  assert_true(started.reading)
+  let (_, failed) = update(
+    emit,
+    Read(0, started.read_serial, Err("unreadable")),
+    started,
+  )
+  let (_, polled) = update(emit, Poll, failed)
+  assert_false(polled.reading)
+  let (_, reload) = update(emit, Reload, polled)
+  let empty = {
+    ..page_fixture(0L, false),
+    text: "",
+    next_offset: 0L,
+    size: 0L,
+  }
+  let (_, finished) = update(
+    emit,
+    Read(0, reload.read_serial, Ok(empty)),
+    reload,
+  )
+  let (_, polled) = update(emit, Poll, finished)
+  assert_false(polled.reading)
+  assert_eq(polled.cursor, Some(0L))
+}
+
+///|
+test "stopping and terminal jobs reject repeat stop even if controllable" {
+  let emit : @cmd.Emit[Msg] = Emit(_ => @cmd.none)
+  let states : Array[@wire.JobState] = [
+    Stopping,
+    Exited(0),
+    Stopped("user"),
+    Interrupted,
+  ]
+  for status in states {
+    let view = { ..fixture_job("bg-1", status), controllable: true, }
+    let (_, next) = update(emit, Stop, { ..reading_fixture(), jobs: [view], })
+    assert_false(next.stopping)
+  }
+}
+
+///|
+test "initial selection prefers an active job and preserves selected history" {
+  let emit : @cmd.Emit[Msg] = Emit(_ => @cmd.none)
+  let reply : @protocol.JobsListReply = {
+    jobs: [fixture_job("done", Exited(0)), fixture_job("live", Running)],
+    selected: None,
+    next_offset: None,
+    errors: [],
+  }
+  let (_, initial) = update(emit, Listed(0, 0, Ok(reply)), State::empty())
+  assert_eq(initial.selected, Some(("runtime", "live")))
+  let (_, history) = update(emit, Select("runtime", "done"), initial)
+  let (_, refreshed) = update(emit, Listed(0, 0, Ok(reply)), history)
+  assert_eq(refreshed.selected, Some(("runtime", "done")))
+  let (_, history_only) = update(
+    emit,
+    Listed(0, 0, Ok({ ..reply, jobs: [reply.jobs[0]], })),
+    State::empty(),
+  )
+  assert_eq(history_only.selected, Some(("runtime", "done")))
+}
+
+///|
+test "historical tail commands do not wait for more output" {
+  assert_eq(
+    tail_command("/tmp/a'b.out", follow=false),
+    "tail -n 100 -- '/tmp/a'\\''b.out'",
+  )
+  assert_eq(
+    tail_command("C:\\a'b.out", follow=false),
+    "Get-Content -LiteralPath 'C:\\a''b.out' -Tail 100",
+  )
+  assert_eq(
+    job_timing(fixture_job("old", Interrupted).job),
+    "End time unavailable",
+  )
+}

--- a/desktop/frontend/jobs/state_wbtest.mbt
+++ b/desktop/frontend/jobs/state_wbtest.mbt
@@ -389,7 +389,7 @@ test "initial selection prefers an active job and preserves selected history" {
     Listed(0, 0, Ok({ ..reply, jobs: [reply.jobs[0]], })),
     State::empty(),
   )
-  assert_eq(history_only.selected, Some(("runtime", "done")))
+  assert_true(history_only.selected is None)
 }
 
 ///|

--- a/desktop/frontend/jobs/view.mbt
+++ b/desktop/frontend/jobs/view.mbt
@@ -2,7 +2,7 @@
 fn status_label(state : @wire.JobState) -> String {
   match state {
     Running => "Running"
-    Stopping => "Stopping"
+    Stopping => "Stopping…"
     Exited(0) => "Completed"
     Exited(code) => "Failed · exit \{code}"
     Stopped("user") => "Stopped"
@@ -18,7 +18,8 @@ fn status_label(state : @wire.JobState) -> String {
 ///|
 fn status_class(state : @wire.JobState) -> String {
   match state {
-    Running | Stopping => "running"
+    Running => "running"
+    Stopping => "stopping"
     Exited(0) => "completed"
     Exited(_) | Stopped("capture_failed" | "output_limit" | "time_limit") =>
       "failed"
@@ -29,21 +30,43 @@ fn status_class(state : @wire.JobState) -> String {
 ///|
 /// The host normalizes output paths: POSIX double-leading slashes collapse to
 /// one, so a normalized // prefix here denotes a Windows UNC path.
-fn tail_command(path : String) -> String {
+fn tail_command(path : String, follow? : Bool = true) -> String {
   if (path.length() >= 2 && path[1] == ':') ||
     path.has_prefix("\\\\") ||
     path.has_prefix("//") {
     "Get-Content -LiteralPath '" +
     path.replace_all(old="'", new="''") +
-    "' -Tail 100 -Wait"
+    "' -Tail 100" +
+    (if follow { " -Wait" } else { "" })
   } else {
-    "tail -n 100 -f -- '" + path.replace_all(old="'", new="'\\''") + "'"
+    "tail -n 100" +
+    (if follow { " -f" } else { "" }) +
+    " -- '" +
+    path.replace_all(old="'", new="'\\''") +
+    "'"
   }
 }
 
 ///|
 extern "js" fn timestamp(value : Double) -> String =
   #| value => new Date(value).toLocaleString()
+
+///|
+fn job_timing(job : @wire.JobRecord) -> String {
+  if job.state.is_terminal() {
+    match job.finished_at_ms {
+      Some(end) => {
+        let seconds = ((end - job.started_at_ms).to_double().max(0) / 1000).to_int()
+        "Ended \{timestamp(end.to_double())} · Total \{seconds}s"
+      }
+      None => "End time unavailable"
+    }
+  } else {
+    let seconds = ((@interop.now_ms() - job.started_at_ms.to_double()).max(0) /
+    1000).to_int()
+    "Running for \{seconds}s"
+  }
+}
 
 ///|
 extern "js" fn away_from_end() -> Bool =
@@ -57,10 +80,17 @@ pub fn panel(state : State, emit : @cmd.Emit[Msg]) -> @html.Html {
   let header = @html.div(class="jobs-heading", [
     @html.div([
       @html.h3("Background jobs"),
-      @html.span(
-        class="jobs-summary",
-        "\{running} active · \{state.jobs.length()} loaded",
-      ),
+      @html.div(class="jobs-summary", [
+        @html.span(
+          class=if running > 0 {
+            "jobs-summary-active"
+          } else {
+            "jobs-summary-idle"
+          },
+          "\{running} in progress",
+        ),
+        @html.span("\{state.jobs.length() - running} in history"),
+      ]),
     ]),
     @html.button(
       class="jobs-action",
@@ -114,37 +144,57 @@ pub fn panel(state : State, emit : @cmd.Emit[Msg]) -> @html.Html {
       ]),
     )
   } else {
-    let rows = state.jobs.map(view => {
-      let job = view.job
-      let selected = state.selected == Some((job.generation, job.id))
-      @html.button(
-        class="jobs-row" + (if selected { " selected" } else { "" }),
-        attrs=@html.Attrs::build().aria_pressed(selected.to_string()),
-        title=job.command,
-        on_click=emit(Select(job.generation, job.id)),
-        [
-          @html.div(class="jobs-row-head", [
-            @html.span(
-              class="jobs-id",
-              title=job.id,
-              short_job_id(job.id, state.jobs),
+    let rows : Array[@html.Html] = []
+    for terminal in [false, true] {
+      let group = state.jobs.filter(view => {
+        view.job.state.is_terminal() == terminal
+      })
+      if group.is_empty() {
+        continue
+      }
+      let title = if terminal { "History" } else { "In progress" }
+      let cards = group.map(view => {
+        let job = view.job
+        let selected = state.selected == Some((job.generation, job.id))
+        @html.button(
+          class="jobs-row jobs-row-\{status_class(job.state)}" +
+            (if selected { " selected" } else { "" }),
+          attrs=@html.Attrs::build().aria_pressed(selected.to_string()),
+          title=job.command,
+          on_click=emit(Select(job.generation, job.id)),
+          [
+            @html.div(class="jobs-row-head", [
+              @html.span(class="jobs-id", title=job.id, short_job_id(job.id, state.jobs)),
+              @html.span(
+                class="jobs-status jobs-status-\{status_class(job.state)}",
+                status_label(job.state),
+              ),
+            ]),
+            @html.div(
+              class="jobs-command",
+              job.description.unwrap_or(job.command),
             ),
-            @html.span(
-              class="jobs-status jobs-status-\{status_class(job.state)}",
-              status_label(job.state),
+            @html.div(
+              class="jobs-row-meta",
+              "\{job_timing(job)} · \{job.output_bytes} B",
             ),
-          ]),
-          @html.div(
-            class="jobs-command",
-            job.description.unwrap_or(job.command),
-          ),
-          @html.div(
-            class="jobs-row-meta",
-            "\{timestamp(job.backgrounded_at_ms.to_double())} · \{job.output_bytes} B",
-          ),
-        ],
+          ],
+        )
+      })
+      rows.push(
+        @html.div(
+          class="jobs-group",
+          attrs=@html.Attrs::build().role("group").aria_label(title),
+          [
+            @html.h4(class="jobs-group-title", [
+              @html.span(title),
+              @html.span(class="jobs-group-count", group.length().to_string()),
+            ]),
+            @html.div(class="jobs-cards", cards),
+          ],
+        ),
       )
-    })
+    }
     if state.next_offset is Some(_) {
       rows.push(
         @html.button(
@@ -183,21 +233,15 @@ pub fn panel(state : State, emit : @cmd.Emit[Msg]) -> @html.Html {
           @html.div(class="jobs-detail-meta", "Working directory: \{cwd}"),
         )
       }
-      let end = job.finished_at_ms
-        .map(n => n.to_double())
-        .unwrap_or(@interop.now_ms())
-      let seconds = ((end - job.started_at_ms.to_double()).max(0) / 1000).to_int()
-      let activity = match job.last_output_at_ms {
-        Some(last) =>
-          "Last output \{((@interop.now_ms() - last.to_double()).max(0) / 1000).to_int()}s ago"
-        None => "No output yet"
+      details.push(@html.div(class="jobs-detail-meta", job_timing(job)))
+      if !job.state.is_terminal() {
+        let activity = match job.last_output_at_ms {
+          Some(last) =>
+            "Last output \{((@interop.now_ms() - last.to_double()).max(0) / 1000).to_int()}s ago"
+          None => "No output yet"
+        }
+        details.push(@html.div(class="jobs-detail-meta", activity))
       }
-      details.push(
-        @html.div(
-          class="jobs-detail-meta",
-          "Elapsed \{seconds}s · \{activity}",
-        ),
-      )
       let actions : Array[@html.Html] = [
         @html.button(
           class="jobs-action",
@@ -217,9 +261,20 @@ pub fn panel(state : State, emit : @cmd.Emit[Msg]) -> @html.Html {
           ),
           @html.button(
             class="jobs-action",
-            on_click=@clipboard.copy(Text(tail_command(path))),
+            on_click=@clipboard.copy(
+              Text(tail_command(path, follow=!job.state.is_terminal())),
+            ),
             "Copy tail command",
           ),
+          @html.button(
+            class="jobs-action",
+            on_click=emit(Reload),
+            "Reload tail",
+          ),
+        ])
+      }
+      if view.output_path is Some(_) && !job.state.is_terminal() {
+        actions.push(
           @html.button(
             class="jobs-action",
             on_click=emit(ToggleFollow),
@@ -230,25 +285,24 @@ pub fn panel(state : State, emit : @cmd.Emit[Msg]) -> @html.Html {
               "Follow output"
             },
           ),
-          @html.button(
-            class="jobs-action",
-            on_click=emit(Reload),
-            "Reload tail",
-          ),
-        ])
+        )
       }
-      actions.push(
-        @html.button(
-          class="jobs-action jobs-stop",
-          disabled=!view.controllable || state.stopping,
-          on_click=emit(Stop),
-          if state.stopping {
-            "Stopping…"
-          } else {
-            "Stop job"
-          },
-        ),
-      )
+      if !job.state.is_terminal() {
+        actions.push(
+          @html.button(
+            class="jobs-action jobs-stop",
+            disabled=!view.controllable ||
+              state.stopping ||
+              job.state is Stopping,
+            on_click=emit(Stop),
+            if state.stopping || job.state is Stopping {
+              "Stopping…"
+            } else {
+              "Stop job"
+            },
+          ),
+        )
+      }
       details.push(@html.div(class="jobs-toolbar", actions))
       for
         error in [
@@ -289,6 +343,12 @@ pub fn panel(state : State, emit : @cmd.Emit[Msg]) -> @html.Html {
         "No retained log file for this job."
       } else if state.read_error is Some(_) {
         "Output unavailable · reload to retry."
+      } else if job.state.is_terminal() {
+        if output_complete(state, job) && !state.reading {
+          "Output ended"
+        } else {
+          "Loading remaining output…"
+        }
       } else if state.follow {
         if state.catching_up {
           "Catching up with output…"
@@ -328,6 +388,8 @@ pub fn panel(state : State, emit : @cmd.Emit[Msg]) -> @html.Html {
                 if state.text.is_empty() {
                   if state.reading {
                     "Loading output…"
+                  } else if job.state.is_terminal() {
+                    "No retained output."
                   } else {
                     "No output yet."
                   }

--- a/desktop/frontend/jobs/view.mbt
+++ b/desktop/frontend/jobs/view.mbt
@@ -149,7 +149,7 @@ pub fn panel(state : State, emit : @cmd.Emit[Msg]) -> @html.Html {
       let group = state.jobs.filter(view => {
         view.job.state.is_terminal() == terminal
       })
-      if group.is_empty() {
+      if group.is_empty() && (!terminal || state.next_offset is None) {
         continue
       }
       let title = if terminal { "History" } else { "In progress" }
@@ -164,7 +164,11 @@ pub fn panel(state : State, emit : @cmd.Emit[Msg]) -> @html.Html {
           on_click=emit(Select(job.generation, job.id)),
           [
             @html.div(class="jobs-row-head", [
-              @html.span(class="jobs-id", title=job.id, short_job_id(job.id, state.jobs)),
+              @html.span(
+                class="jobs-id",
+                title=job.id,
+                short_job_id(job.id, state.jobs),
+              ),
               @html.span(
                 class="jobs-status jobs-status-\{status_class(job.state)}",
                 status_label(job.state),
@@ -181,27 +185,44 @@ pub fn panel(state : State, emit : @cmd.Emit[Msg]) -> @html.Html {
           ],
         )
       })
+      let label = [
+        @html.span(title),
+        @html.span(class="jobs-group-count", group.length().to_string()),
+      ]
+      let content : Array[@html.Html] = [@html.div(class="jobs-cards", cards)]
+      if terminal && state.next_offset is Some(_) {
+        content.push(
+          @html.button(
+            class="jobs-action jobs-more",
+            disabled=state.listing,
+            on_click=emit(More),
+            "Load older jobs",
+          ),
+        )
+      }
       rows.push(
         @html.div(
           class="jobs-group",
           attrs=@html.Attrs::build().role("group").aria_label(title),
-          [
-            @html.h4(class="jobs-group-title", [
-              @html.span(title),
-              @html.span(class="jobs-group-count", group.length().to_string()),
-            ]),
-            @html.div(class="jobs-cards", cards),
-          ],
-        ),
-      )
-    }
-    if state.next_offset is Some(_) {
-      rows.push(
-        @html.button(
-          class="jobs-action jobs-more",
-          disabled=state.listing,
-          on_click=emit(More),
-          "Load older jobs",
+          if terminal {
+            [
+              @html.button(
+                class="jobs-group-title jobs-history-toggle",
+                attrs=@html.Attrs::build()
+                  .aria_expanded(state.history_expanded.to_string())
+                  .aria_controls("jobs-history-content"),
+                on_click=emit(ToggleHistory),
+                label,
+              ),
+              @html.div(
+                id="jobs-history-content",
+                hidden=!state.history_expanded,
+                content,
+              ),
+            ]
+          } else {
+            [@html.h4(class="jobs-group-title", label), ..content]
+          },
         ),
       )
     }

--- a/desktop/styles/file_panel.css
+++ b/desktop/styles/file_panel.css
@@ -2871,30 +2871,51 @@ button.git-history-file.selected {
 .editor.mode-jobs .jobs-panel { display: flex; }
 .jobs-panel { flex: 1; min-height: 0; min-width: 0; flex-direction: column; overflow: auto; padding: 18px; gap: 12px; color: var(--color-text-primary); }
 .jobs-heading, .jobs-row-head, .jobs-detail-title { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
-.jobs-heading h3 { margin: 0 0 4px; font-size: 16px; font-weight: 600; }
+.jobs-heading h3 { margin: 0 0 8px; font-size: 16px; font-weight: 600; letter-spacing: -.2px; }
 .jobs-summary, .jobs-host, .jobs-row-meta, .jobs-detail-meta, .jobs-output-note, .jobs-footnote { font-size: 11px; color: var(--color-text-secondary); overflow-wrap: anywhere; }
-.jobs-host { padding-bottom: 8px; border-bottom: 1px solid var(--color-border); }
-.jobs-list { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(220px,100%),1fr)); gap: 7px; max-height: 220px; flex-shrink: 0; overflow: auto; }
-.jobs-row { display: flex; flex-direction: column; gap: 7px; text-align: left; padding: 11px; border: 1px solid var(--color-border); background: var(--color-bg-surface); border-radius: 7px; color: inherit; min-width: 0; cursor: pointer; }
-.jobs-row.selected { border-color: var(--color-accent); background: color-mix(in srgb, var(--color-accent) 6%, var(--color-bg-surface)); }
-.jobs-row:hover { border-color: var(--color-accent); }
-.jobs-id { font-family: var(--font-family-mono); font-size: 12px; }
-.jobs-command { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 100%; font-size: 12px; }
-.jobs-status { font-size: 11px; font-weight: 500; white-space: nowrap; }
-.jobs-status-running { color: var(--color-accent); }
-.jobs-status-completed { color: light-dark(#227644,#7ccc98); }
-.jobs-status-failed, .jobs-stop { color: light-dark(#b33732,#f09d94); }
-.jobs-status-stopped { color: var(--color-text-secondary); }
+.jobs-summary { display: flex; align-items: center; flex-wrap: wrap; gap: 6px 12px; }
+.jobs-summary-active { display: inline-flex; align-items: center; gap: 6px; color: var(--color-text-primary); }
+.jobs-summary-active::before { content: ""; width: 6px; height: 6px; border-radius: 50%; background: var(--color-accent); }
+.jobs-host { padding-bottom: 12px; border-bottom: 1px solid var(--color-border); }
+.jobs-list { display: flex; flex-direction: column; gap: 18px; max-height: min(360px, 42vh); flex-shrink: 0; overflow: auto; padding: 2px; scrollbar-width: thin; }
+.jobs-group { flex-shrink: 0; min-width: 0; }
+.jobs-group-title { display: flex; align-items: center; gap: 8px; margin: 0 0 10px; font-size: 12px; font-weight: 600; color: var(--color-text-secondary); }
+.jobs-group-title::after { content: ""; height: 1px; flex: 1; background: var(--color-border); }
+.jobs-group-count { min-width: 20px; padding: 1px 6px; border-radius: 5px; background: var(--color-bg-surface); border: 1px solid var(--color-border); font-size: 10px; text-align: center; font-variant-numeric: tabular-nums; }
+.jobs-cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(220px,100%),1fr)); gap: 8px; }
+.jobs-row { display: flex; flex-direction: column; gap: 9px; text-align: left; padding: 12px; border: 1px solid var(--color-border); border-left: 3px solid color-mix(in srgb, var(--job-color) 55%, var(--color-border)); background: var(--color-bg-surface); border-radius: 8px; color: inherit; min-width: 0; cursor: pointer; }
+.jobs-row.selected { border-color: color-mix(in srgb, var(--color-accent) 60%, var(--color-border)); border-left-color: var(--color-accent); background: color-mix(in srgb, var(--color-accent) 7%, var(--color-bg-surface)); }
+.jobs-row:hover { border-color: var(--color-accent); background: color-mix(in srgb, var(--color-accent) 4%, var(--color-bg-surface)); }
+.jobs-row:focus-visible, .jobs-action:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 2px; }
+.jobs-row-head { flex-wrap: wrap; gap: 6px; }
+.jobs-id { font-family: var(--font-family-mono); font-size: 11px; color: var(--color-text-secondary); overflow-wrap: anywhere; }
+.jobs-command { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 100%; font-size: 12px; font-weight: 600; }
+.jobs-row-meta { font-size: 10px; line-height: 1.5; font-variant-numeric: tabular-nums; }
+.jobs-status { display: inline-flex; align-items: center; gap: 5px; padding: 3px 7px; border-radius: 5px; background: color-mix(in srgb, var(--job-color) 10%, transparent); color: var(--job-color); font-size: 10px; font-weight: 600; line-height: 1.4; overflow-wrap: anywhere; }
+.jobs-status::before { content: ""; flex: 0 0 auto; width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
+.jobs-row-running, .jobs-status-running { --job-color: var(--color-accent); }
+.jobs-row-stopping, .jobs-status-stopping { --job-color: light-dark(#925b10,#e7ba70); }
+.jobs-row-completed, .jobs-status-completed { --job-color: light-dark(#227644,#7ccc98); }
+.jobs-row-failed, .jobs-status-failed { --job-color: light-dark(#b33732,#f09d94); }
+.jobs-row-stopped, .jobs-status-stopped { --job-color: var(--color-text-secondary); }
+.jobs-status-running::before { width: 8px; height: 8px; background: none; border: 1.5px solid currentColor; border-right-color: transparent; animation: jobs-spin 1s linear infinite; }
+.jobs-status-stopping::before { background: none; border: 1.5px solid currentColor; }
+.jobs-status-completed::before { width: 7px; height: 4px; border-radius: 0; background: none; border-left: 1.5px solid currentColor; border-bottom: 1.5px solid currentColor; transform: translateY(-1px) rotate(-45deg); }
+.jobs-status-failed::before { border-radius: 1px; transform: rotate(45deg); }
+.jobs-status-stopped::before { border-radius: 1px; }
+@keyframes jobs-spin { to { transform: rotate(360deg); } }
+@media (prefers-reduced-motion: reduce) { .jobs-status-running::before { animation: none; } }
 .jobs-detail { display: flex; flex-direction: column; gap: 9px; flex: 1; min-height: 290px; min-width: 0; }
-.jobs-detail-title { justify-content: flex-start; border-top: 1px solid var(--color-border); padding-top: 12px; }
+.jobs-detail-title { justify-content: space-between; flex-wrap: wrap; border-top: 1px solid var(--color-border); padding-top: 16px; }
 .jobs-full-command { margin: 0; padding: 9px 11px; font: 12px/1.5 var(--font-family-mono); white-space: pre-wrap; overflow-wrap: anywhere; background: var(--color-bg-surface); border-radius: 5px; max-height: 110px; overflow: auto; }
 .jobs-path { font-size: 11px; overflow-wrap: anywhere; line-height: 1.5; }
 .jobs-toolbar { display: flex; flex-wrap: wrap; gap: 6px; }
 .jobs-action { border: 1px solid var(--color-border); background: var(--color-bg-surface); color: inherit; border-radius: 5px; padding: 5px 8px; font-size: 11px; cursor: pointer; }
+.jobs-action.jobs-stop { color: light-dark(#b33732,#f09d94); }
 .jobs-action:disabled { opacity: .45; cursor: default; }
 .jobs-action:hover:not(:disabled) { border-color: var(--color-accent); }
 .jobs-error { font-size: 12px; line-height: 1.5; padding: 8px 10px; border-radius: 5px; background: light-dark(#fff0e8,#452a20); color: light-dark(#934020,#edb798); overflow-wrap: anywhere; }
-.jobs-output { flex: 1; min-height: 170px; max-height: 60vh; overflow: auto; background: light-dark(#f7f8fa,#15181e); border: 1px solid var(--color-border); border-radius: 6px; padding: 12px; }
+.jobs-output { flex: 1; min-height: 170px; max-height: 60vh; overflow: auto; background: light-dark(#f7f8fa,#15181e); border: 1px solid var(--color-border); border-radius: 8px; padding: 14px; }
 .jobs-output pre { margin: 0; font: 12px/1.65 var(--font-family-mono); white-space: pre-wrap; overflow-wrap: anywhere; tab-size: 4; }
 .jobs-empty { margin: auto; max-width: 330px; text-align: center; padding: 40px 12px; }
 .jobs-empty h3 { font-size: 14px; }

--- a/desktop/styles/file_panel.css
+++ b/desktop/styles/file_panel.css
@@ -2880,6 +2880,13 @@ button.git-history-file.selected {
 .jobs-list { display: flex; flex-direction: column; gap: 18px; max-height: min(360px, 42vh); flex-shrink: 0; overflow: auto; padding: 2px; scrollbar-width: thin; }
 .jobs-group { flex-shrink: 0; min-width: 0; }
 .jobs-group-title { display: flex; align-items: center; gap: 8px; margin: 0 0 10px; font-size: 12px; font-weight: 600; color: var(--color-text-secondary); }
+.jobs-history-toggle { width: 100%; padding: 0; border: 0; background: transparent; cursor: pointer; text-align: left; font-family: inherit; }
+.jobs-history-toggle::before { content: ""; width: 6px; height: 6px; border-right: 1.5px solid currentColor; border-bottom: 1.5px solid currentColor; transform: rotate(-45deg); margin: 0 3px; }
+.jobs-history-toggle[aria-expanded="true"]::before { transform: translateY(-2px) rotate(45deg); }
+.jobs-history-toggle[aria-expanded="false"] { margin-bottom: 0; }
+.jobs-history-toggle:hover { color: var(--color-text-primary); }
+.jobs-history-toggle:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 2px; }
+.jobs-more { margin-top: 8px; }
 .jobs-group-title::after { content: ""; height: 1px; flex: 1; background: var(--color-border); }
 .jobs-group-count { min-width: 20px; padding: 1px 6px; border-radius: 5px; background: var(--color-bg-surface); border: 1px solid var(--color-border); font-size: 10px; text-align: center; font-variant-numeric: tabular-nums; }
 .jobs-cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(220px,100%),1fr)); gap: 8px; }


### PR DESCRIPTION
Jobs that had completed or stopped remained mixed with running jobs and still displayed live-output controls and messages. Split the loaded list into In progress and History. History starts collapsed, including its pagination control, while in-progress jobs remain visible. Preserve the expansion choice across refreshes, select an active job initially, and preserve the selection when it moves into history. History-only sessions load a log after explicit selection. Historical rows retain distinct completed, failed, stopped, and interrupted statuses and show an end time and total duration when available. Status badges use distinct shapes as well as colors, with a reduced-motion-aware running indicator; group counters, card accents, and responsive spacing make the lifecycle states easier to scan.

Stopping jobs show a disabled Stopping… control. Terminal jobs hide Stop and Pause/Follow, copy a non-following tail command, and show Output ended after the remaining retained output has loaded. Remaining pages are drained even if output was paused, with the existing per-tick budget and scroll position preserved; subsequent polls refresh history without rereading an exhausted log. Completion requires an EOF from a read started in the current terminal state, so stale persisted byte counts after an engine interruption cannot hide final diagnostics. Reload and read-error recovery remain available.

Follow-up to #1469.

Validation:

- `just check`, `just test`, `just build` (3,110 native and 3,204 JS tests, plus offline CLI/cram/workflow checks)
- `moon test desktop/frontend/jobs --target js`: 14 passed
- Production browser build and `npm --prefix desktop/e2e test -- background_jobs.spec.js`: 14 passed
- Inspected light, dark, and narrow-panel screenshots; browser assertions check long stop-reason badges for horizontal overflow
- `moon info && moon fmt`
- Fresh Codex CLI review of the interrupted-log fix: no actionable regressions after resolving the initial P2 finding
