### PR TITLE
refactor(desktop): reuse x/uuid and propagate minting errors

### DIFF
--- a/desktop/internal/engine/jobs.mbt
+++ b/desktop/internal/engine/jobs.mbt
@@ -162,9 +162,7 @@ pub async fn list_jobs(
     // live data; duplicate session ids in different stores must stay isolated.
     if engine.session_root is Some(root) &&
       directory == jobs_store_path(root, scope.session) {
-      guard @uuid.mint() is Some(request_id) else {
-        raise EngineError("could not allocate a job request id")
-      }
+      let request_id = @uuid.mint()
       try engine.job_request(request_id, JobsSnapshot(request_id~)) catch {
         error => {
           refresh_failed = true
@@ -441,9 +439,7 @@ pub async fn read_job(
         directory == jobs_store_path(root, scope.session) else {
         raise metadata_error
       }
-      guard @uuid.mint() is Some(request_id) else {
-        raise EngineError("could not allocate a job request id")
-      }
+      let request_id = @uuid.mint()
       match engine.job_request(request_id, JobsSnapshot(request_id~)) {
         JobsSnapshot(jobs~, ..) => {
           guard jobs
@@ -520,9 +516,7 @@ pub async fn stop_job(
     directory == jobs_store_path(root, target.scope.session) else {
     raise EngineError("job controls require its current live engine")
   }
-  guard @uuid.mint() is Some(request_id) else {
-    raise EngineError("could not allocate a job request id")
-  }
+  let request_id = @uuid.mint()
   match
     engine.job_request(
       request_id,

--- a/desktop/internal/engine/ops.mbt
+++ b/desktop/internal/engine/ops.mbt
@@ -127,8 +127,8 @@ pub async fn start_run(
 /// engine protocol syntax; UUID formatting and entropy ownership belong to the
 /// shared package.
 fn mint_run_id() -> String raise EngineError {
-  guard @uuid.mint() is Some(id) else {
-    raise EngineError("cannot mint a run id: OS entropy unavailable")
+  let id = @uuid.mint() catch {
+    error => raise EngineError("cannot mint a run id: \{error}")
   }
   "r\{id}"
 }

--- a/desktop/internal/terminal/terminal.mbt
+++ b/desktop/internal/terminal/terminal.mbt
@@ -177,9 +177,7 @@ pub async fn open_terminal(
 ) -> String {
   guard !state.closed else { raise TerminalError("terminal service is closed") }
   let argv = session_argv(command?)
-  guard @uuid.mint() is Some(id) else {
-    raise TerminalError("could not create a terminal id")
-  }
+  let id = @uuid.mint()
   let reply : @async.Queue[Result[Unit, String]] = Queue(kind=Blocking(1))
   state.requests.put({
     id,

--- a/desktop/internal/uuid/moon.pkg
+++ b/desktop/internal/uuid/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "moonbitlang/core/env",
+  "moonbitlang/x/uuid" @x_uuid,
 }
 
 warnings = "+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"

--- a/desktop/internal/uuid/pkg.generated.mbti
+++ b/desktop/internal/uuid/pkg.generated.mbti
@@ -2,7 +2,7 @@
 package "openseek_desktop/internal/uuid"
 
 // Values
-pub fn mint() -> String?
+pub fn mint() -> String raise
 
 // Errors
 

--- a/desktop/internal/uuid/uuid.mbt
+++ b/desktop/internal/uuid/uuid.mbt
@@ -5,23 +5,7 @@
 /// reports that failure.
 pub fn mint() -> String? {
   guard @env.rand(16) is Some(bytes) else { return None }
-  let text = StringBuilder()
-  for index, byte in bytes {
-    if index == 4 || index == 6 || index == 8 || index == 10 {
-      text.write_char('-')
-    }
-    let raw = byte.to_int()
-    let value = if index == 6 {
-      (raw & 0x0f) | 0x40
-    } else if index == 8 {
-      (raw & 0x3f) | 0x80
-    } else {
-      raw
-    }
-    if value < 0x10 {
-      text.write_char('0')
-    }
-    text.write_string(value.to_string(radix=16))
-  }
-  Some(text.to_string())
+  // from_bytes only rejects lengths other than the 16 bytes requested above.
+  let uuid = try! @x_uuid.from_bytes(bytes)
+  Some(uuid.as_version(V4).to_string())
 }

--- a/desktop/internal/uuid/uuid.mbt
+++ b/desktop/internal/uuid/uuid.mbt
@@ -1,11 +1,8 @@
 ///|
 /// Mint a lowercase RFC 9562 UUID version 4 from 128 bits supplied by the
-/// platform entropy source. `None` means the current runtime cannot provide
-/// cryptographically secure randomness; callers decide how their boundary
-/// reports that failure.
-pub fn mint() -> String? {
-  guard @env.rand(16) is Some(bytes) else { return None }
-  // from_bytes only rejects lengths other than the 16 bytes requested above.
-  let uuid = try! @x_uuid.from_bytes(bytes)
-  Some(uuid.as_version(V4).to_string())
+/// platform entropy source. Raises when the current runtime cannot provide
+/// cryptographically secure randomness.
+pub fn mint() -> String raise {
+  guard @env.rand(16) is Some(bytes) else { fail("OS entropy unavailable") }
+  @x_uuid.from_bytes(bytes).as_version(V4).to_string()
 }

--- a/desktop/internal/uuid/uuid_test.mbt
+++ b/desktop/internal/uuid/uuid_test.mbt
@@ -1,7 +1,7 @@
 ///|
 test "mint returns distinct RFC 9562 version 4 UUIDs" {
-  guard @uuid.mint() is Some(first) else { fail("OS entropy unavailable") }
-  guard @uuid.mint() is Some(second) else { fail("OS entropy unavailable") }
+  let first = @uuid.mint()
+  let second = @uuid.mint()
   assert_not_eq(first, second)
   assert_eq(first.length(), 36)
   assert_eq(first[8], '-')


### PR DESCRIPTION
Desktop's UUID helper duplicated version/variant bit handling and hexadecimal formatting. Reuse `moonbitlang/x/uuid` via `from_bytes(...).as_version(V4).to_string()`, retaining the platform's secure random source.

Change `mint()` to return `String raise`: entropy failures and UUID construction errors propagate without `try!`. Update job, terminal, and run-ID callers; the run-ID boundary preserves its declared `EngineError` contract. Keep the dependency alias `@x_uuid` because Moon automatically imports the tested package as `@uuid`, making the default dependency alias produce a duplicate-alias warning.

Validation: UUID tests on native and JS; `moon info && moon fmt`, `just check`, `just test` (3,095 native tests, 3,198 JS tests, 38 cram cases, CLI lifecycle and bundled workflow checks), and `just build`. The generated interface change is limited to `mint() -> String raise`.
