### PR TITLE
refactor(desktop): use default trim character set

### DIFF
--- a/desktop/internal/session_record/record.mbt
+++ b/desktop/internal/session_record/record.mbt
@@ -348,7 +348,7 @@ fn Tail::consume(
         "the session record holds a line that is not UTF-8 at byte \{line.length() - rest.length()}: \{@debug.Repr(if rest.length() > 4 { rest[:4] } else { rest })}",
       )
   }
-  let text = text.trim(chars="\r\n \t")
+  let text = text.trim()
   if text.is_empty() {
     return None
   }

--- a/desktop/internal/subrun/probe.mbt
+++ b/desktop/internal/subrun/probe.mbt
@@ -131,7 +131,7 @@ async fn SubrunProbeState::poll(self : SubrunProbeState) -> Bool {
 /// reader would see moved. The header line and any item this build does not
 /// know about are simply not progress.
 fn SubrunProbeState::consume(self : SubrunProbeState, line : BytesView) -> Bool {
-  let text = @utf8.decode_lossy(line).trim(chars="\r\n \t")
+  let text = @utf8.decode_lossy(line).trim()
   if text.is_empty() {
     return false
   }

--- a/desktop/internal/workflow/tail.mbt
+++ b/desktop/internal/workflow/tail.mbt
@@ -105,9 +105,7 @@ async fn FileTail::poll(self : FileTail) -> Array[String] {
     if pending[index] != b'\n' {
       continue
     }
-    let text = @utf8.decode_lossy(pending[line_start:index])
-      .trim(chars="\r\n \t")
-      .to_owned()
+    let text = @utf8.decode_lossy(pending[line_start:index]).trim().to_owned()
     if !text.is_empty() {
       lines.push(text)
     }


### PR DESCRIPTION
Three desktop JSONL readers explicitly passed the same four whitespace characters as `String::trim`'s default. Use `trim()` at those sites after verifying the current core implementation treats the argument as a character set, so its order does not affect behavior. Non-default character sets, owned results, and public interfaces are unchanged.

Validation: the 29 focused native tests pass before and after; `moon info && moon fmt`, `just check`, `just test` (3086 native tests, 3204 JS tests, 38 cram cases, and the CLI lifecycle/workflow fixtures), and `just build` all pass. A separate final-diff review found no blocker.
