### PR TITLE
refactor(workflow): carry audit criteria in hosted context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,28 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  workflows:
+    name: bundled workflow checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up MoonBit
+        run: |
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
+          echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
+
+      - name: Update MoonBit package registry
+        run: moon update
+
+      # Standalone scripts resolve their own declared imports. Check all of them
+      # without executing their main functions or setting up Desktop's runtime.
+      - name: Check all bundled workflow scripts
+        run: python3 scripts/check_workflows.py
+
   sandbox-macos:
     name: sandbox (macOS, native)
     runs-on: macos-latest

--- a/agent_subrun/host/host.mbt
+++ b/agent_subrun/host/host.mbt
@@ -34,9 +34,8 @@ pub let block_size : Int = 32
 /// and whether the worktree was already dirty at it.
 ///
 /// The host reads it at reservation time, so a snippet sees the LIVE goal
-/// rather than a turn-start snapshot, and hands it over as guest environment
-/// (`OPENSEEK_GOAL`, `OPENSEEK_GOAL_SHA`, `OPENSEEK_GOAL_DIRTY`) beside the
-/// workflow handoff. The audited party does not get to restate its own
+/// rather than a turn-start snapshot, and hands it over in
+/// `WORKFLOW_HOST.openseek.audit`. The audited party does not restate its own
 /// criteria: a paraphrased goal is where quiet narrowing hides, and the
 /// baseline is something the model does not reliably know at all.
 pub(all) struct AuditCriteria {
@@ -160,9 +159,8 @@ pub fn SubrunReservation::events_path(self : SubrunReservation) -> String {
 }
 
 ///|
-/// The guest environment to set: `WORKFLOW_HOST`, plus the standing goal
-/// (`OPENSEEK_GOAL`, with `OPENSEEK_GOAL_SHA`/`OPENSEEK_GOAL_DIRTY` when it
-/// recorded a baseline) while one stands — and nothing else.
+/// The guest environment to set: `WORKFLOW_HOST`, including the standing
+/// goal and its optional baseline in `openseek.audit`.
 pub fn SubrunReservation::env(self : SubrunReservation) -> Map[String, String] {
   self.env
 }
@@ -223,13 +221,16 @@ pub fn SubrunInjection::reserve(self : SubrunInjection) -> SubrunReservation {
     "events": events_path,
     "cwd": self.workspace_root,
   }
-  let env = { "WORKFLOW_HOST": handoff.stringify() }
   if (self.criteria)() is Some(criteria) {
-    env["OPENSEEK_GOAL"] = criteria.goal
-    if criteria.sha is Some(sha) {
-      env["OPENSEEK_GOAL_SHA"] = sha
-      env["OPENSEEK_GOAL_DIRTY"] = if criteria.dirty { "true" } else { "false" }
+    let audit : Json = match criteria.sha {
+      Some(sha) =>
+        { "goal": criteria.goal, "sha": sha, "dirty": criteria.dirty }
+      None => { "goal": criteria.goal }
+    }
+    if handoff is Object(fields) {
+      fields["openseek"] = { "audit": audit }
     }
   }
+  let env = { "WORKFLOW_HOST": handoff.stringify() }
   { base, limit: block_size, dir, journal_path, events_path, env, }
 }

--- a/agent_subrun/host/host_test.mbt
+++ b/agent_subrun/host/host_test.mbt
@@ -51,7 +51,13 @@ test "what this host writes is what the library reads" {
   }
   assert_eq(reservation.env().length(), 1)
   let document = @json.parse(raw)
-  guard @hosted.parse(document) is Some(ctx) else {
+  let previous = @env.get_env_var("WORKFLOW_HOST")
+  @env.set_env_var("WORKFLOW_HOST", raw)
+  defer (match previous {
+    Some(value) => @env.set_env_var("WORKFLOW_HOST", value)
+    None => @env.unset_env_var("WORKFLOW_HOST")
+  })
+  guard @hosted.context() is Some(ctx) else {
     fail("the library must accept what this host wrote")
   }
   assert_eq(ctx.child_capacity(), @host.block_size)
@@ -86,7 +92,7 @@ test "what this host writes is what the library reads" {
 }
 
 ///|
-test "the standing goal rides the guest environment beside the handoff" {
+test "the standing goal rides the hosted extension" {
   // Read at reservation time, so the closure sees whatever goal stands when
   // the snippet actually runs; absent, nothing but the handoff is set.
   let goal : Ref[@host.AuditCriteria?] = Ref(None)
@@ -98,20 +104,50 @@ test "the standing goal rides the guest environment beside the handoff" {
     reserve_ordinals=_ => 1,
     criteria=() => goal.val,
   )
-  assert_eq(injection.reserve().env().length(), 1)
+  let env = injection.reserve().env()
+  assert_eq(env.length(), 1)
+  guard env.get("WORKFLOW_HOST") is Some(raw) else { fail("missing handoff") }
+  assert_true(@json.parse(raw) is { "openseek"? : None, .. })
   goal.val = Some({ goal: "ship the parser", sha: None, dirty: true, })
   let env = injection.reserve().env()
-  assert_eq(env.get("OPENSEEK_GOAL"), Some("ship the parser"))
-  // A dirty flag without a commit describes nothing: neither is set.
-  assert_eq(env.get("OPENSEEK_GOAL_SHA"), None)
-  assert_eq(env.get("OPENSEEK_GOAL_DIRTY"), None)
+  assert_eq(env.length(), 1)
+  guard env.get("WORKFLOW_HOST") is Some(raw) else { fail("missing handoff") }
+  assert_true(
+    @json.parse(raw)
+    is {
+      "openseek": {
+        "audit": {
+          "goal": "ship the parser",
+          "sha"? : None,
+          "dirty"? : None,
+          ..
+        },
+        ..
+      },
+      ..
+    },
+  )
   goal.val = Some({
     goal: "ship the parser",
     sha: Some("abc123"),
     dirty: false,
   })
   let env = injection.reserve().env()
-  assert_eq(env.get("OPENSEEK_GOAL_SHA"), Some("abc123"))
-  assert_eq(env.get("OPENSEEK_GOAL_DIRTY"), Some("false"))
-  assert_true(env.get("WORKFLOW_HOST") is Some(_))
+  assert_eq(env.length(), 1)
+  guard env.get("WORKFLOW_HOST") is Some(raw) else { fail("missing handoff") }
+  assert_true(
+    @json.parse(raw)
+    is {
+      "openseek": {
+        "audit": {
+          "goal": "ship the parser",
+          "sha": "abc123",
+          "dirty": false,
+          ..
+        },
+        ..
+      },
+      ..
+    },
+  )
 }

--- a/agent_subrun/host/moon.pkg
+++ b/agent_subrun/host/moon.pkg
@@ -4,6 +4,7 @@ import {
 
 import {
   "moonbitlang/workflow/hosted",
+  "moonbitlang/core/env",
   "moonbitlang/core/json",
 } for "test"
 

--- a/agent_tool/mbtx/README.mbt.md
+++ b/agent_tool/mbtx/README.mbt.md
@@ -405,8 +405,8 @@ same hosted workflow as scouts. Set `subrun: true`; `args` are optional:
 ```
 
 With empty `args` the child audits the standing goal and the baseline it
-recorded. The engine hands both to the snippet's environment at reservation
-time (`OPENSEEK_GOAL`, `OPENSEEK_GOAL_SHA`, `OPENSEEK_GOAL_DIRTY`; see
+recorded. The engine hands both to `WORKFLOW_HOST.openseek.audit` at reservation
+time (`goal`, optional `sha` and `dirty`; see
 `@host.AuditCriteria`), read from the live session rather than a turn-start
 snapshot, so the audited party never restates its own criteria. Given `args`,
 they narrow that goal as an audit focus, or are the whole criteria when no

--- a/justfile
+++ b/justfile
@@ -9,10 +9,15 @@ default:
 
 # Check the two production targets together and verify repository formatting.
 check:
+    just check-workflows
     just check-prompt
     moon check --target native --deny-warn
     moon check --target js --deny-warn
     moon fmt --check
+
+# Check standalone bundled scripts against their declared dependencies without running them.
+check-workflows:
+    {{ PYTHON }} scripts/check_workflows.py
 
 # Build every root workspace member for the production targets.
 build:

--- a/moon.mod
+++ b/moon.mod
@@ -9,7 +9,7 @@ import {
   "bobzhang/openseek_protocol@0.1.1",
   "moonbit-community/rabbita@0.15.7",
   "moonbitlang/editor@0.4.5",
-  "moonbitlang/workflow@0.7.0",
+  "moonbitlang/workflow@0.7.1",
 }
 
 readme = "README.mbt.md"

--- a/scripts/check_workflows.py
+++ b/scripts/check_workflows.py
@@ -1,0 +1,25 @@
+"""Type-check every bundled workflow without executing its main function."""
+
+from pathlib import Path
+import subprocess
+
+
+def main():
+    root = Path(__file__).resolve().parents[1]
+    scripts = sorted((root / "share" / "workflow").glob("*.mbtx"))
+    if not scripts:
+        raise SystemExit("No bundled workflow scripts found")
+    for script in scripts:
+        relative = script.relative_to(root)
+        print(f"Checking {relative}", flush=True)
+        result = subprocess.run(
+            ["moon", "check", "--target", "wasm", "--deny-warn", str(relative)],
+            cwd=root,
+        )
+        if result.returncode:
+            raise SystemExit(result.returncode)
+    print(f"Checked {len(scripts)} bundled workflows", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/share/workflow/README.md
+++ b/share/workflow/README.md
@@ -195,3 +195,14 @@ head replacement, external statuses, unknown states, and timeouts. It runs in
 argument forwarding without requiring GitHub credentials.
 
 All bundled-workflow fixtures run in MoonBit; they require no Python runtime.
+
+## Validation
+
+Run `just check-workflows` to type-check every `.mbtx` under `share/workflow`
+against its declared imports with `moon check --target wasm --deny-warn`.
+This does not execute the scripts. `just check` includes this gate, and CI
+runs it in the independent `bundled workflow checks` job. Newly added scripts
+are discovered automatically.
+
+`just test-workflows` separately compiles and executes the hosted review,
+repository mapping, change review, and CI watch scripts with offline fixtures.

--- a/share/workflow/README.md
+++ b/share/workflow/README.md
@@ -84,8 +84,8 @@ Run these with the hosted child-agent handoff:
 
 `review.mbtx` launches one `review` child (100-step ceiling). With no
 arguments it audits the standing goal and the baseline it recorded, which the
-engine places in the snippet's environment (`OPENSEEK_GOAL`,
-`OPENSEEK_GOAL_SHA`, `OPENSEEK_GOAL_DIRTY`) when one stands; arguments, joined
+engine places in `WORKFLOW_HOST.openseek.audit` (`goal`, optional `sha` and
+`dirty`) when one stands; arguments, joined
 with spaces, narrow that goal as an audit focus, or are the whole criteria
 when no goal stands. It prints the full report JSON, then a
 `findings=N blockers=M` line, and exits unsuccessfully when any finding is a

--- a/share/workflow/change-review.mbtx
+++ b/share/workflow/change-review.mbtx
@@ -1,8 +1,8 @@
 ///|
 import {
   "moonbitlang/async@0.21.1",
-  "moonbitlang/workflow@0.7.0",
-  "moonbitlang/workflow@0.7.0/hosted",
+  "moonbitlang/workflow@0.7.1",
+  "moonbitlang/workflow@0.7.1/hosted",
 }
 
 ///|

--- a/share/workflow/repo-map.mbtx
+++ b/share/workflow/repo-map.mbtx
@@ -2,8 +2,8 @@
 import {
   "moonbitlang/async@0.21.1",
   "moonbitlang/async@0.21.1/fs",
-  "moonbitlang/workflow@0.7.0",
-  "moonbitlang/workflow@0.7.0/hosted",
+  "moonbitlang/workflow@0.7.1",
+  "moonbitlang/workflow@0.7.1/hosted",
 }
 
 ///|

--- a/share/workflow/review.mbtx
+++ b/share/workflow/review.mbtx
@@ -2,8 +2,8 @@
 import {
   "moonbitlang/async@0.21.1",
   "moonbitlang/core/env",
-  "moonbitlang/workflow@0.7.0",
-  "moonbitlang/workflow@0.7.0/hosted",
+  "moonbitlang/workflow@0.7.1",
+  "moonbitlang/workflow@0.7.1/hosted",
 }
 
 ///|
@@ -16,8 +16,8 @@ const Usage : String =
   #|usage: @builtin/review.mbtx [--sha COMMIT [--dirty]] [--] [CRITERIA...]
   #|
   #|With no arguments the reviewer audits the standing goal and the baseline
-  #|it recorded, which the engine supplies in OPENSEEK_GOAL (and
-  #|OPENSEEK_GOAL_SHA/OPENSEEK_GOAL_DIRTY). The remaining arguments, joined
+  #|it recorded, which the engine supplies in WORKFLOW_HOST.openseek.audit.
+  #|The remaining arguments, joined
   #|with spaces, narrow that goal as an audit focus, or are the whole criteria
   #|when no goal stands. --sha names the baseline commit the criteria were
   #|recorded at (--dirty: the worktree was already dirty then) and overrides
@@ -56,25 +56,44 @@ async fn main {
   }
   guard sha is Some(_) || !dirty else { fail("--dirty needs --sha\n\{Usage}") }
   let focus = criteria.join(" ")
-  let standing = @env.get_env_var("OPENSEEK_GOAL")
+  guard @hosted.context() is Some(ctx) else {
+    fail(
+      "This workflow needs OpenSeek: call mbtx with filename=@builtin/review.mbtx and subrun=true",
+    )
+  }
+  let audit = match ctx.extension("openseek") {
+    None => None
+    Some({ "audit"? : audit, .. }) => audit
+    Some(_) => fail("invalid WORKFLOW_HOST.openseek: expected an object")
+  }
+  let (standing, baseline) : (String?, (String, Bool)?) = match audit {
+    None => (None, None)
+    Some({ "goal": String(goal), "sha"? : sha, "dirty"? : dirty, .. }) => {
+      let baseline = match (sha, dirty) {
+        (None, None) => None
+        (Some(String(sha)), Some(True)) => Some((sha, true))
+        (Some(String(sha)), Some(False)) => Some((sha, false))
+        _ =>
+          fail(
+            "invalid audit baseline: sha and dirty must be a string and boolean pair",
+          )
+      }
+      (Some(goal), baseline)
+    }
+    Some(_) =>
+      fail("invalid WORKFLOW_HOST.openseek.audit: expected a goal string")
+  }
   let goal = match (standing, focus.is_blank()) {
     (Some(text), true) => text
     (Some(text), false) => "\{text}\n\nAudit focus:\n\{focus}"
     (None, false) => focus
     (None, true) => fail("no criteria given and no standing goal\n\{Usage}")
   }
-  // An explicit baseline wins; the engine's accompanies only the standing
-  // goal it was recorded for.
-  let (sha, dirty) = match (sha, standing, @env.get_env_var("OPENSEEK_GOAL_SHA")) {
-    (Some(sha), _, _) => (Some(sha), dirty)
-    (None, Some(_), Some(sha)) =>
-      (Some(sha), @env.get_env_var("OPENSEEK_GOAL_DIRTY") == Some("true"))
-    _ => (None, false)
-  }
-  guard @hosted.context() is Some(ctx) else {
-    fail(
-      "This workflow needs OpenSeek: call mbtx with filename=@builtin/review.mbtx and subrun=true",
-    )
+  // An explicit baseline wins; the host's accompanies its standing goal.
+  let (sha, dirty) = match (sha, baseline) {
+    (Some(sha), _) => (Some(sha), dirty)
+    (None, Some((sha, dirty))) => (Some(sha), dirty)
+    (None, None) => (None, false)
   }
   // The same input a `subrun review` child reads from the goal-met gate.
   let input : Json = match sha {

--- a/tests/integration/workflows/hosted.mbt
+++ b/tests/integration/workflows/hosted.mbt
@@ -136,7 +136,7 @@ async fn verify_review(root : String, temp : String, exe : String) -> Unit {
   for
     mode in [
       "success", "baseline", "blockers", "standing", "focus", "override", "missing",
-      "no-criteria", "dirty-without-sha", "help",
+      "no-criteria", "dirty-without-sha", "help", "invalid-audit", "invalid-baseline",
     ] {
     let calls = temp + "/review-" + mode + ".jsonl"
     let env = clean_env()
@@ -150,17 +150,28 @@ async fn verify_review(root : String, temp : String, exe : String) -> Unit {
         "cwd": repo,
         "deadline_ms": 10000,
       }
-      env["WORKFLOW_HOST"] = handoff.stringify()
-    }
-    // The engine's standing goal, as the host hands it over.
-    match mode {
-      "standing" | "override" => {
-        env["OPENSEEK_GOAL"] = "Standing goal"
-        env["OPENSEEK_GOAL_SHA"] = "def"
-        env["OPENSEEK_GOAL_DIRTY"] = "false"
+      // The engine's standing goal, in the same handoff as its coordinates.
+      if handoff is Object(fields) {
+        match mode {
+          "standing" | "override" =>
+            fields["openseek"] = {
+              "audit": { "goal": "Standing goal", "sha": "def", "dirty": false },
+            }
+          "focus" =>
+            fields["openseek"] = { "audit": { "goal": "Standing goal" } }
+          "invalid-audit" => fields["openseek"] = { "audit": { "goal": 42 } }
+          "invalid-baseline" =>
+            fields["openseek"] = {
+              "audit": {
+                "goal": "Standing goal",
+                "sha": "def",
+                "dirty": "false",
+              },
+            }
+          _ => ()
+        }
       }
-      "focus" => env["OPENSEEK_GOAL"] = "Standing goal"
-      _ => ()
+      env["WORKFLOW_HOST"] = handoff.stringify()
     }
     let args = match mode {
       "baseline" =>
@@ -194,6 +205,8 @@ async fn verify_review(root : String, temp : String, exe : String) -> Unit {
     assert_eq(launched.length(), reviewed, msg=output)
     let expected = match mode {
       "blockers" => "does not hold yet"
+      "invalid-audit" => "invalid WORKFLOW_HOST.openseek.audit"
+      "invalid-baseline" => "invalid audit baseline"
       "missing" => "subrun=true"
       "no-criteria" => "no criteria given"
       "dirty-without-sha" => "--dirty needs --sha"

--- a/tests/integration/workflows/main.mbt
+++ b/tests/integration/workflows/main.mbt
@@ -78,8 +78,5 @@ fn clean_env() -> Map[String, String] {
   let env = @env.get_env_vars()
   env.remove("WORKFLOW_HOST")
   env.remove("OPENSEEK_CI_FIXTURE")
-  env.remove("OPENSEEK_GOAL")
-  env.remove("OPENSEEK_GOAL_SHA")
-  env.remove("OPENSEEK_GOAL_DIRTY")
   env
 }


### PR DESCRIPTION
Review workflows currently read runtime configuration from hosted context but obtain audit criteria from three separate environment variables. Move the standing goal and optional baseline into `WORKFLOW_HOST.openseek.audit`, and read them through `ctx.extension("openseek")` so one handoff carries both.

Upgrade the module and bundled scripts to the published workflow 0.7.1 release ([upstream change](https://github.com/moonbitlang/workflow/pull/32)). Remove the old `OPENSEEK_GOAL*` variables, preserve audit-focus and explicit baseline overrides, and reject malformed audit input before launching a child. Update the host round-trip test to use the public `hosted.context()` reader.

Add an independent `bundled workflow checks` CI job and `just check-workflows` (included in `just check`). The shared checker discovers every bundled `.mbtx` and runs `moon check --target wasm --deny-warn` without executing scripts or requiring the Desktop runtime.

Validation:
- All 10 bundled scripts pass; a temporary newly added script with a type error was automatically discovered and rejected
- `just check`
- `just test`: 3,092 native tests, 3,212 JS tests, 38 cram cases, CLI lifecycle tests, and offline workflow integration tests, including malformed audit/baseline cases
- `just build`
- `moon info && moon fmt`; no generated interface changes

