### PR TITLE
fix(mbtx): run hosted children in the selected worktree

### DIFF
--- a/agent_subrun/host/host.mbt
+++ b/agent_subrun/host/host.mbt
@@ -182,7 +182,12 @@ pub fn SubrunReservation::env(self : SubrunReservation) -> Map[String, String] {
 /// write the same document. `attempt_id` in the resulting ledger is the
 /// rendered `child_id` — `<parent>-sr-N` — which is exactly the session id the
 /// transcript viewer links to and the desktop's progress probe tails.
-pub fn SubrunInjection::reserve(self : SubrunInjection) -> SubrunReservation {
+/// `cwd` selects this invocation's child workspace. The caller resolves it
+/// to an absolute directory; omitting it keeps the injection's workspace.
+pub fn SubrunInjection::reserve(
+  self : SubrunInjection,
+  cwd? : String,
+) -> SubrunReservation {
   let base = (self.reserve_ordinals)(block_size)
   // The run's directory lives in the session store's root, beside the store's
   // own `sessions/` tree that holds the transcripts it accounts for — with the
@@ -221,7 +226,7 @@ pub fn SubrunInjection::reserve(self : SubrunInjection) -> SubrunReservation {
     ],
     "journal": journal_path,
     "events": events_path,
-    "cwd": self.workspace_root,
+    "cwd": cwd.unwrap_or(self.workspace_root),
   }
   let env = { "WORKFLOW_HOST": handoff.stringify() }
   if (self.criteria)() is Some(criteria) {

--- a/agent_subrun/host/host_test.mbt
+++ b/agent_subrun/host/host_test.mbt
@@ -115,3 +115,22 @@ test "the standing goal rides the guest environment beside the handoff" {
   assert_eq(env.get("OPENSEEK_GOAL_DIRTY"), Some("false"))
   assert_true(env.get("WORKFLOW_HOST") is Some(_))
 }
+
+///|
+test "a reservation's cwd does not change later reservations or session ownership" {
+  let injection = injection(Ref(0))
+  let selected = injection.reserve(cwd="/other worktree")
+  let next = injection.reserve()
+  let selected_env = selected.env()
+  let next_env = next.env()
+  guard selected_env.get("WORKFLOW_HOST") is Some(raw) else {
+    fail("missing selected handoff")
+  }
+  assert_true(@json.parse(raw) is { "cwd": "/other worktree", .. })
+  guard next_env.get("WORKFLOW_HOST") is Some(raw) else {
+    fail("missing default handoff")
+  }
+  assert_true(@json.parse(raw) is { "cwd": "/ws", .. })
+  assert_eq(selected.dir(), "/store/run7-wf-1")
+  assert_eq(next.dir(), "/store/run7-wf-33")
+}

--- a/agent_subrun/host/pkg.generated.mbti
+++ b/agent_subrun/host/pkg.generated.mbti
@@ -16,7 +16,7 @@ pub(all) struct AuditCriteria {
 type SubrunInjection
 pub fn SubrunInjection::SubrunInjection(exe~ : String, session_root~ : String, parent~ : String, workspace_root~ : String, reserve_ordinals~ : (Int) -> Int, model? : String, api_url? : String, criteria? : () -> AuditCriteria?) -> Self
 pub fn SubrunInjection::exe(Self) -> String
-pub fn SubrunInjection::reserve(Self) -> SubrunReservation
+pub fn SubrunInjection::reserve(Self, cwd? : String) -> SubrunReservation
 
 type SubrunReservation
 pub fn SubrunReservation::base(Self) -> Int

--- a/agent_tool/mbtx/README.mbt.md
+++ b/agent_tool/mbtx/README.mbt.md
@@ -124,7 +124,10 @@ with `args=["--help"]`. No standalone `read` tool is registered.
   and run without that policy. `native` is deliberately unavailable because
   moonrun cannot apply the policy to it.
 - `cwd` (string, optional, default workspace root): the working directory the
-  program runs in. A relative `cwd` resolves against the workspace root.
+  program and its hosted children run in. A relative `cwd` resolves against
+  the workspace root. With `subrun: true`, scouts and reviewers read this
+  selected worktree; saved-script filenames still resolve against the original
+  workspace, and the snippet's write roots do not change.
 - `escalated` (boolean, optional, default `false`): ask the user to run this
   one snippet with **no sandbox policy**. Offered only when the tool was built
   with an `ask_approval` channel — see *Escalation* below. Absent from the

--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -589,7 +589,9 @@ async fn execute(
   // snippet cannot name a session that was not reserved for it.
   let reservation = if input.subrun {
     match subrun {
-      Some(injection) => Some(injection.reserve())
+      Some(injection) =>
+        // A relative cwd must not resolve again inside the running snippet.
+        Some(injection.reserve(cwd=@fs.realpath(run_cwd.unwrap_or("."))))
       // Asked, and cannot be served: say so. A snippet that believed it had a
       // handoff would spawn children with no transcript, and the model would
       // learn nothing until its subagents failed to appear anywhere.
@@ -1586,7 +1588,7 @@ fn schema(escalation~ : Bool, hosting~ : Bool) -> Json {
             "cwd",
             {
               "type": "string",
-              "description": "Working directory the program runs in (relative paths resolve against the workspace root); defaults to the workspace root.",
+              "description": "Working directory for the program and its hosted children (relative paths resolve against the workspace root); defaults to the workspace root. Saved-script filenames still resolve against the original workspace.",
             },
           ),
           (

--- a/agent_tool/mbtx/mbtx_test.mbt
+++ b/agent_tool/mbtx/mbtx_test.mbt
@@ -2140,3 +2140,46 @@ async test "CI monitor bundled entry forwards arguments before querying GitHub" 
     assert_true(out.content.contains("Expected seconds"), msg=out.content)
   })
 }
+
+///|
+// Exercise mbtx's handoff; the hosted library owns the subsequent child spawn.
+async test "the handoff reserves the worktree selected by cwd" {
+  @vfs.with_tmpdir(prefix="mbtx-ws-", ws => {
+    @vfs.with_tmpdir(prefix="mbtx-store-", store => {
+      let other = ws + "/other worktree"
+      @fs.mkdir(other)
+      @fs.write_file(ws + "/marker", "parent", create_mode=CreateOrTruncate)
+      @fs.write_file(
+        other + "/marker",
+        "selected",
+        create_mode=CreateOrTruncate,
+      )
+      let source =
+        #|import { "moonbitlang/async", "moonbitlang/async/fs", "moonbitlang/core/env", "moonbitlang/core/json" }
+        #|async fn main {
+        #|  guard @env.get_env_var("WORKFLOW_HOST") is Some(raw) else { fail("missing handoff") }
+        #|  guard @json.parse(raw) is { "cwd": String(child_cwd), .. } else { fail("missing child cwd") }
+        #|  println("snippet=" + @fs.read_file("marker").text())
+        #|  println("child=" + @fs.read_file(child_cwd + "/marker").text())
+        #|}
+      for cwd in ["other worktree", other] {
+        let (out, issued) = run_hosted_with(ws, store, {
+          "source": source,
+          "cwd": cwd,
+          "subrun": true,
+        })
+        assert_false(out.is_error, msg=out.content)
+        assert_eq(issued, @host.block_size)
+        assert_true(out.content.contains("snippet=selected"), msg=out.content)
+        assert_true(out.content.contains("child=selected"), msg=out.content)
+      }
+      let (out, _) = run_hosted_with(ws, store, {
+        "source": source,
+        "subrun": true,
+      })
+      assert_false(out.is_error, msg=out.content)
+      assert_true(out.content.contains("snippet=parent"), msg=out.content)
+      assert_true(out.content.contains("child=parent"), msg=out.content)
+    })
+  })
+}


### PR DESCRIPTION
When `mbtx` runs a hosted workflow with `cwd` selecting another worktree, its script used that directory but its scouts/reviewers still read the original parent workspace. Pass the validated absolute script directory into each child reservation. Omitted reservation overrides retain the injection default; session storage, ordinal ownership, saved-script resolution and snippet write roots stay unchanged.

Validation: the new mbtx handoff regression fails before this patch (`snippet=selected`, `child=parent`) and passes after it for relative, absolute and omitted cwd. Host reservation tests cover subsequent-invocation isolation and session ownership. All 112 host/mbtx native tests, `moon info`, `moon fmt`, `just check`, `just test` and `just build` pass. A live two-worktree workflow also confirmed the actual child process directories. The optional `reserve(cwd?)` argument is the intended additive interface change.

CI snapshot at `e5219dc08`: 1 pending, 1 pass.
