### PR TITLE
fix(desktop): apply shared font settings across panels

### DIFF
--- a/desktop/e2e/tests/background_jobs.spec.js
+++ b/desktop/e2e/tests/background_jobs.spec.js
@@ -390,3 +390,59 @@ test('history-only sessions wait for explicit selection before loading a log', a
   await expect(page.locator('.jobs-history-toggle')).toHaveAttribute('aria-expanded', 'true');
   expect(app.pageErrors).toEqual([]);
 });
+
+test('font settings scale Jobs with the transcript and persist code font choices', async ({ page }, testInfo) => {
+  await mount(page);
+  const jobs = page.locator('.jobs-panel');
+  const prose = page.locator('.transcript .msg-content').first();
+  const command = jobs.locator('.jobs-command').first();
+  const output = jobs.locator('.jobs-output pre');
+  await expect(command).toHaveCSS('font-size', '14px');
+  await expect(jobs.locator('.jobs-group-title').first()).toHaveCSS('font-size', '13px');
+  await expect(jobs.locator('.jobs-group-count').first()).toHaveCSS('font-size', '12px');
+  await expect(command).toHaveCSS('font-family', await prose.evaluate(el => getComputedStyle(el).fontFamily));
+  await expect(jobs.locator('.jobs-row-meta').first()).toHaveCSS('font-size', '12px');
+  await expect(output).toHaveCSS('font-size', '13px');
+  await page.screenshot({ path: testInfo.outputPath('jobs-font-default.png'), fullPage: true });
+
+  await page.getByRole('button', { name: 'Settings', exact: true }).click();
+  await page.getByRole('button', { name: 'Font size', exact: true }).click();
+  await page.getByRole('option', { name: '18px', exact: true }).click();
+  await page.getByRole('button', { name: 'Monospace font', exact: true }).click();
+  await page.getByRole('option', { name: 'Menlo', exact: true }).click();
+  await app.openSession();
+  await expect(prose).toHaveCSS('font-size', '18px');
+  await expect(command).toHaveCSS('font-size', '18px');
+  await expect(jobs.locator('.jobs-group-title').first()).toHaveCSS('font-size', '17px');
+  await expect(jobs.locator('.jobs-group-count').first()).toHaveCSS('font-size', '16px');
+  await expect(jobs.locator('.jobs-row-meta').first()).toHaveCSS('font-size', '16px');
+  await expect(jobs.locator('.jobs-action').first()).toHaveCSS('font-size', '17px');
+  await expect(output).toHaveCSS('font-size', '17px');
+  await expect(output).toHaveCSS('font-family', /^Menlo,/);
+  await expect(jobs.locator('.jobs-full-command')).toHaveCSS('font-family', await output.evaluate(el => getComputedStyle(el).fontFamily));
+  await expect(prose).not.toHaveCSS('font-family', /Menlo/);
+
+  await page.reload();
+  await app.openSession();
+  await app.openJobs();
+  await expect(command).toHaveCSS('font-size', '18px');
+  await expect(output).toHaveCSS('font-size', '17px');
+  await expect(output).toHaveCSS('font-family', /^Menlo,/);
+  await page.setViewportSize({ width: 1000, height: 850 });
+  await expect.poll(() => jobs.evaluate(el => el.scrollWidth <= el.clientWidth + 1)).toBe(true);
+  await page.screenshot({ path: testInfo.outputPath('jobs-font-large-light.png'), fullPage: true });
+  await page.emulateMedia({ colorScheme: 'dark' });
+  await page.screenshot({ path: testInfo.outputPath('jobs-font-large-dark.png'), fullPage: true });
+
+  await page.getByRole('button', { name: 'Settings', exact: true }).click();
+  await page.getByRole('button', { name: 'Font size', exact: true }).click();
+  await page.getByRole('option', { name: '12px', exact: true }).click();
+  await app.openSession();
+  await expect(command).toHaveCSS('font-size', '12px');
+  await expect(output).toHaveCSS('font-size', '11px');
+  await page.setViewportSize({ width: 390, height: 844 });
+  await expect(page.locator('.sidebar-toggle')).toHaveAttribute('aria-label', 'Show sidebar');
+  await expect.poll(() => jobs.evaluate(el => el.scrollWidth <= el.clientWidth + 1)).toBe(true);
+  await page.screenshot({ path: testInfo.outputPath('jobs-font-small-narrow.png'), animations: 'disabled' });
+  expect(app.pageErrors).toEqual([]);
+});

--- a/desktop/e2e/tests/close_shortcut.spec.js
+++ b/desktop/e2e/tests/close_shortcut.spec.js
@@ -220,3 +220,39 @@ test('Close respects dialogs and closes successive dock tabs without closing the
     .toHaveLength(0);
   expect(app.pageErrors).toEqual([]);
 });
+
+
+test('new terminals and existing terminals use the current font settings', async ({ page }) => {
+  const app = await installDesktop(page);
+  // Observe the real xterm instance; rendering and options remain production code.
+  await page.evaluate(() => {
+    window.fontTestTerminals = [];
+    window.__openseek_xterm.Terminal = new Proxy(window.__openseek_xterm.Terminal, {
+      construct(target, args) {
+        const terminal = Reflect.construct(target, args);
+        window.fontTestTerminals.push(terminal);
+        return terminal;
+      },
+    });
+  });
+  await page.getByRole('button', { name: 'Settings', exact: true }).click();
+  const fontSize = page.getByRole('button', { name: 'Font size', exact: true });
+  await fontSize.click();
+  await page.getByRole('option', { name: '18px', exact: true }).click();
+  await page.getByRole('button', { name: 'Monospace font', exact: true }).click();
+  await page.getByRole('option', { name: 'Menlo', exact: true }).click();
+  await app.openSession();
+  await page.keyboard.press('Control+Backquote');
+  await expect(page.locator('.terminal-instance:visible .xterm-helper-textarea')).toBeFocused();
+  await expect.poll(() => page.evaluate(() => window.fontTestTerminals.map(t => t.options.fontSize))).toEqual([17]);
+  await expect.poll(() => page.evaluate(() => window.fontTestTerminals[0].options.fontFamily)).toMatch(/^Menlo/);
+
+  await page.getByRole('button', { name: 'Settings', exact: true }).click();
+  await fontSize.click();
+  await page.getByRole('option', { name: '12px', exact: true }).click();
+  await expect.poll(() => page.evaluate(() => window.fontTestTerminals.map(t => t.options.fontSize))).toEqual([11]);
+  await app.openSession();
+  await page.getByTitle('New terminal in this workspace', { exact: true }).click();
+  await expect.poll(() => page.evaluate(() => window.fontTestTerminals.map(t => t.options.fontSize))).toEqual([11, 11]);
+  expect(app.pageErrors).toEqual([]);
+});

--- a/desktop/styles/README.md
+++ b/desktop/styles/README.md
@@ -34,6 +34,39 @@ Component styles consume semantic names such as `--color-text-muted` and
 `--color-focus-ring`. They do not introduce aliases for a single call site or
 encode component names into global tokens.
 
+### Typography and appearance settings
+
+`Font size` sets `--font-size-base` (14px by default). Use the existing scale
+for all readable app text, including Jobs, Codex conversations, and dock UI:
+
+| Role | Token | Default |
+| --- | --- | --- |
+| Body text and task names | `--font-size-md` | 14px |
+| Controls and code | `--font-size-sm` | 13px |
+| Timestamps, status, and other metadata | `--font-size-xs` | 12px |
+| Panel headings | `--font-size-lg` | 17px |
+
+Do not hardcode text sizes in pixels. Markdown may size headings relative to
+its surrounding text; larger page headings may derive from the base. Use
+unitless line heights so text grows without clipping. Icon glyphs use the
+icon scale and do not acquire text-sizing rules merely to size an SVG.
+
+Ordinary text inherits `--font-family-sans` and `--font-weight-regular` from
+the app. Code blocks, commands, logs, and paths displayed as code use
+`--font-family-mono`, which follows the `Monospace font` setting. Avoid
+independent font stacks or misspelled fallback tokens that bypass that
+setting. Task names may use weight 500 and headings 600 to express hierarchy.
+
+The code editor and terminal also need their measured options updated:
+`AppFont::apply` and `AppFontSize::apply` do that alongside the root settings.
+New terminals read `--font-size-sm` through CSSOM, so its registered `<length>`
+type must keep resolving to pixels. The Viewer theme's standalone defaults
+are overridden for every embedded app code surface in `tokens.css`.
+
+Verify changed typography at the minimum and maximum font settings, after
+reload, and with a different monospace font. Include narrow panels and both
+light and dark themes; let content wrap or reduce columns as text grows.
+
 ## Form-field focus ownership
 
 Every form field has exactly one element that draws its focus border:

--- a/desktop/styles/codex.css
+++ b/desktop/styles/codex.css
@@ -72,7 +72,7 @@
   padding: 5px 9px;
   border-color: transparent;
   background: var(--color-control-surface);
-  font-size: 11.5px;
+  font-size: var(--font-size-sm);
 }
 
 .codex-raw {
@@ -83,7 +83,7 @@
   border-radius: var(--radius-sm);
   background: var(--color-bg-subtle);
   color: var(--color-code);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   line-height: 1.5;
   white-space: pre-wrap;
 
@@ -104,7 +104,7 @@
 
 .codex-request-detail-label {
   color: var(--color-text-muted);
-  font-size: 10.5px;
+  font-size: var(--font-size-xs);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -117,20 +117,20 @@
   border-radius: var(--radius-sm);
   background: var(--color-bg-surface);
   color: var(--color-code);
-  font-size: 11.5px;
+  font-size: var(--font-size-sm);
   line-height: 1.5;
   white-space: pre-wrap;
 }
 
 .codex-request-value {
   color: var(--color-code);
-  font-size: 11.5px;
+  font-size: var(--font-size-sm);
   overflow-wrap: anywhere;
 }
 
 .codex-request-raw {
   color: var(--color-text-muted);
-  font-size: 11px;
+  font-size: var(--font-size-xs);
 }
 
 .codex-request-raw-summary {
@@ -145,7 +145,7 @@
 
 .codex-request-unsupported {
   color: var(--color-danger);
-  font-size: 11.5px;
+  font-size: var(--font-size-sm);
 }
 
 .codex-pending {
@@ -209,7 +209,7 @@
   display: inline-grid;
   place-items: center;
   min-width: 14px;
-  font-size: 10px;
+  font-size: var(--icon-xs);
   font-weight: 700;
 }
 
@@ -280,7 +280,7 @@
   border: 1px solid currentColor;
   border-radius: 50%;
   color: var(--color-text-secondary);
-  font-size: 10px;
+  font-size: var(--icon-xs);
   font-weight: 700;
 }
 
@@ -305,7 +305,7 @@
 
 .codex-permission-check {
   color: var(--color-text-secondary);
-  font-size: 16px;
+  font-size: var(--icon-lg);
   text-align: center;
 }
 
@@ -332,7 +332,7 @@
 .codex-question-text {
   margin: 0;
   color: var(--color-text-secondary);
-  font-size: 12px;
+  font-size: var(--font-size-sm);
 }
 
 .codex-question {
@@ -342,7 +342,7 @@
 
 .codex-question-header {
   color: var(--color-text-muted);
-  font-size: 10.5px;
+  font-size: var(--font-size-xs);
   letter-spacing: 0.1em;
   text-transform: uppercase;
 }
@@ -371,7 +371,7 @@
 
 .codex-option-desc {
   color: var(--color-text-muted);
-  font-size: 11px;
+  font-size: var(--font-size-xs);
 }
 
 /* These controls belong to the conversation pane, whose width can change

--- a/desktop/styles/file_panel.css
+++ b/desktop/styles/file_panel.css
@@ -1601,7 +1601,7 @@ html.is-resizing-review * {
   border-radius: 10px;
   color: var(--color-bg-surface);
   background: var(--git-graph-current);
-  font-size: 12px;
+  font-size: var(--font-size-xs);
   line-height: 18px;
   white-space: nowrap;
 }
@@ -1834,7 +1834,7 @@ button.git-history-file.selected {
 
 .history-commit-crumb {
   color: var(--color-text-secondary);
-  font-family: var(--font-mono, ui-monospace, monospace);
+  font-family: var(--font-family-mono);
 }
 
 .file-panel-empty {
@@ -2580,9 +2580,9 @@ button.git-history-file.selected {
   flex: 0 1 auto;
   min-width: 0;
   overflow: hidden;
-  font-size: 14px;
+  font-size: var(--font-size-md);
   font-weight: 500;
-  line-height: 22px;
+  line-height: var(--line-height-relaxed);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -2593,8 +2593,8 @@ button.git-history-file.selected {
   margin-left: 8px;
   overflow: hidden;
   color: var(--color-text-secondary);
-  font-size: 12px;
-  line-height: 22px;
+  font-size: var(--font-size-xs);
+  line-height: var(--line-height-relaxed);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -2660,7 +2660,7 @@ button.git-history-file.selected {
 
 .semantic-review-host .diff-notice strong {
   flex: 0 0 auto;
-  font-size: 10px;
+  font-size: inherit;
   letter-spacing: 0.04em;
   text-transform: uppercase;
 }
@@ -2750,7 +2750,7 @@ button.git-history-file.selected {
   font-size: var(--font-size-sm);
 }
 .workflow-run-id {
-  font-family: var(--font-mono, ui-monospace, monospace);
+  font-family: var(--font-family-mono);
   color: var(--color-text);
 }
 .workflow-run-state {
@@ -2839,7 +2839,7 @@ button.git-history-file.selected {
 
 .moonbit-diff-hunk-action .review-hunk-marker {
   font-family: var(--font-family-sans);
-  font-size: 13px;
+  font-size: var(--font-size-sm);
   line-height: 16px;
   color: var(--color-text-muted);
   border-color: var(--color-text-muted);
@@ -2871,15 +2871,15 @@ button.git-history-file.selected {
 .editor.mode-jobs .jobs-panel { display: flex; }
 .jobs-panel { flex: 1; min-height: 0; min-width: 0; flex-direction: column; overflow: auto; padding: 18px; gap: 12px; color: var(--color-text-primary); }
 .jobs-heading, .jobs-row-head, .jobs-detail-title { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
-.jobs-heading h3 { margin: 0 0 8px; font-size: 16px; font-weight: 600; letter-spacing: -.2px; }
-.jobs-summary, .jobs-host, .jobs-row-meta, .jobs-detail-meta, .jobs-output-note, .jobs-footnote { font-size: 11px; color: var(--color-text-secondary); overflow-wrap: anywhere; }
+.jobs-heading h3 { margin: 0 0 8px; font-size: var(--font-size-lg); font-weight: 600; letter-spacing: -.2px; }
+.jobs-summary, .jobs-host, .jobs-row-meta, .jobs-detail-meta, .jobs-output-note, .jobs-footnote { font-size: var(--font-size-xs); color: var(--color-text-secondary); overflow-wrap: anywhere; }
 .jobs-summary { display: flex; align-items: center; flex-wrap: wrap; gap: 6px 12px; }
 .jobs-summary-active { display: inline-flex; align-items: center; gap: 6px; color: var(--color-text-primary); }
 .jobs-summary-active::before { content: ""; width: 6px; height: 6px; border-radius: 50%; background: var(--color-accent); }
 .jobs-host { padding-bottom: 12px; border-bottom: 1px solid var(--color-border); }
 .jobs-list { display: flex; flex-direction: column; gap: 18px; max-height: min(360px, 42vh); flex-shrink: 0; overflow: auto; padding: 2px; scrollbar-width: thin; }
 .jobs-group { flex-shrink: 0; min-width: 0; }
-.jobs-group-title { display: flex; align-items: center; gap: 8px; margin: 0 0 10px; font-size: 12px; font-weight: 600; color: var(--color-text-secondary); }
+.jobs-group-title { display: flex; align-items: center; gap: 8px; margin: 0 0 10px; font-size: var(--font-size-sm); font-weight: 600; color: var(--color-text-secondary); }
 .jobs-history-toggle { width: 100%; padding: 0; border: 0; background: transparent; cursor: pointer; text-align: left; font-family: inherit; }
 .jobs-history-toggle::before { content: ""; width: 6px; height: 6px; border-right: 1.5px solid currentColor; border-bottom: 1.5px solid currentColor; transform: rotate(-45deg); margin: 0 3px; }
 .jobs-history-toggle[aria-expanded="true"]::before { transform: translateY(-2px) rotate(45deg); }
@@ -2888,17 +2888,17 @@ button.git-history-file.selected {
 .jobs-history-toggle:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 2px; }
 .jobs-more { margin-top: 8px; }
 .jobs-group-title::after { content: ""; height: 1px; flex: 1; background: var(--color-border); }
-.jobs-group-count { min-width: 20px; padding: 1px 6px; border-radius: 5px; background: var(--color-bg-surface); border: 1px solid var(--color-border); font-size: 10px; text-align: center; font-variant-numeric: tabular-nums; }
-.jobs-cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(220px,100%),1fr)); gap: 8px; }
+.jobs-group-count { min-width: 20px; padding: 1px 6px; border-radius: 5px; background: var(--color-bg-surface); border: 1px solid var(--color-border); font-size: var(--font-size-xs); text-align: center; font-variant-numeric: tabular-nums; }
+.jobs-cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(18em,100%),1fr)); gap: 8px; }
 .jobs-row { display: flex; flex-direction: column; gap: 9px; text-align: left; padding: 12px; border: 1px solid var(--color-border); border-left: 3px solid color-mix(in srgb, var(--job-color) 55%, var(--color-border)); background: var(--color-bg-surface); border-radius: 8px; color: inherit; min-width: 0; cursor: pointer; }
 .jobs-row.selected { border-color: color-mix(in srgb, var(--color-accent) 60%, var(--color-border)); border-left-color: var(--color-accent); background: color-mix(in srgb, var(--color-accent) 7%, var(--color-bg-surface)); }
 .jobs-row:hover { border-color: var(--color-accent); background: color-mix(in srgb, var(--color-accent) 4%, var(--color-bg-surface)); }
 .jobs-row:focus-visible, .jobs-action:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 2px; }
 .jobs-row-head { flex-wrap: wrap; gap: 6px; }
-.jobs-id { font-family: var(--font-family-mono); font-size: 11px; color: var(--color-text-secondary); overflow-wrap: anywhere; }
-.jobs-command { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 100%; font-size: 12px; font-weight: 600; }
-.jobs-row-meta { font-size: 10px; line-height: 1.5; font-variant-numeric: tabular-nums; }
-.jobs-status { display: inline-flex; align-items: center; gap: 5px; padding: 3px 7px; border-radius: 5px; background: color-mix(in srgb, var(--job-color) 10%, transparent); color: var(--job-color); font-size: 10px; font-weight: 600; line-height: 1.4; overflow-wrap: anywhere; }
+.jobs-id { min-width: 0; font-size: var(--font-size-xs); color: var(--color-text-secondary); overflow-wrap: anywhere; font-variant-numeric: tabular-nums; }
+.jobs-command { overflow-wrap: anywhere; max-width: 100%; font-size: var(--font-size-md); font-weight: 500; }
+.jobs-row-meta { font-size: var(--font-size-xs); line-height: 1.5; font-variant-numeric: tabular-nums; }
+.jobs-status { display: inline-flex; align-items: center; gap: 5px; padding: 3px 7px; border-radius: 5px; background: color-mix(in srgb, var(--job-color) 10%, transparent); color: var(--job-color); font-size: var(--font-size-xs); font-weight: 500; line-height: 1.4; overflow-wrap: anywhere; }
 .jobs-status::before { content: ""; flex: 0 0 auto; width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
 .jobs-row-running, .jobs-status-running { --job-color: var(--color-accent); }
 .jobs-row-stopping, .jobs-status-stopping { --job-color: light-dark(#925b10,#e7ba70); }
@@ -2914,17 +2914,17 @@ button.git-history-file.selected {
 @media (prefers-reduced-motion: reduce) { .jobs-status-running::before { animation: none; } }
 .jobs-detail { display: flex; flex-direction: column; gap: 9px; flex: 1; min-height: 290px; min-width: 0; }
 .jobs-detail-title { justify-content: space-between; flex-wrap: wrap; border-top: 1px solid var(--color-border); padding-top: 16px; }
-.jobs-full-command { margin: 0; padding: 9px 11px; font: 12px/1.5 var(--font-family-mono); white-space: pre-wrap; overflow-wrap: anywhere; background: var(--color-bg-surface); border-radius: 5px; max-height: 110px; overflow: auto; }
-.jobs-path { font-size: 11px; overflow-wrap: anywhere; line-height: 1.5; }
+.jobs-full-command { margin: 0; padding: 9px 11px; font: var(--font-size-sm)/var(--line-height-normal) var(--font-family-mono); white-space: pre-wrap; overflow-wrap: anywhere; background: var(--color-bg-surface); border-radius: 5px; max-height: 110px; overflow: auto; }
+.jobs-path { font-size: var(--font-size-sm); overflow-wrap: anywhere; line-height: var(--line-height-normal); }
 .jobs-toolbar { display: flex; flex-wrap: wrap; gap: 6px; }
-.jobs-action { border: 1px solid var(--color-border); background: var(--color-bg-surface); color: inherit; border-radius: 5px; padding: 5px 8px; font-size: 11px; cursor: pointer; }
+.jobs-action { border: 1px solid var(--color-border); background: var(--color-bg-surface); color: inherit; border-radius: 5px; padding: 5px 8px; font-size: var(--font-size-sm); cursor: pointer; }
 .jobs-action.jobs-stop { color: light-dark(#b33732,#f09d94); }
 .jobs-action:disabled { opacity: .45; cursor: default; }
 .jobs-action:hover:not(:disabled) { border-color: var(--color-accent); }
-.jobs-error { font-size: 12px; line-height: 1.5; padding: 8px 10px; border-radius: 5px; background: light-dark(#fff0e8,#452a20); color: light-dark(#934020,#edb798); overflow-wrap: anywhere; }
+.jobs-error { font-size: var(--font-size-sm); line-height: var(--line-height-normal); padding: 8px 10px; border-radius: 5px; background: light-dark(#fff0e8,#452a20); color: light-dark(#934020,#edb798); overflow-wrap: anywhere; }
 .jobs-output { flex: 1; min-height: 170px; max-height: 60vh; overflow: auto; background: light-dark(#f7f8fa,#15181e); border: 1px solid var(--color-border); border-radius: 8px; padding: 14px; }
-.jobs-output pre { margin: 0; font: 12px/1.65 var(--font-family-mono); white-space: pre-wrap; overflow-wrap: anywhere; tab-size: 4; }
+.jobs-output pre { margin: 0; font: var(--font-size-sm)/var(--line-height-relaxed) var(--font-family-mono); white-space: pre-wrap; overflow-wrap: anywhere; tab-size: 4; }
 .jobs-empty { margin: auto; max-width: 330px; text-align: center; padding: 40px 12px; }
-.jobs-empty h3 { font-size: 14px; }
-.jobs-empty p { color: var(--color-text-secondary); font-size: 12px; line-height: 1.7; }
+.jobs-empty h3 { font-size: var(--font-size-md); }
+.jobs-empty p { color: var(--color-text-secondary); font-size: var(--font-size-sm); line-height: var(--line-height-relaxed); }
 .jobs-panel > :not(.jobs-detail), .jobs-detail > :not(.jobs-output) { flex-shrink: 0; }

--- a/desktop/styles/main_header.css
+++ b/desktop/styles/main_header.css
@@ -52,7 +52,6 @@ main {
   border-radius: var(--radius-sm);
   background: transparent;
   color: var(--color-text-muted);
-  font-size: 15px;
   line-height: var(--line-height-tight);
   cursor: pointer;
 }

--- a/desktop/styles/overlays.css
+++ b/desktop/styles/overlays.css
@@ -335,7 +335,7 @@
 }
 .portal-header h1 {
   margin: 0;
-  font-size: 20px;
+  font-size: calc(var(--font-size-base) + 6px);
 }
 .portal-card {
   border: 1px solid var(--color-border);

--- a/desktop/styles/pages.css
+++ b/desktop/styles/pages.css
@@ -384,7 +384,7 @@ h2 {
 }
 
 .skills-header h1 {
-  font-size: 26px;
+  font-size: calc(var(--font-size-base) + 12px);
   letter-spacing: -0.02em;
 }
 

--- a/desktop/styles/sidebar.css
+++ b/desktop/styles/sidebar.css
@@ -680,8 +680,8 @@ button.row-twisty:hover {
   min-width: 0;
 }
 .picker-header .modal-title {
-  font-size: 15px;
-  font-weight: 650;
+  font-size: var(--font-size-md);
+  font-weight: 600;
   line-height: 1.3;
 }
 .picker-subtitle {
@@ -1128,7 +1128,7 @@ button.row-twisty:hover {
   place-items: center;
   width: 20px;
   color: var(--color-text-muted);
-  font-size: 14px;
+  font-size: var(--icon-md);
   line-height: var(--line-height-tight);
 }
 

--- a/desktop/styles/terminal.css
+++ b/desktop/styles/terminal.css
@@ -100,7 +100,7 @@ html.is-resizing-terminal * {
   border: 0;
   background: none;
   color: var(--color-text-muted);
-  font: 500 10px/1 var(--font-family-sans);
+  font: 500 var(--icon-xs)/1 var(--font-family-sans);
   cursor: pointer;
 }
 .terminal-tab-close:hover {
@@ -112,7 +112,7 @@ html.is-resizing-terminal * {
   border-radius: var(--radius-sm);
   background: none;
   color: var(--color-text-muted);
-  font: 500 14px/1 var(--font-family-sans);
+  font: 500 var(--icon-md)/1 var(--font-family-sans);
   cursor: pointer;
 }
 .terminal-new:hover {

--- a/desktop/styles/tokens.css
+++ b/desktop/styles/tokens.css
@@ -24,6 +24,14 @@
   initial-value: #eef2fe;
 }
 
+/* xterm reads this size through CSSOM when a terminal opens. Register the
+   length so it receives pixels instead of an unevaluated calc() expression. */
+@property --font-size-sm {
+  syntax: "<length>";
+  inherits: true;
+  initial-value: 13px;
+}
+
 :root {
   color-scheme: light dark;
 
@@ -218,7 +226,9 @@
    dense editor surface uses the adjacent smaller step. The measured code view
    also receives that concrete size through ViewerOptions so glyph widths and
    wrapping remain correct. */
-.editor-shell {
+.editor-shell,
+.moonbit-source,
+.composer-approval-body {
   --editor-font-family: var(--font-family-mono);
   --editor-font-size: var(--font-size-sm);
   --editor-line-height: var(--line-height-relaxed);

--- a/desktop/styles/transcript.css
+++ b/desktop/styles/transcript.css
@@ -68,7 +68,6 @@
   border-radius: var(--radius-pill);
   background: var(--color-bg-surface);
   color: var(--color-text-secondary);
-  font-size: 15px;
   line-height: var(--line-height-tight);
   cursor: pointer;
   box-shadow: var(--shadow-overlay);


### PR DESCRIPTION
Changing Font size left Jobs and several desktop controls at fixed pixel sizes, while terminals opened afterward could fall back to 13px. Apply the shared type scale and font families across these surfaces, resolve the terminal CSS size to pixels, and let Jobs titles wrap and cards reduce columns as text grows.

Document the typography contract and add browser regressions for persisted font choices, minimum/maximum sizes, narrow layouts, and new versus existing terminals.

Validation:
- `just check`, `just test`, and `just build`
- `npm --prefix desktop/e2e test -- tests/background_jobs.spec.js tests/close_shortcut.spec.js`
- Visual checks at 12px, 14px, and 18px in light/dark themes, including a 390px viewport
- `moon info && moon fmt`; no generated interface changes
