### PR TITLE
refactor: use `let mut` for non-escaping local Ref cells

### DIFF
--- a/agent_workflow/subrun_runner_test.mbt
+++ b/agent_workflow/subrun_runner_test.mbt
@@ -88,19 +88,19 @@ async test "the seam sees the canonical argv it may transform" {
   let ok =
     #|read line
     #|printf '{"subrun_report": {"ok": true}}\n'
-  let seen : Ref[@spawn.LaunchSpec?] = { val: None, }
+  let mut seen : @spawn.LaunchSpec? = None
   let runner = @agent_workflow.subrun_runner(
     exe="/usr/local/bin/openseek",
     model="deepseek-reasoner",
     api_url="http://localhost:9",
     map_launch=(canonical, _) => {
-      seen.val = Some(canonical)
+      seen = Some(canonical)
       { ..canonical, command: "sh", args: ["-c", ok], }
     },
   )
   let wf = @workflow.Workflow(runner~)
   let _ = wf.agent(prompt="q", kind="explore", max_steps=42)
-  guard seen.val is Some(spec) else {
+  guard seen is Some(spec) else {
     fail("the seam never saw the canonical launch spec")
   }
   assert_eq(spec.command, "/usr/local/bin/openseek")

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -303,7 +303,7 @@ async fn run_task_turn(
     let exe = self_executable()
     // Mirror the latest appended session so a review a snippet delegates
     // audits against the LIVE standing goal, not the turn-start snapshot.
-    let latest_session : Ref[@agent_session.Session] = { val: session, }
+    let mut latest_session : @agent_session.Session = session
     let extra_tools = build_extra_tools(
       matches,
       scope,
@@ -317,7 +317,7 @@ async fn run_task_turn(
     // cannot collide on one transcript file.
     let mbtx_subrun = child_session.map(spec => {
       spec.injection(exe~, workspace_root~, model="\{model}", api_url?, criteria=() => {
-        audit_criteria(latest_session.val)
+        audit_criteria(latest_session)
       })
     })
     let tools = @agent.build_tools(
@@ -351,7 +351,7 @@ async fn run_task_turn(
         task~,
         append_item=(current, item) => {
           let next = append_item(current, item)
-          latest_session.val = next
+          latest_session = next
           next
         },
         max_steps?,

--- a/desktop/frontend/fileeditor/feedback/service_test.mbt
+++ b/desktop/frontend/fileeditor/feedback/service_test.mbt
@@ -2,18 +2,18 @@
 test "Desktop feedback backing connects host controls to the Viewer handle" {
   let service = @feedback.DesktopFeedbackService()
   let resource = @common.Uri::parse("file:///workspace/main.mbt")
-  let added : Ref[String?] = Ref(None)
-  let changes = Ref(0)
-  service.on_did_add_feedback(event => added.val = Some(event.feedback.id))
+  let mut added : String? = None
+  let mut changes = 0
+  service.on_did_add_feedback(event => added = Some(event.feedback.id))
   |> ignore
   let handle = service.agent_feedback_handle()
-  handle.on_did_change_feedback(_event => changes.val += 1) |> ignore
+  handle.on_did_change_feedback(_event => changes += 1) |> ignore
   service.set_feedback_enabled(resource, true)
   assert_true(handle.is_feedback_enabled(resource))
   let item = handle.add_feedback(resource, Range(2, 1, 2, 5), "rename this")
-  assert_eq(added.val, Some(item.id))
+  assert_eq(added, Some(item.id))
   assert_eq(handle.get_feedback(resource).length(), 1)
-  assert_true(changes.val >= 2)
+  assert_true(changes >= 2)
   service.clear_feedback(resource)
   assert_true(handle.get_feedback(resource).is_empty())
 }
@@ -22,9 +22,9 @@ test "Desktop feedback backing connects host controls to the Viewer handle" {
 test "Desktop feedback backing implements every stateful handle mutation" {
   let service = @feedback.DesktopFeedbackService()
   let resource = @common.Uri::parse("file:///workspace/lib.mbt")
-  let submitted_ids : Ref[Array[String]] = Ref([])
+  let mut submitted_ids : Array[String] = []
   service.on_did_submit_feedback(event => {
-    submitted_ids.val = event.items.map(item => item.id)
+    submitted_ids = event.items.map(item => item.id)
   })
   |> ignore
   let handle = service.agent_feedback_handle()
@@ -42,7 +42,7 @@ test "Desktop feedback backing implements every stateful handle mutation" {
   assert_eq(stored.map(item => item.text), Some("reworded"))
   assert_eq(stored.map(item => item.replies), Some(["done"]))
   assert_eq(stored.map(item => item.state), Some(Submitted))
-  assert_eq(submitted_ids.val, [item.id])
+  assert_eq(submitted_ids, [item.id])
   let navigation_id = "agentFeedback:" + item.id
   handle.set_navigation_anchor(resource, Some(navigation_id))
   let bearing = handle.get_navigation_bearing(resource, [navigation_id])

--- a/desktop/frontend/fileeditor/files.mbt
+++ b/desktop/frontend/fileeditor/files.mbt
@@ -398,9 +398,9 @@ fn watch_workspace(
 
 ///|
 test "a cross-host file read settles through its generation-fenced failure" {
-  let seen : Ref[Msg?] = Ref(None)
+  let mut seen : Msg? = None
   let dispatch = @cmd.Emit(message => {
-    seen.val = Some(message)
+    seen = Some(message)
     @cmd.none
   })
   guard @resource.of_path(@interop.ChannelId::Local, "/work") is Some(workspace) else {
@@ -419,7 +419,7 @@ test "a cross-host file read settles through its generation-fenced failure" {
     ),
   )
   assert_true(
-    seen.val
+    seen
     is Some(
       FileFailed(
         owner={ channel: @interop.ChannelId::Remote("other"), .. },

--- a/desktop/internal/engine/follower.mbt
+++ b/desktop/internal/engine/follower.mbt
@@ -1059,12 +1059,12 @@ async test "workspace detach drains an orphaned pending follower before commit" 
     write_session_record(root, session, [session_user_event(1, "tail")])
     // The drain has to finish before the workspace's removal is committed:
     // once the store is gone, nothing could read what the writer left.
-    let drained_before_commit : Ref[Bool] = Ref(false)
+    let mut drained_before_commit : Bool = false
     let detached = detach_workspace(manager, workspace.to_string(), fn(_) {
-      drained_before_commit.val = follower.retired &&
+      drained_before_commit = follower.retired &&
         emitted.any(event => event is SessionCommit({ sequence: 1, .. }))
     })
-    assert_true(drained_before_commit.val)
+    assert_true(drained_before_commit)
     assert_true(detached is Workspaces([]))
     assert_true(manager.followers.get(session) is None)
     group.return_immediately(())

--- a/desktop/internal/engine/worktree_seam_wbtest.mbt
+++ b/desktop/internal/engine/worktree_seam_wbtest.mbt
@@ -682,7 +682,7 @@ async test "permanent archived deletion drops placement but keeps files and bran
   )
   let manager = new_engine_manager("unused")
   manager.pump = Serving(sessions=Map([]))
-  let worktree_changed = Ref(false)
+  let mut worktree_changed = false
   let committed_infos : Array[WorktreeInfo] = []
   delete_archived_session_commit(
     manager,
@@ -690,7 +690,7 @@ async test "permanent archived deletion drops placement but keeps files and bran
     workspace.resource_path(),
     (_, _) => (),
     on_worktree_changed=(_, infos) => {
-      worktree_changed.val = true
+      worktree_changed = true
       committed_infos.clear()
       for info in infos {
         committed_infos.push(info)
@@ -700,7 +700,7 @@ async test "permanent archived deletion drops placement but keeps files and bran
   let entries = @worktree.list(workspace.to_string()).worktrees
   assert_eq(entries.length(), 1)
   assert_eq(entries[0].session, Some("other"))
-  assert_true(worktree_changed.val)
+  assert_true(worktree_changed)
   assert_eq(committed_infos.length(), 1)
   assert_eq(committed_infos[0].session, Some("other"))
   assert_true(@fsx.exists(workspace.join("project-note.txt").to_path()))

--- a/desktop/internal/host/file_search.mbt
+++ b/desktop/internal/host/file_search.mbt
@@ -682,20 +682,20 @@ async test "file scan keeps lexicographic DFS and skips ignored directories" {
 ///|
 async test "file scan uses one ordered coordinator" {
   let root = @pathx.Path("/virtual-sequential").resolve()
-  let active = Ref(0)
-  let maximum = Ref(0)
+  let mut active = 0
+  let mut maximum = 0
   let snapshot = scan_directory_tree(root, async fn(dir) {
-    active.val += 1
-    maximum.val = maximum.val.max(active.val)
+    active += 1
+    maximum = maximum.max(active)
     @async.pause()
-    active.val -= 1
+    active -= 1
     if dir.to_string() == root.to_string() {
       [test_scan_entry("a", true), test_scan_entry("b", true)]
     } else {
       [test_scan_entry("one.mbt", false)]
     }
   })
-  assert_eq(maximum.val, 1)
+  assert_eq(maximum, 1)
   assert_eq(snapshot.files, ["a/one.mbt", "b/one.mbt"])
 }
 
@@ -885,10 +885,10 @@ async test "one connection serializes discovery across cache sessions" {
 ///|
 async test "a failed cache population is not installed and can retry" {
   @async.with_task_group(group => {
-    let attempts = Ref(0)
+    let mut attempts = 0
     let service = FileSearchService::new_with_scan(_ => {
-      attempts.val += 1
-      if attempts.val == 1 {
+      attempts += 1
+      if attempts == 1 {
         raise HostError("injected discovery failure")
       }
       { files: ["recovered.mbt"], }
@@ -904,7 +904,7 @@ async test "a failed cache population is not installed and can retry" {
     let recovered = service.search(root, "cache-a", "recover", 512, 2)
     assert_false(recovered.from_cache)
     assert_eq(recovered.files, ["recovered.mbt"])
-    assert_eq(attempts.val, 2)
+    assert_eq(attempts, 2)
     group.return_immediately(())
   })
 }

--- a/editor/base/browser/animation_frame_reference_wbtest.mbt
+++ b/editor/base/browser/animation_frame_reference_wbtest.mbt
@@ -95,16 +95,16 @@ test "initial and reentrant current queues select descending priority" {
 test "current-or-next outside a drain waits for the next native frame" {
   let driver = TestAnimationFrameDriver()
   let coordinator = driver.coordinator()
-  let observed_frame = Ref(0)
+  let mut observed_frame = 0
   coordinator.run_at_this_or_schedule_at_next_animation_frame(
-    () => observed_frame.val = driver.frame,
+    () => observed_frame = driver.frame,
     0,
   )
   |> ignore
-  assert_eq(observed_frame.val, 0)
+  assert_eq(observed_frame, 0)
   assert_eq(driver.request_count, 1)
   driver.run_next()
-  assert_eq(observed_frame.val, 1)
+  assert_eq(observed_frame, 1)
 }
 
 ///|

--- a/editor/base/browser/resize_observer.mbt
+++ b/editor/base/browser/resize_observer.mbt
@@ -11,14 +11,14 @@ pub fn observe_element_resize(
   target : @rdom.Element,
   notify : () -> Unit,
 ) -> @base_common.Disposable? {
-  let native : Ref[NativeResizeObserver?] = Ref(None)
+  let mut native : NativeResizeObserver? = None
   let observed = try_observe_element_resize(target, notify, observer => {
-    native.val = Some(observer)
+    native = Some(observer)
   })
   if !observed {
     return None
   }
-  guard native.val is Some(observer) else { return None }
+  guard native is Some(observer) else { return None }
   Some(
     @base_common.Disposable::from(() => {
       native_resize_observer_disconnect(observer)

--- a/editor/base/browser/runtime.mbt
+++ b/editor/base/browser/runtime.mbt
@@ -19,19 +19,19 @@ pub fn schedule_timeout(
   callback : () -> Unit,
   delay_ms : Int,
 ) -> @base_common.Disposable {
-  let active = Ref(true)
+  let mut active = true
   let handle = set_timeout_js(
     () => {
-      if active.val {
-        active.val = false
+      if active {
+        active = false
         callback()
       }
     },
     delay_ms,
   )
   @base_common.Disposable::from(() => {
-    if active.val {
-      active.val = false
+    if active {
+      active = false
       clear_timeout_js(handle)
     }
   })

--- a/editor/base/common/lifecycle_wbtest.mbt
+++ b/editor/base/common/lifecycle_wbtest.mbt
@@ -1,26 +1,26 @@
 ///|
 test "disposable is idempotent" {
-  let count = Ref(0)
-  let disposable = Disposable::from(() => count.val += 1)
+  let mut count = 0
+  let disposable = Disposable::from(() => count += 1)
   disposable.dispose()
   disposable.dispose()
-  assert_eq(count.val, 1)
+  assert_eq(count, 1)
 }
 
 ///|
 test "emitter listener disposable removes only that listener" {
   let emitter : Emitter[String] = Emitter()
-  let first = Ref("")
-  let second = Ref("")
-  let first_subscription = emitter.event(value => first.val += value)
-  let second_subscription = emitter.event(value => second.val += value)
+  let mut first = ""
+  let mut second = ""
+  let first_subscription = emitter.event(value => first += value)
+  let second_subscription = emitter.event(value => second += value)
   emitter.fire("a")
   first_subscription.dispose()
   emitter.fire("b")
   second_subscription.dispose()
   emitter.fire("c")
-  assert_eq(first.val, "a")
-  assert_eq(second.val, "ab")
+  assert_eq(first, "a")
+  assert_eq(second, "ab")
 }
 
 ///|
@@ -69,12 +69,12 @@ test "microtask emitter default schedule flushes inline" {
 ///|
 test "emitter dispose stops active and later listeners" {
   let emitter : Emitter[String] = Emitter()
-  let seen = Ref("")
-  emitter.event(value => seen.val += value).dispose()
-  emitter.event(value => seen.val += value) |> ignore
+  let mut seen = ""
+  emitter.event(value => seen += value).dispose()
+  emitter.event(value => seen += value) |> ignore
   emitter.fire("a")
   emitter.dispose()
-  emitter.event(value => seen.val += value) |> ignore
+  emitter.event(value => seen += value) |> ignore
   emitter.fire("b")
-  assert_eq(seen.val, "a")
+  assert_eq(seen, "a")
 }

--- a/editor/internal/shell/workbench/definition_navigation_wbtest.mbt
+++ b/editor/internal/shell/workbench/definition_navigation_wbtest.mbt
@@ -157,7 +157,7 @@ async test "remote definition provider preserves ordered locations and cancellat
   assert_eq(locations[1].range, Range(9, 1, 9, 5))
 
   let cancelled = @language.CancellationTokenSource()
-  let late_response_consumed = Ref(false)
+  let mut late_response_consumed = false
   let cancelled_request_id = Ref("")
   protocol_send.val = Some(packet => {
     match packet {
@@ -176,7 +176,7 @@ async test "remote definition provider preserves ordered locations and cancellat
   assert_true(cancelled_locations.is_empty())
   // The local cancellation has resumed the provider. A later server response
   // is consumed through the retained request-id tombstone.
-  late_response_consumed.val = resolve_pending_response(
+  late_response_consumed = resolve_pending_response(
     DefinitionResult({
       id: cancelled_request_id.val,
       uri: source_uri,
@@ -184,18 +184,18 @@ async test "remote definition provider preserves ordered locations and cancellat
       locations: [{ uri: first_uri, range: Range(1, 1, 1, 2), }],
     }),
   )
-  assert_true(late_response_consumed.val)
+  assert_true(late_response_consumed)
   assert_false(unexpected_packet.val)
   freshness.invalidate()
   markers.dispose()
 
   let preview_uri = definition_navigation_test_uri("definition-preview")
-  let preview_open_count = Ref(0)
-  let preview_close_count = Ref(0)
+  let mut preview_open_count = 0
+  let mut preview_close_count = 0
   protocol_send.val = Some(packet => {
     match packet {
       OpenDocument(request) => {
-        preview_open_count.val += 1
+        preview_open_count += 1
         resolve_pending_response(
           DocumentLoaded({
             id: request.id,
@@ -210,7 +210,7 @@ async test "remote definition provider preserves ordered locations and cancellat
         )
         |> ignore
       }
-      CloseDocument(_) => preview_close_count.val += 1
+      CloseDocument(_) => preview_close_count += 1
       _ => unexpected_packet.val = true
     }
   })
@@ -222,22 +222,21 @@ async test "remote definition provider preserves ordered locations and cancellat
     is Some(second_preview) else {
     fail("cached preview resolution returned no model")
   }
-  assert_eq(preview_open_count.val, 1)
+  assert_eq(preview_open_count, 1)
   assert_true(first_preview.model().same(second_preview.model()))
   let preview_model = first_preview.model()
   first_preview.dispose()
   assert_false(preview_model.is_disposed())
-  assert_eq(preview_close_count.val, 0)
+  assert_eq(preview_close_count, 0)
   second_preview.dispose()
   assert_true(preview_model.is_disposed())
-  assert_eq(preview_close_count.val, 1)
+  assert_eq(preview_close_count, 1)
   assert_false(preview_resources.contains(preview_uri.to_string()))
 
-  let opened_uri = Ref("")
+  let mut opened_uri = ""
   workbench_dispatch.val = Some(msg => {
     match msg {
-      OpenDefinitionLocation(location) =>
-        opened_uri.val = location.uri.to_string()
+      OpenDefinitionLocation(location) => opened_uri = location.uri.to_string()
       _ => unexpected_packet.val = true
     }
   })
@@ -248,21 +247,21 @@ async test "remote definition provider preserves ordered locations and cancellat
     mode: Current,
   }
   assert_true(opener.open(open_request))
-  assert_eq(opened_uri.val, first_uri.to_string())
+  assert_eq(opened_uri, first_uri.to_string())
   assert_false(opener.open({ ..open_request, mode: Side, }))
   assert_false(unexpected_packet.val)
 
   let shutdown_uri = definition_navigation_test_uri("definition-shutdown")
-  let shutdown_open_count = Ref(0)
-  let shutdown_close_count = Ref(0)
-  let shutdown_saw_real_in_flight = Ref(false)
+  let mut shutdown_open_count = 0
+  let mut shutdown_close_count = 0
+  let mut shutdown_saw_real_in_flight = false
   protocol_send.val = Some(packet => {
     match packet {
       OpenDocument(request) => {
-        shutdown_open_count.val += 1
+        shutdown_open_count += 1
         match preview_resources.get(request.uri.to_string()) {
           Some(state) =>
-            shutdown_saw_real_in_flight.val = state.in_flight == 1 &&
+            shutdown_saw_real_in_flight = state.in_flight == 1 &&
               state.lifecycle == PreviewResourceOpen
           None => ()
         }
@@ -283,7 +282,7 @@ async test "remote definition provider preserves ordered locations and cancellat
         )
         |> ignore
       }
-      CloseDocument(_) => shutdown_close_count.val += 1
+      CloseDocument(_) => shutdown_close_count += 1
       _ => unexpected_packet.val = true
     }
   })
@@ -291,10 +290,10 @@ async test "remote definition provider preserves ordered locations and cancellat
     shutdown_uri,
     @language.CancellationToken::none(),
   )
-  assert_true(shutdown_saw_real_in_flight.val)
+  assert_true(shutdown_saw_real_in_flight)
   assert_true(shutdown_result is None)
-  assert_eq(shutdown_open_count.val, 1)
-  assert_eq(shutdown_close_count.val, 1)
+  assert_eq(shutdown_open_count, 1)
+  assert_eq(shutdown_close_count, 1)
   assert_false(preview_resources.contains(shutdown_uri.to_string()))
 
   let rejected_after_shutdown = resolve_preview_model(
@@ -302,7 +301,7 @@ async test "remote definition provider preserves ordered locations and cancellat
     @language.CancellationToken::none(),
   )
   assert_true(rejected_after_shutdown is None)
-  assert_eq(shutdown_open_count.val, 1)
+  assert_eq(shutdown_open_count, 1)
   preview_resources_shutdown.val = previous_preview_shutdown
 
   protocol_send.val = previous_send

--- a/editor/internal/shell/workbench/protocol_client_wbtest.mbt
+++ b/editor/internal/shell/workbench/protocol_client_wbtest.mbt
@@ -89,13 +89,13 @@ test "push packets without a pending id fall through" {
 ///|
 test "cancelling an in-flight request resumes once and consumes its late response" {
   let id = next_request_id("definition-cancel")
-  let observed_provider_code = Ref("")
+  let mut observed_provider_code = ""
   let unexpected_packet = Ref(false)
   let subscription_disposals = Ref(0)
   pending_requests[id] = {
     resolve: packet => {
       match packet {
-        RemoteError(error) => observed_provider_code.val = error.provider_code
+        RemoteError(error) => observed_provider_code = error.provider_code
         _ => unexpected_packet.val = true
       }
     },
@@ -106,7 +106,7 @@ test "cancelling an in-flight request resumes once and consumes its late respons
   }
 
   cancel_pending_request(id)
-  assert_eq(observed_provider_code.val, "Cancelled")
+  assert_eq(observed_provider_code, "Cancelled")
   assert_false(unexpected_packet.val)
   assert_eq(subscription_disposals.val, 1)
   assert_false(pending_requests.contains(id))

--- a/editor/internal/viewer/browser/config/font_measurements_geometry_wbtest.mbt
+++ b/editor/internal/viewer/browser/config/font_measurements_geometry_wbtest.mbt
@@ -445,16 +445,16 @@ test "cache hit, one pending retry, callback ordering, and conditional event" {
 
 ///|
 test "evicting an all-trusted cache is silent" {
-  let scheduled = Ref(0)
+  let mut scheduled = 0
   let measurements = new_font_measurements_for_test(
     (_bare, _requests) => (),
     () => 1.0,
-    (_callback, _delay) => scheduled.val += 1,
+    (_callback, _delay) => scheduled += 1,
   )
   let trusted = trusted_font("Trusted")
   measurements.write_to_cache(trusted.get_id(), trusted)
   // Trusted plus no pending retry is the missing false arm of the timer gate.
-  assert_eq(scheduled.val, 0)
+  assert_eq(scheduled, 0)
   let events = Ref(0)
   let listener = measurements.on_did_change(() => events.val += 1)
   measurements.evict_untrusted_readings()

--- a/editor/internal/viewer/browser/controller/mouse_handler.mbt
+++ b/editor/internal/viewer/browser/controller/mouse_handler.mbt
@@ -232,10 +232,10 @@ pub fn MouseHandler::MouseHandler(
   // PointerEvent.detail is always zero, so it cannot drive double/triple
   // click semantics. Capture only its id and reuse it in the following
   // mousedown, exactly like MouseHandler's EditorPointerEventFactory seam.
-  let capture_pointer_id = Ref(0)
+  let mut capture_pointer_id = 0
   handler.listeners.push(
     mouse_events.on_pointer_down(view_helper.view_dom_node, (_event, pointer_id) => {
-      capture_pointer_id.val = pointer_id
+      capture_pointer_id = pointer_id
     }),
   )
   // The `pointerup` listener registered by `GlobalEditorPointerMoveMonitor`
@@ -252,7 +252,7 @@ pub fn MouseHandler::MouseHandler(
   )
   handler.listeners.push(
     mouse_events.on_mouse_down(view_helper.view_dom_node, e => {
-      handler.on_mouse_down(e, capture_pointer_id.val)
+      handler.on_mouse_down(e, capture_pointer_id)
     }),
   )
   handler.install_touch_scroll_gesture()

--- a/editor/internal/viewer/browser/markdown/markdown_dom.mbt
+++ b/editor/internal/viewer/browser/markdown/markdown_dom.mbt
@@ -341,17 +341,17 @@ fn resolve_allowed_markdown_uri(
   has_base_uri : Bool,
   kind : MarkdownUriKind,
 ) -> String {
-  let allowed = Ref("")
+  let mut allowed = ""
   with_resolved_markdown_uri(raw, base_uri, has_base_uri, (href, protocol) => {
     let accepted = protocol == "http:" ||
       protocol == "https:" ||
       (kind == LinkUri && protocol == "mailto:")
     if accepted {
-      allowed.val = href
+      allowed = href
     }
   })
   |> ignore
-  allowed.val
+  allowed
 }
 
 ///|

--- a/editor/internal/viewer/browser/markdown/markdown_wbtest.mbt
+++ b/editor/internal/viewer/browser/markdown/markdown_wbtest.mbt
@@ -899,7 +899,7 @@ test "Mermaid load and syntax failures keep fallback and retry cleanly" {
   install_markdown_test_dom()
   let load_mermaid_loader = markdown_test_mermaid_loader("reject", "resolve")
   let load_target = markdown_test_target()
-  let load_size_changes = Ref(0)
+  let mut load_size_changes = 0
   let load_failure = render_markdown_with_mermaid_loader(
     (
       #|```mermaid
@@ -910,7 +910,7 @@ test "Mermaid load and syntax failures keep fallback and retry cleanly" {
     load_mermaid_loader,
     options=MarkdownRenderOptions(
       code_block_renderer=markdown_test_render_code_block,
-      on_size_changed=() => load_size_changes.val += 1,
+      on_size_changed=() => load_size_changes += 1,
       mermaid_theme=Light,
     ),
     target=load_target,
@@ -920,7 +920,7 @@ test "Mermaid load and syntax failures keep fallback and retry cleanly" {
   assert_eq(markdown_test_mermaid_render_count(), 0)
   assert_eq(markdown_test_count(load_target, "svg"), 0)
   assert_eq(markdown_test_count_tokenized_fallbacks(load_target), 1)
-  assert_eq(load_size_changes.val, 0)
+  assert_eq(load_size_changes, 0)
 
   // A rejected module promise is evicted, so the same loader identity can
   // succeed when a later theme rerender retries it.
@@ -931,12 +931,12 @@ test "Mermaid load and syntax failures keep fallback and retry cleanly" {
   assert_eq(markdown_test_mermaid_render_count(), 1)
   assert_eq(markdown_test_mermaid_render_theme(0), "dark")
   assert_eq(markdown_test_count(load_target, "svg"), 1)
-  assert_eq(load_size_changes.val, 1)
+  assert_eq(load_size_changes, 1)
   load_failure.dispose.dispose()
 
   let syntax_mermaid_loader = markdown_test_mermaid_loader("resolve", "reject")
   let syntax_target = markdown_test_target()
-  let syntax_size_changes = Ref(0)
+  let mut syntax_size_changes = 0
   let syntax_failure = render_markdown_with_mermaid_loader(
     (
       #|```mermaid
@@ -946,7 +946,7 @@ test "Mermaid load and syntax failures keep fallback and retry cleanly" {
     syntax_mermaid_loader,
     options=MarkdownRenderOptions(
       code_block_renderer=markdown_test_render_code_block,
-      on_size_changed=() => syntax_size_changes.val += 1,
+      on_size_changed=() => syntax_size_changes += 1,
       mermaid_theme=Light,
     ),
     target=syntax_target,
@@ -956,7 +956,7 @@ test "Mermaid load and syntax failures keep fallback and retry cleanly" {
   assert_eq(markdown_test_mermaid_render_count(), 1)
   assert_eq(markdown_test_count(syntax_target, "svg"), 0)
   assert_eq(markdown_test_count_tokenized_fallbacks(syntax_target), 1)
-  assert_eq(syntax_size_changes.val, 0)
+  assert_eq(syntax_size_changes, 0)
 
   // A render rejection does not poison either the module cache or render
   // queue; the next request uses the cached module and succeeds.
@@ -968,7 +968,7 @@ test "Mermaid load and syntax failures keep fallback and retry cleanly" {
   assert_eq(markdown_test_mermaid_render_count(), 2)
   assert_eq(markdown_test_mermaid_render_theme(1), "dark")
   assert_eq(markdown_test_count(syntax_target, "svg"), 1)
-  assert_eq(syntax_size_changes.val, 1)
+  assert_eq(syntax_size_changes, 1)
   syntax_failure.dispose.dispose()
 }
 
@@ -977,7 +977,7 @@ test "target reuse and dispose reject late Mermaid render commits" {
   install_markdown_test_dom()
   let mermaid_loader = markdown_test_mermaid_loader("resolve", "defer")
   let target = markdown_test_target()
-  let first_size_changes = Ref(0)
+  let mut first_size_changes = 0
   let first = render_markdown_with_mermaid_loader(
     (
       #|```mermaid
@@ -988,7 +988,7 @@ test "target reuse and dispose reject late Mermaid render commits" {
     mermaid_loader,
     options=MarkdownRenderOptions(
       code_block_renderer=markdown_test_render_code_block,
-      on_size_changed=() => first_size_changes.val += 1,
+      on_size_changed=() => first_size_changes += 1,
       mermaid_theme=Light,
     ),
     target~,
@@ -997,7 +997,7 @@ test "target reuse and dispose reject late Mermaid render commits" {
   assert_eq(markdown_test_mermaid_pending_render_count(), 1)
   let first_wrapper = markdown_test_mermaid_wrapper_at(target, 0)
 
-  let second_size_changes = Ref(0)
+  let mut second_size_changes = 0
   let second = render_markdown_with_mermaid_loader(
     (
       #|```mermaid
@@ -1008,7 +1008,7 @@ test "target reuse and dispose reject late Mermaid render commits" {
     mermaid_loader,
     options=MarkdownRenderOptions(
       code_block_renderer=markdown_test_render_code_block,
-      on_size_changed=() => second_size_changes.val += 1,
+      on_size_changed=() => second_size_changes += 1,
       mermaid_theme=Dark,
     ),
     target~,
@@ -1022,7 +1022,7 @@ test "target reuse and dispose reject late Mermaid render commits" {
   assert_eq(markdown_test_mermaid_pending_render_count(), 1)
   markdown_test_resolve_next_mermaid_render()
   markdown_test_flush_mermaid_microtasks()
-  assert_eq(first_size_changes.val, 0)
+  assert_eq(first_size_changes, 0)
   assert_eq(markdown_test_count(target, "svg"), 0)
   assert_eq(markdown_test_mermaid_pending_render_count(), 1)
 
@@ -1030,7 +1030,7 @@ test "target reuse and dispose reject late Mermaid render commits" {
   // drained.
   markdown_test_resolve_next_mermaid_render()
   markdown_test_flush_mermaid_microtasks()
-  assert_eq(second_size_changes.val, 1)
+  assert_eq(second_size_changes, 1)
   assert_eq(markdown_test_count(target, "svg"), 1)
   assert_eq(markdown_test_mermaid_bind_count(), 1)
   assert_eq(markdown_test_mermaid_render_count(), 2)
@@ -1038,7 +1038,7 @@ test "target reuse and dispose reject late Mermaid render commits" {
     markdown_test_mermaid_render_id(0) == markdown_test_mermaid_render_id(1),
   )
 
-  let third_size_changes = Ref(0)
+  let mut third_size_changes = 0
   let third = render_markdown_with_mermaid_loader(
     (
       #|```mermaid
@@ -1049,7 +1049,7 @@ test "target reuse and dispose reject late Mermaid render commits" {
     mermaid_loader,
     options=MarkdownRenderOptions(
       code_block_renderer=markdown_test_render_code_block,
-      on_size_changed=() => third_size_changes.val += 1,
+      on_size_changed=() => third_size_changes += 1,
       mermaid_theme=Light,
     ),
     target~,
@@ -1060,7 +1060,7 @@ test "target reuse and dispose reject late Mermaid render commits" {
   third.dispose.dispose()
   markdown_test_resolve_next_mermaid_render()
   markdown_test_flush_mermaid_microtasks()
-  assert_eq(third_size_changes.val, 0)
+  assert_eq(third_size_changes, 0)
   assert_eq(markdown_test_count(target, "svg"), 0)
   assert_eq(markdown_test_count_tokenized_fallbacks(target), 1)
   assert_eq(markdown_test_mermaid_bind_count(), 1)

--- a/editor/internal/viewer/browser/markdown/mermaid_runtime.mbt
+++ b/editor/internal/viewer/browser/markdown/mermaid_runtime.mbt
@@ -158,16 +158,16 @@ fn MermaidRenderRequest::commit(
   result : MermaidRenderResult,
 ) -> Unit {
   guard self.is_current() else { return }
-  let committed = Ref(false)
+  let mut committed = false
   with_mermaid_render_svg(result, svg => {
     if self.is_current() {
       self.diagram.wrapper.set_inner_html(svg)
       self.diagram.wrapper.set_attribute("data-mermaid-state", "rendered")
-      committed.val = true
+      committed = true
     }
   })
   |> ignore
-  guard committed.val else { return }
+  guard committed else { return }
   try_bind_mermaid_result(result, self.diagram.wrapper)
   if self.is_current() {
     match self.lifetime.on_size_changed {

--- a/editor/internal/viewer/browser/markdown_document/markdown_document.mbt
+++ b/editor/internal/viewer/browser/markdown_document/markdown_document.mbt
@@ -214,11 +214,9 @@ fn render_markdown_document_presentation(
   article : @rdom.Element,
   on_size_changed : () -> Unit,
 ) -> (@browser_markdown.RenderedMarkdown, @diagram_viewport.DiagramViewports) {
-  let diagram_viewports_slot : Ref[@diagram_viewport.DiagramViewports?] = Ref(
-    None,
-  )
+  let mut diagram_viewports_slot : @diagram_viewport.DiagramViewports? = None
   let on_rendered_size_changed = () => {
-    match diagram_viewports_slot.val {
+    match diagram_viewports_slot {
       Some(diagram_viewports) => diagram_viewports.refresh()
       None => ()
     }
@@ -230,7 +228,7 @@ fn render_markdown_document_presentation(
   let diagram_viewports = @diagram_viewport.DiagramViewports(
     article, on_size_changed,
   )
-  diagram_viewports_slot.val = Some(diagram_viewports)
+  diagram_viewports_slot = Some(diagram_viewports)
   (rendered, diagram_viewports)
 }
 

--- a/editor/internal/viewer/browser/view/content_widgets_wbtest.mbt
+++ b/editor/internal/viewer/browser/view/content_widgets_wbtest.mbt
@@ -466,14 +466,14 @@ test "configuration visits every retained widget and gates layout cache reads" {
   let document = @rdom.document()
   let content_left = Ref(12.0)
   let content_width = Ref(240.0)
-  let layout_reads = Ref(0)
+  let mut layout_reads = 0
   let widgets = ContentWidgets::ContentWidgets(
     document,
     document.create_element("section"),
   )
   widgets.install_live_view_context(
     () => {
-      layout_reads.val += 1
+      layout_reads += 1
       (content_left.val, content_width.val)
     },
     position => Some(position),
@@ -494,7 +494,7 @@ test "configuration visits every retained widget and gates layout cache reads" {
   widgets.set_widget_position(first.content_widget_handle())
   widgets.add_widget(second.content_widget_handle())
   widgets.set_widget_position(second.content_widget_handle())
-  assert_eq(layout_reads.val, 2)
+  assert_eq(layout_reads, 2)
   let first_state = widgets.widgets["first"]
   let second_state = widgets.widgets["second"]
   assert_eq(first_state.content_left, 12.0)
@@ -509,7 +509,7 @@ test "configuration visits every retained widget and gates layout cache reads" {
   content_left.val = 30.0
   content_width.val = 500.0
   widgets.on_configuration_changed(false)
-  assert_eq(layout_reads.val, 2)
+  assert_eq(layout_reads, 2)
   assert_eq(first_state.content_left, 12.0)
   assert_eq(first_state.content_width, 240.0)
   assert_eq(first_state.max_width, 240.0)
@@ -532,14 +532,14 @@ test "configuration visits every retained widget and gates layout cache reads" {
     viewport_width: 500.0,
     viewport_height: 200.0,
   })
-  assert_eq(layout_reads.val, 2)
+  assert_eq(layout_reads, 2)
   assert_eq(first_state.max_width, 240.0)
   assert_eq(second_state.max_width, 240.0)
 
   // `layoutInfo` true visits every retained widget in key order; each reads
   // the live context and refreshes contentLeft/contentWidth/maxWidth.
   widgets.on_configuration_changed(true)
-  assert_eq(layout_reads.val, 4)
+  assert_eq(layout_reads, 4)
   assert_eq(first_state.content_left, 30.0)
   assert_eq(first_state.content_width, 500.0)
   assert_eq(first_state.max_width, 500.0)
@@ -665,7 +665,7 @@ test "onBefore distinguishes null and empty preference and includes viewport end
 test "mapping reprojection retains model anchors and visits widgets in key order" {
   install_content_widgets_test_browser()
   let document = @rdom.document()
-  let projection_delta = Ref(10)
+  let mut projection_delta = 10
   let projected_model_positions : Array[@base_common.Position] = []
   let widgets = ContentWidgets::ContentWidgets(
     document,
@@ -675,8 +675,8 @@ test "mapping reprojection retains model anchors and visits widgets in key order
     projected_model_positions.push(position)
     Some(
       Position(
-        position.line_number + projection_delta.val,
-        position.column + projection_delta.val,
+        position.line_number + projection_delta,
+        position.column + projection_delta,
       ),
     )
   })
@@ -697,7 +697,7 @@ test "mapping reprojection retains model anchors and visits widgets in key order
   widgets.add_widget(second.content_widget_handle())
   widgets.set_widget_position(second.content_widget_handle())
   projected_model_positions.clear()
-  projection_delta.val = 20
+  projection_delta = 20
 
   widgets.update_anchors_view_positions()
   assert_eq(projected_model_positions.length(), 3)
@@ -1335,17 +1335,11 @@ test "focused off-viewport widgets park without hiding and hidden writes are gat
   })
   widgets.add_widget(widget.content_widget_handle())
   widgets.set_widget_position(widget.content_widget_handle())
-  let measurable = Ref(true)
+  let mut measurable = true
   let ctx : ContentWidgetsRenderContext = {
     vertical_offset_for_line: _ => 50.0,
     line_height_for_line: _ => 20.0,
-    visible_range_for_position: _ => {
-      if measurable.val {
-        Some(10.0)
-      } else {
-        None
-      }
-    },
+    visible_range_for_position: _ => if measurable { Some(10.0) } else { None },
     typical_fullwidth_character_width: 16.0,
     scroll_top: 0.0,
     scroll_left: 0.0,
@@ -1359,7 +1353,7 @@ test "focused off-viewport widgets park without hiding and hidden writes are gat
     "inherit",
   )
   content_widgets_test_set_active_element(document, focus_child)
-  measurable.val = false
+  measurable = false
   widgets.prepare_render_widgets(ctx)
   content_widgets_test_clear_events()
   widgets.render_widgets(0.0, 0.0)
@@ -1382,11 +1376,11 @@ test "focused off-viewport widgets park without hiding and hidden writes are gat
   assert_true(content_widgets_test_events() == ["after:focus:null:null"])
 
   // Re-enter, then leave without focus: this branch hides instead of parks.
-  measurable.val = true
+  measurable = true
   widgets.prepare_render_widgets(ctx)
   widgets.render_widgets(0.0, 0.0)
   content_widgets_test_clear_active_element(document)
-  measurable.val = false
+  measurable = false
   widgets.prepare_render_widgets(ctx)
   widgets.render_widgets(0.0, 0.0)
   assert_eq(
@@ -1501,12 +1495,12 @@ test "empty single and mixed preferences preserve source order" {
     Some(position)
   })
   widgets.add_widget(widget.content_widget_handle())
-  let query_count = Ref(0)
+  let mut query_count = 0
   let ctx : ContentWidgetsRenderContext = {
     vertical_offset_for_line: _ => 50.0,
     line_height_for_line: _ => 20.0,
     visible_range_for_position: _ => {
-      query_count.val += 1
+      query_count += 1
       Some(30.0)
     },
     typical_fullwidth_character_width: 16.0,
@@ -1525,7 +1519,7 @@ test "empty single and mixed preferences preserve source order" {
   widgets.set_widget_position(widget.content_widget_handle())
   widgets.prepare_render_widgets(ctx)
   assert_true(widgets.widgets["preference-matrix"].render_data is None)
-  assert_eq(query_count.val, 0)
+  assert_eq(query_count, 0)
 
   widget.position = Some({
     position: Some(Position(1, 2)),
@@ -1894,15 +1888,15 @@ test "iOS owner visual viewport precedes inner and document client areas" {
     true, 700.0, 0.0, 0.0, 650.0, 600.0,
   )
   let node = owner.create_element("div")
-  let visual_width = Ref(-1.0)
-  let visual_height = Ref(-1.0)
+  let mut visual_width = -1.0
+  let mut visual_height = -1.0
   content_widgets_test_with_ios_visual_viewport(owner, 321.0, 123.0, () => {
     let (width, height) = body_client_area(node)
-    visual_width.val = width
-    visual_height.val = height
+    visual_width = width
+    visual_height = height
   })
-  assert_eq(visual_width.val, 321.0)
-  assert_eq(visual_height.val, 123.0)
+  assert_eq(visual_width, 321.0)
+  assert_eq(visual_height, 123.0)
   let (restored_width, restored_height) = body_client_area(node)
   assert_eq(restored_width, 700.0)
   assert_eq(restored_height, 700.0)

--- a/editor/internal/viewer/browser/view/view_events_wbtest.mbt
+++ b/editor/internal/viewer/browser/view/view_events_wbtest.mbt
@@ -78,12 +78,12 @@ test "consumed payloads retain independent flags and array identity" {
 test "dispatcher gives every handler a whole batch before reentrant FIFO batch" {
   let deliveries : Array[String] = []
   let holder : Ref[ViewEventDispatcher?] = { val: None, }
-  let did_reenter = Ref(false)
+  let mut did_reenter = false
   let dispatcher = ViewEventDispatcher::ViewEventDispatcher(events => {
     let batch = view_event_test_batch_name(events)
     deliveries.push("h1:\{batch}")
-    if !did_reenter.val {
-      did_reenter.val = true
+    if !did_reenter {
+      did_reenter = true
       match holder.val {
         Some(dispatcher) =>
           emit_dispatcher_test_batch(dispatcher, [
@@ -834,15 +834,15 @@ test "ContentWidgets handlers refresh layout and reproject every mapping event" 
   install_view_lifecycle_test_browser()
   let view = View::View()
   let widgets = view.content_widgets
-  let layout_reads = Ref(0)
-  let projections = Ref(0)
+  let mut layout_reads = 0
+  let mut projections = 0
   widgets.install_live_view_context(
     () => {
-      layout_reads.val += 1
+      layout_reads += 1
       (14.0, 420.0)
     },
     position => {
-      projections.val += 1
+      projections += 1
       Some(position)
     },
   )
@@ -851,8 +851,8 @@ test "ContentWidgets handlers refresh layout and reproject every mapping event" 
   }
   widgets.add_widget(widget.content_widget_handle())
   widgets.set_widget_position(widget.content_widget_handle())
-  assert_eq(layout_reads.val, 1)
-  assert_eq(projections.val, 1)
+  assert_eq(layout_reads, 1)
+  assert_eq(projections, 1)
 
   // Outer Configuration always invalidates. Only its exact LayoutInfo bit is
   // forwarded to the retained widgets' cache-refresh branch.
@@ -864,7 +864,7 @@ test "ContentWidgets handlers refresh layout and reproject every mapping event" 
       ),
     ),
   )
-  assert_eq(layout_reads.val, 1)
+  assert_eq(layout_reads, 1)
   assert_true(
     content_widgets_on_view_event(
       widgets,
@@ -873,11 +873,11 @@ test "ContentWidgets handlers refresh layout and reproject every mapping event" 
       ),
     ),
   )
-  assert_eq(layout_reads.val, 2)
+  assert_eq(layout_reads, 2)
 
-  projections.val = 0
+  projections = 0
   assert_true(content_widgets_on_view_event(widgets, ViewLineMappingChanged))
-  assert_eq(projections.val, 1)
+  assert_eq(projections, 1)
   view.dispose()
   restore_view_lifecycle_test_browser()
 }
@@ -1354,9 +1354,9 @@ test "View renders text before prepare and completes all prepares before writes"
   view.view_lines.should_render = true
   view.view_zones.force_should_render()
   view.view_cursors.should_render = true
-  let cursor_prepare_seen = Ref(false)
-  let text_was_complete = Ref(false)
-  let ordinary_write_was_pending = Ref(false)
+  let mut cursor_prepare_seen = false
+  let mut text_was_complete = false
+  let mut ordinary_write_was_pending = false
   let view_context : ViewContext = {
     measure_line_selection: (_line, _start, _end) => [],
     measure_line_decorations: (_line, _start, _end) => [],
@@ -1364,12 +1364,12 @@ test "View renders text before prepare and completes all prepares before writes"
       // Cursor prepare follows ViewZones prepare in the ordinary-part
       // order. Text completion is already visible, but no ordinary render
       // may have written its DOM yet.
-      text_was_complete.val = !view.view_lines.should_render
-      ordinary_write_was_pending.val = view_event_test_style_top(
+      text_was_complete = !view.view_lines.should_render
+      ordinary_write_was_pending = view_event_test_style_top(
           view.view_zones.margin_dom_node(),
         ) ==
         ""
-      cursor_prepare_seen.val = true
+      cursor_prepare_seen = true
       0.0
     },
     model_position_to_view_position: position => position,
@@ -1393,9 +1393,9 @@ test "View renders text before prepare and completes all prepares before writes"
     show_deprecated: true,
   }
   view.render(view_context, input)
-  assert_true(cursor_prepare_seen.val)
-  assert_true(text_was_complete.val)
-  assert_true(ordinary_write_was_pending.val)
+  assert_true(cursor_prepare_seen)
+  assert_true(text_was_complete)
+  assert_true(ordinary_write_was_pending)
   assert_true(
     view_event_test_style_top(view.view_zones.margin_dom_node()) != "",
   )

--- a/editor/internal/viewer/browser/view/view_lifecycle_wbtest.mbt
+++ b/editor/internal/viewer/browser/view/view_lifecycle_wbtest.mbt
@@ -173,35 +173,33 @@ test "View disposes ViewParts before its lifetime store exactly once" {
   let vertical_slider = scrollable.slider(true)
   assert_eq(vertical_slider.get_attribute("class"), Some("slider active"))
 
-  let base_dispose_count = Ref(0)
-  let scrollbar_was_already_disposed = Ref(false)
+  let mut base_dispose_count = 0
+  let mut scrollbar_was_already_disposed = false
   view.add_disposable(
     @base_common.Disposable::from(() => {
-      base_dispose_count.val += 1
-      scrollbar_was_already_disposed.val = vertical_slider.get_attribute(
-          "class",
-        ) ==
+      base_dispose_count += 1
+      scrollbar_was_already_disposed = vertical_slider.get_attribute("class") ==
         Some("slider")
     }),
   )
   view.dispose()
   assert_true(view.disposed)
   assert_eq(vertical_slider.get_attribute("class"), Some("slider"))
-  assert_true(scrollbar_was_already_disposed.val)
-  assert_eq(base_dispose_count.val, 1)
+  assert_true(scrollbar_was_already_disposed)
+  assert_eq(base_dispose_count, 1)
   assert_eq(view_lifecycle_test_clear_count(), 1)
   assert_true(view.lifetime_disposables.is_empty())
 
   // Repeated disposal neither re-runs a ViewPart nor drains the base store a
   // second time. Late registration is released immediately.
   view.dispose()
-  assert_eq(base_dispose_count.val, 1)
+  assert_eq(base_dispose_count, 1)
   assert_eq(view_lifecycle_test_clear_count(), 1)
-  let late_dispose_count = Ref(0)
+  let mut late_dispose_count = 0
   view.add_disposable(
-    @base_common.Disposable::from(() => late_dispose_count.val += 1),
+    @base_common.Disposable::from(() => late_dispose_count += 1),
   )
-  assert_eq(late_dispose_count.val, 1)
+  assert_eq(late_dispose_count, 1)
   assert_true(view.lifetime_disposables.is_empty())
   restore_view_lifecycle_test_browser()
 }

--- a/editor/internal/viewer/browser/view/view_zones.mbt
+++ b/editor/internal/viewer/browser/view/view_zones.mbt
@@ -303,8 +303,8 @@ fn ViewZones::change_view_zones(
   guard !self.disposed && self.context is Some(context) else { return false }
   let changed = Ref(false)
   let had_layout_change = context.view_model.change_whitespace(whitespace_accessor => {
-    let valid = Ref(true)
-    let assert_valid = () => if !valid.val { abort("Invalid change accessor") }
+    let mut valid = true
+    let assert_valid = () => if !valid { abort("Invalid change accessor") }
     let accessor = @editor_browser.ViewZoneChangeAccessor::from_callbacks(
       zone => {
         assert_valid()
@@ -328,7 +328,7 @@ fn ViewZones::change_view_zones(
       },
     )
     defer {
-      valid.val = false
+      valid = false
     }
     update(accessor) catch {
       _ => self.report_callback_error("changeViewZones")

--- a/editor/internal/viewer/browser/view/view_zones_branch_matrix_wbtest.mbt
+++ b/editor/internal/viewer/browser/view/view_zones_branch_matrix_wbtest.mbt
@@ -741,9 +741,9 @@ test "ViewZones layoutZone rereads geometry and width but retains ordinal and no
   defer fixture.dispose()
   let original_node = @rdom.document().create_element("div")
   let original_margin = @rdom.document().create_element("div")
-  let original_callback_count = Ref(0)
-  let replacement_callback_count = Ref(0)
-  let replacement_callback_height = Ref(-1.0)
+  let mut original_callback_count = 0
+  let mut replacement_callback_count = 0
+  let mut replacement_callback_height = -1.0
   let zone = @editor_browser.ViewZone(
     1,
     original_node,
@@ -754,7 +754,7 @@ test "ViewZones layoutZone rereads geometry and width but retains ordinal and no
     height_in_px=5.5,
     min_width_in_px=42.9,
     margin_dom_node=original_margin,
-    on_computed_height=_ => original_callback_count.val += 1,
+    on_computed_height=_ => original_callback_count += 1,
   )
   let id = fixture.add_zone(zone)
   let initial = fixture.whitespace(id)
@@ -762,7 +762,7 @@ test "ViewZones layoutZone rereads geometry and width but retains ordinal and no
   assert_eq(initial.height, 5)
   assert_eq(initial.ordinal, 17)
   assert_eq(initial.min_width, 42)
-  assert_eq(original_callback_count.val, 1)
+  assert_eq(original_callback_count, 1)
   assert_true(
     view_lifecycle_test_has_parent(
       original_node,
@@ -789,8 +789,8 @@ test "ViewZones layoutZone rereads geometry and width but retains ordinal and no
   zone.dom_node = replacement_node
   zone.margin_dom_node = Some(replacement_margin)
   zone.on_computed_height = Some(height => {
-    replacement_callback_count.val += 1
-    replacement_callback_height.val = height
+    replacement_callback_count += 1
+    replacement_callback_height = height
   })
   fixture.view.change_view_zones(accessor => accessor.layout_zone(id))
 
@@ -799,9 +799,9 @@ test "ViewZones layoutZone rereads geometry and width but retains ordinal and no
   assert_eq(updated.height, 40)
   assert_eq(updated.ordinal, 17)
   assert_eq(updated.min_width, 999)
-  assert_eq(original_callback_count.val, 1)
-  assert_eq(replacement_callback_count.val, 1)
-  assert_eq(replacement_callback_height.val, 40.0)
+  assert_eq(original_callback_count, 1)
+  assert_eq(replacement_callback_count, 1)
+  assert_eq(replacement_callback_height, 40.0)
   assert_true(
     view_lifecycle_test_has_parent(
       original_node,
@@ -1066,7 +1066,7 @@ test "ViewZones recompute freezes keys but reads future delegates live" {
     10,
   )
   defer fixture.dispose()
-  let first_id = Ref("")
+  let mut first_id = ""
   let future_id = Ref("")
   let added_id = Ref("")
   let first_callbacks : Array[Double] = []
@@ -1101,7 +1101,7 @@ test "ViewZones recompute freezes keys but reads future delegates live" {
         future_zone.height_in_lines = Some(3.0)
         fixture.view.change_view_zones(accessor => {
           added_id.val = accessor.add_zone(added_zone)
-          accessor.remove_zone(first_id.val)
+          accessor.remove_zone(first_id)
         })
         // The new key was absent from Object.keys' frozen snapshot. Mutating
         // it after add distinguishes "skipped now" (20) from recomputed (80).
@@ -1109,7 +1109,7 @@ test "ViewZones recompute freezes keys but reads future delegates live" {
       }
     },
   )
-  first_id.val = fixture.add_zone(first_zone)
+  first_id = fixture.add_zone(first_zone)
   future_id.val = fixture.add_zone(future_zone)
   assert_eq(first_callbacks.length(), 1)
   assert_eq(first_callbacks[0], 10.0)
@@ -1118,7 +1118,7 @@ test "ViewZones recompute freezes keys but reads future delegates live" {
 
   fixture.configuration.val = (20, 320.0, 40.0)
   assert_true(fixture.view.view_zones.on_configuration_changed(true))
-  assert_false(fixture.has_whitespace(first_id.val))
+  assert_false(fixture.has_whitespace(first_id))
   assert_true(fixture.has_whitespace(future_id.val))
   assert_true(fixture.has_whitespace(added_id.val))
   assert_eq(fixture.whitespace(future_id.val).height, 60)
@@ -1149,32 +1149,32 @@ test "ViewZones render freezes keys, writes after callback, and reads live value
   defer fixture.dispose()
   fixture.view_model.view_layout.set_viewport_size(width=300.0, height=200.0)
   |> ignore
-  let current_id = Ref("")
+  let mut current_id = ""
   let future_id = Ref("")
   let added_id = Ref("")
   let current_node = @rdom.document().create_element("div")
   let future_node = @rdom.document().create_element("div")
   let added_node = @rdom.document().create_element("div")
-  let callback_display = Ref("unset")
-  let callback_top = Ref("unset")
-  let callback_height = Ref("unset")
-  let old_future_top_callbacks = Ref(0)
-  let live_future_top_callbacks = Ref(0)
-  let added_top_callbacks = Ref(0)
+  let mut callback_display = "unset"
+  let mut callback_top = "unset"
+  let mut callback_height = "unset"
+  let mut old_future_top_callbacks = 0
+  let mut live_future_top_callbacks = 0
+  let mut added_top_callbacks = 0
   let did_reenter = Ref(false)
   let future_zone = @editor_browser.ViewZone(
     0,
     future_node,
     ordinal=1,
     height_in_px=11.0,
-    on_dom_node_top=_ => old_future_top_callbacks.val += 1,
+    on_dom_node_top=_ => old_future_top_callbacks += 1,
   )
   let added_zone = @editor_browser.ViewZone(
     0,
     added_node,
     ordinal=2,
     height_in_px=12.0,
-    on_dom_node_top=_ => added_top_callbacks.val += 1,
+    on_dom_node_top=_ => added_top_callbacks += 1,
   )
   let current_zone = @editor_browser.ViewZone(
     0,
@@ -1184,22 +1184,20 @@ test "ViewZones render freezes keys, writes after callback, and reads live value
     on_dom_node_top=_ => {
       if !did_reenter.val {
         did_reenter.val = true
-        callback_display.val = view_zones_branch_style(current_node, "display")
-        callback_top.val = view_zones_branch_style(current_node, "top")
-        callback_height.val = view_zones_branch_style(current_node, "height")
+        callback_display = view_zones_branch_style(current_node, "display")
+        callback_top = view_zones_branch_style(current_node, "top")
+        callback_height = view_zones_branch_style(current_node, "height")
         // The future key's registered record is fetched after this callback,
         // so the replacement delegate callback is used immediately.
-        future_zone.on_dom_node_top = Some(_ => {
-          live_future_top_callbacks.val += 1
-        })
+        future_zone.on_dom_node_top = Some(_ => live_future_top_callbacks += 1)
         fixture.view.change_view_zones(accessor => {
           added_id.val = accessor.add_zone(added_zone)
-          accessor.remove_zone(current_id.val)
+          accessor.remove_zone(current_id)
         })
       }
     },
   )
-  current_id.val = fixture.add_zone(current_zone)
+  current_id = fixture.add_zone(current_zone)
   future_id.val = fixture.add_zone(future_zone)
   let visible = fixture.view_model.view_layout.get_whitespace_viewport_data()
   assert_eq(visible.length(), 2)
@@ -1207,9 +1205,9 @@ test "ViewZones render freezes keys, writes after callback, and reads live value
 
   // onDomNodeTop runs before top/height/display writes. Removing the current
   // key detaches it, but the already-captured record still receives writes.
-  assert_eq(callback_display.val, "none")
-  assert_eq(callback_top.val, "")
-  assert_eq(callback_height.val, "")
+  assert_eq(callback_display, "none")
+  assert_eq(callback_top, "")
+  assert_eq(callback_height, "")
   assert_eq(view_zones_branch_style(current_node, "top"), "0px")
   assert_eq(view_zones_branch_style(current_node, "height"), "10px")
   assert_eq(view_zones_branch_style(current_node, "display"), "block")
@@ -1219,13 +1217,13 @@ test "ViewZones render freezes keys, writes after callback, and reads live value
       fixture.view.view_zones.dom_node(),
     ),
   )
-  assert_false(fixture.has_whitespace(current_id.val))
+  assert_false(fixture.has_whitespace(current_id))
 
-  assert_eq(old_future_top_callbacks.val, 0)
-  assert_eq(live_future_top_callbacks.val, 1)
+  assert_eq(old_future_top_callbacks, 0)
+  assert_eq(live_future_top_callbacks, 1)
   assert_true(fixture.has_whitespace(future_id.val))
   // The key added during the callback was absent from the frozen key list.
-  assert_eq(added_top_callbacks.val, 0)
+  assert_eq(added_top_callbacks, 0)
   assert_true(fixture.has_whitespace(added_id.val))
   assert_eq(view_zones_branch_style(added_node, "display"), "none")
   assert_eq(view_zones_branch_style(added_node, "top"), "")

--- a/editor/internal/viewer/code_editor_widget/agent_feedback_host_wbtest.mbt
+++ b/editor/internal/viewer/code_editor_widget/agent_feedback_host_wbtest.mbt
@@ -385,13 +385,13 @@ test "feedback disposal drains entries tears down model state and silences servi
   viewer.update_agent_feedback_hover_glyph(3)
   viewer.highlight_agent_feedback_range(comment)
   widgets.reply_drafts.set(comment.id, "retained reference draft")
-  let input_service_deliveries = Ref(0)
-  let widget_service_deliveries = Ref(0)
+  let mut input_service_deliveries = 0
+  let mut widget_service_deliveries = 0
   input_entry.listeners.push(
-    handle.on_did_change_feedback(_ => input_service_deliveries.val += 1),
+    handle.on_did_change_feedback(_ => input_service_deliveries += 1),
   )
   widget_entry.listeners.push(
-    handle.on_did_change_feedback(_ => widget_service_deliveries.val += 1),
+    handle.on_did_change_feedback(_ => widget_service_deliveries += 1),
   )
   assert_eq(input_entry.listeners.length(), 10)
   assert_eq(widget_entry.listeners.length(), 6)
@@ -424,8 +424,8 @@ test "feedback disposal drains entries tears down model state and silences servi
 
   service.set_feedback_enabled(resource, false)
   handle.add_feedback(resource, Range(2, 1, 2, 5), "after dispose") |> ignore
-  assert_eq(input_service_deliveries.val, 0)
-  assert_eq(widget_service_deliveries.val, 0)
+  assert_eq(input_service_deliveries, 0)
+  assert_eq(widget_service_deliveries, 0)
   assert_eq(input_entry.listeners.length(), 0)
   assert_eq(widget_entry.listeners.length(), 0)
   assert_eq(input.hover_decoration_ids.length(), 0)

--- a/editor/internal/viewer/code_editor_widget/browser_host.mbt
+++ b/editor/internal/viewer/code_editor_widget/browser_host.mbt
@@ -123,14 +123,14 @@ async fn run_async_tasks_concurrently(tasks : Array[async () -> Unit]) -> Unit {
     return
   }
   @js.suspend((resolve : (Unit) -> Unit, _reject : (Error) -> Unit) => {
-    let remaining = Ref(tasks.length())
+    let mut remaining = tasks.length()
     for task in tasks {
       @js.async_run(() => {
         task() catch {
           _ => ()
         }
-        remaining.val -= 1
-        if remaining.val == 0 {
+        remaining -= 1
+        if remaining == 0 {
           resolve(())
         }
       })

--- a/editor/internal/viewer/code_editor_widget/browser_host_wbtest.mbt
+++ b/editor/internal/viewer/code_editor_widget/browser_host_wbtest.mbt
@@ -53,11 +53,11 @@ test "BIA adapter selects once and the global wrapper is asynchronous cancellabl
   local_cancel()
   idle_target_run_timeout(target, 0)
 
-  let global_called = Ref(false)
+  let mut global_called = false
   let global_handle = schedule_tokenization_idle(_deadline => {
-    global_called.val = true
+    global_called = true
   })
-  assert_false(global_called.val)
+  assert_false(global_called)
   global_handle.dispose()
   global_handle.dispose()
 }
@@ -114,12 +114,12 @@ test "BIA fallback schedules zero-timeout and freezes a plus-15ms deadline" {
   let adapter = create_tokenization_idle_adapter_js(target)
   let remaining : Array[Double] = []
   let did_timeout = Ref(false)
-  let frozen = Ref(false)
+  let mut frozen = false
   let cancel = run_tokenization_idle_adapter_js(
     adapter,
     deadline => {
       did_timeout.val = browser_idle_deadline_did_timeout_js(deadline)
-      frozen.val = browser_idle_deadline_is_frozen_js(deadline)
+      frozen = browser_idle_deadline_is_frozen_js(deadline)
       remaining.push(browser_idle_deadline_time_remaining_js(deadline))
       idle_target_set_now(target, 114.0)
       remaining.push(browser_idle_deadline_time_remaining_js(deadline))
@@ -136,7 +136,7 @@ test "BIA fallback schedules zero-timeout and freezes a plus-15ms deadline" {
   assert_true(remaining.is_empty())
   idle_target_run_timeout(target, 0)
   assert_true(did_timeout.val)
-  assert_true(frozen.val)
+  assert_true(frozen)
   assert_eq(remaining.length(), 4)
   assert_eq(remaining[0], 15.0)
   assert_eq(remaining[1], 1.0)

--- a/editor/internal/viewer/code_editor_widget/cursor_tokenization_reference_wbtest.mbt
+++ b/editor/internal/viewer/code_editor_widget/cursor_tokenization_reference_wbtest.mbt
@@ -45,7 +45,7 @@ test "issue #46314: ViewModel is out of sync with Model!" {
   first.set_position(Position(1, 5))
 
   let mut cursor_events = 0
-  let projections_were_current = Ref(true)
+  let mut projections_were_current = true
   let subscription = first.on_did_change_cursor_position(_ => {
     cursor_events += 1
     // The callback itself owns a fresh two-line visible demand. A temporary
@@ -57,7 +57,7 @@ test "issue #46314: ViewModel is out of sync with Model!" {
       true,
     )
     model.on_before_detached(demand_view)
-    projections_were_current.val = projections_were_current.val &&
+    projections_were_current = projections_were_current &&
       first.test_view_model().line_count() == model.get_line_count() &&
       second.test_view_model().line_count() == model.get_line_count() &&
       first.test_view_model().get_line_content(1) == model.get_line_content(1) &&
@@ -73,7 +73,7 @@ test "issue #46314: ViewModel is out of sync with Model!" {
     ),
   )
   assert_eq(cursor_events, 1)
-  assert_true(projections_were_current.val)
+  assert_true(projections_were_current)
   assert_eq(first.test_view_model().line_count(), 3)
   assert_eq(second.test_view_model().line_count(), 3)
   assert_eq(first.test_view_model().get_line_content(3), "third")

--- a/editor/internal/viewer/code_editor_widget/definition_peek_host.mbt
+++ b/editor/internal/viewer/code_editor_widget/definition_peek_host.mbt
@@ -119,15 +119,15 @@ pub fn code_editor_references_preview_factory(
         Range(start.line_number, start.column, start.line_number, start.column),
       )
       preview.handle_initialized()
-      let owner_slot : Ref[CodeReferencesPeekPreviewOwner?] = Ref(None)
+      let mut owner_slot : CodeReferencesPeekPreviewOwner? = None
       let resize_observer = @base_browser.observe_element_resize(host, () => {
-        match owner_slot.val {
+        match owner_slot {
           Some(owner) if !owner.disposed => preview.layout()
           _ => ()
         }
       })
       let layout_frame = @base_browser.schedule_at_next_animation_frame(() => {
-        match owner_slot.val {
+        match owner_slot {
           Some(owner) if !owner.disposed => preview.layout()
           _ => ()
         }
@@ -139,7 +139,7 @@ pub fn code_editor_references_preview_factory(
         layout_frame,
         disposed: false,
       }
-      owner_slot.val = Some(owner)
+      owner_slot = Some(owner)
       Some(
         ReferencesPeekPreview(
           contains_focus=() => owner.contains_focus(),

--- a/editor/internal/viewer/code_editor_widget/editor_extensions_wbtest.mbt
+++ b/editor/internal/viewer/code_editor_widget/editor_extensions_wbtest.mbt
@@ -128,12 +128,12 @@ test "peek preview descriptors cannot recursively create references markdown or 
 
 ///|
 test "duplicate contribution ids are first-wins before later side effects" {
-  let first_constructed = Ref(0)
-  let first_initialized = Ref(0)
-  let first_disposed = Ref(0)
-  let second_constructed = Ref(0)
-  let second_initialized = Ref(0)
-  let second_disposed = Ref(0)
+  let mut first_constructed = 0
+  let mut first_initialized = 0
+  let mut first_disposed = 0
+  let mut second_constructed = 0
+  let mut second_initialized = 0
+  let mut second_disposed = 0
   let registry : EditorContributionRegistry = {
     contributions: [],
     commands: Map([]),
@@ -144,17 +144,17 @@ test "duplicate contribution ids are first-wins before later side effects" {
     QuickDiff,
     Eager,
     viewer => {
-      first_constructed.val += 1
+      first_constructed += 1
       let state = QuickDiffContributionState(
         viewer.create_decorations_collection(),
       )
       state.listeners.push(
-        @base_common.Disposable::from(() => first_disposed.val += 1),
+        @base_common.Disposable::from(() => first_disposed += 1),
       )
       QuickDiff(state)
     },
     _viewer => {
-      first_initialized.val += 1
+      first_initialized += 1
       []
     },
   )
@@ -163,17 +163,17 @@ test "duplicate contribution ids are first-wins before later side effects" {
     QuickDiff,
     Eager,
     viewer => {
-      second_constructed.val += 1
+      second_constructed += 1
       let state = QuickDiffContributionState(
         viewer.create_decorations_collection(),
       )
       state.listeners.push(
-        @base_common.Disposable::from(() => second_disposed.val += 1),
+        @base_common.Disposable::from(() => second_disposed += 1),
       )
       QuickDiff(state)
     },
     _viewer => {
-      second_initialized.val += 1
+      second_initialized += 1
       []
     },
   )
@@ -189,21 +189,21 @@ test "duplicate contribution ids are first-wins before later side effects" {
     viewer,
     CodeEditorContributionDescriptors::standalone(),
   )
-  assert_eq(first_constructed.val, 1)
-  assert_eq(first_initialized.val, 1)
-  assert_eq(second_constructed.val, 0)
-  assert_eq(second_initialized.val, 0)
+  assert_eq(first_constructed, 1)
+  assert_eq(first_initialized, 1)
+  assert_eq(second_constructed, 0)
+  assert_eq(second_initialized, 0)
   guard viewer.contributions.instances.get("test.duplicate") is Some(entry) else {
     fail("first duplicate row was not installed")
   }
   entry.dispose(viewer)
   entry.dispose(viewer)
-  assert_eq(first_disposed.val, 1)
-  assert_eq(second_disposed.val, 0)
+  assert_eq(first_disposed, 1)
+  assert_eq(second_disposed, 0)
   viewer.dispose()
   viewer.dispose()
-  assert_eq(first_disposed.val, 1)
-  assert_eq(second_disposed.val, 0)
+  assert_eq(first_disposed, 1)
+  assert_eq(second_disposed, 0)
   assert_false(viewer.contributions.instances.contains("test.duplicate"))
 }
 
@@ -242,21 +242,21 @@ test "viewer disposes all nine real rows once in order while the map stays insta
     references_contribution_id,
   ]
   let order : Array[String] = []
-  let map_stayed_installed = Ref(true)
-  let typed_row_stayed_available = Ref(true)
-  let wrapper_stayed_live = Ref(true)
+  let mut map_stayed_installed = true
+  let mut typed_row_stayed_available = true
+  let mut wrapper_stayed_live = true
   let track = label => {
     @base_common.Disposable::from(() => {
       order.push(label)
       if viewer.contributions.lifecycle != ContributionsLive {
-        wrapper_stayed_live.val = false
+        wrapper_stayed_live = false
       }
       if viewer.contributions.instances.length() != expected_ids.length() {
-        map_stayed_installed.val = false
+        map_stayed_installed = false
       }
       for id in expected_ids {
         if !viewer.contributions.instances.contains(id) {
-          map_stayed_installed.val = false
+          map_stayed_installed = false
         }
       }
       let available = match label {
@@ -272,7 +272,7 @@ test "viewer disposes all nine real rows once in order while the map stays insta
         _ => false
       }
       if !available {
-        typed_row_stayed_available.val = false
+        typed_row_stayed_available = false
       }
     })
   }
@@ -305,9 +305,9 @@ test "viewer disposes all nine real rows once in order while the map stays insta
     "input", "widget", "folding", "markdown", "hover", "quickDiff", "contextMenu",
     "definition", "references",
   ])
-  assert_true(map_stayed_installed.val)
-  assert_true(typed_row_stayed_available.val)
-  assert_true(wrapper_stayed_live.val)
+  assert_true(map_stayed_installed)
+  assert_true(typed_row_stayed_available)
+  assert_true(wrapper_stayed_live)
   assert_true(viewer.contributions.lifecycle == ContributionsDisposed)
   assert_eq(viewer.contributions.instances.length(), 0)
 }
@@ -573,9 +573,9 @@ test "model removal and reattach preserve central contribution identities" {
   let context_menu = viewer.context_menu_contribution().unwrap()
   let definition = viewer.definition_contribution().unwrap()
   let references = viewer.references_contribution().unwrap()
-  let markdown_listener_disposed = Ref(false)
+  let mut markdown_listener_disposed = false
   markdown.listeners.push(
-    @base_common.Disposable::from(() => markdown_listener_disposed.val = true),
+    @base_common.Disposable::from(() => markdown_listener_disposed = true),
   )
   let markdown_listener_count = markdown.listeners.length()
   let model = test_model("alpha\nbeta")
@@ -597,7 +597,7 @@ test "model removal and reattach preserve central contribution identities" {
     physical_equal(markdown, viewer.markdown_comment_contribution().unwrap()),
   )
   assert_eq(markdown.listeners.length(), markdown_listener_count)
-  assert_false(markdown_listener_disposed.val)
+  assert_false(markdown_listener_disposed)
   assert_true(physical_equal(hover, viewer.content_hover_controller().unwrap()))
   assert_true(
     physical_equal(quick_diff, viewer.quick_diff_contribution().unwrap()),
@@ -612,7 +612,7 @@ test "model removal and reattach preserve central contribution identities" {
     physical_equal(references, viewer.references_contribution().unwrap()),
   )
   viewer.dispose()
-  assert_true(markdown_listener_disposed.val)
+  assert_true(markdown_listener_disposed)
   model.dispose()
 }
 

--- a/editor/internal/viewer/code_editor_widget/hidden_areas_api.mbt
+++ b/editor/internal/viewer/code_editor_widget/hidden_areas_api.mbt
@@ -17,7 +17,7 @@ pub fn CodeEditorWidget::set_hidden_areas(
 ) -> Unit {
   guard self.get_view_model() is Some(view_model) else { return }
   guard self.get_model() is Some(model) else { return }
-  let previous_view_selection : Ref[@core.Selection?] = Ref(None)
+  let mut previous_view_selection : @core.Selection? = None
   let mapping_changed = view_model.set_hidden_areas(
     ranges,
     source~,
@@ -28,7 +28,7 @@ pub fn CodeEditorWidget::set_hidden_areas(
       // events, layout flush, recovery Scroll, and root bookkeeping.
       let event_batch = self.begin_view_event_batch()
       defer end_view_event_batch(event_batch)
-      previous_view_selection.val = Some(view_model.cursor.get_view_selection())
+      previous_view_selection = Some(view_model.cursor.get_view_selection())
       let changed = mutation()
       if changed {
         self.on_line_mapping_changed(
@@ -47,7 +47,7 @@ pub fn CodeEditorWidget::set_hidden_areas(
       self.emit_view_event(ViewLineMappingChanged)
       self.emit_view_event(ViewDecorationsChanged)
       reproject_cursor()
-      match previous_view_selection.val {
+      match previous_view_selection {
         Some(previous) =>
           self.emit_view_cursor_reprojection(view_model, previous)
         None => ()

--- a/editor/internal/viewer/code_editor_widget/hidden_areas_changed_event_wbtest.mbt
+++ b/editor/internal/viewer/code_editor_widget/hidden_areas_changed_event_wbtest.mbt
@@ -131,7 +131,7 @@ test "public hidden-area event follows cursor layout and recovery scroll" {
       order.push("scroll")
     })
     defer scroll_subscription.dispose()
-    let committed_before_public = Ref(false)
+    let mut committed_before_public = false
     let mut public_cursor_events = 0
     viewer.on_did_change_cursor_position(_ => public_cursor_events += 1)
     |> ignore
@@ -139,7 +139,7 @@ test "public hidden-area event follows cursor layout and recovery scroll" {
     |> ignore
     viewer.on_did_change_hidden_areas(() => {
       order.push("hidden")
-      committed_before_public.val = view_model.cursor.model_state().position ==
+      committed_before_public = view_model.cursor.model_state().position ==
         Position(4, 2) &&
         view_model.cursor.view_state().position == Position(2, 2) &&
         view_model.line_count() == 6 &&
@@ -151,7 +151,7 @@ test "public hidden-area event follows cursor layout and recovery scroll" {
 
     viewer.set_hidden_areas([Range(2, 1, 3, 1)])
     assert_true(order == ["scroll", "scroll", "hidden"])
-    assert_true(committed_before_public.val)
+    assert_true(committed_before_public)
     // Mapping-only cursor reprojection is committed before the hidden event,
     // but does not fabricate a public model-coordinate cursor transition.
     assert_eq(public_cursor_events, 0)

--- a/editor/internal/viewer/code_editor_widget/initialization_order_reference_wbtest.mbt
+++ b/editor/internal/viewer/code_editor_widget/initialization_order_reference_wbtest.mbt
@@ -82,10 +82,10 @@ test "initialization reentry does not initialize a replacement model" {
     language_id="initialization-order-reentry-replacement",
   )
   defer replacement.dispose()
-  let replaced = Ref(false)
+  let mut replaced = false
   let subscription = debug_on_did_build_view_model(viewer, _ => {
-    if !replaced.val && first_calls.val > 0 {
-      replaced.val = true
+    if !replaced && first_calls.val > 0 {
+      replaced = true
       viewer.set_model(Some(replacement))
     }
   })
@@ -94,7 +94,7 @@ test "initialization reentry does not initialize a replacement model" {
   viewer.test_set_viewport(width=200.0, height=90.0)
 
   viewer.handle_initialized()
-  assert_true(replaced.val)
+  assert_true(replaced)
   assert_true(viewer.get_model().unwrap().same(replacement))
   assert_eq(replacement_calls.val, 0)
 

--- a/editor/internal/viewer/code_editor_widget/lifecycle_ownership_wbtest.mbt
+++ b/editor/internal/viewer/code_editor_widget/lifecycle_ownership_wbtest.mbt
@@ -315,20 +315,20 @@ async test "navigation handles stay optional and borrowed after bundle disposal"
   let model = @model.TextModel(
     target, "definition.mbt", "moonbit", 1, "definition-rev", "let definition = 1",
   )
-  let open_calls = Ref(0)
-  let resolve_calls = Ref(0)
-  let release_calls = Ref(0)
+  let mut open_calls = 0
+  let mut resolve_calls = 0
+  let mut release_calls = 0
   let opener = @navigation_api.LocationOpenerHandle(open=request => {
-    open_calls.val += 1
+    open_calls += 1
     request.location.uri.to_string() == target.to_string()
   })
   let resolver = @navigation_api.TextModelResolverHandle(resolve=(
     resource,
     _token,
   ) => {
-    resolve_calls.val += 1
+    resolve_calls += 1
     if resource.to_string() == target.to_string() {
-      Some(TextModelReference(model, release=() => release_calls.val += 1))
+      Some(TextModelReference(model, release=() => release_calls += 1))
     } else {
       None
     }
@@ -353,9 +353,9 @@ async test "navigation handles stay optional and borrowed after bundle disposal"
   }
   assert_true(reference.model().same(model))
   reference.dispose()
-  assert_eq(open_calls.val, 1)
-  assert_eq(resolve_calls.val, 1)
-  assert_eq(release_calls.val, 1)
+  assert_eq(open_calls, 1)
+  assert_eq(resolve_calls, 1)
+  assert_eq(release_calls, 1)
   assert_false(model.is_disposed())
   model.dispose()
 
@@ -378,25 +378,25 @@ test "omitted services are owned and CodeEditorWidget disposal is idempotent" {
   seed_lifecycle_marker(owned_markers, model)
   viewer.set_model(Some(model))
   let marker_deliveries = Ref(0)
-  let feedback_deliveries = Ref(0)
+  let mut feedback_deliveries = 0
   let marker_subscription = owned_markers.on_did_change_markers(_ => {
     marker_deliveries.val += 1
   })
   let feedback_subscription = owned_feedback_handle.on_did_change_feedback(_ => {
-    feedback_deliveries.val += 1
+    feedback_deliveries += 1
   })
   let mut dispose_events = 0
-  let contribution_alive_in_event = Ref(false)
-  let lifetime_store_alive_in_event = Ref(false)
-  let model_detached_in_event = Ref(false)
+  let mut contribution_alive_in_event = false
+  let mut lifetime_store_alive_in_event = false
+  let mut model_detached_in_event = false
   viewer.on_did_dispose(() => {
     dispose_events += 1
-    contribution_alive_in_event.val = viewer.contributions.lookup(
+    contribution_alive_in_event = viewer.contributions.lookup(
         "editor.contrib.contentHover",
       )
       is Some(_)
-    lifetime_store_alive_in_event.val = !viewer.lifetime_disposables.is_empty()
-    model_detached_in_event.val = viewer.get_model() is None
+    lifetime_store_alive_in_event = !viewer.lifetime_disposables.is_empty()
+    model_detached_in_event = viewer.get_model() is None
   })
   |> ignore
   viewer.dispose()
@@ -405,9 +405,9 @@ test "omitted services are owned and CodeEditorWidget disposal is idempotent" {
   assert_true(viewer.disposed)
   assert_true(services.disposed)
   assert_eq(dispose_events, 1)
-  assert_true(contribution_alive_in_event.val)
-  assert_true(lifetime_store_alive_in_event.val)
-  assert_true(model_detached_in_event.val)
+  assert_true(contribution_alive_in_event)
+  assert_true(lifetime_store_alive_in_event)
+  assert_true(model_detached_in_event)
   assert_eq(viewer.lifetime_disposables.length(), 0)
   // A never-attached CodeEditorWidget remains semantically headless through disposal:
   // it has no browser frame, focus, host, or placeholder capability to tear
@@ -427,7 +427,7 @@ test "omitted services are owned and CodeEditorWidget disposal is idempotent" {
   )
   |> ignore
   assert_eq(marker_deliveries.val, 0)
-  assert_eq(feedback_deliveries.val, 0)
+  assert_eq(feedback_deliveries, 0)
   let later_model = test_model("later")
   let owned_marker_handle = owned_marker_decorations.marker_decorations_handle()
   let late_lease = owned_marker_handle.acquire_model(later_model)

--- a/editor/internal/viewer/code_editor_widget/markdown_comments_contribution.mbt
+++ b/editor/internal/viewer/code_editor_widget/markdown_comments_contribution.mbt
@@ -406,15 +406,13 @@ fn render_markdown_comment_presentations(
   @base_common.Disposable?,
   @diagram_viewport.DiagramViewports,
 ) {
-  let diagram_viewports_slot : Ref[@diagram_viewport.DiagramViewports?] = Ref(
-    None,
-  )
+  let mut diagram_viewports_slot : @diagram_viewport.DiagramViewports? = None
   // Renderer notifications include asynchronous Mermaid commits, so reconcile
   // before measuring. Diagram viewport and fold interactions only change
   // geometry; keep their pointer-driven path on the already-coalesced size
   // observer instead of rescanning the rendered Markdown tree per event.
   let on_rendered_size_changed = () => {
-    match diagram_viewports_slot.val {
+    match diagram_viewports_slot {
       Some(diagram_viewports) => diagram_viewports.refresh()
       None => ()
     }
@@ -452,7 +450,7 @@ fn render_markdown_comment_presentations(
     rendered_markdown.element,
     on_interaction_size_changed,
   )
-  diagram_viewports_slot.val = Some(diagram_viewports)
+  diagram_viewports_slot = Some(diagram_viewports)
   (
     rendered_markdown, preview_rendered_markdown, fold_lifetime, diagram_viewports,
   )

--- a/editor/internal/viewer/code_editor_widget/quick_diff_host_wbtest.mbt
+++ b/editor/internal/viewer/code_editor_widget/quick_diff_host_wbtest.mbt
@@ -228,17 +228,17 @@ test "quick diff: disposal window is live and later service events are silent" {
   )
   viewer.set_model(Some(model))
   assert_true(state.collection.length() > 0)
-  let original_change_deliveries = Ref(0)
+  let mut original_change_deliveries = 0
   state.listeners.push(
     quick_diff
     .quick_diff_handle()
-    .on_did_change_original(_ => original_change_deliveries.val += 1),
+    .on_did_change_original(_ => original_change_deliveries += 1),
   )
-  let callback_seen = Ref(false)
-  let contribution_live_in_callback = Ref(false)
+  let mut callback_seen = false
+  let mut contribution_live_in_callback = false
   viewer.on_did_dispose(() => {
-    callback_seen.val = true
-    contribution_live_in_callback.val = viewer.contributions.lookup(
+    callback_seen = true
+    contribution_live_in_callback = viewer.contributions.lookup(
         "quickDiff.decorator",
       )
       is Some(_)
@@ -249,12 +249,12 @@ test "quick diff: disposal window is live and later service events are silent" {
   })
   |> ignore
   viewer.dispose()
-  assert_true(callback_seen.val)
-  assert_true(contribution_live_in_callback.val)
-  assert_eq(original_change_deliveries.val, 1)
+  assert_true(callback_seen)
+  assert_true(contribution_live_in_callback)
+  assert_eq(original_change_deliveries, 1)
   assert_eq(state.collection.length(), 0)
   quick_diff.set_original_content(resource, Some("after dispose"))
-  assert_eq(original_change_deliveries.val, 1)
+  assert_eq(original_change_deliveries, 1)
   assert_eq(state.collection.length(), 0)
   model.dispose()
   backings.dispose()

--- a/editor/internal/viewer/code_editor_widget/test_viewer_wbtest.mbt
+++ b/editor/internal/viewer/code_editor_widget/test_viewer_wbtest.mbt
@@ -175,9 +175,9 @@ test "model change fires before outgoing owner decorations are swept" {
     },
   ])
   assert_eq(ids.length(), 1)
-  let decorations_seen_in_event = Ref(-1)
+  let mut decorations_seen_in_event = -1
   let subscription = viewer.on_did_change_model(_ => {
-    decorations_seen_in_event.val = model
+    decorations_seen_in_event = model
       .get_decorations_in_range(
         model.get_full_model_range(),
         owner_id=viewer.editor_id,
@@ -186,7 +186,7 @@ test "model change fires before outgoing owner decorations are swept" {
   })
 
   viewer.set_model(None)
-  assert_eq(decorations_seen_in_event.val, 1)
+  assert_eq(decorations_seen_in_event, 1)
   assert_eq(
     model
     .get_decorations_in_range(

--- a/editor/internal/viewer/code_editor_widget/view_event_sources_wbtest.mbt
+++ b/editor/internal/viewer/code_editor_widget/view_event_sources_wbtest.mbt
@@ -427,15 +427,15 @@ test "validation option rotates the headless decoration provider" {
 ///|
 test "view-zone callback is skipped without a real model view" {
   let viewer = CodeEditorWidget::CodeEditorWidget()
-  let called = Ref(false)
-  viewer.change_view_zones(_ => called.val = true)
+  let mut called = false
+  viewer.change_view_zones(_ => called = true)
   assert_false(viewer.configuration.measure_requested)
-  assert_false(called.val)
+  assert_false(called)
   viewer.dispose()
   with_test_viewer("alpha", headless => {
     let measure_requested_before = headless.configuration.measure_requested
-    headless.change_view_zones(_ => called.val = true)
-    assert_false(called.val)
+    headless.change_view_zones(_ => called = true)
+    assert_false(called)
     assert_eq(
       headless.configuration.measure_requested,
       measure_requested_before,

--- a/editor/internal/viewer/code_editor_widget/view_host.mbt
+++ b/editor/internal/viewer/code_editor_widget/view_host.mbt
@@ -199,26 +199,26 @@ pub fn CodeEditorWidget::after_next_render(
     return @base_common.Disposable::from(() => ())
   }
   let target_generation = self.render_generation + 1
-  let registration : Ref[@base_common.Disposable?] = Ref(None)
+  let mut registration : @base_common.Disposable? = None
   let listener = self.did_render.event(generation => {
     if generation < target_generation {
       return
     }
-    match registration.val {
+    match registration {
       Some(disposable) => {
-        registration.val = None
+        registration = None
         disposable.dispose()
       }
       None => return
     }
     callback()
   })
-  registration.val = Some(listener)
+  registration = Some(listener)
   self.schedule_render()
   @base_common.Disposable::from(() => {
-    match registration.val {
+    match registration {
       Some(disposable) => {
-        registration.val = None
+        registration = None
         disposable.dispose()
       }
       None => ()

--- a/editor/internal/viewer/contrib/folding/browser/folding_model.mbt
+++ b/editor/internal/viewer/contrib/folding/browser/folding_model.mbt
@@ -137,32 +137,31 @@ pub fn FoldingModel::toggle_collapse_state(
   let processed : Map[String, Bool] = Map([])
   self.decoration_access.change_decorations(accessor => {
     // index from [0 ... this.regions.length]
-    let k : Ref[Int] = { val: 0, }
+    let mut k : Int = 0
     // end of the range where decorations need to be updated
-    let dirty_region_end_line : Ref[Int] = { val: -1, }
+    let mut dirty_region_end_line : Int = -1
     // the end of the last hidden lines
     let last_hidden_line : Ref[Int] = { val: -1, }
     let update_decorations_until = (index : Int) => {
-      while k.val < index {
-        let end_line_number = self.regions.get_end_line_number(k.val)
-        let is_collapsed = self.regions.is_collapsed(k.val)
-        if end_line_number <= dirty_region_end_line.val {
-          let is_manual = self.regions.get_source(k.val) != Provider
+      while k < index {
+        let end_line_number = self.regions.get_end_line_number(k)
+        let is_collapsed = self.regions.is_collapsed(k)
+        if end_line_number <= dirty_region_end_line {
+          let is_manual = self.regions.get_source(k) != Provider
           (accessor.change_decoration_options)(
-            self.editor_decoration_ids[k.val],
+            self.editor_decoration_ids[k],
             self.decoration_access.get_decoration_option(
               is_collapsed,
               end_line_number <= last_hidden_line.val,
               is_manual,
-              self.regions.get_type(k.val) ==
-              Some(OUTLINE_BODY_FOLDING_RANGE_TYPE),
+              self.regions.get_type(k) == Some(OUTLINE_BODY_FOLDING_RANGE_TYPE),
             ),
           )
         }
         if is_collapsed && end_line_number > last_hidden_line.val {
           last_hidden_line.val = end_line_number
         }
-        k.val += 1
+        k += 1
       }
     }
     for region in toggled_regions {
@@ -176,7 +175,7 @@ pub fn FoldingModel::toggle_collapse_state(
           update_decorations_until(index)
           let new_collapse_state = !self.regions.is_collapsed(index)
           self.regions.set_collapsed(index, new_collapse_state)
-          dirty_region_end_line.val = dirty_region_end_line.val.max(
+          dirty_region_end_line = dirty_region_end_line.max(
             self.regions.get_end_line_number(index),
           )
         }

--- a/editor/internal/viewer/contrib/folding/browser/indent_range_provider_reference_wbtest.mbt
+++ b/editor/internal/viewer/contrib/folding/browser/indent_range_provider_reference_wbtest.mbt
@@ -517,10 +517,10 @@ test "Limit by indent" {
     expected_ranges : Array[(Int, Int)],
     message : String,
   ) => {
-    let reported : Ref[Int?] = { val: None, }
+    let mut reported : Int? = None
     let indent_ranges = compute_ranges(model, true, folding_ranges_limit={
       limit: () => max_entries,
-      update: (_computed, limited) => reported.val = limited,
+      update: (_computed, limited) => reported = limited,
     })
     guard indent_ranges.length() <= max_entries else { fail("max \{message}") }
     let actual : Array[(Int, Int)] = []
@@ -540,7 +540,7 @@ test "Limit by indent" {
     } else {
       Some(max_entries)
     }
-    if reported.val != expected_reported {
+    if reported != expected_reported {
       fail("limited \{message}")
     }
   }

--- a/editor/internal/viewer/contrib/hover/browser/content_hover_widget_wbtest.mbt
+++ b/editor/internal/viewer/contrib/hover/browser/content_hover_widget_wbtest.mbt
@@ -73,23 +73,23 @@ test "a tall hover near the page bottom flips above" {
 
 ///|
 test "hover render lifetimes dispose on replacement hide and teardown" {
-  let first_count = Ref(0)
-  let second_count = Ref(0)
-  let third_count = Ref(0)
+  let mut first_count = 0
+  let mut second_count = 0
+  let mut third_count = 0
   let lifetimes : Array[@base_common.Disposable] = []
-  lifetimes.push(@base_common.Disposable::from(() => first_count.val += 1))
-  lifetimes.push(@base_common.Disposable::from(() => second_count.val += 1))
+  lifetimes.push(@base_common.Disposable::from(() => first_count += 1))
+  lifetimes.push(@base_common.Disposable::from(() => second_count += 1))
 
   // `_setRenderedHover` begins a replacement with the same clear operation.
   dispose_hover_render_disposables(lifetimes)
-  assert_eq(first_count.val, 1)
-  assert_eq(second_count.val, 1)
+  assert_eq(first_count, 1)
+  assert_eq(second_count, 1)
 
-  lifetimes.push(@base_common.Disposable::from(() => third_count.val += 1))
+  lifetimes.push(@base_common.Disposable::from(() => third_count += 1))
   // `hide` and retained-widget `dispose` both converge on this operation.
   dispose_hover_render_disposables(lifetimes)
   dispose_hover_render_disposables(lifetimes)
-  assert_eq(third_count.val, 1)
+  assert_eq(third_count, 1)
 }
 
 ///|

--- a/editor/internal/viewer/contrib/hover/content_hover_computer_wbtest.mbt
+++ b/editor/internal/viewer/contrib/hover/content_hover_computer_wbtest.mbt
@@ -253,18 +253,18 @@ async test "async-each skips participants without an async callback" {
   let computer : ContentHoverComputer = {
     participants: [HoverParticipantHandle(10, _ctx => [])],
   }
-  let runner_called = Ref(false)
+  let mut runner_called = false
   let emitted = Ref(0)
   computer.compute_async_each(
     computer_test_model(),
     async_test_anchor(),
     run_tasks=tasks => {
-      runner_called.val = true
+      runner_called = true
       assert_true(tasks.is_empty())
     },
     emit=_parts => emitted.val += 1,
   )
-  assert_true(runner_called.val)
+  assert_true(runner_called)
   assert_eq(emitted.val, 0)
 }
 

--- a/editor/internal/viewer/contrib/markdown_comments/browser/markdown_comment_dom.mbt
+++ b/editor/internal/viewer/contrib/markdown_comments/browser/markdown_comment_dom.mbt
@@ -289,43 +289,43 @@ pub fn MarkdownCommentDom::observe_size(
   on_height_changed : (Int) -> Unit,
 ) -> MarkdownCommentSizeObserver {
   let disposed = Ref(false)
-  let frame_scheduled = Ref(false)
-  let force_hidden_measure = Ref(false)
-  let pending_frame : Ref[@base_common.Disposable?] = Ref(None)
-  let last_height = Ref(0)
+  let mut frame_scheduled = false
+  let mut force_hidden_measure = false
+  let mut pending_frame : @base_common.Disposable? = None
+  let mut last_height = 0
   let measure = () => {
-    frame_scheduled.val = false
-    pending_frame.val = None
+    frame_scheduled = false
+    pending_frame = None
     if disposed.val || !@base_browser.element_is_connected(self.content) {
       return
     }
-    let allow_hidden = force_hidden_measure.val || last_height.val == 0
-    force_hidden_measure.val = false
+    let allow_hidden = force_hidden_measure || last_height == 0
+    force_hidden_measure = false
     let height = markdown_comment_measured_height(
       self.outer,
       self.content,
       allow_hidden,
     )
-    if height <= 0 || height == last_height.val {
+    if height <= 0 || height == last_height {
       return
     }
-    last_height.val = height
+    last_height = height
     on_height_changed(height)
   }
   let schedule_measure = (force_hidden : Bool) => {
     if disposed.val {
       return
     }
-    force_hidden_measure.val = force_hidden_measure.val || force_hidden
-    if frame_scheduled.val {
+    force_hidden_measure = force_hidden_measure || force_hidden
+    if frame_scheduled {
       return
     }
-    frame_scheduled.val = true
+    frame_scheduled = true
     let registration = @base_browser.schedule_at_next_animation_frame(measure)
     // Native requestAnimationFrame is asynchronous, but retaining this branch
     // makes the owner correct under a synchronous test/browser shim too.
-    if frame_scheduled.val {
-      pending_frame.val = Some(registration)
+    if frame_scheduled {
+      pending_frame = Some(registration)
     } else {
       registration.dispose()
     }
@@ -338,11 +338,11 @@ pub fn MarkdownCommentDom::observe_size(
     if observer is Some(observer) {
       observer.dispose()
     }
-    if pending_frame.val is Some(registration) {
+    if pending_frame is Some(registration) {
       registration.dispose()
     }
-    pending_frame.val = None
-    frame_scheduled.val = false
+    pending_frame = None
+    frame_scheduled = false
   })
   { request_measure_: () => schedule_measure(true), lifetime, }
 }
@@ -380,18 +380,16 @@ pub fn MarkdownCommentDom::observe_viewport_width(
   let disposed = Ref(false)
   let lifetime = match markdown_comment_content_viewport(self.outer) {
     Some(viewport) => {
-      let last_width = Ref(
-        @base_browser.element_client_width(viewport).to_int(),
-      )
+      let mut last_width = @base_browser.element_client_width(viewport).to_int()
       let observer = @base_browser.observe_element_resize(viewport, () => {
         if disposed.val {
           return
         }
         let width = @base_browser.element_client_width(viewport).to_int()
-        if width == last_width.val {
+        if width == last_width {
           return
         }
-        last_width.val = width
+        last_width = width
         if width > 0 {
           on_width_changed()
         }

--- a/editor/internal/viewer/contrib/references/browser/references_controller_wbtest.mbt
+++ b/editor/internal/viewer/contrib/references/browser/references_controller_wbtest.mbt
@@ -354,14 +354,12 @@ async test "dispose marks the controller stale before resource callbacks can reo
   assert_true(controller.toggle_locations(anchor, Definitions, [location]))
   tasks.run_all()
   assert_true(controller.phase() is PeekShown(_, _))
-  let reopen_result = Ref(true)
+  let mut reopen_result = true
   previews.on_dispose.val = Some(() => {
-    reopen_result.val = controller.toggle_locations(anchor, Definitions, [
-      location,
-    ])
+    reopen_result = controller.toggle_locations(anchor, Definitions, [location])
   })
   controller.dispose()
-  assert_false(reopen_result.val)
+  assert_false(reopen_result)
   assert_eq(controller.phase(), PeekClosed)
   assert_eq(host.mount_count.val, 1)
   assert_eq(host.mount_dispose_count.val, 1)
@@ -379,8 +377,8 @@ async test "resolver leases transfer on preview replacement and release on close
   defer source.dispose()
   defer target_a.dispose()
   defer target_b.dispose()
-  let release_a = Ref(0)
-  let release_b = Ref(0)
+  let mut release_a = 0
+  let mut release_b = 0
   let resolver_calls : Array[String] = []
   let resolver = @navigation_api.TextModelResolverHandle(resolve=(
     resource,
@@ -388,9 +386,9 @@ async test "resolver leases transfer on preview replacement and release on close
   ) => {
     resolver_calls.push(resource.to_string())
     if resource.to_string() == target_a.uri.to_string() {
-      Some(TextModelReference(target_a, release=() => release_a.val += 1))
+      Some(TextModelReference(target_a, release=() => release_a += 1))
     } else if resource.to_string() == target_b.uri.to_string() {
-      Some(TextModelReference(target_b, release=() => release_b.val += 1))
+      Some(TextModelReference(target_b, release=() => release_b += 1))
     } else {
       None
     }
@@ -424,24 +422,24 @@ async test "resolver leases transfer on preview replacement and release on close
   assert_eq(resolver_calls[0], target_a.uri.to_string())
   assert_eq(resolver_calls[1], target_a.uri.to_string())
   assert_eq(previews.resources, [target_a.uri.to_string()])
-  assert_eq(release_a.val, 0)
+  assert_eq(release_a, 0)
 
   controller.move_selection(1)
-  assert_eq(release_a.val, 0)
+  assert_eq(release_a, 0)
   assert_eq(previews.dispose_count.val, 0)
   assert_eq(tasks.tasks.length(), 2)
   tasks.run_all()
-  assert_eq(release_a.val, 1)
+  assert_eq(release_a, 1)
   assert_eq(previews.dispose_count.val, 1)
   assert_eq(resolver_calls.length(), 4)
   assert_eq(resolver_calls[2], target_b.uri.to_string())
   assert_eq(resolver_calls[3], target_b.uri.to_string())
   assert_eq(previews.resources[1], target_b.uri.to_string())
-  assert_eq(release_b.val, 0)
+  assert_eq(release_b, 0)
 
   controller.close(restore_focus=false)
-  assert_eq(release_a.val, 2)
-  assert_eq(release_b.val, 2)
+  assert_eq(release_a, 2)
+  assert_eq(release_b, 2)
   assert_eq(previews.dispose_count.val, 2)
   assert_false(target_a.is_disposed())
   assert_false(target_b.is_disposed())
@@ -459,14 +457,14 @@ async test "stale and invalid resolver results are released without preview inst
   defer source.dispose()
   defer requested.dispose()
   defer wrong.dispose()
-  let releases = Ref(0)
-  let saw_cancelled = Ref(false)
+  let mut releases = 0
+  let mut saw_cancelled = false
   let resolver = @navigation_api.TextModelResolverHandle(resolve=(
     _resource,
     token,
   ) => {
-    saw_cancelled.val = token.is_cancellation_requested()
-    Some(TextModelReference(wrong, release=() => releases.val += 1))
+    saw_cancelled = token.is_cancellation_requested()
+    Some(TextModelReference(wrong, release=() => releases += 1))
   })
   let surface_generation = Ref(5)
   let host = references_controller_test_host(source, surface_generation)
@@ -491,8 +489,8 @@ async test "stale and invalid resolver results are released without preview inst
   )
   controller.close(restore_focus=false)
   tasks.run_all()
-  assert_true(saw_cancelled.val)
-  assert_eq(releases.val, 2)
+  assert_true(saw_cancelled)
+  assert_eq(releases, 2)
   assert_eq(previews.resources.length(), 0)
   assert_eq(controller.phase(), PeekClosed)
 
@@ -504,7 +502,7 @@ async test "stale and invalid resolver results are released without preview inst
     ),
   )
   tasks.run_all()
-  assert_eq(releases.val, 4)
+  assert_eq(releases, 4)
   assert_eq(previews.resources.length(), 0)
   assert_true(controller.phase() is PeekUnavailable(_, _))
   browser.flush_animation_frames()

--- a/editor/internal/viewer/diff_editor/view_model_wbtest.mbt
+++ b/editor/internal/viewer/diff_editor/view_model_wbtest.mbt
@@ -764,14 +764,14 @@ test "one model will-dispose atomically clears the pair and both pane slots" {
   let modified = diff_view_model_test_model(
     "will-dispose-modified", "old right",
   )
-  let original_slot : Ref[@model.TextModel?] = Ref(None)
-  let modified_slot : Ref[@model.TextModel?] = Ref(None)
+  let mut original_slot : @model.TextModel? = None
+  let mut modified_slot : @model.TextModel? = None
   let pane_commit = new_diff_editor_model_pair_commit_barrier()
-  let model_changes = Ref(0)
-  let update_count = Ref(0)
-  let every_update_saw_synchronized_slots = Ref(true)
+  let mut model_changes = 0
+  let mut update_count = 0
+  let mut every_update_saw_synchronized_slots = true
   let model_subscription = view_model.on_did_change_model(() => {
-    model_changes.val += 1
+    model_changes += 1
     let generation_before = pane_commit.committed_generation
     commit_diff_editor_model_pair_transaction(pane_commit, () => {
       commit_diff_editor_model_pair(
@@ -784,14 +784,14 @@ test "one model will-dispose atomically clears the pair and both pane slots" {
             pane_commit.committed_generation != generation_before {
             abort("original setter escaped the pair commit barrier")
           }
-          original_slot.val = model
+          original_slot = model
         },
         model => {
           if !pane_commit.is_committing ||
             pane_commit.committed_generation != generation_before {
             abort("modified setter observed an early committed generation")
           }
-          modified_slot.val = model
+          modified_slot = model
         },
       )
     })
@@ -800,9 +800,9 @@ test "one model will-dispose atomically clears the pair and both pane slots" {
     if pane_commit.is_committing {
       abort("outer diff update escaped before both pane setters committed")
     }
-    update_count.val += 1
+    update_count += 1
     let synchronized = match
-      (view_model.get_model(), original_slot.val, modified_slot.val) {
+      (view_model.get_model(), original_slot, modified_slot) {
       (None, None, None) => true
       (Some(current), Some(slot_original), Some(slot_modified)) =>
         current.original.same(slot_original) &&
@@ -810,12 +810,12 @@ test "one model will-dispose atomically clears the pair and both pane slots" {
       _ => false
     }
     if !synchronized {
-      every_update_saw_synchronized_slots.val = false
+      every_update_saw_synchronized_slots = false
     }
   })
 
   view_model.set_model(Some({ original, modified, })) |> ignore
-  guard (original_slot.val, modified_slot.val)
+  guard (original_slot, modified_slot)
     is (Some(installed_original), Some(installed_modified)) else {
     fail("both pane slots must receive the installed pair")
   }
@@ -834,14 +834,14 @@ test "one model will-dispose atomically clears the pair and both pane slots" {
   assert_true(view_model.get_model() is None)
   assert_true(view_model.get_state() == NoModel)
   assert_true(view_model.get_diff() is None)
-  assert_true(original_slot.val is None)
-  assert_true(modified_slot.val is None)
+  assert_true(original_slot is None)
+  assert_true(modified_slot is None)
   assert_true(timer.active_delays().is_empty())
-  assert_eq(model_changes.val, 2)
+  assert_eq(model_changes, 2)
   assert_false(pane_commit.is_committing)
   assert_eq(pane_commit.committed_generation, 2)
-  assert_eq(update_count.val, 4)
-  assert_true(every_update_saw_synchronized_slots.val)
+  assert_eq(update_count, 4)
+  assert_true(every_update_saw_synchronized_slots)
   assert_true(original.is_disposed())
   assert_false(modified.is_disposed())
 
@@ -897,13 +897,13 @@ test "replacement owns the only detached-pair return and old disposal is inert" 
   let first_modified = diff_view_model_test_model("replace-count-modified", "b")
   let next_original = diff_view_model_test_model("replace-next-original", "c")
   let next_modified = diff_view_model_test_model("replace-next-modified", "d")
-  let first_original_disposes = Ref(0)
-  let first_modified_disposes = Ref(0)
+  let mut first_original_disposes = 0
+  let mut first_modified_disposes = 0
   let original_dispose_subscription = first_original.on_will_dispose(() => {
-    first_original_disposes.val += 1
+    first_original_disposes += 1
   })
   let modified_dispose_subscription = first_modified.on_will_dispose(() => {
-    first_modified_disposes.val += 1
+    first_modified_disposes += 1
   })
 
   view_model.set_model(
@@ -924,8 +924,8 @@ test "replacement owns the only detached-pair return and old disposal is inert" 
   assert_true(timer.active_delays() == [0])
   returned.original.dispose()
   returned.modified.dispose()
-  assert_eq(first_original_disposes.val, 1)
-  assert_eq(first_modified_disposes.val, 1)
+  assert_eq(first_original_disposes, 1)
+  assert_eq(first_modified_disposes, 1)
 
   // Disposal of a pair whose subscriptions were retired cannot clear the new
   // pair, and even an explicitly invoked stale callback cannot compute it.

--- a/editor/internal/viewer/markdown/markdown_wbtest.mbt
+++ b/editor/internal/viewer/markdown/markdown_wbtest.mbt
@@ -26,12 +26,12 @@ test "conversion failure becomes one escaped plaintext paragraph" {
 
 ///|
 test "code override receives MoonBit DTO, fence language, and active language" {
-  let observed_code = Ref("")
-  let observed_fence = Ref("")
-  let observed_info = Ref("")
-  let observed_remainder = Ref("")
-  let observed_source_line = Ref(0)
-  let observed_active = Ref("")
+  let mut observed_code = ""
+  let mut observed_fence = ""
+  let mut observed_info = ""
+  let mut observed_remainder = ""
+  let mut observed_source_line = 0
+  let mut observed_active = ""
   let rendered = render_markdown(
     (
       #|```mbt extra
@@ -40,21 +40,21 @@ test "code override receives MoonBit DTO, fence language, and active language" {
     ),
     language_id="moonbit",
     code_block_renderer=fn(block, active_language_id) {
-      observed_code.val = block.code
-      observed_fence.val = block.language_id.unwrap_or("")
-      observed_info.val = block.full_info_string.unwrap_or("")
-      observed_remainder.val = block.info_remainder.unwrap_or("")
-      observed_source_line.val = block.code_lines[0].source_line_number
-      observed_active.val = active_language_id.unwrap_or("")
+      observed_code = block.code
+      observed_fence = block.language_id.unwrap_or("")
+      observed_info = block.full_info_string.unwrap_or("")
+      observed_remainder = block.info_remainder.unwrap_or("")
+      observed_source_line = block.code_lines[0].source_line_number
+      observed_active = active_language_id.unwrap_or("")
       "<pre data-rendered=\"yes\">override</pre>"
     },
   )
-  assert_eq(observed_code.val, "let answer = 42\n")
-  assert_eq(observed_fence.val, "mbt")
-  assert_eq(observed_info.val, "mbt extra")
-  assert_eq(observed_remainder.val, "extra")
-  assert_eq(observed_source_line.val, 2)
-  assert_eq(observed_active.val, "moonbit")
+  assert_eq(observed_code, "let answer = 42\n")
+  assert_eq(observed_fence, "mbt")
+  assert_eq(observed_info, "mbt extra")
+  assert_eq(observed_remainder, "extra")
+  assert_eq(observed_source_line, 2)
+  assert_eq(observed_active, "moonbit")
   assert_eq(rendered.html, "<pre data-rendered=\"yes\">override</pre>")
   assert_true(rendered.has_code_block)
   assert_eq(rendered.projection.code_blocks.length(), 1)

--- a/editor/internal/viewer/markdown_viewer/markdown_viewer_definition.mbt
+++ b/editor/internal/viewer/markdown_viewer/markdown_viewer_definition.mbt
@@ -53,15 +53,15 @@ fn MarkdownViewerWidgetDefinitionBridge::MarkdownViewerWidgetDefinitionBridge(
   model : @model.TextModel,
   attach_generation : Int,
 ) -> MarkdownViewerWidgetDefinitionBridge {
-  let bridge_slot : Ref[MarkdownViewerWidgetDefinitionBridge?] = Ref(None)
+  let mut bridge_slot : MarkdownViewerWidgetDefinitionBridge? = None
   let anchor_is_current = anchor => {
-    bridge_slot.val.map_or(false, bridge => bridge.anchor_is_current(anchor))
+    bridge_slot.map_or(false, bridge => bridge.anchor_is_current(anchor))
   }
   let navigation_action = @goto_symbol.SymbolNavigationAction(
     viewer.services.languages(),
     {
       prepare_navigation: () => {
-        if bridge_slot.val is Some(bridge) {
+        if bridge_slot is Some(bridge) {
           bridge.prepare_navigation()
         }
       },
@@ -69,18 +69,18 @@ fn MarkdownViewerWidgetDefinitionBridge::MarkdownViewerWidgetDefinitionBridge(
       // `open_location` is async, so its body stays a match rather than moving
       // into a non-async `map_or` closure.
       open_location: (_anchor, location, mode, _source) => {
-        match bridge_slot.val {
+        match bridge_slot {
           Some(bridge) => bridge.open_location(location, mode)
           None => false
         }
       },
       open_in_peek: (anchor, mode, locations) => {
-        bridge_slot.val.map_or(false, bridge => {
+        bridge_slot.map_or(false, bridge => {
           bridge.open_in_peek(anchor, mode, locations)
         })
       },
       show_message: (_anchor, message) => {
-        if bridge_slot.val is Some(bridge) {
+        if bridge_slot is Some(bridge) {
           bridge.show_message(message)
         }
       },
@@ -99,10 +99,10 @@ fn MarkdownViewerWidgetDefinitionBridge::MarkdownViewerWidgetDefinitionBridge(
         {
           is_anchor_current: anchor_is_current,
           mount: (root, anchor) => {
-            bridge_slot.val.bind(bridge => bridge.mount_peek(root, anchor))
+            bridge_slot.bind(bridge => bridge.mount_peek(root, anchor))
           },
           reveal_anchor: anchor => {
-            if bridge_slot.val is Some(bridge) {
+            if bridge_slot is Some(bridge) {
               bridge.reveal_anchor(anchor)
             }
           },
@@ -110,13 +110,13 @@ fn MarkdownViewerWidgetDefinitionBridge::MarkdownViewerWidgetDefinitionBridge(
           // `open_location` is async, so its body stays a match rather than
           // moving into a non-async `map_or` closure.
           open_location: (location, mode, _source) => {
-            match bridge_slot.val {
+            match bridge_slot {
               Some(bridge) => bridge.open_location(location, mode)
               None => false
             }
           },
           show_message: (_anchor, message) => {
-            if bridge_slot.val is Some(bridge) {
+            if bridge_slot is Some(bridge) {
               bridge.show_message(message)
             }
           },
@@ -147,7 +147,7 @@ fn MarkdownViewerWidgetDefinitionBridge::MarkdownViewerWidgetDefinitionBridge(
     active: false,
     disposed: false,
   }
-  bridge_slot.val = Some(bridge)
+  bridge_slot = Some(bridge)
   bridge
 }
 

--- a/editor/internal/viewer/markdown_viewer/markdown_viewer_wbtest.mbt
+++ b/editor/internal/viewer/markdown_viewer/markdown_viewer_wbtest.mbt
@@ -31,16 +31,16 @@ test "MarkdownViewerWidget detaches the returned old model before set_model retu
     first.dispose()
     second.dispose()
   }
-  let detached_after_cleanup = Ref(false)
+  let mut detached_after_cleanup = false
   let detach_count = Ref(0)
   let detach_listener = viewer.on_did_detach_for_diagnostics(() => {
     detach_count.val += 1
-    detached_after_cleanup.val = viewer.current is None
+    detached_after_cleanup = viewer.current is None
   })
   defer detach_listener.dispose()
-  let content_deliveries = Ref(0)
+  let mut content_deliveries = 0
   let content_listener = viewer.on_did_change_model_content(_ => {
-    content_deliveries.val += 1
+    content_deliveries += 1
   })
   defer content_listener.dispose()
   assert_true(
@@ -54,14 +54,14 @@ test "MarkdownViewerWidget detaches the returned old model before set_model retu
   assert_true(returned.model.same(first))
   assert_true(returned.resource_kind == MoonBitMarkdown)
   assert_eq(detach_count.val, 1)
-  assert_true(detached_after_cleanup.val)
+  assert_true(detached_after_cleanup)
   guard viewer.current is Some(current) else { fail("expected replacement") }
   assert_true(current.model.model.same(second))
   assert_true(current.model.resource_kind == OrdinaryMarkdown)
   first.set_value("detached change")
-  assert_eq(content_deliveries.val, 0)
+  assert_eq(content_deliveries, 0)
   second.set_value("# replacement changed")
-  assert_eq(content_deliveries.val, 1)
+  assert_eq(content_deliveries, 1)
 }
 
 ///|

--- a/editor/language/cancellation_reference_test.mbt
+++ b/editor/language/cancellation_reference_test.mbt
@@ -91,17 +91,17 @@ test "cancel happens only once" {
   let source = @language.CancellationTokenSource()
   let token = source.token()
   assert_false(token.is_cancellation_requested())
-  let cancel_count = Ref(0)
-  let observed_cancelled = Ref(false)
+  let mut cancel_count = 0
+  let mut observed_cancelled = false
   token.on_cancellation_requested(() => {
-    observed_cancelled.val = token.is_cancellation_requested()
-    cancel_count.val += 1
+    observed_cancelled = token.is_cancellation_requested()
+    cancel_count += 1
   })
   |> ignore
   source.cancel()
   source.cancel()
-  assert_eq(cancel_count.val, 1)
-  assert_true(observed_cancelled.val)
+  assert_eq(cancel_count, 1)
+  assert_true(observed_cancelled)
 }
 
 ///|

--- a/editor/server/host/freshness_wbtest.mbt
+++ b/editor/server/host/freshness_wbtest.mbt
@@ -78,19 +78,17 @@ async test "native hover requires exact disk state and runs ordinary moon ide ho
       Ref(root),
       moon_command="unused",
     )
-    let seen : Ref[Array[String]] = Ref([])
+    let mut seen : Array[String] = []
     let hover = provider.provide_hover_with_runner(model, Position(1, 8), (
       _root,
       args,
     ) => {
-      seen.val = args
+      seen = args
       Some((0, hover_test_output()))
     })
     assert_true(hover is Some(_))
-    assert_eq(seen.val, [
-      "ide", "hover", "--loc", "main.mbt:1:8", "--output-json",
-    ])
-    assert_false(seen.val.contains("--no-check"))
+    assert_eq(seen, ["ide", "hover", "--loc", "main.mbt:1:8", "--output-json"])
+    assert_false(seen.contains("--no-check"))
   }
 }
 
@@ -611,12 +609,12 @@ async test "moon check schedule restores running after collector failure" {
   }
   @async.with_task_group() <| group => {
     let task = group.spawn(() => run(), allow_failure=true)
-    let caught = Ref(false)
+    let mut caught = false
     task.wait() catch {
-      CheckCollectorFailure => caught.val = true
+      CheckCollectorFailure => caught = true
       _ => ()
     }
-    assert_true(caught.val)
+    assert_true(caught)
     assert_false(diagnostics.running.val)
   }
 }
@@ -643,11 +641,11 @@ async test "moon check schedule restores running after cancellation" {
     let task = group.spawn(() => run(), allow_failure=true)
     started.get()
     task.cancel()
-    let cancelled = Ref(false)
+    let mut cancelled = false
     task.wait() catch {
-      error => cancelled.val = @async.is_cancellation_error(error)
+      error => cancelled = @async.is_cancellation_error(error)
     }
-    assert_true(cancelled.val)
+    assert_true(cancelled)
     assert_false(diagnostics.running.val)
   }
 }

--- a/editor/syntax/tokenizer_test.mbt
+++ b/editor/syntax/tokenizer_test.mbt
@@ -145,19 +145,19 @@ test "registry replacement makes stale dispose inert and active dispose notifies
   let registry = @syntax.TokenizationRegistry()
   let changed_languages : Array[Array[String]] = []
   let color_flags : Array[Bool] = []
-  let support_visible_when_registered = Ref(false)
+  let mut support_visible_when_registered = false
   registry.on_did_change(event => {
     changed_languages.push(event.changed_languages)
     color_flags.push(event.changed_color_map)
     if changed_languages.length() == 1 {
-      support_visible_when_registered.val = registry.get("toy") is Some(_)
+      support_visible_when_registered = registry.get("toy") is Some(_)
     }
   })
   |> ignore
 
   let stale = registry.register("toy", BlockCommentToy::{ })
   let active = registry.register("toy", BlockCommentToy::{ })
-  assert_true(support_visible_when_registered.val)
+  assert_true(support_visible_when_registered)
   assert_eq(changed_languages.length(), 2)
   assert_false(color_flags[0])
   assert_false(color_flags[1])

--- a/editor/tests/browser/moonbit/agent_feedback/agent_feedback_scenario.mbt
+++ b/editor/tests/browser/moonbit/agent_feedback/agent_feedback_scenario.mbt
@@ -36,25 +36,24 @@ pub fn run_agent_feedback_test() -> Unit {
       let replies = Ref(0)
       let submitted = Ref(0)
       let items = Ref(0)
-      let last_text : Ref[String] = Ref("")
-      let previous_items : Ref[
-        Array[(String, @agent_feedback_api.AgentFeedbackState, Int)],
-      ] = Ref([])
-      let track_interactions = Ref(false)
+      let mut last_text : String = ""
+      let mut previous_items : Array[
+        (String, @agent_feedback_api.AgentFeedbackState, Int),
+      ] = []
+      let mut track_interactions = false
       let write_log = () => {
         event_log.set_attribute("data-added", added.val.to_string())
         event_log.set_attribute("data-replies", replies.val.to_string())
         event_log.set_attribute("data-submitted", submitted.val.to_string())
         event_log.set_attribute("data-items", items.val.to_string())
-        event_log.set_attribute("data-last-text", last_text.val)
+        event_log.set_attribute("data-last-text", last_text)
       }
       feedback_handle.on_did_change_feedback(event => {
-        if track_interactions.val {
+        if track_interactions {
           for item in event.feedback_items {
-            match
-              previous_items.val.search_by(snapshot => snapshot.0 == item.id) {
+            match previous_items.search_by(snapshot => snapshot.0 == item.id) {
               Some(index) => {
-                let (_, previous_state, previous_reply_count) = previous_items.val[index]
+                let (_, previous_state, previous_reply_count) = previous_items[index]
                 if item.replies.length() > previous_reply_count {
                   replies.val += item.replies.length() - previous_reply_count
                 }
@@ -67,11 +66,11 @@ pub fn run_agent_feedback_test() -> Unit {
           }
         }
         items.val = event.feedback_items.length()
-        last_text.val = match event.feedback_items.last() {
+        last_text = match event.feedback_items.last() {
           Some(item) => item.text
-          None => last_text.val
+          None => last_text
         }
-        previous_items.val = event.feedback_items.map(item => {
+        previous_items = event.feedback_items.map(item => {
           (item.id, item.state, item.replies.length())
         })
         write_log()
@@ -86,7 +85,7 @@ pub fn run_agent_feedback_test() -> Unit {
         seed_item("seed-2", uri, 5, "Second seeded note"),
         seed_item("seed-far", uri, 30, "Far seeded note"),
       ])
-      track_interactions.val = true
+      track_interactions = true
       let viewer = @viewer.Viewer::create(
         host,
         services~,

--- a/editor/tests/browser/moonbit/base_browser/base_browser_scenario.mbt
+++ b/editor/tests/browser/moonbit/base_browser/base_browser_scenario.mbt
@@ -285,7 +285,7 @@ fn setup_pointer_lifecycle_fixture(
   let moves = Ref(0)
   let stops = Ref(0)
   let starts = Ref(0)
-  let active_pointer : Ref[(Int, Int)?] = Ref(None)
+  let mut active_pointer : (Int, Int)? = None
   let start = (pointer_id : Int, buttons : Int) => {
     starts.val += 1
     target.set_attribute("data-starts", starts.val.to_string())
@@ -306,7 +306,7 @@ fn setup_pointer_lifecycle_fixture(
   target.add_event_listener("pointerdown", event => {
     let pointer_id = pointer_event_pointer_id(event)
     let buttons = pointer_event_buttons(event)
-    active_pointer.val = Some((pointer_id, buttons))
+    active_pointer = Some((pointer_id, buttons))
     target.set_attribute("data-pointer-id", pointer_id.to_string())
     start(pointer_id, buttons)
     target.set_attribute(
@@ -318,7 +318,7 @@ fn setup_pointer_lifecycle_fixture(
   restart.set_attribute("id", "pointer-restart")
   restart.set_inner_html("Restart monitor")
   restart.add_event_listener("click", _ => {
-    match active_pointer.val {
+    match active_pointer {
       Some((pointer_id, buttons)) => start(pointer_id, buttons)
       None => ()
     }

--- a/editor/tests/browser/moonbit/component/diff_markdown_comments_scenario.mbt
+++ b/editor/tests/browser/moonbit/component/diff_markdown_comments_scenario.mbt
@@ -206,7 +206,7 @@ pub fn run_diff_markdown_comments_test() -> Unit {
     ),
   )
   let content_height_event_count = Ref(0)
-  let auto_height_enabled = Ref(false)
+  let mut auto_height_enabled = false
   let apply_content_height = content_height => {
     if content_height <= 0.0 {
       return
@@ -220,7 +220,7 @@ pub fn run_diff_markdown_comments_test() -> Unit {
   }
   diff_editor.on_did_change_content_height(content_height => {
     content_height_event_count.val += 1
-    if auto_height_enabled.val {
+    if auto_height_enabled {
       apply_content_height(content_height)
     }
   })
@@ -308,7 +308,7 @@ pub fn run_diff_markdown_comments_test() -> Unit {
       )
     },
     () => {
-      auto_height_enabled.val = true
+      auto_height_enabled = true
       apply_content_height(diff_editor.get_content_height())
     },
     () => content_height_event_count.val,

--- a/editor/tests/browser/moonbit/component/initial_size_scenario.mbt
+++ b/editor/tests/browser/moonbit/component/initial_size_scenario.mbt
@@ -30,10 +30,10 @@ pub fn run_initial_size_test() -> Unit {
     host,
     options=ViewerOptions(soft_wrap=false, font_size=12.0, line_height=18.0),
   )
-  let rendered_notifications = Ref(0)
+  let mut rendered_notifications = 0
   let rendered_subscription = @viewer_testing.on_did_render_model(
     viewer.get_id(),
-    _ => rendered_notifications.val += 1,
+    _ => rendered_notifications += 1,
   )
   let initial_layout = viewer.get_layout_info()
   ctx.metric_number("initialLayoutWidth", initial_layout.width)
@@ -74,7 +74,7 @@ pub fn run_initial_size_test() -> Unit {
   viewer.handle_initialized()
   initial_size_next_frame(() => {
     ctx.assert_true(
-      rendered_notifications.val > 0,
+      rendered_notifications > 0,
       "the first mounted flush did not render the attached model",
     )
     rendered_subscription.dispose()

--- a/editor/tests/browser/moonbit/component/markdown_document_scenario.mbt
+++ b/editor/tests/browser/moonbit/component/markdown_document_scenario.mbt
@@ -372,7 +372,7 @@ pub fn run_markdown_document_test() -> Unit {
   |> ignore
   viewer.handle_initialized()
   secondary_viewer.handle_initialized()
-  let code_viewer : Ref[@viewer.Viewer?] = Ref(None)
+  let mut code_viewer : @viewer.Viewer? = None
   install_markdown_document_controls(
     () => markdown_model.get_value(),
     () => markdown_model.set_value(markdown_document_diagram_source()),
@@ -392,13 +392,13 @@ pub fn run_markdown_document_test() -> Unit {
       )
       code.set_model(Some(code_model))
       code.handle_initialized()
-      code_viewer.val = Some(code)
+      code_viewer = Some(code)
     },
     () => {
-      match code_viewer.val {
+      match code_viewer {
         Some(code) => {
           code.dispose()
-          code_viewer.val = None
+          code_viewer = None
         }
         None => ()
       }
@@ -439,13 +439,13 @@ pub fn run_markdown_document_test() -> Unit {
     width => {
       host.set_attribute("style", "height:220px;width:\{width}px;")
       viewer.layout()
-      match code_viewer.val {
+      match code_viewer {
         Some(code) => code.layout()
         None => ()
       }
     },
     () => {
-      match code_viewer.val {
+      match code_viewer {
         Some(code) => code.dispose()
         None => ()
       }

--- a/editor/tests/browser/moonbit/component/render_invalidation_scenario.mbt
+++ b/editor/tests/browser/moonbit/component/render_invalidation_scenario.mbt
@@ -145,8 +145,8 @@ pub fn run_render_invalidation_test() -> Unit {
     },
   ])
   |> ignore
-  let spacing_ids : Ref[Array[String]] = Ref([])
-  let token_registration : Ref[@base_common.Disposable?] = Ref(None)
+  let mut spacing_ids : Array[String] = []
+  let mut token_registration : @base_common.Disposable? = None
   guard viewer.get_dom_node() is Some(root) else {
     ctx.fail("viewer did not expose its root DOM node")
     ctx.finish()
@@ -184,10 +184,10 @@ pub fn run_render_invalidation_test() -> Unit {
       )
     },
     () => {
-      if spacing_ids.val.length() > 0 {
-        viewer.remove_decorations(spacing_ids.val)
+      if spacing_ids.length() > 0 {
+        viewer.remove_decorations(spacing_ids)
       }
-      spacing_ids.val = viewer.delta_decorations([], [
+      spacing_ids = viewer.delta_decorations([], [
         {
           range: Range(1, 1, 1, 7),
           options: ModelDecorationOptions(
@@ -200,16 +200,16 @@ pub fn run_render_invalidation_test() -> Unit {
       ])
     },
     () => {
-      viewer.remove_decorations(spacing_ids.val)
-      spacing_ids.val = []
+      viewer.remove_decorations(spacing_ids)
+      spacing_ids = []
     },
     () => render_invalidation_position_json(viewer),
     () => viewer.focus(),
     () => {
-      if token_registration.val is Some(registration) {
+      if token_registration is Some(registration) {
         registration.dispose()
       }
-      token_registration.val = Some(
+      token_registration = Some(
         languages.set_tokens_provider("plaintext", RenderInvalidationTokenizer::{
         }),
       )

--- a/editor/tests/browser/moonbit/component/view_zones_scenario.mbt
+++ b/editor/tests/browser/moonbit/component/view_zones_scenario.mbt
@@ -52,23 +52,23 @@ pub fn run_view_zones_test() -> Unit {
     view_zones_source(),
   )
   let viewer = @viewer.Viewer::create(host)
-  let public_mouse_events = Ref(0)
-  let public_mouse_target_id = Ref("")
-  let public_mouse_target_kind = Ref("other")
+  let mut public_mouse_events = 0
+  let mut public_mouse_target_id = ""
+  let mut public_mouse_target_kind = "other"
   viewer.on_mouse_down(event => {
-    public_mouse_events.val += 1
+    public_mouse_events += 1
     match event.target {
       MouseTargetViewZone(type_~, detail~, ..) => {
-        public_mouse_target_id.val = detail.view_zone_id
-        public_mouse_target_kind.val = match type_ {
+        public_mouse_target_id = detail.view_zone_id
+        public_mouse_target_kind = match type_ {
           ContentViewZone => "content"
           GutterViewZone => "gutter"
           _ => "other"
         }
       }
       _ => {
-        public_mouse_target_id.val = ""
-        public_mouse_target_kind.val = "other"
+        public_mouse_target_id = ""
+        public_mouse_target_kind = "other"
       }
     }
   })
@@ -97,7 +97,7 @@ pub fn run_view_zones_test() -> Unit {
   primary_margin.set_attribute("data-caller-owned", "margin")
   primary_margin.set_inner_html("preserved margin content")
 
-  let primary_last_top = Ref(-2000000.0)
+  let mut primary_last_top = -2000000.0
   let primary = @viewer.view_zone(
     1,
     primary_node,
@@ -105,7 +105,7 @@ pub fn run_view_zones_test() -> Unit {
     height_in_px=32.0,
     min_width_in_px=700.0,
     margin_dom_node=primary_margin,
-    on_dom_node_top=top => primary_last_top.val = top,
+    on_dom_node_top=top => primary_last_top = top,
   )
 
   let secondary_node = document.create_element("div")
@@ -141,22 +141,22 @@ pub fn run_view_zones_test() -> Unit {
   let offscreen_node = document.create_element("div")
   offscreen_node.set_attribute("class", "vz-offscreen")
   offscreen_node.set_inner_html("offscreen view zone")
-  let offscreen_last_top = Ref(-2000000.0)
+  let mut offscreen_last_top = -2000000.0
   let offscreen_zone = @viewer.view_zone(
     40,
     offscreen_node,
     height_in_px=28.0,
-    on_dom_node_top=top => offscreen_last_top.val = top,
+    on_dom_node_top=top => offscreen_last_top = top,
   )
 
-  let primary_id = Ref("")
-  let suppress_id = Ref("")
-  let omitted_id = Ref("")
+  let mut primary_id = ""
+  let mut suppress_id = ""
+  let mut omitted_id = ""
   viewer.change_view_zones(accessor => {
-    primary_id.val = accessor.add_zone(primary)
+    primary_id = accessor.add_zone(primary)
     accessor.add_zone(secondary) |> ignore
-    suppress_id.val = accessor.add_zone(suppress_zone)
-    omitted_id.val = accessor.add_zone(omitted_zone)
+    suppress_id = accessor.add_zone(suppress_zone)
+    omitted_id = accessor.add_zone(omitted_zone)
     accessor.add_zone(offscreen_zone) |> ignore
   })
 
@@ -174,14 +174,14 @@ pub fn run_view_zones_test() -> Unit {
     () => {
       let layout = viewer.get_layout_info()
       Json({
-        "primaryId": primary_id.val.to_json(),
-        "suppressId": suppress_id.val.to_json(),
-        "omittedId": omitted_id.val.to_json(),
-        "mouseEvents": public_mouse_events.val.to_json(),
-        "mouseTargetId": public_mouse_target_id.val.to_json(),
-        "mouseTargetKind": public_mouse_target_kind.val.to_json(),
-        "primaryLastTop": Json::number(primary_last_top.val),
-        "offscreenLastTop": Json::number(offscreen_last_top.val),
+        "primaryId": primary_id.to_json(),
+        "suppressId": suppress_id.to_json(),
+        "omittedId": omitted_id.to_json(),
+        "mouseEvents": public_mouse_events.to_json(),
+        "mouseTargetId": public_mouse_target_id.to_json(),
+        "mouseTargetKind": public_mouse_target_kind.to_json(),
+        "primaryLastTop": Json::number(primary_last_top),
+        "offscreenLastTop": Json::number(offscreen_last_top),
         "scrollTop": Json::number(viewer.get_scroll_top()),
         "scrollWidth": Json::number(viewer.get_scroll_width()),
         "contentWidth": Json::number(viewer.get_content_width()),

--- a/editor/tests/browser/moonbit/component/viewer_api_scenario.mbt
+++ b/editor/tests/browser/moonbit/component/viewer_api_scenario.mbt
@@ -103,13 +103,10 @@ pub fn run_viewer_api_test() -> Unit {
           placeholder="Loading component fixture...",
         ),
       )
-      let scroll_event_count = Ref(0)
+      let mut scroll_event_count = 0
       viewer.on_did_scroll_change(event => {
-        scroll_event_count.val += 1
-        host.set_attribute(
-          "data-scroll-events",
-          scroll_event_count.val.to_string(),
-        )
+        scroll_event_count += 1
+        host.set_attribute("data-scroll-events", scroll_event_count.to_string())
         host.set_attribute("data-scroll-top", event.scroll_top.to_string())
       })
       |> ignore

--- a/editor/viewer/browser/diagram_viewport/diagram_viewport.mbt
+++ b/editor/viewer/browser/diagram_viewport/diagram_viewport.mbt
@@ -300,18 +300,18 @@ fn mount_diagram_viewport(
   fill_container : Bool,
 ) -> DiagramViewportMountResult {
   guard direct_svg_child(wrapper) is Some(svg) else { return Skipped }
-  let result : Ref[DiagramViewportMountResult] = Ref(Skipped)
+  let mut result : DiagramViewportMountResult = Skipped
   let found = with_diagram_viewport_environment(wrapper, fallback_target, (
     owner_document,
     owner_window,
   ) => {
-    result.val = mount_diagram_viewport_in_environment(
+    result = mount_diagram_viewport_in_environment(
       wrapper, svg, owner_document, owner_window, on_size_changed, schedule_frame,
       fill_container,
     )
   })
   if found {
-    result.val
+    result
   } else {
     Skipped
   }
@@ -443,15 +443,15 @@ fn mount_diagram_viewport_in_environment(
     controller.dispose()
     return Failed
   }
-  let frame_pending = Ref(true)
+  let mut frame_pending = true
   let cancel_frame = schedule_frame(() => {
-    frame_pending.val = false
+    frame_pending = false
     controller.pending_frame = None
     if controller.active {
       controller.layout() |> ignore
     }
   })
-  if frame_pending.val {
+  if frame_pending {
     controller.pending_frame = Some(cancel_frame)
   } else {
     cancel_frame()
@@ -1108,7 +1108,7 @@ fn MarkdownDiagramViewport::acquire_body_cursor(
   if self.body_cursor_lease is Some(_) {
     return false
   }
-  let acquired = Ref(false)
+  let mut acquired = false
   with_document_body(self.owner_document, body => {
     let coordinator = body_cursor_coordinator_for(self.owner_document)
     if coordinator.active {
@@ -1123,10 +1123,10 @@ fn MarkdownDiagramViewport::acquire_body_cursor(
     }
     @base_browser.set_style_property(body, "cursor", "ns-resize")
     self.body_cursor_lease = Some(lease)
-    acquired.val = true
+    acquired = true
   })
   |> ignore
-  acquired.val
+  acquired
 }
 
 ///|

--- a/editor/viewer/common/diff/default_lines_diff_computer_wbtest.mbt
+++ b/editor/viewer/common/diff/default_lines_diff_computer_wbtest.mbt
@@ -47,10 +47,10 @@ test "Line provider satisfies the public provider contract" {
   )
   assert_eq(result.changes.length(), 1)
 
-  let notifications = Ref(0)
-  let subscription = provider.on_did_change(() => notifications.val += 1)
+  let mut notifications = 0
+  let subscription = provider.on_did_change(() => notifications += 1)
   subscription.dispose()
-  assert_eq(notifications.val, 0)
+  assert_eq(notifications, 0)
 }
 
 ///|

--- a/editor/viewer/common/markers/marker_decorations_lifecycle_wbtest.mbt
+++ b/editor/viewer/common/markers/marker_decorations_lifecycle_wbtest.mbt
@@ -162,10 +162,10 @@ test "reentrant marker updates drain after the active decoration delta" {
   let service = MarkerDecorationsService(markers.marker_service_handle())
   let model = lifecycle_model(uri, "nested-update.mbt", "alpha")
   let lease = service.acquire_model(model)
-  let reentered = Ref(false)
+  let mut reentered = false
   let model_subscription = model.on_did_change_decorations(_ => {
-    if !reentered.val {
-      reentered.val = true
+    if !reentered {
+      reentered = true
       markers.change_one("host", uri, [lifecycle_marker("nested")])
       // MicrotaskEmitter deliberately drops an event re-fired during its own
       // flush. Invoke the same service ingress directly to exercise the
@@ -173,14 +173,14 @@ test "reentrant marker updates drain after the active decoration delta" {
       service.handle_marker_change([uri])
     }
   })
-  let outward_events = Ref(0)
+  let mut outward_events = 0
   let outward_subscription = service.on_did_change_marker_decorations(_ => {
-    outward_events.val += 1
+    outward_events += 1
   })
 
   markers.change_one("host", uri, [lifecycle_marker("outer")])
-  assert_true(reentered.val)
-  assert_eq(outward_events.val, 2)
+  assert_true(reentered)
+  assert_eq(outward_events, 2)
   assert_eq(marker_model_decorations(model).length(), 1)
   let live = service.get_live_markers_for_model(model)
   assert_eq(live.length(), 1)

--- a/editor/viewer/common/model/abstract_syntax_token_backend_wbtest.mbt
+++ b/editor/viewer/common/model/abstract_syntax_token_backend_wbtest.mbt
@@ -87,26 +87,26 @@ test "AttachedViews preserves identity and emits committed and absent states" {
 test "AttachedViewHandler debounces unstable state and stable state cancels then refreshes" {
   let delayed : Array[ScheduledCallback] = []
   let scheduler = deterministic_scheduler(delayed)
-  let refresh_count = Ref(0)
-  let handler = AttachedViewHandler(() => refresh_count.val += 1, () => {
+  let mut refresh_count = 0
+  let handler = AttachedViewHandler(() => refresh_count += 1, () => {
     Some(scheduler)
   })
   handler.handle_state_change(AttachedViewState([LineRange(1, 3)], false))
   assert_eq(delayed.length(), 1)
-  assert_eq(refresh_count.val, 0)
+  assert_eq(refresh_count, 0)
   handler.handle_state_change(AttachedViewState([LineRange(2, 4)], false))
   assert_eq(delayed.length(), 2)
   run_scheduled(delayed[0])
-  assert_eq(refresh_count.val, 0)
+  assert_eq(refresh_count, 0)
   run_scheduled(delayed[1])
-  assert_eq(refresh_count.val, 1)
+  assert_eq(refresh_count, 1)
   handler.handle_state_change(AttachedViewState([LineRange(5, 7)], false))
   assert_eq(delayed.length(), 3)
   handler.handle_state_change(AttachedViewState([LineRange(5, 7)], true))
-  assert_eq(refresh_count.val, 2)
+  assert_eq(refresh_count, 2)
   run_scheduled(delayed[2])
-  assert_eq(refresh_count.val, 2)
+  assert_eq(refresh_count, 2)
   // Equal requested/computed ranges suppress a repeated stable refresh.
   handler.handle_state_change(AttachedViewState([LineRange(5, 7)], true))
-  assert_eq(refresh_count.val, 2)
+  assert_eq(refresh_count, 2)
 }

--- a/editor/viewer/common/model/default_background_tokenizer_wbtest.mbt
+++ b/editor/viewer/common/model/default_background_tokenizer_wbtest.mbt
@@ -27,8 +27,8 @@ fn worker_scheduler_harness() -> WorkerSchedulerHarness {
   let idle : Array[WorkerIdleTask] = []
   let zero : Array[WorkerZeroTask] = []
   let now_values : Array[Double] = []
-  let now_index = Ref(0)
-  let fallback_now = Ref(0.0)
+  let mut now_index = 0
+  let fallback_now = 0.0
   let before_next_now : Ref[(() -> Unit)?] = Ref(None)
   let trace : Array[String] = []
   let scheduler = TokenizationScheduler(
@@ -59,12 +59,12 @@ fn worker_scheduler_harness() -> WorkerSchedulerHarness {
         }
         None => ()
       }
-      let value = if now_index.val < now_values.length() {
-        let result = now_values[now_index.val]
-        now_index.val += 1
+      let value = if now_index < now_values.length() {
+        let result = now_values[now_index]
+        now_index += 1
         result
       } else {
-        fallback_now.val
+        fallback_now
       }
       trace.push("now")
       value
@@ -192,14 +192,14 @@ test "deadline is read immediately and end time is now plus remaining" {
     let scheduling = worker_scheduler_harness()
     scheduling.now_values.append([10.0, 10.0, 10.0, 12.0, boundary])
     let harness = default_worker_harness(2, 1, scheduling)
-    let deadline_live = Ref(true)
-    let deadline_reads = Ref(0)
-    scheduling.before_next_now.val = Some(() => deadline_live.val = false)
+    let mut deadline_live = true
+    let mut deadline_reads = 0
+    scheduling.before_next_now.val = Some(() => deadline_live = false)
     let deadline = TokenizationIdleDeadline(() => {
-      if !deadline_live.val {
+      if !deadline_live {
         abort("deadline read after leaving its live interval")
       }
-      deadline_reads.val += 1
+      deadline_reads += 1
       scheduling.trace.push("remaining")
       5.0
     })
@@ -207,8 +207,8 @@ test "deadline is read immediately and end time is now plus remaining" {
       deadline,
       harness.worker.generation.val,
     )
-    assert_eq(deadline_reads.val, 1)
-    assert_false(deadline_live.val)
+    assert_eq(deadline_reads, 1)
+    assert_false(deadline_live)
     assert_eq(scheduling.trace[0], "remaining")
     assert_eq(harness.lexer_calls.length(), 1)
     if boundary < 15.0 {

--- a/editor/viewer/common/model/text_model_tokenization_wbtest.mbt
+++ b/editor/viewer/common/model/text_model_tokenization_wbtest.mbt
@@ -128,37 +128,37 @@ test "model listener ownership includes token-part listeners through disposal" {
 ///|
 test "TextModel disposal marks disposed between token part and registered resources" {
   let trace : Array[String] = []
-  let is_disposing = Ref(false)
-  let tokenization_disposed = Ref(false)
-  let is_disposed = Ref(false)
+  let mut is_disposing = false
+  let mut tokenization_disposed = false
+  let mut is_disposed = false
 
   run_text_model_dispose_sequence(
     set_disposing=value => {
       trace.push(
-        "disposing=\{value}:\{is_disposing.val}:\{tokenization_disposed.val}:\{is_disposed.val}",
+        "disposing=\{value}:\{is_disposing}:\{tokenization_disposed}:\{is_disposed}",
       )
-      is_disposing.val = value
+      is_disposing = value
     },
     fire_will_dispose=() => {
       trace.push(
-        "willDispose:\{is_disposing.val}:\{tokenization_disposed.val}:\{is_disposed.val}",
+        "willDispose:\{is_disposing}:\{tokenization_disposed}:\{is_disposed}",
       )
     },
     dispose_tokenization=() => {
       trace.push(
-        "tokenization.dispose:\{is_disposing.val}:\{tokenization_disposed.val}:\{is_disposed.val}",
+        "tokenization.dispose:\{is_disposing}:\{tokenization_disposed}:\{is_disposed}",
       )
-      tokenization_disposed.val = true
+      tokenization_disposed = true
     },
     set_disposed=() => {
       trace.push(
-        "isDisposed=true:\{is_disposing.val}:\{tokenization_disposed.val}:\{is_disposed.val}",
+        "isDisposed=true:\{is_disposing}:\{tokenization_disposed}:\{is_disposed}",
       )
-      is_disposed.val = true
+      is_disposed = true
     },
     dispose_registered_resources=() => {
       trace.push(
-        "super.dispose:\{is_disposing.val}:\{tokenization_disposed.val}:\{is_disposed.val}",
+        "super.dispose:\{is_disposing}:\{tokenization_disposed}:\{is_disposed}",
       )
     },
   )
@@ -167,7 +167,7 @@ test "TextModel disposal marks disposed between token part and registered resour
     trace.join(","),
     "disposing=true:false:false:false,willDispose:true:false:false,tokenization.dispose:true:false:false,isDisposed=true:true:true:false,super.dispose:true:true:true,disposing=false:true:true:true",
   )
-  assert_false(is_disposing.val)
+  assert_false(is_disposing)
 }
 
 ///|
@@ -177,8 +177,8 @@ priv suberror ModelProductionTokenizationError {
 
 ///|
 test "TextModel reports a failing tokenizer and remains live for later reset" {
-  let attempts = Ref(0)
-  let tokenizer_calls = Ref(0)
+  let mut attempts = 0
+  let mut tokenizer_calls = 0
   let (model, reported) = tokenization_model_with_resolver(
     "one\ntwo",
     "text-model-production-error-reporter",
@@ -186,14 +186,14 @@ test "TextModel reports a failing tokenizer and remains live for later reset" {
       Some(
         InternalTokenizationSupportAdapter(
           initial_state=() => {
-            attempts.val += 1
-            if attempts.val == 1 {
+            attempts += 1
+            if attempts == 1 {
               raise ModelProductionTokenizationError::InitialStateFailure
             }
             TokenizerState()
           },
           tokenize_encoded=(_text, _has_eol, _state) => {
-            tokenizer_calls.val += 1
+            tokenizer_calls += 1
             {
               tokens: [0, tag_to_metadata(Plain)],
               end_state: @syntax.TokenizerState().push_mode(b'l'),
@@ -206,7 +206,7 @@ test "TextModel reports a failing tokenizer and remains live for later reset" {
   assert_eq(reported.length(), 1)
   assert_true(reported[0].contains("InitialStateFailure"))
   assert_eq(model.get_value(), "one\ntwo")
-  assert_eq(tokenizer_calls.val, 0)
+  assert_eq(tokenizer_calls, 0)
 
   // A later production flush reacquires support after the reported failure;
   // an attached visible range can then tokenize normally.
@@ -215,8 +215,8 @@ test "TextModel reports a failing tokenizer and remains live for later reset" {
   view.set_visible_lines([{ start_line_number: 1, end_line_number: 2, }], true)
   // One successful reset probes support and then seeds the state store, so
   // the initial-state callback runs twice after the first reported failure.
-  assert_eq(attempts.val, 3)
-  assert_eq(tokenizer_calls.val, 2)
+  assert_eq(attempts, 3)
+  assert_eq(tokenizer_calls, 2)
   assert_eq(model.get_value(), "still\nlive")
   model.on_before_detached(view)
   model.dispose()

--- a/editor/viewer/common/model/tokenizer_syntax_token_backend.mbt
+++ b/editor/viewer/common/model/tokenizer_syntax_token_backend.mbt
@@ -88,16 +88,16 @@ fn TokenizerSyntaxTokenBackend::handle_attached_view_state_change(
       let handler = if existing is Some(index) {
         self.attached_view_states[index].handler
       } else {
-        let holder : Ref[AttachedViewHandler?] = Ref(None)
+        let mut holder : AttachedViewHandler? = None
         let handler = AttachedViewHandler(
           () => {
-            if holder.val is Some(current) {
+            if holder is Some(current) {
               self.refresh_ranges(current.line_ranges())
             }
           },
           () => self.model_state.scheduler.val,
         )
-        holder.val = Some(handler)
+        holder = Some(handler)
         self.attached_view_states.push({ view: change.view, handler, })
         handler
       }

--- a/editor/viewer/common/model/tokenizer_syntax_token_backend_wbtest.mbt
+++ b/editor/viewer/common/model/tokenizer_syntax_token_backend_wbtest.mbt
@@ -94,20 +94,20 @@ test "passive reads never invoke support; stable attached ranges store exact ran
 ///|
 test "too-large and missing support stay passive defaults and schedule nothing" {
   let harness = backend_harness(["one"], too_large=true)
-  let resolves = Ref(0)
+  let mut resolves = 0
   let attached_views = AttachedViews()
   let backend = TokenizerSyntaxTokenBackend::new_with_support_resolver(
     harness.model_state,
     attached_views,
     _ => {
-      resolves.val += 1
+      resolves += 1
       Some(logging_support([], Ref(0)))
     },
   )
-  assert_eq(resolves.val, 0)
+  assert_eq(resolves, 0)
   let view = attached_views.attach_view()
   view.set_visible_lines([{ start_line_number: 1, end_line_number: 1, }], true)
-  assert_eq(resolves.val, 0)
+  assert_eq(resolves, 0)
   assert_eq(backend.get_line_tokens(1).get_count(), 1)
 }
 
@@ -169,13 +169,13 @@ test "disposing guard drops token events from reset and visible refresh" {
     attached_views,
     _ => Some(logging_support([], Ref(0))),
   )
-  let token_events = Ref(0)
-  backend.on_did_change_tokens(_ => token_events.val += 1) |> ignore
+  let mut token_events = 0
+  backend.on_did_change_tokens(_ => token_events += 1) |> ignore
   harness.disposing.val = true
   backend.reset_tokenization()
   let view = attached_views.attach_view()
   view.set_visible_lines([{ start_line_number: 1, end_line_number: 1, }], true)
-  assert_eq(token_events.val, 0)
+  assert_eq(token_events, 0)
 }
 
 ///|

--- a/editor/viewer/common/navigation_api/navigation_api_wbtest.mbt
+++ b/editor/viewer/common/navigation_api/navigation_api_wbtest.mbt
@@ -55,11 +55,11 @@ async test "TextModelResolverHandle forwards resource and cancellation token" {
   let target = try! @base_common.Uri::parse("memory://workspace/target.mbt")
   let model = navigation_test_model(target)
   let release_count = Ref(0)
-  let observed_resource = Ref("")
-  let observed_token : Ref[@language.CancellationToken?] = Ref(None)
+  let mut observed_resource = ""
+  let mut observed_token : @language.CancellationToken? = None
   let resolver = TextModelResolverHandle(resolve=(resource, token) => {
-    observed_resource.val = resource.to_string()
-    observed_token.val = Some(token)
+    observed_resource = resource.to_string()
+    observed_token = Some(token)
     Some(TextModelReference(model, release=() => release_count.val += 1))
   })
   let source = @language.CancellationTokenSource()
@@ -67,8 +67,8 @@ async test "TextModelResolverHandle forwards resource and cancellation token" {
   guard resolver.resolve(target, token) is Some(reference) else {
     fail("resolver did not return its model lease")
   }
-  assert_eq(observed_resource.val, target.to_string())
-  guard observed_token.val is Some(forwarded_token) else {
+  assert_eq(observed_resource, target.to_string())
+  guard observed_token is Some(forwarded_token) else {
     fail("resolver did not observe the caller token")
   }
   assert_true(physical_equal(forwarded_token, token))
@@ -82,17 +82,17 @@ async test "TextModelResolverHandle forwards resource and cancellation token" {
 ///|
 async test "TextModelResolverHandle preserves unavailable and cancelled failures" {
   let target = try! @base_common.Uri::parse("memory://workspace/missing.mbt")
-  let calls = Ref(0)
-  let saw_cancelled = Ref(false)
+  let mut calls = 0
+  let mut saw_cancelled = false
   let resolver = TextModelResolverHandle(resolve=(_resource, token) => {
-    calls.val += 1
-    saw_cancelled.val = token.is_cancellation_requested()
+    calls += 1
+    saw_cancelled = token.is_cancellation_requested()
     None
   })
   let source = @language.CancellationTokenSource()
   source.cancel()
   assert_true(resolver.resolve(target, source.token()) is None)
-  assert_eq(calls.val, 1)
-  assert_true(saw_cancelled.val)
+  assert_eq(calls, 1)
+  assert_true(saw_cancelled)
   source.dispose()
 }

--- a/editor/viewer/common/view_layout/lines_layout_gate_c_wbtest.mbt
+++ b/editor/viewer/common/view_layout/lines_layout_gate_c_wbtest.mbt
@@ -177,10 +177,10 @@ test "LinesLayout mixed bulk commit resolves conflicts, stably sorts, and resets
   assert_eq(layout.prefix_sum_valid_index, 22)
 
   let inserted_peers : Array[String] = []
-  let inserted_primary_before = Ref("")
-  let inserted_ordinal_before = Ref("")
-  let inserted_ordinal_after = Ref("")
-  let inserted_primary_after = Ref("")
+  let mut inserted_primary_before = ""
+  let mut inserted_ordinal_before = ""
+  let mut inserted_ordinal_after = ""
+  let mut inserted_primary_after = ""
   assert_true(
     layout.change_whitespace(accessor => {
       for i in 0..<20 {
@@ -188,10 +188,10 @@ test "LinesLayout mixed bulk commit resolves conflicts, stably sorts, and resets
           accessor.insert_whitespace(4, 2, (1000 + i).to_double(), 0.0),
         )
       }
-      inserted_primary_before.val = accessor.insert_whitespace(3, 99, 60.0, 0.0)
-      inserted_ordinal_before.val = accessor.insert_whitespace(4, 0, 61.0, 0.0)
-      inserted_ordinal_after.val = accessor.insert_whitespace(4, 3, 62.0, 0.0)
-      inserted_primary_after.val = accessor.insert_whitespace(7, -9, 63.0, 0.0)
+      inserted_primary_before = accessor.insert_whitespace(3, 99, 60.0, 0.0)
+      inserted_ordinal_before = accessor.insert_whitespace(4, 0, 61.0, 0.0)
+      inserted_ordinal_after = accessor.insert_whitespace(4, 3, 62.0, 0.0)
+      inserted_primary_after = accessor.insert_whitespace(7, -9, 63.0, 0.0)
 
       // Zero operations: peer[0]. One operation: peer[1]. More than one:
       // peer[2] (last change wins), peer[3]/peer[4] (remove wins).
@@ -225,10 +225,7 @@ test "LinesLayout mixed bulk commit resolves conflicts, stably sorts, and resets
   // cache before the first post-commit accumulated-height query.
   assert_eq(layout.prefix_sum_valid_index, -1)
   let expected_ids : Array[String] = [
-    old_primary_before,
-    inserted_primary_before.val,
-    inserted_ordinal_before.val,
-    old_ordinal_before,
+    old_primary_before, inserted_primary_before, inserted_ordinal_before, old_ordinal_before,
   ]
   let expected_after_line_numbers : Array[Int] = [2, 3, 4, 4]
   let expected_ordinals : Array[Int] = [9, 99, 0, 1]
@@ -265,7 +262,7 @@ test "LinesLayout mixed bulk commit resolves conflicts, stably sorts, and resets
       )
     }
   }
-  expected_ids.push(inserted_ordinal_after.val)
+  expected_ids.push(inserted_ordinal_after)
   expected_after_line_numbers.push(4)
   expected_ordinals.push(3)
   expected_heights.push(62)
@@ -273,7 +270,7 @@ test "LinesLayout mixed bulk commit resolves conflicts, stably sorts, and resets
   expected_after_line_numbers.push(6)
   expected_ordinals.push(0)
   expected_heights.push(152)
-  expected_ids.push(inserted_primary_after.val)
+  expected_ids.push(inserted_primary_after)
   expected_after_line_numbers.push(7)
   expected_ordinals.push(-9)
   expected_heights.push(63)

--- a/editor/viewer/common/view_model/cursor_event_dispatcher_wbtest.mbt
+++ b/editor/viewer/common/view_model/cursor_event_dispatcher_wbtest.mbt
@@ -159,9 +159,9 @@ test "model-token outgoing typed listener receives every event in FIFO order" {
 test "empty model-token outgoing event remains observable" {
   let dispatcher = CursorEventDispatcher::CursorEventDispatcher()
   let mut delivered = 0
-  let observed_range_count = Ref(-1)
+  let mut observed_range_count = -1
   dispatcher.on_model_tokens_changed(event => {
-    observed_range_count.val = event.event.ranges.length()
+    observed_range_count = event.event.ranges.length()
     delivered += 1
   })
   |> ignore
@@ -172,7 +172,7 @@ test "empty model-token outgoing event remains observable" {
     }),
   )
   assert_eq(delivered, 1)
-  assert_eq(observed_range_count.val, 0)
+  assert_eq(observed_range_count, 0)
 }
 
 ///|
@@ -482,15 +482,15 @@ test "disposing a view model retires cursor outgoing subscriptions" {
 test "ViewModel exposes and retires ViewZones outgoing subscriptions" {
   let view_model = cursor_reference_view_model()
   let mut delivered = 0
-  let kind_was_view_zones = Ref(false)
+  let mut kind_was_view_zones = false
   view_model.on_view_zones_changed(event => {
-    kind_was_view_zones.val = event.kind == ViewZonesChanged
+    kind_was_view_zones = event.kind == ViewZonesChanged
     delivered += 1
   })
   |> ignore
   view_model.emit_view_zones_changed()
   assert_eq(delivered, 1)
-  assert_true(kind_was_view_zones.val)
+  assert_true(kind_was_view_zones)
   view_model.dispose()
   view_model.emit_view_zones_changed()
   assert_eq(delivered, 1)

--- a/editor/viewer/common/view_model/hidden_areas_outgoing_wbtest.mbt
+++ b/editor/viewer/common/view_model/hidden_areas_outgoing_wbtest.mbt
@@ -29,10 +29,10 @@ test "hidden-area outgoing fires after mapping cursor layout and recovery" {
   let order : Array[String] = []
   let scroll_subscription = layout.on_did_scroll(_change => order.push("scroll"))
   defer scroll_subscription.dispose()
-  let state_was_committed = Ref(false)
+  let mut state_was_committed = false
   let outgoing_subscription = view_model.on_hidden_areas_changed(event => {
     order.push("outgoing")
-    state_was_committed.val = event.kind == HiddenAreasChanged &&
+    state_was_committed = event.kind == HiddenAreasChanged &&
       view_model.line_count() == 6 &&
       layout.line_count() == 6 &&
       view_model.cursor.model_state().position == Position(4, 2) &&
@@ -50,7 +50,7 @@ test "hidden-area outgoing fires after mapping cursor layout and recovery" {
     }),
   )
   assert_true(order == ["mapping", "cursor", "scroll", "scroll", "outgoing"])
-  assert_true(state_was_committed.val)
+  assert_true(state_was_committed)
 }
 
 ///|

--- a/editor/viewer/common/view_model/hidden_areas_test.mbt
+++ b/editor/viewer/common/view_model/hidden_areas_test.mbt
@@ -50,14 +50,14 @@ test "hidden-area mapping phase precedes layout flush and recovery scroll" {
 
   // The unchanged contribution returns before the owner is asked to open an
   // event batch, matching the source's VI-008 → VI-010 control flow.
-  let batch_calls = Ref(0)
+  let mut batch_calls = 0
   assert_false(
     view_model.set_hidden_areas([Range(2, 1, 3, 1)], with_event_batch=mutation => {
-      batch_calls.val += 1
+      batch_calls += 1
       mutation()
     }),
   )
-  assert_eq(batch_calls.val, 0)
+  assert_eq(batch_calls, 0)
 }
 
 ///|

--- a/editor/viewer/common/view_model/inline_decorations_matrix_wbtest.mbt
+++ b/editor/viewer/common/view_model/inline_decorations_matrix_wbtest.mbt
@@ -181,12 +181,12 @@ test "matrix viewport suppresses endpoint decorations and scopes font flags" {
 ///|
 /// Query-flag forwarding (`inlineDecorations.ts:78-80`).
 test "matrix minimap and margin query flags reach source context" {
-  let seen_minimap = Ref(false)
-  let seen_margin = Ref(false)
+  let mut seen_minimap = false
+  let mut seen_margin = false
   let context : ReferenceInlineModelContext = {
     get_model_decorations: fn(_view_range, minimap, margin) {
-      seen_minimap.val = minimap
-      seen_margin.val = margin
+      seen_minimap = minimap
+      seen_margin = margin
       []
     },
   }
@@ -195,11 +195,11 @@ test "matrix minimap and margin query flags reach source context" {
     TestTextModel::create("abc"),
   )
   ignore(computer.computer.get_decorations(Range(1, 1, 1, 4), true, false))
-  assert_true(seen_minimap.val)
-  assert_false(seen_margin.val)
+  assert_true(seen_minimap)
+  assert_false(seen_margin)
   ignore(computer.computer.get_decorations(Range(1, 1, 1, 4), false, true))
-  assert_false(seen_minimap.val)
-  assert_true(seen_margin.val)
+  assert_false(seen_minimap)
+  assert_true(seen_margin)
 }
 
 ///|

--- a/editor/viewer/common/view_model/view_model_impl_tokenization_reference_wbtest.mbt
+++ b/editor/viewer/common/view_model/view_model_impl_tokenization_reference_wbtest.mbt
@@ -47,11 +47,11 @@ test "view models react first to model changes" {
   let second = ViewModel(model)
   let observed : Array[String] = []
   let mut is_first = true
-  let callbacks_valid = Ref(true)
+  let mut callbacks_valid = true
   let _subscription = model.on_did_change_content(event => {
     // Both registered ViewModels complete loop one before any public model
     // listener runs, including the hostile nested mutation below.
-    callbacks_valid.val = callbacks_valid.val &&
+    callbacks_valid = callbacks_valid &&
       first.line_count() == model.get_line_count() &&
       second.line_count() == model.get_line_count() &&
       reference_range_is_valid(first, model) &&
@@ -66,7 +66,7 @@ test "view models react first to model changes" {
   })
   model.set_value("Hello\nworld!")
   assert_true(observed == ["public:2:2", "public:3:1"])
-  assert_true(callbacks_valid.val)
+  assert_true(callbacks_valid)
   assert_eq(first.line_count(), 1)
   assert_eq(second.line_count(), 1)
   assert_true(reference_range_is_valid(first, model))
@@ -119,9 +119,9 @@ test "model-token callback converts wrapped and hidden ranges before outgoing de
     ),
     "/model-token-order.mbt",
   )
-  let original : Ref[@model.ModelTokensChangedEvent?] = Ref(None)
+  let mut original : @model.ModelTokensChangedEvent? = None
   let _model_subscription = model.on_did_change_tokens(event => {
-    original.val = Some(event)
+    original = Some(event)
   })
   let delivery_order : Array[String] = []
   let converted : Array[Array[ViewTokensChangedRange]] = []
@@ -135,13 +135,13 @@ test "model-token callback converts wrapped and hidden ranges before outgoing de
   )
   assert_true(view_model.set_hidden_areas([Range(2, 1, 2, 1)]))
   let outgoing_events : Array[@model.ModelTokensChangedEvent] = []
-  let outgoing_identity = Ref(false)
+  let mut outgoing_identity = false
   let _outgoing_subscription = view_model.on_model_tokens_changed(outgoing => {
     delivery_order.push("outgoing")
-    match original.val {
+    match original {
       Some(source_event) =>
-        outgoing_identity.val = physical_equal(outgoing.event, source_event)
-      None => outgoing_identity.val = false
+        outgoing_identity = physical_equal(outgoing.event, source_event)
+      None => outgoing_identity = false
     }
     outgoing_events.push(outgoing.event)
   })
@@ -157,8 +157,8 @@ test "model-token callback converts wrapped and hidden ranges before outgoing de
   assert_eq(converted[0][0].from_line_number, 1)
   assert_eq(converted[0][0].to_line_number, 4)
   assert_eq(outgoing_events.length(), 1)
-  assert_true(outgoing_identity.val)
-  assert_true(physical_equal(outgoing_events[0], original.val.unwrap()))
+  assert_true(outgoing_identity)
+  assert_true(physical_equal(outgoing_events[0], original.unwrap()))
   view_model.dispose()
   registration.dispose()
   model.dispose()
@@ -170,17 +170,17 @@ test "headless token callback defaults to no-op and disposal removes delivery" {
     "one\ntwo", "/model-token-headless.mbt",
   )
   let view_model = ViewModel(model)
-  let delivered = Ref(0)
-  let _subscription = view_model.on_model_tokens_changed(_ => delivered.val += 1)
+  let mut delivered = 0
+  let _subscription = view_model.on_model_tokens_changed(_ => delivered += 1)
   // No browser callback was supplied: the private default sink completes as a
   // no-op, then the typed outgoing listener still observes the source event.
   let registration = @syntax.tokenization_registry.register(
     "view-model-impl-reference",
     @plain_tokenizer.PlainTokenizer(),
   )
-  assert_eq(delivered.val, 1)
+  assert_eq(delivered, 1)
   view_model.dispose()
   registration.dispose()
-  assert_eq(delivered.val, 1)
+  assert_eq(delivered, 1)
   model.dispose()
 }

--- a/jsonrpc/client_wbtest.mbt
+++ b/jsonrpc/client_wbtest.mbt
@@ -257,8 +257,8 @@ async test "peer notifications reach the installed handler" {
   @async.with_task_group(group => {
     let transport = new_transport()
     let client = Client::Client(transport)
-    let seen : Ref[String] = { val: "", }
-    client.set_notification_handler((method_, _params) => seen.val = method_)
+    let mut seen : String = ""
+    client.set_notification_handler((method_, _params) => seen = method_)
     spawn_client(group, client)
     group.spawn_bg(no_wait=true, allow_failure=true, () => {
       let request = transport.outbound.get()
@@ -270,7 +270,7 @@ async test "peer notifications reach the installed handler" {
       transport.inbound.put(reply_for(request))
     })
     client.request(method_="ping", params=Json::empty_object()) |> ignore
-    assert_eq(seen.val, "notifications/message")
+    assert_eq(seen, "notifications/message")
   })
 }
 

--- a/mcp/client_test.mbt
+++ b/mcp/client_test.mbt
@@ -229,12 +229,12 @@ async test "list_tools returns tools with pass-through schemas" {
 ///|
 async test "list_tools follows nextCursor pagination" {
   @async.with_task_group(group => {
-    let calls : Ref[Int] = { val: 0, }
+    let mut calls : Int = 0
     let reply = fn(request : Json) -> Json? {
       match method_of(request) {
         "tools/list" => {
-          calls.val += 1
-          if calls.val == 1 {
+          calls += 1
+          if calls == 1 {
             Some(
               success(request, {
                 "tools": [{ "name": "a" }],

--- a/mcp/streamhttp/streamhttp_test.mbt
+++ b/mcp/streamhttp/streamhttp_test.mbt
@@ -292,8 +292,8 @@ async test "tools/list waits for the initialized notification to complete" {
       is Some(server) else {
       return
     }
-    let initialized_done : Ref[Bool] = { val: false, }
-    let list_saw_initialized : Ref[Bool] = { val: false, }
+    let mut initialized_done : Bool = false
+    let mut list_saw_initialized : Bool = false
     group.spawn_bg(no_wait=true, allow_failure=true) <| () => {
       server.run_forever(
         (_request, body, conn) => {
@@ -307,11 +307,11 @@ async test "tools/list waits for the initialized notification to complete" {
               // A slow lifecycle handler: without the transport's gate, the
               // detached tools/list POST overtakes this notification.
               @async.sleep(150)
-              initialized_done.val = true
+              initialized_done = true
               conn.send_response(202, "Accepted")
             }
             { "method": "tools/list", "id": id, .. } => {
-              list_saw_initialized.val = initialized_done.val
+              list_saw_initialized = initialized_done
               let reply : Json = {
                 "jsonrpc": "2.0",
                 "id": id,
@@ -334,7 +334,7 @@ async test "tools/list waits for the initialized notification to complete" {
     )
     let tools = conn.client().list_tools()
     assert_eq(tools[0].name, "ordered")
-    assert_true(list_saw_initialized.val)
+    assert_true(list_saw_initialized)
     conn.shutdown()
   }
 }

--- a/mcp/streamhttp/transport.mbt
+++ b/mcp/streamhttp/transport.mbt
@@ -198,14 +198,14 @@ impl @jsonrpc.Transport for HttpTransport with fn send(self, message) {
   // Whether the exchange task already ran to completion: TaskGroup::spawn's
   // start timing is undefined, so registration below must not resurrect a
   // ticket whose task finished before `spawn` returned.
-  let done : Ref[Bool] = { val: false, }
+  let mut done : Bool = false
   let task = (self.spawn)(() => {
     // All defers sit at the task-body scope (a defer inside an `if` block
     // would fire at that block's end — i.e. immediately), so they run when the
     // task exits: feeding the gate however this exchange ends means a failed
     // lifecycle notification cannot wedge every later request.
     defer {
-      done.val = true
+      done = true
     }
     defer self.pending_posts.remove(ticket)
     defer feed_gate(completion)
@@ -222,7 +222,7 @@ impl @jsonrpc.Transport for HttpTransport with fn send(self, message) {
   // Register only if the task has not already finished (spawn's start timing is
   // undefined): inserting a completed task would strand its ticket and consume
   // the exchange cap forever.
-  if !done.val {
+  if !done {
     self.pending_posts[ticket] = task
   }
 }


### PR DESCRIPTION
## What

Sweep the workspace for local `Ref[T]` cells that never escape and
replace them with ordinary `let mut` locals. MoonBit mutates a captured
`let mut` local through an automatically boxed cell, so a local `Ref` is
only needed when the Ref value itself escapes: passed to a callee, stored
in a struct/array, aliased, or returned.

Rewrites:

- `let x : Ref[T] = Ref(init)` -> `let mut x : T = init`
- `x.val` -> `x`
- `x.val = e` -> `x = e`

196 cells in 79 files: 195 become `let mut`, and one read-only cell
becomes a plain `let`. Cells captured by closures are included, since the
boxed `let mut` cell is shared exactly like the Ref was. Refs that escape
(struct fields, function parameters, module-level cells, aliases) keep
their `Ref`, because another holder shares their identity.

## Verification

- `moon check --target native|js|wasm --deny-warn`
- editor `moon check --target all --warn-list +73 --deny-warn`, plus
  `moon fmt --check` for root and editor
- `moon info` reports no `.mbti` change (no public interface change)
- root tests: native 3110/3110, js 3198/3198, wasm 2359/2359
- editor tests: wasm 1090, js 1876, native 1224, 0 failures
- `moon run tests/integration/workflows`, `moon cram test tests/cram`,
  and the generated-prompt check

Generated with SeekMoon