### PR TITLE
Reuse moonbitlang/x/uuid in Desktop UUID generation

### DIFF
--- a/desktop/internal/uuid/moon.pkg
+++ b/desktop/internal/uuid/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "moonbitlang/core/env",
+  "moonbitlang/x/uuid" @x_uuid,
 }
 
 warnings = "+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"

--- a/desktop/internal/uuid/uuid.mbt
+++ b/desktop/internal/uuid/uuid.mbt
@@ -5,23 +5,8 @@
 /// reports that failure.
 pub fn mint() -> String? {
   guard @env.rand(16) is Some(bytes) else { return None }
-  let text = StringBuilder()
-  for index, byte in bytes {
-    if index == 4 || index == 6 || index == 8 || index == 10 {
-      text.write_char('-')
-    }
-    let raw = byte.to_int()
-    let value = if index == 6 {
-      (raw & 0x0f) | 0x40
-    } else if index == 8 {
-      (raw & 0x3f) | 0x80
-    } else {
-      raw
-    }
-    if value < 0x10 {
-      text.write_char('0')
-    }
-    text.write_string(value.to_string(radix=16))
-  }
-  Some(text.to_string())
+  // env.rand(16) supplies exactly 16 bytes; from_bytes only rejects other
+  // lengths. Entropy unavailability is handled above, before this invariant.
+  let id = try! @x_uuid.from_bytes(bytes)
+  Some(id.as_version(V4).to_string())
 }


### PR DESCRIPTION
Desktop's UUID helper manually set RFC version/variant bits and formatted the hexadecimal string. Delegate those operations to the existing `moonbitlang/x/uuid` dependency, keeping `env.rand(16)` as the entropy source and preserving the `mint() -> String?` API and UUIDv4 output.

The byte conversion asserts the fixed 16-byte contract of `env.rand(16)`; entropy unavailability still returns `None` before conversion.

Validation: existing UUID tests pass on native and JS, `just check` passes, and `moon info && moon fmt` produces no interface changes. This is independent of the background-job UUID PR #1476 and targets `main` directly.
