### PR TITLE
refactor(cmd): inline the single-use subrun_args helper

### DIFF
--- a/cmd/openseek/gate.mbt
+++ b/cmd/openseek/gate.mbt
@@ -85,12 +85,21 @@ fn build_goal_met_gate(
   child_session? : @agent_subrun.ChildSession,
 ) -> async (String, @agent_session.GoalBaseline?) -> String? {
   (goal, baseline) => {
-    let args = subrun_args(
+    // The `subrun review` child argv, shaped like every sub-run spawn: the
+    // command and its kind, the inherited model and step ceiling, plus
+    // `--api-url` only when one is configured (absent, the child falls back
+    // to its own default endpoint).
+    let args = [
+      "subrun",
       "review",
-      model~,
-      max_steps=@agent_review.default_audit_max_steps,
-      api_url~,
-    )
+      "--model",
+      "\{model}",
+      "--max-steps",
+      "\{@agent_review.default_audit_max_steps}",
+      ..if api_url is Some(url) {
+        ["--api-url", url]
+      },
+    ]
     let input = review_subrun_input(goal, baseline)
     let result = @agent_subrun.run_subrun(
       command=self_exe,

--- a/cmd/openseek/subrun.mbt
+++ b/cmd/openseek/subrun.mbt
@@ -1,30 +1,4 @@
 ///|
-/// The child argv every subrun spawn shares — the parent half of the contract
-/// `run_subrun_command` below reads: the subcommand and its kind, the
-/// inherited model and step ceiling, plus `--api-url` only when one is
-/// configured (absent, the child falls back to its own default endpoint).
-fn subrun_args(
-  kind : String,
-  model~ : @deepseek.Model,
-  max_steps~ : Int,
-  api_url~ : String?,
-) -> Array[String] {
-  let args = [
-    "subrun",
-    kind,
-    "--model",
-    "\{model}",
-    "--max-steps",
-    "\{max_steps}",
-  ]
-  if api_url is Some(url) {
-    args.push("--api-url")
-    args.push(url)
-  }
-  args
-}
-
-///|
 /// `openseek subrun <kind>` — the INTERNAL child mode the engine spawns for
 /// one sub-run. Contract (see `agent_subrun`, and the normative text in the
 /// `moonbitlang/workflow` library's docs/child-contract.md — §7 records what


### PR DESCRIPTION
The child-argv helper `subrun_args` in `cmd/openseek/subrun.mbt` had exactly one caller — the goal-met review gate in `cmd/openseek/gate.mbt` — so its body is inlined there and the helper is deleted. The conditional `--api-url` pair is now a declarative array spread inside the literal, instead of two pushes into a mutable array:

```moonbit
let args = [
  "subrun",
  "review",
  "--model",
  "\{model}",
  "--max-steps",
  "\{@agent_review.default_audit_max_steps}",
  ..if api_url is Some(url) {
    ["--api-url", url]
  },
]
```

The argv is byte-identical to before: `subrun review --model <model> --max-steps <steps>`, with `--api-url <url>` appended only when an endpoint is configured. `rg subrun_args` finds no remaining references. Nothing public changes and no `.mbti` is regenerated.

Validation:
- `moon check --target native --deny-warn` and `moon check --target js --deny-warn`: clean
- `moon fmt --check` (whole repo): clean
- `moon info`: no `.mbti` diff
- `moon test cmd/openseek --target native`: 83/83 pass

Caveat: two `cmd/openseek` snapshot tests ("environment section reports empty directory layout" and "environment section inline snapshot for deterministic layout") fail in a shell that exports `OPENSEEK_REFERENCES`, because the snapshot does not expect that line. With `OPENSEEK_REFERENCES` unset they pass; this is pre-existing environment sensitivity, unrelated to this change.

Generated with SeekMoon