### PR TITLE
refactor(editor): write string views directly to builders

### DIFF
--- a/editor/base/common/strings.mbt
+++ b/editor/base/common/strings.mbt
@@ -213,7 +213,7 @@ fn to_lower_js(s : String) -> String {
     let lowered = to_lower_code_unit(code)
     if lowered != code {
       if chunk_start < i {
-        sb.write_string(s[chunk_start:i].to_owned())
+        sb.write_view(s[chunk_start:i])
       }
       if lowered.to_char() is Some(ch) {
         sb.write_char(ch)
@@ -224,7 +224,7 @@ fn to_lower_js(s : String) -> String {
     chunk_start
   }
   if chunk_start < len {
-    sb.write_string(s[chunk_start:].to_owned())
+    sb.write_view(s[chunk_start:])
   }
   sb.to_string()
 }

--- a/editor/viewer/common/view_model/injected_text.mbt
+++ b/editor/viewer/common/view_model/injected_text.mbt
@@ -325,7 +325,7 @@ fn append_source_text(
   parts : Array[ProjectedLinePart],
   view_cursor : Int,
 ) -> Unit {
-  builder.write_string(line_text[start_column:end_column].to_owned())
+  builder.write_view(line_text[start_column:end_column])
   let mut view = view_cursor
   for column in start_column..<end_column {
     injected_text_indices.push(-1)


### PR DESCRIPTION
Write three existing slices directly to StringBuilder in lowercase conversion and injected-text projection, instead of first converting them to owned strings. Slice boundaries and output order are unchanged. Non-JS builders copy directly from the view into their buffer, removing the intermediate owned slice; JS write_view still materializes internally, so this makes no JS allocation-saving claim.

Validation: affected-package tests pass before/after (313 JS); root just check, just test and just build pass. Editor all-target tests pass (1,090 wasm, 1,876 JS, 1,224 native; wasm-gc has no test entry), as do all-target deny-warning checks, formatting and all 112 browser smoke/component tests. moon info and moon fmt leave interfaces unchanged. Browser asset build uses the installed Command Line Tools clang 17 (DEVELOPER_DIR=/Library/Developer/CommandLineTools); the default Xcode clang 16 fails compiling async's existing atomic switch. Final source review found no introduced behavior defect. CI at publication: no checks reported yet.
