### PR TITLE
refactor(cmd): tidy the subrun child-mode entry points

### DIFF
--- a/cmd/openseek/subrun.mbt
+++ b/cmd/openseek/subrun.mbt
@@ -31,16 +31,15 @@ async fn run_subrun_command(matches : @argparse.Matches) -> Unit {
   with_jsonl_stdout(() => {
     let workspace_root = prepare_workspace_root(matches, log_created=false)
     let (model, thinking, api_url) = agent_settings(matches)
-    let kind = match matches {
-      { values: { "kind": [kind, ..], .. }, .. } => "\{kind}"
-      _ => fail("missing parsed argument: kind")
+    guard matches is { values: { "kind": [kind, ..], .. }, .. } else {
+      fail("missing parsed argument: kind")
     }
     // One input line; the pipe stays open afterwards as the cancel channel.
     guard @stdio.stdin.read_until("\n") is Some(line) else {
       // EOF before input: the parent gave up before we started.
       return
     }
-    let parsed = @json.parse(line.trim(chars="\r\n")) catch {
+    let parsed = @json.parse(line.trim()) catch {
       _ => {
         @emit.emit(CommandError(error="subrun input is not JSON"))
         return
@@ -435,13 +434,6 @@ async fn self_executable() -> String {
   let argv0 = match @env.args() {
     [first, ..] => first
     _ => "openseek"
-  }
-  // Under `moon run` on the tcc debug path argv0 is the generated .c
-  // SOURCE, not an executable: spawning it would fail every subrun launch.
-  // Fall back to PATH resolution — the same case the terminal UI handles for
-  // its engine spawn.
-  if argv0.has_suffix(".c") {
-    return "openseek"
   }
   if argv0.contains("/") || argv0.contains("\\") {
     @fs.realpath(argv0) catch {


### PR DESCRIPTION
Three small cleanups in the `openseek subrun` child mode, all in `cmd/openseek/subrun.mbt`.

**1. A guard instead of a two-arm match, and no re-binding of `kind`.**
`Matches.values` is `Map[String, Array[String]]`, so the pattern binding is already the `String` the rest of the function uses — the interpolation re-binding was only a copy:

```moonbit
guard matches is { values: { "kind": [kind, ..], .. }, .. } else {
  fail("missing parsed argument: kind")
}
```

The guard fires only when the `kind` key is absent; an unknown-but-present kind still reaches `dispatch_kind`'s `command_error` path, exactly as before.

**2. `line.trim()` without an explicit character set.**
The default set already covers CR and LF — verified equal on a CRLF-terminated input line — so `chars="\r\n"` only restated the default.

**3. `self_executable` drops its `.c` argv0 fallback.**
The removed comment claimed that `moon run`'s tcc debug path hands the process the generated `.c` source. That no longer holds: argv0 was probed with throwaway packages and is always the linked executable — `…/main.exe` for `moon run <pkg> --target native`, the same for `--release`, and `…/single/single.exe` for a single-file `.mbtx` run. Forcing the bundled tcc via `MOON_CC` cannot even link (`main.o: unrecognized file type`), so the historical "tcc `-run` the .c" path cannot be live. The function's contract is unchanged: an argv0 with a path separator is realpath'd (the child runs with a different cwd), a bare name stays PATH-resolved.

Validation:
- `moon check --deny-warn`: clean
- `moon fmt --check`: clean
- `moon cram test tests/cram/subrun.md --shell bash`: 3/3 cases pass
- `moon test cmd/openseek --target native`: 83/83 tests pass
- `moon run tests/integration/workflows`: all offline child-contract cases pass

Caveat: two `cmd/openseek` snapshot tests ("environment section reports empty directory layout" and "environment section inline snapshot for deterministic layout") fail in a shell that exports `OPENSEEK_REFERENCES`, since the snapshot does not expect that line. With the variable unset they pass; this is pre-existing environment sensitivity, unrelated to this change.

Generated with SeekMoon