### PR TITLE
Use argparse for review workflow CLI and add cram coverage

### DIFF
--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -566,7 +566,10 @@ stderr warning while exit stays 0 — treat skipped blocks as a blind spot.
   `mbtx` tool offers `subrun`: run `@builtin/review.mbtx` with `subrun: true`.
   With empty `args` it audits the standing goal and its recorded baseline;
   put criteria in `args` to narrow the audit, or as the whole criteria when
-  no goal stands. A review subagent reads the files, runs the project's own
+  no goal stands. Put free-text criteria after `--`, for example
+  `args: ["--", "Check CSV handling"]`, so leading hyphens remain literal.
+  Put baseline options (`--sha COMMIT`, optionally `--dirty`) before `--`.
+  A review subagent reads the files, runs the project's own
   checks, hunts for vacuous success, and returns severity-tagged findings
   with file:line citations in the printed report. A blocker finding fails
   the call: the claim does not hold yet. Costs a bounded subagent run; for

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -590,7 +590,10 @@ fn default_prompt() -> String {
     #|  `mbtx` tool offers `subrun`: run `@builtin/review.mbtx` with `subrun: true`.
     #|  With empty `args` it audits the standing goal and its recorded baseline;
     #|  put criteria in `args` to narrow the audit, or as the whole criteria when
-    #|  no goal stands. A review subagent reads the files, runs the project's own
+    #|  no goal stands. Put free-text criteria after `--`, for example
+    #|  `args: ["--", "Check CSV handling"]`, so leading hyphens remain literal.
+    #|  Put baseline options (`--sha COMMIT`, optionally `--dirty`) before `--`.
+    #|  A review subagent reads the files, runs the project's own
     #|  checks, hunts for vacuous success, and returns severity-tagged findings
     #|  with file:line citations in the printed report. A blocker finding fails
     #|  the call: the claim does not hold yet. Costs a bounded subagent run; for

--- a/share/workflow/README.md
+++ b/share/workflow/README.md
@@ -71,7 +71,7 @@ other colons. Paths with spaces are single args without shell quoting.
 Run these with the hosted child-agent handoff:
 
 ```json
-{"description":"Audit the parser","filename":"@builtin/review.mbtx","args":["Check the CSV parser's CRLF and escaped-quote handling."],"subrun":true}
+{"description":"Audit the parser","filename":"@builtin/review.mbtx","args":["--","Check the CSV parser's CRLF and escaped-quote handling."],"subrun":true}
 ```
 
 ```json
@@ -91,7 +91,8 @@ when no goal stands. It prints the full report JSON, then a
 `findings=N blockers=M` line, and exits unsuccessfully when any finding is a
 blocker so the caller cannot read past it. `--sha COMMIT` (with `--dirty`
 when the worktree was already dirty at that commit) overrides the engine's
-baseline; `--help` prints usage.
+baseline; `--help` prints usage. Put free-text criteria after `--` so leading
+hyphens remain literal, and put baseline options before `--`.
 
 The other two use `moonbitlang/workflow`'s `fan_out` and `attempt` with
 read-only `explore` children. Change review runs three scouts, allowing 16 steps each.

--- a/share/workflow/review.mbtx
+++ b/share/workflow/review.mbtx
@@ -8,7 +8,7 @@ import {
 }
 
 ///|
-/// Run with mbtx(description="Review the worktree", filename="@builtin/review.mbtx", args=["What to audit against"], subrun=true).
+/// Run with mbtx(description="Review the worktree", filename="@builtin/review.mbtx", args=["--", "What to audit against"], subrun=true).
 /// One review child audits the current worktree against the standing goal
 /// the engine supplies and/or the criteria in args, prints its full
 /// structured report, and fails on a blocker finding; no retries or

--- a/share/workflow/review.mbtx
+++ b/share/workflow/review.mbtx
@@ -1,6 +1,7 @@
 ///|
 import {
   "moonbitlang/async@0.21.1",
+  "moonbitlang/core/argparse",
   "moonbitlang/core/env",
   "moonbitlang/workflow@0.7.0",
   "moonbitlang/workflow@0.7.0/hosted",
@@ -12,9 +13,7 @@ import {
 /// the engine supplies and/or the criteria in args, prints its full
 /// structured report, and fails on a blocker finding; no retries or
 /// automatic edits.
-const Usage : String =
-  #|usage: @builtin/review.mbtx [--sha COMMIT [--dirty]] [--] [CRITERIA...]
-  #|
+const About : String =
   #|With no arguments the reviewer audits the standing goal and the baseline
   #|it recorded, which the engine supplies in OPENSEEK_GOAL (and
   #|OPENSEEK_GOAL_SHA/OPENSEEK_GOAL_DIRTY). The remaining arguments, joined
@@ -26,42 +25,44 @@ const Usage : String =
 
 ///|
 async fn main {
-  let mut sha : String? = None
-  let mut dirty = false
-  let criteria : Array[String] = []
-  for args = @env.args()[1:] {
-    match args {
-      [] => break
-      ["--help" | "-h", ..] => {
-        println(Usage)
-        return
-      }
-      ["--sha", commit, .. rest] => {
-        sha = Some(commit)
-        continue rest
-      }
-      ["--dirty", .. rest] => {
-        dirty = true
-        continue rest
-      }
-      ["--", .. rest] => {
-        criteria.append(rest.to_owned())
-        break
-      }
-      [word, .. rest] => {
-        criteria.push(word)
-        continue rest
-      }
-    }
+  let command = @argparse.Command(
+    "@builtin/review.mbtx",
+    about=About,
+    flags=[
+      @argparse.FlagArg(
+        "dirty",
+        about="The worktree was already dirty at the baseline commit.",
+        requires=["sha"],
+      ),
+    ],
+    options=[
+      @argparse.OptionArg(
+        "sha",
+        about="Baseline commit; overrides the standing goal's baseline.",
+      ),
+    ],
+    positionals=[
+      @argparse.PositionArg(
+        "criteria",
+        about="Audit focus, or the whole criteria when no goal stands.",
+        num_args=@argparse.ValueRange(lower=0),
+      ),
+    ],
+  )
+  let parsed = command.parse()
+  let sha = match parsed.values {
+    { "sha": [commit], .. } => Some(commit)
+    _ => None
   }
-  guard sha is Some(_) || !dirty else { fail("--dirty needs --sha\n\{Usage}") }
+  let dirty = parsed.flags is { "dirty": true, .. }
+  let criteria = parsed.values.get("criteria").unwrap_or([])
   let focus = criteria.join(" ")
   let standing = @env.get_env_var("OPENSEEK_GOAL")
   let goal = match (standing, focus.is_blank()) {
     (Some(text), true) => text
     (Some(text), false) => "\{text}\n\nAudit focus:\n\{focus}"
     (None, false) => focus
-    (None, true) => fail("no criteria given and no standing goal\n\{Usage}")
+    (None, true) => fail("no criteria given and no standing goal\n\{command.render_help()}")
   }
   // An explicit baseline wins; the engine's accompanies only the standing
   // goal it was recorded for.

--- a/tests/cram/review-workflow.md
+++ b/tests/cram/review-workflow.md
@@ -1,0 +1,102 @@
+# Review workflow CLI
+
+Run the bundled script directly, without a hosted handoff or standing goal.
+The build stays in cram's scratch directory. Successful hosted reviews and
+baseline/goal resolution are covered by `just test-workflows`.
+
+```mooncram
+$ cat > review.sh <<'EOF'
+> unset WORKFLOW_HOST OPENSEEK_GOAL OPENSEEK_GOAL_SHA OPENSEEK_GOAL_DIRTY
+> moon run -q "$TESTDIR/../../share/workflow/review.mbtx" --target-dir _build -- "$@"
+> EOF
+```
+
+Argparse generates the help without requiring a goal or a host.
+
+```mooncram
+$ sh review.sh --help
+Usage: @builtin/review.mbtx [options] [criteria...]
+
+With no arguments the reviewer audits the standing goal and the baseline
+it recorded, which the engine supplies in OPENSEEK_GOAL (and
+OPENSEEK_GOAL_SHA/OPENSEEK_GOAL_DIRTY). The remaining arguments, joined
+with spaces, narrow that goal as an audit focus, or are the whole criteria
+when no goal stands. --sha names the baseline commit the criteria were
+recorded at (--dirty: the worktree was already dirty then) and overrides
+the engine's. A blocker finding fails the call: the claim does not hold
+yet. Requires the hosted handoff: call mbtx with subrun=true.
+
+Arguments:
+  criteria...  Audit focus, or the whole criteria when no goal stands.
+
+Options:
+  -h, --help   Show help information.
+  --dirty      The worktree was already dirty at the baseline commit.
+  --sha <sha>  Baseline commit; overrides the standing goal's baseline.
+```
+
+```mooncram
+$ sh review.sh -h > short-help && sh review.sh --help > long-help && diff short-help long-help
+```
+
+Argument errors fail before starting a review. Pin the diagnostic and exit
+status without repeating the generated help.
+
+```mooncram
+$ sh <<'EOF'
+> sh review.sh --sha > output 2>&1
+> status=$?
+> sed -n '1p' output
+> exit "$status"
+> EOF
+error: a value is required for '--sha' but none was supplied
+[1]
+```
+
+```mooncram
+$ sh <<'EOF'
+> sh review.sh --unknown > output 2>&1
+> status=$?
+> sed -n '1p' output
+> exit "$status"
+> EOF
+error: unexpected argument '--unknown' found
+[1]
+```
+
+```mooncram
+$ sh <<'EOF'
+> sh review.sh --dirty audit > output 2>&1
+> status=$?
+> sed -n '1p' output
+> exit "$status"
+> EOF
+error: the following required argument was not provided: 'sha' (required by 'dirty')
+[1]
+```
+
+`--` makes option-looking words literal criteria. Valid criteria (including
+multiple words and an explicit baseline) reach the hosted-context check.
+Normalize only the source location in the runtime failure.
+
+```mooncram
+$ sh <<'EOF'
+> sh review.sh -- --help --sha --dirty > output 2>&1
+> status=$?
+> sed -E 's/^Failure\([^ ]+ FAILED: /Failure(/' output
+> exit "$status"
+> EOF
+Failure(This workflow needs OpenSeek: call mbtx with filename=@builtin/review.mbtx and subrun=true)
+[1]
+```
+
+```mooncram
+$ sh <<'EOF'
+> sh review.sh Check CSV --sha=abc --dirty CRLF handling > output 2>&1
+> status=$?
+> sed -E 's/^Failure\([^ ]+ FAILED: /Failure(/' output
+> exit "$status"
+> EOF
+Failure(This workflow needs OpenSeek: call mbtx with filename=@builtin/review.mbtx and subrun=true)
+[1]
+```

--- a/tests/integration/workflows/hosted.mbt
+++ b/tests/integration/workflows/hosted.mbt
@@ -196,8 +196,8 @@ async fn verify_review(root : String, temp : String, exe : String) -> Unit {
       "blockers" => "does not hold yet"
       "missing" => "subrun=true"
       "no-criteria" => "no criteria given"
-      "dirty-without-sha" => "--dirty needs --sha"
-      "help" => "usage:"
+      "dirty-without-sha" => "'sha' (required by 'dirty')"
+      "help" => "Usage:"
       _ => "findings=0 blockers=0"
     }
     assert_true(output.contains(expected), msg=output)


### PR DESCRIPTION
Replace the review workflow's hand-written CLI parser with argparse. Unknown flags and a bare `--sha` now produce argument errors, repeated `--sha` options are rejected, `--dirty` requires `--sha`, and help is generated from the command definition. Standing-goal and baseline resolution remain unchanged.

Add eight cram cases covering help, argument errors, literal criteria after `--`, and options mixed with criteria; update the hosted integration checks for argparse's diagnostics. Update the system prompt and workflow examples to place free-text criteria after `--` and baseline options before it, and regenerate the prompt.

Validation: `just check`, `just test`, `just build`, and `moon info && moon fmt` passed for the parser and tests. This includes 3,092 native tests, 3,212 JS tests, all 46 cram cases, and the offline hosted workflow checks. After the documentation update, prompt regeneration, `just check-prompt`, `moon info && moon fmt`, and `git diff --check` passed. No generated public interfaces changed.
