### PR TITLE
fix(desktop): pin package overview files in directory browsers

### DIFF
--- a/desktop/e2e/tests/rabbita_dom.spec.js
+++ b/desktop/e2e/tests/rabbita_dom.spec.js
@@ -724,8 +724,10 @@ test('tab strip closes every tab type into the New Tab launcher', async ({ page 
 test('file breadcrumbs browse cached directories with keyboard navigation', async ({ page }) => {
   const app = new DesktopBrowserHarness(page);
   app.directoryEntries['/workspace/src'] = [
-    { name: 'docs', is_dir: true },
     { name: 'main.mbt', is_dir: false },
+    { name: 'pkg.generated.mbti', is_dir: false },
+    { name: 'docs', is_dir: true },
+    { name: 'README.mbt.md', is_dir: false },
   ];
   app.directoryEntries['/workspace/src/docs'] = [];
   await app.install();
@@ -742,12 +744,20 @@ test('file breadcrumbs browse cached directories with keyboard navigation', asyn
     request.method === 'fs.read_directory' && request.params?.path === '/workspace/src'))
     .toBeTruthy();
   const menu = page.getByRole('menu', { name: 'Files in src' });
+  await expect(menu.getByRole('menuitem').locator('.breadcrumb-picker-name')).toHaveText([
+    'README.mbt.md', 'pkg.generated.mbti', 'docs', 'main.mbt',
+  ]);
   await expect(menu.getByRole('menuitem').last()).toHaveAttribute('aria-current', 'page');
   await expect(menu.getByRole('menuitem').first()).toBeFocused();
   await page.keyboard.press('ArrowDown');
+  await expect(menu.getByRole('menuitem').nth(1)).toBeFocused();
+  await page.keyboard.press('End');
   await expect(menu.getByRole('menuitem').last()).toBeFocused();
   await page.keyboard.press('Home');
   await expect(menu.getByRole('menuitem').first()).toBeFocused();
+  await page.keyboard.press('ArrowDown');
+  await page.keyboard.press('ArrowDown');
+  await expect(menu.getByRole('menuitem').nth(2)).toBeFocused();
   await page.keyboard.press('ArrowRight');
 
   await expect.poll(() => app.requests.find(request =>

--- a/desktop/frontend/fileeditor/tree_entries.mbt
+++ b/desktop/frontend/fileeditor/tree_entries.mbt
@@ -2,6 +2,39 @@
 // matching; this package renders only the expanded directory tree.
 
 ///|
+/// Cache a single presentation order for the tree and breadcrumb picker.
+/// Only the two exact package overview filenames are pinned; directories with
+/// those names remain directories. Copy before sorting to preserve messages
+/// and previous state snapshots. The provider index breaks otherwise equal
+/// keys because Array::sort_by is unstable.
+fn ordered_directory_entries(entries : Array[FileEntry]) -> Array[FileEntry] {
+  fn rank(entry : FileEntry) -> Int {
+    if entry.is_dir {
+      2
+    } else {
+      match entry.name {
+        "README.mbt.md" => 0
+        "pkg.generated.mbti" => 1
+        _ => 3
+      }
+    }
+  }
+  let order = Array::makei(entries.length(), index => index)
+  order.sort_by((left, right) => {
+    match rank(entries[left]).compare(rank(entries[right])) {
+      0 =>
+        // String::compare is shortlex, not filename lexicographic order.
+        match entries[left].name.lexical_compare(entries[right].name) {
+          0 => left.compare(right)
+          by_name => by_name
+        }
+      by_rank => by_rank
+    }
+  })
+  order.map(index => entries[index])
+}
+
+///|
 /// Tree rows currently on screen, in depth-first render order with indentation
 /// depth. Only listed, expanded directories contribute descendants.
 fn visible_entries(state : State) -> Array[(FileEntry, Int)] {

--- a/desktop/frontend/fileeditor/tree_entries_wbtest.mbt
+++ b/desktop/frontend/fileeditor/tree_entries_wbtest.mbt
@@ -1,0 +1,99 @@
+///|
+fn ordering_test_entry(name : String, is_dir? : Bool = false) -> FileEntry {
+  { name, path: Relative(name), is_dir, }
+}
+
+///|
+test "directory overview order handles absent files and exact names without mutation" {
+  let entries = [
+    ordering_test_entry("z"),
+    ordering_test_entry("pkg.generated.mbti"),
+    ordering_test_entry("README.mbt.md.bak"),
+    ordering_test_entry("src", is_dir=true),
+    ordering_test_entry("README.mbt.md"),
+    ordering_test_entry("aa"),
+    ordering_test_entry("README.mbt.md", is_dir=true),
+    ordering_test_entry("pkg.generated.mbti", is_dir=true),
+    ordering_test_entry("readme.mbt.md"),
+    ordering_test_entry("moon.pkg"),
+  ]
+  let original = entries.copy()
+  let sorted = ordered_directory_entries(entries)
+  assert_true(
+    sorted ==
+    [
+      entries[4],
+      entries[1],
+      entries[6],
+      entries[7],
+      entries[3],
+      entries[2],
+      entries[5],
+      entries[9],
+      entries[8],
+      entries[0],
+    ],
+  )
+  assert_true(entries == original)
+  assert_true(ordered_directory_entries(sorted) == sorted)
+  assert_true(ordered_directory_entries([]) == [])
+  assert_true(
+    ordered_directory_entries([
+      ordering_test_entry("z"),
+      ordering_test_entry("aa"),
+    ]) ==
+    [ordering_test_entry("aa"), ordering_test_entry("z")],
+  )
+  for name in ["README.mbt.md", "pkg.generated.mbti"] {
+    assert_true(
+      ordered_directory_entries([
+        ordering_test_entry("src", is_dir=true),
+        ordering_test_entry(name),
+      ]) ==
+      [ordering_test_entry(name), ordering_test_entry("src", is_dir=true)],
+    )
+  }
+  // Equal display keys retain provider order even with distinct identities.
+  let duplicate = { ..ordering_test_entry("aa"), path: Relative("other/aa"), }
+  assert_true(
+    ordered_directory_entries([ordering_test_entry("aa"), duplicate]) ==
+    [ordering_test_entry("aa"), duplicate],
+  )
+}
+
+///|
+test "directory loads and refreshes cache the same order used by the tree" {
+  let root = @pathx.Relative::root()
+  let ctx = test_ctx()
+  let entries : Array[FileEntry] = [
+    { name: "z", path: Relative("z"), is_dir: false, },
+    {
+      name: "pkg.generated.mbti",
+      path: Relative("pkg.generated.mbti"),
+      is_dir: false,
+    },
+    { name: "README.mbt.md", path: Relative("README.mbt.md"), is_dir: false, },
+  ]
+  let initial = owned_state()
+  let (_, loaded) = update(
+    test_emit(),
+    DirLoaded(owner=ctx.owner, epoch=0, path=root, entries~),
+    initial,
+    ctx,
+  )
+  let expected = [entries[2], entries[1], entries[0]]
+  assert_true(loaded.children.get(root) == Some(expected))
+  assert_true(visible_entries(loaded).map(pair => pair.0) == expected)
+  assert_true(initial.children.get(root) == None)
+  let (_, refreshed) = update(
+    test_emit(),
+    DirLoaded(owner=ctx.owner, epoch=0, path=root, entries=[
+      entries[0],
+      entries[1],
+    ]),
+    loaded,
+    ctx,
+  )
+  assert_true(refreshed.children.get(root) == Some([entries[1], entries[0]]))
+  assert_true(loaded.children.get(root) == Some(expected))
+}

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -2817,7 +2817,7 @@ pub fn update(
         (@cmd.none, state)
       } else {
         let children = state.children.copy()
-        children[path] = entries
+        children[path] = ordered_directory_entries(entries)
         let breadcrumb_cmd = if state.highlighted is Some(highlighted) &&
           highlighted == path {
           focus_breadcrumb_entry_after_render(0)


### PR DESCRIPTION
Pin `README.mbt.md` and `pkg.generated.mbti`, in that order, at the beginning of each Desktop directory listing. Previously the interface file was mixed into the alphabetical file list. Remaining entries retain directories-first, lexicographic ordering.

Apply the order when caching directory loads so the file tree, breadcrumb picker, and keyboard navigation agree. Only exact filenames are pinned; same-named directories are not. Sorting preserves input arrays and provider order for equal keys. No public API changes.

Validation:
- `just check`, `just test`, and `just build` passed (3,092 native and 3,214 JS tests, plus offline integration gates).
- All 156 fileeditor tests passed, including absence, exact matching, refresh, and state preservation coverage.
- Playwright breadcrumb regression passed for ordering, arrow keys, Home/End, and entering a directory.
- `moon info`, `moon fmt`, and `git diff --check` passed.
