### PR TITLE
fix(desktop): nest live workflow agents under their parent

### DIFF
--- a/desktop/frontend/sidebar/conversation/conversation.mbt
+++ b/desktop/frontend/sidebar/conversation/conversation.mbt
@@ -351,6 +351,9 @@ pub fn component(
     by=child => child.id(),
   )
   state.map3(input, child_rows, (state, input, child_rows) => {
+    // Opening a workflow child must keep its selected row visible under the parent.
+    let children_open = state.children_open ||
+      input.children.any(child => child.active || child.loading)
     let mut class = "conversation-row"
     if input.nested {
       class += " nested"
@@ -376,11 +379,7 @@ pub fn component(
     } else {
       children.push(
         @html.button(
-          class=if state.children_open {
-            "row-twisty expanded"
-          } else {
-            "row-twisty"
-          },
+          class=if children_open { "row-twisty expanded" } else { "row-twisty" },
           type_="button",
           title=if input.children.length() == 1 {
             "1 subagent run"
@@ -639,7 +638,7 @@ pub fn component(
       children,
     )
     let rows : Array[(String, @html.Html)] = [(input.id.key(), row)]
-    if state.children_open {
+    if children_open {
       for group in child_rows {
         for child in group {
           rows.push(child)

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -204,6 +204,8 @@ fn Model::push_group_component_inputs(
   // Every row in this group shares the group's store placement; it becomes
   // the `root` half of each conversation's component id.
   let root = workspace.path
+  let items : Array[@transcript.SessionListItem] = []
+  let local_worktrees : Map[String, String?] = Map([])
   for conv in self.conversations.rev_iter() {
     if conv.device != dev.channel ||
       conv.project() != workspace ||
@@ -231,40 +233,39 @@ fn Model::push_group_component_inputs(
     } else {
       worktree_name_for(dev, workspace, conv.session_id)
     }
-    rows.push(
-      (
-        // An in-memory conversation the durable listing does not hold yet is
-        // this session's own work; it leads the stamped history below.
-        ComposingNow,
-        session_component_input(
-          self,
-          dev.channel,
-          conv.session_id,
-          if standalone &&
-            !conv.has_begun() &&
-            conv.task.is_empty() &&
-            conv.pending_prompt is None {
-            "New chat"
-          } else {
-            conversation_title(conv)
-          },
-          nested=!standalone,
-          worktree?,
-          root~,
-        ),
+    local_worktrees[conv.session_id] = worktree
+    items.push({
+      id: conv.session_id,
+      title: Some(
+        if standalone &&
+          !conv.has_begun() &&
+          conv.task.is_empty() &&
+          conv.pending_prompt is None {
+          "New chat"
+        } else {
+          conversation_title(conv)
+        },
       ),
-    )
+      workspace,
+      workspace_name: workspace.path,
+      updated_at_ms: None,
+    })
   }
-  let durable = dev.sessions.filter(item => {
-    item.workspace == workspace && !archived(item.id)
-  })
+  // A child opened from Workflows may not be in the host inventory yet.
+  // Fold live and listed sessions together so either source can own a parent
+  // or child without creating a second top-level conversation.
+  for item in dev.sessions {
+    if item.workspace == workspace && !archived(item.id) {
+      items.push(item)
+    }
+  }
   // Sub-run transcripts fold under the conversation that launched them: they
   // are that turn's evidence, not conversations of their own. They ride the
   // parent's component input, so their disclosure state lives in the
   // conversation component. A label follows the live conversation while it
   // is the one on screen (its title settles at the first send), and
   // otherwise comes from the host's listing.
-  for tree in @transcript.session_tree(durable) {
+  for tree in @transcript.session_tree(items) {
     let parent_label = if tree.item.title is Some(title) && !title.is_blank() {
       title
     } else if self.find_conversation(dev.channel, tree.item.id) is Some(conv) &&
@@ -301,9 +302,13 @@ fn Model::push_group_component_inputs(
         ),
       )
     }
-    let stamp = match tree.item.updated_at_ms {
-      Some(ms) => ActiveAt(ms)
-      None => Unstamped
+    let stamp = if local_worktrees.contains(tree.item.id) {
+      ComposingNow
+    } else {
+      match tree.item.updated_at_ms {
+        Some(ms) => ActiveAt(ms)
+        None => Unstamped
+      }
     }
     rows.push(
       (
@@ -317,9 +322,12 @@ fn Model::push_group_component_inputs(
           // action. A child-shaped root is legacy split state (or belongs to a
           // parent in another store), so it remains independently archivable;
           // once beside its archived parent, family restore picks it up.
-          archivable=true,
+          archivable=!local_worktrees.contains(tree.item.id),
           nested=!standalone,
-          worktree?=worktree_name_for(dev, workspace, tree.item.id),
+          worktree?=match local_worktrees.get(tree.item.id) {
+            Some(worktree) => worktree
+            None => worktree_name_for(dev, workspace, tree.item.id)
+          },
           root~,
           children~,
         ),

--- a/desktop/frontend/view_wbtest.mbt
+++ b/desktop/frontend/view_wbtest.mbt
@@ -54,3 +54,66 @@ test "a fresh chat selects its project and materializes on first send" {
     codex_page.conversation_selection() == submitted.conversation_selection(),
   )
 }
+
+///|
+test "workflow children fold under live or listed parents before inventory refresh" {
+  let workspace = @interop.ChannelId::Local.test_project()
+  for parent_listed in [false, true] {
+    let page = subrun_page(active="desktop-test-sr-1")
+    let page = page
+      .replace_conversation({
+        ..subrun_child_of(page),
+        messages: [
+          { kind: User("The criteria under audit"), ts: None, sequence: None, },
+        ],
+      })
+      .with_dev(dev => {
+        ..dev,
+        active_project: Some(workspace),
+        sessions: if parent_listed {
+          [
+            {
+              id: "desktop-test",
+              title: Some("<user_mentions>"),
+              workspace,
+              workspace_name: "work",
+              updated_at_ms: Some(1.0),
+            },
+          ]
+        } else {
+          []
+        },
+      })
+    let project = sidebar_project_for_test(page)
+    assert_eq(project.conversations.length(), 1)
+    let parent = project.conversations[0]
+    assert_eq(parent.children.length(), 1)
+    assert_eq(parent.children[0].label, "sr-1 · The criteria under audit")
+    assert_true(parent.children[0].active)
+    assert_true(parent.children[0].subrun)
+
+    // Once the host lists both records, the same family remains without duplicates.
+    let refreshed = page.with_dev(dev => {
+      ..dev,
+      sessions: [
+        {
+          id: "desktop-test",
+          title: Some("<user_mentions>"),
+          workspace,
+          workspace_name: "work",
+          updated_at_ms: Some(1.0),
+        },
+        {
+          id: "desktop-test-sr-1",
+          title: Some("The criteria under audit"),
+          workspace,
+          workspace_name: "work",
+          updated_at_ms: Some(2.0),
+        },
+      ],
+    })
+    let project = sidebar_project_for_test(refreshed)
+    assert_eq(project.conversations.length(), 1)
+    assert_eq(project.conversations[0].children.length(), 1)
+  }
+}


### PR DESCRIPTION
Opening a subagent from Workflows before the session inventory refreshes currently puts it beside its main agent in the sidebar. Merge live conversations and listed sessions before grouping so the child appears under its parent immediately and remains there after refresh. Automatically reveal the selected child's group.

Validation: added regression coverage for live and listed parents, selected children, and duplicate prevention after inventory refresh. `just check`, `just test`, `just build`, and `moon info && moon fmt` passed; generated interfaces are unchanged.
