### PR TITLE
refactor(desktop): avoid temporary parsing allocations

### DIFF
--- a/desktop/frontend/preview/preview_test.mbt
+++ b/desktop/frontend/preview/preview_test.mbt
@@ -183,6 +183,12 @@ test "host_of strips scheme, userinfo, and port" {
   assert_true(@preview.host_of("http://127.0.0.1") == Some("127.0.0.1"))
   assert_true(@preview.host_of("ftp://x/") is None)
   assert_true(@preview.host_of("not a url") is None)
+  assert_eq(
+    @preview.host_of("https://first@second@EXAMPLE.com:443/path"),
+    Some("example.com"),
+  )
+  assert_eq(@preview.host_of("https://user@"), Some(""))
+  assert_eq(@preview.host_of("https://user@Ä.EXAMPLE"), Some("Ä.example"))
 }
 
 ///|

--- a/desktop/frontend/preview/url.mbt
+++ b/desktop/frontend/preview/url.mbt
@@ -32,9 +32,9 @@ fn authority_of(url : String) -> String? {
 /// and port. An IPv6 literal keeps its brackets (`[::1]`).
 pub fn host_of(url : String) -> String? {
   guard authority_of(url) is Some(authority) else { return None }
-  let host_port = match authority.split("@").collect() {
-    [.., after] => after.to_owned()
-    [] => authority
+  let host_port = match authority.rev_split_once("@") {
+    Some((_, after)) => after.to_owned()
+    None => authority
   }
   if host_port.has_prefix("[") {
     // An IPv6 literal's colons are not a port separator.

--- a/desktop/internal/subrun/probe.mbt
+++ b/desktop/internal/subrun/probe.mbt
@@ -131,7 +131,7 @@ async fn SubrunProbeState::poll(self : SubrunProbeState) -> Bool {
 /// reader would see moved. The header line and any item this build does not
 /// know about are simply not progress.
 fn SubrunProbeState::consume(self : SubrunProbeState, line : BytesView) -> Bool {
-  let text = @utf8.decode_lossy(line).trim(chars="\r\n \t").to_owned()
+  let text = @utf8.decode_lossy(line).trim(chars="\r\n \t")
   if text.is_empty() {
     return false
   }


### PR DESCRIPTION
Subrun progress parsing copies each trimmed JSON record into an owned string even though the JSON parser accepts a view. Browser host extraction also collects every userinfo segment only to keep the last one. This change removes the temporary string copy and uses `rev_split_once("@")`, preserving existing host parsing and ownership.

The URL tests cover repeated `@`, an empty host after userinfo, and non-ASCII casing. Public interfaces are unchanged.

Validation: `just check`, `just test`, and `just build`; 8 subrun native tests and 12 preview JS tests. The de-slop workflow and its evaluation artifacts are outside this PR.
