### PR TITLE
refactor(mbtx): replace working directory counter with UUIDv7

### DIFF
--- a/agent/tool_definition.mbt
+++ b/agent/tool_definition.mbt
@@ -375,18 +375,21 @@ async test "a handed-off job cleans builds but keeps result files until teardown
       prefix="openseek-job-result-",
       auto_background_after_ms=1,
     )
-    let result_path = "\{spill_dir}/snippet-0/tmp/report.txt"
-    let source = (
+    let source =
       #|import { "moonbitlang/async", "moonbitlang/async/fs" }
       #|
       #|async fn main {
-      #|  @fs.write_file("RESULT_PATH", "kept", create_mode=CreateOrTruncate)
-      #|  println("RESULT_PATH")
+      #|  @async.sleep(100)
+      #|  let path = "\{@fs.tmpdir(prefix="result-")}/report.txt"
+      #|  @fs.write_file(path, "kept", create_mode=CreateOrTruncate)
+      #|  println(path)
       #|}
-    ).replace_all(old="RESULT_PATH", new=result_path)
     let action = run_async_tool(mbtx, { "source": source })
     guard action is Respond(output) else { fail("expected Respond") }
-    assert_true(output.content.contains("moved to the background"))
+    assert_true(
+      output.content.contains("moved to the background"),
+      msg=output.content,
+    )
     guard bg_runtime.list() is [job, ..] else { fail("no job registered") }
     @async.with_timeout(120_000, () => bg_runtime.wait_any([job.id]))
     let read = run_async_tool(@job_output.definition(bg_runtime), {
@@ -394,11 +397,17 @@ async test "a handed-off job cleans builds but keeps result files until teardown
     })
     guard read is Respond(result) else { fail("expected Respond") }
     assert_false(result.is_error)
+    let dirs = @fs.readdir(spill_dir).filter(name => name.has_prefix("snippet-"))
+    assert_eq(dirs.length(), 1)
+    let call_dir = "\{spill_dir}/\{dirs[0]}"
+    let results = @fs.readdir("\{call_dir}/tmp")
+    assert_eq(results.length(), 1)
+    let result_path = "\{call_dir}/tmp/\{results[0]}/report.txt"
     assert_eq(@fs.read_file(result_path).text(), "kept")
-    let build_dir = "\{spill_dir}/snippet-0/build"
+    let build_dir = "\{call_dir}/build"
     // wait_any includes launcher cleanup and completion publication.
     assert_false(@fs.exists(build_dir))
-    assert_true(@fs.exists("\{spill_dir}/snippet-0/tmp"))
+    assert_true(@fs.exists("\{call_dir}/tmp"))
     @fs.rmdir(spill_dir, recursive=true) catch {
       _ => ()
     }

--- a/agent_tool/bgjobs/id.mbt
+++ b/agent_tool/bgjobs/id.mbt
@@ -1,92 +1,13 @@
 ///|
-priv suberror JobIdError {
-  JobIdError(String)
-}
-
-///|
 /// RFC 9562 UUIDv7: a 48-bit millisecond timestamp and 74 random bits.
 /// A logical millisecond advances for same-tick allocation or clock rollback,
 /// preserving runtime creation order without reading every historical record.
 /// Randomness, rather than the clock or runtime generation, provides uniqueness
 /// across processes/restarts. Fail before spawning/registering on entropy loss.
 fn BgJobRuntime::next_id(self : BgJobRuntime) -> String raise {
-  let (id, stamp) = mint_job_id(@env.now(), self.last_id_ms, @env.rand(10))
+  let (id, stamp) = @uuid.mint(@env.now(), self.last_id_ms, @env.rand(10))
   self.last_id_ms = Some(stamp)
   id
-}
-
-///|
-fn mint_job_id(
-  now : UInt64,
-  previous : UInt64?,
-  entropy : Bytes?,
-) -> (String, UInt64) raise {
-  guard entropy is Some(bytes) && bytes.length() == 10 else {
-    raise JobIdError(
-      "Cannot allocate background job ID: secure entropy unavailable",
-    )
-  }
-  let max_stamp = 0xffffffffffffUL
-  guard now <= max_stamp &&
-    previous.map(last => last < max_stamp).unwrap_or(true) else {
-    raise JobIdError(
-      "Cannot allocate background job ID: UUID timestamp exhausted",
-    )
-  }
-  let stamp = match previous {
-    Some(last) => if now > last { now } else { last + 1 }
-    None => now
-  }
-  let payload = Bytes::makei(16, index => {
-    if index < 6 {
-      (stamp >> ((5 - index) * 8)).to_byte()
-    } else {
-      bytes[index - 6]
-    }
-  })
-  // x/uuid owns the UUID representation, version/variant bits and formatting.
-  // Its Version enum names V1–V5; Unknown(7) selects the RFC 9562 v7 bits.
-  let id = @uuid.from_bytes(payload).as_version(Unknown(7)).to_string()
-  (id, stamp)
-}
-
-///|
-test "UUIDv7 layout matches the RFC 9562 A.6 test vector" {
-  let (id, stamp) = mint_job_id(
-    0x017f22e279b0UL,
-    None,
-    Some(b"\xcc\xc3\x18\xc4\xdc\x0c\x0c\x07\x39\x8f"),
-  )
-  assert_eq(id, "017f22e2-79b0-7cc3-98c4-dc0c0c07398f")
-  assert_eq(stamp, 0x017f22e279b0UL)
-}
-
-///|
-test "UUID job order survives same-millisecond allocation and clock rollback" {
-  let entropy = Some(b"0123456789")
-  let (first, stamp) = mint_job_id(100UL, None, entropy)
-  let (second, stamp) = mint_job_id(100UL, Some(stamp), entropy)
-  let (third, stamp) = mint_job_id(50UL, Some(stamp), entropy)
-  assert_true(first < second && second < third)
-  assert_eq(stamp, 102UL)
-}
-
-///|
-test "UUID allocation reports entropy failure and timestamp exhaustion" {
-  for
-    (now, previous, entropy) in [
-      (1UL, None, None),
-      (1UL, None, Some(b"short")),
-      (0x1000000000000UL, None, Some(b"0123456789")),
-      (1UL, Some(0xffffffffffffUL), Some(b"0123456789")),
-    ] {
-    try mint_job_id(now, previous, entropy) catch {
-      JobIdError(_) => ()
-      error => fail("unexpected error: \{error}")
-    } noraise {
-      _ => fail("invalid allocation must fail explicitly")
-    }
-  }
 }
 
 ///|

--- a/agent_tool/bgjobs/moon.pkg
+++ b/agent_tool/bgjobs/moon.pkg
@@ -7,7 +7,7 @@ import {
   "bobzhang/openseek_protocol" @protocol,
   "moonbitlang/async/process",
   "moonbitlang/core/env",
-  "moonbitlang/x/uuid",
+  "bobzhang/openseek/agent_tool/internal/uuid",
 }
 
 warnings = "+unnecessary_annotation"

--- a/agent_tool/internal/uuid/moon.pkg
+++ b/agent_tool/internal/uuid/moon.pkg
@@ -1,0 +1,6 @@
+import {
+  "moonbitlang/core/env",
+  "moonbitlang/x/uuid" @x_uuid,
+}
+
+warnings = "+unnecessary_annotation"

--- a/agent_tool/internal/uuid/pkg.generated.mbti
+++ b/agent_tool/internal/uuid/pkg.generated.mbti
@@ -1,0 +1,15 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_tool/internal/uuid"
+
+// Values
+pub fn mint(UInt64, UInt64?, Bytes?) -> (String, UInt64) raise
+
+pub fn v7() -> String raise
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits

--- a/agent_tool/internal/uuid/uuid.mbt
+++ b/agent_tool/internal/uuid/uuid.mbt
@@ -1,0 +1,44 @@
+///|
+priv suberror UuidError {
+  UuidError(String)
+}
+
+///|
+/// Generate a UUIDv7 without retaining state between calls.
+pub fn v7() -> String raise {
+  let (id, _) = mint(@env.now(), None, @env.rand(10))
+  id
+}
+
+///|
+/// Generate a UUIDv7, optionally advancing beyond a caller-owned timestamp.
+/// Raises on unavailable entropy or exhausted 48-bit timestamps.
+pub fn mint(
+  now : UInt64,
+  previous : UInt64?,
+  entropy : Bytes?,
+) -> (String, UInt64) raise {
+  guard entropy is Some(bytes) && bytes.length() == 10 else {
+    raise UuidError("Cannot allocate UUID: secure entropy unavailable")
+  }
+  let max_stamp = 0xffffffffffffUL
+  guard now <= max_stamp &&
+    previous.map(last => last < max_stamp).unwrap_or(true) else {
+    raise UuidError("Cannot allocate UUID: UUID timestamp exhausted")
+  }
+  let stamp = match previous {
+    Some(last) => if now > last { now } else { last + 1 }
+    None => now
+  }
+  let payload = Bytes::makei(16, index => {
+    if index < 6 {
+      (stamp >> ((5 - index) * 8)).to_byte()
+    } else {
+      bytes[index - 6]
+    }
+  })
+  // x/uuid owns the UUID representation, version/variant bits and formatting.
+  // Its Version enum names V1–V5; Unknown(7) selects the RFC 9562 v7 bits.
+  let id = @x_uuid.from_bytes(payload).as_version(Unknown(7)).to_string()
+  (id, stamp)
+}

--- a/agent_tool/internal/uuid/uuid_wbtest.mbt
+++ b/agent_tool/internal/uuid/uuid_wbtest.mbt
@@ -1,0 +1,38 @@
+///|
+test "UUIDv7 layout matches the RFC 9562 A.6 test vector" {
+  let (id, stamp) = mint(
+    0x017f22e279b0UL,
+    None,
+    Some(b"\xcc\xc3\x18\xc4\xdc\x0c\x0c\x07\x39\x8f"),
+  )
+  assert_eq(id, "017f22e2-79b0-7cc3-98c4-dc0c0c07398f")
+  assert_eq(stamp, 0x017f22e279b0UL)
+}
+
+///|
+test "UUID job order survives same-millisecond allocation and clock rollback" {
+  let entropy = Some(b"0123456789")
+  let (first, stamp) = mint(100UL, None, entropy)
+  let (second, stamp) = mint(100UL, Some(stamp), entropy)
+  let (third, stamp) = mint(50UL, Some(stamp), entropy)
+  assert_true(first < second && second < third)
+  assert_eq(stamp, 102UL)
+}
+
+///|
+test "UUID allocation reports entropy failure and timestamp exhaustion" {
+  for
+    (now, previous, entropy) in [
+      (1UL, None, None),
+      (1UL, None, Some(b"short")),
+      (0x1000000000000UL, None, Some(b"0123456789")),
+      (1UL, Some(0xffffffffffffUL), Some(b"0123456789")),
+    ] {
+    try mint(now, previous, entropy) catch {
+      UuidError(_) => ()
+      error => fail("unexpected error: \{error}")
+    } noraise {
+      _ => fail("invalid allocation must fail explicitly")
+    }
+  }
+}

--- a/agent_tool/mbtx/build_cache_test.mbt
+++ b/agent_tool/mbtx/build_cache_test.mbt
@@ -253,6 +253,9 @@ async test "cache: a detached job's cleanup keeps the cache and its own run" {
       let output = dispatch(definition, { "source": source })
       assert_false(output.is_error, msg=output.content)
       assert_true(output.content.contains("moved to the background"))
+      let dirs = @fs.readdir(spill).filter(name => name.has_prefix("snippet-"))
+      assert_eq(dirs.length(), 1)
+      let call_dir = "\{spill}/\{dirs[0]}"
       // Rebuild the shared snippet dir underneath the running job. With the
       // 1ms handoff bound this run is adopted too, but its BUILD happened
       // synchronously first, in the shared directory, while the job ran.
@@ -263,7 +266,7 @@ async test "cache: a detached job's cleanup keeps the cache and its own run" {
       // The job's per-call build dir is reclaimed when it ends...
       let mut reclaimed = false
       for _ in 0..<200 {
-        if !@fs.exists("\{spill}/snippet-0/build") {
+        if !@fs.exists("\{call_dir}/build") {
           reclaimed = true
           break
         }

--- a/agent_tool/mbtx/mbtx.mbt
+++ b/agent_tool/mbtx/mbtx.mbt
@@ -130,11 +130,6 @@ pub fn definition(
   approval? : @agent_runtime.ApprovalChannel,
   subrun? : @host.SubrunInjection,
 ) -> @agent_tool.AgentToolDefinition {
-  // Background snippet directories are numbered inside the caller's scratch
-  // dir rather than created as fresh system temp dirs: a detached job outlives
-  // this call, so its snippet, build artifacts, and output log cannot be
-  // removed here — the caller's scratch dir is what eventually reclaims them.
-  let next_background = Ref(0)
   // Per cache key, the generation a stopped build retired (see
   // `open_generation`). Session memory, deliberately: see there.
   let generations : Map[String, Int] = Map([])
@@ -172,7 +167,6 @@ pub fn definition(
         auto_background_after_ms~,
         foreground_timeout_ms~,
         build_timeout_ms~,
-        next_background~,
         generations~,
         approval?,
         subrun?,
@@ -235,7 +229,6 @@ async fn execute(
   auto_background_after_ms~ : Int,
   foreground_timeout_ms~ : Int,
   build_timeout_ms~ : Int,
-  next_background~ : Ref[Int],
   generations~ : Map[String, Int],
   approval? : @agent_runtime.ApprovalChannel,
   subrun? : @host.SubrunInjection,
@@ -433,13 +426,12 @@ async fn execute(
   let policy_active = input.target == "wasm" && !escalated
   let handoff_dir_has_owner = job_dir is Some(_) || scratch_dir is Some(_)
   // A directory that an automatic handoff may give to a job must outlive this
-  // call, so it is numbered inside a caller-owned job dir or scratch lab when
+  // call, so it is UUID-named inside a caller-owned job dir or scratch lab when
   // one exists. Its `tmp` subtree is the snippet's writable result area and may
   // contain paths named in completion output, so only the separate build subtree
   // is reclaimed when a handed-off job becomes terminal.
   let dir = if job_dir is Some(scratch) {
-    let dir = "\{scratch}/snippet-\{next_background.val}"
-    next_background.val += 1
+    let dir = "\{scratch}/snippet-\{@uuid.v7()}"
     @fs.mkdir(dir, recursive=true) catch {
       error if @async.is_being_cancelled() => raise error
       _ =>
@@ -453,8 +445,7 @@ async fn execute(
     // With a lab wired, the snippet builds INSIDE it: the profile re-allows
     // exactly one subtree, and pointing it at the lab then covers both the
     // lab writes the caller sanctioned and moon's own build output.
-    let dir = "\{lab}/mbtx-\{next_background.val}"
-    next_background.val += 1
+    let dir = "\{lab}/mbtx-\{@uuid.v7()}"
     @fs.mkdir(dir, recursive=true) catch {
       error if @async.is_being_cancelled() => raise error
       _ =>
@@ -499,7 +490,7 @@ async fn execute(
   defer cleanup()
   // Keep disposable compiler inputs and artifacts apart from `tmp`, whose
   // result files may need to remain readable after a background job exits.
-  // `dir` is one numbered call directory under `job_dir` or `scratch_dir`,
+  // `dir` is one UUID-named call directory under `job_dir` or `scratch_dir`,
   // or a fresh system temp directory when neither was supplied. Keep moon's
   // target directory in `build/_build`: single-file builds append the input
   // filename, so targeting `build` itself collides with `build/snippet.mbtx`.

--- a/agent_tool/mbtx/moon.pkg
+++ b/agent_tool/mbtx/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "bobzhang/openseek/agent_tool/internal/uuid",
   "bobzhang/openseek/agent_tool",
   "bobzhang/openseek/agent_tool/write_scope",
   "bobzhang/openseek/agent_subrun/host",


### PR DESCRIPTION
mbtx now creates caller-owned working directories with UUIDv7 names, removing the per-tool `next_background` counter and its parameter plumbing. Recreating a tool against the same scratch root no longer restarts directory numbering.

Extract the existing UUIDv7 generator into a shared internal package backed by `moonbitlang/x/uuid`. mbtx uses it without retaining state; background jobs retain their existing timestamp state for strict ordering. Update cleanup tests to discover generated paths and use the snippet temporary-directory API.

Validation: `just check`, `just build`, and `just test` passed (3,092 native tests, 3,216 JS tests, 38 cram cases, and offline CLI lifecycle/workflow checks). Completed `moon info && moon fmt`; existing public interfaces are unchanged. Live Kimi smoke tests were skipped by their environment guards.
