### PR TITLE
fix(desktop): soften chat typography

### DIFF
--- a/desktop/styles/README.md
+++ b/desktop/styles/README.md
@@ -41,7 +41,7 @@ for all readable app text, including Jobs, Codex conversations, and dock UI:
 
 | Role | Token | Default |
 | --- | --- | --- |
-| Body text and task names | `--font-size-md` | 14px |
+| Body text, chat prose, composer input, and task names | `--font-size-md` | 14px |
 | Controls and code | `--font-size-sm` | 13px |
 | Timestamps, status, and other metadata | `--font-size-xs` | 12px |
 | Panel headings | `--font-size-lg` | 17px |
@@ -52,7 +52,10 @@ unitless line heights so text grows without clipping. Icon glyphs use the
 icon scale and do not acquire text-sizing rules merely to size an SVG.
 
 Ordinary text inherits `--font-family-sans` and `--font-weight-regular` from
-the app. Code blocks, commands, logs, and paths displayed as code use
+the app (400), with antialiased font smoothing on macOS. Markdown emphasis
+uses 600 rather than the browser's default bold weight. Chat prose and
+composer input use normal letter spacing for mixed Chinese and Latin text.
+Code blocks, commands, logs, and paths displayed as code use
 `--font-family-mono`, which follows the `Monospace font` setting. Avoid
 independent font stacks or misspelled fallback tokens that bypass that
 setting. Task names may use weight 500 and headings 600 to express hierarchy.

--- a/desktop/styles/base.css
+++ b/desktop/styles/base.css
@@ -39,6 +39,7 @@ body {
   line-height: var(--line-height-relaxed);
   letter-spacing: -0.01em;
   text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
 }
 
 button,

--- a/desktop/styles/composer.css
+++ b/desktop/styles/composer.css
@@ -593,7 +593,9 @@
   background: transparent;
   padding: 6px 6px 2px;
   resize: none;
+  font-size: var(--font-size-md);
   line-height: var(--line-height-relaxed);
+  letter-spacing: normal;
 }
 
 .composer-toolbar {

--- a/desktop/styles/tokens.css
+++ b/desktop/styles/tokens.css
@@ -45,7 +45,7 @@
   --font-size-sm: calc(var(--font-size-base) - 1px);
   --font-size-md: var(--font-size-base);
   --font-size-lg: calc(var(--font-size-base) + 3px);
-  --font-weight-regular: 450;
+  --font-weight-regular: 400;
   --line-height-tight: 1;
   --line-height-normal: 1.5;
   --line-height-relaxed: 1.6;

--- a/desktop/styles/transcript.css
+++ b/desktop/styles/transcript.css
@@ -479,7 +479,7 @@
 .user-bubble {
   min-width: 0;
   max-width: 85%;
-  padding: 10px 14px;
+  padding: 12px 16px;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   background: var(--color-bg-subtle);
@@ -566,6 +566,7 @@
   color: var(--color-text-primary);
   font-size: var(--font-size-md);
   line-height: var(--line-height-relaxed);
+  letter-spacing: normal;
   overflow-wrap: anywhere;
   white-space: pre-wrap;
 }
@@ -611,6 +612,9 @@
    so the pre-wrap used for plain text would double every newline */
 .msg-content.markdown {
   white-space: normal;
+}
+.msg-content.markdown :is(strong, b) {
+  font-weight: 600;
 }
 .msg-content.markdown > :first-child {
   margin-top: 0;


### PR DESCRIPTION
Desktop chat looked too heavy and cramped, especially with Chinese/English text in dark mode. Use 400 for regular text, enable antialiased font smoothing on macOS, and set Markdown emphasis to 600. Restore normal letter spacing in messages and the composer, and give user bubbles slightly more padding.

Keep the default text size at 14px and preserve the existing font-size and monospace-font settings. The final appearance was compared in the running macOS desktop and approved at 14px / 400.

Validation:
- `just check`, `just test`, and `just build` passed during implementation; `just check` rerun after rebasing onto main.
- Font-size and monospace persistence browser test passed for the final 14px version; narrow-layout and transcript browser checks passed during implementation.
- `moon info && moon fmt`; no generated interface changes.
